### PR TITLE
PERF: Reduce verbosity of `itk::GaussianOperator` warning

### DIFF
--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -52,9 +52,9 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coef
     }
     if (coeff.size() > m_MaximumKernelWidth)
     {
-      itkWarningMacro("Kernel size has exceeded the specified maximum width of "
-                      << m_MaximumKernelWidth << " and has been truncated to " << coeff.size()
-                      << " elements.  You can raise the maximum width using the SetMaximumKernelWidth method.");
+      itkDebugMacro(<< "Kernel size has exceeded the specified maximum width of " << m_MaximumKernelWidth
+                    << " and has been truncated to " << coeff.size()
+                    << " elements.  You can raise the maximum width using the SetMaximumKernelWidth method.");
       break;
     }
   }


### PR DESCRIPTION
`itk::GaussianOperator` can be set with a `MaximumKernelWidth` parameter
such that a kernel that would otherwise overflow this size is cropped to
the maximum width. Cropping to the set maximum width happens frequently
in cases such as Gaussian blurring for multiscale pyramid generation and
is expected behavior, but the previous warning message makes it seem
like a failure case. This commit reduces the verbosity of the message
from a warning to a debug printout so that developers can get insights
into kernel cropping when needed, but are not alarmed by default warning
printouts.

Previous behavior: Warning whenever Gaussian kernel is correctly truncated to user specifications.
> WARNING: In C:\P\IPP\ITK-source\ITK\Modules\Core\Common\include\itkGaussianOperator.hxx, line 57
GaussianOperator (000000C7587FC630): Kernel size has exceeded the specified maximum width of 32 and has been truncated to 33 elements.  You can raise the maximum width using the SetMaximumKernelWidth method.

New behavior: No printout unless explicitly enabled.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
