### PR TITLE
BUG: Fix class name in RTTI

### DIFF
--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(Image, Object);
+  itkTypeMacro(ImageRegistrationMethodImageSource, Object);
 
 
   using MovingImageType = itk::Image<TMovingPixelType, VDimension>;


### PR DESCRIPTION
Fix class name in RTTI.

Fixes:
```
Name of Class = Image
Name of Superclass = Object
Class name provided does not match object's NameOfClass
```

raised for example in:
https://open.cdash.org/test/667512903

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)