### PR TITLE
BUG: Replace `bit_cast<HANDLE>` calls with `reinterpret_cast<HANDLE>`

### DIFF
--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -26,7 +26,6 @@
  *
  *=========================================================================*/
 #include "itkPlatformMultiThreader.h"
-#include "itkBitCast.h"
 #include "itkObjectFactory.h"
 #include "itksys/SystemTools.hxx"
 #include <cstdlib>
@@ -72,7 +71,7 @@ PlatformMultiThreader::MultipleMethodExecute()
     m_ThreadInfoArray[threadCount].UserData = m_MultipleData[threadCount];
     m_ThreadInfoArray[threadCount].NumberOfWorkUnits = m_NumberOfWorkUnits;
 
-    processId[threadCount] = bit_cast<HANDLE>(_beginthreadex(
+    processId[threadCount] = reinterpret_cast<HANDLE>(_beginthreadex(
       nullptr, 0, m_MultipleMethod[threadCount], &m_ThreadInfoArray[threadCount], 0, (unsigned int *)&threadId));
 
     if (processId[threadCount] == nullptr)
@@ -137,8 +136,8 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
 
   // Using _beginthreadex on a PC
   //
-  m_SpawnedThreadProcessID[id] =
-    bit_cast<HANDLE>(_beginthreadex(nullptr, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId));
+  m_SpawnedThreadProcessID[id] = reinterpret_cast<HANDLE>(
+    _beginthreadex(nullptr, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId));
   if (m_SpawnedThreadProcessID[id] == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");
@@ -177,8 +176,8 @@ PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::Wo
 {
   // Using _beginthreadex on a PC
   DWORD threadId;
-  auto  threadHandle =
-    bit_cast<HANDLE>(_beginthreadex(nullptr, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId));
+  auto  threadHandle = reinterpret_cast<HANDLE>(
+    _beginthreadex(nullptr, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId));
   if (threadHandle == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");


### PR DESCRIPTION
It appears that commit 548b45f46dc9459bd9e6273a88485482794c3eaa ("BUG: Replace
C-style casts from `_beginthreadex` with `bit_cast<HANDLE>`", from pull request
https://github.com/InsightSoftwareConsortium/ITK/pull/3380) was wrong:
`bit_cast<HANDLE>` might do a different conversion than the corresponding
C-style cast, `(HANDLE)`.

The C-style cast `(HANDLE)` behaves exactly like `reinterpret_cast<HANDLE>`, by
definition.

`reinterpret_cast<HANDLE>` does an implementation-defined conversion, as was
explained by Jonathan Wakely at https://github.com/isocpp/CppCoreGuidelines/issues/1517#issuecomment-1104120989
(issue "Favor bit_cast over reinterpret_cast").

Fixed by replacing all `bit_cast<HANDLE>` calls with `reinterpret_cast<HANDLE>`.