### PR TITLE
BUG: Provide appropriate enum value to `itkCellVisitMacro`

### DIFF
--- a/Modules/Core/Common/include/itkPolyLineCell.h
+++ b/Modules/Core/Common/include/itkPolyLineCell.h
@@ -112,7 +112,7 @@ public:
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::LINE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::POLYLINE_CELL);
 
   /** Constructor and destructor */
   PolyLineCell() = default;


### PR DESCRIPTION
Provide appropriate geometry enum value to `itkCellVisitMacro` in
`itk::PolyLineCell`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)