### PR TITLE
BUG: Re-add coverage for `itk::RegistrationParameterScales` types

### DIFF
--- a/Modules/Registration/Metricsv4/wrapping/itkMetricv4Types.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkMetricv4Types.wrap
@@ -58,8 +58,8 @@ _add_image_filter_types("MSITIM" "itk::MeanSquaresImageToImageMetricv4")
 _add_image_filter_types("ITIM" "itk::ImageToImageMetricv4")
 
 # not sure why we are articially adding double, but this is consistent across the Metricv4 types
-UNIQUE(_scalar_plus_double "${WRAP_ITK_SCALAR};D")
-_cartesian(_real_pointsets "${_scalar_plus_double}" "${ITK_WRAP_IMAGE_DIMS}")
+UNIQUE(_real_plus_double "${WRAP_ITK_REAL};D")
+_cartesian(_real_pointsets "${_real_plus_double}" "${ITK_WRAP_IMAGE_DIMS}")
 _cartesian(_int_pointsets "${WRAP_ITK_INT}" "${ITK_WRAP_IMAGE_DIMS}")
 
 macro(_add_pointset_types mangle cpp_name pointsets)
@@ -71,12 +71,12 @@ foreach(z ${pointsets})
 endforeach()
 endmacro()
 
-_add_pointset_types("EDPSTPSM" "itk::EuclideanDistancePointSetToPointSetMetricv4" ${_real_pointsets})
-_add_pointset_types("EBPSTPSM" "itk::ExpectationBasedPointSetToPointSetMetricv4" ${_real_pointsets})
-_add_pointset_types("JHCTPSTPSM" "itk::JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4" ${_real_pointsets})
-_add_pointset_types("PSTPSM" "itk::PointSetToPointSetMetricv4" ${_real_pointsets})
-_add_pointset_types("PSTPSMWI" "itk::PointSetToPointSetMetricWithIndexv4" ${_real_pointsets})
-_add_pointset_types("LPSTPSM" "itk::LabeledPointSetToPointSetMetricv4" ${_int_pointsets})
+_add_pointset_types("EDPSTPSM" "itk::EuclideanDistancePointSetToPointSetMetricv4" "${_real_pointsets}")
+_add_pointset_types("EBPSTPSM" "itk::ExpectationBasedPointSetToPointSetMetricv4" "${_real_pointsets}")
+_add_pointset_types("JHCTPSTPSM" "itk::JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4" "${_real_pointsets}")
+_add_pointset_types("PSTPSM" "itk::PointSetToPointSetMetricv4" "${_real_pointsets}")
+_add_pointset_types("PSTPSMWI" "itk::PointSetToPointSetMetricWithIndexv4" "${_real_pointsets}")
+_add_pointset_types("LPSTPSM" "itk::LabeledPointSetToPointSetMetricv4" "${_int_pointsets}")
 
 set(ITK_METRICV4_TYPES "${ITK_METRICV4_IMAGE_TYPES};${ITK_METRICV4_POINTSET_TYPES}")
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Resolves [https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/issues/349](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/issues/349) in ITKSphinxExamples where `itk.RegistrationParameterScalesFromPhysicalShift` is wrapped only for `itk.JensenHavrdaChandraTsallisPointSetToPointSetMetricv4` inputs that are templated over `itk.PointSet[itk.SS,2]`.

Fixes template wrappings such that scales classes are templated over pointset-to-pointset metrics including real types (`itk.F`) and more than two dimensions if configured. Previously only the first template list entry was being parsed by the `_add_pointset_types` macro.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
