### PR TITLE
BUG: Doxygen tarball links must be https

### DIFF
--- a/Documentation/Doxygen/DoxygenFooter.html
+++ b/Documentation/Doxygen/DoxygenFooter.html
@@ -15,9 +15,9 @@
 <div class="footer" align="left">
   <small>Tarballs of the nightly generated Doxygen documentation are available
     for the
-    <a href="http://itk.org/files/NightlyDoxygen/InsightDoxygenDocHtml.tar.gz">html</a>,
-    <a href="http://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz">xml</a>, and
-    <a href="http://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz">tag file</a>.
+    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocHtml.tar.gz">html</a>,
+    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz">xml</a>, and
+    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz">tag file</a>.
   </small>
 </div>
 <address class="footer"><small>


### PR DESCRIPTION
Chrome will fail to download because the web pages are served via https.
