### PR TITLE
ENH: Call superclass `PrintSelf` method in child `PrintSelf`

### DIFF
--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -198,6 +198,8 @@ template <typename TPointSet, typename TOutput, typename TCoordRep>
 void
 ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  Superclass::PrintSelf(os, indent);
+
   os << indent << "Covariance neighborhood: " << this->m_CovarianceKNeighborhood << std::endl;
   os << indent << "Evaluation neighborhood: " << this->m_EvaluationKNeighborhood << std::endl;
   os << indent << "Regularization sigma: " << this->m_RegularizationSigma << std::endl;


### PR DESCRIPTION
Call the superclass `PrintSelf` method in the child `PrintSelf` method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)