### PR TITLE
STYLE: Remove casts from `MersenneTwisterRandomVariateGenerator::hash`

### DIFF
--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -89,31 +89,27 @@ MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
 MersenneTwisterRandomVariateGenerator::~MersenneTwisterRandomVariateGenerator() = default;
 
 MersenneTwisterRandomVariateGenerator::IntegerType
-MersenneTwisterRandomVariateGenerator ::hash(time_t t, clock_t c)
+MersenneTwisterRandomVariateGenerator::hash(const time_t t, const clock_t c)
 {
   itkInitGlobalsMacro(PimplGlobals);
   // Get an IntegerType from t and c
   // Better than IntegerType(x) in case x is floating point in [0,1]
   // Based on code by Lawrence Kirby: fred at genesis dot demon dot co dot uk
 
-  IntegerType h1 = 0;
-  auto *      p = (unsigned char *)&t;
+  const auto convert = [](const auto arg) {
+    IntegerType        h{ 0 };
+    const auto * const p = reinterpret_cast<const unsigned char *>(&arg);
 
-  const auto sizeOfT = static_cast<unsigned int>(sizeof(t));
-  for (unsigned int i = 0; i < sizeOfT; ++i)
-  {
-    h1 *= UCHAR_MAX + 2U;
-    h1 += p[i];
-  }
-  IntegerType h2 = 0;
-  p = (unsigned char *)&c;
+    for (size_t i = 0; i < sizeof(arg); ++i)
+    {
+      h *= UCHAR_MAX + 2U;
+      h += p[i];
+    }
+    return h;
+  };
 
-  const auto sizeOfC = static_cast<unsigned int>(sizeof(c));
-  for (unsigned int j = 0; j < sizeOfC; ++j)
-  {
-    h2 *= UCHAR_MAX + 2U;
-    h2 += p[j];
-  }
+  const IntegerType h1 = convert(t);
+  const IntegerType h2 = convert(c);
   return (h1 + m_PimplGlobals->m_StaticDiffer++) ^ h2;
 }
 


### PR DESCRIPTION
Moved duplicate code into a lambda, replacing two unsafe C-style
pointer casts by a static_cast, and removing two unnecessary
`static_cast<unsigned int>` casts.
