### PR TITLE
Add const to first parameter of "SwapWrite" member functions, and other ByteSwapper style improvements

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -110,7 +110,7 @@ public:
    * others raise an exception. The method is used to
    * swap to and from Big Endian. */
   static void
-  SwapWriteRangeFromSystemToBigEndian(T * p, int num, OStreamType * fp);
+  SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp);
 
   /** Generic swap method handles type T. The swapping is
    * done in-place. 2, 4 and 8 byte swapping
@@ -136,7 +136,7 @@ public:
    * others raise an exception. The method is used to
    * swap to and from Little Endian. */
   static void
-  SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamType * fp);
+  SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp);
 
 protected:
   ByteSwapper() = default;
@@ -154,7 +154,7 @@ protected:
   /** Swap and write a range of two-byte words. Num is the number of two-byte
    * words to swap and write. */
   static void
-  SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite2Range(const void * ptr, BufferSizeType num, OStreamType * fp);
 
   /** Swap four bytes. */
   static void
@@ -168,7 +168,7 @@ protected:
   /** Swap and write a range of four-byte words. Num is the number of four-byte
    * words to swap and write. */
   static void
-  SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite4Range(const void * ptr, BufferSizeType num, OStreamType * fp);
 
   /** Swap 8 bytes. */
   static void
@@ -182,7 +182,7 @@ protected:
   /** Swap and write a range of 8-byte words. Num is the number of four-byte
    * words to swap and write. */
   static void
-  SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamType * fp);
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -27,6 +27,7 @@
  *=========================================================================*/
 #ifndef itkByteSwapper_hxx
 #define itkByteSwapper_hxx
+#include <algorithm> // For swap.
 #include <memory>
 #include <cstring>
 
@@ -273,10 +274,8 @@ template <typename T>
 void
 ByteSwapper<T>::Swap2(void * pin)
 {
-  auto *               p = static_cast<unsigned short *>(pin);
-  const unsigned short h1 = (*p) << static_cast<short unsigned int>(8);
-  const unsigned short h2 = (*p) >> static_cast<short unsigned int>(8);
-  *p = h1 | h2;
+  auto * p = static_cast<char *>(pin);
+  std::swap(p[0], p[1]);
 }
 
 // Swap bunch of bytes. Num is the number of two byte words to swap.
@@ -287,9 +286,7 @@ ByteSwapper<T>::Swap2Range(void * ptr, BufferSizeType num)
   auto * pos = static_cast<char *>(ptr);
   for (BufferSizeType i = 0; i < num; ++i)
   {
-    const char one_byte = pos[0];
-    pos[0] = pos[1];
-    pos[1] = one_byte;
+    Self::Swap2(pos);
     pos = pos + 2;
   }
 }
@@ -328,16 +325,9 @@ template <typename T>
 void
 ByteSwapper<T>::Swap4(void * ptr)
 {
-  char   one_byte;
   auto * p = static_cast<char *>(ptr);
-
-  one_byte = p[0];
-  p[0] = p[3];
-  p[3] = one_byte;
-
-  one_byte = p[1];
-  p[1] = p[2];
-  p[2] = one_byte;
+  std::swap(p[0], p[3]);
+  std::swap(p[1], p[2]);
 }
 
 // Swap bunch of bytes. Num is the number of four byte words to swap.
@@ -390,24 +380,12 @@ template <typename T>
 void
 ByteSwapper<T>::Swap8(void * ptr)
 {
-  char   one_byte;
   auto * p = static_cast<char *>(ptr);
 
-  one_byte = p[0];
-  p[0] = p[7];
-  p[7] = one_byte;
-
-  one_byte = p[1];
-  p[1] = p[6];
-  p[6] = one_byte;
-
-  one_byte = p[2];
-  p[2] = p[5];
-  p[5] = one_byte;
-
-  one_byte = p[3];
-  p[3] = p[4];
-  p[4] = one_byte;
+  std::swap(p[0], p[7]);
+  std::swap(p[1], p[6]);
+  std::swap(p[2], p[5]);
+  std::swap(p[3], p[4]);
 }
 
 // Swap bunch of bytes. Num is the number of eight byte words to swap.

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -309,14 +309,8 @@ ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     memcpy(cpy, ptr, chunkSize * 2);
 
-    char * pos = cpy;
-    for (BufferSizeType i = 0; i < chunkSize; ++i)
-    {
-      const char one_byte = pos[0];
-      pos[0] = pos[1];
-      pos[1] = one_byte;
-      pos = pos + 2;
-    }
+    Self::Swap2Range(cpy, num);
+
     fp->write((char *)cpy, static_cast<std::streamsize>(2 * chunkSize));
     ptr = (char *)ptr + chunkSize * 2;
     num -= chunkSize;
@@ -356,13 +350,7 @@ ByteSwapper<T>::Swap4Range(void * ptr, BufferSizeType num)
 
   for (BufferSizeType i = 0; i < num; ++i)
   {
-    char one_byte = pos[0];
-    pos[0] = pos[3];
-    pos[3] = one_byte;
-
-    one_byte = pos[1];
-    pos[1] = pos[2];
-    pos[2] = one_byte;
+    Self::Swap4(pos);
     pos = pos + 4;
   }
 }
@@ -384,18 +372,8 @@ ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     memcpy(cpy, ptr, chunkSize * 4);
 
-    char * pos = cpy;
-    for (BufferSizeType i = 0; i < chunkSize; ++i)
-    {
-      char one_byte = pos[0];
-      pos[0] = pos[3];
-      pos[3] = one_byte;
+    Self::Swap4Range(cpy, num);
 
-      one_byte = pos[1];
-      pos[1] = pos[2];
-      pos[2] = one_byte;
-      pos = pos + 4;
-    }
     fp->write((char *)cpy, static_cast<std::streamsize>(4 * chunkSize));
     ptr = (char *)ptr + chunkSize * 4;
     num -= chunkSize;
@@ -443,21 +421,7 @@ ByteSwapper<T>::Swap8Range(void * ptr, BufferSizeType num)
 
   for (BufferSizeType i = 0; i < num; ++i)
   {
-    char one_byte = pos[0];
-    pos[0] = pos[7];
-    pos[7] = one_byte;
-
-    one_byte = pos[1];
-    pos[1] = pos[6];
-    pos[6] = one_byte;
-
-    one_byte = pos[2];
-    pos[2] = pos[5];
-    pos[5] = one_byte;
-
-    one_byte = pos[3];
-    pos[3] = pos[4];
-    pos[4] = one_byte;
+    Self::Swap8(pos);
     pos = pos + 8;
   }
 }

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -136,16 +136,16 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
 #ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp)
 {
   num *= sizeof(T);
-  fp->write((char *)p, num);
+  fp->write(reinterpret_cast<const char *>(p), num);
 }
 
 #else
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp)
 {
   switch (sizeof(T))
   {
@@ -232,7 +232,7 @@ ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T *, BufferSizeType)
 #ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp)
 {
   switch (sizeof(T))
   {
@@ -255,10 +255,10 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamTy
 #else
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp)
 {
   num *= sizeof(T);
-  fp->write((char *)p, num);
+  fp->write(reinterpret_cast<const char *>(p), num);
 }
 
 #endif
@@ -297,7 +297,7 @@ ByteSwapper<T>::Swap2Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite2Range(const void * ptr, BufferSizeType num, OStreamType * fp)
 {
   BufferSizeType chunkSize = 1000000;
   if (num < chunkSize)
@@ -312,7 +312,7 @@ ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp
     Self::Swap2Range(cpy.get(), num);
 
     fp->write(cpy.get(), static_cast<std::streamsize>(2 * chunkSize));
-    ptr = (char *)ptr + chunkSize * 2;
+    ptr = static_cast<const char *>(ptr) + chunkSize * 2;
     num -= chunkSize;
     if (num < chunkSize)
     {
@@ -357,7 +357,7 @@ ByteSwapper<T>::Swap4Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite4Range(const void * ptr, BufferSizeType num, OStreamType * fp)
 {
   BufferSizeType chunkSize = 1000000;
 
@@ -374,7 +374,7 @@ ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp
     Self::Swap4Range(cpy.get(), num);
 
     fp->write(cpy.get(), static_cast<std::streamsize>(4 * chunkSize));
-    ptr = (char *)ptr + chunkSize * 4;
+    ptr = static_cast<const char *>(ptr) + chunkSize * 4;
     num -= chunkSize;
     if (num < chunkSize)
     {
@@ -427,7 +427,7 @@ ByteSwapper<T>::Swap8Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamType * fp)
 {
   BufferSizeType chunkSize = 1000000;
   if (num < chunkSize)
@@ -443,7 +443,7 @@ ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp
     Self::Swap8Range(cpy.get(), chunkSize);
 
     fp->write(cpy.get(), static_cast<std::streamsize>(8 * chunkSize));
-    ptr = (char *)ptr + chunkSize * 8;
+    ptr = static_cast<const char *>(ptr) + chunkSize * 8;
     num -= chunkSize;
     if (num < chunkSize)
     {

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -304,14 +304,14 @@ ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     chunkSize = num;
   }
-  auto * cpy = new char[chunkSize * 2];
+  const std::unique_ptr<char[]> cpy(new char[chunkSize * 2]);
   while (num)
   {
-    memcpy(cpy, ptr, chunkSize * 2);
+    memcpy(cpy.get(), ptr, chunkSize * 2);
 
-    Self::Swap2Range(cpy, num);
+    Self::Swap2Range(cpy.get(), num);
 
-    fp->write((char *)cpy, static_cast<std::streamsize>(2 * chunkSize));
+    fp->write(cpy.get(), static_cast<std::streamsize>(2 * chunkSize));
     ptr = (char *)ptr + chunkSize * 2;
     num -= chunkSize;
     if (num < chunkSize)
@@ -319,7 +319,6 @@ ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp
       chunkSize = num;
     }
   }
-  delete[] cpy;
 }
 
 //------4-byte methods----------------------------------------------
@@ -366,15 +365,15 @@ ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     chunkSize = num;
   }
-  auto * cpy = new char[chunkSize * 4];
+  const std::unique_ptr<char[]> cpy(new char[chunkSize * 4]);
 
   while (num)
   {
-    memcpy(cpy, ptr, chunkSize * 4);
+    memcpy(cpy.get(), ptr, chunkSize * 4);
 
-    Self::Swap4Range(cpy, num);
+    Self::Swap4Range(cpy.get(), num);
 
-    fp->write((char *)cpy, static_cast<std::streamsize>(4 * chunkSize));
+    fp->write(cpy.get(), static_cast<std::streamsize>(4 * chunkSize));
     ptr = (char *)ptr + chunkSize * 4;
     num -= chunkSize;
     if (num < chunkSize)
@@ -382,7 +381,6 @@ ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp
       chunkSize = num;
     }
   }
-  delete[] cpy;
 }
 
 //------8-byte methods----------------------------------------------
@@ -436,15 +434,15 @@ ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     chunkSize = num;
   }
-  auto * cpy = new char[chunkSize * 8];
+  const std::unique_ptr<char[]> cpy(new char[chunkSize * 8]);
 
   while (num)
   {
-    memcpy(cpy, ptr, chunkSize * 8);
+    memcpy(cpy.get(), ptr, chunkSize * 8);
 
-    Self::Swap8Range(cpy, chunkSize);
+    Self::Swap8Range(cpy.get(), chunkSize);
 
-    fp->write((char *)cpy, static_cast<std::streamsize>(8 * chunkSize));
+    fp->write(cpy.get(), static_cast<std::streamsize>(8 * chunkSize));
     ptr = (char *)ptr + chunkSize * 8;
     num -= chunkSize;
     if (num < chunkSize)
@@ -452,7 +450,6 @@ ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp
       chunkSize = num;
     }
   }
-  delete[] cpy;
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -81,13 +81,13 @@ ByteSwapper<T>::SwapFromSystemToBigEndian(T * p)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2(p);
+      Self::Swap2(p);
       return;
     case 4:
-      ByteSwapper<T>::Swap4(p);
+      Self::Swap4(p);
       return;
     case 8:
-      ByteSwapper<T>::Swap8(p);
+      Self::Swap8(p);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -118,13 +118,13 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2Range(p, num);
+      Self::Swap2Range(p, num);
       return;
     case 4:
-      ByteSwapper<T>::Swap4Range(p, num);
+      Self::Swap4Range(p, num);
       return;
     case 8:
-      ByteSwapper<T>::Swap8Range(p, num);
+      Self::Swap8Range(p, num);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -152,13 +152,13 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(T * p, int num, OStreamType 
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::SwapWrite2Range(p, num, fp);
+      Self::SwapWrite2Range(p, num, fp);
       return;
     case 4:
-      ByteSwapper<T>::SwapWrite4Range(p, num, fp);
+      Self::SwapWrite4Range(p, num, fp);
       return;
     case 8:
-      ByteSwapper<T>::SwapWrite8Range(p, num, fp);
+      Self::SwapWrite8Range(p, num, fp);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -179,13 +179,13 @@ ByteSwapper<T>::SwapFromSystemToLittleEndian(T * p)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2(p);
+      Self::Swap2(p);
       return;
     case 4:
-      ByteSwapper<T>::Swap4(p);
+      Self::Swap4(p);
       return;
     case 8:
-      ByteSwapper<T>::Swap8(p);
+      Self::Swap8(p);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -209,13 +209,13 @@ ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T * p, BufferSizeType num)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2Range(p, num);
+      Self::Swap2Range(p, num);
       return;
     case 4:
-      ByteSwapper<T>::Swap4Range(p, num);
+      Self::Swap4Range(p, num);
       return;
     case 8:
-      ByteSwapper<T>::Swap8Range(p, num);
+      Self::Swap8Range(p, num);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -239,13 +239,13 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamTy
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::SwapWrite2Range(p, num, fp);
+      Self::SwapWrite2Range(p, num, fp);
       return;
     case 4:
-      ByteSwapper<T>::SwapWrite4Range(p, num, fp);
+      Self::SwapWrite4Range(p, num, fp);
       return;
     case 8:
-      ByteSwapper<T>::SwapWrite8Range(p, num, fp);
+      Self::SwapWrite8Range(p, num, fp);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -478,7 +478,7 @@ ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     memcpy(cpy, ptr, chunkSize * 8);
 
-    ByteSwapper<T>::Swap8Range(cpy, chunkSize);
+    Self::Swap8Range(cpy, chunkSize);
 
     fp->write((char *)cpy, static_cast<std::streamsize>(8 * chunkSize));
     ptr = (char *)ptr + chunkSize * 8;

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -81,13 +81,13 @@ ByteSwapper<T>::SwapFromSystemToBigEndian(T * p)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2((void *)p);
+      ByteSwapper<T>::Swap2(p);
       return;
     case 4:
-      ByteSwapper<T>::Swap4((void *)p);
+      ByteSwapper<T>::Swap4(p);
       return;
     case 8:
-      ByteSwapper<T>::Swap8((void *)p);
+      ByteSwapper<T>::Swap8(p);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -118,13 +118,13 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2Range((void *)p, num);
+      ByteSwapper<T>::Swap2Range(p, num);
       return;
     case 4:
-      ByteSwapper<T>::Swap4Range((void *)p, num);
+      ByteSwapper<T>::Swap4Range(p, num);
       return;
     case 8:
-      ByteSwapper<T>::Swap8Range((void *)p, num);
+      ByteSwapper<T>::Swap8Range(p, num);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -152,13 +152,13 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(T * p, int num, OStreamType 
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::SwapWrite2Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite2Range(p, num, fp);
       return;
     case 4:
-      ByteSwapper<T>::SwapWrite4Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite4Range(p, num, fp);
       return;
     case 8:
-      ByteSwapper<T>::SwapWrite8Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite8Range(p, num, fp);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -179,13 +179,13 @@ ByteSwapper<T>::SwapFromSystemToLittleEndian(T * p)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2((void *)p);
+      ByteSwapper<T>::Swap2(p);
       return;
     case 4:
-      ByteSwapper<T>::Swap4((void *)p);
+      ByteSwapper<T>::Swap4(p);
       return;
     case 8:
-      ByteSwapper<T>::Swap8((void *)p);
+      ByteSwapper<T>::Swap8(p);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -209,13 +209,13 @@ ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T * p, BufferSizeType num)
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::Swap2Range((void *)p, num);
+      ByteSwapper<T>::Swap2Range(p, num);
       return;
     case 4:
-      ByteSwapper<T>::Swap4Range((void *)p, num);
+      ByteSwapper<T>::Swap4Range(p, num);
       return;
     case 8:
-      ByteSwapper<T>::Swap8Range((void *)p, num);
+      ByteSwapper<T>::Swap8Range(p, num);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -239,13 +239,13 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(T * p, int num, OStreamTy
     case 1:
       return;
     case 2:
-      ByteSwapper<T>::SwapWrite2Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite2Range(p, num, fp);
       return;
     case 4:
-      ByteSwapper<T>::SwapWrite4Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite4Range(p, num, fp);
       return;
     case 8:
-      ByteSwapper<T>::SwapWrite8Range((void *)p, num, fp);
+      ByteSwapper<T>::SwapWrite8Range(p, num, fp);
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
@@ -478,7 +478,7 @@ ByteSwapper<T>::SwapWrite8Range(void * ptr, BufferSizeType num, OStreamType * fp
   {
     memcpy(cpy, ptr, chunkSize * 8);
 
-    ByteSwapper<T>::Swap8Range((void *)cpy, chunkSize);
+    ByteSwapper<T>::Swap8Range(cpy, chunkSize);
 
     fp->write((char *)cpy, static_cast<std::streamsize>(8 * chunkSize));
     ptr = (char *)ptr + chunkSize * 8;


### PR DESCRIPTION
Declared the first parameter of its "SwapWrite" member functions pointer-to-const, and made various other `ByteSwapper` style improvements 