### PR TITLE
BUG: Use itk.ULL type for Python Windows test

### DIFF
--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -21,6 +21,8 @@ import itk
 import numpy as np
 import pickle
 import sys
+import os
+
 
 Dimension = 3
 PixelType = itk.D
@@ -34,7 +36,10 @@ point_set.SetObjectName("testpointset")
 
 # Set Points in the PointSet
 PointType = itk.Point[itk.F, 3]
-v_point = itk.VectorContainer[itk.UL, PointType].New()
+if os.name == 'nt':
+    v_point = itk.VectorContainer[itk.ULL, PointType].New()
+else:
+    v_point = itk.VectorContainer[itk.UL, PointType].New()
 v_point.Reserve(NumberOfPoints)
 
 point = PointType()

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -20,6 +20,7 @@ import itk
 import numpy as np
 import pickle
 import sys
+import os
 
 Dimension = 3
 PixelType = itk.D
@@ -33,7 +34,10 @@ mesh = MeshType.New()
 
 # Set Points in the Mesh
 PointType = itk.Point[itk.F, 3]
-v_point = itk.VectorContainer[itk.UL, PointType].New()
+if os.name == 'nt':
+    v_point = itk.VectorContainer[itk.ULL, PointType].New()
+else:
+    v_point = itk.VectorContainer[itk.UL, PointType].New()
 v_point.Reserve(NumberOfPoints)
 
 point = PointType()


### PR DESCRIPTION
Use `itk.ULL` for Python windows test. Closes #3310.


## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
