### PR TITLE
COMP: Replace add_definitions(/bigobj) by add_compile_options(/bigobj)

### DIFF
--- a/Modules/Core/GPUCommon/test/CMakeLists.txt
+++ b/Modules/Core/GPUCommon/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()

--- a/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()

--- a/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()

--- a/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()

--- a/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if (ITK_USE_GPU)
 # format.
 # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
 if(CMAKE_CL_64 OR CMAKE_COMPILER_2005)
-add_definitions(/bigobj)
+add_compile_options(/bigobj)
 endif()
 
 itk_module_test()


### PR DESCRIPTION
Avoids duplicate "/bigobj" flags in vcxproj files generated by CMake.
(Unlike `add_definitions`, `add_compile_options` does "de-duplication":
https://cmake.org/cmake/help/v3.16/command/add_compile_options.html#arguments)
