### PR TITLE
ENH: Handle itk.ULL in _get_itk_pixelid for Windows

### DIFF
--- a/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
@@ -28,5 +28,5 @@ if(ITK_WRAP_PYTHON)
 
   itk_python_add_test(NAME itkMeshArrayPixelTypePythonTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkMeshArrayPixelTypeTest.py)
   itk_python_add_test(NAME itkConnectedRegionsMeshFilterPythonTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkConnectedRegionsMeshFilterTest.py DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha} 15 2154)
-  itk_python_add_test(NAME itkMeshSerializationTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkMeshSerializationTest.py DATA{${ITK_DATA_ROOT}/mushroom.vtk)
+  itk_python_add_test(NAME itkMeshSerializationTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkMeshSerializationTest.py DATA{${ITK_DATA_ROOT}/Input/mushroom.vtk})
 endif()

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -54,7 +54,7 @@ mesh.SetPoints(points_vc)
 
 
 # Set Cells in the Mesh as Triangle Cell
-cells_array = np.zeros([NumberOfCells, Dimension], np.uint)
+cells_array = np.zeros([NumberOfCells, Dimension], np.uint64)
 
 # Insert point ids in that cell
 for i in range(NumberOfCells):
@@ -116,7 +116,7 @@ mesh["pointData"] = points_data_array
 assert np.array_equal(mesh["pointData"], points_data_array)
 
 cells_array = np.array(
-    [itk.CommonEnums.CellGeometry_TRIANGLE_CELL, 3, 1, 2, 3], dtype=np.uint
+    [itk.CommonEnums.CellGeometry_TRIANGLE_CELL, 3, 1, 2, 3], dtype=np.uint64
 )
 mesh["cells"] = cells_array
 assert np.array_equal(mesh["cells"], cells_array)
@@ -163,7 +163,7 @@ try:
 
         # Extracting only the points by removing first column that denotes the VTK cell type
         polys_numpy = polys_numpy[:, 1:]
-        polys_numpy = polys_numpy.flatten().astype(np.uint)
+        polys_numpy = polys_numpy.flatten().astype(np.uint64)
 
         # Get point data from VTK mesh to insert in ITK Mesh
         point_data_numpy = np.array(vtk_mesh.GetPointData().GetScalars())

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -260,13 +260,18 @@ def _get_itk_pixelid(numpy_array_type):
     """Returns a ITK PixelID given a numpy array."""
 
     import itk
+    def _long_type():
+        if os.name == "nt":
+            return itk.ULL
+        else:
+            return itk.UL
 
     # This is a Mapping from numpy array types to itk pixel types.
     _np_itk = {
         np.uint8: itk.UC,
         np.uint16: itk.US,
         np.uint32: itk.UI,
-        np.uint64: itk.UL,
+        np.uint64: _long_type(),
         np.int8: itk.SC,
         np.int16: itk.SS,
         np.int32: itk.SI,


### PR DESCRIPTION
Added conditional long type in itk.support.extras._get_itk_pixelid for Windows.
The failing MeshSerialization test is also modified.
Refer https://github.com/InsightSoftwareConsortium/ITK/issues/3310

