### PR TITLE
Add `bit_cast`, and use it for `_beginthreadex` calls

### DIFF
--- a/Modules/Core/Common/include/itkBitCast.h
+++ b/Modules/Core/Common/include/itkBitCast.h
@@ -1,0 +1,60 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkBitCast_h
+#define itkBitCast_h
+
+#if __cplusplus < 202002L
+
+#  include <cstring>     // For memcpy.
+#  include <type_traits> // For is_trivially_copyable and remove_const_t.
+
+namespace itk
+{
+
+/** Rudimentary `bit_cast` implementation for C++14/C++17. From C++20, `std::bit_cast` is preferred.
+ */
+template <typename TDestination, class TSource>
+TDestination
+bit_cast(const TSource & source)
+{
+  static_assert(sizeof(TDestination) == sizeof(TSource),
+                "The destination type should have the same size as the source type.");
+  static_assert(std::is_trivially_copyable<TDestination>::value, "The destination type should be trivially copyable");
+  static_assert(std::is_trivially_copyable<TSource>::value, "The source type should be trivially copyable.");
+
+  std::remove_const_t<TDestination> result;
+  std::memcpy(&result, &source, sizeof(TSource));
+  return result;
+}
+
+} // namespace itk
+
+#else
+
+// From C++20, std::bit_cast is included with the C++ Standard Library.
+#  include <bit>
+
+namespace itk
+{
+using ::std::bit_cast;
+}
+
+#endif
+
+#endif // itkBitCast_h

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -26,6 +26,7 @@
  *
  *=========================================================================*/
 #include "itkPlatformMultiThreader.h"
+#include "itkBitCast.h"
 #include "itkObjectFactory.h"
 #include "itksys/SystemTools.hxx"
 #include <cstdlib>
@@ -71,8 +72,8 @@ PlatformMultiThreader::MultipleMethodExecute()
     m_ThreadInfoArray[threadCount].UserData = m_MultipleData[threadCount];
     m_ThreadInfoArray[threadCount].NumberOfWorkUnits = m_NumberOfWorkUnits;
 
-    processId[threadCount] = (void *)_beginthreadex(
-      nullptr, 0, m_MultipleMethod[threadCount], &m_ThreadInfoArray[threadCount], 0, (unsigned int *)&threadId);
+    processId[threadCount] = bit_cast<HANDLE>(_beginthreadex(
+      nullptr, 0, m_MultipleMethod[threadCount], &m_ThreadInfoArray[threadCount], 0, (unsigned int *)&threadId));
 
     if (processId[threadCount] == nullptr)
     {
@@ -137,7 +138,7 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
   // Using _beginthreadex on a PC
   //
   m_SpawnedThreadProcessID[id] =
-    (void *)_beginthreadex(nullptr, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId);
+    bit_cast<HANDLE>(_beginthreadex(nullptr, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId));
   if (m_SpawnedThreadProcessID[id] == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");
@@ -175,9 +176,9 @@ ThreadProcessIdType
 PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
 {
   // Using _beginthreadex on a PC
-  DWORD  threadId;
-  HANDLE threadHandle =
-    (HANDLE)_beginthreadex(nullptr, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId);
+  DWORD threadId;
+  auto  threadHandle =
+    bit_cast<HANDLE>(_beginthreadex(nullptr, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId));
   if (threadHandle == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -626,6 +626,7 @@ endif()
 
 set(ITKCommonGTests
       itkAggregateTypesGTest.cxx
+      itkBitCastGTest.cxx
       itkBooleanStdVectorGTest.cxx
       itkBuildInformationGTest.cxx
       itkConnectedImageNeighborhoodShapeGTest.cxx

--- a/Modules/Core/Common/test/itkBitCastGTest.cxx
+++ b/Modules/Core/Common/test/itkBitCastGTest.cxx
@@ -1,0 +1,46 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkBitCast.h"
+#include <gtest/gtest.h>
+#include <cstring> // For memcmp.
+
+namespace
+{
+template <typename TDestination, class TSource>
+void
+Expect_return_value_is_bitwise_equal_to_function_argument(const TSource & source)
+{
+  const auto result = itk::bit_cast<TDestination>(source);
+  EXPECT_EQ(std::memcmp(&result, &source, sizeof(TSource)), 0);
+}
+} // namespace
+
+
+TEST(BitCast, ResultIsBitwiseEqualToArgument)
+{
+  for (const int i : { -1, 0, 1 })
+  {
+    Expect_return_value_is_bitwise_equal_to_function_argument<unsigned int>(i);
+  }
+
+  int value;
+  (void)value;
+  Expect_return_value_is_bitwise_equal_to_function_argument<intptr_t>(&value);
+}


### PR DESCRIPTION
`bit_cast` helps to avoid undefined behavior when doing a bitwise cast.