### PR TITLE
STYLE: removed obsolete and confusing old comment

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1173,7 +1173,6 @@ GDCMImageIO::Write(const void * buffer)
     case IOComponentEnum::UINT:
       pixeltype = gdcm::PixelFormat::UINT32;
       break;
-    // Disabling FLOAT and DOUBLE for now...
     case IOComponentEnum::FLOAT:
       pixeltype = gdcm::PixelFormat::FLOAT32;
       break;


### PR DESCRIPTION
It should have been removed in 14fbe528a78efb5696b3526de3c3968b14dcbe71, but was missed.