### PR TITLE
BUG: Let MeshIOTestHelper AllocateBuffer return `std::shared_ptr<void>`

### DIFF
--- a/Modules/IO/MeshBYU/test/itkBYUMeshIOTest.cxx
+++ b/Modules/IO/MeshBYU/test/itkBYUMeshIOTest.cxx
@@ -47,11 +47,8 @@ itkBYUMeshIOTest(int argc, char * argv[])
   testStatus = TestBaseClassMethodsMeshIO<itk::BYUMeshIO>(byuMeshIOBaseTest);
 
   // Test reading exceptions
-  void * pointBuffer = nullptr;
-  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->ReadPoints(pointBuffer));
-
-  void * cellBuffer = nullptr;
-  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->ReadCells(cellBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->ReadPoints(nullptr));
+  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->ReadCells(nullptr));
 
   std::string inputFileName = argv[3];
   ITK_TEST_EXPECT_TRUE(!byuMeshIO->CanReadFile(inputFileName.c_str()));
@@ -98,16 +95,18 @@ itkBYUMeshIOTest(int argc, char * argv[])
   itk::SizeValueType pointBufferSize = 1000;
   itk::SizeValueType cellBufferSize = 1000;
 
-  AllocateBuffer(&pointBuffer, byuMeshIO->GetPointComponentType(), pointBufferSize);
-  AllocateBuffer(&cellBuffer, byuMeshIO->GetCellComponentType(), cellBufferSize);
+  const std::shared_ptr<void> pointBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(byuMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> cellBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(byuMeshIO->GetCellComponentType(), cellBufferSize);
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->ReadPoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->ReadPoints(pointBuffer.get()));
 
   void * pointDataBuffer = nullptr;
   // Not used; empty method body; called for coverage purposes
   byuMeshIO->ReadPointData(pointDataBuffer);
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->ReadCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->ReadCells(cellBuffer.get()));
 
   void * cellDataBuffer = nullptr;
   // Not used; empty method body; called for coverage purposes
@@ -116,8 +115,8 @@ itkBYUMeshIOTest(int argc, char * argv[])
   // Test writing exceptions
   std::string outputFileName = "";
   byuMeshIO->SetFileName(outputFileName);
-  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->WritePoints(pointBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->WritePoints(pointBuffer.get()));
+  ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->WriteCells(cellBuffer.get()));
   ITK_TRY_EXPECT_EXCEPTION(byuMeshIO->WriteMeshInformation());
 
   outputFileName = argv[4];
@@ -128,12 +127,12 @@ itkBYUMeshIOTest(int argc, char * argv[])
   byuMeshIO->SetFileName(outputFileName.c_str());
 
   // Write the actual data
-  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->WritePoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->WritePoints(pointBuffer.get()));
 
   // Not used; empty method body; called for coverage purposes
   byuMeshIO->WritePointData(pointDataBuffer);
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(byuMeshIO->WriteCells(cellBuffer.get()));
 
   // Not used; empty method body; called for coverage purposes
   byuMeshIO->WriteCellData(cellDataBuffer);
@@ -173,9 +172,6 @@ itkBYUMeshIOTest(int argc, char * argv[])
   ITK_TEST_EXPECT_EQUAL(byuMeshIO->GetNumberOfCellPixelComponents(),
                         readWriteByuMeshIO->GetNumberOfCellPixelComponents());
 
-
-  ::operator delete(pointBuffer);
-  ::operator delete(cellBuffer);
 
   std::cout << "Test finished." << std::endl;
   return testStatus;

--- a/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
@@ -375,59 +375,59 @@ TestBaseClassMethodsMeshIO(typename TMeshIO::Pointer meshIO)
   return EXIT_SUCCESS;
 }
 
-void
-AllocateBuffer(void ** data, itk::IOComponentEnum componentType, itk::SizeValueType bufferSize)
+namespace itk
 {
-  void * buffer = nullptr;
+namespace MeshIOTestHelper
+{
 
+template <typename T>
+std::shared_ptr<void>
+MakeSharedArray(const std::size_t bufferSize)
+{
+  return std::shared_ptr<void>(new T[bufferSize], std::default_delete<T[]>());
+}
+
+inline std::shared_ptr<void>
+AllocateBuffer(itk::IOComponentEnum componentType, itk::SizeValueType bufferSize)
+{
   switch (componentType)
   {
     case itk::IOComponentEnum::CHAR:
-      buffer = new char[bufferSize];
-      break;
+      return MakeSharedArray<char>(bufferSize);
     case itk::IOComponentEnum::UCHAR:
-      buffer = new unsigned char[bufferSize];
-      break;
+      return MakeSharedArray<unsigned char>(bufferSize);
     case itk::IOComponentEnum::USHORT:
-      buffer = new unsigned short[bufferSize];
-      break;
+      return MakeSharedArray<unsigned short>(bufferSize);
     case itk::IOComponentEnum::SHORT:
-      buffer = new short[bufferSize];
-      break;
+      return MakeSharedArray<short>(bufferSize);
     case itk::IOComponentEnum::UINT:
-      buffer = new unsigned int[bufferSize];
-      break;
+      return MakeSharedArray<unsigned int>(bufferSize);
     case itk::IOComponentEnum::INT:
-      buffer = new unsigned int[bufferSize];
-      break;
+      return MakeSharedArray<int>(bufferSize);
     case itk::IOComponentEnum::ULONG:
-      buffer = new unsigned long[bufferSize];
-      break;
+      return MakeSharedArray<unsigned long>(bufferSize);
     case itk::IOComponentEnum::LONG:
-      buffer = new long[bufferSize];
-      break;
+      return MakeSharedArray<long>(bufferSize);
     case itk::IOComponentEnum::LONGLONG:
-      buffer = new long long[bufferSize];
-      break;
+      return MakeSharedArray<long long>(bufferSize);
     case itk::IOComponentEnum::ULONGLONG:
-      buffer = new unsigned long long[bufferSize];
-      break;
+      return MakeSharedArray<unsigned long long>(bufferSize);
     case itk::IOComponentEnum::FLOAT:
-      buffer = new float[bufferSize];
-      break;
+      return MakeSharedArray<float>(bufferSize);
     case itk::IOComponentEnum::DOUBLE:
-      buffer = new double[bufferSize];
-      break;
+      return MakeSharedArray<double>(bufferSize);
     case itk::IOComponentEnum::LDOUBLE:
-      buffer = new long double[bufferSize];
-      break;
+      return MakeSharedArray<long double>(bufferSize);
     case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       break;
     default:
       break;
   }
 
-  *data = buffer;
+  return nullptr;
 }
+
+} // namespace MeshIOTestHelper
+} // namespace itk
 
 #endif

--- a/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
+++ b/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
@@ -79,19 +79,17 @@ itkFreeSurferMeshIOTestHelper(typename TMeshIO::Pointer       fsMeshIO,
 
   itk::SizeValueType cellBufferSize = 2000;
 
-  void * pointBuffer = nullptr;
-  AllocateBuffer(&pointBuffer, fsMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> pointBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(fsMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> pointDataBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(fsMeshIO->GetPointPixelComponentType(), pointDataBufferSize);
+  const std::shared_ptr<void> cellBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(fsMeshIO->GetCellComponentType(), cellBufferSize);
 
-  void * pointDataBuffer = nullptr;
-  AllocateBuffer(&pointDataBuffer, fsMeshIO->GetPointPixelComponentType(), pointDataBufferSize);
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadPoints(pointBuffer.get()));
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadPointData(pointDataBuffer.get()));
 
-  void * cellBuffer = nullptr;
-  AllocateBuffer(&cellBuffer, fsMeshIO->GetCellComponentType(), cellBufferSize);
-
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadPoints(pointBuffer));
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadPointData(pointDataBuffer));
-
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->ReadCells(cellBuffer.get()));
 
   void * cellDataBuffer = nullptr;
   // Not used; empty method body; called for coverage purposes
@@ -99,13 +97,13 @@ itkFreeSurferMeshIOTestHelper(typename TMeshIO::Pointer       fsMeshIO,
 
   // Test writing exceptions
   fsMeshIO->SetFileName("");
-  ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WritePoints(pointBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WritePoints(pointBuffer.get()));
   if (dynamic_cast<itk::FreeSurferBinaryMeshIO *>(fsMeshIO.GetPointer()))
   {
-    ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WritePointData(pointDataBuffer));
+    ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WritePointData(pointDataBuffer.get()));
   }
 
-  ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WriteCells(cellBuffer.get()));
   ITK_TRY_EXPECT_EXCEPTION(fsMeshIO->WriteMeshInformation());
 
   ITK_TEST_EXPECT_TRUE(!fsMeshIO->CanWriteFile(notAFsOutputFileName));
@@ -114,10 +112,10 @@ itkFreeSurferMeshIOTestHelper(typename TMeshIO::Pointer       fsMeshIO,
   fsMeshIO->SetFileName(outputFileName);
 
   // Write the actual data
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WritePoints(pointBuffer));
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WritePointData(pointDataBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WritePoints(pointBuffer.get()));
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WritePointData(pointDataBuffer.get()));
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(fsMeshIO->WriteCells(cellBuffer.get()));
 
   // Not used; empty method body; called for coverage purposes
   fsMeshIO->WriteCellData(cellDataBuffer);
@@ -147,12 +145,6 @@ itkFreeSurferMeshIOTestHelper(typename TMeshIO::Pointer       fsMeshIO,
                         readWritefsMeshIO->GetNumberOfPointPixelComponents());
   ITK_TEST_EXPECT_EQUAL(fsMeshIO->GetNumberOfCellPixelComponents(),
                         readWritefsMeshIO->GetNumberOfCellPixelComponents());
-
-
-  ::operator delete(pointBuffer);
-  ::operator delete(pointDataBuffer);
-  ::operator delete(cellBuffer);
-  ::operator delete(cellDataBuffer);
 
   return testStatus;
 }

--- a/Modules/IO/MeshOFF/test/itkOFFMeshIOTest.cxx
+++ b/Modules/IO/MeshOFF/test/itkOFFMeshIOTest.cxx
@@ -98,19 +98,18 @@ itkOFFMeshIOTest(int argc, char * argv[])
   itk::SizeValueType pointBufferSize = 1000;
   itk::SizeValueType cellBufferSize = 1000;
 
-  void * pointBuffer = nullptr;
-  AllocateBuffer(&pointBuffer, offMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> pointBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(offMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> cellBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(offMeshIO->GetCellComponentType(), cellBufferSize);
 
-  void * cellBuffer = nullptr;
-  AllocateBuffer(&cellBuffer, offMeshIO->GetCellComponentType(), cellBufferSize);
-
-  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->ReadPoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->ReadPoints(pointBuffer.get()));
 
   void * pointDataBuffer = nullptr;
   // Not used; empty method body; called for coverage purposes
   offMeshIO->ReadPointData(pointDataBuffer);
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->ReadCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->ReadCells(cellBuffer.get()));
 
   void * cellDataBuffer = nullptr;
   // Not used; empty method body; called for coverage purposes
@@ -119,8 +118,8 @@ itkOFFMeshIOTest(int argc, char * argv[])
   // Test writing exceptions
   std::string outputFileName = "";
   offMeshIO->SetFileName(outputFileName);
-  ITK_TRY_EXPECT_EXCEPTION(offMeshIO->WritePoints(pointBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(offMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(offMeshIO->WritePoints(pointBuffer.get()));
+  ITK_TRY_EXPECT_EXCEPTION(offMeshIO->WriteCells(cellBuffer.get()));
   ITK_TRY_EXPECT_EXCEPTION(offMeshIO->WriteMeshInformation());
 
   outputFileName = argv[4];
@@ -131,12 +130,12 @@ itkOFFMeshIOTest(int argc, char * argv[])
   offMeshIO->SetFileName(outputFileName);
 
   // Write the actual data
-  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->WritePoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->WritePoints(pointBuffer.get()));
 
   // Not used; empty method body; called for coverage purposes
   offMeshIO->WritePointData(pointDataBuffer);
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(offMeshIO->WriteCells(cellBuffer.get()));
 
   // Not used; empty method body; called for coverage purposes
   offMeshIO->WriteCellData(cellDataBuffer);
@@ -167,10 +166,6 @@ itkOFFMeshIOTest(int argc, char * argv[])
                         readWriteByuMeshIO->GetNumberOfPointPixelComponents());
   ITK_TEST_EXPECT_EQUAL(offMeshIO->GetNumberOfCellPixelComponents(),
                         readWriteByuMeshIO->GetNumberOfCellPixelComponents());
-
-
-  ::operator delete(pointBuffer);
-  ::operator delete(cellBuffer);
 
   std::cout << "Test finished." << std::endl;
   return testStatus;

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOTest.cxx
@@ -52,15 +52,10 @@ itkVTKPolyDataMeshIOTest(int argc, char * argv[])
   vtkPolyDataMeshIO->SetFileName(inputFileName);
   ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadMeshInformation());
 
-  void * pointBuffer = nullptr;
-  void * pointDataBuffer = nullptr;
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPoints(pointBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(pointDataBuffer));
-
-  void * cellBuffer = nullptr;
-  void * cellDataBuffer = nullptr;
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCells(cellBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(cellDataBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPoints(nullptr));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(nullptr));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCells(nullptr));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(nullptr));
 
   inputFileName = argv[3];
   vtkPolyDataMeshIO->SetFileName(inputFileName);
@@ -125,45 +120,48 @@ itkVTKPolyDataMeshIOTest(int argc, char * argv[])
   itk::SizeValueType cellBufferSize = 2000;
   itk::SizeValueType cellDataBufferSize = 2000;
 
-  AllocateBuffer(&pointBuffer, vtkPolyDataMeshIO->GetPointComponentType(), pointBufferSize);
-  AllocateBuffer(&pointDataBuffer, vtkPolyDataMeshIO->GetPointPixelComponentType(), pointDataBufferSize);
-
-  AllocateBuffer(&cellBuffer, vtkPolyDataMeshIO->GetCellComponentType(), cellBufferSize);
-  AllocateBuffer(&cellDataBuffer, vtkPolyDataMeshIO->GetCellPixelComponentType(), cellDataBufferSize);
+  const std::shared_ptr<void> pointBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(vtkPolyDataMeshIO->GetPointComponentType(), pointBufferSize);
+  const std::shared_ptr<void> pointDataBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(vtkPolyDataMeshIO->GetPointPixelComponentType(), pointDataBufferSize);
+  const std::shared_ptr<void> cellBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(vtkPolyDataMeshIO->GetCellComponentType(), cellBufferSize);
+  const std::shared_ptr<void> cellDataBuffer =
+    itk::MeshIOTestHelper::AllocateBuffer(vtkPolyDataMeshIO->GetCellPixelComponentType(), cellDataBufferSize);
 
   auto pointPixelComponentType = vtkPolyDataMeshIO->GetPointPixelComponentType();
   auto cellPixelComponentType = vtkPolyDataMeshIO->GetCellPixelComponentType();
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadPoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadPoints(pointBuffer.get()));
 
   if (pointPixelComponentType == itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE)
   {
-    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(pointDataBuffer));
+    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(pointDataBuffer.get()));
   }
   else
   {
-    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(pointDataBuffer));
+    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadPointData(pointDataBuffer.get()));
   }
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadCells(cellBuffer.get()));
 
   if (cellPixelComponentType == itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE)
   {
-    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(cellDataBuffer));
+    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(cellDataBuffer.get()));
   }
   else
   {
-    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(cellDataBuffer));
+    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->ReadCellData(cellDataBuffer.get()));
   }
 
   // Test writing exceptions
   std::string outputFileName = "";
   vtkPolyDataMeshIO->SetFileName(outputFileName);
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePoints(pointBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePoints(pointBuffer.get()));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer.get()));
 
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCells(cellBuffer));
-  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCells(cellBuffer.get()));
+  ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer.get()));
 
   ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteMeshInformation());
 
@@ -185,26 +183,26 @@ itkVTKPolyDataMeshIOTest(int argc, char * argv[])
     vtkPolyDataMeshIO->SetFileType(itk::IOFileEnum::BINARY);
   }
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WritePoints(pointBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WritePoints(pointBuffer.get()));
 
   if (pointPixelComponentType == itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE)
   {
-    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer));
+    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer.get()));
   }
   else
   {
-    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer));
+    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WritePointData(pointDataBuffer.get()));
   }
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WriteCells(cellBuffer));
+  ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WriteCells(cellBuffer.get()));
 
   if (cellPixelComponentType == itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE)
   {
-    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer));
+    ITK_TRY_EXPECT_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer.get()));
   }
   else
   {
-    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer));
+    ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WriteCellData(cellDataBuffer.get()));
   }
 
   ITK_TRY_EXPECT_NO_EXCEPTION(vtkPolyDataMeshIO->WriteMeshInformation());
@@ -273,12 +271,6 @@ itkVTKPolyDataMeshIOTest(int argc, char * argv[])
   // written properly
   // ITK_TEST_EXPECT_EQUAL(vtkPolyDataMeshIO->GetNumberOfCellPixelComponents(),
   //                      readWriteVtkPolyDataMeshIO->GetNumberOfCellPixelComponents());
-
-
-  ::operator delete(pointBuffer);
-  ::operator delete(pointDataBuffer);
-  ::operator delete(cellBuffer);
-  ::operator delete(cellDataBuffer);
 
   std::cout << "Test finished." << std::endl;
   return testStatus;


### PR DESCRIPTION
Let AllocateBuffer (from MeshIOTestHelper) return a `std::shared_ptr<void>`,
instead of producing a void pointer, to ensure that it is deleted correctly,
automatically.

Aims to fix Valgrind errors, saying:

> Mismatched free() / delete / delete []

As reported and discussed by Jon Haitz Legarreta Gorroño (@jhlegarreta) and Mihail Isakov (@issakomi) at pull request #3459