### PR TITLE
COMP: Fix overly narrow cast

### DIFF
--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -376,8 +376,8 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUp
   double msigma = 0.0;
   double jointsigma = 0.0;
 
-  const double numsamplesB{ fixedSamplesB.size() };
-  const double numsamplesA{ fixedSamplesA.size() };
+  const double numsamplesB{ static_cast<double>(fixedSamplesB.size()) };
+  const double numsamplesA{ static_cast<double>(fixedSamplesA.size()) };
   double       nsamp = numsamplesB;
   //  if (maxf == minf && maxm == minm) return update;
   //    else std::cout << " b samps " << fixedSamplesB.size()


### PR DESCRIPTION
Fix so that the build no longer (correctly) complains that an `unsigned int` is cast to `double` in a context where narrowing casts are prohibited. 