### PR TITLE
ENH: Increase coverage for `itk::GDCMSeriesFileNames`

### DIFF
--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -92,14 +92,14 @@ set_property(TEST itkGDCMSeriesReadImageWriteTest APPEND PROPERTY DEPENDS ITKDat
 itk_add_test(NAME itkGDCMSeriesStreamReadImageWriteTest1
       COMMAND ITKIOGDCMTestDriver itkGDCMSeriesStreamReadImageWriteTest
               DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
-              ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest1.mhd 0.859375 0.85939 1.60016 0)
+              ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest1.mhd 0.859375 0.85939 1.60016 0 1 0 0 0)
 
 set_property(TEST itkGDCMSeriesStreamReadImageWriteTest1 APPEND PROPERTY DEPENDS ITKData)
 
 itk_add_test(NAME itkGDCMSeriesStreamReadImageWriteTest2
       COMMAND ITKIOGDCMTestDriver itkGDCMSeriesStreamReadImageWriteTest
               DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
-              ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest2.mhd 0.859375 0.85939 1.60016 1)
+              ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest2.mhd 0.859375 0.85939 1.60016 0 1 0 0 1)
 
 set_property(TEST itkGDCMSeriesStreamReadImageWriteTest2 APPEND PROPERTY DEPENDS ITKData)
 

--- a/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
@@ -47,11 +47,13 @@ IsEqualTolerant(const float lm, const float rm, double tol)
 int
 itkGDCMSeriesStreamReadImageWriteTest(int argc, char * argv[])
 {
-  if (argc < 6)
+  if (argc < 10)
   {
     std::cerr << "Missing Parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomDirectory  outputFile "
-              << " spacingX spacingY spacingZ [ force-no-streaming 1|0]" << std::endl;
+              << " spacingX spacingY spacingZ recursive useSeriesDetails loadSequences loadPrivateTags [ "
+                 "force-no-streaming 1|0]"
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -65,11 +67,10 @@ itkGDCMSeriesStreamReadImageWriteTest(int argc, char * argv[])
   expectedSpacing[1] = std::stod(argv[4]);
   expectedSpacing[2] = std::stod(argv[5]);
 
-
   bool forceNoStreaming = true;
-  if (argc > 6)
+  if (argc > 10)
   {
-    if (std::stoi(argv[6]) != 1)
+    if (std::stoi(argv[10]) != 1)
     {
       forceNoStreaming = false;
     }
@@ -85,6 +86,19 @@ itkGDCMSeriesStreamReadImageWriteTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filenameGenerator, GDCMSeriesFileNames, ProcessObject);
 
+
+  auto recursive = static_cast<bool>(std::stoi(argv[6]));
+  ITK_TEST_SET_GET_BOOLEAN(filenameGenerator, Recursive, recursive);
+
+  auto useSeriesDetails = static_cast<bool>(std::stoi(argv[7]));
+  filenameGenerator->SetUseSeriesDetails(useSeriesDetails);
+  ITK_TEST_SET_GET_VALUE(useSeriesDetails, filenameGenerator->GetUseSeriesDetails());
+
+  auto loadSequences = static_cast<bool>(std::stoi(argv[8]));
+  ITK_TEST_SET_GET_BOOLEAN(filenameGenerator, LoadSequences, loadSequences);
+
+  auto loadPrivateTags = static_cast<bool>(std::stoi(argv[9]));
+  ITK_TEST_SET_GET_BOOLEAN(filenameGenerator, LoadPrivateTags, loadPrivateTags);
 
   // Test exceptions
   const char * pInputDirectory = nullptr;


### PR DESCRIPTION
Increase coverage for `itk::GDCMSeriesFileNames`:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Refactor the test to accept more input parameters to allow checking
  the class under a broader range of conditions.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)