### PR TITLE
Pass bool and numeric parameters by (const) value, not by const reference

### DIFF
--- a/Modules/Core/Common/include/itkCompensatedSummation.h
+++ b/Modules/Core/Common/include/itkCompensatedSummation.h
@@ -130,9 +130,9 @@ private:
 };
 
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(float & compensation, float & sum, const float & element);
+     CompensatedSummationAddElement(float & compensation, float & sum, const float element);
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(double & compensation, double & sum, const double & element);
+     CompensatedSummationAddElement(double & compensation, double & sum, const double element);
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -23,9 +23,9 @@ namespace itk
 {
 
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(float & compensation, float & sum, const float & element);
+     CompensatedSummationAddElement(float & compensation, float & sum, const float element);
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(double & compensation, double & sum, const double & element);
+     CompensatedSummationAddElement(double & compensation, double & sum, const double element);
 
 #ifndef itkCompensatedSummation_cxx
 // We try the looser pragma guards if we don't have an explicit instantiation.

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -81,7 +81,7 @@ public:
 
   /** Sets the order of the derivative. */
   void
-  SetOrder(const unsigned int & order)
+  SetOrder(const unsigned int order)
   {
     this->m_Order = order;
   }

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -78,7 +78,7 @@ public:
 
   /** Sets the desired variance of the Gaussian kernel. */
   void
-  SetVariance(const double & variance)
+  SetVariance(const double variance)
   {
     m_Variance = variance;
   }
@@ -88,7 +88,7 @@ public:
    * and the area under the continuous Gaussian. Maximum error affects the
    * Gaussian operator size. The value must be between 0.0 and 1.0. */
   void
-  SetMaximumError(const double & max_error)
+  SetMaximumError(const double max_error)
   {
     if (max_error >= 1 || max_error <= 0)
     {

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -177,7 +177,7 @@ public:
 
   /** Get a random variate in the range [0, n] */
   double
-  GetVariateWithClosedRange(const double & n);
+  GetVariateWithClosedRange(const double n);
 
   /** Get a range variate in the range [0, 1) */
   double
@@ -185,7 +185,7 @@ public:
 
   /** Get a range variate in the range [0, n) */
   double
-  GetVariateWithOpenUpperRange(const double & n);
+  GetVariateWithOpenUpperRange(const double n);
 
   /** Get a range variate in the range (0, 1) */
   double
@@ -193,7 +193,7 @@ public:
 
   /** Get a range variate in the range (0, n) */
   double
-  GetVariateWithOpenRange(const double & n);
+  GetVariateWithOpenRange(const double n);
 
   /** Get an integer variate in [0, 2^32-1] */
   IntegerType
@@ -211,12 +211,12 @@ public:
   /* Access to a normal random number distribution
    * TODO: Compare with vnl_sample_normal */
   double
-  GetNormalVariate(const double & mean = 0.0, const double & variance = 1.0);
+  GetNormalVariate(const double mean = 0.0, const double variance = 1.0);
 
   /* Access to a uniform random number distribution in the range [a, b)
    * TODO: Compare with vnl_sample_uniform */
   double
-  GetUniformVariate(const double & a, const double & b);
+  GetUniformVariate(const double a, const double b);
 
   /** Get a variate in the range [0, 1]
    * Do NOT use for CRYPTOGRAPHY without securely hashing several returned
@@ -435,7 +435,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange()
 
 /** Get a random variate in the range [0, n] */
 inline double
-MersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange(const double & n)
+MersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange(const double n)
 {
   return GetVariateWithClosedRange() * n;
 }
@@ -449,7 +449,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange()
 
 /** Get a range variate in the range [0, n) */
 inline double
-MersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange(const double & n)
+MersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange(const double n)
 {
   return GetVariateWithOpenUpperRange() * n;
 }
@@ -463,7 +463,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange()
 
 /** Get a range variate in the range (0, n) */
 inline double
-MersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange(const double & n)
+MersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange(const double n)
 {
   return GetVariateWithOpenRange() * n;
 }
@@ -504,7 +504,7 @@ MersenneTwisterRandomVariateGenerator::Get53BitVariate()
 /** Access to a normal random number distribution. */
 // TODO: Compare with vnl_sample_normal
 inline double
-MersenneTwisterRandomVariateGenerator::GetNormalVariate(const double & mean, const double & variance)
+MersenneTwisterRandomVariateGenerator::GetNormalVariate(const double mean, const double variance)
 {
   // Return a real number from a normal (Gaussian) distribution with given
   // mean and variance by Box-Muller method
@@ -517,7 +517,7 @@ MersenneTwisterRandomVariateGenerator::GetNormalVariate(const double & mean, con
 /** Access to a uniform random number distribution */
 // TODO: Compare with vnl_sample_uniform
 inline double
-MersenneTwisterRandomVariateGenerator::GetUniformVariate(const double & a, const double & b)
+MersenneTwisterRandomVariateGenerator::GetUniformVariate(const double a, const double b)
 {
   double u = GetVariateWithOpenUpperRange();
 

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -91,7 +91,7 @@ public:
 
   /** Sets the dimensional direction of a directional operator. */
   void
-  SetDirection(const unsigned long & direction)
+  SetDirection(const unsigned long direction)
   {
     m_Direction = direction;
   }

--- a/Modules/Core/Common/src/itkCompensatedSummation.cxx
+++ b/Modules/Core/Common/src/itkCompensatedSummation.cxx
@@ -26,12 +26,12 @@ namespace itk
 {
 
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(float & compensation, float & sum, const float & element)
+     CompensatedSummationAddElement(float & compensation, float & sum, const float element)
 {
   CompensatedSummationAddElement(compensation, sum, element, 1);
 }
 void ITKCommon_EXPORT
-     CompensatedSummationAddElement(double & compensation, double & sum, const double & element)
+     CompensatedSummationAddElement(double & compensation, double & sum, const double element)
 {
   CompensatedSummationAddElement(compensation, sum, element, 1);
 }

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -71,13 +71,13 @@ mammal::operator==(mammal & o)
 }
 
 int
-lookup(const int & i)
+lookup(const int i)
 {
   static int table[5] = { 23, 42, 42, 32, 12 };
   if (!(0 <= i && i < 5))
   {
     itk::RangeError e(__FILE__, __LINE__);
-    e.SetLocation("int lookup(const int& )");
+    e.SetLocation("int lookup(const int )");
     e.SetDescription("Attempted to access out-of-bounds array element");
     throw e;
   }

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -35,28 +35,28 @@ using PixelType = ImageType::PixelType;
 using ImagePointerType = ImageType::Pointer;
 
 void
-CreateCubeConfig(ImagePointerType      image,
-                 const unsigned int &  StartX,
-                 const unsigned int &  StartY,
-                 const unsigned int &  StartZ,
-                 const unsigned char & value1,
-                 const unsigned char & value2,
-                 const unsigned char & value3,
-                 const unsigned char & value4,
-                 const unsigned char & value5,
-                 const unsigned char & value6,
-                 const unsigned char & value7,
-                 const unsigned char & value8);
+CreateCubeConfig(ImagePointerType    image,
+                 const unsigned int  StartX,
+                 const unsigned int  StartY,
+                 const unsigned int  StartZ,
+                 const unsigned char value1,
+                 const unsigned char value2,
+                 const unsigned char value3,
+                 const unsigned char value4,
+                 const unsigned char value5,
+                 const unsigned char value6,
+                 const unsigned char value7,
+                 const unsigned char value8);
 
 void
-Create16CubeConfig(ImagePointerType      image,
-                   const unsigned int &  StartX,
-                   const unsigned int &  StartY,
-                   const unsigned int &  StartZ,
-                   const unsigned char & value1,
-                   const unsigned char & value2,
-                   const unsigned char & value3,
-                   const unsigned char & value4);
+Create16CubeConfig(ImagePointerType    image,
+                   const unsigned int  StartX,
+                   const unsigned int  StartY,
+                   const unsigned int  StartZ,
+                   const unsigned char value1,
+                   const unsigned char value2,
+                   const unsigned char value3,
+                   const unsigned char value4);
 
 int
 itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
@@ -131,18 +131,18 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
 }
 
 void
-CreateCubeConfig(ImagePointerType      image,
-                 const unsigned int &  StartX,
-                 const unsigned int &  StartY,
-                 const unsigned int &  StartZ,
-                 const unsigned char & value1,
-                 const unsigned char & value2,
-                 const unsigned char & value3,
-                 const unsigned char & value4,
-                 const unsigned char & value5,
-                 const unsigned char & value6,
-                 const unsigned char & value7,
-                 const unsigned char & value8)
+CreateCubeConfig(ImagePointerType    image,
+                 const unsigned int  StartX,
+                 const unsigned int  StartY,
+                 const unsigned int  StartZ,
+                 const unsigned char value1,
+                 const unsigned char value2,
+                 const unsigned char value3,
+                 const unsigned char value4,
+                 const unsigned char value5,
+                 const unsigned char value6,
+                 const unsigned char value7,
+                 const unsigned char value8)
 {
   IndexType index;
 
@@ -196,14 +196,14 @@ CreateCubeConfig(ImagePointerType      image,
 }
 
 void
-Create16CubeConfig(ImagePointerType      image,
-                   const unsigned int &  StartX,
-                   const unsigned int &  StartY,
-                   const unsigned int &  StartZ,
-                   const unsigned char & value1,
-                   const unsigned char & value2,
-                   const unsigned char & value3,
-                   const unsigned char & value4)
+Create16CubeConfig(ImagePointerType    image,
+                   const unsigned int  StartX,
+                   const unsigned int  StartY,
+                   const unsigned int  StartZ,
+                   const unsigned char value1,
+                   const unsigned char value2,
+                   const unsigned char value3,
+                   const unsigned char value4)
 {
   // Case 0
   CreateCubeConfig(image, StartX + 0, StartY + 0, StartZ + 0, value1, value2, value3, value4, 0, 0, 0, 0);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
@@ -140,7 +140,7 @@ protected:
    * \return false else
    */
   bool
-  IsFaceIsolated(QEType * e, const bool & iWasLeftFace, std::stack<TQEType *> & oToBeDeleted);
+  IsFaceIsolated(QEType * e, const bool iWasLeftFace, std::stack<TQEType *> & oToBeDeleted);
 
   bool
   IsSamosa(QEType * e);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -297,7 +297,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedFace
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QEType *                e,
-                                                                            const bool &            iWasLeftFace,
+                                                                            const bool              iWasLeftFace,
                                                                             std::stack<TQEType *> & oToBeDeleted)
 {
   bool     border;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -46,7 +46,7 @@ AssertTopologicalInvariants(TMesh *        mesh,
 //----------------------------------------------------------------------------
 template <typename TMesh>
 std::vector<typename TMesh::PointType>
-GeneratePointCoordinates(const unsigned int & iN)
+GeneratePointCoordinates(const unsigned int iN)
 {
   using PointType = typename TMesh::PointType;
   using CoordRepType = typename PointType::CoordRepType;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
@@ -187,7 +187,7 @@ public:
 
   /** Set/Get the conductance parameter.  The conductance parameter. */
   void
-  SetConductanceParameter(const double & c)
+  SetConductanceParameter(const double c)
   {
     m_ConductanceParameter = c;
   }
@@ -206,7 +206,7 @@ public:
   }
 
   void
-  SetAverageGradientMagnitudeSquared(const double & c)
+  SetAverageGradientMagnitudeSquared(const double c)
   {
     m_AverageGradientMagnitudeSquared = c;
   }

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -224,7 +224,7 @@ public:
    * may be written to the cache file
    */
   static void
-  SetNewWisdomAvailable(const bool & v);
+  SetNewWisdomAvailable(const bool v);
   static bool
   GetNewWisdomAvailable();
 
@@ -260,7 +260,7 @@ public:
    * If true, will create a wisdom file in the location
    */
   static void
-  SetReadWisdomCache(const bool & v);
+  SetReadWisdomCache(const bool v);
   static bool
   GetReadWisdomCache();
 
@@ -272,7 +272,7 @@ public:
    * If true, will create a wisdom file in the location
    */
   static void
-  SetWriteWisdomCache(const bool & v);
+  SetWriteWisdomCache(const bool v);
   static bool
   GetWriteWisdomCache();
 

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -237,7 +237,7 @@ public:
    * FFTW_MEASURE, FFTW_PATIENT, FFTW_EXHAUSTIVE
    */
   static void
-  SetPlanRigor(const int & v);
+  SetPlanRigor(const int v);
 
   static int
   GetPlanRigor();
@@ -250,7 +250,7 @@ public:
 
   /** Translate plan rigor value to name. An exception is sent if the value is not valid. */
   static std::string
-  GetPlanRigorName(const int & value);
+  GetPlanRigorName(const int value);
 
   /**
    * \brief Set/Get the behavior of wisdom file caching

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -110,7 +110,7 @@ FFTWGlobalConfiguration::GetPlanRigorValue(const std::string & name)
 }
 
 std::string
-FFTWGlobalConfiguration::GetPlanRigorName(const int & value)
+FFTWGlobalConfiguration::GetPlanRigorName(const int value)
 {
   switch (value)
   {
@@ -758,7 +758,7 @@ FFTWGlobalConfiguration::GetNewWisdomAvailable()
 }
 
 void
-FFTWGlobalConfiguration::SetPlanRigor(const int & v)
+FFTWGlobalConfiguration::SetPlanRigor(const int v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   // use that method to check the value

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -744,7 +744,7 @@ FFTWGlobalConfiguration::GetLockMutex()
 }
 
 void
-FFTWGlobalConfiguration::SetNewWisdomAvailable(const bool & v)
+FFTWGlobalConfiguration::SetNewWisdomAvailable(const bool v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_NewWisdomAvailable = v;
@@ -781,7 +781,7 @@ FFTWGlobalConfiguration::SetPlanRigor(const std::string & name)
 }
 
 void
-FFTWGlobalConfiguration::SetReadWisdomCache(const bool & v)
+FFTWGlobalConfiguration::SetReadWisdomCache(const bool v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_ReadWisdomCache = v;
@@ -799,7 +799,7 @@ FFTWGlobalConfiguration::GetReadWisdomCache()
 }
 
 void
-FFTWGlobalConfiguration::SetWriteWisdomCache(const bool & v)
+FFTWGlobalConfiguration::SetWriteWisdomCache(const bool v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_WriteWisdomCache = v;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
@@ -109,7 +109,7 @@ public:
 
   /** Get one of the extended auxiliary variable image. */
   AuxImageType *
-  GetAuxiliaryImage(const unsigned int & idx);
+  GetAuxiliaryImage(const unsigned int idx);
 
   /** Set the container auxiliary values at the initial alive points. */
   itkSetObjectMacro(AuxiliaryAliveValues, AuxValueContainerType);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
@@ -54,7 +54,7 @@ FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>:
 template <typename TInput, typename TOutput, typename TAuxValue, unsigned int VAuxDimension>
 typename FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>::AuxImageType *
 FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>::GetAuxiliaryImage(
-  const unsigned int & idx)
+  const unsigned int idx)
 {
   if (idx >= AuxDimension || this->GetNumberOfIndexedOutputs() < idx + 2)
   {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.h
@@ -135,11 +135,11 @@ protected:
         const OutputVectorRealType & iF,
         const NodeType &             iId1,
         const OutputPointType &      iP1,
-        const bool &                 iIsFar1,
+        const bool                   iIsFar1,
         const OutputVectorRealType   iVal1,
         const NodeType &             iId2,
         const OutputPointType &      iP2,
-        const bool &                 iIsFar2,
+        const bool                   iIsFar2,
         const OutputVectorRealType & iVal2) const;
 
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -223,11 +223,11 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::Solve(OutputMeshType *     
                                                            const OutputVectorRealType & iF,
                                                            const NodeType &             iId1,
                                                            const OutputPointType &      iP1,
-                                                           const bool &                 iIsFar1,
+                                                           const bool                   iIsFar1,
                                                            const OutputVectorRealType   iVal1,
                                                            const NodeType &             iId2,
                                                            const OutputPointType &      iP2,
-                                                           const bool &                 iIsFar2,
+                                                           const bool                   iIsFar2,
                                                            const OutputVectorRealType & iVal2) const
 {
   OutputVectorType Edge1 = iP1 - iCurrentPoint;

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
@@ -86,7 +86,7 @@ public:
 
   /** Set/Get the conductance parameter.  The conductance parameter. */
   void
-  SetConductanceParameter(const double & c)
+  SetConductanceParameter(const double c)
   {
     m_ConductanceParameter = c;
   }
@@ -105,7 +105,7 @@ public:
   }
 
   void
-  SetAverageGradientMagnitudeSquared(const double & c)
+  SetAverageGradientMagnitudeSquared(const double c)
   {
     m_AverageGradientMagnitudeSquared = c;
   }

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -41,7 +41,7 @@ public:
   }
 
   double
-  Evaluate(const IndexType & index, const SizeType & size, const SizeType & clampSize, const float & padValue)
+  Evaluate(const IndexType & index, const SizeType & size, const SizeType & clampSize, const float padValue)
   {
     double accum = m_Offset;
     for (int j = 0; j < VDimension; ++j)

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
@@ -78,7 +78,7 @@ protected:
 
   // Clamp and round the input value to the output
   static OutputImagePixelType
-  ClampCast(const double & value);
+  ClampCast(const double value);
 
 private:
   uint32_t m_Seed{ 0 };

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -44,7 +44,7 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::SetSeed()
 
 template <class TInputImage, class TOutputImage>
 auto
-NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double & value) -> OutputImagePixelType
+NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double value) -> OutputImagePixelType
 {
   if (value >= static_cast<double>(NumericTraits<OutputImagePixelType>::max()))
   {

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -352,7 +352,7 @@ public:
   }
 
   void
-  SetPhysicalSize(const double & v)
+  SetPhysicalSize(const double v)
   {
     m_PhysicalSize = v;
   }
@@ -400,7 +400,7 @@ public:
   }
 
   void
-  SetPerimeterOnBorder(const double & v)
+  SetPerimeterOnBorder(const double v)
   {
     m_PerimeterOnBorder = v;
   }
@@ -412,7 +412,7 @@ public:
   }
 
   void
-  SetFeretDiameter(const double & v)
+  SetFeretDiameter(const double v)
   {
     m_FeretDiameter = v;
   }
@@ -448,7 +448,7 @@ public:
   }
 
   void
-  SetElongation(const double & v)
+  SetElongation(const double v)
   {
     m_Elongation = v;
   }
@@ -460,7 +460,7 @@ public:
   }
 
   void
-  SetPerimeter(const double & v)
+  SetPerimeter(const double v)
   {
     m_Perimeter = v;
   }
@@ -472,7 +472,7 @@ public:
   }
 
   void
-  SetRoundness(const double & v)
+  SetRoundness(const double v)
   {
     m_Roundness = v;
   }
@@ -484,7 +484,7 @@ public:
   }
 
   void
-  SetEquivalentSphericalRadius(const double & v)
+  SetEquivalentSphericalRadius(const double v)
   {
     m_EquivalentSphericalRadius = v;
   }
@@ -496,7 +496,7 @@ public:
   }
 
   void
-  SetEquivalentSphericalPerimeter(const double & v)
+  SetEquivalentSphericalPerimeter(const double v)
   {
     m_EquivalentSphericalPerimeter = v;
   }
@@ -520,7 +520,7 @@ public:
   }
 
   void
-  SetFlatness(const double & v)
+  SetFlatness(const double v)
   {
     m_Flatness = v;
   }
@@ -532,7 +532,7 @@ public:
   }
 
   void
-  SetPerimeterOnBorderRatio(const double & v)
+  SetPerimeterOnBorderRatio(const double v)
   {
     m_PerimeterOnBorderRatio = v;
   }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -288,7 +288,7 @@ public:
   }
 
   void
-  SetMinimum(const double & v)
+  SetMinimum(const double v)
   {
     m_Minimum = v;
   }
@@ -300,7 +300,7 @@ public:
   }
 
   void
-  SetMaximum(const double & v)
+  SetMaximum(const double v)
   {
     m_Maximum = v;
   }
@@ -312,7 +312,7 @@ public:
   }
 
   void
-  SetMean(const double & v)
+  SetMean(const double v)
   {
     m_Mean = v;
   }
@@ -324,7 +324,7 @@ public:
   }
 
   void
-  SetSum(const double & v)
+  SetSum(const double v)
   {
     m_Sum = v;
   }
@@ -336,7 +336,7 @@ public:
   }
 
   void
-  SetStandardDeviation(const double & v)
+  SetStandardDeviation(const double v)
   {
     m_StandardDeviation = v;
   }
@@ -348,7 +348,7 @@ public:
   }
 
   void
-  SetVariance(const double & v)
+  SetVariance(const double v)
   {
     m_Variance = v;
   }
@@ -360,7 +360,7 @@ public:
   }
 
   void
-  SetMedian(const double & v)
+  SetMedian(const double v)
   {
     m_Median = v;
   }
@@ -443,7 +443,7 @@ public:
   }
 
   void
-  SetSkewness(const double & v)
+  SetSkewness(const double v)
   {
     m_Skewness = v;
   }
@@ -455,7 +455,7 @@ public:
   }
 
   void
-  SetKurtosis(const double & v)
+  SetKurtosis(const double v)
   {
     m_Kurtosis = v;
   }
@@ -467,7 +467,7 @@ public:
   }
 
   void
-  SetWeightedElongation(const double & v)
+  SetWeightedElongation(const double v)
   {
     m_WeightedElongation = v;
   }
@@ -491,7 +491,7 @@ public:
   }
 
   void
-  SetWeightedFlatness(const double & v)
+  SetWeightedFlatness(const double v)
   {
     m_WeightedFlatness = v;
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -165,7 +165,7 @@ public:
 
   /// TODO to be implemented!!!
   PointType
-  ComputeOptimalLocation(const unsigned int &)
+  ComputeOptimalLocation(const unsigned int)
   {}
 
   void

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
@@ -103,7 +103,7 @@ public:
 
   /** Returns a Row. Input to the method is a row index. */
   NumericVectorType
-  GetRow(const unsigned int &) const;
+  GetRow(const unsigned int) const;
 
   /** Returns a Column. Input to the method is a column header string. */
   NumericVectorType
@@ -111,7 +111,7 @@ public:
 
   /** Get Column method. Input to the method is a column index. */
   NumericVectorType
-  GetColumn(const unsigned int &) const;
+  GetColumn(const unsigned int) const;
 
   /** Method to access a data field from the Array2D object. Inputs are row and
    *  column header strings in that order. */
@@ -121,17 +121,17 @@ public:
   /** Method to access a data field from the Array2D object. Inputs are row and
    *  column indices in that order. */
   TData
-  GetData(const unsigned int &, const unsigned int &) const;
+  GetData(const unsigned int, const unsigned int) const;
 
   /** Method to access a data field from a particular column. Inputs are the
    *  column header string and the row index. */
   TData
-  GetColumnData(const std::string &, const unsigned int &) const;
+  GetColumnData(const std::string &, const unsigned int) const;
 
   /** Method to access a data field from a particular row. Inputs are the row
    *  header string and the column index. */
   TData
-  GetRowData(const std::string &, const unsigned int &) const;
+  GetRowData(const std::string &, const unsigned int) const;
 
   /** Method to access a data field from the Array2D object using the ()
    *  operator.Inputs are the row and column header strings in that order. */
@@ -141,7 +141,7 @@ public:
   /** Method to access a data field from the Array2D object using the ()
    *  operator. Inputs are the row and column indices in that order. */
   TData
-  operator()(const unsigned int &, const unsigned int &) const;
+  operator()(const unsigned int, const unsigned int) const;
 
   /** Method to set the size of the Array2D object. */
   void

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -79,7 +79,7 @@ CSVArray2DDataObject<TData>::GetColumnIndexByName(const std::string & column_nam
 
 template <typename TData>
 auto
-CSVArray2DDataObject<TData>::GetRow(const unsigned int & row_index) const -> NumericVectorType
+CSVArray2DDataObject<TData>::GetRow(const unsigned int row_index) const -> NumericVectorType
 {
   NumericVectorType row;
   unsigned int      max_rows = this->m_Matrix.rows() - 1;
@@ -107,7 +107,7 @@ CSVArray2DDataObject<TData>::GetRow(const std::string & row_name) const -> Numer
 
 template <typename TData>
 auto
-CSVArray2DDataObject<TData>::GetColumn(const unsigned int & column_index) const -> NumericVectorType
+CSVArray2DDataObject<TData>::GetColumn(const unsigned int column_index) const -> NumericVectorType
 {
   NumericVectorType column;
   unsigned int      max_columns = this->m_Matrix.columns() - 1;
@@ -136,7 +136,7 @@ CSVArray2DDataObject<TData>::GetColumn(const std::string & column_name) const ->
 
 template <typename TData>
 TData
-CSVArray2DDataObject<TData>::GetData(const unsigned int & row, const unsigned int & column) const
+CSVArray2DDataObject<TData>::GetData(const unsigned int row, const unsigned int column) const
 {
   if (row > this->m_Matrix.rows() - 1)
   {
@@ -161,7 +161,7 @@ CSVArray2DDataObject<TData>::GetData(const std::string & row_name, const std::st
 
 template <typename TData>
 TData
-CSVArray2DDataObject<TData>::GetRowData(const std::string & row_name, const unsigned int & column_index) const
+CSVArray2DDataObject<TData>::GetRowData(const std::string & row_name, const unsigned int column_index) const
 {
   unsigned int row_index = this->GetRowIndexByName(row_name);
   return this->GetData(row_index, column_index);
@@ -169,7 +169,7 @@ CSVArray2DDataObject<TData>::GetRowData(const std::string & row_name, const unsi
 
 template <typename TData>
 TData
-CSVArray2DDataObject<TData>::GetColumnData(const std::string & column_name, const unsigned int & row_index) const
+CSVArray2DDataObject<TData>::GetColumnData(const std::string & column_name, const unsigned int row_index) const
 {
   unsigned int column_index = this->GetColumnIndexByName(column_name);
   return this->GetData(row_index, column_index);
@@ -177,7 +177,7 @@ CSVArray2DDataObject<TData>::GetColumnData(const std::string & column_name, cons
 
 template <typename TData>
 TData
-CSVArray2DDataObject<TData>::operator()(const unsigned int & row_index, const unsigned int & column_index) const
+CSVArray2DDataObject<TData>::operator()(const unsigned int row_index, const unsigned int column_index) const
 {
   return this->GetData(row_index, column_index);
 }

--- a/Modules/IO/HDF5/include/itkHDF5ImageIO.h
+++ b/Modules/IO/HDF5/include/itkHDF5ImageIO.h
@@ -156,15 +156,15 @@ private:
   ReadString(const std::string & path);
 
   void
-  WriteScalar(const std::string & path, const bool & value);
+  WriteScalar(const std::string & path, const bool value);
   void
-  WriteScalar(const std::string & path, const long & value);
+  WriteScalar(const std::string & path, const long value);
   void
-  WriteScalar(const std::string & path, const unsigned long & value);
+  WriteScalar(const std::string & path, const unsigned long value);
   void
-  WriteScalar(const std::string & path, const long long & value);
+  WriteScalar(const std::string & path, const long long value);
   void
-  WriteScalar(const std::string & path, const unsigned long long & value);
+  WriteScalar(const std::string & path, const unsigned long long value);
 
   template <typename TScalar>
   void

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -284,7 +284,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const bool value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const long & value)
+HDF5ImageIO ::WriteScalar(const std::string & path, const long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -307,7 +307,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const long & value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long & value)
+HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -330,7 +330,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long & value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const long long & value)
+HDF5ImageIO ::WriteScalar(const std::string & path, const long long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -352,7 +352,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const long long & value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long long & value)
+HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -262,7 +262,7 @@ doesAttrExist(const H5::H5Object & object, const char * const name)
 } // namespace
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const bool & value)
+HDF5ImageIO ::WriteScalar(const std::string & path, const bool value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -115,7 +115,7 @@ Utf8StringToWString(const std::string & str)
 // Get a file descriptor from a filename (using utf8 to wstring
 // on windows if requested) without specifying any specific permissions
 inline int
-I18nOpen(const std::string & str, const int & flags)
+I18nOpen(const std::string & str, const int flags)
 {
 #if LOCAL_USE_WIN32_WOPEN
   // mingw has _wopen
@@ -130,7 +130,7 @@ I18nOpen(const std::string & str, const int & flags)
 // Get a file descriptor from a filename (using utf8 to wstring
 // on windows if requested)
 inline int
-I18nOpen(const std::string & str, const int & flags, const int & mode)
+I18nOpen(const std::string & str, const int flags, const int mode)
 {
 #if LOCAL_USE_WIN32_WOPEN
   // mingw has _wopen

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
@@ -337,7 +337,7 @@ public:
 
   /** Set function id.  */
   void
-  SetFunctionId(const unsigned int & iFid)
+  SetFunctionId(const unsigned int iFid)
   {
     this->m_FunctionId = iFid;
   }

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -128,7 +128,7 @@ public:
   using LevelSetDataPointerVectorIterator = typename LevelSetDataPointerVector::iterator;
 
   void
-  SetFunctionCount(const unsigned int & n)
+  SetFunctionCount(const unsigned int n)
   {
     this->m_FunctionCount = n;
     this->m_LevelSetDataPointerVector.resize(n, nullptr);
@@ -143,13 +143,13 @@ public:
   }
 
   void
-  SetNumberOfNeighbors(const unsigned int & n)
+  SetNumberOfNeighbors(const unsigned int n)
   {
     this->m_NumberOfNeighbors = n;
   }
 
   void
-  CreateHeavisideFunctionOfLevelSetImage(const unsigned int & j, const InputImageType * image)
+  CreateHeavisideFunctionOfLevelSetImage(const unsigned int j, const InputImageType * image)
   {
     m_LevelSetDataPointerVector[j]->CreateHeavisideFunctionOfLevelSetImage(image);
   }

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
@@ -125,7 +125,7 @@ public:
   shared data which contains information from the other level sets). Using the
   new H values, the previous c_i are updated. */
   void
-  UpdatePixel(const unsigned int &                idx,
+  UpdatePixel(const unsigned int                  idx,
               NeighborhoodIterator<TInputImage> & iterator,
               InputPixelType &                    newValue,
               bool &                              status);

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
@@ -68,7 +68,7 @@ filter */
 template <typename TInputImage, typename TFeatureImage, typename TSharedData>
 void
 ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::UpdatePixel(
-  const unsigned int &                idx,
+  const unsigned int                  idx,
   NeighborhoodIterator<TInputImage> & iterator,
   InputPixelType &                    newValue,
   bool &                              itkNotUsed(status))

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
@@ -161,7 +161,7 @@ public:
   this value (positive and negative distance to the zero level set).
   The user of the narrow band container should set up this value properly. */
   void
-  SetTotalRadius(const float & val)
+  SetTotalRadius(const float val)
   {
     m_TotalRadius = val;
   }
@@ -175,7 +175,7 @@ public:
   /** Set/Get the narrow band inner radius. The inner radius is the safe are
   where the level set can be computed.*/
   void
-  SetInnerRadius(const float & val)
+  SetInnerRadius(const float val)
   {
     m_InnerRadius = val;
   }

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -142,7 +142,7 @@ public:
   }
 
   void
-  InsertNarrowBandNode(const IndexType & index, const PixelType & value, const signed char & nodestate)
+  InsertNarrowBandNode(const IndexType & index, const PixelType & value, const signed char nodestate)
   {
     BandNodeType tmpnode;
 
@@ -158,7 +158,7 @@ public:
    * twice this value (positive and negative distance to the zero level
    * set). The default value is 3. */
   void
-  SetNarrowBandTotalRadius(const float & val)
+  SetNarrowBandTotalRadius(const float val)
   {
     if (m_NarrowBand->GetTotalRadius() != val)
     {
@@ -177,7 +177,7 @@ public:
   /** Set the narrow band inner radius. The inner radius is the safe
    * are where the level set can be computed. The default value is 1. */
   void
-  SetNarrowBandInnerRadius(const float & val)
+  SetNarrowBandInnerRadius(const float val)
   {
     if (m_NarrowBand->GetInnerRadius() != val)
     {

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -129,7 +129,7 @@ public:
   GetRegion() const;
 
   void
-  SetUseImageRegion(const bool & flag);
+  SetUseImageRegion(const bool flag);
 
   /** Method to get UseImageRegion flag */
   itkGetConstMacro(UseImageRegion, bool);

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -207,7 +207,7 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetRegion() const 
 
 template <typename TImage, typename TBoundaryCondition>
 void
-ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::SetUseImageRegion(const bool & flag)
+ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::SetUseImageRegion(const bool flag)
 {
   if (flag != m_UseImageRegion)
   {

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -136,7 +136,7 @@ public:
   /** returns the measurement element which is the 'n'-th element
    * in the 'd' dimension of the measurement vector */
   MeasurementType
-  GetMeasurement(const InstanceIdentifier & id, const unsigned int & dimension);
+  GetMeasurement(const InstanceIdentifier & id, const unsigned int dimension);
 
   /** returns the frequency of the instance which is identified by the 'id' */
   AbsoluteFrequencyType

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
@@ -108,7 +108,7 @@ MembershipSample<TSample>::GetMeasurementVector(const InstanceIdentifier & id) c
 
 template <typename TSample>
 inline typename MembershipSample<TSample>::MeasurementType
-MembershipSample<TSample>::GetMeasurement(const InstanceIdentifier & id, const unsigned int & dimension)
+MembershipSample<TSample>::GetMeasurement(const InstanceIdentifier & id, const unsigned int dimension)
 {
   return m_Sample->GetMeasurement(id, dimension);
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -141,7 +141,7 @@ public:
 
   /** Compute information from data object and/or allocate new level set image */
   void
-  CopyInformationAndAllocate(const Self * iOther, const bool & iAllocate)
+  CopyInformationAndAllocate(const Self * iOther, const bool iAllocate)
   {
     LevelSetContainerType              internalContainer = iOther->GetContainer();
     LevelSetContainerConstIteratorType it = internalContainer.begin();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
@@ -139,7 +139,7 @@ protected:
   /** Update separately the zero layer for points with positive/negative update values
    *  Move points to -1 or +1 layers */
   void
-  EvolveWithPhasedPropagation(LevelSetLayerType & ioList, LevelSetLayerType & ioUpdate, const bool & iContraction);
+  EvolveWithPhasedPropagation(LevelSetLayerType & ioList, LevelSetLayerType & ioUpdate, const bool iContraction);
 
   /** Make sure the layers are of single pixel thickness only. This method is related
     to the minimal interface function described in the original paper. */

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -253,7 +253,7 @@ template <unsigned int VDimension, typename TEquationContainer>
 void
 UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithPhasedPropagation(LevelSetLayerType & ioList,
                                                                                          LevelSetLayerType & ioUpdate,
-                                                                                         const bool & iContraction)
+                                                                                         const bool iContraction)
 {
   itkAssertInDebugAndIgnoreInReleaseMacro(ioList.size() == ioUpdate.size());
 


### PR DESCRIPTION
Removed the ampersand (`&`) from declarations of "in" (`const`) bool and numeric parameters.

Following C++ Core Guidelines, April 10, 2022, "For “in” parameters, pass cheaply-copied types by value and others by reference to `const`": https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const