### PR TITLE
STYLE: Encapsulate NiftiImage qto_xyz mat44 data as `Matrix<float,4,4>`

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -364,6 +364,7 @@ extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Array<char>>;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Array<int>>;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Array<float>>;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Array<double>>;
+extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Matrix<float, 4, 4>>;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Matrix<double>>;
 
 ITK_GCC_PRAGMA_DIAG_POP()

--- a/Modules/Core/Common/src/itkMetaDataObject.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObject.cxx
@@ -43,6 +43,7 @@ template class ITKCommon_EXPORT MetaDataObject<Array<char>>;
 template class ITKCommon_EXPORT MetaDataObject<Array<int>>;
 template class ITKCommon_EXPORT MetaDataObject<Array<float>>;
 template class ITKCommon_EXPORT MetaDataObject<Array<double>>;
+template class ITKCommon_EXPORT MetaDataObject<Matrix<float, 4, 4>>;
 template class ITKCommon_EXPORT MetaDataObject<Matrix<double>>;
 template class ITKCommon_EXPORT MetaDataObject<std::vector<float>>;
 template class ITKCommon_EXPORT MetaDataObject<std::vector<double>>;

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -999,15 +999,9 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
 
   EncapsulateMetaData<float>(thisDic, "qfac", nim->qfac);
 
-  std::vector<float> qto_xyz;
-  for (int row = 0; row < 4; ++row)
-  {
-    for (int column = 0; column < 4; ++column)
-    {
-      qto_xyz.push_back(nim->qto_xyz.m[row][column]);
-    }
-  }
-  EncapsulateMetaData<std::vector<float>>(thisDic, "qto_xyz", qto_xyz);
+  // Use the ITK Matrix template instantiation that matches the `mat44` typedef from niftilib.
+  using Matrix44Type = Matrix<float, 4, 4>;
+  EncapsulateMetaData<Matrix44Type>(thisDic, "qto_xyz", Matrix44Type(nim->qto_xyz.m));
 }
 
 void


### PR DESCRIPTION
Using `itk::Matrix<float, 4, 4>` (instead of `std::vector<float>`) to store the "qto_xyz" data from m_NiftiImage, as this `Matrix` template instantiation more closely resembles the original niftilib `mat44` data structure.

Follow-up to pull request #3242 commit 9eb4c1209d215eed244e5e0a1d8f15942a61cb76 "ENH: bug #3241: Add qfac and qto_xyz to itkNiftiImageIO metadata" by Sean McBride (@seanm), which was merged on March 17, 2022.