### PR TITLE
ENH: Support C-style arrays as MetaDataObjectType for MetaDataDictionary

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataObject.hxx
+++ b/Modules/Core/Common/include/itkMetaDataObject.hxx
@@ -56,7 +56,7 @@ template <typename MetaDataObjectType>
 void
 MetaDataObject<MetaDataObjectType>::SetMetaDataObjectValue(const MetaDataObjectType & newValue)
 {
-  m_MetaDataObjectValue = newValue;
+  Self::Assign(m_MetaDataObjectValue, newValue);
 }
 
 template <typename MetaDataObjectType>


### PR DESCRIPTION
Allows passing a N-dimensional C-style array as value, when calling
`itk::EncapsulateMetaData(dictionary, key, value)`.