### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -592,7 +592,11 @@ itk_add_test(NAME itkMultithreadingTest COMMAND ITKCommon2TestDriver itkMultithr
 
 itk_add_test(NAME itkMultiThreaderExceptionsTest COMMAND ITKCommon2TestDriver itkMultiThreaderExceptionsTest)
 
-itk_add_test(NAME itkXMLFileOutputWindowTest
+itk_add_test(NAME itkXMLFileOutputWindowTestNoFilename
+      COMMAND ITKCommon2TestDriver
+    itkXMLFileOutputWindowTest)
+
+itk_add_test(NAME itkXMLFileOutputWindowTestFilename
       COMMAND ITKCommon2TestDriver
     itkXMLFileOutputWindowTest ${ITK_TEST_OUTPUT_DIR}/itkXMLFileOutputWindowTest.xml)
 

--- a/Modules/Core/Common/test/itkLoggerOutputTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerOutputTest.cxx
@@ -63,8 +63,13 @@ itkLoggerOutputTest(int argc, char * argv[])
 
     // Create an ITK LoggerOutput and then test it.
     itk::LoggerOutput::Pointer pOver = itk::LoggerOutput::New();
+
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(pOver, LoggerOutput, OutputWindow);
+
+
     pOver->OverrideITKWindow();
     pOver->SetLogger(logger); // redirect messages from ITK OutputWindow -> logger2
+    ITK_TEST_SET_GET_VALUE(logger, pOver->GetLogger());
 
     // test message for ITK OutputWindow
     itk::OutputWindow::GetInstance()->DisplayText("** This is from ITK OutputWindow **\n");

--- a/Modules/Core/Common/test/itkThreadedImageRegionPartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedImageRegionPartitionerTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkThreadedImageRegionPartitioner.h"
+#include "itkTestingMacros.h"
 
 /*
  * Main test entry function
@@ -28,6 +29,10 @@ itkThreadedImageRegionPartitionerTest(int, char *[])
   using ThreadedImageRegionPartitionerType = itk::ThreadedImageRegionPartitioner<Dimension>;
   ThreadedImageRegionPartitionerType::Pointer threadedImageRegionPartitioner =
     ThreadedImageRegionPartitionerType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    threadedImageRegionPartitioner, ThreadedImageRegionPartitioner, ThreadedDomainPartitioner);
+
 
   using ImageRegionType = ThreadedImageRegionPartitionerType::DomainType;
 

--- a/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
+++ b/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
@@ -25,10 +25,10 @@
 int
 itkXMLFileOutputWindowTest(int argc, char * argv[])
 {
-  if (argc != 2)
+  if (argc < 1)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " filename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " [filename]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -36,8 +36,13 @@ itkXMLFileOutputWindowTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(logger, XMLFileOutputWindow, FileOutputWindow);
 
-  logger->SetFileName(argv[1]);
+  if (argc > 1)
+  {
+    logger->SetFileName(argv[1]);
+  }
+
   logger->FlushOn();
+  logger->AppendOn();
 
   logger->SetInstance(logger);
 
@@ -71,7 +76,7 @@ itkXMLFileOutputWindowTest(int argc, char * argv[])
   // Check the number of lines written
   unsigned int  numLinesExpected = 7;
   unsigned int  numLinesRead = 0;
-  std::ifstream in(argv[1]);
+  std::ifstream in(logger->GetFileName());
   std::string   line;
   while (std::getline(in, line))
   {

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -19,6 +19,7 @@
 #include "itkCentralDifferenceImageFunction.h"
 #include "itkImageRegionIterator.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkCentralDifferenceImageFunctionTest(int, char *[])
@@ -57,6 +58,9 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
   using OutputValueType = FunctionType::OutputValueType;
 
   auto function = FunctionType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(function, CentralDifferenceImageFunction, ImageFunction);
+
 
   function->SetInputImage(image);
 
@@ -294,7 +298,9 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
 
   // with image direction disabled, result should be same as with
   // identity direction
-  function->SetUseImageDirection(false);
+  bool useImageDirection = false;
+  ITK_TEST_SET_GET_BOOLEAN(function, UseImageDirection, useImageDirection);
+
   OutputType directionOffDerivative = function->Evaluate(point);
   std::cout << "Point: " << point << " directionOffDerivative: " << directionOffDerivative << std::endl;
 

--- a/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
@@ -22,6 +22,7 @@
 #include "itkRegularSphereMeshSource.h"
 #include "itkDefaultDynamicMeshTraits.h"
 #include "itkTriangleMeshToSimplexMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkSimplexMeshVolumeCalculatorTest(int, char *[])
@@ -57,6 +58,9 @@ itkSimplexMeshVolumeCalculatorTest(int, char *[])
 
 
   auto calculator = VolumeCalculatorType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(calculator, SimplexMeshVolumeCalculator, Object);
+
 
   calculator->SetSimplexMesh(simplexFilter->GetOutput());
   for (int i = 1; i <= 5; ++i)

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -72,6 +72,12 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     centerOfRotation.Fill(0);
     transform->SetCenterOfRotation(centerOfRotation);
     ITK_TEST_SET_GET_VALUE(centerOfRotation, transform->GetCenterOfRotation());
+
+    // This transform has no fixed parameters; empty method body; called for coverage purposes
+    typename TransformType::FixedParametersType::ValueType fixedParametersValues = 0;
+    typename TransformType::FixedParametersType            fixedParameters;
+    fixedParameters.Fill(fixedParametersValues);
+    transform->SetFixedParameters(fixedParameters);
   }
 
   /* Create a 3D identity transformation and show its parameters */
@@ -107,6 +113,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     ioffset.Fill(0.0);
 
     translation->SetOffset(ioffset);
+    ITK_TEST_SET_GET_VALUE(ioffset, translation->GetOffset());
 
     TransformType::OffsetType offset = translation->GetOffset();
     std::cout << "pure Translation test:  ";
@@ -184,6 +191,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
 
     rotation.Set(axis, angle);
     rigid->SetRotation(rotation);
+    ITK_TEST_SET_GET_VALUE(rotation, rigid->GetRotation());
 
     {
       // Project an itk::Point

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkTimeVaryingBSplineVelocityFieldTransform.h"
+#include "itkTestingMacros.h"
 
 int
 itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
@@ -58,8 +59,6 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
   integrator->SetLowerTimeBound(0.3);
   integrator->SetUpperTimeBound(0.75);
   integrator->Update();
-
-  integrator->Print(std::cout, 3);
 
   DisplacementFieldType::IndexType index;
   index.Fill(0);
@@ -117,18 +116,35 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
 
   using TransformType = itk::TimeVaryingBSplineVelocityFieldTransform<double, 3>;
   auto transform = TransformType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(transform, TimeVaryingBSplineVelocityFieldTransform, VelocityFieldTransform);
+
+
   transform->SetLowerTimeBound(0.0);
   transform->SetUpperTimeBound(1.0);
-  transform->SetSplineOrder(splineOrder);
-  transform->SetVelocityFieldOrigin(timeVaryingVelocityFieldOrigin);
-  transform->SetVelocityFieldDirection(timeVaryingVelocityFieldDirection);
-  transform->SetVelocityFieldSize(timeVaryingVelocityFieldSize);
-  transform->SetVelocityFieldSpacing(timeVaryingVelocityFieldSpacing);
-  transform->SetNumberOfIntegrationSteps(10);
-  transform->SetTimeVaryingVelocityFieldControlPointLattice(timeVaryingVelocityFieldControlPointLattice);
-  transform->IntegrateVelocityField();
 
-  transform->Print(std::cout, 3);
+  transform->SetSplineOrder(splineOrder);
+  ITK_TEST_SET_GET_VALUE(splineOrder, transform->GetSplineOrder());
+
+  transform->SetVelocityFieldOrigin(timeVaryingVelocityFieldOrigin);
+  ITK_TEST_SET_GET_VALUE(timeVaryingVelocityFieldOrigin, transform->GetVelocityFieldOrigin());
+
+  transform->SetVelocityFieldDirection(timeVaryingVelocityFieldDirection);
+  ITK_TEST_SET_GET_VALUE(timeVaryingVelocityFieldDirection, transform->GetVelocityFieldDirection());
+
+  transform->SetVelocityFieldSize(timeVaryingVelocityFieldSize);
+  ITK_TEST_SET_GET_VALUE(timeVaryingVelocityFieldSize, transform->GetVelocityFieldSize());
+
+  transform->SetVelocityFieldSpacing(timeVaryingVelocityFieldSpacing);
+  ITK_TEST_SET_GET_VALUE(timeVaryingVelocityFieldSpacing, transform->GetVelocityFieldSpacing());
+
+  transform->SetNumberOfIntegrationSteps(10);
+
+  transform->SetTimeVaryingVelocityFieldControlPointLattice(timeVaryingVelocityFieldControlPointLattice);
+  ITK_TEST_SET_GET_VALUE(timeVaryingVelocityFieldControlPointLattice,
+                         transform->GetTimeVaryingVelocityFieldControlPointLattice());
+
+  transform->IntegrateVelocityField();
 
   TransformType::InputPointType point;
   point.Fill(1.3);
@@ -163,7 +179,6 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
     return EXIT_FAILURE;
   }
 
-  transform->Print(std::cout, 3);
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -179,7 +179,7 @@ itk_add_test(NAME itkBinaryImageToShapeLabelMapFilterTest1
       COMMAND ITKLabelMapTestDriver
     --compare DATA{Baseline/Spots-binaryimage-to-shapelabel.mha}
               ${ITK_TEST_OUTPUT_DIR}/Spots-binaryimage-to-shapelabel.mha
-    itkBinaryImageToShapeLabelMapFilterTest1 DATA{${ITK_DATA_ROOT}/Input/Spots.png} ${ITK_TEST_OUTPUT_DIR}/Spots-binaryimage-to-shapelabel.mha 1 255 0 1 1)
+    itkBinaryImageToShapeLabelMapFilterTest1 DATA{${ITK_DATA_ROOT}/Input/Spots.png} ${ITK_TEST_OUTPUT_DIR}/Spots-binaryimage-to-shapelabel.mha 1 255 0 1 1 1)
 itk_add_test(NAME itkBinaryImageToStatisticsLabelMapFilterTest1
       COMMAND ITKLabelMapTestDriver
     --compare DATA{Baseline/Spots-binaryimage-to-statisticslabel.mha}

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
@@ -27,13 +27,13 @@ int
 itkBinaryImageToShapeLabelMapFilterTest1(int argc, char * argv[])
 {
 
-  if (argc != 8)
+  if (argc != 9)
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputBinaryImage outputShapeLabelMap";
     std::cerr << " fullyConnected(0/1) foregroundValue backgroundValue";
-    std::cerr << " feretDiameter, perimeter";
+    std::cerr << " feretDiameter perimeter computeOrientedBoundingBox";
     std::cerr << std::endl;
     return EXIT_FAILURE;
   }
@@ -52,7 +52,11 @@ itkBinaryImageToShapeLabelMapFilterTest1(int argc, char * argv[])
 
   // converting binary image to shape label map
   using I2LType = itk::BinaryImageToShapeLabelMapFilter<ImageType, LabelMapType>;
-  auto                     i2l = I2LType::New();
+  auto i2l = I2LType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(i2l, BinaryImageToShapeLabelMapFilter, ImageToImageFilter);
+
+
   itk::SimpleFilterWatcher watcher1(i2l);
 
   i2l->SetInput(reader->GetOutput());
@@ -79,32 +83,14 @@ itkBinaryImageToShapeLabelMapFilterTest1(int argc, char * argv[])
   i2l->SetOutputBackgroundValue(outputBackgroundValue);
   ITK_TEST_SET_GET_VALUE(outputBackgroundValue, i2l->GetOutputBackgroundValue());
 
-  // testing get/set ComputeFeretDiameter macro
   bool computeFeretDiameter = (std::stoi(argv[6]));
-  i2l->SetComputeFeretDiameter(computeFeretDiameter);
-  ITK_TEST_SET_GET_VALUE(computeFeretDiameter, i2l->GetComputeFeretDiameter());
+  ITK_TEST_SET_GET_BOOLEAN(i2l, ComputeFeretDiameter, computeFeretDiameter);
 
-  // testing boolean ComputeFeretDiameter macro
-  i2l->ComputeFeretDiameterOff();
-  ITK_TEST_SET_GET_VALUE(false, i2l->GetComputeFeretDiameter());
-
-  i2l->ComputeFeretDiameterOn();
-  ITK_TEST_SET_GET_VALUE(true, i2l->GetComputeFeretDiameter());
-
-  // testing get/set ComputePerimeter macro
   bool computePerimeter = std::stoi(argv[7]);
-  i2l->SetComputePerimeter(computePerimeter);
-  ITK_TEST_SET_GET_VALUE(computePerimeter, i2l->GetComputePerimeter());
+  ITK_TEST_SET_GET_BOOLEAN(i2l, ComputePerimeter, computePerimeter);
 
-  // testing boolean ComputePerimeter macro
-  i2l->ComputePerimeterOff();
-  ITK_TEST_SET_GET_VALUE(false, i2l->GetComputePerimeter());
-
-  i2l->ComputePerimeterOn();
-  ITK_TEST_SET_GET_VALUE(true, i2l->GetComputePerimeter());
-
-  i2l->SetComputeOrientedBoundingBox(true);
-  ITK_TEST_SET_GET_VALUE(true, i2l->GetComputeOrientedBoundingBox());
+  bool computeOrientedBoundingBox = std::stoi(argv[8]);
+  ITK_TEST_SET_GET_BOOLEAN(i2l, ComputeOrientedBoundingBox, computeOrientedBoundingBox);
 
 
   using L2IType = itk::LabelMapToLabelImageFilter<LabelMapType, ImageType>;

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -127,6 +127,10 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(
     extractOrthogonalSwath2DImageFilter, ExtractOrthogonalSwath2DImageFilter, ImageAndPathToImageFilter);
 
+
+  auto defaultPixelValue = itk::NumericTraits<typename ImageType::PixelType>::ZeroValue();
+  extractOrthogonalSwath2DImageFilter->SetDefaultPixelValue(defaultPixelValue);
+
   extractOrthogonalSwath2DImageFilter->SetImageInput(inputImage);
   extractOrthogonalSwath2DImageFilter->SetPathInput(chainCodeToFourierSeriesPathFilte->GetOutput());
   // Set the desired size of the filter's output

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkQuadEdgeMesh.h"
+#include "itkMath.h"
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 
@@ -67,8 +68,30 @@ itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   using CleanFilterType = itk::CleanQuadEdgeMeshFilter<MeshType, MeshType>;
   auto filter = CleanFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, CleanQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
+
+
   filter->SetInput(mesh);
+
+  auto absTol = itk::NumericTraits<typename CleanFilterType::InputCoordRepType>::ZeroValue();
+  filter->SetAbsoluteTolerance(absTol);
+  ITK_TEST_SET_GET_VALUE(absTol, filter->GetAbsoluteTolerance());
+
   filter->SetRelativeTolerance(tol);
+  const Coord epsilon = 1e-6;
+  Coord       obtainedValue = filter->GetRelativeTolerance();
+  if (!itk::Math::FloatAlmostEqual(tol, obtainedValue, 10, epsilon))
+  {
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in pixel GetRelativeTolerance" << std::endl;
+    std::cerr << "Expected value " << tol << std::endl;
+    std::cerr << " differs from " << obtainedValue;
+    std::cerr << " by more than " << epsilon << std::endl;
+    return EXIT_FAILURE;
+  }
+
   filter->Update();
 
   // ** WRITE OUTPUT **
@@ -77,7 +100,6 @@ itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   writer->Update();
 
-  // ** PRINT **
-  std::cout << filter;
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -55,15 +55,20 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
 
 
   filter->SetInput(reader->GetOutput());
-  filter->SetOrder(2);
+
+  unsigned int order = 2;
+  filter->SetOrder(order);
+  ITK_TEST_SET_GET_VALUE(order, filter->GetOrder());
 
   if (std::stoi(argv[3]) == 1)
   {
     filter->SetAreaComputationType(FilterType::AreaEnum::MIXEDAREA);
+    ITK_TEST_SET_GET_VALUE(FilterType::AreaEnum::MIXEDAREA, filter->GetAreaComputationType());
   }
   else
   {
     filter->SetAreaComputationType(FilterType::AreaEnum::NONE);
+    ITK_TEST_SET_GET_VALUE(FilterType::AreaEnum::NONE, filter->GetAreaComputationType());
   }
 
   using CoefficientType = itk::ConformalMatrixCoefficients<MeshType>;

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -81,6 +81,7 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   auto seriesWriter = SeriesWriterType::New();
   seriesWriter->SetInput(reader->GetOutput());
   seriesWriter->SetImageIO(gdcmIO);
+  ITK_TEST_SET_GET_VALUE(gdcmIO, seriesWriter->GetImageIO());
 
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
   ImageType::IndexType  start = region.GetIndex();

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
@@ -59,7 +59,9 @@ itkImageFileReaderStreamingTest(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
-  reader->SetUseStreaming(true);
+
+  bool useStreaming = true;
+  ITK_TEST_SET_GET_BOOLEAN(reader, UseStreaming, useStreaming);
 
   using MonitorFilter = itk::PipelineMonitorImageFilter<ImageType>;
   auto monitor = MonitorFilter::New();

--- a/Modules/IO/ImageBase/test/itkImageSeriesWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesWriterTest.cxx
@@ -80,12 +80,25 @@ itkImageSeriesWriterTest(int argc, char * argv[])
 
     auto writer = WriterType::New();
 
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(writer, ImageSeriesWriter, ProcessObject);
+
+
     itk::SimpleFilterWatcher watcher2(writer);
 
     writer->SetInput(rescaler->GetOutput());
+
+    itk::SizeValueType startIndex = 1;
+    writer->SetStartIndex(startIndex);
+    ITK_TEST_SET_GET_VALUE(startIndex, writer->GetStartIndex());
+
+    itk::SizeValueType incrementIndex = 1;
+    writer->SetIncrementIndex(incrementIndex);
+    ITK_TEST_SET_GET_VALUE(incrementIndex, writer->GetIncrementIndex());
+
     char format[4096];
     sprintf(format, "%s/series.%%d.%s", argv[2], argv[3]);
     writer->SetSeriesFormat(format);
+    ITK_TEST_SET_GET_VALUE(std::string(format), std::string(writer->GetSeriesFormat()));
 
     ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
@@ -95,6 +108,9 @@ itkImageSeriesWriterTest(int argc, char * argv[])
     writer->SetMetaDataDictionaryArray(reader->GetMetaDataDictionaryArray());
 
     ITK_TRY_EXPECT_EXCEPTION(writer->Update());
+
+    writer->SetImageIO(io);
+    ITK_TEST_SET_GET_VALUE(io, writer->GetImageIO());
 
 
     std::cout << "Old API PASSED !" << std::endl;
@@ -116,10 +132,20 @@ itkImageSeriesWriterTest(int argc, char * argv[])
     ImageNDType::RegionType region = reader->GetOutput()->GetBufferedRegion();
     ImageNDType::SizeType   size = region.GetSize();
 
-    fit->SetStartIndex(0);
-    fit->SetEndIndex(size[2] - 1); // The number of slices to write
-    fit->SetIncrementIndex(1);
+    itk::SizeValueType startIndex = 0;
+    fit->SetStartIndex(startIndex);
+    ITK_TEST_SET_GET_VALUE(startIndex, fit->GetStartIndex());
+
+    itk::SizeValueType endIndex = size[2] - 1;
+    fit->SetEndIndex(endIndex); // The number of slices to write
+    ITK_TEST_SET_GET_VALUE(endIndex, fit->GetEndIndex());
+
+    itk::SizeValueType incrementIndex = 1;
+    fit->SetIncrementIndex(incrementIndex);
+    ITK_TEST_SET_GET_VALUE(incrementIndex, fit->GetIncrementIndex());
+
     fit->SetSeriesFormat(format);
+    ITK_TEST_SET_GET_VALUE(std::string(format), std::string(fit->GetSeriesFormat()));
 
     writer->SetInput(rescaler->GetOutput());
     writer->SetFileNames(fit->GetFileNames());
@@ -130,9 +156,8 @@ itkImageSeriesWriterTest(int argc, char * argv[])
       std::cerr << "Wrong default use compression value" << std::endl;
       return EXIT_FAILURE;
     }
-    writer->SetUseCompression(true);
-    writer->UseCompressionOn();
-    writer->UseCompressionOff();
+    bool useCompression = false;
+    ITK_TEST_SET_GET_BOOLEAN(writer, UseCompression, useCompression);
 
     ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 

--- a/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
@@ -18,16 +18,32 @@
 
 #include "itkNumericSeriesFileNames.h"
 #include "itksys/SystemTools.hxx"
+#include "itkTestingMacros.h"
 
 int
 itkNumericSeriesFileNamesTest(int, char *[])
 {
 
   itk::NumericSeriesFileNames::Pointer fit = itk::NumericSeriesFileNames::New();
-  fit->SetStartIndex(10);
-  fit->SetEndIndex(20);
-  fit->SetIncrementIndex(2);
-  fit->SetSeriesFormat("foo.%0200d.png");
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(fit, NumericSeriesFileNames, Object);
+
+
+  itk::SizeValueType startIndex = 10;
+  fit->SetStartIndex(startIndex);
+  ITK_TEST_SET_GET_VALUE(startIndex, fit->GetStartIndex());
+
+  itk::SizeValueType endIndex = 20;
+  fit->SetEndIndex(endIndex);
+  ITK_TEST_SET_GET_VALUE(endIndex, fit->GetEndIndex());
+
+  itk::SizeValueType incrementIndex = 2;
+  fit->SetIncrementIndex(incrementIndex);
+  ITK_TEST_SET_GET_VALUE(incrementIndex, fit->GetIncrementIndex());
+
+  std::string format = "foo.%0200d.png";
+  fit->SetSeriesFormat(format);
+  ITK_TEST_SET_GET_VALUE(format, fit->GetSeriesFormat());
 
   std::vector<std::string>           names = fit->GetFileNames();
   std::vector<std::string>::iterator nit;
@@ -44,8 +60,6 @@ itkNumericSeriesFileNamesTest(int, char *[])
     }
     std::cout << "File: " << (*nit).c_str() << std::endl;
   }
-
-  std::cout << fit;
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
+++ b/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
@@ -49,6 +49,10 @@ itkLSMImageIOTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(lsmImageIO, LSMImageIO, TIFFImageIO);
 
+
+  // Not used; empty method body; called for coverage purposes
+  lsmImageIO->WriteImageInformation();
+
   reader->SetImageIO(lsmImageIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/MINC/test/itkMINCImageIOTest2.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest2.cxx
@@ -24,6 +24,8 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
+#include <vector>
+#include <numeric>
 
 int
 itkMINCImageIOTest2(int argc, char * argv[])
@@ -42,6 +44,16 @@ itkMINCImageIOTest2(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(mincIO1, MINCImageIO, ImageIOBase);
 
+
+  unsigned int               supportedDimCount = 4; // includes the degenerate 0-dimensional case
+  std::vector<unsigned long> supportedDims(supportedDimCount);
+  std::iota(std::begin(supportedDims), std::end(supportedDims), 0);
+  for (auto const & value : supportedDims)
+  {
+    ITK_TEST_EXPECT_TRUE(mincIO1->SupportsDimension(value));
+  }
+
+  ITK_TEST_EXPECT_TRUE(!mincIO1->SupportsDimension(supportedDims.back() + 1));
 
   itk::MINCImageIO::Pointer mincIO2 = itk::MINCImageIO::New();
 

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -470,6 +470,9 @@ itkMRCImageIOTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(mrcIO, MRCImageIO, StreamingImageIOBase);
 
 
+  // Not used; empty method body; called for coverage purposes
+  mrcIO->WriteImageInformation();
+
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/MeshBase/test/itkMeshFileReaderWriterTest.cxx
+++ b/Modules/IO/MeshBase/test/itkMeshFileReaderWriterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkQuadEdgeMesh.h"
 #include "itkTestingMacros.h"
 #include "itkMeshFileTestHelper.h"
+#include <fstream>
+#include <cstdio>
 
 
 int
@@ -49,8 +51,21 @@ itkMeshFileReaderWriterTest(int argc, char * argv[])
   reader->SetFileName(inputFileName);
   ITK_TRY_EXPECT_EXCEPTION(reader->Update());
 
+  inputFileName = "NonExistingFile.vtk";
+  reader->SetFileName(inputFileName);
+  ITK_TRY_EXPECT_EXCEPTION(reader->Update());
+
+  inputFileName = "UnsupportedExtensionFile.mesh";
+  std::ofstream unsupportedExtFileOfs(inputFileName);
+  reader->SetFileName(inputFileName);
+  ITK_TRY_EXPECT_EXCEPTION(reader->Update());
+
+  // Delete the created file
+  std::remove(inputFileName.c_str());
+
   inputFileName = argv[1];
   reader->SetFileName(inputFileName);
+  ITK_TEST_SET_GET_VALUE(inputFileName, reader->GetFileName());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -30,8 +30,8 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
               << "<OutputMesh3D.vtk> " << std::endl;
     return EXIT_FAILURE;
   }
-  const char * outputMesh2D = argv[1];
-  const char * outputMesh3D = argv[2];
+  const auto outputMesh2D = std::string(argv[1]);
+  const auto outputMesh3D = std::string(argv[2]);
 
   using TensorElementType = float;
   using Tensor2dType = itk::SymmetricSecondRankTensor<TensorElementType, 2>;
@@ -69,8 +69,16 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   ITK_TEST_EXPECT_TRUE(vtkPolyDataMeshIO->GetSupportedWriteExtensions() == supportedExtensions);
 
   mesh2dWriter->SetMeshIO(vtkPolyDataMeshIO);
-  mesh2dWriter->SetInput(mesh2d);
+  ITK_TEST_SET_GET_VALUE(vtkPolyDataMeshIO, mesh2dWriter->GetMeshIO());
+
   mesh2dWriter->SetFileName(outputMesh2D);
+  ITK_TEST_SET_GET_VALUE(outputMesh2D, std::string(mesh2dWriter->GetFileName()));
+
+  bool useCompression = false;
+  ITK_TEST_SET_GET_BOOLEAN(mesh2dWriter, UseCompression, useCompression);
+
+  mesh2dWriter->SetInput(mesh2d);
+
   try
   {
     mesh2dWriter->Update();
@@ -100,9 +108,16 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(mesh3dWriter, MeshFileWriter, ProcessObject);
 
-  mesh3dWriter->SetMeshIO(itk::VTKPolyDataMeshIO::New());
-  mesh3dWriter->SetInput(mesh3d);
+
+  itk::VTKPolyDataMeshIO::Pointer vtkPolyDataMeshIO2 = itk::VTKPolyDataMeshIO::New();
+  mesh3dWriter->SetMeshIO(vtkPolyDataMeshIO2);
+  ITK_TEST_SET_GET_VALUE(vtkPolyDataMeshIO2, mesh3dWriter->GetMeshIO());
+
   mesh3dWriter->SetFileName(outputMesh3D);
+  ITK_TEST_SET_GET_VALUE(outputMesh3D, std::string(mesh3dWriter->GetFileName()));
+
+  mesh3dWriter->SetInput(mesh3d);
+
   try
   {
     mesh3dWriter->Update();

--- a/Modules/IO/XML/test/itkDOMTest5.cxx
+++ b/Modules/IO/XML/test/itkDOMTest5.cxx
@@ -55,14 +55,20 @@ itkDOMTest5(int argc, char * argv[])
     // write the test object to an XML file
     itk::DOMTestObjectDOMWriter::Pointer writer = itk::DOMTestObjectDOMWriter::New();
     writer->SetInput(testobj1);
-    writer->SetFileName(argv[1]);
+
+    const auto filename = std::string(argv[1]);
+    writer->SetFileName(filename);
+    ITK_TEST_SET_GET_VALUE(filename, std::string(writer->GetFileName()));
+
     writer->Update();
 
     itk::DOMTestObject::Pointer testobj2;
 
     // read the object back to memory from the disk
     itk::DOMTestObjectDOMReader::Pointer reader = itk::DOMTestObjectDOMReader::New();
-    reader->SetFileName(argv[1]);
+    reader->SetFileName(filename);
+    ITK_TEST_SET_GET_VALUE(filename, std::string(reader->GetFileName()));
+
     reader->Update();
     testobj2 = reader->GetOutput();
 

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -129,8 +129,7 @@ itkLBFGSOptimizerTest(int, char *[])
 
   // Set some optimizer parameters
   bool trace = false;
-  itkOptimizer->SetTrace(trace);
-  ITK_TEST_SET_GET_VALUE(trace, itkOptimizer->GetTrace());
+  ITK_TEST_SET_GET_BOOLEAN(itkOptimizer, Trace, trace);
 
   unsigned int maximumNumberOfFunctionEvaluations = 1000;
   itkOptimizer->SetMaximumNumberOfFunctionEvaluations(maximumNumberOfFunctionEvaluations);

--- a/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
@@ -194,6 +194,10 @@ itkPowellOptimizerTest(int argc, char * argv[])
   // Exercise various member functions.
   std::cout << "CurrentIteration: " << itkOptimizer->GetCurrentIteration();
   std::cout << std::endl;
+
+  ITK_TEST_EXPECT_EQUAL(itkOptimizer->GetValue(), itkOptimizer->GetCurrentCost());
+
+  std::cout << "Value: " << itkOptimizer->GetValue() << std::endl;
   std::cout << "CurrentCost: " << itkOptimizer->GetCurrentCost() << std::endl;
   std::cout << "CurrentLineIteration: " << itkOptimizer->GetCurrentLineIteration() << std::endl;
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
@@ -22,6 +22,7 @@
 #include "itkGradientDescentOptimizer.h"
 
 #include "itkImageRegistrationMethodImageSource.h"
+#include "itkTestingMacros.h"
 
 /**
  *  This program tests one instantiation of the itk::ImageRegistrationMethod class
@@ -76,6 +77,9 @@ itkImageRegistrationMethodTest_1(int argc, char * argv[])
   auto registration = RegistrationType::New();
 
   auto imageSource = ImageSourceType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(imageSource, ImageRegistrationMethodImageSource, Object);
+
 
   SizeType size;
   size[0] = 100;

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -18,6 +18,7 @@
 #include "itkCorrelationImageToImageMetricv4.h"
 #include "itkTranslationTransform.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 /* Simple test to verify that class builds and runs.
  * Results are not verified. See ImageToImageMetricv4Test
@@ -209,6 +210,8 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   using MetricType = itk::CorrelationImageToImageMetricv4<ImageType, ImageType, ImageType>;
 
   auto metric = MetricType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(metric, CorrelationImageToImageMetricv4, ImageToImageMetricv4);
 
   /* Assign images and transforms.
    * By not setting a virtual domain image or virtual domain settings,

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -20,6 +20,7 @@
 #include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
 #include "itkTranslationTransform.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 /* Simple test to verify that class builds and runs.
  * Results are not verified. See ImageToImageMetricv4Test
@@ -97,6 +98,17 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   using MetricType = itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType>;
   auto metric = MetricType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(metric, JointHistogramMutualInformationImageToImageMetricv4, ImageToImageMetricv4);
+
+
+  itk::SizeValueType numberOfHistogramBins = 6;
+  metric->SetNumberOfHistogramBins(numberOfHistogramBins);
+  ITK_TEST_SET_GET_VALUE(numberOfHistogramBins, metric->GetNumberOfHistogramBins());
+
+  double varianceForJointPDFSmoothing = 1.5;
+  metric->SetVarianceForJointPDFSmoothing(varianceForJointPDFSmoothing);
+  ITK_TEST_SET_GET_VALUE(varianceForJointPDFSmoothing, metric->GetVarianceForJointPDFSmoothing());
+
   /* Assign images and transforms.
    * By not setting a virtual domain image or virtual domain settings,
    * the metric will use the fixed image for the virtual domain. */
@@ -104,7 +116,6 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   metric->SetMovingImage(movingImage);
   metric->SetFixedTransform(fixedTransform);
   metric->SetMovingTransform(movingTransform);
-  metric->SetNumberOfHistogramBins(6);
 
   /* Initialize. */
   try
@@ -139,6 +150,8 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
     std::cerr << "Value return results are not identical: " << valueReturn1 << ", " << valueReturn2 << std::endl;
   }
 
+  std::cout << "JointPDF: " << metric->GetJointPDF() << std::endl;
+
   // Test that non-overlapping images will generate a warning
   // and return max value for metric value.
   MovingTransformType::ParametersType parameters(movingTransform->GetNumberOfParameters());
@@ -158,10 +171,6 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   movingTransform->SetIdentity();
 
   std::cout << "Test passed." << std::endl;
-
-  // exercise methods
-  metric->SetVarianceForJointPDFSmoothing(3);
-  metric->GetVarianceForJointPDFSmoothing();
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -205,6 +205,8 @@ PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(
     velocityFieldRegistration, TimeVaryingBSplineVelocityFieldImageRegistrationMethod, ImageRegistrationMethodv4);
 
+  // For coverage purposes
+  velocityFieldRegistration->DebugOn();
 
   auto convergenceThreshold = static_cast<typename VelocityFieldRegistrationType::RealType>(1.0e-7);
   if (argc >= 11)

--- a/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkThresholdSegmentationLevelSetImageFilter.h"
+#include "itkTestingMacros.h"
 
 namespace TSIFTN
 {
@@ -187,11 +188,36 @@ itkThresholdSegmentationLevelSetImageFilterTest(int, char *[])
   using FilterType = itk::ThresholdSegmentationLevelSetImageFilter<::TSIFTN::SeedImageType, ::TSIFTN::ImageType>;
 
   auto filter = FilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ThresholdSegmentationLevelSetImageFilter, SegmentationLevelSetImageFilter);
+
+
   filter->SetInput(seedImage);
   filter->SetFeatureImage(inputImage);
 
-  filter->SetUpperThreshold(63);
-  filter->SetLowerThreshold(50);
+  typename FilterType::ValueType upperThreshold = 63;
+  filter->SetUpperThreshold(upperThreshold);
+  ITK_TEST_SET_GET_VALUE(upperThreshold, filter->GetUpperThreshold());
+
+  typename FilterType::ValueType lowerThreshold = 50;
+  filter->SetLowerThreshold(lowerThreshold);
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, filter->GetLowerThreshold());
+
+  typename FilterType::ValueType edgeWeight = 0.0;
+  filter->SetEdgeWeight(edgeWeight);
+  ITK_TEST_SET_GET_VALUE(edgeWeight, filter->GetEdgeWeight());
+
+  int smoothingIterations = 5;
+  filter->SetSmoothingIterations(smoothingIterations);
+  ITK_TEST_SET_GET_VALUE(smoothingIterations, filter->GetSmoothingIterations());
+
+  typename FilterType::ValueType smoothingTimeStep = 0.1;
+  filter->SetSmoothingTimeStep(smoothingTimeStep);
+  ITK_TEST_SET_GET_VALUE(smoothingTimeStep, filter->GetSmoothingTimeStep());
+
+  typename FilterType::ValueType smoothingConductance = 0.8;
+  filter->SetSmoothingConductance(smoothingConductance);
+  ITK_TEST_SET_GET_VALUE(smoothingConductance, filter->GetSmoothingConductance());
 
   filter->SetMaximumRMSError(0.04);
   filter->SetNumberOfIterations(10);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 
 #include "itkLevelSetTestFunction.h"
+#include "itkTestingMacros.h"
 
 /**
  * \class ToleranceChecker
@@ -130,7 +131,12 @@ itkLevelSetDenseImageTest(int, char *[])
   }
 
   auto level_set = LevelSetType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(level_set, LevelSetDenseImage, DiscreteLevelSetImage);
+
+
   level_set->SetImage(input);
+  ITK_TEST_SET_GET_VALUE(input, level_set->GetImage());
 
   idx[0] = 9;
   idx[1] = 18;

--- a/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
@@ -61,10 +61,15 @@ itkImageToVideoFilterTest(int argc, char * argv[])
 
   using VideoFilterType = itk::ImageToVideoFilter<ImageType>;
   auto videoFilter = VideoFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(videoFilter, ImageToVideoFilter, VideoSource);
+
+
   videoFilter->SetInput(inputImage);
   // Arbitrarily set 0th axis as temporal dimension to split frames
   itk::IndexValueType frameAxis = 0;
   videoFilter->SetFrameAxis(frameAxis);
+  ITK_TEST_SET_GET_VALUE(frameAxis, videoFilter->GetFrameAxis());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(videoFilter->Update());
 

--- a/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
+++ b/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
@@ -56,6 +56,7 @@ itkVectorImageToVideoTest(int argc, char * argv[])
   // Arbitrarily set last axis as temporal dimension to split frames
   itk::IndexValueType frameAxis = Dimension - 1;
   videoFilter->SetFrameAxis(frameAxis);
+  ITK_TEST_SET_GET_VALUE(frameAxis, videoFilter->GetFrameAxis());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(videoFilter->Update());
 


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Exercise basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro. Remove redundant calls to
  print the filter: rely on the basic method exercising macro call.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Use other testing macros to check the expected value of a number of
  ivars and method return values.
- Test exceptions using the `ITK_TRY_EXPECT_EXCEPTION` macro.
- Refactor the tests to accept (more) input parameters to allow checking
  the classes under a broader range of conditions.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)