### PR TITLE
STYLE: Replace unsafe `(T)x` and `T(x)` casts with `T{x}` in Common/src

### DIFF
--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -218,7 +218,7 @@ MultiThreaderBase::SetGlobalMaximumNumberOfThreads(ThreadIdType val)
 
   // clamp between 1 and ITK_MAX_THREADS
   m_PimplGlobals->m_GlobalMaximumNumberOfThreads =
-    std::min(m_PimplGlobals->m_GlobalMaximumNumberOfThreads, (ThreadIdType)ITK_MAX_THREADS);
+    std::min(m_PimplGlobals->m_GlobalMaximumNumberOfThreads, ThreadIdType{ ITK_MAX_THREADS });
   m_PimplGlobals->m_GlobalMaximumNumberOfThreads =
     std::max(m_PimplGlobals->m_GlobalMaximumNumberOfThreads, NumericTraits<ThreadIdType>::OneValue());
 
@@ -351,7 +351,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
     }
 
     // limit the number of threads to m_GlobalMaximumNumberOfThreads
-    threadCount = std::min(threadCount, ThreadIdType(ITK_MAX_THREADS));
+    threadCount = std::min(threadCount, ThreadIdType{ ITK_MAX_THREADS });
 
     // verify that the default number of threads is larger than zero
     threadCount = std::max(threadCount, NumericTraits<ThreadIdType>::OneValue());

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -352,7 +352,7 @@ MapData::MemoryLoadType
 MapData::GetTotalMemoryUsage()
 {
   return std::accumulate(
-    this->m_Records.begin(), this->m_Records.end(), MapData::MemoryLoadType(0), MapRecordPlusor<MemoryLoadType>());
+    this->m_Records.begin(), this->m_Records.end(), MapData::MemoryLoadType{ 0 }, MapRecordPlusor<MemoryLoadType>());
 }
 
 MapData::MemoryLoadType
@@ -360,7 +360,7 @@ MapData::GetMemoryUsage(const char * filter, const char * token)
 {
   return std::accumulate(this->m_Records.begin(),
                          this->m_Records.end(),
-                         MapData::MemoryLoadType(0),
+                         MapData::MemoryLoadType{ 0 },
                          MapRecordConditionalPlusor<MemoryLoadType>(filter, token));
 }
 


### PR DESCRIPTION
Replaced C-style casts and function-style casts, `(T)x` and `T(x)`, with
the corresponding but safer braced-initialization syntax, `T{ x }`, in
"Common/src", in cases where `x` is a compile-time constant integer.

Detected by LLVM 14.0.0 clang-tidy option `google-readability-casting`:
https://clang.llvm.org/extra/clang-tidy/checks/google-readability-casting.html

Follow-up to:

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3342/
commit 2fa80e8bd329fd4f2240949fcb8eb71dd748432d
"STYLE: Avoid old, C-style cast", by Lee Newberg (@Leengit)
