### PR TITLE
BUG: Copy to xarray by default

### DIFF
--- a/Wrapping/Generators/Python/Tests/test_xarray.py
+++ b/Wrapping/Generators/Python/Tests/test_xarray.py
@@ -120,6 +120,12 @@ try:
     assert np.allclose(arr.transpose(), itk.array_view_from_image(image))
     assert np.allclose(arr.shape[::-1], itk.array_view_from_image(image).shape)
 
+    # Test in-place "view" where xarray data is valid only as long as ITK image
+    data_array = itk.xarray_from_image(image, view=True)
+    assert data_array.name == image.GetObjectName()
+    # verify we can run a computation on xarray data
+    assert float(data_array.min().compute()) == 1.0
+
     data_array = xr.DataArray(arr, dims=["q", "x", "y"])
     try:
         image = itk.image_from_xarray(data_array)


### PR DESCRIPTION
Previously observed behavior where ITK data was released after ITK
Python filter went out of scope, resulting in cascading and difficult to
trace fatal memory r/w error on xarray access. This change makes data
copy the default behavior while exposing `in_place` option for cases
where operations are contained within a single block and behavior
benefits from in-place operations.

Addresses discussion in [https://github.com/spatial-image/multiscale-spatial-image/issues/44](https://github.com/spatial-image/multiscale-spatial-image/issues/44)

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
