### PR TITLE
STYLE: Remove duplicate MSVC `/bigobj` flags from GPU test projects

### DIFF
--- a/Modules/Core/GPUCommon/test/CMakeLists.txt
+++ b/Modules/Core/GPUCommon/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUCommon-tests

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUAnisotropicSmoothing-tests

--- a/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUImageFilterBase-tests

--- a/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUSmoothing-tests

--- a/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUThresholding-tests

--- a/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
@@ -1,13 +1,5 @@
 if (ITK_USE_GPU)
 
-# With MS compilers on Win64, we need the /bigobj switch, else generated
-# code results in objects with number of sections exceeding object file
-# format.
-# see http://msdn.microsoft.com/en-us/library/ms173499.aspx
-if(CMAKE_CL_64)
-add_definitions(/bigobj)
-endif()
-
 itk_module_test()
 
 set(ITKGPUPDEDeformableRegistration-tests


### PR DESCRIPTION
This MSVC specific compiler flag is already added to `CMAKE_CXX_FLAGS`,
by the "CMakeLists.txt" file in the root directory of ITK (as it is part
of `ITK_REQUIRED_CXX_FLAGS`).