### PR TITLE
STYLE: Remove CMake checks on old MSVC versions (before version 1910)

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -145,7 +145,7 @@ function(check_avx_flags avx_flags_var)
   set(CMAKE_REQUIRED_FLAGS)
 
   # Check AVX
-  if(MSVC_VERSION GREATER_EQUAL 1600)
+  if(MSVC)
     set(CMAKE_REQUIRED_FLAGS "/arch:AVX") # set flags to be used in check_cxx_source_runs below
   endif()
   check_cxx_source_runs("
@@ -171,7 +171,7 @@ function(check_avx_flags avx_flags_var)
     have_avx_extensions_var)
 
   # Check AVX2
-  if(MSVC_VERSION GREATER_EQUAL 1800)
+  if(MSVC)
     set(CMAKE_REQUIRED_FLAGS "/arch:AVX2") # set flags to be used in check_cxx_source_runs below
   endif()
   check_cxx_source_runs("
@@ -199,9 +199,9 @@ function(check_avx_flags avx_flags_var)
   set(CMAKE_REQUIRED_FLAGS "${_safe_cmake_required_flags}")
 
   # Set Flags
-  if(have_avx2_extensions_var AND MSVC_VERSION GREATER_EQUAL 1800)
+  if(have_avx2_extensions_var AND MSVC)
     set(avx_flags_var "${avx_flags_var} /arch:AVX2")
-  elseif(have_avx_extensions_var AND MSVC_VERSION GREATER_EQUAL 1600)
+  elseif(have_avx_extensions_var AND MSVC)
     set(avx_flags_var "${avx_flags_var} /arch:AVX")
   endif()
 endfunction()
@@ -279,7 +279,7 @@ macro(check_compiler_platform_flags)
          # code results in objects with number of sections exceeding object file
          # format.
          # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-         if(MSVC_VERSION GREATER 1310)
+         if(MSVC)
            set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} /bigobj")
          endif()
        endif()

--- a/Modules/Core/GPUCommon/test/CMakeLists.txt
+++ b/Modules/Core/GPUCommon/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 

--- a/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 

--- a/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 

--- a/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 

--- a/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
@@ -4,7 +4,7 @@ if (ITK_USE_GPU)
 # code results in objects with number of sections exceeding object file
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
+if(CMAKE_CL_64)
 add_definitions(/bigobj)
 endif()
 


### PR DESCRIPTION
ITKv5.3 requires at least MSVC version 1910 (Visual Studio 2017) now, so it is no longer useful to check if `MSVC_VERSION GREATER_EQUAL 1600`, or `1800`, or `MSVC_VERSION GREATER 1310`.

Checks on `CMAKE_COMPILER_2005` (Visual Studio 2005) are also obsolete.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2563 commit 4e812d60743a3ed7c09647e7f3f0e8498583c2da "COMP: Require compiler versions that support C++14" (merged on 3 June 2021)