### PR TITLE
COMP: Fix missing initialization braces warning

### DIFF
--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
@@ -73,7 +73,7 @@ itkPointSetToImageFilterTest1(int argc, char * argv[])
   filter->SetSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, filter->GetSpacing());
 
-  BinaryImageType::PointType origin{ { -125, -125 } };
+  BinaryImageType::PointType origin{ { { -125, -125 } } };
   filter->SetOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, filter->GetOrigin());
 


### PR DESCRIPTION
Fix missing initialization braces warning.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Core/Common/test/itkPointSetToImageFilterTest1.cxx:76:40:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  BinaryImageType::PointType origin{ { -125, -125 } };
                                       ^~~~~~~~~~
                                       {         }
[CTest: warning suppressed] 1 warning generated.
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=7794978

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)