### PR TITLE
STYLE: Use `bit_cast` to convert random seeds from uint32_t to int32_t

### DIFF
--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkAdditiveGaussianNoiseImageFilter_hxx
 #define itkAdditiveGaussianNoiseImageFilter_hxx
 
+#include "itkBitCast.h"
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
 #include "itkNormalVariateGenerator.h"
@@ -53,7 +54,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDat
   typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
   const uint32_t                                       seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   // Convert the seed bit for bit to int32_t
-  randn->Initialize(*reinterpret_cast<const int32_t *>(&seed));
+  randn->Initialize(bit_cast<int32_t>(seed));
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkShotNoiseImageFilter_hxx
 #define itkShotNoiseImageFilter_hxx
 
+#include "itkBitCast.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
@@ -54,7 +55,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   rand->Initialize(seed);
   typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
-  randn->Initialize(*reinterpret_cast<const int32_t *>(&seed));
+  randn->Initialize(bit_cast<int32_t>(seed));
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input


### PR DESCRIPTION
Instead of doing `*reinterpret_cast<const int32_t *>(&seed)`, which appears
more complicated.