### PR TITLE
COMP: Allow setting DisplacementField with a VectorImage

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -21,6 +21,7 @@
 #include "itkTransform.h"
 
 #include "itkImage.h"
+#include "itkVectorImage.h"
 #include "itkMatrixOffsetTransformBase.h"
 #include "itkImageVectorOptimizerParametersHelper.h"
 #include "itkVectorInterpolateImageFunction.h"
@@ -157,6 +158,7 @@ public:
 
   /** Define the displacement field type and corresponding interpolator type. */
   using DisplacementFieldType = Image<OutputVectorType, Dimension>;
+  using VectorImageDisplacementFieldType = VectorImage<TParametersValueType, Dimension>;
   using DisplacementFieldPointer = typename DisplacementFieldType::Pointer;
   using DisplacementFieldConstPointer = typename DisplacementFieldType::ConstPointer;
 
@@ -181,6 +183,9 @@ public:
    * container. */
   virtual void
   SetDisplacementField(DisplacementFieldType * field);
+  virtual void
+               SetDisplacementField(VectorImageDisplacementFieldType * field);
+  virtual void SetDisplacementField(std::nullptr_t) = delete;
   itkGetModifiableObjectMacro(DisplacementField, DisplacementFieldType);
 
   /** Get/Set the inverse displacement field. This must be supplied by the user for

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -24,6 +24,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
+#include "itkCastImageFilter.h"
 
 namespace itk
 {
@@ -344,6 +345,18 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::SetDisplacementFie
 
 template <typename TParametersValueType, unsigned int VDimension>
 void
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetDisplacementField(
+  VectorImageDisplacementFieldType * field)
+{
+  using CasterType = CastImageFilter<VectorImageDisplacementFieldType, DisplacementFieldType>;
+  auto caster = CasterType::New();
+  caster->SetInput(field);
+  caster->Update();
+  this->SetDisplacementField(caster->GetOutput());
+}
+
+template <typename TParametersValueType, unsigned int VDimension>
+void
 DisplacementFieldTransform<TParametersValueType, VDimension>::SetInverseDisplacementField(
   DisplacementFieldType * inverseField)
 {
@@ -477,7 +490,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::SetFixedParameters
   }
   if (nullState)
   {
-    this->SetDisplacementField(nullptr);
+    this->SetDisplacementField(static_cast<DisplacementFieldType *>(nullptr));
     this->SetInverseDisplacementField(nullptr);
     return;
   }

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -92,6 +92,9 @@ public:
   using typename Superclass::DisplacementFieldType;
   using DisplacementFieldPointer = typename DisplacementFieldType::Pointer;
 
+  /** Define alternate displacement field interface. */
+  using typename Superclass::VectorImageDisplacementFieldType;
+
   /** Define the displacement field type and corresponding interpolator type. */
   using VelocityFieldType = Image<OutputVectorType, VelocityFieldDimension>;
   using VelocityFieldPointer = typename VelocityFieldType::Pointer;
@@ -111,6 +114,8 @@ public:
   /** Define the internal parameter helper used to access the field */
   using OptimizerParametersHelperType =
     ImageVectorOptimizerParametersHelper<ScalarType, Dimension, VelocityFieldDimension>;
+
+  using Superclass::SetDisplacementField;
 
   /** Get/Set the velocity field.
    * Set the displacement field. Create special set accessor to update

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -189,6 +189,10 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   displacementTransform->SetDisplacementField(displacementField);
   ITK_TEST_SET_GET_VALUE(displacementField, displacementTransform->GetDisplacementField());
 
+  DisplacementTransformType::VectorImageDisplacementFieldType::Pointer vectorImageDisplacementField =
+    DisplacementTransformType::VectorImageDisplacementFieldType::New();
+  displacementTransform->SetDisplacementField(vectorImageDisplacementField);
+
   DisplacementTransformType::DisplacementFieldType::Pointer inverseDisplacementField =
     DisplacementTransformType::DisplacementFieldType::New();
   displacementTransform->SetInverseDisplacementField(inverseDisplacementField);
@@ -627,7 +631,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   displacementTransform->SetIdentity();
 
-  displacementTransform->SetDisplacementField(nullptr);
+  displacementTransform->SetDisplacementField(static_cast<DisplacementFieldType *>(nullptr));
   displacementTransform->SetInverseDisplacementField(nullptr);
 
   // Check setting all zero for fixed parameters

--- a/Modules/Filtering/DisplacementField/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/wrapping/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(ITK_WRAP_PYTHON)
+  itk_python_add_test(NAME itkDisplacementFieldTransformPythonTest
+                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkDisplacementFieldTransformTest.py)
+endif()

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
@@ -1,0 +1,60 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+import itk
+itk.auto_progress(2)
+
+ScalarType = itk.F
+VectorDimension = 2
+VectorType = itk.Vector[ScalarType,VectorDimension]
+
+ImageDimension = 2
+ImageType = itk.Image[VectorType, ImageDimension]
+
+image_size = [10, 10]
+
+transform = itk.DisplacementFieldTransform[ScalarType, ImageDimension].New()
+
+# Test setting image of vectors
+pixel_value = 5
+image = ImageType.New()
+image.SetRegions(image_size)
+image.Allocate()
+image.FillBuffer([pixel_value] * VectorDimension)
+
+transform.SetDisplacementField(image)
+
+# Verify all parameters match expected value
+for value in list(transform.GetParameters()):
+    assert value == pixel_value
+
+# Test setting vector image
+pixel_value = 20
+vector_image = itk.VectorImage[ScalarType, ImageDimension].New()
+vector_image.SetRegions(image_size)
+vector_image.SetVectorLength(VectorDimension)
+vector_image.Allocate()
+pixel_default = itk.VariableLengthVector[ScalarType]()
+pixel_default.SetSize(VectorDimension)
+pixel_default.Fill(pixel_value)
+vector_image.FillBuffer(pixel_default)
+
+transform.SetDisplacementField(vector_image)
+
+# Verify all parameters match expected value
+for value in list(transform.GetParameters()):
+    assert value == pixel_value

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -296,7 +296,7 @@ set(itk_Wrap_Image ${WRAPPER_TEMPLATES})
 WRAP_TYPE("itk::VectorImage" "VI" "itkVectorImage.h")
   # Make a list of all of the selected image pixel types and also uchar
   # (for 8-bit image output)
-  UNIQUE(wrap_image_types "${WRAP_ITK_COMPLEX_REAL};${WRAP_ITK_SCALAR};UC")
+  UNIQUE(wrap_image_types "${WRAP_ITK_COMPLEX_REAL};${WRAP_ITK_SCALAR};UC;D")
 
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(type ${wrap_image_types})


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

`itk::DisplacementFieldTransform` is typically set from an array of displacement vectors. Previously only inputs of `itk::Image[itk::Vector[<type>,<VectorDimension>],<ImageDimension>]` were accepted. 

This PR aims to expose a method for setting the transform from an input of type `itk::VectorImage[<type>,<ImageDimension>]` . 

The difference between an "image of vectors" and a "vector image" is that the former has compile-time fixed-length vector pixels whereas the latter has variable-length vector pixels which have been fixed at a certain length at runtime. 

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)  <-- (added Python test, C++ test pending)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
