### PR TITLE
COMP: Update ITKModuleExternal CMake message to avoid CTest false positive

### DIFF
--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -12,7 +12,7 @@ if(MSVC AND ${CMAKE_MINIMUM_REQUIRED_VERSION} LESS 3.16.3)
   message(WARNING "cmake_minimum_required must be at least 3.16.3")
   message(STATUS "This is needed to allow proper setting of CMAKE_MSVC_RUNTIME_LIBRARY.")
   message(STATUS "Do not be surprised if you run into link errors of the style:
-  error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj")
+  LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj")
 endif()
 if(NOT EXISTS ${ITK_CMAKE_DIR}/ITKModuleMacros.cmake)
   message(FATAL_ERROR "Modules can only be built against an ITK build tree; they cannot be built against an ITK install tree.")


### PR DESCRIPTION
This commit updates message introduced in 4b010e724 (ENH: use the new
CMake mechanism to specify MSVC's static or DLL CRT) to avoid false
positive when building module like `ITKUltrasound` as a standalone project.

Removing the "error" string avoid the regular expression associated
with `cmCTestBuildHandler.cxx` (see [1]) from reporting an error.

[1] https://github.com/Kitware/CMake/blob/7dc7907837a8ce4608f8cc762409617e62c496fe/Source/CTest/cmCTestBuildHandler.cxx#L28-L169

cc: @dzenanz @thewtex 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
<s>- [ ] Added test (or behavior not changed)</s>
<s>- [ ] Updated API documentation (or API not changed)
<s>- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)</s>
<s>- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5</s>
<s>- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)</s>
