### PR TITLE
COMP: Do not use ITK_AUTOLOAD_PATH when ITK_WRAP_PYTHON is set

### DIFF
--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -262,7 +262,7 @@ ObjectFactoryBase::Initialize()
     m_PimplGlobals->m_Initialized = true;
     ObjectFactoryBase::InitializeFactoryList();
     ObjectFactoryBase::RegisterInternal();
-#ifdef ITK_DYNAMIC_LOADING
+#if defined(ITK_DYNAMIC_LOADING) && !defined(ITK_WRAPPING)
     ObjectFactoryBase::LoadDynamicFactories();
 #endif
   }


### PR DESCRIPTION
For the use case of Slicer using ITK Python wheels, ITK_AUTOLOAD_PATH
is set, and the Python wheel binaries will load the Slicer ITK binaries,
which will cause a crash.

Dynamic loading in Python is unnecessary and can be performed in a more
explicit and controlled manner by Python scripting, so disable this
feature by default when ITK_WRAP_PYTHON is set.
