### PR TITLE
BUG: XMLFileOutputWindowTest failed subsequent runs

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -592,10 +592,6 @@ itk_add_test(NAME itkMultithreadingTest COMMAND ITKCommon2TestDriver itkMultithr
 
 itk_add_test(NAME itkMultiThreaderExceptionsTest COMMAND ITKCommon2TestDriver itkMultiThreaderExceptionsTest)
 
-itk_add_test(NAME itkXMLFileOutputWindowTestNoFilename
-      COMMAND ITKCommon2TestDriver
-    itkXMLFileOutputWindowTest)
-
 itk_add_test(NAME itkXMLFileOutputWindowTestFilename
       COMMAND ITKCommon2TestDriver
     itkXMLFileOutputWindowTest ${ITK_TEST_OUTPUT_DIR}/itkXMLFileOutputWindowTest.xml)


### PR DESCRIPTION
The XMLFileOutputWindowTest only passed on the iniital run
of the test.  Subsequent runs would append to the file and
cause incorrect file line counts.  Merged two test scenerios
into one test run, and explicitly define the testing environment.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
