### PR TITLE
BUG: Fix generated file name pattern

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -339,9 +339,10 @@ macro(itk_end_wrap_submodule_python group_name)
 
   # create the swig interface for all the groups in the module
   set(interface_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${base_name}.i")
-  set(lib ${base_name}Python)
-  set(python_file "${ITK_PYTHON_PACKAGE_DIR}/${base_name}.py")
-  set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${lib}.cpp")
+  set(_swig_python_suffix "Python")
+  set(python_file "${ITK_PYTHON_PACKAGE_DIR}/${base_name}${_swig_python_suffix}.py")
+  set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${base_name}${_swig_python_suffix}.cpp")
+  unset(_swig_python_suffix)
 
   # create the python customization for that wrap_*.cmake file.
   configure_file("${ITK_WRAP_PYTHON_SOURCE_DIR}/module_ext.i.in"
@@ -380,7 +381,6 @@ macro(itk_end_wrap_submodule_python group_name)
     }
 ")
 
-  unset(lib)
   unset(interface_file)
   unset(doc_file)
   unset(cpp_file)

--- a/Wrapping/TypedefMacros.cmake
+++ b/Wrapping/TypedefMacros.cmake
@@ -474,9 +474,11 @@ ${DO_NOT_WAIT_FOR_THREADS_DECLS}
 
     # set some var reused later
     set(interface_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_LIBRARY_NAME}.i")
-    set(lib ${WRAPPER_LIBRARY_NAME}Python)
-    set(python_file "${ITK_PYTHON_PACKAGE_DIR}/${lib}.py")
-    set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${lib}.cpp")
+    set(_swig_python_suffix "Python")
+    set(lib ${WRAPPER_LIBRARY_NAME}${_swig_python_suffix})
+    set(python_file "${ITK_PYTHON_PACKAGE_DIR}/${WRAPPER_LIBRARY_NAME}${_swig_python_suffix}.py")
+    set(cpp_file "${CMAKE_CURRENT_BINARY_DIR}/${WRAPPER_LIBRARY_NAME}${_swig_python_suffix}.cpp")
+    unset(_swig_python_suffix)
 
     # if this is for an external library, let the user add extra swig args
     if(EXTERNAL_WRAP_ITK_PROJECT)
@@ -564,6 +566,7 @@ ${DO_NOT_WAIT_FOR_THREADS_DECLS}
   if(BUILD_TESTING AND EXISTS ${wrapping_test_directory}/CMakeLists.txt)
     add_subdirectory(${wrapping_test_directory})
   endif()
+  unset(lib)
 endmacro()
 
 


### PR DESCRIPTION
The name of the file generatd by swig has a
"Python" suffix.

% ninja -d explain /home/johnsonhj/Dashboard/src/ITK/cmake-debug-PythonDebugWrapping_cxx14-build/Wrapping/Generators/Python/itk/itkVariableSizeMatrix.py
     ninja explain: output build.ninja older than most recent input ../Wrapping/Generators/Python/CMakeLists.txt (1647177499575465604 vs 1647261272321982426)

The filename for the output of the swig command had been
incorrectly specified, thus causing continous rebuilds.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
