### PR TITLE
STYLE: Use ReadImage and WriteImage in a few iterator examples

### DIFF
--- a/Examples/Iterators/ImageRegionIterator.cxx
+++ b/Examples/Iterators/ImageRegionIterator.cxx
@@ -81,9 +81,6 @@ main(int argc, char * argv[])
   using IteratorType = itk::ImageRegionIterator<ImageType>;
   // Software Guide : EndCodeSnippet
 
-  using ReaderType = itk::ImageFileReader<ImageType>;
-  using WriterType = itk::ImageFileWriter<ImageType>;
-
   // Software Guide : BeginLatex
   //
   // Information about the subregion to copy is read from the command line.
@@ -108,7 +105,6 @@ main(int argc, char * argv[])
   inputRegion.SetIndex(inputStart);
   // Software Guide : EndCodeSnippet
 
-
   // Software Guide : BeginLatex
   //
   // The destination region in the output image is defined using the input
@@ -129,12 +125,10 @@ main(int argc, char * argv[])
   outputRegion.SetIndex(outputStart);
   // Software Guide : EndCodeSnippet
 
-
-  auto reader = ReaderType::New();
-  reader->SetFileName(argv[1]);
+  ImageType::ConstPointer inputImage;
   try
   {
-    reader->Update();
+    inputImage = itk::ReadImage<ImageType>(argv[1]);
   }
   catch (const itk::ExceptionObject & err)
   {
@@ -144,12 +138,12 @@ main(int argc, char * argv[])
   }
 
   // Check that the region is contained within the input image.
-  if (!reader->GetOutput()->GetRequestedRegion().IsInside(inputRegion))
+  if (!inputImage->GetRequestedRegion().IsInside(inputRegion))
   {
     std::cerr << "Error" << std::endl;
     std::cerr << "The region " << inputRegion
               << "is not contained within the input image region "
-              << reader->GetOutput()->GetRequestedRegion() << std::endl;
+              << inputImage->GetRequestedRegion() << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -170,9 +164,9 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   auto outputImage = ImageType::New();
   outputImage->SetRegions(outputRegion);
-  const ImageType::SpacingType & spacing = reader->GetOutput()->GetSpacing();
-  const ImageType::PointType & inputOrigin = reader->GetOutput()->GetOrigin();
-  double                       outputOrigin[Dimension];
+  const ImageType::SpacingType & spacing = inputImage->GetSpacing();
+  const ImageType::PointType &   inputOrigin = inputImage->GetOrigin();
+  double                         outputOrigin[Dimension];
 
   for (unsigned int i = 0; i < Dimension; ++i)
   {
@@ -183,7 +177,6 @@ main(int argc, char * argv[])
   outputImage->SetOrigin(outputOrigin);
   outputImage->Allocate();
   // Software Guide : EndCodeSnippet
-
 
   // Software Guide : BeginLatex
   //
@@ -199,7 +192,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConstIteratorType inputIt(reader->GetOutput(), inputRegion);
+  ConstIteratorType inputIt(inputImage, inputRegion);
   IteratorType      outputIt(outputImage, outputRegion);
 
   inputIt.GoToBegin();
@@ -213,7 +206,6 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-
   // Software Guide : BeginLatex
   //
   // \index{Iterators!image dimensionality}
@@ -225,13 +217,9 @@ main(int argc, char * argv[])
   //
   // Software Guide : EndLatex
 
-  auto writer = WriterType::New();
-  writer->SetFileName(argv[2]);
-  writer->SetInput(outputImage);
-
   try
   {
-    writer->Update();
+    itk::WriteImage(outputImage, argv[2]);
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
@@ -82,16 +82,11 @@ main(int argc, char * argv[])
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;
   // Software Guide : EndCodeSnippet
 
-  using ReaderType = itk::ImageFileReader<ImageType>;
-  using WriterType = itk::ImageFileWriter<ImageType>;
 
   ImageType::ConstPointer inputImage;
-  auto                    reader = ReaderType::New();
-  reader->SetFileName(argv[1]);
   try
   {
-    reader->Update();
-    inputImage = reader->GetOutput();
+    inputImage = itk::ReadImage<ImageType>(argv[1]);
   }
   catch (const itk::ExceptionObject & err)
   {
@@ -149,12 +144,9 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-  auto writer = WriterType::New();
-  writer->SetFileName(argv[2]);
-  writer->SetInput(outputImage);
   try
   {
-    writer->Update();
+    itk::WriteImage(outputImage, argv[2]);
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -145,16 +145,10 @@ main(int argc, char * argv[])
     itk::ImageSliceConstIteratorWithIndex<ImageType3D>;
   // Software Guide : EndCodeSnippet
 
-  using ReaderType = itk::ImageFileReader<ImageType3D>;
-  using WriterType = itk::ImageFileWriter<ImageType2D>;
-
   ImageType3D::ConstPointer inputImage;
-  auto                      reader = ReaderType::New();
-  reader->SetFileName(argv[1]);
   try
   {
-    reader->Update();
-    inputImage = reader->GetOutput();
+    inputImage = itk::ReadImage<ImageType3D>(argv[1]);
   }
   catch (const itk::ExceptionObject & err)
   {
@@ -186,7 +180,6 @@ main(int argc, char * argv[])
     }
   }
   // Software Guide : EndCodeSnippet
-
 
   // Software Guide : BeginLatex
   //
@@ -286,12 +279,9 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-  auto writer = WriterType::New();
-  writer->SetFileName(argv[2]);
-  writer->SetInput(outputImage);
   try
   {
-    writer->Update();
+    itk::WriteImage(outputImage, argv[2]);
   }
   catch (const itk::ExceptionObject & err)
   {


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refactors 3 iterator examples to use the itk:ReadImage and itk:WriteImage convenience functions as directed by #2802

<!-- **Thanks for contributing to ITK!** -->
