### PR TITLE
COMP: Fix ImageBufferRange GTest clang `tautological-compare` warnings

### DIFF
--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -629,19 +629,8 @@ TEST(ImageBufferRange, IteratorsCanBePassedToStdNthElement)
 
 TEST(ImageBufferRange, IteratorIsDefaultConstructible)
 {
-  using RangeType = ImageBufferRange<itk::Image<int>>;
-
-  RangeType::iterator defaultConstructedIterator{};
-
-  // Test that a default-constructed iterator behaves according to C++ proposal
-  // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
-  // C++14: "value-initialized iterators may be compared and shall compare
-  // equal to other value-initialized iterators of the same type."
-  // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
-
-  EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator);
-  EXPECT_FALSE(defaultConstructedIterator != defaultConstructedIterator);
-  EXPECT_EQ(defaultConstructedIterator, RangeType::iterator{});
+  RangeGTestUtilities::ExpectIteratorIsDefaultConstructible<ImageBufferRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectIteratorIsDefaultConstructible<ImageBufferRange<itk::VectorImage<int>>>();
 }
 
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -500,19 +500,7 @@ TEST(ImageRegionRange, SupportsVectorImage)
 
 TEST(ImageRegionRange, IteratorIsDefaultConstructible)
 {
-  using RangeType = ImageRegionRange<itk::Image<int>>;
-
-  RangeType::iterator defaultConstructedIterator{};
-
-  // Test that a default-constructed iterator behaves according to C++ proposal
-  // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
-  // C++14: "value-initialized iterators may be compared and shall compare
-  // equal to other value-initialized iterators of the same type."
-  // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
-
-  EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator);
-  EXPECT_FALSE(defaultConstructedIterator != defaultConstructedIterator);
-  EXPECT_EQ(defaultConstructedIterator, RangeType::iterator{});
+  itk::RangeGTestUtilities::ExpectIteratorIsDefaultConstructible<ImageRegionRange<itk::Image<int>>>();
 }
 
 

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -104,6 +104,24 @@ public:
   }
 
 
+  template <typename TRange>
+  static void
+  ExpectIteratorIsDefaultConstructible()
+  {
+    using IteratorType = typename TRange::iterator;
+    IteratorType defaultConstructedIterator{};
+
+    // Test that a default-constructed iterator behaves according to C++ proposal
+    // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
+    // C++14: "value-initialized iterators may be compared and shall compare
+    // equal to other value-initialized iterators of the same type."
+    // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
+
+    ExpectIteratorEqualsItself(defaultConstructedIterator);
+    EXPECT_EQ(defaultConstructedIterator, IteratorType());
+  }
+
+
   // Checks the `constexpr` member functions begin() and end() of a container like FixedArray, Index, Offset and Size.
   template <typename TContainer>
   static constexpr bool
@@ -144,6 +162,27 @@ private:
   {
     EXPECT_EQ(std::begin(range1), std::begin(range2));
     EXPECT_EQ(std::end(range1), std::end(range2));
+  }
+
+  template <typename TIterator>
+  static void
+  ExpectIteratorEqualsItself(const TIterator & it)
+  {
+    static_assert(!std::is_pointer<TIterator>::value,
+                  "There should be a specific `ExpectIteratorEqualsItself` overload for a pointer as argument");
+
+    // Checks the (typically) user-defined `operator==` and `operator!=` of TIterator.
+    EXPECT_TRUE(it == it);
+    EXPECT_FALSE(it != it);
+  }
+
+  template <typename TValue>
+  static void
+  ExpectIteratorEqualsItself(TValue *)
+  {
+    // Overload for the use of a pointer type as iterator. Intensionally does "nothing", as a pointer always
+    // equals itself, by definition. Aims to avoid "warning: self-comparison always evaluates to false/true
+    // [-Wtautological-compare]", as produced by clang 13.0.1 on Ubuntu 20.04.
   }
 };
 

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -727,19 +727,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdNthElement)
 
 TEST(ShapedImageNeighborhoodRange, IteratorIsDefaultConstructible)
 {
-  using RangeType = itk::ShapedImageNeighborhoodRange<itk::Image<int>>;
-
-  RangeType::iterator defaultConstructedIterator;
-
-  // Test that a default-constructed iterator behaves according to C++ proposal
-  // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
-  // C++14: "value-initialized iterators may be compared and shall compare
-  // equal to other value-initialized iterators of the same type."
-  // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
-
-  EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator);
-  EXPECT_FALSE(defaultConstructedIterator != defaultConstructedIterator);
-  EXPECT_EQ(defaultConstructedIterator, RangeType::iterator{});
+  RangeGTestUtilities::ExpectIteratorIsDefaultConstructible<itk::ShapedImageNeighborhoodRange<itk::Image<int>>>();
 }
 
 


### PR DESCRIPTION
Fixed clang warnings from `IteratorIsDefaultConstructible` checks like
`EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator)`
saying:

> warning: self-comparison always evaluates to true [-Wtautological-compare]

Fixed by avoiding such checks whenever the iterator is a pointer.

Reported by issue https://github.com/InsightSoftwareConsortium/ITK/issues/3268
"Minor compiler warning.", from Hans Johnson (@hjmjohnson).

Also reduced the amount of duplicate code from the three
`IteratorIsDefaultConstructible` GoogleTest unit tests.