### PR TITLE
COMP: Fix older gcc build error including "cstddef" for "ptrdiff_t"

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkAtomicInt.h
+++ b/Modules/Compatibility/Deprecated/include/itkAtomicInt.h
@@ -39,6 +39,7 @@
 #include "itkConceptChecking.h"
 
 #include <atomic>
+#include <cstddef> // For ptrdiff_t.
 
 
 namespace itk

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -20,6 +20,8 @@
 
 #include "itkMakeFilled.h"
 #include "itkOffset.h"
+
+#include <cstddef>     // For ptrdiff_t.
 #include <type_traits> // For is_integral.
 
 namespace itk

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -21,6 +21,8 @@
 #include "itkSize.h"
 #include "itkMath.h"
 
+#include <cstddef> // For ptrdiff_t.
+
 namespace itk
 {
 

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -22,6 +22,7 @@
 #include "itkMacro.h"
 #include "itkMakeFilled.h"
 #include <algorithm>   // For copy_n.
+#include <cstddef>     // For ptrdiff_t.
 #include <type_traits> // For is_integral.
 #include <memory>
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -25,6 +25,7 @@
 #include "itkMath.h"
 #include "itkProgressReporter.h"
 #include "itkMetaDataObject.h"
+#include <cstddef> // For ptrdiff_t.
 #include <iomanip>
 
 namespace itk


### PR DESCRIPTION
This commit fixes a regression likely introduced in c173dfd80 (STYLE: Remove `std::` prefix from types that work without it) to support building ITK wheels using manylinux_2_24 providing gcc 6.3.

It fixes build error like the following:

```
  In file included from /work/ITK-source/ITK/Modules/Core/Common/include/itkImageRegion.h:33:0,
                   from /work/ITK-source/ITK/Modules/Core/Common/include/itkMultiThreaderBase.h:35,
                   from /work/ITK-source/ITK/Modules/Core/Common/src/itkTotalProgressReporter.cxx:19:
  /work/ITK-source/ITK/Modules/Core/Common/include/itkSize.h:242:27: error: ‘ptrdiff_t’ does not name a type
     using difference_type = ptrdiff_t;
                             ^~~~~~~~~
```

cc: @Leengit 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)