### PR TITLE
STYLE: Catch exceptions by _const_ reference

### DIFF
--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -455,15 +455,15 @@ MultiThreaderBase::SingleMethodProxy(void * arg)
     (*workUnitInfoStruct->ThreadFunction)(arg);
     workUnitInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeEnum::SUCCESS;
   }
-  catch (ProcessAborted &)
+  catch (const ProcessAborted &)
   {
     workUnitInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeEnum::ITK_PROCESS_ABORTED_EXCEPTION;
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     workUnitInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeEnum::ITK_EXCEPTION;
   }
-  catch (std::exception &)
+  catch (const std::exception &)
   {
     workUnitInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeEnum::STD_EXCEPTION;
   }

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -139,7 +139,7 @@ PlatformMultiThreader::SingleMethodExecute()
       process_id[thread_loop] = this->SpawnDispatchSingleMethodThread(&m_ThreadInfoArray[thread_loop]);
     }
   }
-  catch (std::exception & e)
+  catch (const std::exception & e)
   {
     // get the details of the exception to rethrow them
     exceptionDetails = e.what();
@@ -163,7 +163,7 @@ PlatformMultiThreader::SingleMethodExecute()
     m_ThreadInfoArray[0].NumberOfWorkUnits = m_NumberOfWorkUnits;
     m_SingleMethod((void *)(&m_ThreadInfoArray[0]));
   }
-  catch (ProcessAborted &)
+  catch (const ProcessAborted &)
   {
     // Need cleanup and rethrow ProcessAborted
     // close down other threads
@@ -180,7 +180,7 @@ PlatformMultiThreader::SingleMethodExecute()
     // rethrow
     throw;
   }
-  catch (std::exception & e)
+  catch (const std::exception & e)
   {
     // get the details of the exception to rethrow them
     exceptionDetails = e.what();
@@ -208,7 +208,7 @@ PlatformMultiThreader::SingleMethodExecute()
         exceptionOccurred = true;
       }
     }
-    catch (std::exception & e)
+    catch (const std::exception & e)
     {
       // get the details of the exception to rethrow them
       exceptionDetails = e.what();

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1707,7 +1707,7 @@ ProcessObject::UpdateOutputData(DataObject * itkNotUsed(output))
   {
     this->GenerateData();
   }
-  catch (ProcessAborted &)
+  catch (const ProcessAborted &)
   {
     this->InvokeEvent(AbortEvent());
     this->ResetPipeline();

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -107,7 +107,7 @@ ITKCommon_EXPORT std::istream &
       lastPos = in.tellg();
     }
   }
-  catch (ExceptionObject & excp)
+  catch (const ExceptionObject & excp)
   {
     record.Reset();
     // propagate the exception
@@ -162,7 +162,7 @@ ITKCommon_EXPORT std::istream &
       itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad right bracket: " << bracket);
     }
   }
-  catch (ExceptionObject & excp)
+  catch (const ExceptionObject & excp)
   {
     record.Reset();
     // propagate the exception
@@ -283,7 +283,7 @@ ITKCommon_EXPORT std::istream &
       itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad end of line: " << line);
     }
   }
-  catch (ExceptionObject & excp)
+  catch (const ExceptionObject & excp)
   {
     record.Reset();
     // propagate the exception
@@ -405,7 +405,7 @@ operator>>(std::istream & smapsStream, SmapsData_2_6 & data)
       record = new SmapsRecord;
     }
   }
-  catch (ExceptionObject & excp)
+  catch (const ExceptionObject & excp)
   {
     // in case of error, erase the records.
     data.Reset();
@@ -524,7 +524,7 @@ operator>>(std::istream & stream, VMMapData_10_2 & data)
       }
     }
   }
-  catch (ExceptionObject & excp)
+  catch (const ExceptionObject & excp)
   {
     // in case of error, erase the records.
     data.Reset();

--- a/Modules/Core/Common/src/itkStreamingProcessObject.cxx
+++ b/Modules/Core/Common/src/itkStreamingProcessObject.cxx
@@ -84,7 +84,7 @@ StreamingProcessObject::GenerateData()
       this->StreamedGenerateData(piece);
       this->UpdateProgress(static_cast<float>(piece + 1) / numberOfInputRequestRegion);
     }
-    catch (ProcessAborted &)
+    catch (const ProcessAborted &)
     {
       this->InvokeEvent(AbortEvent());
       this->ResetPipeline();

--- a/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
@@ -109,7 +109,7 @@ itkAbortProcessObjectTest(int, char *[])
   {
     extract->UpdateLargestPossibleRegion();
   }
-  catch (itk::ProcessAborted &)
+  catch (const itk::ProcessAborted &)
   {
     if (onAbortCalled)
     {

--- a/Modules/Core/Common/test/itkAnnulusOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkAnnulusOperatorTest.cxx
@@ -53,7 +53,7 @@ itkAnnulusOperatorTest(int, char *[])
     std::cout << e;
     return EXIT_FAILURE;
   }
-  catch (std::exception & e)
+  catch (const std::exception & e)
   {
     std::cout << "Std exception" << e.what();
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -142,7 +142,7 @@ itkExceptionObjectTest(int, char *[])
     //       the OneShouldFail variable is never actually set to false!
     OneShouldFail &= (hal == john); // ERROR
   }
-  catch (itk::IncompatibleOperandsError & e)
+  catch (const itk::IncompatibleOperandsError & e)
   {
     std::cout << e << std::endl;
     raised = true;
@@ -170,7 +170,7 @@ itkExceptionObjectTest(int, char *[])
     E.SetDescription("sample error");
     throw E;
   }
-  catch (itk::ExceptionObject &e) { std::cout << e << std::endl; }
+  catch (const itk::ExceptionObject &e) { std::cout << e << std::endl; }
   */
 
   delete Fp;

--- a/Modules/Core/Common/test/itkFilterDispatchTest.cxx
+++ b/Modules/Core/Common/test/itkFilterDispatchTest.cxx
@@ -241,7 +241,7 @@ itkFilterDispatchTest(int, char *[])
     std::cout << "Executing 5-d filter: ";
     filter5d->Update();
   }
-  catch (std::string & err)
+  catch (const std::string & err)
   {
     std::cout << err;
     passed = false;

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -114,7 +114,7 @@ itkImageSpatialObjectTest(int, char *[])
   {
     imageSO->ValueAtInWorldSpace(q, returnedValue);
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     throw;
   }

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -523,11 +523,11 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::EstimateBia
       optimizer->StartOptimization();
     }
   }
-  catch (ExceptionObject & ie)
+  catch (const ExceptionObject & ie)
   {
     std::cerr << ie << std::endl;
   }
-  catch (std::exception & e)
+  catch (const std::exception & e)
   {
     std::cerr << e.what() << std::endl;
   }

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -168,7 +168,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Gau
     {
       smoother->Update();
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       std::string msg("Caught exception: ");
       msg += exc.what();

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -161,7 +161,7 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
     {
       smoother->Update();
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       std::string msg("Caught exception: ");
       msg += exc.what();

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -108,7 +108,7 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::BeforeThreadedG
         m_InputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
         m_OutputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
       }
-      catch (std::bad_alloc &)
+      catch (const std::bad_alloc &)
       {
         itkExceptionMacro("Problem allocating memory for internal computations");
       }

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -108,7 +108,7 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
         m_InputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
         m_OutputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
       }
-      catch (std::bad_alloc &)
+      catch (const std::bad_alloc &)
       {
         itkExceptionMacro("Problem allocating memory for internal computations");
       }

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -109,7 +109,7 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
         m_InputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
         m_OutputBufferArray[i] = new typename FFTW1DProxyType::ComplexType[lineSize];
       }
-      catch (std::bad_alloc &)
+      catch (const std::bad_alloc &)
       {
         itkExceptionMacro("Problem allocating memory for internal computations");
       }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
@@ -174,7 +174,7 @@ FastMarchingBase<TInput, TOutput>::GenerateData()
       }
     }
   }
-  catch (ProcessAborted &)
+  catch (const ProcessAborted &)
   {
     // User aborted filter execution Here we catch an exception thrown by the
     // progress reporter and rethrow it with the correct line number and file

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -536,7 +536,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     {
       relabeler->Update();
     }
-    catch (ExceptionObject & excep)
+    catch (const ExceptionObject & excep)
     {
       std::cout << excep << std::endl;
     }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -114,7 +114,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::GenerateData()
   {
     Superclass::GenerateData();
   }
-  catch (ProcessAborted & exc)
+  catch (const ProcessAborted & exc)
   {
     // process was aborted, clean up the state of the filter
     // (most of the cleanup will have already been done by the

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
@@ -210,7 +210,7 @@ itkJoinSeriesImageFilterTest(int, char *[])
   {
     joinSeriesImage->Update();
   }
-  catch (itk::InvalidRequestedRegionError & err)
+  catch (const itk::InvalidRequestedRegionError & err)
   {
     std::cout << err << std::endl;
     passed = true;

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -151,7 +151,7 @@ itkShrinkImageTest(int, char *[])
     // this should fail due to a bad requested region
     shrink->Update();
   }
-  catch (itk::InvalidRequestedRegionError & e)
+  catch (const itk::InvalidRequestedRegionError & e)
   {
     std::cout << e << std::endl;
     std::cout << std::endl << std::endl << "Exception caught, updating largest possible region instead." << std::endl;

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -371,7 +371,7 @@ itkHistogramMatchingImageFilterTest()
         << "ERROR: Reached code that should have aborted due to thrown exception of missing ReferenceHistogram\n"
         << __FILE__ << ":" << __LINE__ << std::endl;
     }
-    catch (itk::ExceptionObject &)
+    catch (const itk::ExceptionObject &)
     {
       std::cout << "Test caught known exception for SetReferenceHistogram correctly, NO FAILURE!" << std::endl;
     }
@@ -391,7 +391,7 @@ itkHistogramMatchingImageFilterTest()
       std::cout << "ERROR: Reached code that should have aborted due to thrown exception of missing ReferenceImage\n"
                 << __FILE__ << ":" << __LINE__ << std::endl;
     }
-    catch (itk::ExceptionObject &)
+    catch (const itk::ExceptionObject &)
     {
       std::cout << "Test caught known exception for SetReferenceImage correctly, NO FAILURE!" << std::endl;
     }

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -76,7 +76,7 @@ BMPImageIO::CanReadFile(const char * filename)
   {
     this->OpenFileForReading(inputStream, fname);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -153,7 +153,7 @@ BioRadImageIO::CanReadFile(const char * filename)
   {
     this->OpenFileForReading(file, fname);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -224,7 +224,7 @@ DCMTKImageIO::CanReadFile(const char * filename)
     {
       this->OpenFileForReading(file, filename);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       return false;
     }

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -216,7 +216,7 @@ GDCMImageIO::CanReadFile(const char * filename)
   {
     this->OpenFileForReading(file, filename);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -43,7 +43,7 @@ GE4ImageIO::CanReadFile(const char * FileNameToRead)
   {
     this->OpenFileForReading(f, FileNameToRead);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -62,7 +62,7 @@ GE5ImageIO ::CheckGE5xImages(char const * const imageFileTemplate, std::string &
   {
     this->OpenFileForReading(f, imageFileTemplate);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     reason = "File could not be opened for read";
     return -1;

--- a/Modules/IO/GE/src/itkGEAdwImageIO.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIO.cxx
@@ -51,7 +51,7 @@ GEAdwImageIO::CanReadFile(const char * FileNameToRead)
   {
     this->OpenFileForReading(f, FileNameToRead);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -118,7 +118,7 @@ GiplImageIO::CanReadFile(const char * filename)
     {
       this->OpenFileForReading(inputStream, filename);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       return false;
     }

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -880,26 +880,26 @@ HDF5ImageIO ::ReadImageInformation()
     imageSet.close();
   }
   // catch failure caused by the H5File operations
-  catch (H5::AttributeIException & error)
+  catch (const H5::AttributeIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
-  catch (H5::FileIException & error)
+  catch (const H5::FileIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSet operations
-  catch (H5::DataSetIException & error)
+  catch (const H5::DataSetIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataSpaceIException & error)
+  catch (const H5::DataSpaceIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataTypeIException & error)
+  catch (const H5::DataTypeIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
@@ -1227,22 +1227,22 @@ HDF5ImageIO ::WriteImageInformation()
     }
   }
   // catch failure caused by the H5File operations
-  catch (H5::FileIException & error)
+  catch (const H5::FileIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSet operations
-  catch (H5::DataSetIException & error)
+  catch (const H5::DataSetIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataSpaceIException & error)
+  catch (const H5::DataSpaceIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataTypeIException & error)
+  catch (const H5::DataTypeIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
@@ -1282,22 +1282,22 @@ HDF5ImageIO ::Write(const void * buffer)
     this->m_VoxelDataSet->write(buffer, dataType, dspace, imageSpace);
   }
   // catch failure caused by the H5File operations
-  catch (H5::FileIException & error)
+  catch (const H5::FileIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSet operations
-  catch (H5::DataSetIException & error)
+  catch (const H5::DataSetIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataSpaceIException & error)
+  catch (const H5::DataSpaceIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
   // catch failure caused by the DataSpace operations
-  catch (H5::DataTypeIException & error)
+  catch (const H5::DataTypeIException & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -217,7 +217,7 @@ IPLCommonImageIO::ReadImageInformation()
     {
       curImageHeader = this->ReadHeader(fullPath.c_str());
     }
-    catch (itk::ExceptionObject &)
+    catch (const itk::ExceptionObject &)
     {
       // ReadGE4XHeader throws an exception on any error.
       // So if, for example we run into a subdirectory, it would

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -72,7 +72,7 @@ MRCImageIO::CanReadFile(const char * filename)
     // this may throw an expection, but we just return false
     this->OpenFileForReading(file, fname);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
@@ -83,7 +83,7 @@ TestUnknowMetaDataBug(const std::string & fname)
 
     ITK_TEST_EXPECT_EQUAL(originalHash, readHash);
   }
-  catch (std::exception & e)
+  catch (const std::exception & e)
   {
     std::cerr << "Exception: " << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
@@ -121,7 +121,7 @@ itkNiftiImageIOTest12(int argc, char * argv[])
       std::cerr << origPhysLocationIndexThree << " != " << readPhysLocationIndexThree << std::endl;
     }
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception occurred: " << std::endl;
     std::cerr << e.GetDescription() << std::endl;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
@@ -56,7 +56,7 @@ itkNiftiImageIOTest2(int argc, char * argv[])
     input = imageReader->GetOutput();
     input = itk::IOTestHelper::ReadImage<ImageType>(std::string(arg2));
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     test_success = 1;
   }

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -224,7 +224,7 @@ NrrdImageIO::CanReadFile(const char * filename)
   {
     this->OpenFileForReading(inputStream, fname);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -1801,7 +1801,7 @@ PhilipsPAR::GetImageTypesScanningSequence(std::string parFile)
   {
     this->ReadPAR(parFile, &parParam);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return recImageTypesScanSequence;
   }
@@ -2081,7 +2081,7 @@ PhilipsPAR::GetDiffusionGradientOrientationAndBValues(std::string               
     {
       this->ReadPAR(parFile, &tempPar);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       return false;
     }
@@ -2139,7 +2139,7 @@ PhilipsPAR::GetLabelTypesASL(std::string parFile, PhilipsPAR::PARLabelTypesASLCo
     {
       this->ReadPAR(parFile, &tempPar);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       return false;
     }

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -534,7 +534,7 @@ PhilipsRECImageIO::CanReadFile(const char * FileNameToRead)
       return false;
     }
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }
@@ -557,7 +557,7 @@ PhilipsRECImageIO::ReadImageInformation()
   {
     philipsPAR->ReadPAR(HeaderFileName, &par);
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     throw;
   }

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -47,7 +47,7 @@ SiemensVisionImageIO::CanReadFile(const char * FileNameToRead)
   {
     this->OpenFileForReading(f, FileNameToRead);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
@@ -56,7 +56,7 @@ buildPolygonGroup(PolygonGroup3DPointer & PolygonGroup)
       PolygonGroup->Update();
     }
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cerr << "Error creating PolygonGroup" << std::endl;
     return EXIT_FAILURE;
@@ -174,7 +174,7 @@ itkPolygonGroupSpatialObjectXMLFileTest(int argc, char * argv[])
     pw->SetObject(&(*PolygonGroup));
     pw->WriteFile();
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cerr << "Error Creating file" << std::endl;
     return EXIT_FAILURE;
@@ -200,7 +200,7 @@ itkPolygonGroupSpatialObjectXMLFileTest(int argc, char * argv[])
       return EXIT_FAILURE;
     }
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cerr << "Error Reading file" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -79,7 +79,7 @@ StimulateImageIO::CanReadFile(const char * filename)
   {
     this->OpenFileForReading(file, fname);
   }
-  catch (ExceptionObject &)
+  catch (const ExceptionObject &)
   {
     return false;
   }
@@ -127,7 +127,7 @@ StimulateImageIO::Read(void * buffer)
     {
       this->OpenFileForReading(file_data, m_DataFileName);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       // option 2:
       m_DataFileName = m_FileName;
@@ -136,7 +136,7 @@ StimulateImageIO::Read(void * buffer)
       {
         this->OpenFileForReading(file_data, m_DataFileName);
       }
-      catch (ExceptionObject &)
+      catch (const ExceptionObject &)
       {
         itkExceptionMacro(<< "No Data file was specified in header (spr) file and guessing file data name failed.");
       }

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -358,7 +358,7 @@ HDF5TransformIOTemplate<TParametersValueType>::Read()
     this->m_H5File->close();
   }
   // catch failure caused by the H5File operations
-  catch (H5::Exception & error)
+  catch (const H5::Exception & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }
@@ -455,7 +455,7 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
     this->m_H5File->close();
   }
   // catch failure caused by the H5File operations
-  catch (H5::Exception & error)
+  catch (const H5::Exception & error)
   {
     itkExceptionMacro(<< error.getCDetailMsg());
   }

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -117,7 +117,7 @@ ImageMetricLoad<TMoving, TFixed>::InitializeMetric()
   {
     m_Metric->Initialize();
   }
-  catch (ExceptionObject & e)
+  catch (const ExceptionObject & e)
   {
     std::cout << "Metric initialization failed" << std::endl;
     std::cout << "Reason " << e.GetDescription() << std::endl;
@@ -188,7 +188,7 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Element::ArrayType
       {
         tempe = itk::Math::abs(GetMetric(InVec));
       }
-      catch (itk::ExceptionObject &)
+      catch (const itk::ExceptionObject &)
       {
         // do nothing we dont care if the metric region is outside the image
         // std::cerr << e << std::endl;
@@ -255,7 +255,7 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution1(Element::ArrayTyp
       {
         tempe = itk::Math::abs(GetMetric(InVec));
       }
-      catch (itk::ExceptionObject &)
+      catch (const itk::ExceptionObject &)
       {
         // do nothing we dont care if the metric region is outside the image
         // std::cerr << e << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -259,7 +259,7 @@ itkFEMElement2DTest(int argc, char * argv[])
       }
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -234,7 +234,7 @@ itkFEMElement3DTest(int argc, char * argv[])
       }
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
@@ -370,7 +370,7 @@ itkFEMElementTest(int argc, char * argv[])
       std::cout << comment << "Test PASSED" << std::endl;
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMExceptionTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMExceptionTest.cxx
@@ -34,7 +34,7 @@ itkFEMExceptionTest(int, char *[])
   {
     throw itk::fem::FEMException(__FILE__, __LINE__, "itkFEMException");
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Exception caught\n";
   }
@@ -43,7 +43,7 @@ itkFEMExceptionTest(int, char *[])
   {
     throw itk::fem::FEMExceptionIO(__FILE__, __LINE__, "itkFEMExceptionIO", "IO exception");
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "IO exception caught\n";
   }
@@ -52,7 +52,7 @@ itkFEMExceptionTest(int, char *[])
   {
     throw itk::fem::FEMExceptionWrongClass(__FILE__, __LINE__, "itkFEMExceptionWrongClass");
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Wrong class exception caught\n";
   }
@@ -61,7 +61,7 @@ itkFEMExceptionTest(int, char *[])
   {
     throw itk::fem::FEMExceptionObjectNotFound(__FILE__, __LINE__, "itkFEMExceptionObjectNotFound", "baseClassName", 0);
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Not found exception caught\n";
   }
@@ -70,7 +70,7 @@ itkFEMExceptionTest(int, char *[])
   {
     throw itk::fem::FEMExceptionSolution(__FILE__, __LINE__, "itkFEMExceptionSolution", "Solution exception");
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Solution exception caught\n";
   }

--- a/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
@@ -80,7 +80,7 @@ itkFEMGenerateMeshTest(int, char *[])
     itk::fem::Generate2DRectilinearMesh(e1, S, MeshOriginV, MeshSizeV, ElementsPerDim);
     std::cout << "Generated 2D rectilinear mesh" << std::endl;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cerr << "Could not generate 2D mesh - test FAILED" << std::endl;
     return EXIT_FAILURE;
@@ -107,7 +107,7 @@ itkFEMGenerateMeshTest(int, char *[])
     itk::fem::Generate3DRectilinearMesh(e2, S, MeshOriginV, MeshSizeV, ElementsPerDim);
     std::cout << "Generated 3D rectilinear mesh" << std::endl;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cerr << "Could not create 3D mesh - test FAILED" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -88,7 +88,7 @@ GradientDescentOptimizer::ResumeOptimization()
     {
       m_CostFunction->GetValueAndDerivative(this->GetCurrentPosition(), m_Value, m_Gradient);
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject & err)
     {
       // An exception has occurred.
       // Terminate immediately.

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -104,7 +104,7 @@ RegularStepGradientDescentBaseOptimizer::ResumeOptimization()
     {
       m_CostFunction->GetValueAndDerivative(this->GetCurrentPosition(), m_Value, m_Gradient);
     }
-    catch (ExceptionObject & excp)
+    catch (const ExceptionObject & excp)
     {
       m_StopCondition = StopConditionEnum::CostFunctionError;
       m_StopConditionDescription << "Cost function error after " << m_CurrentIteration << " iterations. "

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -228,7 +228,7 @@ SPSAOptimizer::AdvanceOneStep()
   {
     this->ComputeGradient(currentPosition, m_Gradient);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // An exception has occurred.
     // Terminate immediately.

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -89,7 +89,7 @@ ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::A
     /* Pass gradient to transform and let it do its own updating. */
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -82,7 +82,7 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Adv
     /* Pass gradient to transform and let it do its own updating */
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -98,7 +98,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
       // proper size, no new allocation is done.
       this->m_Metric->GetValueAndDerivative(this->m_CurrentMetricValue, this->m_Gradient);
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject & err)
     {
       this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::COSTFUNCTION_ERROR;
       this->m_StopConditionDescription << "Metric error during optimization";
@@ -132,7 +132,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
           break;
         }
       }
-      catch (std::exception & e)
+      catch (const std::exception & e)
       {
         itkWarningMacro(<< "GetConvergenceValue() failed with exception: " << e.what() << std::endl);
       }
@@ -175,7 +175,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::AdvanceOneSte
     // Pass gradient to transform and let it do its own updating
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -206,7 +206,7 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::ResumeOptimizat
       itkDebugMacro(" combine-grad ");
       this->m_OptimizersList[0]->GetModifiableMetric()->UpdateTransformParameters(this->m_Gradient);
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject & err)
     {
       this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
       this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -177,7 +177,7 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::ResumeOptimization
       this->m_CurrentMetricValue = this->m_Metric->GetValue();
       this->m_MetricValuesList.push_back(this->m_CurrentMetricValue);
     }
-    catch (ExceptionObject &)
+    catch (const ExceptionObject &)
     {
       /** We simply ignore this exception because it may just be a bad starting point.
        *  We hope that other start points are better.

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -165,7 +165,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::AdvanceOneStep()
     /* Pass gradient to transform and let it do its own updating */
     this->m_Metric->UpdateTransformParameters(this->m_NewtonStep);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
@@ -159,7 +159,7 @@ RegularStepGradientDescentOptimizerv4<TInternalComputationValueType>::AdvanceOne
     // Pass gradient to transform and let it do its own updating
     this->m_Metric->UpdateTransformParameters(this->m_Gradient, factor);
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";

--- a/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
@@ -34,7 +34,7 @@
     std::cerr << std::endl;                                           \
     return EXIT_FAILURE;                                              \
   }                                                                   \
-  catch (itk::ExceptionObject &)                                      \
+  catch (const itk::ExceptionObject &)                                \
   {}                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
@@ -46,7 +46,7 @@
     std::cerr << std::endl;                                        \
     return EXIT_FAILURE;                                           \
   }                                                                \
-  catch (itk::ExceptionObject &)                                   \
+  catch (const itk::ExceptionObject &)                             \
   {}                                                               \
   ITK_MACROEND_NOOP_STATEMENT
 

--- a/Modules/Numerics/Statistics/test/itkNeighborhoodSamplerTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkNeighborhoodSamplerTest1.cxx
@@ -154,7 +154,7 @@ itkNeighborhoodSamplerTest1(int, char *[])
     std::cerr << " due to nullptr SetRadiusInput()";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest.cxx
@@ -84,7 +84,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::MissingHistogramSizeInput & e)
+  catch (const itk::MissingHistogramSizeInput & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;
@@ -108,7 +108,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " of calling SetMeasurementVectorSize() in the sample";
     return EXIT_FAILURE;
   }
-  catch (itk::NullSizeHistogramInputMeasurementVectorSize & e)
+  catch (const itk::NullSizeHistogramInputMeasurementVectorSize & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;
@@ -692,7 +692,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " due to nullptr SetHistogramSizeInput()";
     return EXIT_FAILURE;
   }
-  catch (itk::MissingHistogramSizeInput & e)
+  catch (const itk::MissingHistogramSizeInput & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;
@@ -719,7 +719,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " due to nullptr SetMarginalScaleInput()";
     return EXIT_FAILURE;
   }
-  catch (itk::MissingHistogramMarginalScaleInput & e)
+  catch (const itk::MissingHistogramMarginalScaleInput & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;
@@ -752,7 +752,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " due to nullptr SetHistogramBinMinimumInput()";
     return EXIT_FAILURE;
   }
-  catch (itk::MissingHistogramBinMinimumInput & e)
+  catch (const itk::MissingHistogramBinMinimumInput & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;
@@ -780,7 +780,7 @@ itkSampleToHistogramFilterTest(int, char *[])
     std::cerr << " due to nullptr SetHistogramBinMaximumInput()";
     return EXIT_FAILURE;
   }
-  catch (itk::MissingHistogramBinMaximumInput & e)
+  catch (const itk::MissingHistogramBinMaximumInput & e)
   {
     std::cout << "Exception received:" << std::endl;
     std::cout << e << std::endl;

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest2.cxx
@@ -89,7 +89,7 @@ itkSampleToHistogramFilterTest2(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest3.cxx
@@ -89,7 +89,7 @@ itkSampleToHistogramFilterTest3(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest4.cxx
@@ -105,7 +105,7 @@ itkSampleToHistogramFilterTest4(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest6.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest6.cxx
@@ -98,7 +98,7 @@ itkSampleToHistogramFilterTest6(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest7.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest7.cxx
@@ -89,7 +89,7 @@ itkSampleToHistogramFilterTest7(int, char *[])
     std::cerr << " of calling SetHistogramSize() in the filter ";
     return EXIT_FAILURE;
   }
-  catch (itk::ExceptionObject &)
+  catch (const itk::ExceptionObject &)
   {
     std::cout << "Expected exception received" << std::endl;
   }

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -217,7 +217,7 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::StartOptimization()
     // do the optimization
     m_Optimizer->StartOptimization();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // An error has occurred in the optimization.
     // Update the parameters
@@ -266,7 +266,7 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     // initialize the interconnects between components
     this->Initialize();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     m_LastTransformParameters = empty;
 

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -124,7 +124,7 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Gener
     // Initialize the interconnects between components
     this->Initialize();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // Pass exception to caller
     throw err;
@@ -135,7 +135,7 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Gener
     // Do the optimization
     m_Optimizer->StartOptimization();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // An error has occurred in the optimization.
     // Update the parameters

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -350,7 +350,7 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData(
       // initialize the interconnects between components
       this->Initialize();
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject & err)
     {
       m_LastTransformParameters = ParametersType(1);
       m_LastTransformParameters.Fill(0.0f);
@@ -364,7 +364,7 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData(
       // do the optimization
       m_Optimizer->StartOptimization();
     }
-    catch (ExceptionObject & err)
+    catch (const ExceptionObject & err)
     {
       // An error has occurred in the optimization.
       // Update the parameters

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -116,7 +116,7 @@ PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GenerateData()
   {
     this->Initialize();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     m_LastTransformParameters = ParametersType(1);
     m_LastTransformParameters.Fill(0.0f);
@@ -130,7 +130,7 @@ PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GenerateData()
   {
     m_Optimizer->StartOptimization();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // An error has occurred in the optimization.
     // Update the parameters

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -110,7 +110,7 @@ PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GenerateD
   {
     this->Initialize();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     m_LastTransformParameters = ParametersType(1);
     m_LastTransformParameters.Fill(0.0f);
@@ -124,7 +124,7 @@ PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GenerateD
   {
     m_Optimizer->StartOptimization();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // An error has occurred in the optimization.
     // Update the parameters

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -290,7 +290,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
     {
       registrator->RunRegistration();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test failed!" << std::endl;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -294,7 +294,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
       // Register the images
       registrator->RunRegistration();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test FAILED" << std::endl;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -317,7 +317,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
       // Register the images
       registrator->RunRegistration();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test failed!" << std::endl;

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -74,7 +74,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
           scanIt, scanMem, scanParameters, localDerivativeResult, metricValueResult, threadId);
       }
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       // NOTE: there must be a cleaner way to do this:
       std::string msg("Caught exception: \n");
@@ -191,7 +191,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
             this->m_ANTSAssociate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
         }
       }
-      catch (ExceptionObject & exc)
+      catch (const ExceptionObject & exc)
       {
         // NOTE: there must be a cleaner way to do this:
         std::string msg("Caught exception: \n");
@@ -275,7 +275,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
           this->m_ANTSAssociate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
       }
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       // NOTE: there must be a cleaner way to do this:
       std::string msg("Caught exception: \n");
@@ -468,7 +468,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       }
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");
@@ -620,7 +620,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
         scanIt, scanMem, scanParameters, localDerivativeResult, metricValueResult, threadId);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -207,7 +207,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       this->m_CorrelationAssociate->ComputeFixedImageGradientAtPoint(mappedFixedPoint, mappedFixedImageGradient);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");
@@ -230,7 +230,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       this->m_CorrelationAssociate->ComputeMovingImageGradientAtPoint(mappedMovingPoint, mappedMovingImageGradient);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     std::string msg("Caught exception: \n");
     msg += exc.what();
@@ -258,7 +258,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
                                       this->m_GetValueAndDerivativePerThreadVariables[threadId].LocalDerivatives,
                                       threadId);
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Exception in GetValueAndDerivativeProcessPoint:\n");

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
@@ -120,7 +120,7 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
     pointIsValid = this->m_CorrelationAssociate->TransformAndEvaluateFixedPoint(
       virtualPoint, mappedFixedPoint, mappedFixedPixelValue);
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");
@@ -138,7 +138,7 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
     pointIsValid = this->m_CorrelationAssociate->TransformAndEvaluateMovingPoint(
       virtualPoint, mappedMovingPoint, mappedMovingPixelValue);
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     std::string msg("Caught exception: \n");
     msg += exc.what();
@@ -156,7 +156,7 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
     this->m_CorrelationMetricPerThreadVariables[threadId].FixSum += mappedFixedPixelValue;
     this->m_CorrelationMetricPerThreadVariables[threadId].MovSum += mappedMovingPixelValue;
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     std::string msg("Exception in ProcessVirtualPoint:\n");
     msg += exc.what();

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
@@ -208,7 +208,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
       this->m_Associate->ComputeFixedImageGradientAtPoint(mappedFixedPoint, mappedFixedImageGradient);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");
@@ -231,7 +231,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
       this->m_Associate->ComputeMovingImageGradientAtPoint(mappedMovingPoint, mappedMovingImageGradient);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     std::string msg("Caught exception: \n");
     msg += exc.what();
@@ -259,7 +259,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
                                       this->m_GetValueAndDerivativePerThreadVariables[threadId].LocalDerivatives,
                                       threadId);
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Exception in GetValueAndDerivativeProcessPoint:\n");
@@ -324,7 +324,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
           this->m_GetValueAndDerivativePerThreadVariables[threadId].LocalDerivatives[i];
       }
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       std::string msg("Caught exception: \n");
       msg += exc.what();

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -82,7 +82,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
         this->m_Associate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     // NOTE: there must be a cleaner way to do this:
     std::string msg("Caught exception: \n");

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -223,7 +223,7 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
     {
       this->m_MetricQueue[j]->Initialize();
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       std::string msg("Caught exception initializing metric: \n");
       msg += exc.what();

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -464,7 +464,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
       field[offset + i] += pointDerivative[i];
     }
   }
-  catch (ExceptionObject & exc)
+  catch (const ExceptionObject & exc)
   {
     std::string msg("Caught exception: \n");
     msg += exc.what();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -768,7 +768,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
     {
       smoother->Update();
     }
-    catch (ExceptionObject & exc)
+    catch (const ExceptionObject & exc)
     {
       std::string msg("Caught exception: ");
       msg += exc.what();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkImageRegistrationSamplingTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkImageRegistrationSamplingTest.cxx
@@ -52,7 +52,7 @@ itkImageRegistrationSamplingTest(int, char *[])
       registrationMethod->SetMetricSamplingPercentage(errorValue);
       return EXIT_FAILURE;
     }
-    catch (itk::ExceptionObject &)
+    catch (const itk::ExceptionObject &)
     {
       std::cerr << "Caught expected exception." << std::endl;
     }

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -104,7 +104,7 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
   {
     kmeansFilter->Update();
   }
-  catch (ExceptionObject & err)
+  catch (const ExceptionObject & err)
   {
     // Pass exception to caller
     throw err;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -388,7 +388,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         progress.CompletedPixel(); // potential exception thrown here
       }
     }
-    catch (ProcessAborted &)
+    catch (const ProcessAborted &)
     {
       break; // interrupt the iterations loop
     }

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -329,7 +329,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         progress.CompletedPixel(); // potential exception thrown here
       }
     }
-    catch (ProcessAborted &)
+    catch (const ProcessAborted &)
     {
       break; // interrupt the iterations loop
     }

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -352,7 +352,7 @@ TemporalProcessObject::UpdateOutputData(DataObject * itkNotUsed(output))
     }
     this->GenerateData();
   }
-  catch (ProcessAborted & excp)
+  catch (const ProcessAborted & excp)
   {
     this->InvokeEvent(AbortEvent());
     this->ResetPipeline();


### PR DESCRIPTION
Replaced `catch \((\w+) &` with `catch (const $1 &`, using Visual Studio 2019, Find and Replace, Replace in Files, Use regular expressions.

Following C++ Core Guidelines, April 10, 2022, which says that it is "typically better" to catch by `const` reference than to catch by non-const reference. At https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference

Discussed at C++ Core Guidelines issue https://github.com/isocpp/CppCoreGuidelines/issues/518 "Catch exceptions by _const_ reference?", from February 3, 2016.
