### PR TITLE
ENH: Let `MetaDataDictionary` support non-equality-comparable data

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -134,7 +134,7 @@ public:
   friend bool
   operator==(const Self & lhs, const Self & rhs)
   {
-    return lhs.m_MetaDataObjectValue == rhs.m_MetaDataObjectValue;
+    return EqualMetaDataObjects(&lhs.m_MetaDataObjectValue, &rhs.m_MetaDataObjectValue);
   }
 
   /** Returns (metaDataObject1 != metaDataObject2). */
@@ -149,6 +149,24 @@ protected:
   ~MetaDataObject() override = default;
 
 private:
+  /** Tells whether the specified pointers point to objects that compare equal.
+   * \note The template parameter and the trailing return type are there, just to enable SFINAE.*/
+  template <typename TMetaDataObject>
+  static auto
+  EqualMetaDataObjects(const TMetaDataObject * const lhs, const TMetaDataObject * const rhs) -> decltype(*lhs == *rhs)
+  {
+    static_assert(std::is_same<TMetaDataObject, MetaDataObjectType>::value, "Check the template argument.");
+    return *lhs == *rhs;
+  }
+
+  /** Overload for MetaDataObject types that do not have an `operator==`.*/
+  static bool
+  EqualMetaDataObjects(const void * const lhs, const void * const rhs)
+  {
+    return std::memcmp(lhs, rhs, sizeof(MetaDataObjectType)) == 0;
+  }
+
+
   /** Internal helper function used to implement operator== for MetaDataObjectBase. */
   bool
   Equal(const MetaDataObjectBase & metaDataObjectBase) const override

--- a/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
@@ -286,7 +286,8 @@ TEST(MetaDataDictionary, Equal)
 
   const auto createMetaDataDictionary = [](const int value) {
     itk::MetaDataDictionary metaDataDictionary;
-    itk::EncapsulateMetaData(metaDataDictionary, "key", value);
+    itk::EncapsulateMetaData(metaDataDictionary, "key1", value);
+    itk::EncapsulateMetaData(metaDataDictionary, "key2", std::to_string(value));
     return metaDataDictionary;
   };
 
@@ -301,4 +302,34 @@ TEST(MetaDataDictionary, Equal)
   expectUnequal(metaDataDictionary1, metaDataDictionary2);
   expectUnequal(metaDataDictionary1, defaultMetaDataDictionary);
   expectUnequal(metaDataDictionary2, defaultMetaDataDictionary);
+}
+
+
+TEST(MetaDataDictionary, SupportsNonEqualityComparableData)
+{
+  // An example of a data type that is not "equality-comparable".
+  struct DataStruct
+  {
+    int data;
+  };
+
+  itk::MetaDataDictionary dictionary;
+
+  for (const int i : { 0, 1 })
+  {
+    const auto       key = "key_" + std::to_string(i);
+    const DataStruct inputDataObjectValue = { i };
+    itk::EncapsulateMetaData(dictionary, key, inputDataObjectValue);
+
+    // Now retrieve the encapsulated data, and check if it has the expected value:
+
+    const itk::MetaDataObjectBase * const base = dictionary.Get(key);
+    ASSERT_NE(base, nullptr);
+
+    const auto * const dataObject = dynamic_cast<const itk::MetaDataObject<DataStruct> *>(base);
+    ASSERT_NE(dataObject, nullptr);
+
+    const DataStruct & dataObjectValue = dataObject->GetMetaDataObjectValue();
+    EXPECT_EQ(dataObjectValue.data, inputDataObjectValue.data);
+  }
 }


### PR DESCRIPTION
No longer require `operator==` for the types of values stored in `itk::MetaDataDictionary`.

Follow-up to:
pull request #2246
commit 694bbc0a1f58bdb4564252e6f75d8611f4e2a5ed
"ENH: Add operator==, operator!= to MetaDataObject and MetaDataDictionary"
