### PR TITLE
DOC: Fix typos and grammar

### DIFF
--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -923,7 +923,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetCellNeighbors(CellIdentifier cellI
   }
 
   /**
-   * The cell's UsingCells list was empy.  We use set operations
+   * The cell's UsingCells list was empty.  We use set operations
    * through point neighboring information to get the neighbors.  This
    * requires that the CellLinks be built.
    */

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
@@ -26,7 +26,7 @@ namespace itk
 {
 /**
  *\class MRASlabIdentifier
- * \brief identifies slab in MR images comparing minimum intensity averages
+ * \brief Identifies slabs in MR images comparing minimum intensity averages.
  *
  * This class is templated over the type of image.
  * In many cases, a 3D MR image is constructed by merging smaller 3D
@@ -35,14 +35,14 @@ namespace itk
  * can be present in the resulting image. Such artifacts are called "slab
  * boundary" artifacts or "venetian blind" artifacts.
  *
- * With the slab boundary artifacts in an image, even a same tissue class's
+ * Due to the slab boundary artifacts in an image, even same tissue class'
  * intensity values might vary significantly along the borders of slabs.
  * Such rough value changes are not appropriate for some image processing
  * methods. For example, MRIBiasFieldCorrectionFilter assumes a smooth bias
  * field. However, with the slab boundary artifacts, the bias field estimation
- * scheme that MRIBiasFieldCorrectionFilter uses might not adopt well.
- * So, the MRIBiasFieldCorrectionFilter creates regions for slabs using the
- * MRASlabIdentifier and then apply its bias correction scheme to each slab.
+ * scheme that MRIBiasFieldCorrectionFilter uses might not adapt well.
+ * The MRIBiasFieldCorrectionFilter creates regions for slabs using the
+ * MRASlabIdentifier and then applies its bias correction scheme to each slab.
  *
  * For this identifier, a slice means 2D image data which is extracted from
  * the input image along one of three axes (x, y, z). Users can specify

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
@@ -45,19 +45,19 @@ namespace itk
  * MRASlabIdentifier and then applies its bias correction scheme to each slab.
  *
  * For this identifier, a slice means 2D image data which is extracted from
- * the input image along one of three axes (x, y, z). Users can specify
- * the slicing axis using the SetSlicingDirection(int dimension) member.
- * (0 - x, 1 - y, 2 - z).
+ * the input image along one of three axes \f$(x, y, z)\f$. Users can specify
+ * the slicing axis using the SetSlicingDirection(int dimension) member, where
+ * the \p dimension variable follows the convention \f{X, Y, Z} : {0, 1, 2}\f$.
  *
- * The identification scheme used here is very simple.
- * 1) Users should specify how many pixels per slice the identifier
+ * The identification scheme used works according to the following steps:
+ * -# Users should specify how many pixels per slice the identifier
  *    will sample.
- * 2) For each slice, the identifier searches the specified number of pixels
+ * -# For each slice, the identifier searches the specified number of pixels
  *    of which intensity values are greater than 0 and less than those
- *    of the other pixels in the slice
- * 3) The identifier calculates the average for each slice and the overall
+ *    of the other pixels in the slice.
+ * -# The identifier calculates the average for each slice and the overall
  *    average using the search results.
- * 4) For each slice, it subtracts the overall average from the slice average.
+ * -# For each slice, it subtracts the overall average from the slice average.
  *    If the sign of the subtraction result changes, then it assumes that a
  *    slab ends and another slab begins.
  * \ingroup ITKBiasCorrection

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -249,7 +249,7 @@ public:
   {
     if (idx >= m_NumberOfGradientDirections)
     {
-      itkExceptionMacro(<< "Gradient direction " << idx << "does not exist");
+      itkExceptionMacro(<< "Gradient direction " << idx << " does not exist");
     }
     return m_GradientDirectionContainer->ElementAt(idx);
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
@@ -31,7 +31,7 @@ itkClosingByReconstructionImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " Inputimage OutputImage Radius PreserveIntensities(0,1) fullyConnected [Diffmage]" << std::endl;
+              << " Inputimage OutputImage Radius PreserveIntensities(0,1) fullyConnected [DiffImage]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
@@ -30,7 +30,7 @@ itkOpeningByReconstructionImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " Inputimage OutputImage Radius PreserveIntensities(0,1) fullyConnected [Diffmage]" << std::endl;
+              << " Inputimage OutputImage Radius PreserveIntensities(0,1) fullyConnected [DiffImage]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
@@ -30,7 +30,7 @@ itkOpeningByReconstructionImageFilterTest2(int argc, char * argv[])
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr
       << "Usage: " << itkNameOfTestExecutableMacro(argv)
-      << " OutputImage Radius PreserveIntensities(0,1) fullyConnected OriginX OriginY SpacingX SpacingY [Diffmage]"
+      << " OutputImage Radius PreserveIntensities(0,1) fullyConnected OriginX OriginY SpacingX SpacingY [DiffImage]"
       << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -153,11 +153,11 @@ public:
     return m_UseSeriesDetails;
   }
 
-  /** Add more restriction on the selection of a Series. This follow the same
-   * approach as SetUseSeriesDetails, but allow a user to add even more DICOM
+  /** Add more restriction on the selection of a Series. This follows the same
+   * approach as SetUseSeriesDetails, but allows a user to add even more DICOM
    * tags to take into account for subrefining a set of DICOM files into multiple
-   * series. Format for tag is "group|element" of a DICOM tag.
-   * \warning User need to set SetUseSeriesDetails(true)
+   * series. The tag format is "group|element" of a DICOM tag.
+   * \warning UseSeriesDetails needs to be set to true.
    */
   void
   AddSeriesRestriction(const std::string & /* tag */)

--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -160,11 +160,11 @@ public:
     return m_UseSeriesDetails;
   }
 
-  /** Add more restriction on the selection of a Series. This follow the same
-   * approach as SetUseSeriesDetails, but allow a user to add even more DICOM
+  /** Add more restriction on the selection of a Series. This follows the same
+   * approach as SetUseSeriesDetails, but allows a user to add even more DICOM
    * tags to take into account for subrefining a set of DICOM files into multiple
-   * series. Format for tag is "group|element" of a DICOM tag.
-   * \warning User need to set SetUseSeriesDetails(true)
+   * series. The tag format is "group|element" of a DICOM tag.
+   * \warning UseSeriesDetails needs to be set to true.
    */
   void
   AddSeriesRestriction(const std::string & tag);

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -538,7 +538,7 @@ private:
   void
   AdvanceOneStep() override
   {
-    itkWarningMacro("LBFGS2Optimizerv4Template does not implemenetd single step advance");
+    itkWarningMacro("LBFGS2Optimizerv4Template does not implement single step advance");
   };
 };
 

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -24,7 +24,7 @@
 
 
 // This tests the supervised image classifier methods. The test,
-// however, only exercises a pathalogical case, where the covariances
+// however, only exercises a pathological case, where the covariances
 // of all the classes are singular.  In this case, the methods degrade
 // to classifying based on euclidean distance to the mean.
 


### PR DESCRIPTION
- DOC: Fix typos and grammar in class and method documentation
- DOC: Increase `itk::MRASlabIdentifier` description Doxygen syntax use
- DOC: Fix typo in warning macro message
- DOC: Fix typos in miscellaneous comments
- DOC: Fix typo in variable names in test input argument usage
- STYLE: Allow a whitespace after variable in warning macro message

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)