### PR TITLE
STYLE: Call convenience member function, `ImageBase::SetRegions(region)`

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -82,9 +82,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterat
   m_TemporaryPointer = TTempImage::New();
   typename TTempImage::RegionType tempRegion = this->m_Image->GetBufferedRegion();
 
-  m_TemporaryPointer->SetLargestPossibleRegion(tempRegion);
-  m_TemporaryPointer->SetBufferedRegion(tempRegion);
-  m_TemporaryPointer->SetRequestedRegion(tempRegion);
+  m_TemporaryPointer->SetRegions(tempRegion);
   m_TemporaryPointer->Allocate(true); // initialize buffer to zero
 
   // Initialize the queue by adding the start index assuming one of

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -325,9 +325,7 @@ public:
     RegionType region;
     region.SetSize(size);
 
-    this->SetLargestPossibleRegion(region);
-    this->SetBufferedRegion(region);
-    this->SetRequestedRegion(region);
+    this->Self::SetRegions(region);
   }
 
   /** Get the offset table.  The offset table gives increments for

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -268,9 +268,7 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::GetImage() -> ImageTypePoin
   const typename ImageType::IndexType  imageIndex = { { 0, 0, 0 } };
   const typename ImageType::RegionType region(imageIndex, imageSize);
   auto                                 img = ImageType::New();
-  img->SetLargestPossibleRegion(region);
-  img->SetBufferedRegion(region);
-  img->SetRequestedRegion(region);
+  img->SetRegions(region);
   img->Allocate();
   typename ImageType::IndexType setIndex;
   for (unsigned int i = 0; i < m_TrueDims[0]; ++i)

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -92,9 +92,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   m_TempPtr = TTempImage::New();
   typename TTempImage::RegionType tempRegion = this->m_Image->GetBufferedRegion();
 
-  m_TempPtr->SetLargestPossibleRegion(tempRegion);
-  m_TempPtr->SetBufferedRegion(tempRegion);
-  m_TempPtr->SetRequestedRegion(tempRegion);
+  m_TempPtr->SetRegions(tempRegion);
   m_TempPtr->Allocate(true); // initialize buffer to zero
 
   // Initialize the queue by adding the start index assuming one of

--- a/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
@@ -190,14 +190,10 @@ itkAdaptorComparisonTest(int, char *[])
   auto scalar_image = ScalarImageType::New();
   auto vector_image = VectorImageType::New();
 
-  scalar_image->SetLargestPossibleRegion(region);
-  scalar_image->SetBufferedRegion(region);
-  scalar_image->SetRequestedRegion(region);
+  scalar_image->SetRegions(region);
   scalar_image->Allocate(true); // initialize buffer to zero
 
-  vector_image->SetLargestPossibleRegion(region);
-  vector_image->SetBufferedRegion(region);
-  vector_image->SetRequestedRegion(region);
+  vector_image->SetRegions(region);
   vector_image->Allocate();
 
   VectorImageType::PixelType initialVectorValue;

--- a/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
@@ -120,17 +120,9 @@ itkBoundaryConditionTest(int, char *[])
   auto image3D = ImageType3D::New();
   auto imageND = ImageTypeND::New();
 
-  image2D->SetLargestPossibleRegion(Region2D);
-  image3D->SetLargestPossibleRegion(Region3D);
-  imageND->SetLargestPossibleRegion(RegionND);
-
-  image2D->SetBufferedRegion(Region2D);
-  image3D->SetBufferedRegion(Region3D);
-  imageND->SetBufferedRegion(RegionND);
-
-  image2D->SetRequestedRegion(Region2D);
-  image3D->SetRequestedRegion(Region3D);
-  imageND->SetRequestedRegion(RegionND);
+  image2D->SetRegions(Region2D);
+  image3D->SetRegions(Region3D);
+  imageND->SetRegions(RegionND);
 
   image2D->Allocate();
   image3D->Allocate();

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -42,9 +42,7 @@ GetTestImage(int d1, int d2, int d3, int d4)
   RegionND.SetIndex(origND);
 
   auto imageND = TestImageType::New();
-  imageND->SetLargestPossibleRegion(RegionND);
-  imageND->SetBufferedRegion(RegionND);
-  imageND->SetRequestedRegion(RegionND);
+  imageND->SetRegions(RegionND);
   imageND->Allocate();
 
   FillImage<4>(imageND.GetPointer());

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -37,9 +37,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestGetTestImage(int d1, int d2, int d3
   RegionND.SetIndex(origND);
 
   auto imageND = TImage::New();
-  imageND->SetLargestPossibleRegion(RegionND);
-  imageND->SetBufferedRegion(RegionND);
-  imageND->SetRequestedRegion(RegionND);
+  imageND->SetRegions(RegionND);
 
   return imageND;
 }

--- a/Modules/Core/Common/test/itkFloodFillIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFillIteratorTest.cxx
@@ -56,12 +56,9 @@ itkFloodFillIteratorTest(int, char *[])
   TImageType::RegionType largestPossibleRegion;
   // Resize the region
   largestPossibleRegion.SetSize(sourceImageSizeObject);
-  // Set the largest legal region size (i.e. the size of the whole sourceImage) to what we just defined
-  sourceImage->SetLargestPossibleRegion(largestPossibleRegion);
-  // Set the buffered region
-  sourceImage->SetBufferedRegion(largestPossibleRegion);
-  // Set the requested region
-  sourceImage->SetRequestedRegion(largestPossibleRegion);
+  // Set the largest legal region size (i.e. the size of the whole sourceImage), the buffered, and
+  // the requested region to what we just defined.
+  sourceImage->SetRegions(largestPossibleRegion);
   // Now allocate memory for the sourceImage
   sourceImage->Allocate();
 

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
@@ -60,14 +60,9 @@ itkFloodFilledSpatialFunctionTest(int, char *[])
   // Resize the region
   largestPossibleRegion.SetSize(sourceImageSizeObject);
 
-  // Set the largest legal region size (i.e. the size of the whole sourceImage) to what we just defined
-  sourceImage->SetLargestPossibleRegion(largestPossibleRegion);
-
-  // Set the buffered region
-  sourceImage->SetBufferedRegion(largestPossibleRegion);
-
-  // Set the requested region
-  sourceImage->SetRequestedRegion(largestPossibleRegion);
+  // Set the largest legal region size (i.e. the size of the whole sourceImage), the buffered, and
+  // the requested region to what we just defined.
+  sourceImage->SetRegions(largestPossibleRegion);
 
   // Now allocate memory for the sourceImage
   sourceImage->Allocate();

--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -92,9 +92,7 @@ itkImageAdaptorPipeLineTest(int, char *[])
 
   auto myRGBPixelImage = myRGBPixelImageType::New();
 
-  myRGBPixelImage->SetLargestPossibleRegion(region);
-  myRGBPixelImage->SetBufferedRegion(region);
-  myRGBPixelImage->SetRequestedRegion(region);
+  myRGBPixelImage->SetRegions(region);
   myRGBPixelImage->Allocate();
   myRGBPixelImage->SetSpacing(spacing);
 
@@ -141,9 +139,7 @@ itkImageAdaptorPipeLineTest(int, char *[])
 
   auto myFloatImage = myFloatImageType::New();
 
-  myFloatImage->SetLargestPossibleRegion(region);
-  myFloatImage->SetBufferedRegion(region);
-  myFloatImage->SetRequestedRegion(region);
+  myFloatImage->SetRegions(region);
   myFloatImage->Allocate();
   myFloatImage->SetSpacing(spacing);
 

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -125,9 +125,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     index.Fill(0);                                           \
     region.SetSize(size);                                    \
     region.SetIndex(index);                                  \
-    myImage->SetLargestPossibleRegion(region);               \
-    myImage->SetBufferedRegion(region);                      \
-    myImage->SetRequestedRegion(region);                     \
+    myImage->SetRegions(region);                             \
     myImage->Allocate();                                     \
     collector.Start("ComputeIndexFast " #dim "D");           \
     unsigned int totalSize = 1;                              \
@@ -157,9 +155,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     index.Fill(0);                                       \
     region.SetSize(size);                                \
     region.SetIndex(index);                              \
-    myImage->SetLargestPossibleRegion(region);           \
-    myImage->SetBufferedRegion(region);                  \
-    myImage->SetRequestedRegion(region);                 \
+    myImage->SetRegions(region);                         \
     myImage->Allocate();                                 \
     collector.Start("ComputeIndex " #dim "D");           \
     unsigned int totalSize = 1;                          \
@@ -189,9 +185,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     index.Fill(0);                                                      \
     region.SetSize(size);                                               \
     region.SetIndex(index);                                             \
-    myImage->SetLargestPossibleRegion(region);                          \
-    myImage->SetBufferedRegion(region);                                 \
-    myImage->SetRequestedRegion(region);                                \
+    myImage->SetRegions(region);                                        \
     myImage->Allocate();                                                \
     collector.Start("ComputeOffsetFast " #dim "D");                     \
     unsigned int repeat = 1;                                            \
@@ -216,9 +210,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     index.Fill(0);                                                  \
     region.SetSize(size);                                           \
     region.SetIndex(index);                                         \
-    myImage->SetLargestPossibleRegion(region);                      \
-    myImage->SetBufferedRegion(region);                             \
-    myImage->SetRequestedRegion(region);                            \
+    myImage->SetRegions(region);                                    \
     myImage->Allocate();                                            \
     collector.Start("ComputeOffset " #dim "D");                     \
     unsigned int repeat = 1;                                        \

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -42,9 +42,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -48,9 +48,7 @@ itkImageLinearIteratorTest(int, char *[])
   region0.SetIndex(start0);
   region0.SetSize(size0);
 
-  myImage->SetLargestPossibleRegion(region0);
-  myImage->SetBufferedRegion(region0);
-  myImage->SetRequestedRegion(region0);
+  myImage->SetRegions(region0);
   myImage->Allocate();
 
   using IteratorType = itk::ImageLinearIteratorWithIndex<ImageType>;

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -50,9 +50,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
   region0.SetIndex(start0);
   region0.SetSize(size0);
 
-  myImage->SetLargestPossibleRegion(region0);
-  myImage->SetBufferedRegion(region0);
-  myImage->SetRequestedRegion(region0);
+  myImage->SetRegions(region0);
   myImage->Allocate();
 
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -50,9 +50,7 @@ itkImageRandomIteratorTest(int, char *[])
   region0.SetIndex(start0);
   region0.SetSize(size0);
 
-  myImage->SetLargestPossibleRegion(region0);
-  myImage->SetBufferedRegion(region0);
-  myImage->SetRequestedRegion(region0);
+  myImage->SetRegions(region0);
   myImage->Allocate();
 
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -52,9 +52,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   ImageType::RegionType region0;
   region0.SetIndex(start0);
   region0.SetSize(size0);
-  myImage->SetLargestPossibleRegion(region0);
-  myImage->SetBufferedRegion(region0);
-  myImage->SetRequestedRegion(region0);
+  myImage->SetRegions(region0);
   myImage->Allocate();
   // Make the priority image
   auto                        priorityImage = PriorityImageType::New();
@@ -67,9 +65,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   PriorityImageType::RegionType priorityRegion;
   priorityRegion.SetIndex(priorityStart);
   priorityRegion.SetSize(prioritySize);
-  priorityImage->SetLargestPossibleRegion(priorityRegion);
-  priorityImage->SetBufferedRegion(priorityRegion);
-  priorityImage->SetRequestedRegion(priorityRegion);
+  priorityImage->SetRegions(priorityRegion);
   priorityImage->Allocate();
   // we will make most of this image ones, with a small region of
   // zeros.  Then pixels from the zero region should be selected

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
@@ -44,9 +44,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest2(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
   auto myImage = ImageType::New();
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
   using WalkType = std::vector<ImageType::IndexType>;
   using WalkIteratorType = WalkType::iterator;

--- a/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -36,16 +36,12 @@ RunTest(const TRegion & region, const TRegion & exclusionRegion)
 
   auto myIndexImage = IndexImageType::New();
 
-  myIndexImage->SetLargestPossibleRegion(region);
-  myIndexImage->SetBufferedRegion(region);
-  myIndexImage->SetRequestedRegion(region);
+  myIndexImage->SetRegions(region);
   myIndexImage->Allocate();
 
   auto myValueImage = ValueImageType::New();
 
-  myValueImage->SetLargestPossibleRegion(region);
-  myValueImage->SetBufferedRegion(region);
-  myValueImage->SetRequestedRegion(region);
+  myValueImage->SetRegions(region);
   myValueImage->Allocate();
 
   using ValueIteratorType = itk::ImageRegionIteratorWithIndex<ValueImageType>;

--- a/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
@@ -47,9 +47,7 @@ itkImageSliceIteratorTest(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   using IteratorType = itk::ImageSliceIteratorWithIndex<ImageType>;

--- a/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
+++ b/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
@@ -40,9 +40,7 @@ itkMinimumMaximumImageCalculatorTest(int, char *[])
   auto                  image = ImageType::New();
   ImageType::RegionType region;
   region.SetSize(size);
-  image->SetLargestPossibleRegion(region);
-  image->SetRequestedRegion(region);
-  image->SetBufferedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   // Set origin and spacing of physical coordinates

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -46,9 +46,7 @@ itkOctreeTest(int, char *[])
   region.SetSize(imageSize);
   region.SetIndex(imageIndex);
   auto img = ImageType::New();
-  img->SetLargestPossibleRegion(region);
-  img->SetBufferedRegion(region);
-  img->SetRequestedRegion(region);
+  img->SetRegions(region);
   img->Allocate();
   srand(static_cast<unsigned int>(time(nullptr)));
   itk::ImageRegionIterator<ImageType> ri(img, region);

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -171,9 +171,7 @@ itkSliceIteratorTest(int, char *[])
     idx[0] = idx[1] = 0;
 
     itk::Image<int, 2>::Pointer ip = itk::Image<int, 2>::New();
-    ip->SetRequestedRegion(reg);
-    ip->SetBufferedRegion(reg);
-    ip->SetLargestPossibleRegion(reg);
+    ip->SetRegions(reg);
     ip->Allocate();
 
     FillRegionSequential<int, 2>(ip);

--- a/Modules/Core/Common/test/itkSparseImageTest.cxx
+++ b/Modules/Core/Common/test/itkSparseImageTest.cxx
@@ -53,9 +53,7 @@ itkSparseImageTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im->SetLargestPossibleRegion(r);
-  im->SetBufferedRegion(r);
-  im->SetRequestedRegion(r);
+  im->SetRegions(r);
   im->Allocate();
 
   ImageType::IndexType index;

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
@@ -72,9 +72,7 @@ itkImageAdaptorTest(int, char *[])
   auto myImage = myImageType::New();
 
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   myIteratorType it1(myImage, myImage->GetRequestedRegion());

--- a/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
@@ -69,9 +69,7 @@ itkNthElementPixelAccessorTest(int, char *[])
 
   auto myImage = myImageType::New();
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   myIteratorType it1(myImage, myImage->GetRequestedRegion());

--- a/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
@@ -71,9 +71,7 @@ itkRGBToVectorImageAdaptorTest(int, char *[])
   auto image = ImageType::New();
 
 
-  image->SetLargestPossibleRegion(region);
-  image->SetBufferedRegion(region);
-  image->SetRequestedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   IteratorType it1(image, image->GetRequestedRegion());

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -158,12 +158,10 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
 
     const typename OutputImageType::RegionType region(m_Index, m_Size);
 
-    OutputImage->SetLargestPossibleRegion(region); //
-    OutputImage->SetBufferedRegion(region);        // set the region
-    OutputImage->SetRequestedRegion(region);       //
-    OutputImage->SetSpacing(m_Spacing);            // set spacing
-    OutputImage->SetOrigin(m_Origin);              //   and origin
-    OutputImage->SetDirection(m_Direction);        // direction cosines
+    OutputImage->SetRegions(region);        // set the region
+    OutputImage->SetSpacing(m_Spacing);     // set spacing
+    OutputImage->SetOrigin(m_Origin);       //   and origin
+    OutputImage->SetDirection(m_Direction); // direction cosines
   }
   else
   {

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -74,17 +74,9 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(start);
 
-  imageX->SetLargestPossibleRegion(region);
-  imageY->SetLargestPossibleRegion(region);
-  imageZ->SetLargestPossibleRegion(region);
-
-  imageX->SetBufferedRegion(region);
-  imageY->SetBufferedRegion(region);
-  imageZ->SetBufferedRegion(region);
-
-  imageX->SetRequestedRegion(region);
-  imageY->SetRequestedRegion(region);
-  imageZ->SetRequestedRegion(region);
+  imageX->SetRegions(region);
+  imageY->SetRegions(region);
+  imageZ->SetRegions(region);
 
   imageX->Allocate();
   imageY->Allocate();

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -92,9 +92,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
   region3D.SetIndex(index3D);
 
   auto inputImage = ImageType::New();
-  inputImage->SetLargestPossibleRegion(region3D);
-  inputImage->SetBufferedRegion(region3D);
-  inputImage->SetRequestedRegion(region3D);
+  inputImage->SetRegions(region3D);
   inputImage->SetOrigin(origin);
   inputImage->SetSpacing(spacing);
   inputImage->Allocate();

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -66,9 +66,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::AllocateImage(con
   }
 
   const RegionType region(size);
-  rval->SetLargestPossibleRegion(region);
-  rval->SetBufferedRegion(region);
-  rval->SetRequestedRegion(region);
+  rval->SetRegions(region);
   rval->SetSpacing(spacing);
   rval->Allocate();
   return rval;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -313,11 +313,9 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
 
   region.SetIndex(m_Index);
 
-  OutputImage->SetLargestPossibleRegion(region); //
-  OutputImage->SetBufferedRegion(region);        // set the region
-  OutputImage->SetRequestedRegion(region);       //
-  OutputImage->SetSpacing(m_Spacing);            // set spacing
-  OutputImage->SetOrigin(m_Origin);              //   and origin
+  OutputImage->SetRegions(region);    // set the region
+  OutputImage->SetSpacing(m_Spacing); // set spacing
+  OutputImage->SetOrigin(m_Origin);   //   and origin
   OutputImage->SetDirection(m_Direction);
   OutputImage->Allocate(); // allocate the image
 

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -54,9 +54,7 @@ itkImageSpatialObjectTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   image->SetOrigin(origin);
-  image->SetLargestPossibleRegion(region);
-  image->SetBufferedRegion(region);
-  image->SetRequestedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   Iterator it(image, region);

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
@@ -59,9 +59,7 @@ itkTensorFractionalAnisotropyImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
@@ -59,9 +59,7 @@ itkTensorRelativeAnisotropyImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
@@ -64,9 +64,7 @@ itkExponentialDisplacementFieldImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
@@ -45,9 +45,7 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
   region2D.SetIndex(index2D);
 
   auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetLargestPossibleRegion(region2D);
-  inputImage2D->SetBufferedRegion(region2D);
-  inputImage2D->SetRequestedRegion(region2D);
+  inputImage2D->SetRegions(region2D);
   inputImage2D->Allocate(true);
 
   // Set pixel (4,4) with the value 1

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -76,9 +76,7 @@ FastChamferDistanceImageFilterTest(unsigned int iPositive, unsigned int iNegativ
   region.SetIndex(index);
 
   auto inputImage = ImageType::New();
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
@@ -44,16 +44,12 @@ itkReflectiveImageRegionIteratorTest(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   auto visitImage = ImageVisitsType::New();
 
-  visitImage->SetLargestPossibleRegion(region);
-  visitImage->SetRequestedRegion(region);
-  visitImage->SetBufferedRegion(region);
+  visitImage->SetRegions(region);
   visitImage->Allocate();
 
   IteratorType       nit(myImage, region);

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -63,9 +63,7 @@ test(int testIdx)
   region2D.SetIndex(index2D);
 
   auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetLargestPossibleRegion(region2D);
-  inputImage2D->SetBufferedRegion(region2D);
-  inputImage2D->SetRequestedRegion(region2D);
+  inputImage2D->SetRegions(region2D);
   inputImage2D->Allocate(true);
 
   if (!testIdx)

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
@@ -42,9 +42,7 @@ itkSignedDanielssonDistanceMapImageFilterTest11(int, char *[])
   region2D.SetIndex(index2D);
 
   auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetLargestPossibleRegion(region2D);
-  inputImage2D->SetBufferedRegion(region2D);
-  inputImage2D->SetRequestedRegion(region2D);
+  inputImage2D->SetRegions(region2D);
   inputImage2D->Allocate(true);
 
   /* Set pixel (4,4) with the value 1

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
@@ -42,9 +42,7 @@ itkSignedMaurerDistanceMapImageFilterTest11(int, char *[])
   region2D.SetIndex(index2D);
 
   auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetLargestPossibleRegion(region2D);
-  inputImage2D->SetBufferedRegion(region2D);
-  inputImage2D->SetRequestedRegion(region2D);
+  inputImage2D->SetRegions(region2D);
   inputImage2D->Allocate(true);
 
   /* Set pixel (4,4) with the value 1

--- a/Modules/Filtering/FFT/test/itkFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkFFTTest.h
@@ -65,9 +65,7 @@ test_fft(unsigned int * SizeOfDimensions)
 
   auto realImage = RealImageType::New();
   // Create the Real Image.
-  realImage->SetLargestPossibleRegion(region);
-  realImage->SetBufferedRegion(region);
-  realImage->SetRequestedRegion(region);
+  realImage->SetRegions(region);
   realImage->Allocate();
 
   // Set up spacing and origin to test passing of metadata
@@ -302,9 +300,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
   auto realImage = RealImageType::New();
 
   // Create the Real Image.
-  realImage->SetLargestPossibleRegion(region);
-  realImage->SetBufferedRegion(region);
-  realImage->SetRequestedRegion(region);
+  realImage->SetRegions(region);
   realImage->Allocate();
   vnl_sample_reseed(static_cast<int>(itksys::SystemTools::GetTime() / 10000.0));
 

--- a/Modules/Filtering/FFT/test/itkRealFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkRealFFTTest.h
@@ -66,9 +66,7 @@ test_fft(unsigned int * SizeOfDimensions)
 
   // Create the Real Image.
   auto realImage = RealImageType::New();
-  realImage->SetLargestPossibleRegion(region);
-  realImage->SetBufferedRegion(region);
-  realImage->SetRequestedRegion(region);
+  realImage->SetRegions(region);
   realImage->Allocate();
   vnl_sample_reseed(123456);
 
@@ -253,9 +251,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
   auto realImage = RealImageType::New();
 
   // Create the Real Image.
-  realImage->SetLargestPossibleRegion(region);
-  realImage->SetBufferedRegion(region);
-  realImage->SetRequestedRegion(region);
+  realImage->SetRegions(region);
   realImage->Allocate();
   vnl_sample_reseed(static_cast<int>(itksys::SystemTools::GetTime() / 10000.0));
 

--- a/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
@@ -72,15 +72,11 @@ itkAbsoluteValueDifferenceImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
@@ -77,15 +77,11 @@ itkCheckerBoardImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
@@ -72,15 +72,11 @@ itkConstrainedValueDifferenceImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types for each image

--- a/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
@@ -72,15 +72,11 @@ itkSquaredDifferenceImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -61,21 +61,15 @@ itkJoinImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize Image C
-  inputImageC->SetLargestPossibleRegion(region);
-  inputImageC->SetBufferedRegion(region);
-  inputImageC->SetRequestedRegion(region);
+  inputImageC->SetRegions(region);
   inputImageC->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
@@ -69,19 +69,13 @@ itkGradientVectorFlowImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
-  interImage->SetLargestPossibleRegion(region);
-  interImage->SetBufferedRegion(region);
-  interImage->SetRequestedRegion(region);
+  interImage->SetRegions(region);
   interImage->Allocate();
 
-  inter1Image->SetLargestPossibleRegion(region);
-  inter1Image->SetBufferedRegion(region);
-  inter1Image->SetRequestedRegion(region);
+  inter1Image->SetRegions(region);
   inter1Image->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -65,9 +65,7 @@ itkHessian3DToVesselnessMeasureImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -59,9 +59,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
   inputImage->SetOrigin(origin);
   inputImage->SetSpacing(spacing);
 
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
@@ -62,9 +62,7 @@ itkHessianRecursiveGaussianFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
@@ -57,9 +57,7 @@ itkUnsharpMaskImageFilterTestSimple(int, char *[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare an Iterator type for the input image

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -146,9 +146,7 @@ NullImageToImageFilterDriver<TInputImage, TOutputImage>::Execute()
   const typename TOutputImage::RegionType region(index, m_ImageSize);
 
   // Allocate the input
-  ip->SetLargestPossibleRegion(region);
-  ip->SetBufferedRegion(region);
-  ip->SetRequestedRegion(region);
+  ip->SetRegions(region);
   ip->Allocate();
 
   // Construct a pixel to fill the image

--- a/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
@@ -65,12 +65,9 @@ itkDifferenceOfGaussiansGradientTest(int, char *[])
   TImageType::RegionType largestPossibleRegion;
   // Resize the region
   largestPossibleRegion.SetSize(sourceImageSizeObject);
-  // Set the largest legal region size (i.e. the size of the whole sourceImage) to what we just defined
-  sourceImage->SetLargestPossibleRegion(largestPossibleRegion);
-  // Set the buffered region
-  sourceImage->SetBufferedRegion(largestPossibleRegion);
-  // Set the requested region
-  sourceImage->SetRequestedRegion(largestPossibleRegion);
+  // Set the largest legal region size (i.e. the size of the whole sourceImage), the buffered, and
+  // the requested region to what we just defined.
+  sourceImage->SetRegions(largestPossibleRegion);
   // Now allocate memory for the sourceImage
   sourceImage->Allocate();
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -67,9 +67,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -64,9 +64,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
@@ -57,9 +57,7 @@ itkGradientRecursiveGaussianFilterTest2(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -72,9 +72,7 @@ itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   my
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(myComponents);
   inputImage->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -32,9 +32,7 @@ CreateRandomImage()
   region.SetSize(imageSize);
   region.SetIndex(imageIndex);
   auto img = ImageType::New();
-  img->SetLargestPossibleRegion(region);
-  img->SetBufferedRegion(region);
-  img->SetRequestedRegion(region);
+  img->SetRegions(region);
   img->Allocate();
   itk::ImageRegionIterator<ImageType> ri(img, region);
   while (!ri.IsAtEnd())

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -55,9 +55,7 @@ CreateAxialImage()
   region.SetSize(imageSize);
   region.SetIndex(imageIndex);
   auto img = ImageType::New();
-  img->SetLargestPossibleRegion(region);
-  img->SetBufferedRegion(region);
-  img->SetRequestedRegion(region);
+  img->SetRegions(region);
   img->Allocate();
 
   std::string row, column, slice, label;
@@ -109,9 +107,7 @@ CreateCoronalImage()
   region.SetSize(imageSize);
   region.SetIndex(imageIndex);
   auto img = ImageType::New();
-  img->SetLargestPossibleRegion(region);
-  img->SetBufferedRegion(region);
-  img->SetRequestedRegion(region);
+  img->SetRegions(region);
   img->Allocate();
 
   ImageType::DirectionType imageDirection;

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
@@ -74,9 +74,7 @@ itkOrientedImageAdaptorTest(int, char *[])
   auto myImage = myImageType::New();
 
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   myIteratorType it1(myImage, myImage->GetRequestedRegion());

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -327,9 +327,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   itkDebugMacro(<< "Projection image start index:" << projectionStart);
   itkDebugMacro(<< "Projection image origin:" << origin);
 
-  projectionImagePtr->SetRequestedRegion(projectionRegion);
-  projectionImagePtr->SetBufferedRegion(projectionRegion);
-  projectionImagePtr->SetLargestPossibleRegion(projectionRegion);
+  projectionImagePtr->SetRegions(projectionRegion);
   projectionImagePtr->Allocate(true); // initialize buffer to zero
 
   using ProjectionImageIteratorType = ImageRegionIterator<ProjectionImageType>;

--- a/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -74,9 +74,7 @@ itkAdaptImageFilterTest2(int, char *[])
   auto myImage = myVectorImageType::New();
 
 
-  myImage->SetLargestPossibleRegion(region);
-  myImage->SetBufferedRegion(region);
-  myImage->SetRequestedRegion(region);
+  myImage->SetRegions(region);
   myImage->Allocate();
 
   myVectorIteratorType it1(myImage, myImage->GetRequestedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
@@ -61,9 +61,7 @@ itkAddImageAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare Iterator type apropriated for this image

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -70,15 +70,11 @@ itkAddImageFilterFrameTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
@@ -70,15 +70,11 @@ itkAddImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize the content of Image A

--- a/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
@@ -70,15 +70,11 @@ itkAndImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
@@ -69,9 +69,7 @@ itkAsinImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
@@ -69,9 +69,7 @@ itkAtanImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
@@ -66,15 +66,11 @@ itkBinaryMagnitudeImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare appropriate Iterator types for each image

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkComplexToImaginaryFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkComplexToModulusFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkComplexToPhaseFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkComplexToRealFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
@@ -72,15 +72,11 @@ itkConstrainedValueAdditionImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
@@ -69,9 +69,7 @@ itkCosImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
@@ -69,15 +69,11 @@ itkDivideImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize the content of Image A

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
@@ -70,16 +70,12 @@ itkDivideImageFilterTest2(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->SetNumberOfComponentsPerPixel(4);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize the content of Image A

--- a/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
@@ -65,9 +65,7 @@ itkEdgePotentialImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image.

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -114,15 +114,11 @@ itkEqualTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
@@ -64,9 +64,7 @@ itkExpImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
@@ -64,9 +64,7 @@ itkExpNegativeImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -75,15 +75,11 @@ itkGreaterEqualTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -74,15 +74,11 @@ itkGreaterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -96,9 +96,7 @@ itkImageAdaptorNthElementTest(int, char *[])
 
   auto myContainerPixelImage = myContainerPixelImageType::New();
 
-  myContainerPixelImage->SetLargestPossibleRegion(region);
-  myContainerPixelImage->SetBufferedRegion(region);
-  myContainerPixelImage->SetRequestedRegion(region);
+  myContainerPixelImage->SetRegions(region);
   myContainerPixelImage->Allocate();
   myContainerPixelImage->SetSpacing(spacing);
 
@@ -145,9 +143,7 @@ itkImageAdaptorNthElementTest(int, char *[])
 
   auto myFloatImage = myFloatImageType::New();
 
-  myFloatImage->SetLargestPossibleRegion(region);
-  myFloatImage->SetBufferedRegion(region);
-  myFloatImage->SetRequestedRegion(region);
+  myFloatImage->SetRegions(region);
   myFloatImage->Allocate();
   myFloatImage->SetSpacing(spacing);
 

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -75,15 +75,11 @@ itkLessEqualTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -75,15 +75,11 @@ itkLessTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
@@ -67,9 +67,7 @@ itkLog10ImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkLogImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -62,15 +62,11 @@ itkMaskImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 
@@ -154,9 +150,7 @@ itkMaskImageFilterTest(int, char *[])
   using myVectorImageType = itk::VectorImage<float, myDimension>;
 
   auto inputVectorImage = myVectorImageType::New();
-  inputVectorImage->SetLargestPossibleRegion(region);
-  inputVectorImage->SetBufferedRegion(region);
-  inputVectorImage->SetRequestedRegion(region);
+  inputVectorImage->SetRegions(region);
   inputVectorImage->SetNumberOfComponentsPerPixel(3);
   inputVectorImage->Allocate();
 
@@ -215,9 +209,7 @@ itkMaskImageFilterTest(int, char *[])
 
   // Add components to image
   inputVectorImage->Initialize();
-  inputVectorImage->SetLargestPossibleRegion(region);
-  inputVectorImage->SetBufferedRegion(region);
-  inputVectorImage->SetRequestedRegion(region);
+  inputVectorImage->SetRegions(region);
   inputVectorImage->SetNumberOfComponentsPerPixel(5);
   inputVectorImage->Allocate();
 

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -61,15 +61,11 @@ itkMaskNegatedImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize the image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Initialize the mask
-  inputMask->SetLargestPossibleRegion(region);
-  inputMask->SetBufferedRegion(region);
-  inputMask->SetRequestedRegion(region);
+  inputMask->SetRegions(region);
   inputMask->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
@@ -65,15 +65,11 @@ itkMaximumImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Define the pixel values for each image

--- a/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
@@ -65,15 +65,11 @@ itkMinimumImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Define the pixel values for each image

--- a/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
@@ -69,15 +69,11 @@ itkMultiplyImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize the content of Image A

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -42,9 +42,7 @@ InitializeImage(ImageType * image, const typename ImageType::PixelType & value)
   region.SetIndex(start);
   region.SetSize(size);
 
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   inputImage->FillBuffer(value);

--- a/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
@@ -71,9 +71,7 @@ InitializeImage(InputImageType * image, double value)
   region.SetIndex(start);
   region.SetSize(size);
 
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   InImageIteratorType it(inputImage, inputImage->GetRequestedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -75,15 +75,11 @@ itkNotEqualTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
@@ -65,9 +65,7 @@ itkNotImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Declare appropriate Iterator types for each image

--- a/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
@@ -74,9 +74,7 @@ itkNthElementPixelAccessorTest2(int, char *[])
 
   auto vectorImage = VectorImageType::New();
 
-  vectorImage->SetLargestPossibleRegion(region);
-  vectorImage->SetBufferedRegion(region);
-  vectorImage->SetRequestedRegion(region);
+  vectorImage->SetRegions(region);
   vectorImage->SetNumberOfComponentsPerPixel(VectorLength);
   vectorImage->Allocate();
   PixelType pixel;

--- a/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
@@ -74,15 +74,11 @@ itkOrImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare appropriate Iterator types for each image

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
@@ -72,9 +72,7 @@ itkRGBToLuminanceImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
@@ -67,9 +67,7 @@ itkSigmoidImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the input image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
@@ -69,9 +69,7 @@ itkSinImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
@@ -69,9 +69,7 @@ itkSqrtImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the input image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
@@ -66,9 +66,7 @@ itkSquareImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   // Create one iterator for the Input Image (this is a light object)
   InputIteratorType it(inputImage, inputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
@@ -70,15 +70,11 @@ itkSubtractImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize the content of Image A

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -78,9 +78,7 @@ public:
     region.SetSize(size);
 
     // Initialize the input image
-    inputImage->SetLargestPossibleRegion(region);
-    inputImage->SetBufferedRegion(region);
-    inputImage->SetRequestedRegion(region);
+    inputImage->SetRegions(region);
     inputImage->Allocate();
 
     // Declare Iterator type for the input image
@@ -212,9 +210,7 @@ public:
     region.SetSize(size);
 
     // Initialize the input image
-    inputImage->SetLargestPossibleRegion(region);
-    inputImage->SetBufferedRegion(region);
-    inputImage->SetRequestedRegion(region);
+    inputImage->SetRegions(region);
     inputImage->Allocate();
 
     // Declare Iterator type for the input image

--- a/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
@@ -68,9 +68,7 @@ itkTanImageFilterAndAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // Create one iterator for the input image (this is a light object)

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
@@ -72,21 +72,15 @@ itkTernaryMagnitudeImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize Image C
-  inputImageC->SetLargestPossibleRegion(region);
-  inputImageC->SetBufferedRegion(region);
-  inputImageC->SetRequestedRegion(region);
+  inputImageC->SetRegions(region);
   inputImageC->Allocate();
 
   // Declare Iterator types for each image

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
@@ -66,21 +66,15 @@ itkTernaryMagnitudeSquaredImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Initialize Image C
-  inputImageC->SetLargestPossibleRegion(region);
-  inputImageC->SetBufferedRegion(region);
-  inputImageC->SetRequestedRegion(region);
+  inputImageC->SetRegions(region);
   inputImageC->Allocate();
 
   // Declare appropriate Iterator types for each image

--- a/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
@@ -71,9 +71,7 @@ itkVectorToRGBImageAdaptorTest(int, char *[])
   auto image = ImageType::New();
 
 
-  image->SetLargestPossibleRegion(region);
-  image->SetBufferedRegion(region);
-  image->SetRequestedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   IteratorType it1(image, image->GetRequestedRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -79,15 +79,11 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
@@ -72,15 +72,11 @@ itkXorImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   // Declare appropriate Iterator types for each image

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -91,9 +91,7 @@ itkImageMomentsTest(int argc, char * argv[])
 
   ImageType::RegionType region;
   region.SetSize(size);
-  image->SetLargestPossibleRegion(region);
-  image->SetBufferedRegion(region);
-  image->SetRequestedRegion(region);
+  image->SetRegions(region);
 
   /* Set origin and spacing of physical coordinates */
   image->SetOrigin(origin);

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
@@ -49,9 +49,7 @@ itkMinimumMaximumImageFilterTest(int argc, char * argv[])
   auto                  image = ImageType::New();
   ImageType::RegionType region;
   region.SetSize(size);
-  image->SetLargestPossibleRegion(region);
-  image->SetRequestedRegion(region);
-  image->SetBufferedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   // Set origin and spacing of physical coordinates

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -238,9 +238,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   }
   region.SetIndex({ { 0 } });
 
-  OutputImage->SetLargestPossibleRegion(region); //
-  OutputImage->SetBufferedRegion(region);        // set the region
-  OutputImage->SetRequestedRegion(region);       //
+  OutputImage->SetRegions(region); // set the region
 
   // If the spacing has been explicitly specified, the filter
   // will set the output spacing to that explicit spacing, otherwise the spacing

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -114,9 +114,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   typename TTempImage::RegionType tempRegion;
   tempRegion = inputPtr->GetRequestedRegion();
 
-  tempPtr->SetLargestPossibleRegion(tempRegion);
-  tempPtr->SetBufferedRegion(tempRegion);
-  tempPtr->SetRequestedRegion(tempRegion);
+  tempPtr->SetRegions(tempRegion);
   tempPtr->Allocate();
 
   // How big is the input image?

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
@@ -57,9 +57,7 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   auto inputImage = ImageType::New();
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   inputImage->FillBuffer(tensor0);
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
@@ -55,9 +55,7 @@ itkRecursiveGaussianImageFiltersOnVectorImageTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   auto inputImage = ImageType::New();
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(NumberOfComponents);
   inputImage->Allocate();
   inputImage->FillBuffer(vector0);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
@@ -66,9 +66,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     region.SetSize(size);
 
     // Initialize Image A
-    inputImage->SetLargestPossibleRegion(region);
-    inputImage->SetBufferedRegion(region);
-    inputImage->SetRequestedRegion(region);
+    inputImage->SetRegions(region);
     inputImage->Allocate();
 
     // Declare Iterator types apropriated for each image

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
@@ -64,9 +64,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(numberOfComponents);
   inputImage->Allocate();
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
@@ -61,9 +61,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(numberOfComponents);
   inputImage->Allocate();
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -59,9 +59,7 @@ itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(numberOfComponents);
   inputImage->Allocate();
 

--- a/Modules/Filtering/SpatialFunction/test/itkSpatialFunctionImageEvaluatorFilterTest.cxx
+++ b/Modules/Filtering/SpatialFunction/test/itkSpatialFunctionImageEvaluatorFilterTest.cxx
@@ -47,12 +47,9 @@ itkSpatialFunctionImageEvaluatorFilterTest(int, char *[])
   ImageType::RegionType largestPossibleRegion;
   // Resize the region
   largestPossibleRegion.SetSize(sourceImageSizeObject);
-  // Set the largest legal region size (i.e. the size of the whole sourceImage) to what we just defined
-  sourceImage->SetLargestPossibleRegion(largestPossibleRegion);
-  // Set the buffered region
-  sourceImage->SetBufferedRegion(largestPossibleRegion);
-  // Set the requested region
-  sourceImage->SetRequestedRegion(largestPossibleRegion);
+  // Set the largest legal region size (i.e. the size of the whole sourceImage), the buffered, and
+  // the requested region to what we just defined.
+  sourceImage->SetRegions(largestPossibleRegion);
   // Now allocate memory for the sourceImage
   sourceImage->Allocate();
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
@@ -44,9 +44,7 @@ itkOtsuThresholdCalculatorTest(int, char *[])
   SizeType size = { { 20, 20, 20 } };
 
   region.SetSize(size);
-  image->SetLargestPossibleRegion(region);
-  image->SetRequestedRegion(region);
-  image->SetBufferedRegion(region);
+  image->SetRegions(region);
   image->Allocate();
 
   // Set origin and spacing of physical coordinates

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -67,9 +67,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   ImageType::RegionType region;
   region.SetSize(size);
   region.SetIndex(index);
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
   inputImage->FillBuffer(vector0);
 

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -322,9 +322,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
   typename ImageType::RegionType region;
   region.SetSize(size);
   region.SetIndex(index);
-  im->SetLargestPossibleRegion(region);
-  im->SetBufferedRegion(region);
-  im->SetRequestedRegion(region);
+  im->SetRegions(region);
   im->SetSpacing(spacing);
   im->SetOrigin(origin);
   im->Allocate();
@@ -578,9 +576,7 @@ MINCReadWriteTestVector(const char * fileName,
   typename ImageType::RegionType region;
   region.SetSize(size);
   region.SetIndex(index);
-  im->SetLargestPossibleRegion(region);
-  im->SetBufferedRegion(region);
-  im->SetRequestedRegion(region);
+  im->SetRegions(region);
   im->SetSpacing(spacing);
   im->SetOrigin(origin);
   im->SetVectorLength(vector_length);

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -276,9 +276,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
   itk::Index<3> zeroIndex;
   zeroIndex.Fill(0);
   region.SetIndex(zeroIndex);
-  itkImage->SetLargestPossibleRegion(region);
-  itkImage->SetBufferedRegion(region);
-  itkImage->SetRequestedRegion(region);
+  itkImage->SetRegions(region);
   itkImage->SetSpacing(spacing);
   itkImage->Allocate();
 
@@ -302,9 +300,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
   ImageMaskPointer itkImageMask = itkImageMaskType::New();
 
-  itkImageMask->SetLargestPossibleRegion(region);
-  itkImageMask->SetBufferedRegion(region);
-  itkImageMask->SetRequestedRegion(region);
+  itkImageMask->SetRegions(region);
   itkImageMask->SetSpacing(spacing);
   itkImageMask->Allocate();
 

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -181,9 +181,7 @@ check_nonlinear_double(const char * nonlinear_transform)
   region.SetSize(imageSize3D);
   region.SetIndex(startIndex3D);
 
-  field->SetLargestPossibleRegion(region);
-  field->SetBufferedRegion(region);
-  field->SetRequestedRegion(region);
+  field->SetRegions(region);
 
   field->SetSpacing(spacing);
   field->SetOrigin(origin);
@@ -322,9 +320,7 @@ check_nonlinear_float(const char * nonlinear_transform)
   region.SetSize(imageSize3D);
   region.SetIndex(startIndex3D);
 
-  field->SetLargestPossibleRegion(region);
-  field->SetBufferedRegion(region);
-  field->SetRequestedRegion(region);
+  field->SetRegions(region);
 
   field->SetSpacing(spacing);
   field->SetOrigin(origin);
@@ -622,9 +618,7 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
     region.SetSize(imageSize3D);
     region.SetIndex(startIndex3D);
 
-    field->SetLargestPossibleRegion(region);
-    field->SetBufferedRegion(region);
-    field->SetRequestedRegion(region);
+    field->SetRegions(region);
 
     field->SetSpacing(spacing);
     field->SetOrigin(origin);

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -149,9 +149,7 @@ compare_nonlinear_double(const char * nonlinear_transform)
   region.SetSize(imageSize3D);
   region.SetIndex(startIndex3D);
 
-  field->SetLargestPossibleRegion(region);
-  field->SetBufferedRegion(region);
-  field->SetRequestedRegion(region);
+  field->SetRegions(region);
 
   field->SetSpacing(spacing);
   field->SetOrigin(origin);

--- a/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
@@ -59,15 +59,11 @@ itkFilterImageAddTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
 

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -76,9 +76,7 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputDisplacementField->SetLargestPossibleRegion(region);
-  inputDisplacementField->SetBufferedRegion(region);
-  inputDisplacementField->SetRequestedRegion(region);
+  inputDisplacementField->SetRegions(region);
   inputDisplacementField->Allocate();
 
   // Create one iterator for the input image (this is a light object)

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -71,9 +71,7 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   region.SetSize(size);
 
   // Initialize the input image
-  inputDisplacementField->SetLargestPossibleRegion(region);
-  inputDisplacementField->SetBufferedRegion(region);
-  inputDisplacementField->SetRequestedRegion(region);
+  inputDisplacementField->SetRegions(region);
   inputDisplacementField->Allocate();
 
   // Initialize the content of the input image

--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -66,9 +66,7 @@ itkWarpJacobianDeterminantFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputDisplacementField->SetLargestPossibleRegion(region);
-  inputDisplacementField->SetBufferedRegion(region);
-  inputDisplacementField->SetRequestedRegion(region);
+  inputDisplacementField->SetRegions(region);
   inputDisplacementField->Allocate();
 
   // Create one iterator for the Input Image (this is a light object)

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -67,9 +67,7 @@ class EigenAnalysis2DImageFilterTester
     region.SetIndex(start);
     region.SetSize(size);
 
-    inputImage->SetLargestPossibleRegion(region);
-    inputImage->SetBufferedRegion(region);
-    inputImage->SetRequestedRegion(region);
+    inputImage->SetRegions(region);
     inputImage->Allocate();
 
     myIteratorType it(inputImage, inputImage->GetRequestedRegion());

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -133,9 +133,7 @@ itkNarrowBandImageFilterBaseTest(int argc, char * argv[])
   region.SetIndex(index);
 
   auto inputImage = ImageType::New();
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   using Iterator = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -81,14 +81,10 @@ public:
   {
     const typename MovingImageType::RegionType region(size);
 
-    m_MovingImage->SetLargestPossibleRegion(region);
-    m_MovingImage->SetBufferedRegion(region);
-    m_MovingImage->SetRequestedRegion(region);
+    m_MovingImage->SetRegions(region);
     m_MovingImage->Allocate();
 
-    m_FixedImage->SetLargestPossibleRegion(region);
-    m_FixedImage->SetBufferedRegion(region);
-    m_FixedImage->SetRequestedRegion(region);
+    m_FixedImage->SetRegions(region);
     m_FixedImage->Allocate();
 
     /* Fill images with a 2D gaussian*/

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -146,14 +146,10 @@ itkImageRegistrationMethodTest_13(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -153,14 +153,10 @@ itkImageRegistrationMethodTest_14(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
   using MovingImageIterator = itk::ImageRegionIterator<MovingImageType>;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -129,14 +129,10 @@ itkImageRegistrationMethodTest_15(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -135,14 +135,10 @@ itkImageRegistrationMethodTest_17(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
 

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -59,27 +59,19 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
   region.SetIndex(index);
 
   auto imgMoving = MovingImageType::New();
-  imgMoving->SetLargestPossibleRegion(region);
-  imgMoving->SetBufferedRegion(region);
-  imgMoving->SetRequestedRegion(region);
+  imgMoving->SetRegions(region);
   imgMoving->Allocate();
 
   auto imgFixed = FixedImageType::New();
-  imgFixed->SetLargestPossibleRegion(region);
-  imgFixed->SetBufferedRegion(region);
-  imgFixed->SetRequestedRegion(region);
+  imgFixed->SetRegions(region);
   imgFixed->Allocate();
 
   auto imgTrainingMoving = MovingImageType::New();
-  imgTrainingMoving->SetLargestPossibleRegion(region);
-  imgTrainingMoving->SetBufferedRegion(region);
-  imgTrainingMoving->SetRequestedRegion(region);
+  imgTrainingMoving->SetRegions(region);
   imgTrainingMoving->Allocate();
 
   auto imgTrainingFixed = FixedImageType::New();
-  imgTrainingFixed->SetLargestPossibleRegion(region);
-  imgTrainingFixed->SetBufferedRegion(region);
-  imgTrainingFixed->SetRequestedRegion(region);
+  imgTrainingFixed->SetRegions(region);
   imgTrainingFixed->Allocate();
 
   // Fill images with a 2D gaussian

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -37,9 +37,7 @@ CreateTestImage()
   fIndex.Fill(0);
   fRegion.SetSize(fSize);
   fRegion.SetIndex(fIndex);
-  image->SetLargestPossibleRegion(fRegion);
-  image->SetBufferedRegion(fRegion);
-  image->SetRequestedRegion(fRegion);
+  image->SetRegions(fRegion);
   image->Allocate();
   return image;
 }

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -74,17 +74,13 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   imgOrigin[1] = 0.0;
 
   auto imgMoving = MovingImageType::New();
-  imgMoving->SetLargestPossibleRegion(region);
-  imgMoving->SetBufferedRegion(region);
-  imgMoving->SetRequestedRegion(region);
+  imgMoving->SetRegions(region);
   imgMoving->Allocate();
   imgMoving->SetSpacing(imgSpacing);
   imgMoving->SetOrigin(imgOrigin);
 
   auto imgFixed = FixedImageType::New();
-  imgFixed->SetLargestPossibleRegion(region);
-  imgFixed->SetBufferedRegion(region);
-  imgFixed->SetRequestedRegion(region);
+  imgFixed->SetRegions(region);
   imgFixed->Allocate();
   imgFixed->SetSpacing(imgSpacing);
   imgFixed->SetOrigin(imgOrigin);
@@ -481,17 +477,13 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   imgOrigin[1] = 0.0;
 
   auto imgMoving = MovingImageType::New();
-  imgMoving->SetLargestPossibleRegion(region);
-  imgMoving->SetBufferedRegion(region);
-  imgMoving->SetRequestedRegion(region);
+  imgMoving->SetRegions(region);
   imgMoving->Allocate();
   imgMoving->SetSpacing(imgSpacing);
   imgMoving->SetOrigin(imgOrigin);
 
   auto imgFixed = FixedImageType::New();
-  imgFixed->SetLargestPossibleRegion(region);
-  imgFixed->SetBufferedRegion(region);
-  imgFixed->SetRequestedRegion(region);
+  imgFixed->SetRegions(region);
   imgFixed->Allocate();
   imgFixed->SetSpacing(imgSpacing);
   imgFixed->SetOrigin(imgOrigin);

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -127,14 +127,10 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
 

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -125,14 +125,10 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  fixedImage->SetLargestPossibleRegion(region);
-  fixedImage->SetBufferedRegion(region);
-  fixedImage->SetRequestedRegion(region);
+  fixedImage->SetRegions(region);
   fixedImage->Allocate();
 
-  movingImage->SetLargestPossibleRegion(region);
-  movingImage->SetBufferedRegion(region);
-  movingImage->SetRequestedRegion(region);
+  movingImage->SetRegions(region);
   movingImage->Allocate();
 
 

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -151,9 +151,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   direction[2][0] = 1;
 
   auto imgTarget = InputImageType::New();
-  imgTarget->SetLargestPossibleRegion(region);
-  imgTarget->SetBufferedRegion(region);
-  imgTarget->SetRequestedRegion(region);
+  imgTarget->SetRegions(region);
   imgTarget->SetSpacing(spacing);
   imgTarget->SetDirection(direction);
   imgTarget->Allocate();

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -55,15 +55,11 @@ itkMutualInformationMetricTest(int, char *[])
   region.SetIndex(index);
 
   auto imgMoving = MovingImageType::New();
-  imgMoving->SetLargestPossibleRegion(region);
-  imgMoving->SetBufferedRegion(region);
-  imgMoving->SetRequestedRegion(region);
+  imgMoving->SetRegions(region);
   imgMoving->Allocate();
 
   auto imgFixed = FixedImageType::New();
-  imgFixed->SetLargestPossibleRegion(region);
-  imgFixed->SetBufferedRegion(region);
-  imgFixed->SetRequestedRegion(region);
+  imgFixed->SetRegions(region);
   imgFixed->Allocate();
 
   // Fill images with a 2D gaussian

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -105,9 +105,7 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   region.SetIndex(index);
 
   auto imgTarget = InputImageType::New();
-  imgTarget->SetLargestPossibleRegion(region);
-  imgTarget->SetBufferedRegion(region);
-  imgTarget->SetRequestedRegion(region);
+  imgTarget->SetRegions(region);
   imgTarget->Allocate();
 
   // Fill images with a 3D gaussian with some directional pattern

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -79,17 +79,13 @@ TestMattesMetricWithAffineTransform(TInterpolator * const interpolator, const bo
   imgOrigin[1] = -0.002;
 
   auto imgMoving = MovingImageType::New();
-  imgMoving->SetLargestPossibleRegion(region);
-  imgMoving->SetBufferedRegion(region);
-  imgMoving->SetRequestedRegion(region);
+  imgMoving->SetRegions(region);
   imgMoving->Allocate();
   imgMoving->SetSpacing(imgSpacing);
   imgMoving->SetOrigin(imgOrigin);
 
   auto imgFixed = FixedImageType::New();
-  imgFixed->SetLargestPossibleRegion(region);
-  imgFixed->SetBufferedRegion(region);
-  imgFixed->SetRequestedRegion(region);
+  imgFixed->SetRegions(region);
   imgFixed->Allocate();
   imgFixed->SetSpacing(imgSpacing);
   imgFixed->SetOrigin(imgOrigin);

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -48,9 +48,7 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   size = input->GetLargestPossibleRegion().GetSize();
   const RegionType region(size);
-  output->SetLargestPossibleRegion(region);
-  output->SetBufferedRegion(region);
-  output->SetRequestedRegion(region);
+  output->SetRegions(region);
   output->Allocate();
 
   ImageRegionConstIterator<TInputImage> it(input, input->GetRequestedRegion());

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -54,9 +54,7 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   region.SetSize(size);
   region.SetIndex(index);
 
-  inputimg->SetLargestPossibleRegion(region);
-  inputimg->SetBufferedRegion(region);
-  inputimg->SetRequestedRegion(region);
+  inputimg->SetRegions(region);
   inputimg->Allocate();
 
   int       row, col;

--- a/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
@@ -79,9 +79,7 @@ itkLabelVotingImageFilterTest(int, char *[])
   region.SetSize(size);
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   IteratorType it = IteratorType(inputImageA, inputImageA->GetBufferedRegion());
@@ -92,9 +90,7 @@ itkLabelVotingImageFilterTest(int, char *[])
   }
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   it = IteratorType(inputImageB, inputImageB->GetBufferedRegion());
@@ -104,9 +100,7 @@ itkLabelVotingImageFilterTest(int, char *[])
   }
 
   // Initialize Image C
-  inputImageC->SetLargestPossibleRegion(region);
-  inputImageC->SetBufferedRegion(region);
-  inputImageC->SetRequestedRegion(region);
+  inputImageC->SetRegions(region);
   inputImageC->Allocate();
 
   it = IteratorType(inputImageC, inputImageC->GetBufferedRegion());

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -80,9 +80,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   }
 
   // Initialize Image A
-  inputImageA->SetLargestPossibleRegion(region);
-  inputImageA->SetBufferedRegion(region);
-  inputImageA->SetRequestedRegion(region);
+  inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
   myIteratorType it = myIteratorType(inputImageA, inputImageA->GetBufferedRegion());
@@ -93,9 +91,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   }
 
   // Initialize Image B
-  inputImageB->SetLargestPossibleRegion(region);
-  inputImageB->SetBufferedRegion(region);
-  inputImageB->SetRequestedRegion(region);
+  inputImageB->SetRegions(region);
   inputImageB->Allocate();
 
   it = myIteratorType(inputImageB, inputImageB->GetBufferedRegion());
@@ -105,9 +101,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   }
 
   // Initialize Image C
-  inputImageC->SetLargestPossibleRegion(region);
-  inputImageC->SetBufferedRegion(region);
-  inputImageC->SetRequestedRegion(region);
+  inputImageC->SetRegions(region);
   inputImageC->Allocate();
 
   it = myIteratorType(inputImageC, inputImageC->GetBufferedRegion());

--- a/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -33,9 +33,7 @@ itkAnisotropicFourthOrderLevelSetImageFilterTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
   im_init->Allocate();
 
   IndexType index;

--- a/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
@@ -36,9 +36,7 @@ itkImplicitManifoldNormalVectorFilterTest(int, char *[])
   InputImageType::IndexType  idx = { { 0, 0 } };
   r.SetSize(sz);
   r.SetIndex(idx);
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
   im_init->Allocate();
 
   InputImageType::IndexType index;

--- a/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -33,9 +33,7 @@ itkIsotropicFourthOrderLevelSetImageFilterTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
   im_init->Allocate();
 
   IndexType index;

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -222,13 +222,9 @@ itkLevelSetFunctionTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
 
-  im_target->SetLargestPossibleRegion(r);
-  im_target->SetBufferedRegion(r);
-  im_target->SetRequestedRegion(r);
+  im_target->SetRegions(r);
 
   im_init->Allocate();
   im_target->Allocate();

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -251,17 +251,13 @@ itkParallelSparseFieldLevelSetImageFilterTest(int argc, char * argv[])
   direction.SetIdentity();
   direction(1, 1) = -1.0;
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
 
   im_init->SetOrigin(origin);
   im_init->SetSpacing(spacing);
   im_init->SetDirection(direction);
 
-  im_target->SetLargestPossibleRegion(r);
-  im_target->SetBufferedRegion(r);
-  im_target->SetRequestedRegion(r);
+  im_target->SetRegions(r);
 
   im_target->SetOrigin(origin);
   im_target->SetSpacing(spacing);

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -148,9 +148,7 @@ itkSparseFieldFourthOrderLevelSetImageFilterTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
   im_init->Allocate();
 
   SFFOLSIFT::evaluate_function(im_init, SFFOLSIFT::square);

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -73,9 +73,7 @@ itkUnsharpMaskLevelSetImageFilterTest(int, char *[])
   r.SetSize(sz);
   r.SetIndex(idx);
 
-  im_init->SetLargestPossibleRegion(r);
-  im_init->SetBufferedRegion(r);
-  im_init->SetRequestedRegion(r);
+  im_init->SetRegions(r);
   im_init->Allocate();
 
   evaluate_function(im_init, square);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -90,9 +90,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   const RegionType region(this->GetSize());
 
   m_WorkingImage = RGBHCVImage::New();
-  m_WorkingImage->SetLargestPossibleRegion(region);
-  m_WorkingImage->SetBufferedRegion(region);
-  m_WorkingImage->SetRequestedRegion(region);
+  m_WorkingImage->SetRegions(region);
   m_WorkingImage->Allocate();
 
   itk::ImageRegionIteratorWithIndex<RGBHCVImage>         wit(m_WorkingImage, region);

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
@@ -55,9 +55,7 @@ itkVoronoiSegmentationImageFilterTest(int argc, char * argv[])
   region.SetIndex(index);
 
   std::cout << "Allocating image" << std::endl;
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
 

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -64,9 +64,7 @@ SetUpInputImage()
   ImageType::SizeType   size = { { width, height } };
   ImageType::RegionType region;
   region.SetSize(size);
-  inputImage->SetLargestPossibleRegion(region);
-  inputImage->SetBufferedRegion(region);
-  inputImage->SetRequestedRegion(region);
+  inputImage->SetRegions(region);
   inputImage->Allocate();
 
   // add background random field
@@ -266,9 +264,7 @@ TestWithPrior(ImageType::Pointer inputImage)
   BinaryObjectImage::SizeType   size = { { width, height } };
   BinaryObjectImage::RegionType region;
   region.SetSize(size);
-  prior->SetLargestPossibleRegion(region);
-  prior->SetBufferedRegion(region);
-  prior->SetRequestedRegion(region);
+  prior->SetRegions(region);
   prior->Allocate();
 
   // create prior as 100% segmentation

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -262,9 +262,7 @@ CLANG_PRAGMA_POP
       reg_b.SetIndex(idx_b);
       reg_b.SetSize(sz_b);
 
-      boundary->GetFace(b_idx)->SetLargestPossibleRegion(reg_b);
-      boundary->GetFace(b_idx)->SetRequestedRegion(reg_b);
-      boundary->GetFace(b_idx)->SetBufferedRegion(reg_b);
+      boundary->GetFace(b_idx)->SetRegions(reg_b);
       boundary->GetFace(b_idx)->Allocate();
     }
   }

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
@@ -48,9 +48,7 @@ itkWatershedImageFilterTest(int, char *[])
   region.SetIndex(origin);
 
   auto image2D = ImageType2D::New();
-  image2D->SetLargestPossibleRegion(region);
-  image2D->SetBufferedRegion(region);
-  image2D->SetRequestedRegion(region);
+  image2D->SetRegions(region);
   image2D->Allocate();
 
   auto longimage2D = LongImageType2D::New();


### PR DESCRIPTION
STYLE: Call convenience member function, `ImageBase::SetRegions(region)`

Instead of doing something like:

    image->SetLargestPossibleRegion(region);
    image->SetBufferedRegion(region);
    image->SetRequestedRegion(region);

Did use Notepad++ v8.3.3 Regular expressions:

    Find what:
    ->SetLargestPossibleRegion\((.+)\);\r\n.+->SetBufferedRegion\(\1\);\r\n.+->SetRequestedRegion\(\1\);

    Replace with:
    ->SetRegions\($1\);