### PR TITLE
ENH: Add `NumberToString<>` specialization, deducing its parameter type

### DIFF
--- a/Modules/Core/Common/include/itkNumberToString.h
+++ b/Modules/Core/Common/include/itkNumberToString.h
@@ -36,9 +36,16 @@ namespace itk
  *  float a = 1.0f/3.0f;
  *  std::cout << convert(a) << std::endl;
  *
+ * The specialization `NumberToString<>` allows conversion from any type of number:
+ *
+ *  NumberToString<> convert;
+ *  float a = 1.0f/3.0f;
+ *  auto b = std::numeric_limits<int>::max();
+ *  std::cout << convert(a) << convert(b) << std::endl;
+ *
  * \ingroup ITKCommon
  */
-template <typename TValue>
+template <typename TValue = void>
 class ITK_TEMPLATE_EXPORT NumberToString
 {
 public:
@@ -53,6 +60,19 @@ NumberToString<double>::operator()(double val) const;
 template <>
 ITKCommon_EXPORT std::string
 NumberToString<float>::operator()(float val) const;
+
+template <>
+class NumberToString<void>
+{
+public:
+  template <typename TValue>
+  std::string
+  operator()(const TValue val) const
+  {
+    constexpr NumberToString<TValue> convert{};
+    return convert(val);
+  }
+};
 
 } // namespace itk
 

--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -98,6 +98,28 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
   }
 }
 
+
+template <typename TValue>
+void
+Test_default_specialization_of_NumberToString()
+{
+  using NumericLimitsType = std::numeric_limits<TValue>;
+
+  for (const TValue value : { NumericLimitsType::lowest(),
+                              NumericLimitsType::denorm_min(),
+                              TValue(),
+                              NumericLimitsType::epsilon(),
+                              NumericLimitsType::min(),
+                              NumericLimitsType::max(),
+                              NumericLimitsType::infinity(),
+                              NumericLimitsType::quiet_NaN() })
+  {
+    // Expect the same string from the default specialization `NumberToString<>` as from the TValue specific
+    // `NumberToString<TValue>`.
+    EXPECT_EQ(itk::NumberToString<>()(value), itk::NumberToString<TValue>()(value));
+  }
+}
+
 } // namespace
 
 
@@ -141,4 +163,15 @@ TEST(NumberToString, DecimalNotationUpTo21Digits)
 {
   Test_decimal_notation_supports_up_to_twentyone_digits<float>();
   Test_decimal_notation_supports_up_to_twentyone_digits<double>();
+}
+
+
+TEST(NumberToString, DefaultSpecialization)
+{
+  Test_default_specialization_of_NumberToString<int8_t>();
+  Test_default_specialization_of_NumberToString<uint8_t>();
+  Test_default_specialization_of_NumberToString<intmax_t>();
+  Test_default_specialization_of_NumberToString<uintmax_t>();
+  Test_default_specialization_of_NumberToString<float>();
+  Test_default_specialization_of_NumberToString<double>();
 }


### PR DESCRIPTION
Specialized `NumberToString<TValue>` for `TValue` = `void`, allowing users to convert a number of any type to string without having to specify the type of the number, passed as parameter.

Inspired by the `std::less<T>` function object, which has a similar `std::less<>` specialization: https://en.cppreference.com/w/cpp/utility/functional/less 

Aims to make `NumberToString` more appealing, especially for users who would rather not explicitly specify the type of every number they need to convert.  Otherwise those users might rather use `std::ostream` (`<<`) or `std::to_string`, which might be a pity, because `NumberToString` offers full precision (lossless) conversion.