### PR TITLE
Remove obsolete CMake code for old GCC and Clang compilers

### DIFF
--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -11,12 +11,6 @@ include(${_ITKModuleMacros_DIR}/CppcheckTargets.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleCPPCheckTest.cmake)
 include(${_ITKModuleMacros_DIR}/ITKFactoryRegistration.cmake)
 
-# With Apple's (GGC <=4.2 and LLVM-GCC <=4.2) or (Clang < 3.2)
-# visibility of template  don't work. Set the option to off and hide it.
-if(APPLE AND ((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION  VERSION_LESS "4.3")
-   OR ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND CMAKE_CXX_COMPILER_VERSION  VERSION_LESS "3.2")))
-  set( USE_COMPILER_HIDDEN_VISIBILITY OFF CACHE INTERNAL "" )
-endif()
 include(GenerateExportHeader)
 
 # itk_module(<name>)

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -321,13 +321,6 @@ macro(check_compiler_platform_flags)
   #-----------------------------------------------------------------------------
   #ITK requires special compiler flags on some platforms.
   if(CMAKE_COMPILER_IS_GNUCXX)
-    # GCC's -Warray-bounds has been shown to throw false positives with -O3 on 4.8.
-    if(UNIX AND (
-      ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_EQUAL "4.8") OR
-      ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER "4.8" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9") ))
-      set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} -Wno-array-bounds")
-    endif()
-
     if(APPLE)
       option(ITK_USE_64BITS_APPLE_TRUNCATION_WARNING "Turn on warnings on 64bits to 32bits truncations." OFF)
       mark_as_advanced(ITK_USE_64BITS_APPLE_TRUNCATION_WARNING)


### PR DESCRIPTION
Follow-up to pull request #2563 commit 4e812d60743a3ed7c09647e7f3f0e8498583c2da "COMP: Require compiler versions that support C++14" (merged on 3 June 2021)