### PR TITLE
DOC: typo in itkMath comment

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -80,7 +80,7 @@ static constexpr double deg_per_rad = vnl_math::deg_per_rad;
 static constexpr double sqrt2pi = vnl_math::sqrt2pi;
 /** \brief \f[ \frac{2}{\sqrt{\pi}} \f]  */
 static constexpr double two_over_sqrtpi = vnl_math::two_over_sqrtpi;
-/** \brief \f[ \frac{2}{\sqrt{2\pi}} \f]  */
+/** \brief \f[ \frac{1}{\sqrt{2\pi}} \f]  */
 static constexpr double one_over_sqrt2pi = vnl_math::one_over_sqrt2pi;
 /** \brief \f[ \sqrt{2} \f]  */
 static constexpr double sqrt2 = vnl_math::sqrt2;


### PR DESCRIPTION
![Screenshot 2022-05-04 at 00-07-10 ITK itk Math Namespace Reference](https://user-images.githubusercontent.com/1494580/166574239-4f164b6c-cff5-4cb4-8b30-c49babdb85f1.png)



P.S.
**Not related** to this PR, just FYI, unfortunately actual documentation (itk.org,18 Jan 2022) for [itk::Math](https://itk.org/Doxygen/html/namespaceitk_1_1Math.html#a7c40db0dddb83464c99f3d859abf7faf) is partially affected by the bug #2058 , e.g. `abs()`methods
