### PR TITLE
COMP: Add missing semicolon to `itkExceptionMacro` statement end

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -168,7 +168,7 @@ public:
   {
     if (!m_TargetPoints || m_TargetPoints->Size() == 0)
     {
-      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
+      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.");
     }
     this->SetTargetReachedMode(OneTarget);
     m_NumberOfTargets = 1;
@@ -178,7 +178,7 @@ public:
   {
     if (!m_TargetPoints || m_TargetPoints->Size() == 0)
     {
-      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
+      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.");
     }
 
     SizeValueType availableNumberOfTargets = m_TargetPoints->Size();
@@ -196,13 +196,13 @@ public:
   {
     if (!m_TargetPoints || m_TargetPoints->Size() == 0)
     {
-      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
+      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.");
     }
 
     this->SetTargetReachedMode(AllTargets);
     if (m_TargetPoints->Size() == 0)
     {
-      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
+      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.");
     }
     m_NumberOfTargets = m_TargetPoints->Size();
   }


### PR DESCRIPTION
Add missing semicolon to `itkExceptionMacro` statement end.

Fixes:
```
In file included from Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx:19:
Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h:171:87:
error: expected ';' after static_assert
      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
                                                                                      ^
										      ;
Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h:181:87:
error: expected ';' after static_assert
      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
                                                                                      ^
                                                                                      ;
Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h:199:87:
error: expected ';' after static_assert
      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
                                                                                      ^
                                                                                      ;
Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h:205:87:
error: expected ';' after static_assert
      itkExceptionMacro(<< "No target point set. Cannot set the target reached mode.")
                                                                                      ^
                                                                                      ;
4 errors generated.
```

raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=7829663

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)