### PR TITLE
Replace postfix with prefix increment and decrement

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
@@ -106,7 +106,7 @@ template <typename TTreeType>
 auto
 ChildTreeIterator<TTreeType>::Next() -> const ValueType &
 {
-  m_ListPosition++;
+  ++m_ListPosition;
   this->m_Position = m_ParentNode->GetChild(m_ListPosition);
   if (this->m_Position == nullptr)
   {

--- a/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
@@ -139,7 +139,7 @@ InOrderTreeIterator<TTreeType>::FindNextNode() const
     {
       return help;
     }
-    childPosition++;
+    ++childPosition;
   }
 
   while (parent->HasParent())

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
@@ -159,7 +159,7 @@ LevelOrderTreeIterator<TTreeType>::GetLevel() const
   while (node->HasParent() && node != this->m_Root)
   {
     node = dynamic_cast<TreeNodeType *>(node->GetParent());
-    level++;
+    ++level;
   }
   return level;
 }
@@ -178,7 +178,7 @@ LevelOrderTreeIterator<TTreeType>::GetLevel(const TreeNodeType * node) const
   while (node->HasParent() && node != this->m_Root)
   {
     node = dynamic_cast<const TreeNodeType *>(node->GetParent());
-    level++;
+    ++level;
   }
   return level;
 }

--- a/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
@@ -166,7 +166,7 @@ PostOrderTreeIterator<TTreeType>::FindSister(TreeNodeType * node) const
   {
     if (parent->GetChild(childPosition + 1) == nullptr)
     {
-      childPosition++;
+      ++childPosition;
     }
     else
     {
@@ -206,7 +206,7 @@ PostOrderTreeIterator<TTreeType>::FindMostRightLeaf(TreeNodeType * node) const
           itkGenericExceptionMacro(<< "Can't downcast to TreeNodeType *");
         }
       }
-      i++;
+      ++i;
     } while (helpNode == nullptr && i < childCount);
 
     if (helpNode == nullptr)

--- a/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
@@ -150,7 +150,7 @@ PreOrderTreeIterator<TTreeType>::FindNextNode() const
       {
         return help;
       }
-      childPosition++;
+      ++childPosition;
     }
   }
   return nullptr;

--- a/Modules/Compatibility/Deprecated/include/itkTreeContainer.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeContainer.hxx
@@ -82,7 +82,7 @@ TreeContainer<TValue>::Count() const
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
-    size++;
+    ++size;
     ++it;
   }
   return size;

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
@@ -438,7 +438,7 @@ TreeIteratorBase<TTreeType>::Count()
   }
   while (this->Next())
   {
-    size++;
+    ++size;
   }
   return size;
 }

--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -140,7 +140,7 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
       coeffP[i] = annulusV;
       sumNotExterior += annulusV;
       sumNotExteriorSq += (annulusV * annulusV);
-      countNotExterior++;
+      ++countNotExterior;
       outside[i] = false;
     }
     else
@@ -149,7 +149,7 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
       coeffP[i] = interiorV;
       sumNotExterior += interiorV;
       sumNotExteriorSq += (interiorV * interiorV);
-      countNotExterior++;
+      ++countNotExterior;
       outside[i] = false;
     }
   }

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -322,7 +322,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::IsI
     {
       return false;
     }
-    i++;
+    ++i;
   }
   return true;
 }

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -141,26 +141,26 @@ public:
     void
     operator++(int)
     {
-      m_ListIterator++;
+      ++m_ListIterator;
     }
 
     void
     operator--(int)
     {
-      m_ListIterator--;
+      --m_ListIterator;
     }
 
     const ConstIterator &
     operator++()
     {
-      m_ListIterator++;
+      ++m_ListIterator;
       return *this;
     }
 
     const ConstIterator &
     operator--()
     {
-      m_ListIterator--;
+      --m_ListIterator;
       return *this;
     }
 

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -52,7 +52,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::ActivateIndex(Neigh
   {
     while (n > *it)
     {
-      it++;
+      ++it;
       if (it == m_ActiveIndexList.end())
       {
         break;
@@ -96,7 +96,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::DeactivateIndex(Nei
   {
     while (n != *it)
     {
-      it++;
+      ++it;
       if (it == m_ActiveIndexList.end())
       {
         return;

--- a/Modules/Core/Common/include/itkConstSliceIterator.h
+++ b/Modules/Core/Common/include/itkConstSliceIterator.h
@@ -83,7 +83,7 @@ public:
   ConstSliceIterator
   operator++()
   {
-    m_Pos++;
+    ++m_Pos;
     return *this;
   }
 
@@ -93,7 +93,7 @@ public:
   {
     ConstSliceIterator ans = *this;
 
-    m_Pos++;
+    ++m_Pos;
     return ans;
   }
 

--- a/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
+++ b/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
@@ -50,7 +50,7 @@ template <typename TStructureType>
 void
 CorrespondenceDataStructureIterator<TStructureType>::GoToNext()
 {
-  m_CorrespondingListIterator++;
+  ++m_CorrespondingListIterator;
 
   if (m_CorrespondingListIterator == m_CorrespondingListPointer->end())
   {
@@ -63,7 +63,7 @@ template <typename TStructureType>
 void
 CorrespondenceDataStructureIterator<TStructureType>::GoToNextBaseGroup()
 {
-  m_SecondaryListIterator++;
+  ++m_SecondaryListIterator;
   if (m_SecondaryListIterator != m_SecondaryListPointer->end())
   {
     m_CorrespondingListPointer = &(*m_SecondaryListIterator);
@@ -71,7 +71,7 @@ CorrespondenceDataStructureIterator<TStructureType>::GoToNextBaseGroup()
   }
   else if (m_SecondaryListIterator == m_SecondaryListPointer->end())
   {
-    m_NodeListIterator++;
+    ++m_NodeListIterator;
 
     if (m_NodeListIterator != m_NodeListPointer->end())
     {

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -84,7 +84,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputImageReg
     {
       outputSize[nonzeroSizeCount] = inputSize[i];
       outputIndex[nonzeroSizeCount] = extractRegion.GetIndex()[i];
-      nonzeroSizeCount++;
+      ++nonzeroSizeCount;
     }
   }
 
@@ -194,7 +194,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
               ++nonZeroCount2;
             }
           }
-          nonZeroCount++;
+          ++nonZeroCount;
         }
       }
     }

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -109,7 +109,7 @@ ExtractImageFilterCopyRegion(const typename BinaryUnsignedIntDispatch<T1, T2>::F
     {
       destIndex[dim] = srcIndex[count];
       destSize[dim] = srcSize[count];
-      count++;
+      ++count;
     }
   }
   destRegion.SetIndex(destIndex);

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -233,7 +233,7 @@ public:
         ind[i] += (static_cast<IndexValueType>(size[i]) - 1);
       }
       m_EndOffset = m_Image->ComputeOffset(ind);
-      m_EndOffset++;
+      ++m_EndOffset;
     }
   }
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -190,7 +190,7 @@ public:
   operator++()
   {
     this->RandomJump();
-    m_NumberOfSamplesDone++;
+    ++m_NumberOfSamplesDone;
     return *this;
   }
 
@@ -200,7 +200,7 @@ public:
   operator--()
   {
     this->RandomJump();
-    m_NumberOfSamplesDone--;
+    --m_NumberOfSamplesDone;
     return *this;
   }
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -192,7 +192,7 @@ public:
   operator++()
   {
     this->RandomJump();
-    m_NumberOfSamplesDone++;
+    ++m_NumberOfSamplesDone;
     return *this;
   }
 
@@ -202,7 +202,7 @@ public:
   operator--()
   {
     this->RandomJump();
-    m_NumberOfSamplesDone--;
+    --m_NumberOfSamplesDone;
     return *this;
   }
 

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -307,7 +307,7 @@ public:
   Self &
   operator++()
   {
-    m_NumberOfSamplesDone++;
+    ++m_NumberOfSamplesDone;
     this->UpdatePosition();
     return *this;
   }
@@ -317,7 +317,7 @@ public:
   Self &
   operator--()
   {
-    m_NumberOfSamplesDone--;
+    --m_NumberOfSamplesDone;
     this->UpdatePosition();
     return *this;
   }

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -351,7 +351,7 @@ MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
   for (i = 1; i < MersenneTwisterRandomVariateGenerator::StateVectorLength; ++i)
   {
     *s++ = (1812433253UL * (*r ^ (*r >> 30)) + i) & 0xffffffffUL;
-    r++;
+    ++r;
   }
   reload();
 }

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -49,7 +49,7 @@ printnb(const TIteratorType & nb, bool full)
       if ((count % sz) == 0)
         std::cout << std::endl;
       ++it;
-      count++;
+      ++count;
     }
   }
   else

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -232,7 +232,7 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::BuildFromBuffer(const void 
   while (width < maxSize)
   {
     width *= 2;
-    depth++;
+    ++depth;
   }
   this->SetDepth(depth);
   this->SetWidth(width);

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -92,11 +92,11 @@ namespace itk
  *
    \code
    i = it.End();
-   i--;
+   --i;
    while (i != it.Begin())
    {
      i.Set(i.Get() + 1.0);
-     i--;
+     --i;
    }
     i.Set(i.Get() + 1.0);
    \endcode

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -188,7 +188,7 @@ protected:
     if (m_Process)
     {
       std::lock_guard<std::mutex> outputSerializer(m_ProgressOutput);
-      m_Steps++;
+      ++m_Steps;
       if (!m_Quiet)
       {
         std::cout << " | " << m_Process->GetProgress() << std::flush;
@@ -231,7 +231,7 @@ protected:
   ShowIteration()
   {
     std::cout << " #" << std::flush;
-    m_Iterations++;
+    ++m_Iterations;
   }
 
   /** Callback method to show the StartEvent */

--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -79,7 +79,7 @@ public:
   SliceIterator
   operator++()
   {
-    m_Pos++;
+    ++m_Pos;
     return *this;
   }
 
@@ -89,7 +89,7 @@ public:
   {
     SliceIterator ans = *this;
 
-    m_Pos++;
+    ++m_Pos;
     return ans;
   }
 

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -46,7 +46,7 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
           pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
           this->operator[](pos) = static_cast<TPixel>(coeff[i]);
 
-          i++;
+          ++i;
         }
       }
     }
@@ -61,7 +61,7 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
         pos = center + y * this->GetStride(1) + x * this->GetStride(0);
         this->operator[](pos) = static_cast<TPixel>(coeff[i]);
 
-        i++;
+        ++i;
       }
     }
   }

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -71,7 +71,7 @@ SparseFieldLayer<TNodeType>::SplitRegions(int num) const -> RegionListType
     region.first = position;
     while ((j < regionsize) && (position != last))
     {
-      j++;
+      ++j;
       ++position;
     }
     region.last = position;

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -100,7 +100,7 @@ EquivalencyTable::AddAndFlatten(unsigned long a, unsigned long b)
 //  while (it != this->End() )
 //    {
 //      std::cout << (*it).first << " = " << (*it).second << std::endl;
-//      it++;
+//      ++it;
 //    }
 //}
 

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -123,7 +123,7 @@ ImageIORegion::GetRegionDimension() const
   {
     if (m_Size[i] > 1)
     {
-      dim++;
+      ++dim;
     }
   }
   return dim;

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -135,7 +135,7 @@ SubjectImplementation::AddObserver(const EventObject & event, Command * cmd)
   auto * ptr = new Observer(cmd, event.MakeObject(), m_Count);
 
   m_Observers.push_back(ptr);
-  m_Count++;
+  ++m_Count;
   return ptr->m_Tag;
 }
 

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -347,7 +347,7 @@ ObjectFactoryBase::LoadDynamicFactories()
     }
     else
     {
-      EndSeparatorPosition++; // Skip the separator
+      ++EndSeparatorPosition; // Skip the separator
     }
   }
 #else // ITK_DYNAMIC_LOADING

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -123,7 +123,7 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
     }
     m_SpawnedThreadActiveFlagLock[id]->unlock();
 
-    id++;
+    ++id;
   }
 
   if (id >= ITK_MAX_THREADS)

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -121,7 +121,7 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
     }
     m_SpawnedThreadActiveFlagLock[id]->unlock();
 
-    id++;
+    ++id;
   }
 
   if (id >= ITK_MAX_THREADS)

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -169,7 +169,7 @@ PoolMultiThreader::ParallelizeArray(SizeValueType             firstIndex,
     SizeValueType chunkSize = (lastIndexPlus1 - firstIndex) / m_NumberOfWorkUnits;
     if ((lastIndexPlus1 - firstIndex) % m_NumberOfWorkUnits > 0)
     {
-      chunkSize++; // we want slightly bigger chunks to be processed first
+      ++chunkSize; // we want slightly bigger chunks to be processed first
     }
 
     auto lambda = [aFunc](SizeValueType start, SizeValueType end) {

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -116,11 +116,11 @@ XMLFileOutputWindow::DisplayXML(const char * tag, const char * text)
       default:
       {
         *x = *s;
-        x++;
+        ++x;
         *x = '\0'; // explicitly terminate the new string
       }
     }
-    s++;
+    ++s;
   }
 
   if (!m_Stream)

--- a/Modules/Core/Common/src/itkXMLFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkXMLFilterWatcher.cxx
@@ -25,7 +25,7 @@ XMLFilterWatcher::ShowProgress()
   if (this->GetProcess())
   {
     int steps = this->GetSteps();
-    steps++;
+    ++steps;
     this->SetSteps(steps);
     if (!this->GetQuiet())
     {

--- a/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
@@ -129,7 +129,7 @@ public:
 
     m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;
     m_KernelArgumentReady[kernelIdx][argIdx].m_GPUDataManager = manager;
-    argIdx++;
+    ++argIdx;
 
     // this->SetKernelArg(kernelIdx, argIdx++, sizeof(int), &(TGPUImageDataManager::ImageDimension) );
 
@@ -142,7 +142,7 @@ public:
 
     m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;
     m_KernelArgumentReady[kernelIdx][argIdx].m_GPUDataManager = manager->GetModifiableGPUBufferedRegionIndex();
-    argIdx++;
+    ++argIdx;
 
     // the size for the buffered region
     errid = clSetKernelArg(m_KernelContainer[kernelIdx],
@@ -153,7 +153,7 @@ public:
 
     m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;
     m_KernelArgumentReady[kernelIdx][argIdx].m_GPUDataManager = manager->GetModifiableGPUBufferedRegionSize();
-    argIdx++;
+    ++argIdx;
 
     return true;
   }

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -385,8 +385,8 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
 
       (*it) = m_GaussianFunction->Evaluate(pt);
       sum += (*it);
-      i++;
-      it++;
+      ++i;
+      ++it;
     }
 
     // Make the filter DC-Constant
@@ -394,7 +394,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
     while (it != gaussianNeighborhood.End())
     {
       (*it) /= sum;
-      it++;
+      ++it;
     }
     m_ContinuousOperatorArray[direction] = gaussianNeighborhood;
   }

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -961,7 +961,7 @@ RayCastHelper<TInputImage, TCoordRep>::AdjustRayLength()
       m_RayVoxelStartPosition[1] += m_VoxelIncrement[1];
       m_RayVoxelStartPosition[2] += m_VoxelIncrement[2];
 
-      m_TotalRayVoxelPlanes--;
+      --m_TotalRayVoxelPlanes;
     }
 
     Istart[0] = static_cast<int>(std::floor(m_RayVoxelStartPosition[0] + m_TotalRayVoxelPlanes * m_VoxelIncrement[0]));
@@ -978,7 +978,7 @@ RayCastHelper<TInputImage, TCoordRep>::AdjustRayLength()
     }
     else
     {
-      m_TotalRayVoxelPlanes--;
+      --m_TotalRayVoxelPlanes;
     }
   } while ((!(startOK && endOK)) && (m_TotalRayVoxelPlanes > 1));
 

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -159,7 +159,7 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
       }
 
       // Increment the index
-      iOffset++;
+      ++iOffset;
     }
   }
 }

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -153,7 +153,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::XFlip(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -205,7 +205,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::YFlip(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -257,7 +257,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::ZFlip(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -313,7 +313,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::XRotation(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -369,7 +369,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::YRotation(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -425,7 +425,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::ZRotation(unsigned char * x)
       case 13:
         break;
     }
-    i++;
+    ++i;
   }
 }
 
@@ -1057,7 +1057,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
   {
     ++it3;
     ++it4;
-    i++;
+    ++i;
   }
 
   i = 0;
@@ -1066,7 +1066,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
   {
     ++it2;
     ++it4;
-    i++;
+    ++i;
   }
 
   unsigned char vertexindex;
@@ -1184,7 +1184,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
     {
       this->AddCells(m_LUT[vertexindex][0], m_LUT[vertexindex][1], i);
     }
-    i++;
+    ++i;
   }
 
   // This indicates that the current BufferedRegion is equal to the
@@ -1408,7 +1408,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 2:
       tp[0] = 4;
@@ -1423,7 +1423,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 10;
       tp[1] = 9;
       tp[2] = 2;
@@ -1436,7 +1436,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 3:
       tp[0] = 1;
@@ -1451,7 +1451,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 3;
       tp[2] = 11;
@@ -1464,7 +1464,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 4:
       tp[0] = 1;
@@ -1479,7 +1479,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 6;
       tp[1] = 11;
       tp[2] = 7;
@@ -1492,7 +1492,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 5:
       tp[0] = 1;
@@ -1507,7 +1507,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 9;
@@ -1520,7 +1520,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 9;
       tp[1] = 13;
       tp[2] = 8;
@@ -1533,7 +1533,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 2;
       tp[2] = 6;
@@ -1546,7 +1546,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 6;
       tp[2] = 8;
@@ -1559,7 +1559,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 6:
       tp[0] = 10;
@@ -1574,7 +1574,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 4;
       tp[1] = 2;
       tp[2] = 9;
@@ -1587,7 +1587,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 6;
       tp[1] = 11;
       tp[2] = 7;
@@ -1600,7 +1600,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 7:
       tp[0] = 1;
@@ -1615,7 +1615,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 6;
       tp[1] = 11;
       tp[2] = 7;
@@ -1628,7 +1628,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 3;
       tp[1] = 4;
       tp[2] = 12;
@@ -1641,7 +1641,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 8:
       tp[0] = 13;
@@ -1656,7 +1656,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 6;
       tp[2] = 8;
@@ -1669,7 +1669,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 8;
       tp[2] = 4;
@@ -1682,7 +1682,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 4;
       tp[2] = 2;
@@ -1695,7 +1695,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 9:
       tp[0] = 1;
@@ -1710,7 +1710,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 10;
       tp[1] = 6;
       tp[2] = 13;
@@ -1723,7 +1723,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 6;
       tp[1] = 7;
       tp[2] = 13;
@@ -1736,7 +1736,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 7;
       tp[1] = 12;
       tp[2] = 13;
@@ -1749,7 +1749,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 12;
       tp[1] = 4;
       tp[2] = 13;
@@ -1762,7 +1762,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 4;
@@ -1775,7 +1775,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 10:
       tp[0] = 1;
@@ -1790,7 +1790,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 9;
       tp[1] = 12;
       tp[2] = 3;
@@ -1803,7 +1803,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 5;
       tp[1] = 10;
       tp[2] = 7;
@@ -1816,7 +1816,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 10;
       tp[1] = 11;
       tp[2] = 7;
@@ -1829,7 +1829,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 11:
       tp[0] = 1;
@@ -1844,7 +1844,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 10;
       tp[2] = 11;
@@ -1857,7 +1857,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 7;
       tp[1] = 13;
       tp[2] = 11;
@@ -1870,7 +1870,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 7;
       tp[1] = 8;
       tp[2] = 13;
@@ -1883,7 +1883,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 8;
       tp[2] = 4;
@@ -1896,7 +1896,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 4;
@@ -1909,7 +1909,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 12:
       tp[0] = 1;
@@ -1924,7 +1924,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 9;
@@ -1937,7 +1937,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 9;
       tp[1] = 13;
       tp[2] = 8;
@@ -1950,7 +1950,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 2;
       tp[2] = 6;
@@ -1963,7 +1963,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 6;
       tp[2] = 8;
@@ -1976,7 +1976,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 3;
       tp[1] = 4;
       tp[2] = 12;
@@ -1989,7 +1989,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 13:
       tp[0] = 1;
@@ -2004,7 +2004,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 5;
       tp[1] = 10;
       tp[2] = 6;
@@ -2017,7 +2017,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 3;
       tp[2] = 11;
@@ -2030,7 +2030,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 8;
       tp[1] = 7;
       tp[2] = 12;
@@ -2043,7 +2043,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 14:
       tp[0] = 1;
@@ -2058,7 +2058,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 10;
       tp[1] = 6;
       tp[2] = 13;
@@ -2071,7 +2071,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 6;
       tp[1] = 7;
       tp[2] = 13;
@@ -2084,7 +2084,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 7;
       tp[1] = 12;
       tp[2] = 13;
@@ -2097,7 +2097,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 12;
       tp[1] = 4;
       tp[2] = 13;
@@ -2110,7 +2110,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 4;
@@ -2123,7 +2123,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 3;
       tp[2] = 11;
@@ -2136,7 +2136,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 15:
       tp[0] = 1;
@@ -2151,7 +2151,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 13;
       tp[2] = 10;
@@ -2164,7 +2164,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 3;
       tp[2] = 13;
@@ -2177,7 +2177,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 3;
       tp[1] = 12;
       tp[2] = 13;
@@ -2190,7 +2190,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 4;
       tp[1] = 13;
       tp[2] = 12;
@@ -2203,7 +2203,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 4;
@@ -2216,7 +2216,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
     case 16:
       tp[0] = 13;
@@ -2231,7 +2231,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 5;
       tp[1] = 6;
       tp[2] = 13;
@@ -2244,7 +2244,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 13;
       tp[1] = 6;
       tp[2] = 2;
@@ -2257,7 +2257,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 2;
       tp[1] = 3;
       tp[2] = 13;
@@ -2270,7 +2270,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 3;
       tp[1] = 12;
       tp[2] = 13;
@@ -2283,7 +2283,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 4;
       tp[1] = 13;
       tp[2] = 12;
@@ -2296,7 +2296,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       tp[0] = 1;
       tp[1] = 13;
       tp[2] = 4;
@@ -2309,7 +2309,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       insertCell->SetPointIds(tripoints);
       this->m_OutputMesh->SetCell(m_NumberOfCells, insertCell);
       this->m_OutputMesh->SetCellData(m_NumberOfCells, 0.0);
-      m_NumberOfCells++;
+      ++m_NumberOfCells;
       break;
   }
 
@@ -2347,7 +2347,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       }
     }
 
-    i++;
+    ++i;
   }
 
   for (i = 0; i < 4; ++i)
@@ -2467,7 +2467,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddNodes(int               ind
       globalnodesid[i] = m_NumberOfNodes;
       m_AvailableNodes[nodesid[i]] = 0;
       m_CurrentVoxel[nodesid[i]] = m_NumberOfNodes;
-      m_NumberOfNodes++;
+      ++m_NumberOfNodes;
     }
     else
     {
@@ -2539,7 +2539,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddNodes(int               ind
     if (m_PointFound == 0)
     {
       m_AvailableNodes[nodesid[i]] = 1;
-      i--;
+      --i;
     }
   }
 }

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -204,7 +204,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
           largestRegionId = m_RegionNumber;
         }
 
-        m_RegionNumber++;
+        ++m_RegionNumber;
         m_RegionSizes.push_back(m_NumberOfCellsInRegion);
         m_Wave->clear();
         m_Wave2->clear();
@@ -424,7 +424,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::PropagateConnectedWave()
       if (m_Visited[cellId] < 0)
       {
         m_Visited[cellId] = static_cast<OffsetValueType>(m_RegionNumber);
-        m_NumberOfCellsInRegion++;
+        ++m_NumberOfCellsInRegion;
 
         // now get the cell points, and then cells using these points
         input->GetCell(cellId, cellPtr);

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
@@ -118,7 +118,7 @@ InteriorExteriorMeshFilter<TInputMesh, TOutputMesh, TSpatialFunction>::GenerateD
       {
         outputMesh->SetPointData(pointId, inputData.Value());
       }
-      pointId++;
+      ++pointId;
     }
 
     ++inputPoint;

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
@@ -275,25 +275,25 @@ RegularSphereMeshSource<TOutputMesh>::GenerateData()
         tripoints[1] = newIdx[0];
         tripoints[2] = newIdx[2];
         this->AddCell(result, tripoints, cellIdx);
-        cellIdx++;
+        ++cellIdx;
 
         tripoints[0] = newIdx[0];
         tripoints[1] = tp[1];
         tripoints[2] = newIdx[1];
         this->AddCell(result, tripoints, cellIdx);
-        cellIdx++;
+        ++cellIdx;
 
         tripoints[0] = newIdx[1];
         tripoints[1] = tp[2];
         tripoints[2] = newIdx[2];
         this->AddCell(result, tripoints, cellIdx);
-        cellIdx++;
+        ++cellIdx;
 
         tripoints[0] = newIdx[0];
         tripoints[1] = newIdx[1];
         tripoints[2] = newIdx[2];
         this->AddCell(result, tripoints, cellIdx);
-        cellIdx++;
+        ++cellIdx;
       }
 
       // for all cells

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -194,7 +194,7 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddEdge(PointIdentifier startP
   NewCellPointer->SetPointId(1, endPointId);
 
   this->SetCell(edgeId, NewCellPointer);
-  m_LastCellId++;
+  ++m_LastCellId;
   return edgeId;
 }
 
@@ -203,7 +203,7 @@ auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddFace(CellAutoPointer & cellPointer) -> CellIdentifier
 {
   this->SetCell(m_LastCellId, cellPointer);
-  m_LastCellId++;
+  ++m_LastCellId;
   return m_LastCellId - 1;
 }
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -151,8 +151,8 @@ public:
         id1 = id2;
         val = mesh->GetMeanCurvature(*it);
         meanCurvature += itk::Math::abs(val);
-        cnt++;
-        it++;
+        ++cnt;
+        ++it;
       }
 
       meanCurvature /= static_cast<double>(cnt);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -154,7 +154,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
 
     if (doRefinement)
     {
-      m_ModifiedCount++;
+      ++m_ModifiedCount;
 
       InputCellAutoPointer poly;
       outputMesh->GetCell(curvatureIt.Index(), poly);
@@ -164,18 +164,18 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
       typename InputPolygonType::PointIdIterator pointIds = poly->PointIdsBegin();
 
       PointIdentifier lineOneFirstIdx = *pointIds;
-      pointIds++;
+      ++pointIds;
       PointIdentifier lineOneSecondIdx = *pointIds;
 
       unsigned short cnt = 0;
 
       while (cnt < poly->GetNumberOfPoints() / 2 - 1)
       {
-        pointIds++;
-        cnt++;
+        ++pointIds;
+        ++cnt;
       }
       PointIdentifier lineTwoFirstIdx = *pointIds;
-      pointIds++;
+      ++pointIds;
       PointIdentifier lineTwoSecondIdx = *pointIds;
 
       PointIdentifier newPointId = outputMesh->GetNumberOfPoints();
@@ -314,7 +314,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ModifyNeighborCells(Cel
     {
       result.insert(*cellIt);
     }
-    cellIt++;
+    ++cellIt;
   }
 
   cellIt = result.begin();
@@ -358,7 +358,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ModifyNeighborCells(Cel
           m_NewSimplexCellPointer->SetPointId(cnt++, insertPointId);
         }
         first = second;
-        pointIt++;
+        ++pointIt;
       }
 
       m_NewSimplexCellPointer->SetPointId(cnt++, second);
@@ -369,7 +369,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ModifyNeighborCells(Cel
 
       outputMesh->ReplaceFace(*cellIt, m_NewSimplexCellPointer);
     }
-    cellIt++;
+    ++cellIt;
   }
 
   outputMesh->BuildCellLinks();
@@ -405,7 +405,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(Input
   {
     outputMesh->GetPoint(*pointIt, &p1);
     cellCenter += p1.GetVectorFromOrigin();
-    pointIt++;
+    ++pointIt;
   }
 
   tmp.SetVnlVector(cellCenter.GetVnlVector() / simplexCell->GetNumberOfPoints());

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
@@ -122,7 +122,7 @@ public:
       {
         this->m_Mesh->GetPoint(*it, &p);
         center += p.GetVectorFromOrigin();
-        it++;
+        ++it;
       }
 
       center[0] /= poly->GetNumberOfPoints();

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -102,7 +102,7 @@ SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::FindCellId(CellIdentif
     {
       break;
     }
-    cellIt++;
+    ++cellIt;
   }
 
   if (cellIt == cells1.end())

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -129,7 +129,7 @@ public:
       {
         m_Mesh->GetPoint(*it, &p);
         center += p.GetVectorFromOrigin();
-        it++;
+        ++it;
       }
 
       center[0] /= poly->GetNumberOfPoints();

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -80,7 +80,7 @@ SimplexMeshVolumeCalculator<TInputMesh>::FindCellId(IdentifierType id1, Identifi
     {
       break;
     }
-    cellIt++;
+    ++cellIt;
   }
 
   if (cellIt == cells1.end())
@@ -145,31 +145,31 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
   absu[2] = itk::Math::abs(u[2]);
   if ((absu[0] > absu[1]) && (absu[0] > absu[2]))
   {
-    m_Muncx++;
+    ++m_Muncx;
   }
   else if ((absu[1] > absu[0]) && (absu[1] > absu[2]))
   {
-    m_Muncy++;
+    ++m_Muncy;
   }
   else if ((absu[2] > absu[0]) && (absu[2] > absu[1]))
   {
-    m_Muncz++;
+    ++m_Muncz;
   }
   else if (Math::AlmostEquals(absu[0], absu[1]) && itk::Math::AlmostEquals(absu[0], absu[2]))
   {
-    m_Wxyz++;
+    ++m_Wxyz;
   }
   else if (Math::AlmostEquals(absu[0], absu[1]) && (absu[0] > absu[2]))
   {
-    m_Wxy++;
+    ++m_Wxy;
   }
   else if (Math::AlmostEquals(absu[0], absu[2]) && (absu[0] > absu[1]))
   {
-    m_Wxz++;
+    ++m_Wxz;
   }
   else if (Math::AlmostEquals(absu[1], absu[2]) && (absu[0] < absu[2]))
   {
-    m_Wyz++;
+    ++m_Wyz;
   }
   else
   {
@@ -210,7 +210,7 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
 
   m_Area += area;
 
-  m_NumberOfTriangles++;
+  ++m_NumberOfTriangles;
 }
 
 template <typename TInputMesh>

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -186,14 +186,14 @@ SphereMeshSource<TOutputMesh>::GenerateData()
       testCell->SetPointIds(tripoints);
       outputMesh->SetCell(p, testCell);
       outputMesh->SetCellData(p, (OPixelType)3.0);
-      p++;
+      ++p;
       testCell.TakeOwnership(new TriCellType);
       tripoints[0] = tripoints[1];
       tripoints[1] = tripoints[0] + m_ResolutionY;
       testCell->SetPointIds(tripoints);
       outputMesh->SetCell(p, testCell);
       outputMesh->SetCellData(p, (OPixelType)3.0);
-      p++;
+      ++p;
     }
   }
 
@@ -208,7 +208,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
     testCell->SetPointIds(tripoints);
     outputMesh->SetCell(p, testCell);
     outputMesh->SetCellData(p, (OPixelType)1.0);
-    p++;
+    ++p;
   }
 
   // store cells containing the north pole nodes
@@ -222,7 +222,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
     testCell->SetPointIds(tripoints);
     outputMesh->SetCell(p, testCell);
     outputMesh->SetCellData(p, (OPixelType)2.0);
-    p++;
+    ++p;
   }
 }
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -120,7 +120,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateSimplexPoints()
     unsigned int id = *faceIterator;
     output->SetPoint(id, copyPoint);
     output->SetGeometryData(id, new itk::SimplexMeshGeometry());
-    faceIterator++;
+    ++faceIterator;
   }
 }
 
@@ -206,7 +206,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateNewEdge(CellIden
     m_NewInputMeshCellPointer->SetPointId(0, startPointId);
     m_NewInputMeshCellPointer->SetPointId(1, endPointId);
     nonConstInput->SetCell(boundaryId, m_NewInputMeshCellPointer);
-    m_EdgeCellId++;
+    ++m_EdgeCellId;
   }
   else
   {
@@ -326,10 +326,10 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
             wrongIdx = compare.second;
             break;
           }
-          iterator2++;
+          ++iterator2;
         }
       }
-      iterator1++;
+      ++iterator1;
     }
 
     // create a new cell
@@ -372,7 +372,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
       {
         nextIdx = newIdx;
       }
-      featureId++;
+      ++featureId;
     }
     ++points;
   }

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -145,17 +145,17 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
       switch (static_cast<int>(cellIterator.Value()->GetType()))
       {
         case 0: // VERTEX_CELL:
-          numberOfVertices++;
+          ++numberOfVertices;
           break;
         case 1: // LINE_CELL:
         case 7: // QUADRATIC_EDGE_CELL:
-          numberOfEdges++;
+          ++numberOfEdges;
           break;
         case 2: // TRIANGLE_CELL:
         case 3: // QUADRILATERAL_CELL:
         case 4: // POLYGON_CELL:
         case 8: // QUADRATIC_TRIANGLE_CELL:
-          numberOfPolygons++;
+          ++numberOfPolygons;
           break;
         default:
           std::cerr << "Unhandled cell (volumic?)." << std::endl;
@@ -189,7 +189,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
             while (pointIdIterator != pointIdEnd)
             {
               outputFile << " " << IdMap[*pointIdIterator];
-              pointIdIterator++;
+              ++pointIdIterator;
             }
             outputFile << std::endl;
             break;
@@ -240,7 +240,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
             while (pointIdIterator != pointIdEnd)
             {
               outputFile << " " << IdMap[*pointIdIterator];
-              pointIdIterator++;
+              ++pointIdIterator;
             }
             outputFile << std::endl;
             break;

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -60,8 +60,8 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::SetLnextR
   while (maxSize && (it != this->EndGeomLnext()))
   {
     it.Value()->SetLeft(faceGeom);
-    it++;
-    maxSize--;
+    ++it;
+    --maxSize;
   }
 
   return (true);
@@ -198,8 +198,8 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::IsLnextSh
     {
       return (false);
     }
-    it++;
-    maxSize--;
+    ++it;
+    --maxSize;
   }
 
   if (it != this->EndGeomLnext())
@@ -319,7 +319,7 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::GetNextBo
     {
       return (it.Value());
     }
-    it++;
+    ++it;
   }
 
   // No border edge found
@@ -599,7 +599,7 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::Disconnec
     while (it != e->EndGeomLnext())
     {
       it.Value()->UnsetLeft();
-      it++;
+      ++it;
     }
   }
   else if (this->IsInternal())

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -433,7 +433,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedPointIndex() -> PointI
     if (pid != 0)
     {
       PointsContainerConstIterator last = this->GetPoints()->End();
-      last--;
+      --last;
       pid = last.Index() + 1;
     }
   }
@@ -600,7 +600,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedCellIndex() -> CellIde
     if (cid != 0)
     {
       CellsContainerIterator last = this->GetCells()->End();
-      last--;
+      --last;
       cid = last.Index() + 1;
     }
   }
@@ -735,7 +735,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::PushOnContainer(EdgeCellType * newEdg
   CellAutoPointer pEdge;
   pEdge.TakeOwnership(newEdge);
   this->SetEdgeCell(eid, pEdge);
-  m_NumberOfEdges++;
+  ++m_NumberOfEdges;
 }
 
 /**

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
@@ -63,9 +63,9 @@ QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
   {
     QEType * g = lit.Value();
     vec += this->m_Mesh->GetVector(g->GetOrigin());
-    sum++;
+    ++sum;
     m_AssocBary[g] = pid;
-    lit++;
+    ++lit;
   } // rof
   vec /= CoordRepType(sum);
   PointType p;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
@@ -154,7 +154,7 @@ QuadEdgeMeshLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
   PointIdConstIterator i = first;
 
   this->GetQEGeom()->SetOrigin(*i);
-  i++;
+  ++i;
   this->GetQEGeom()->SetDestination(*i);
 }
 
@@ -166,7 +166,7 @@ QuadEdgeMeshLineCell<TCellInterface>::InternalSetPointIds(PointIdInternalConstIt
   PointIdInternalConstIterator i = first;
 
   this->GetQEGeom()->SetOrigin(*i);
-  i++;
+  ++i;
   this->GetQEGeom()->SetDestination(*i);
 }
 
@@ -177,7 +177,7 @@ QuadEdgeMeshLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first, Po
 {
   (void)last;
   this->GetQEGeom()->SetOrigin(*first);
-  first++;
+  ++first;
   this->GetQEGeom()->SetDestination(*first);
 }
 
@@ -189,7 +189,7 @@ QuadEdgeMeshLineCell<TCellInterface>::InternalSetPointIds(PointIdInternalConstIt
 {
   (void)last;
   this->GetQEGeom()->SetOrigin(*first);
-  first++;
+  ++first;
   this->GetQEGeom()->SetDestination(*first);
 }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
@@ -72,7 +72,7 @@ namespace itk
  *          itk::itkQEMeshForAllPointsMacro
  */
 #define itkQEMeshForAllPointsEndMacro \
-  pointIterator++;                    \
+  ++pointIterator;                    \
   } /* while */                       \
   } /* if */                          \
   }
@@ -120,7 +120,7 @@ namespace itk
  *          itk::itkQEMeshForAllCellsMacro
  */
 #define itkQEMeshForAllCellsEndMacro(cellIterator) \
-  cellIterator++;                                  \
+  ++cellIterator;                                  \
   } /* while */                                    \
   } /* if */                                       \
   }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
@@ -281,8 +281,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::GetPointId(int localId) const -> PointI
     {
       return (it.Value()->GetOrigin());
     }
-    it++;
-    n++;
+    ++it;
+    ++n;
   }
   return (PointIdentifier(-1));
 }

--- a/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
+++ b/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
@@ -431,7 +431,7 @@ QuadEdge::IsEdgeInOnextRing(Self * testEdge) const
       {
         return true;
       }
-      it++;
+      ++it;
     }
   }
   return false;
@@ -462,7 +462,7 @@ QuadEdge::GetOrder() const
     const Self * it = this->GetOnext();
     while (it && it != this)
     {
-      order++;
+      ++order;
       it = it->GetOnext();
     }
     return order;

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -90,7 +90,7 @@ ContourSpatialObject<TDimension>::GetOrientationInObjectSpace() const
         maxPnt[i] = curpoint[i];
       }
     }
-    it++;
+    ++it;
   }
   m_OrientationInObjectSpace = -1;
   for (unsigned int i = 0; i < TDimension; ++i)
@@ -117,7 +117,7 @@ ContourSpatialObject<TDimension>::SetControlPoints(const ContourPointListType & 
   {
     m_ControlPoints.push_back(*it);
     m_ControlPoints.back().SetSpatialObject(this);
-    it++;
+    ++it;
   }
   this->Modified();
 }

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -47,7 +47,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint(const DTIT
   while (it != fields.end())
   {
     this->AddField((*it).first.c_str(), (*it).second);
-    it++;
+    ++it;
   }
   for (unsigned int i = 0; i < 6; ++i)
   {
@@ -106,7 +106,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::SetField(const char * name, float va
     {
       (*it).second = value;
     }
-    it++;
+    ++it;
   }
 }
 
@@ -158,7 +158,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::GetField(const char * name) const
     {
       return (*it).second;
     }
-    it++;
+    ++it;
   }
   return -1;
 }
@@ -190,7 +190,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObject
     while (it != fields.end())
     {
       this->AddField((*it).first.c_str(), (*it).second);
-      it++;
+      ++it;
     }
     for (unsigned int i = 0; i < 6; ++i)
     {

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -83,7 +83,7 @@ LineSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) co
       {
         return true;
       }
-      it++;
+      ++it;
     }
   }
 

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -76,7 +76,7 @@ MetaBlobConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * 
     pnt.SetAlpha((*it2)->m_Color[3]);
 
     blob->AddPoint(pnt);
-    it2++;
+    ++it2;
   }
 
   return SpatialObjectPointer(blob);

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -94,7 +94,7 @@ MetaContourConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
     pnt.SetNormalInObjectSpace(normal);
 
     contourSO->GetControlPoints().push_back(pnt);
-    itCP++;
+    ++itCP;
   }
 
   // Then the interpolated points
@@ -121,7 +121,7 @@ MetaContourConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
 
     pnt.SetPositionInObjectSpace(point);
     contourSO->AddPoint(pnt);
-    itI++;
+    ++itI;
   }
 
   return contourSO.GetPointer();

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -87,7 +87,7 @@ MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
       {
         pnt.AddField((*extraIt).first.c_str(), (*extraIt).second);
       }
-      extraIt++;
+      ++extraIt;
     }
 
     pnt.SetPositionInObjectSpace(point);
@@ -172,7 +172,7 @@ MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
 
     tubeSO->AddPoint(pnt);
 
-    it2++;
+    ++it2;
   }
   return tubeSO.GetPointer();
 }
@@ -257,7 +257,7 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     while (extraIt != metaFields.end())
     {
       pnt->AddField((*extraIt).first.c_str(), (*extraIt).second);
-      extraIt++;
+      ++extraIt;
     }
 
     for (unsigned int d = 0; d < 6; ++d)

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -74,7 +74,7 @@ MetaLandmarkConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTyp
     pnt.SetAlpha((*it2)->m_Color[3]);
 
     landmarkSO->AddPoint(pnt);
-    it2++;
+    ++it2;
   }
 
   return landmarkSO.GetPointer();

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -85,7 +85,7 @@ MetaLineConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * 
     pnt.SetAlpha((*it2)->m_Color[3]);
 
     lineSO->AddPoint(pnt);
-    it2++;
+    ++it2;
   }
   return lineSO.GetPointer();
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -72,7 +72,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
       pt[i] = ((*it_points)->m_X)[i] * _mesh->ElementSpacing(i);
     }
     mesh->SetPoint((*it_points)->m_Id, pt);
-    it_points++;
+    ++it_points;
   }
 
   // Add Cells
@@ -140,7 +140,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
       }
 
       mesh->SetCell((*it_cells)->m_Id, cell);
-      it_cells++;
+      ++it_cells;
     }
   }
 
@@ -160,10 +160,10 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
     while (it_link != (*it_links)->m_Links.end())
     {
       pcl.insert(*it_link);
-      it_link++;
+      ++it_link;
     }
     linkContainer->InsertElement((*it_links)->m_Id, pcl);
-    it_links++;
+    ++it_links;
   }
 
   mesh->SetCellLinks(linkContainer);
@@ -177,7 +177,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   while (it_pd != _mesh->GetPointData().end())
   {
     pointData->InsertElement((*it_pd)->m_Id, static_cast<MeshData<PixelType> *>(*it_pd)->m_Data);
-    it_pd++;
+    ++it_pd;
   }
   mesh->SetPointData(pointData);
 
@@ -190,7 +190,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   {
     using CellPixelType = typename MeshType::CellPixelType;
     cellData->InsertElement((*it_cd)->m_Id, static_cast<MeshData<CellPixelType> *>(*it_cd)->m_Data);
-    it_cd++;
+    ++it_cd;
   }
 
   mesh->SetCellData(cellData);
@@ -257,7 +257,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::SpatialObjectToMetaObject
     while (itptids != (*it_cells)->Value()->PointIdsEnd())
     {
       cell->m_PointsId[i++] = *itptids;
-      itptids++;
+      ++itptids;
     }
     cell->m_Id = (*it_cells)->Index();
 
@@ -315,7 +315,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::SpatialObjectToMetaObject
       while (it != (*it_celllinks)->Value().end())
       {
         link->m_Links.push_back(*it);
-        it++;
+        ++it;
       }
       metamesh->GetCellLinks().push_back(link);
       ++it_celllinks;

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -218,7 +218,7 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateSpatialObjectScene
       soScene = currentSO;
     }
     currentSO->SetParentId(tmpParentId);
-    it++;
+    ++it;
   }
 
   if (soScene != nullptr)
@@ -362,7 +362,7 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
 
     this->SetTransform(currentMeta, (*it)->GetObjectToParentTransform());
     metaScene->AddObject(currentMeta);
-    it++;
+    ++it;
   }
 
   delete childrenList;

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -80,7 +80,7 @@ MetaSurfaceConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
     pnt.SetNormalInObjectSpace(normal);
 
     surfaceSO->AddPoint(pnt);
-    it2++;
+    ++it2;
   }
 
   return surfaceSO.GetPointer();

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -114,7 +114,7 @@ MetaTubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * 
 
     tubeSO->AddPoint(pnt);
 
-    it2++;
+    ++it2;
   }
 
   return tubeSO.GetPointer();

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -125,7 +125,7 @@ MetaVesselTubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectT
 
     vesselTubeSO->AddPoint(pnt);
 
-    it2++;
+    ++it2;
   }
 
   return vesselTubeSO.GetPointer();

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -112,7 +112,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInObje
       closestPoint = (*it);
       closestPointDistance = curdistance;
     }
-    it++;
+    ++it;
   }
 
   return closestPoint;
@@ -142,7 +142,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInWorl
       closestPoint = (*it);
       closestPointDistance = curdistance;
     }
-    it++;
+    ++it;
   }
 
   return closestPoint;
@@ -171,11 +171,11 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingB
 
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pt);
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pt);
-  it++;
+  ++it;
   while (it != end)
   {
     this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint((*it).GetPositionInObjectSpace());
-    it++;
+    ++it;
   }
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
@@ -206,7 +206,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::IsInsideInObjectSp
       {
         return true;
       }
-      it++;
+      ++it;
     }
   }
 

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -78,7 +78,7 @@ PolygonSpatialObject<TDimension>::GetOrientationInObjectSpace() const
         maxPnt[i] = curpoint[i];
       }
     }
-    it++;
+    ++it;
   }
   m_OrientationInObjectSpace = -1;
   for (unsigned int i = 0; i < TDimension; ++i)
@@ -136,7 +136,7 @@ PolygonSpatialObject<TDimension>::MeasureAreaInObjectSpace() const
     }
     area += a[X] * b[Y] - a[Y] * b[X];
     a = b;
-    it++;
+    ++it;
   }
   if (m_IsClosed)
   {
@@ -188,7 +188,7 @@ PolygonSpatialObject<TDimension>::MeasurePerimeterInObjectSpace() const
     double curdistance = a.EuclideanDistanceTo(b);
     perimeter += curdistance;
     a = b;
-    it++;
+    ++it;
   }
   if (m_IsClosed)
   {
@@ -258,7 +258,7 @@ PolygonSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point)
           }
           node1 = node2;
         }
-        it++;
+        ++it;
       }
       if (m_IsClosed)
       {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -210,7 +210,7 @@ SpatialObject<TDimension>::IsInsideChildrenInObjectSpace(const PointType &   poi
     {
       return true;
     }
-    it++;
+    ++it;
   }
 
   return false;
@@ -269,7 +269,7 @@ SpatialObject<TDimension>::IsEvaluableAtChildrenInObjectSpace(const PointType & 
     {
       return true;
     }
-    it++;
+    ++it;
   }
 
   return false;
@@ -343,7 +343,7 @@ SpatialObject<TDimension>::ValueAtChildrenInObjectSpace(const PointType &   poin
       (*it)->ValueAtInObjectSpace(pnt, value, depth, name);
       return true;
     }
-    it++;
+    ++it;
   }
 
   value = m_DefaultOutsideValue;
@@ -553,7 +553,7 @@ SpatialObject<TDimension>::ProtectedComputeObjectToWorldTransform()
   while (it != m_ChildrenList.end())
   {
     (*it)->Update();
-    it++;
+    ++it;
   }
 
   this->Modified();
@@ -635,7 +635,7 @@ SpatialObject<TDimension>::GetMTime() const
     {
       latestTime = localTime;
     }
-    it++;
+    ++it;
   }
 
   return latestTime;
@@ -743,7 +743,7 @@ SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const st
         tPnt = (*it)->GetObjectToParentTransform()->TransformPoint(pnt);
         m_FamilyBoundingBoxInObjectSpace->ConsiderPoint(tPnt);
       }
-      it++;
+      ++it;
     }
   }
 
@@ -766,7 +766,7 @@ SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & n
     {
       childrenSO->push_back((*it));
     }
-    it++;
+    ++it;
   }
 
   if (depth > 0)
@@ -775,7 +775,7 @@ SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & n
     while (it != m_ChildrenList.end())
     {
       (*it)->AddChildrenToList(childrenSO, depth - 1, name);
-      it++;
+      ++it;
     }
   }
 
@@ -799,7 +799,7 @@ SpatialObject<TDimension>::GetConstChildren(unsigned int depth, const std::strin
     {
       childrenSO->push_back((*it));
     }
-    it++;
+    ++it;
   }
 
   if (depth > 0)
@@ -808,7 +808,7 @@ SpatialObject<TDimension>::GetConstChildren(unsigned int depth, const std::strin
     while (it != m_ChildrenList.end())
     {
       (*it)->AddChildrenToConstList(childrenSO, depth - 1, name);
-      it++;
+      ++it;
     }
   }
 
@@ -828,7 +828,7 @@ SpatialObject<TDimension>::AddChildrenToList(ChildrenListType *  childrenList,
     {
       childrenList->push_back((*it));
     }
-    it++;
+    ++it;
   }
 
   if (depth > 0)
@@ -855,7 +855,7 @@ SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childr
     {
       childrenCList->push_back(*it);
     }
-    it++;
+    ++it;
   }
 
   if (depth > 0)
@@ -898,7 +898,7 @@ SpatialObject<TDimension>::GetNumberOfChildren(unsigned int depth, const std::st
     {
       ++ccount;
     }
-    it++;
+    ++it;
   }
 
   if (depth > 0)

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -46,7 +46,7 @@ SpatialObjectDuplicator<TInputSpatialObject>::CopyObject(const InternalSpatialOb
   while (it != children->end())
   {
     this->CopyObject(*it, newSO);
-    it++;
+    ++it;
   }
   delete children;
 }
@@ -84,7 +84,7 @@ SpatialObjectDuplicator<TInputSpatialObject>::Update()
   while (it != children->end())
   {
     this->CopyObject(*it, m_DuplicateSpatialObject);
-    it++;
+    ++it;
   }
   delete children;
 }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -142,7 +142,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
           m_Sum += static_cast<AccumulateType>(mv[i]);
         }
         m_Sample->PushBack(mv);
-        m_NumberOfPixels++;
+        ++m_NumberOfPixels;
       }
       ++it;
     }
@@ -209,7 +209,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
           m_Sum += static_cast<AccumulateType>(mv[i]);
         }
         m_Sample->PushBack(mv);
-        m_NumberOfPixels++;
+        ++m_NumberOfPixels;
       }
       ++it;
     }

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -125,8 +125,8 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
       {
         if (it2 == it)
         {
-          i++;
-          it2++;
+          ++i;
+          ++it2;
           continue;
         }
 
@@ -139,13 +139,13 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
             badPoint = true;
             break;
           }
-          itBadId++;
+          ++itBadId;
         }
 
         if (badPoint)
         {
-          i++;
-          it2++;
+          ++i;
+          ++it2;
           continue;
         }
 
@@ -167,8 +167,8 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
 
         if (Math::AlmostEquals(distance, 0.0f) || !valid)
         {
-          i++;
-          it2++;
+          ++i;
+          ++it2;
           continue;
         }
 
@@ -190,8 +190,8 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
           max[2] = distance;
           identifier[2] = i;
         }
-        i++;
-        it2++;
+        ++i;
+        ++it2;
       }
 
       if ((identifier[0] == identifier[1]) || (identifier[1] == identifier[2]) || (identifier[0] == identifier[2]))
@@ -256,7 +256,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
       return false;
     }
 
-    it++;
+    ++it;
   }
 
   return true;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -157,7 +157,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
   }
   this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint(tmpPt);
 
-  it++;
+  ++it;
   while (it != end)
   {
     pt = it->GetPositionInObjectSpace();
@@ -174,7 +174,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
     }
     this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint(tmpPt);
 
-    it++;
+    ++it;
   }
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
@@ -192,10 +192,10 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
     auto   it = this->m_Points.begin();
     auto   first = it;
     auto   it2 = it;
-    it2++;
+    ++it2;
     auto end = this->m_Points.end();
     auto last = end;
-    last--;
+    --last;
 
     PointType firstP = first->GetPositionInObjectSpace();
     double    firstR = first->GetRadiusInObjectSpace();
@@ -288,8 +288,8 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
           }
         }
       }
-      it++;
-      it2++;
+      ++it;
+      ++it2;
     }
   }
   return false;
@@ -314,7 +314,7 @@ TubeSpatialObject<TDimension, TTubePointType>::RemoveDuplicatePointsInObjectSpac
       if (dist <= minSpacingInObjectSpace)
       {
         it = this->m_Points.erase(it);
-        nPoints++;
+        ++nPoints;
         --it;
       }
     }
@@ -402,9 +402,9 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()
     }
 
     ((TubePointType *)(this->GetPoint(it2)))->SetTangentInObjectSpace(t);
-    it1++;
-    it2++;
-    it3++;
+    ++it1;
+    ++it2;
+    ++it3;
   }
 
   // Calculate tangets are the first and last point on a tube
@@ -553,7 +553,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()
       prevN2 = n2;
     }
 
-    it1++;
+    ++it1;
   }
 
   return true;

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -87,7 +87,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputIma
         outputSize[nonzeroSizeCount] = inputSize[i];
         outputIndex[nonzeroSizeCount] = extractRegion.GetIndex()[i];
       }
-      nonzeroSizeCount++;
+      ++nonzeroSizeCount;
     }
   }
   if (nonzeroSizeCount != OutputImageDimension)
@@ -192,7 +192,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
             ++nonZeroCount2;
           }
         }
-        nonZeroCount++;
+        ++nonZeroCount;
       }
     }
   }

--- a/Modules/Core/TestKernel/src/itkTestDriver.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriver.cxx
@@ -126,7 +126,7 @@ AddEntriesBeforeLibraryPath(const ArgumentsList & args)
       itksys::SystemTools::PutEnv(libpath64.c_str());
     }
 
-    i++;
+    ++i;
   }
 }
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -606,7 +606,7 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Comp
     {
       jacobian(d, number + d * numberOfParametersPerDimension) = weights[counter];
     }
-    counter++;
+    ++counter;
   }
 }
 

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -657,7 +657,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::ComputeJacobia
     {
       jacobian(d, number + d * numberOfParametersPerDimension) = weights[counter];
     }
-    counter++;
+    ++counter;
   }
 }
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -681,7 +681,7 @@ CompositeTransform<TParametersValueType, VDimension>::SetParameters(const Parame
 
     do
     {
-      it--;
+      --it;
       /* If inputParams is same object as m_Parameters, we just pass
        * each sub-transforms own m_Parameters in. This is needed to
        * avoid unnecessary copying of parameters in the sub-transforms,

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
@@ -82,7 +82,7 @@ ScalarAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   }
   while (!iterator_list[0].IsAtEnd())
   {
-    counter++;
+    ++counter;
     for (i = 0; i < ImageDimension; ++i)
     {
       val = iterator_list[i].GetPixel(Center[i] + Stride[i]) - iterator_list[i].GetPixel(Center[i] - Stride[i]);
@@ -108,7 +108,7 @@ ScalarAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
 
     while (!face_iterator_list[0].IsAtEnd())
     {
-      counter++;
+      ++counter;
       for (i = 0; i < ImageDimension; ++i)
       {
         val =

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -79,7 +79,7 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   }
   while (!iterator_list[0].IsAtEnd())
   {
-    counter++;
+    ++counter;
     for (i = 0; i < ImageDimension; ++i)
     {
       val = IP(iterator_list[i], operator_list[i]);
@@ -103,7 +103,7 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
 
     while (!face_iterator_list[0].IsAtEnd())
     {
-      counter++;
+      ++counter;
       for (i = 0; i < ImageDimension; ++i)
       {
         val = SIP(face_iterator_list[i], operator_list[i]);

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -157,8 +157,8 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
       slabBegin += slabLength;
       slabLength = 0;
     }
-    am_iter++;
-    slabLength++;
+    ++am_iter;
+    ++slabLength;
   }
   slabIndex[m_SlicingDirection] = slabBegin;
   slabSize[m_SlicingDirection] = slabLength;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -711,7 +711,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
       this->CorrectImage(bias, *iter);
       itkDebugMacro(<< "  Bias corrected.");
     }
-    iter++;
+    ++iter;
   }
 
   if (this->GetBiasFieldMultiplicative())
@@ -864,7 +864,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GetBiasFiel
   {
     if (size[dim] > 1)
     {
-      biasDim++;
+      ++biasDim;
     }
   }
 
@@ -876,7 +876,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GetBiasFiel
     if (size[dim] > 1)
     {
       biasSize[biasDim] = size[dim];
-      biasDim++;
+      ++biasDim;
     }
   }
 }
@@ -942,7 +942,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
       // No ovelapping, so remove the slab from the vector
       slabs.erase(iter);
     }
-    iter++;
+    ++iter;
   }
 }
 

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -97,7 +97,7 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
     if (length <= sqrRadius)
     {
       *opIter = 1;
-      numPixelsInSphere++;
+      ++numPixelsInSphere;
     }
 
     bool carryOver = true;
@@ -200,7 +200,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
     if (vectorMagnitude >= m_StencilRadius && itk::Math::abs(dotProduct) < 0.262)
     {
       threshold += it.GetPixel(i);
-      numPixels++;
+      ++numPixels;
     }
 
     bool carryOver = true;
@@ -255,7 +255,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
   unsigned int k = 0;
   gradient[k] *= this->m_ScaleCoefficients[k];
   gradMagnitude = Math::sqr(gradient[k]);
-  k++;
+  ++k;
 
   stride = it.GetStride(1);
   gradient[k] = 0.5 * (it.GetPixel(center + stride) - it.GetPixel(center - stride));
@@ -324,12 +324,12 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
   unsigned int k = 0;
   gradient[k] *= this->m_ScaleCoefficients[k];
   gradMagnitude = itk::Math::sqr(gradient[k]);
-  k++;
+  ++k;
 
   gradient[k] = 0.5 * (it.GetPixel(center + strideY) - it.GetPixel(center - strideY));
   gradient[k] *= this->m_ScaleCoefficients[k];
   gradMagnitude += itk::Math::sqr(gradient[k]);
-  k++;
+  ++k;
 
   gradient[k] = 0.5 * (it.GetPixel(center + strideZ) - it.GetPixel(center - strideZ));
   gradient[k] *= this->m_ScaleCoefficients[k];

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -192,7 +192,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
         fieldPoints->SetPoint(numberOfPoints, point);
         fieldPoints->SetPointData(numberOfPoints, data);
         weights->InsertElement(numberOfPoints, boundaryWeight);
-        numberOfPoints++;
+        ++numberOfPoints;
       }
     }
   }
@@ -279,7 +279,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
         fieldPoints->SetPoint(numberOfPoints, parametricPoint);
         fieldPoints->SetPointData(numberOfPoints, data);
         weights->InsertElement(numberOfPoints, weight);
-        numberOfPoints++;
+        ++numberOfPoints;
       }
     }
   }
@@ -346,7 +346,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
         fieldPoints->SetPoint(numberOfPoints, parametricPoint);
         fieldPoints->SetPointData(numberOfPoints, data);
         weights->InsertElement(numberOfPoints, weight);
-        numberOfPoints++;
+        ++numberOfPoints;
       }
 
       ++ItP;

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -215,7 +215,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   for (unsigned int d = m_CurrentDimension + InputImageDimension - 1; d > m_CurrentDimension + 1; d--)
   {
     k[count + 1] = k[count] * size[d % InputImageDimension];
-    count++;
+    ++count;
   }
   k.flip();
 
@@ -242,7 +242,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
         offsetIndex[d % InputImageDimension] + static_cast<OutputIndexValueType>(startIndex[d % InputImageDimension]);
 
       index %= k[count];
-      count++;
+      ++count;
     }
     this->Voronoi(m_CurrentDimension, idx, outputImage);
     progress->CompletedPixel();
@@ -348,7 +348,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::Voronoi(unsigned 
     {
       if (l < 1)
       {
-        l++;
+        ++l;
         g(l) = di;
         h(l) = iw;
       }
@@ -356,9 +356,9 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::Voronoi(unsigned 
       {
         while ((l >= 1) && this->Remove(g(l - 1), g(l), di, h(l - 1), h(l), iw))
         {
-          l--;
+          --l;
         }
-        l++;
+        ++l;
         g(l) = di;
         h(l) = iw;
       }
@@ -398,7 +398,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::Voronoi(unsigned 
       {
         break;
       }
-      l++;
+      ++l;
       d1 = d2;
     }
     idx[d] = i + startIndex[d];

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -89,7 +89,7 @@ VnlHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Generate
     {
       signal[si] = inputPtr->GetPixel(index);
     }
-    si++;
+    ++si;
   }
 
   OutputPixelType * out = outputPtr->GetBufferPointer();

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -171,7 +171,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ComputeCannyEdge(const
                0.25 * it.GetPixel(m_Center + m_Stride[i] + m_Stride[j]);
 
       deriv += 2.0 * dx[i] * dx[j] * dxy[k];
-      k++;
+      ++k;
     }
   }
 

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -64,7 +64,7 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::Genera
   {
     this->UpdatePixels();
     this->UpdateInterImage();
-    i++;
+    ++i;
   }
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -236,10 +236,10 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
           if (j != dima)
           {
             m_DerivativeFilterB->SetDirection(j);
-            j++;
+            ++j;
             break;
           }
-          j++;
+          ++j;
         }
         // find the direction for all the other filters
         while (i < numberOfSmoothingFilters)
@@ -249,12 +249,12 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
             if (j != dima)
             {
               m_SmoothingFilters[i]->SetDirection(j);
-              j++;
+              ++j;
               break;
             }
-            j++;
+            ++j;
           }
-          i++;
+          ++i;
         }
 
         m_DerivativeFilterA->SetDirection(dima);
@@ -283,12 +283,12 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
             if (j != dima && j != dimb)
             {
               m_SmoothingFilters[i]->SetDirection(j);
-              j++;
+              ++j;
               break;
             }
-            j++;
+            ++j;
           }
-          i++;
+          ++i;
         }
 
         m_DerivativeFilterA->SetDirection(dima);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -253,7 +253,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
 
       m_CirclesList.push_back(Circle);
 
-      circles++;
+      ++circles;
       if (circles >= m_NumberOfCircles)
       {
         break;

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -343,7 +343,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() 
           minMaxCalculator->ComputeMaximum();
           max = minMaxCalculator->GetMaximum();
 
-          lines++;
+          ++lines;
           if (lines == m_NumberOfLines)
           {
             break;

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -208,11 +208,11 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
     {
       if (i == dim)
       {
-        j++;
+        ++j;
       }
       m_SmoothingFilters[i]->SetDirection(j);
-      i++;
-      j++;
+      ++i;
+      ++j;
     }
     m_DerivativeFilter->SetDirection(dim);
 

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -85,7 +85,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::ComputeConnectivityOf
       {
         if (off[j] == 0)
         {
-          numberOfZeros++;
+          ++numberOfZeros;
         }
       }
 
@@ -232,7 +232,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
     // index should be inside the mask image (GetPixel = 1)
     if (selectionMap->GetPixel(indexOfPointToPick) && region.IsInside(indexOfPointToPick))
     {
-      numberOfPointsInserted++;
+      ++numberOfPointsInserted;
       // compute and add structure tensor into pointData
       if (m_ComputeStructureTensors)
       {
@@ -285,8 +285,8 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
         // trace should be non-zero
         if (itk::Math::abs(trace) < TRACE_EPSILON)
         {
-          rit++;
-          numberOfPointsInserted--;
+          ++rit;
+          --numberOfPointsInserted;
           continue;
         }
 
@@ -309,7 +309,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
         selectionMap->SetPixel(idx, ineligeblePointCode);
       }
     }
-    rit++;
+    ++rit;
   }
   // set points
   pointSet->SetPoints(points);

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -80,7 +80,7 @@ MovingHistogramImageFilterBase<TInputImage, TOutputImage, TKernel>::SetKernel(co
     {
       kernelImageIt.Set(true);
       kernelOffsets.push_front(kernelImageIt.GetIndex() - centerIndex);
-      count++;
+      ++count;
     }
     else
     {

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -160,7 +160,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Befor
     if (j != static_cast<unsigned int>(m_SliceDimension))
     {
       srad[j] = m_ContourThickness[i];
-      j++;
+      ++j;
     }
   }
   serode->SetKernel(SliceKernelType::Ball(srad));

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -235,11 +235,11 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Genera
     {
       if (i == dim)
       {
-        j++;
+        ++j;
       }
       m_SmoothingFilters[i]->SetDirection(j);
-      i++;
-      j++;
+      ++i;
+      ++j;
     }
     m_DerivativeFilter->SetDirection(dim);
 

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -159,7 +159,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::FindRegionsInArea(long start, l
     result = regionsize / size;
     //      if ((regionsize % size) != 0)
     //  {
-    result++;
+    ++result;
     //  }
     if (offset > 0)
     {
@@ -354,7 +354,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::BuildPreRegions(std::vector<lon
   // the size of the input image.
   for (ctr = 1; ctr < numRegs; ++ctr)
   {
-    regCtr++;
+    ++regCtr;
     offset = 0;
     outputRegionStart[regCtr] = outputRegionStart[regCtr - 1] + static_cast<long>(outputRegionSizes[regCtr - 1]);
     inputRegionStart[regCtr] = inputIndex;
@@ -405,7 +405,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::BuildPostRegions(std::vector<lo
   // Handle the post region.  The post region has a number of
   // areas of size equal to the input region, followed by one
   // region of possibly smaller size.
-  regCtr++;
+  ++regCtr;
   sizeTemp = outputIndex + outputSize - inputIndex - inputSize;
   sizeTemp = ((sizeTemp > 0) ? (sizeTemp % inputSize) : 0);
   outputRegionSizes[regCtr] = sizeTemp;
@@ -424,7 +424,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::BuildPostRegions(std::vector<lo
   for (ctr = numRegs - 1; ctr >= 1; ctr--)
   {
     offset = 0;
-    regCtr++;
+    ++regCtr;
     outputRegionStart[regCtr] = outputRegionStart[regCtr - 1] - inputSize;
     inputRegionStart[regCtr] = inputIndex;
     outputRegionSizes[regCtr] = inputSize;

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -188,7 +188,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData
 
     m_ForegroundLineMap[lineId] = fgLine;
     m_BackgroundLineMap[lineId] = bgLine;
-    lineId++;
+    ++lineId;
   }
 }
 

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -169,7 +169,7 @@ protected:
       {
         cIt->label = label;
         m_UnionFind[label] = label;
-        label++;
+        ++label;
       }
     }
   }
@@ -476,7 +476,7 @@ protected:
     SizeValueType         lastLine = wud.lastLine;
     if (!strictlyLess)
     {
-      lastLine++;
+      ++lastLine;
       // make sure we are not wrapping around
       itkAssertInDebugAndIgnoreInReleaseMacro(lastLine >= wud.lastLine);
     }

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -97,7 +97,7 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateBasisMatrix(
     {
       m_BasisMatrix(i, j++) = image_it.Get();
     }
-    i++;
+    ++i;
   }
   m_BasisMatrixCalculated = true;
   m_ImageAsVector.set_size(m_NumPixels);

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -484,9 +484,9 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType l
     {
       index[0] = bin;
       total += (*mapIt).second.m_Histogram->GetFrequency(index);
-      bin++;
+      ++bin;
     }
-    bin--;
+    --bin;
     index[0] = bin;
 
     // return center of bin range

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
@@ -74,13 +74,13 @@ AttributeRelabelLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
     // avoid the background label if it is used
     if (label == output->GetBackgroundValue())
     {
-      label++;
+      ++label;
     }
     (*it)->SetLabel(label);
     output->AddLabelObject(*it);
 
     // go to the nex label
-    label++;
+    ++label;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
@@ -101,7 +101,7 @@ ChangeLabelLabelMapFilter<TImage>::GenerateData()
     }
 
     progress.CompletedPixel();
-    pairToReplace++;
+    ++pairToReplace;
   }
 
   // ChangeBackgroundIfNeeded
@@ -165,7 +165,7 @@ ChangeLabelLabelMapFilter<TImage>::GenerateData()
 
     // go to the next label object
     progress.CompletedPixel();
-    labelObjectItr++;
+    ++labelObjectItr;
   }
 }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -191,7 +191,7 @@ LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos) -> LabelObj
     {
       return it->second;
     }
-    i++;
+    ++i;
   }
   itkExceptionMacro(<< "Can't access to label object at position " << pos << ". The label map has only "
                     << this->GetNumberOfLabelObjects() << " label objects registered.");
@@ -210,7 +210,7 @@ LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos) const -> co
     {
       return it->second;
     }
-    i++;
+    ++i;
   }
   itkExceptionMacro(<< "Can't access to label object at position " << pos << ". The label map has only "
                     << this->GetNumberOfLabelObjects() << " label objects registered.");
@@ -439,7 +439,7 @@ LabelMap<TLabelObject>::PushLabelObject(LabelObjectType * labelObject)
         assert((it->second.IsNotNull()));
         if (label == m_BackgroundValue)
         {
-          label++;
+          ++label;
         }
         if (label != it->first)
         {

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -252,7 +252,7 @@ LabelObject<TLabel, VImageDimension>::GetIndex(SizeValueType offset) const -> In
       return idx;
     }
 
-    it++;
+    ++it;
   }
   itkGenericExceptionMacro(<< "Invalid offset: " << offset);
 }
@@ -352,7 +352,7 @@ LabelObject<TLabel, VImageDimension>::Optimize()
         currentLength = length;
       }
 
-      it++;
+      ++it;
     }
 
     // complete the last line

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
@@ -226,7 +226,7 @@ MergeLabelMapFilter<TImage>::MergeWithPack()
 
     // go to the next label
     progress.CompletedPixel();
-    it++;
+    ++it;
   }
 
   // now, the next images

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -168,7 +168,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
       if (idx[0] == borderMin[0])
       {
         // One more pixel on the border
-        nbOfPixelsOnBorder++;
+        ++nbOfPixelsOnBorder;
         isOnBorder0 = true;
       }
       if (!isOnBorder0 || length > 1)
@@ -177,7 +177,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
         if (idx[0] + (OffsetValueType)length - 1 == borderMax[0])
         {
           // One more pixel on the border
-          nbOfPixelsOnBorder++;
+          ++nbOfPixelsOnBorder;
         }
       }
     }
@@ -634,7 +634,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
           {
             // go to next neighbor
             nMin = ni->GetIndex()[0] + ni->GetLength();
-            ni++;
+            ++ni;
 
             if (ni != ns.end())
             {
@@ -648,7 +648,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
           else
           {
             // go to next line
-            li++;
+            ++li;
           }
         }
       }

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -158,13 +158,13 @@ protected:
       // Avoid the background label if it is used
       if (label == output->GetBackgroundValue())
       {
-        label++;
+        ++label;
       }
       (*it2)->SetLabel(label);
       output->AddLabelObject(*it2);
 
       // Go to the next label
-      label++;
+      ++label;
       progress.CompletedPixel();
 
       ++it2;

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -101,7 +101,7 @@ AnchorErodeDilateLine<TInputPix, TCompare>::DoLine(std::vector<TInputPix> & buff
       buffer[outLeftP] = Extreme;
     }
     // now finish
-    outLeftP++;
+    ++outLeftP;
     int left = 0;
     for (; outLeftP < static_cast<int>(bufflength); outLeftP++, left++)
     {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -169,7 +169,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
   {
     // Now we need a histogram
     // Initialise it
-    outLeftP++;
+    ++outLeftP;
     for (unsigned int aux = outLeftP; aux <= currentP; ++aux)
     {
       histo.AddPixel(buffer[aux]);

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -808,15 +808,15 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
           FacetArray[pos].P1 = FacetArray[i].P1;
           FacetArray[pos].P2 = Pa;
           FacetArray[pos].P3 = Pc;
-          pos++;
+          ++pos;
           FacetArray[pos].P1 = Pa;
           FacetArray[pos].P2 = FacetArray[i].P2;
           FacetArray[pos].P3 = Pb;
-          pos++;
+          ++pos;
           FacetArray[pos].P1 = Pb;
           FacetArray[pos].P2 = FacetArray[i].P3;
           FacetArray[pos].P3 = Pc;
-          pos++;
+          ++pos;
           FacetArray[i].P1 = Pa;
           FacetArray[i].P2 = Pb;
           FacetArray[i].P3 = Pc;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -238,7 +238,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateData()
       singleIteration->GetOutput()->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
 
       // Keep track of how many iterations have be done
-      m_NumberOfIterationsUsed++;
+      ++m_NumberOfIterationsUsed;
     }
   }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -238,7 +238,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateData()
       singleIteration->GetOutput()->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
 
       // Keep track of how many iterations have be done
-      m_NumberOfIterationsUsed++;
+      ++m_NumberOfIterationsUsed;
     }
   }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
@@ -74,12 +74,12 @@ public:
         // value
         // or the iterator is invalidated.
         TInputPixel toErase = mapIt->first;
-        mapIt++;
+        ++mapIt;
         m_Map.erase(toErase);
       }
       else
       {
-        mapIt++;
+        ++mapIt;
         // don't remove all the zero value found, just remove the one before the
         // current maximum value
         // the histogram may become quite big on real type image, but it's an

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
@@ -75,12 +75,12 @@ public:
         // value
         // or the iterator is invalidated.
         TInputPixel toErase = mapIt->first;
-        mapIt++;
+        ++mapIt;
         m_Map.erase(toErase);
       }
       else
       {
-        mapIt++;
+        ++mapIt;
       }
     }
 
@@ -138,23 +138,23 @@ public:
     {
       m_Min = p;
     }
-    m_Count++;
+    ++m_Count;
   }
 
   inline void
   RemovePixel(const TInputPixel & p)
   {
     m_Vector[p - NumericTraits<TInputPixel>::NonpositiveMin()]--;
-    m_Count--;
+    --m_Count;
     if (m_Count > 0)
     {
       while (m_Vector[m_Max - NumericTraits<TInputPixel>::NonpositiveMin()] == 0)
       {
-        m_Max--;
+        --m_Max;
       }
       while (m_Vector[m_Min - NumericTraits<TInputPixel>::NonpositiveMin()] == 0)
       {
-        m_Min++;
+        ++m_Min;
       }
     }
     else

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -65,7 +65,7 @@ FillForwardExt(std::vector<PixelType> & pixbuffer,
   {
     PixelType V = pixbuffer[i];
     fExtBuffer[i] = V;
-    i++;
+    ++i;
   }
   while (i < size)
   {

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -593,7 +593,7 @@ ContourExtractor2DImageFilter<TInputImage>::FillOutputs(
       ContourConstIterator itC{ (*it).cend() };
       do
       {
-        itC--;
+        --itC;
         path->push_back(*itC);
       } while (itC != (*it).cbegin());
     }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -168,7 +168,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLargestBorder() -> Inp
 
     for (InputIteratorGeom e_it = (*b_it)->BeginGeomLnext(); e_it != (*b_it)->EndGeomLnext(); ++e_it)
     {
-      k++;
+      ++k;
     }
 
     if (k > max_id)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -150,7 +150,7 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdent
           }
 
           temp = temp->GetLnext();
-          k++;
+          ++k;
         } while (temp != edge);
 
         switch (m_Weight)

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -154,7 +154,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   // walk the output image forwards and compute blur
   for (unsigned int rep = 0; rep < m_Repetitions; ++rep)
   {
-    num_reps++;
+    ++num_reps;
 
     itkDebugMacro(<< "Repetition #" << rep);
 

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -60,7 +60,7 @@ KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::Compute()
         if (v <= threshold)
         {
           mean += v;
-          count++;
+          ++count;
         }
       }
       ++iIt;

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -190,14 +190,14 @@ BMPImageIO::Read(void * buffer)
     for (unsigned int i = 0; i < m_BMPDataSize; ++i)
     {
       unsigned char byte1 = value[i];
-      i++;
+      ++i;
       unsigned char byte2 = value[i];
       if (byte1 == 0)
       {
         if (byte2 == 0)
         {
           // End of line
-          line--;
+          --line;
           posLine = 0;
           continue;
         }
@@ -209,9 +209,9 @@ BMPImageIO::Read(void * buffer)
         else if (byte2 == 2)
         {
           // Delta
-          i++;
+          ++i;
           unsigned char dx = value[i];
-          i++;
+          ++i;
           unsigned char dy = value[i];
           posLine += dx;
           line -= dy;
@@ -224,29 +224,29 @@ BMPImageIO::Read(void * buffer)
           {
             for (unsigned long j = 0; j < byte2; ++j)
             {
-              i++;
+              ++i;
               RGBPixelType rgb = this->GetColorPaletteEntry(value[i]);
               l = 3 * (line * m_Dimensions[0] + posLine);
               p[l] = rgb.GetBlue();
               p[l + 1] = rgb.GetGreen();
               p[l + 2] = rgb.GetRed();
-              posLine++;
+              ++posLine;
             }
           }
           else
           {
             for (unsigned long j = 0; j < byte2; ++j)
             {
-              i++;
+              ++i;
               l = (line * m_Dimensions[0] + posLine);
               p[l] = value[i];
-              posLine++;
+              ++posLine;
             }
           }
           // If a run's length is odd, the it is padded with 0
           if (byte2 % 2)
           {
-            i++;
+            ++i;
           }
         }
       }
@@ -262,7 +262,7 @@ BMPImageIO::Read(void * buffer)
             p[l] = rgb.GetBlue();
             p[l + 1] = rgb.GetGreen();
             p[l + 2] = rgb.GetRed();
-            posLine++;
+            ++posLine;
           }
         }
         else
@@ -271,7 +271,7 @@ BMPImageIO::Read(void * buffer)
           {
             l = (line * m_Dimensions[0] + posLine);
             p[l] = byte2;
-            posLine++;
+            ++posLine;
           }
         }
       }
@@ -874,7 +874,7 @@ BMPImageIO::Write(const void * buffer)
       for (i = 0; i < m_Dimensions[0]; ++i)
       {
         m_Ofstream.write(ptr, sizeof(char));
-        ptr++;
+        ++ptr;
       }
       for (i = 0; i < paddedBytes; ++i)
       {
@@ -887,9 +887,9 @@ BMPImageIO::Write(const void * buffer)
       {
         ptr += 2;
         m_Ofstream.write(ptr, sizeof(char)); // blue
-        ptr--;
+        --ptr;
         m_Ofstream.write(ptr, sizeof(char)); // green
-        ptr--;
+        --ptr;
         m_Ofstream.write(ptr, sizeof(char)); // red
         ptr += 3;
       }
@@ -904,13 +904,13 @@ BMPImageIO::Write(const void * buffer)
       {
         ptr += 2;
         m_Ofstream.write(ptr, sizeof(char)); // blue
-        ptr--;
+        --ptr;
         m_Ofstream.write(ptr, sizeof(char)); // green
-        ptr--;
+        --ptr;
         m_Ofstream.write(ptr, sizeof(char)); // red
         ptr += 3;
         m_Ofstream.write(ptr, sizeof(char)); // alpha
-        ptr++;
+        ++ptr;
       }
       for (i = 0; i < paddedBytes; ++i)
       {

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -328,7 +328,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
           ss >> spacing;
           spacing *= 1000; // move to millemeters
           m_Spacing[0] = spacing;
-          punt++;
+          ++punt;
         }
         else if (label == "AXIS_3")
         {
@@ -336,7 +336,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
           ss >> spacing;
           spacing *= 1000; // move to millemeters
           m_Spacing[1] = spacing;
-          punt++;
+          ++punt;
         }
         else if (label == "AXIS_4")
         {
@@ -344,7 +344,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
           ss >> spacing;
           spacing *= 1000; // move to millemeters
           m_Spacing[2] = spacing;
-          punt++;
+          ++punt;
         }
       }
     }

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -96,8 +96,8 @@ SwapSlicesAndVolumes(T *            buffer,
         for (SizeType p = 0; p < szSlice; ++p)
         {
           *toPixel = *fromPixel;
-          toPixel++;
-          fromPixel++;
+          ++toPixel;
+          ++fromPixel;
         }
         fromSlice += sizeToSwap * szSlice;
       }
@@ -135,8 +135,8 @@ ReverseSliceOrder(T * buffer, const SizeType sizeX, const SizeType sizeY, const 
         temp = *toPixel;
         *toPixel = *fromPixel;
         *fromPixel = temp;
-        toPixel++;
-        fromPixel++;
+        ++toPixel;
+        ++fromPixel;
       }
       fromSlice += ss;
       toSlice -= ss;

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -100,9 +100,9 @@ CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
       {
         if (cellnum % 2 != 0)
         {
-          prev_cols++;
+          ++prev_cols;
         }
-        cellnum++;
+        ++cellnum;
       }
     }
 
@@ -112,7 +112,7 @@ CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
     {
       while (std::getline(linestream, cell, this->m_FieldDelimiterCharacter))
       {
-        prev_cols++;
+        ++prev_cols;
       }
     }
     // previous columns now holds the number of headers minus the first header,
@@ -151,9 +151,9 @@ CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
     // Count the entries
     while (std::getline(linestream, cell, this->m_FieldDelimiterCharacter))
     {
-      cols++;
+      ++cols;
     }
-    rows++;
+    ++rows;
 
     // Determine the max #columns and #rows
     current_cols = cols;

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -359,7 +359,7 @@ GE4ImageIO ::MvtSunf(int numb)
   int          sun_exp = 4 * (dg_exp - 64);
   while ((dg_mantissa & signbit) == 0 && dg_mantissa != 0)
   {
-    sun_exp--;
+    --sun_exp;
     dg_mantissa = dg_mantissa << 1;
   }
   sun_exp += 126;

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -544,7 +544,7 @@ GE5ImageIO::ModifyImageInformation()
     std::string file1 = (*it)->GetImageFileName();
 
     // The second file
-    it++;
+    ++it;
     std::string file2 = (*it)->GetImageFileName();
 
     GEImageHeader * hdr1 = this->ReadHeader(file1.c_str());

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -310,11 +310,11 @@ GiplImageIO::ReadImageInformation()
     {
       if (i < 3)
       {
-        numberofdimension++;
+        ++numberofdimension;
       }
       else if (dims[i] > 1)
       {
-        numberofdimension++;
+        ++numberofdimension;
       }
     }
   }

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -490,7 +490,7 @@ HDF5ImageIO ::WriteDirections(const std::string & path, const std::vector<std::v
     for (unsigned int j = 0; j < dim[0]; ++j)
     {
       buf[k] = dir[i][j];
-      k++;
+      ++k;
     }
   }
 
@@ -529,7 +529,7 @@ HDF5ImageIO ::ReadDirections(const std::string & path)
       for (unsigned int j = 0; j < dim[0]; ++j)
       {
         rval[i][j] = buf[k];
-        k++;
+        ++k;
       }
     }
   }
@@ -543,7 +543,7 @@ HDF5ImageIO ::ReadDirections(const std::string & path)
       for (unsigned int j = 0; j < dim[0]; ++j)
       {
         rval[i][j] = buf[k];
-        k++;
+        ++k;
       }
     }
   }
@@ -1066,7 +1066,7 @@ HDF5ImageIO ::WriteImageInformation()
     if (numComponents > 1)
     {
       dims[numDims] = numComponents;
-      numDims++;
+      ++numDims;
     }
     H5::DataSpace imageSpace(numDims, dims.get());
     H5::PredType  dataType = ComponentToPredType(this->GetComponentType());
@@ -1273,7 +1273,7 @@ HDF5ImageIO ::Write(const void * buffer)
     if (numComponents > 1)
     {
       dims[numDims] = numComponents;
-      numDims++;
+      ++numDims;
     }
     H5::DataSpace imageSpace(numDims, dims.get());
     H5::PredType  dataType = ComponentToPredType(this->GetComponentType());

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -219,7 +219,7 @@ public:
       {
         return true;
       }
-      it++;
+      ++it;
     }
     m_List.push_back(new IPLFileSortInfo(filename,
                                          sliceLocation,

--- a/Modules/IO/IPL/src/itkIPLFileNameList.cxx
+++ b/Modules/IO/IPL/src/itkIPLFileNameList.cxx
@@ -155,7 +155,7 @@ IPLFileNameList::~IPLFileNameList()
   while (it != itend)
   {
     delete (*it);
-    it++;
+    ++it;
   }
 }
 

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -174,7 +174,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   while (inputData != endInput)
   {
     OutputConvertTraits::SetNthComponent(0, *outputData++, static_cast<OutputComponentType>(*inputData));
-    inputData++;
+    ++inputData;
   }
 }
 
@@ -303,8 +303,8 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*inputData));
-    inputData++;
-    outputData++;
+    ++inputData;
+    ++outputData;
   }
 }
 
@@ -322,7 +322,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
     OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
     inputData += 3;
-    outputData++;
+    ++outputData;
   }
 }
 
@@ -340,8 +340,8 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
     OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
     inputData += 3;
-    inputData++; // skip alpha
-    outputData++;
+    ++inputData; // skip alpha
+    ++outputData;
   }
 }
 
@@ -365,7 +365,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
       OutputConvertTraits::SetNthComponent(0, *outputData, val);
       OutputConvertTraits::SetNthComponent(1, *outputData, val);
       OutputConvertTraits::SetNthComponent(2, *outputData, val);
-      outputData++;
+      ++outputData;
     }
   }
   // just skip the rest of the data
@@ -380,7 +380,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
       OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
       inputData += 3;
       inputData += diff;
-      outputData++;
+      ++outputData;
     }
   }
 }
@@ -402,8 +402,8 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(
       3, *outputData, static_cast<OutputComponentType>(DefaultAlphaValue<InputPixelType>()));
-    inputData++;
-    outputData++;
+    ++inputData;
+    ++outputData;
   }
 }
 
@@ -426,7 +426,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
       3, *outputData, static_cast<OutputComponentType>(DefaultAlphaValue<InputComponentType>()));
 
     inputData += 3;
-    outputData++;
+    ++outputData;
   }
 }
 
@@ -446,7 +446,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
     OutputConvertTraits::SetNthComponent(3, *outputData, static_cast<OutputComponentType>(*(inputData + 3)));
     inputData += 4;
-    outputData++;
+    ++outputData;
   }
 }
 
@@ -485,7 +485,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
       OutputConvertTraits::SetNthComponent(3, *outputData, static_cast<OutputComponentType>(*(inputData + 3)));
       inputData += 4;
       inputData += diff;
-      outputData++;
+      ++outputData;
     }
   }
 }
@@ -552,8 +552,8 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   {
     OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*inputData));
-    inputData++;
-    outputData++;
+    ++inputData;
+    ++outputData;
   }
 }
 
@@ -571,7 +571,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
     inputData += 2;
-    outputData++;
+    ++outputData;
   }
 }
 
@@ -612,7 +612,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
     inputData += 2;
     inputData += diff;
-    outputData++;
+    ++outputData;
   }
 }
 

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -829,7 +829,7 @@ JPEG2000ImageIO ::Write(const void * buffer)
 
   while (tw && th)
   {
-    numberOfResolutions++;
+    ++numberOfResolutions;
     tw >>= 1;
     th >>= 1;
   }
@@ -920,7 +920,7 @@ JPEG2000ImageIO ::Write(const void * buffer)
       {
         l_image->comps[k].data[index] = *charBuffer++;
       }
-      index++;
+      ++index;
     }
   }
 
@@ -933,7 +933,7 @@ JPEG2000ImageIO ::Write(const void * buffer)
       {
         l_image->comps[k].data[index] = *shortBuffer++;
       }
-      index++;
+      ++index;
     }
   }
   itkDebugMacro(<< " END COPY BUFFER");

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -401,7 +401,7 @@ LSMImageIO::Write(const void * buffer)
         itkExceptionMacro(<< "TIFFImageIO: error out of disk space");
       }
       outPtr += rowLength;
-      row++;
+      ++row;
     }
 
     if (m_NumberOfDimensions == 3)

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -428,7 +428,7 @@ MINCImageIO::ReadImageInformation()
   {
     if (this->m_MINCPImpl->m_DimensionIndices[i] != -1) // this dimension is present
     {
-      spatial_dimension_count++;
+      ++spatial_dimension_count;
     }
   }
 
@@ -488,8 +488,8 @@ MINCImageIO::ReadImageInformation()
       this->SetDirection(i - 1, _dir);
       this->SetSpacing(i - 1, _sep);
 
-      spatial_dimension++;
-      usable_dimensions++;
+      ++spatial_dimension;
+      ++usable_dimensions;
     }
   }
 
@@ -503,7 +503,7 @@ MINCImageIO::ReadImageInformation()
     misize_t _sz;
     miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
     numberOfComponents = _sz;
-    usable_dimensions++;
+    ++usable_dimensions;
   }
 
   if (this->m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
@@ -516,7 +516,7 @@ MINCImageIO::ReadImageInformation()
     misize_t _sz;
     miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
     numberOfComponents = _sz;
-    usable_dimensions++;
+    ++usable_dimensions;
   }
 
   // Set apparent dimension order to the MINC2 api
@@ -914,7 +914,7 @@ MINCImageIO::WriteImageInformation()
     miset_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1],
                                tstep);
 
-    minc_dimensions++;
+    ++minc_dimensions;
   }
   else if (nComp > 1)
   {
@@ -923,7 +923,7 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        nComp,
                        &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
-    minc_dimensions++;
+    ++minc_dimensions;
   }
 
   micreate_dimension(MIxspace,
@@ -931,7 +931,7 @@ MINCImageIO::WriteImageInformation()
                      MI_DIMATTR_REGULARLY_SAMPLED,
                      this->GetDimensions(0),
                      &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
-  minc_dimensions++;
+  ++minc_dimensions;
 
   if (nDims > 1)
   {
@@ -940,7 +940,7 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        this->GetDimensions(1),
                        &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
-    minc_dimensions++;
+    ++minc_dimensions;
   }
 
   if (nDims > 2)
@@ -950,7 +950,7 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        this->GetDimensions(2),
                        &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
-    minc_dimensions++;
+    ++minc_dimensions;
   }
 
   if (nDims > 3)

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
@@ -142,7 +142,7 @@ protected:
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {
       auto numberOfCellPoints = static_cast<unsigned int>(buffer[++index]);
-      index++;
+      ++index;
       for (unsigned int jj = 0; jj < numberOfCellPoints - 1; ++jj)
       {
         outputFile << indent << buffer[index++] + 1;

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -156,7 +156,7 @@ BYUMeshIO ::ReadMeshInformation()
     this->m_CellBufferSize++;
     if (ptId < 0)
     {
-      numLines++;
+      ++numLines;
     }
   }
 
@@ -248,7 +248,7 @@ BYUMeshIO ::ReadCells(void * buffer)
       if (id >= m_FirstCellId && id <= m_LastCellId)
       {
         data[index++] = ptId - 1;
-        numPoints++;
+        ++numPoints;
       }
     }
     else
@@ -256,13 +256,13 @@ BYUMeshIO ::ReadCells(void * buffer)
       if (id >= m_FirstCellId && id <= m_LastCellId)
       {
         data[index++] = -(ptId + 1);
-        numPoints++;
+        ++numPoints;
         data[index - numPoints - 2] = static_cast<unsigned int>(CellGeometryEnum::POLYGON_CELL);
         data[index - numPoints - 1] = numPoints;
         numPoints = 0;
         index += 2;
       }
-      id++;
+      ++id;
     }
   }
 

--- a/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
@@ -38,7 +38,7 @@ ConvertPixelBuffer<InputPixelType, Array<T>, OutputConvertTraits>::Convert(Input
       OutputConvertTraits::SetNthComponent(ii, *outputData, static_cast<T>(*inputData++));
     }
 
-    outputData++;
+    ++outputData;
   }
 }
 } // end namespace itk

--- a/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
@@ -39,7 +39,7 @@ ConvertPixelBuffer<InputPixelType, VariableLengthVector<T>, OutputConvertTraits>
       OutputConvertTraits::SetNthComponent(ii, *outputData, static_cast<T>(*inputData++));
     }
 
-    outputData++;
+    ++outputData;
   }
 }
 } // end namespace itk

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -719,7 +719,7 @@ protected:
       SizeValueType outputIndex = NumericTraits<SizeValueType>::ZeroValue();
       for (SizeValueType ii = 0; ii < m_NumberOfCells; ++ii)
       {
-        inputIndex++; // ignore the cell type
+        ++inputIndex; // ignore the cell type
         auto numberOfPoints = static_cast<unsigned int>(input[inputIndex++]);
         for (unsigned int jj = 0; jj < numberOfPoints; ++jj)
         {

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -679,22 +679,22 @@ GiftiMeshIO::WriteMeshInformation()
 
   if (this->m_UpdatePoints)
   {
-    nda++;
+    ++nda;
   }
 
   if (this->m_UpdateCells)
   {
-    nda++;
+    ++nda;
   }
 
   if (this->m_UpdatePointData)
   {
-    nda++;
+    ++nda;
   }
 
   if (this->m_UpdateCellData)
   {
-    nda++;
+    ++nda;
   }
 
   // Create a new gifti image
@@ -725,7 +725,7 @@ GiftiMeshIO::WriteMeshInformation()
       {
         m_GiftiImage->labeltable.key[mm] = lt->Index();
         m_GiftiImage->labeltable.label[mm] = gifti_strdup(lt->Value().c_str());
-        mm++;
+        ++mm;
       }
     }
 
@@ -742,7 +742,7 @@ GiftiMeshIO::WriteMeshInformation()
           {
             m_GiftiImage->labeltable.rgba[kk * 4 + nn] = lt->Value().GetNthComponent(nn);
           }
-          kk++;
+          ++kk;
         }
       }
     }

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
@@ -138,7 +138,7 @@ protected:
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {
       outputFile << "f ";
-      index++;
+      ++index;
       auto numberOfCellPoints = static_cast<unsigned int>(buffer[index++]);
 
       for (unsigned int jj = 0; jj < numberOfCellPoints; ++jj)

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -156,7 +156,7 @@ OBJMeshIO ::ReadMeshInformation()
         std::string       item;
         while (ss >> item)
         {
-          numberOfCellPoints++;
+          ++numberOfCellPoints;
         }
       }
       else if (type == "vn")

--- a/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
+++ b/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
@@ -146,7 +146,7 @@ protected:
       SizeValueType indOutput = 0;
       for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
       {
-        indInput++; // ignore the cell type
+        ++indInput; // ignore the cell type
         auto numberOfPoints = static_cast<unsigned int>(input[indInput++]);
         output[indOutput++] = static_cast<TOutput>(numberOfPoints);
         for (unsigned int jj = 0; jj < numberOfPoints; ++jj)
@@ -165,7 +165,7 @@ protected:
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {
-      index++;
+      ++index;
       auto numberOfCellPoints = static_cast<unsigned int>(buffer[index++]);
       outputFile << numberOfCellPoints << "  ";
 

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -123,7 +123,7 @@ OFFMeshIO ::ReadMeshInformation()
   if (line.find("nOFF") != std::string::npos)
   {
     m_InputFile >> this->m_PointDimension;
-    m_PointDimension++;
+    ++m_PointDimension;
   }
   else if (line.find("4OFF") != std::string::npos)
   {

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -152,27 +152,27 @@ protected:
       switch (cellType)
       {
         case CellGeometryEnum::VERTEX_CELL:
-          numberOfVertices++;
+          ++numberOfVertices;
           numberOfVertexIndices += nn + 1;
           break;
         case CellGeometryEnum::LINE_CELL:
-          numberOfLines++;
+          ++numberOfLines;
           numberOfLineIndices += nn + 1;
           break;
         case CellGeometryEnum::POLYLINE_CELL:
-          numberOfLines++;
+          ++numberOfLines;
           numberOfLineIndices += nn + 1;
           break;
         case CellGeometryEnum::TRIANGLE_CELL:
-          numberOfPolygons++;
+          ++numberOfPolygons;
           numberOfPolygonIndices += nn + 1;
           break;
         case CellGeometryEnum::POLYGON_CELL:
-          numberOfPolygons++;
+          ++numberOfPolygons;
           numberOfPolygonIndices += nn + 1;
           break;
         case CellGeometryEnum::QUADRILATERAL_CELL:
-          numberOfPolygons++;
+          ++numberOfPolygons;
           numberOfPolygonIndices += nn + 1;
           break;
         default:
@@ -1136,7 +1136,7 @@ protected:
     {
       for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
       {
-        inputIndex++;
+        ++inputIndex;
         auto nn = static_cast<unsigned int>(input[inputIndex++]);
         output[outputIndex++] = nn;
         for (unsigned int jj = 0; jj < nn; ++jj)

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -343,7 +343,7 @@ UpperToLowerOrder(int dim)
     {
       mat[i][j] = index;
       mat[j][i] = index;
-      index++;
+      ++index;
     }
   }
   auto * rval = new int[index + 1];
@@ -414,8 +414,8 @@ SymMatDim(int count)
   while (count > 0)
   {
     count -= row;
-    dim++;
-    row++;
+    ++dim;
+    ++row;
   }
   return dim;
 }

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -274,7 +274,7 @@ PhilipsRECImageIOSetupSliceIndex(PhilipsRECImageIO::SliceIndexType *         ind
                                                                       parParam,
                                                                       sliceImageTypesIndex,
                                                                       sliceScanSequenceIndex);
-          index++;
+          ++index;
         }
       }
     }
@@ -287,7 +287,7 @@ PhilipsRECImageIOSetupSliceIndex(PhilipsRECImageIO::SliceIndexType *         ind
       for (int j = 0; j < actualSlices; ++j)
       {
         (*indexMatrix)[index] = j * parParam.image_blocks + i;
-        index++;
+        ++index;
       }
     }
   }

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -161,9 +161,9 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   PointIdIterator pointIditer = cell->PointIdsBegin();
 
   unsigned int boundaryId0 = *pointIditer;
-  pointIditer++;
+  ++pointIditer;
   unsigned int boundaryId1 = *pointIditer;
-  pointIditer++;
+  ++pointIditer;
   unsigned int boundaryId2 = *pointIditer;
 
   InputPointType ptA;
@@ -291,7 +291,7 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
 
     while (aCellNumberOfPoints < 3) // leave the edges and points untouched
     {
-      cellIterator++;
+      ++cellIterator;
       if (cellIterator != cellEnd)
       {
         aCell = cellIterator.Value();
@@ -306,10 +306,10 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     pointIditer = aCell->PointIdsBegin();
 
     ptIdA = *pointIditer;
-    pointIditer++;
+    ++pointIditer;
 
     ptIdB = *pointIditer;
-    pointIditer++;
+    ++pointIditer;
 
     ptIdC = *pointIditer;
 
@@ -410,7 +410,7 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     D(ptIdC, ptIdB) -= cotgCAB;
     D(ptIdC, ptIdA) -= cotgABC;
 
-    cellIterator++;
+    ++cellIterator;
   }
 
   VectorCoordType x(numberOfPoints, 0.0);
@@ -578,8 +578,8 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       }
 
       outputPointIterator.Value() = point;
-      outputPointIterator++;
-      i++;
+      ++outputPointIterator;
+      ++i;
     }
   }
   else
@@ -618,8 +618,8 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       }
 
       outputPointIterator.Value() = point;
-      outputPointIterator++;
-      i++;
+      ++outputPointIterator;
+      ++i;
     }
   }
 

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -181,7 +181,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
         ++idx;
         ++it;
       }
-      kernelidx++;
+      ++kernelidx;
     }
   }
 }

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -762,7 +762,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       // Update the accumulator value using the update buffer
       temp = static_cast<double>(sparsePtr->m_UpdateBuffer.front() - levelset->GetPixel(activeIt->m_Value));
       m_RMSSum += temp * temp;
-      m_RMSCounter++;
+      ++m_RMSCounter;
 
       levelset->SetPixel(activeIt->m_Value, sparsePtr->m_UpdateBuffer.front());
       ++activeIt;
@@ -930,7 +930,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 
       // Update the rms change
       m_RMSSum += (value - outputIt.GetCenterPixel()) * (value - outputIt.GetCenterPixel());
-      m_RMSCounter++;
+      ++m_RMSCounter;
 
       ++toIt;
     }

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -138,7 +138,7 @@ public:
     while (it != end)
     {
       (*it) = LevelSetDataType::New();
-      it++;
+      ++it;
     }
   }
 

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -364,7 +364,7 @@ FEMObject<VDimension>::GenerateMFC()
       l1->SetIndex(m_NMFC);
 
       // increase the number of MFC
-      m_NMFC++;
+      ++m_NMFC;
     }
   }
 }
@@ -420,7 +420,7 @@ FEMObject<VDimension>::GenerateGFN()
         if (el->GetNode(n)->GetDegreeOfFreedom(dof) == Element::InvalidDegreeOfFreedomID)
         {
           el->GetNode(n)->SetDegreeOfFreedom(dof, m_NGFN);
-          m_NGFN++;
+          ++m_NGFN;
         }
       }
     }

--- a/Modules/Numerics/FEM/include/itkFEMPArray.h
+++ b/Modules/Numerics/FEM/include/itkFEMPArray.h
@@ -115,7 +115,7 @@ FEMPArray<T>::Find(int gn)
     {
       break;
     }
-    it++;
+    ++it;
   }
 
   if (it == this->end())
@@ -149,7 +149,7 @@ FEMPArray<T>::Find(int gn) const
     {
       break;
     }
-    it++;
+    ++it;
   }
 
   if (it == this->end())
@@ -175,7 +175,7 @@ FEMPArray<T>::Renumber()
   for (i = this->begin(); i != this->end(); ++i)
   {
     (*i)->SetGlobalNumber(j);
-    j++;
+    ++j;
   }
 
   return j;

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -561,7 +561,7 @@ RobustSolver<VDimension>::DeleteLandmarksOutOfMesh()
 
     if (landmark->IsOutOfMesh())
     {
-      numToRemoveLoads++;
+      ++numToRemoveLoads;
     }
     else
     {

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -224,7 +224,7 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
 
       this->m_Mesh->SetPoint(globalNumbering, pointCoordinate);
 
-      globalNumbering++;
+      ++globalNumbering;
     }
   }
 
@@ -244,7 +244,7 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
 
       this->m_Mesh->SetCell(globalNumbering, cell);
 
-      globalNumbering++;
+      ++globalNumbering;
     }
   }
 }
@@ -292,7 +292,7 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
         image->TransformContinuousIndexToPhysicalPoint(pointIndex, pointCoordinate);
         this->m_Mesh->SetPoint(globalNumbering, pointCoordinate);
 
-        globalNumbering++;
+        ++globalNumbering;
       }
     }
   }
@@ -344,7 +344,7 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
 
         this->m_Mesh->SetCell(globalNumbering, cell);
 
-        globalNumbering++;
+        ++globalNumbering;
       }
     }
   }

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -218,7 +218,7 @@ Solver<VDimension>::AssembleK()
       l1->SetIndex(NMFC);
 
       // increase the number of MFC
-      NMFC++;
+      ++NMFC;
     }
   }
 

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
@@ -312,7 +312,7 @@ SolverCrankNicolson<VDimension>::RunSolver()
   this->m_LinearSystem->InitializeSolution(m_SolutionTIndex);
   this->m_LinearSystem->Solve();
 
-  m_Iterations++;
+  ++m_Iterations;
   // call this externally    AddToDisplacements();
 }
 
@@ -583,7 +583,7 @@ SolverCrankNicolson<VDimension>::GoldenSection(Float tol, unsigned int MaxIters)
   unsigned int iters = 0;
   while (itk::Math::abs(x3 - x0) > tol * (itk::Math::abs(x1) + itk::Math::abs(x2)) && iters < MaxIters)
   {
-    iters++;
+    ++iters;
     if (f2 < f1)
     {
       x0 = x1;

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -190,7 +190,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate2DRectilinearMesh()
       n = Element::Node::New();
       n->SetCoordinates(pt);
       n->SetGlobalNumber(gn);
-      gn++;
+      ++gn;
       femObject->AddNextNode(n);
     }
   }
@@ -212,7 +212,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate2DRectilinearMesh()
       {
         e->SetMaterial(dynamic_cast<itk::fem::MaterialLinearElasticity *>(femObject->GetMaterial(0).GetPointer()));
       }
-      gn++;
+      ++gn;
       femObject->AddNextElement(e);
     }
   }
@@ -265,7 +265,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate3DRectilinearMesh()
         n = Element::Node::New();
         n->SetCoordinates(pt);
         n->SetGlobalNumber(gn);
-        gn++;
+        ++gn;
         femObject->AddNextNode(n);
       }
     }
@@ -310,7 +310,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate3DRectilinearMesh()
         {
           e->SetMaterial(dynamic_cast<itk::fem::MaterialLinearElasticity *>(femObject->GetMaterial(0).GetPointer()));
         }
-        gn++;
+        ++gn;
         femObject->AddNextElement(e);
       }
     }

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -79,7 +79,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     o1->SetCoordinates(pt);
     myFEMObject->AddNextNode(o1);
-    it_nodes++;
+    ++it_nodes;
   }
 
   // copy all the material information
@@ -104,7 +104,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     o1->SetThickness(material->h);
     o1->SetDensityHeatProduct(material->RhoC);
     myFEMObject->AddNextMaterial(o1);
-    it_material++;
+    ++it_material;
   }
 
   // copy all the Element information
@@ -128,7 +128,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     o1->SetMaterial(myFEMObject->GetMaterialWithGlobalNumber(element->m_MaterialGN).GetPointer());
     myFEMObject->AddNextElement(o1);
-    it_elements++;
+    ++it_elements;
   }
 
   // copy all the load and boundary condition information
@@ -304,7 +304,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
      */
       myFEMObject->AddNextLoad(o1);
     }
-    it_load++;
+    ++it_load;
   }
 
   FEMSO->SetFEMObject(myFEMObject);

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -243,7 +243,7 @@ AmoebaOptimizer::StartOptimization()
         bestValue = currentValue;
         bestPosition = parameters;
       }
-      i++;
+      ++i;
     }
   }
   // get the results, we scale the parameters down if scales are defined

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -128,7 +128,7 @@ ExhaustiveOptimizer::ResumeWalking()
 
     this->InvokeEvent(IterationEvent());
     this->AdvanceOneStep();
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
   }
 }
 
@@ -169,7 +169,7 @@ ExhaustiveOptimizer::IncrementIndex(ParametersType & newPosition)
     if (m_CurrentIndex[idx] > (2 * m_NumberOfSteps[idx]))
     {
       m_CurrentIndex[idx] = 0;
-      idx++;
+      ++idx;
     }
     else
     {

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -143,7 +143,7 @@ FRPROptimizer::StartOptimization()
       {
         this->GetValueAndDerivative(p, &fp, &xi);
         xi[limitCount] = 1;
-        limitCount++;
+        ++limitCount;
       }
       else
       {

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -108,7 +108,7 @@ GradientDescentOptimizer::ResumeOptimization()
 
     AdvanceOneStep();
 
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
 
     if (m_CurrentIteration >= m_NumberOfIterations)
     {

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -457,7 +457,7 @@ ParticleSwarmOptimizerBase::RandomInitialization()
         if (this->m_Particles[i].m_CurrentParameters[j] < parameterBounds[j].first ||
             this->m_Particles[i].m_CurrentParameters[j] > parameterBounds[j].second)
         {
-          j--;
+          --j;
         }
       }
     }

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -120,7 +120,7 @@ RegularStepGradientDescentBaseOptimizer::ResumeOptimization()
 
     this->AdvanceOneStep();
 
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
   }
 }
 

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -163,7 +163,7 @@ SPSAOptimizer::ResumeOptimization()
       break;
     }
 
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
 
     if (m_CurrentIteration >= m_MaximumNumberOfIterations)
     {

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -178,7 +178,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::IncrementIndex(ParametersT
     if (m_CurrentIndex[idx] > (2 * m_NumberOfSteps[idx]))
     {
       m_CurrentIndex[idx] = 0;
-      idx++;
+      ++idx;
     }
     else
     {

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -318,7 +318,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::EstimateNewtonSte
   // we assign this ending block of local parameters to thread_(i+1) .
   if ((subrange[1] + 1) % numLocalPara != 0)
   {
-    high--;
+    --high;
   }
 
   for (IndexValueType loc = low; loc <= high; ++loc)

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -216,7 +216,7 @@ AmoebaOptimizerv4 ::StartOptimization(bool /* doOnlyInitialization */)
         bestValue = currentValue;
         bestPosition = parameters;
       }
-      i++;
+      ++i;
     }
   }
   // get the results, we scale the parameters down if scales are defined

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -575,7 +575,7 @@ Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(InstanceIdentifier n,
     while (include < includeEnd)
     {
       frequency += GetFrequency(include);
-      include++;
+      ++include;
     }
     current += nextOffset;
   }
@@ -613,7 +613,7 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
       cumulated += f_n;
       p_n_prev = p_n;
       p_n = cumulated / totalFrequency;
-      n++;
+      ++n;
     } while (n < size && p_n < p);
 
     binProportion = f_n / totalFrequency;
@@ -634,8 +634,8 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
       cumulated += f_n;
       p_n_prev = p_n;
       p_n = 1.0 - cumulated / totalFrequency;
-      n--;
-      m++;
+      --n;
+      ++m;
     } while (m < size && p_n > p);
 
     binProportion = f_n / totalFrequency;

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -520,7 +520,7 @@ KdTree<TSample>::PrintTree(KdTreeNodeType * node,
                            unsigned int     activeDimension,
                            std::ostream &   os) const
 {
-  level++;
+  ++level;
   if (node->IsTerminal())
   {
     // terminal node

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -362,7 +362,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::StartOptimization()
       break;
     }
 
-    m_CurrentIteration++;
+    ++m_CurrentIteration;
   }
 
   if (m_UseClusterLabels)

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -113,7 +113,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
     while (iter != m_OffsetTable.end())
     {
       it.ActivateOffset(*iter);
-      iter++;
+      ++iter;
     }
 
     for (it.GoToBegin(); !it.IsAtEnd(); ++it)

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -69,7 +69,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToBackIndex--;
+      --moveToBackIndex;
     }
 
     //
@@ -82,7 +82,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToFrontIndex++;
+      ++moveToFrontIndex;
     }
 
     if (moveToFrontIndex < moveToBackIndex)
@@ -113,7 +113,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToBackIndex--;
+      --moveToBackIndex;
     }
 
     //
@@ -126,7 +126,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToFrontIndex++;
+      ++moveToFrontIndex;
     }
 
     if (moveToFrontIndex < moveToBackIndex)
@@ -157,7 +157,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToBackIndex--;
+      --moveToBackIndex;
     }
 
     //
@@ -170,7 +170,7 @@ Partition(TSubsample *                               sample,
       {
         break;
       }
-      moveToFrontIndex++;
+      ++moveToFrontIndex;
     }
 
     if (moveToFrontIndex < moveToBackIndex)

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -152,7 +152,7 @@ NormalVariateGenerator::FastNorm()
 
 startpass:
   /*    Count passes    */
-  m_Nslew++;
+  ++m_Nslew;
   /*    Reset index into Saved values   */
   m_Gaussfaze = m_TLEN - 1; /* We will steal the last one   */
   /*    Update pseudo-random and use to choose type of rotation  */

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -127,7 +127,7 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
       {
         const RealType TrainingMovingValue = this->m_TrainingInterpolator->Evaluate(transformedPoint);
         const RealType TrainingFixedValue = ti.Get();
-        NumberOfPixelsCounted++;
+        ++NumberOfPixelsCounted;
 
         typename HistogramType::MeasurementVectorType sample;
         sample.SetSize(2);

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -230,7 +230,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
         m_MinFixedGradient[iDimension] = gradient;
       }
 
-      nPixels++;
+      ++nPixels;
       ++iterate;
     }
 

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -100,7 +100,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
     //
     if (Math::AlmostEquals(fixedValue, m_ForegroundValue))
     {
-      fixedForegroundArea++;
+      ++fixedForegroundArea;
     }
 
     // Get the point in the transformed moving image corresponding to
@@ -123,11 +123,11 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
       const RealType movingValue = this->m_Interpolator->Evaluate(transformedPoint);
       if (Math::AlmostEquals(movingValue, m_ForegroundValue))
       {
-        movingForegroundArea++;
+        ++movingForegroundArea;
       }
       if (Math::AlmostEquals(movingValue, m_ForegroundValue) && Math::AlmostEquals(fixedValue, m_ForegroundValue))
       {
-        intersection++;
+        ++intersection;
       }
     }
     ++fi;
@@ -214,7 +214,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
     const RealType fixedValue = ti.Value();
     if (Math::AlmostEquals(fixedValue, m_ForegroundValue))
     {
-      fixedArea++;
+      ++fixedArea;
     }
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
@@ -231,12 +231,12 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
 
       if (Math::AlmostEquals(movingValue, m_ForegroundValue))
       {
-        movingArea++;
+        ++movingArea;
       }
 
       if (Math::AlmostEquals(movingValue, m_ForegroundValue) && Math::AlmostEquals(fixedValue, m_ForegroundValue))
       {
-        intersection++;
+        ++intersection;
       }
 
       this->m_Transform->ComputeJacobianWithRespectToParametersCachedTemporaries(inputPoint, jacobian, jacobianCache);

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -163,7 +163,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
       const RealType fixedValue = ti.Get();
       RealType       diff;
 
-      threadNumberOfPixelsCounted++;
+      ++threadNumberOfPixelsCounted;
 
       if (m_MeasureMatches)
       {

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -437,7 +437,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
     {
       if (Math::AlmostEquals(coord[ii], m_ImageOrigin[ii]) || Math::AlmostEquals(coord[ii], ImgSz[ii] - 1))
       {
-        CornerCounter++;
+        ++CornerCounter;
       }
     }
 
@@ -460,7 +460,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
           {
             if (Math::AlmostEquals(coord[ii], m_ImageOrigin[ii]) || Math::AlmostEquals(coord[ii], ImgSz[ii] - 1))
             {
-              CornerCounter++;
+              ++CornerCounter;
             }
           }
           if (CornerCounter == ImageDimension - 1)
@@ -489,12 +489,12 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
 
               m_FEMObject->AddNextLoad(l1);
             }
-            EdgeCounter++;
+            ++EdgeCounter;
           }
         }
       } // end elt loop
     }
-    nodect++;
+    ++nodect;
     itkDebugMacro(<< " Node: " << nodect);
   }
 }
@@ -551,7 +551,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::IterativeSolve(Sol
       itkDebugMacro(<< " Line search done " << std::endl);
     }
 
-    iters++;
+    ++iters;
 
     if (deltE == 0.0)
     {
@@ -594,7 +594,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::IterativeSolve(Sol
       }
     }
     itkDebugMacro(<< " min E: " << m_MinE << "; delt E: " << deltE << "; iters: " << iters << std::endl);
-    m_TotalIterations++;
+    ++m_TotalIterations;
   }
 }
 
@@ -1094,7 +1094,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintVectorField(u
       }
     }
     ++fieldIter;
-    ct++;
+    ++ct;
   }
 
   itkDebugMacro(<< " Max vec: " << max << std::endl);
@@ -1336,7 +1336,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::GoldenSection(Solv
   unsigned int iters = 0;
   while (itk::Math::abs(x3 - x0) > tol * (itk::Math::abs(x1) + itk::Math::abs(x2)) && iters < MaxIters)
   {
-    iters++;
+    ++iters;
     if (f2 < f1)
     {
       x0 = x1;

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -232,7 +232,7 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUp
       //        fixedGradientsB.insert(fixedGradientsB.begin(),fixedGradient);
       //        movingSamplesB.insert(movingSamplesB.begin(),static_cast<double>(movingValue));
 
-      sampct++;
+      ++sampct;
     }
   }
 
@@ -307,8 +307,8 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUp
           fixedSamplesA.insert(fixedSamplesA.begin(), static_cast<double>(fixedValue));
           fixedGradientsA.insert(fixedGradientsA.begin(), fixedGradient);
           movingSamplesA.insert(movingSamplesA.begin(), static_cast<double>(movingValue));
-          sampct++;
-          indct++;
+          ++sampct;
+          ++indct;
         }
       }
       ++randasamit;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -619,7 +619,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
     if (this->TransformPhysicalPointToVirtualIndex(point, tempIndex))
     {
       this->m_VirtualSampledPointSet->SetPoint(virtualIndex, point);
-      virtualIndex++;
+      ++virtualIndex;
     }
     else
     {

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -104,7 +104,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
       typename JointHistogramType::PixelType jointHistogramPixel;
       jointHistogramPixel =
         this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetPixel(jointPDFIndex);
-      jointHistogramPixel++;
+      ++jointHistogramPixel;
       this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->SetPixel(jointPDFIndex, jointHistogramPixel);
       this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogramCount++;
     }

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -407,7 +407,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<TDomain
 
     const PDFValueType derivativeContribution = innerProduct * cubicBSplineDerivativeValue;
     *(localSupportDerivativeResultPtr) += derivativeContribution;
-    localSupportDerivativeResultPtr++;
+    ++localSupportDerivativeResultPtr;
   }
 }
 

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -178,7 +178,7 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
       {
         if (composite->GetNthTransformToOptimize(static_cast<SizeValueType>(n)))
         {
-          count++;
+          ++count;
           transform = composite->GetNthTransformConstPointer(static_cast<SizeValueType>(n));
         }
       }

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -193,12 +193,12 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
 
   if (this->GetFixedImage())
   {
-    num++;
+    ++num;
   }
 
   if (this->GetMovingImage())
   {
-    num++;
+    ++num;
   }
 
   return num;
@@ -469,7 +469,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
     tempField->DisconnectPipeline();
 
     // Increment level counter.
-    m_CurrentLevel++;
+    ++m_CurrentLevel;
     movingLevel =
       std::min(static_cast<int>(m_CurrentLevel), static_cast<int>(m_MovingImagePyramid->GetNumberOfLevels()));
     fixedLevel = std::min(static_cast<int>(m_CurrentLevel), static_cast<int>(m_FixedImagePyramid->GetNumberOfLevels()));

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -77,12 +77,12 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
 
   if (this->GetFixedImage())
   {
-    num++;
+    ++num;
   }
 
   if (this->GetMovingImage())
   {
-    num++;
+    ++num;
   }
 
   return num;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -504,13 +504,13 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
           displacement[d] = metricDerivative[localPointCount * ImageDimension + d];
           spatioTemporalPoint[d] = spatialPoint[d];
         }
-        localPointCount++;
+        ++localPointCount;
 
         spatioTemporalPoint[ImageDimension] = t;
         velocityFieldPointSet->SetPoint(numberOfVelocityFieldPoints, spatioTemporalPoint);
         velocityFieldPointSet->SetPointData(numberOfVelocityFieldPoints, displacement);
         velocityFieldWeights->InsertElement(numberOfVelocityFieldPoints, 1.0);
-        numberOfVelocityFieldPoints++;
+        ++numberOfVelocityFieldPoints;
 
         ++It;
       }
@@ -555,7 +555,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
           velocityFieldPointSet->SetPoint(numberOfVelocityFieldPoints, spatioTemporalPoint);
           velocityFieldPointSet->SetPointData(numberOfVelocityFieldPoints, displacement);
           velocityFieldWeights->InsertElement(numberOfVelocityFieldPoints, this->m_BoundaryWeight);
-          numberOfVelocityFieldPoints++;
+          ++numberOfVelocityFieldPoints;
         }
       }
     }
@@ -833,7 +833,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
     velocityFieldPoints->SetPoint(numberOfVelocityFieldPoints, velocityFieldPoint);
     velocityFieldPoints->SetPointData(numberOfVelocityFieldPoints, displacement);
     velocityFieldWeights->InsertElement(numberOfVelocityFieldPoints, weight);
-    numberOfVelocityFieldPoints++;
+    ++numberOfVelocityFieldPoints;
   }
 }
 

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -385,7 +385,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
       SplitCodewords(m_CurrentNumberOfCodewords - emptycells, emptycells, pass);
 
       olddistortion = distortion;
-      pass++;
+      ++pass;
     }
   } while (pass <= m_MaxSplitAttempts);
   itkExceptionMacro(<< "Lack of convergence");

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -195,7 +195,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThr
         // create the run length object to go in the vector
         RunLength thisRun = { length, thisIndex, 0 };
         thisLine.push_back(thisRun);
-        nbOfLabels++;
+        ++nbOfLabels;
       }
       else
       {
@@ -203,7 +203,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThr
       }
     }
     this->m_LineMap[lineId] = thisLine;
-    lineId++;
+    ++lineId;
   }
 
   this->m_NumberOfLabels.fetch_add(nbOfLabels, std::memory_order_relaxed);

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -158,7 +158,7 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Gener
                                     << std::endl);
     itkDebugMacro("Iteration #:" << iterationCounter);
 
-    iterationCounter++;
+    ++iterationCounter;
 #endif
   } // end of the thresholdloop
 

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -125,7 +125,7 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GenerateData()
     }
 
     this->ComputeDisplacement();
-    m_Step++;
+    ++m_Step;
   }
 
   const InputMeshType *             inputMesh = this->GetInput(0);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -472,7 +472,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
       pcurrentBorder->EvaluateLambda();
 
       // Increment the border counter to go to the next border
-      borderCounter++;
+      ++borderCounter;
 
       // Calculate next indices to atomic region1 and atomic region2
       tmpVal = 1;
@@ -646,7 +646,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
   m_BordersDynamicPointer.erase(m_BordersDynamicPointer.end() - 1);
 
   // Decrement for the one deleted border and a deleted region
-  m_NumberOfRegions--;
+  --m_NumberOfRegions;
   if (m_BordersDynamicPointer.empty())
   {
     itkExceptionMacro(<< "KLM algorithm error");
@@ -714,7 +714,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
   while (regionsPointerIt != regionsPointerItEnd)
   {
     RegionLabelType origLabel = iregion;
-    iregion--;
+    --iregion;
     RegionLabelType currLabel = m_RegionsPointer[iregion]->GetRegionLabel();
 
     // Unresolved chain
@@ -745,7 +745,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
       uniqueLabelsVec.push_back(origLabel);
     }
 
-    regionsPointerIt++;
+    ++regionsPointerIt;
   } // end of all regions
 
   // Sort the unique labels
@@ -763,8 +763,8 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
   while (uniqueLabelsVecIterator != uniqueLabelsVec.end())
   {
     remapLabelsVec[*uniqueLabelsVecIterator - 1] = newLabelValue;
-    uniqueLabelsVecIterator++;
-    newLabelValue++;
+    ++uniqueLabelsVecIterator;
+    ++newLabelValue;
   }
 
   // Assign new consecutive labels

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -343,8 +343,8 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
       (*thatRegionBordersIt)->SetRegion2(nullptr);
       (*thatRegionBordersIt)->SetLambda(-1.0);
 
-      thisRegionBordersIt++;
-      thatRegionBordersIt++;
+      ++thisRegionBordersIt;
+      ++thatRegionBordersIt;
     } // end if loop for case when two borders point to same region
 
     // This neighbor region label is less then that neighbor region label
@@ -358,7 +358,7 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
                (*thatRegionBordersIt)->GetRegion2()->GetRegionLabel())))
     {
       m_RegionBorderVector.push_back(*thisRegionBordersIt);
-      thisRegionBordersIt++;
+      ++thisRegionBordersIt;
     } // end else if
 
     // That neighbor region label is less then this neighbor region label
@@ -372,7 +372,7 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
                (*thisRegionBordersIt)->GetRegion2()->GetRegionLabel())))
     {
       m_RegionBorderVector.push_back(*thatRegionBordersIt);
-      thatRegionBordersIt++;
+      ++thatRegionBordersIt;
     } // end else if
     else
     {
@@ -384,14 +384,14 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
   while (thisRegionBordersIt != endOfThisRegionBorders)
   {
     m_RegionBorderVector.push_back(*thisRegionBordersIt);
-    thisRegionBordersIt++;
+    ++thisRegionBordersIt;
   }
 
   // If any borders remain in thatRegionBorders, put them to the back
   while (thatRegionBordersIt != endOfThatRegionBorders)
   {
     m_RegionBorderVector.push_back(*thatRegionBordersIt);
-    thatRegionBordersIt++;
+    ++thatRegionBordersIt;
   }
 } // end SpliceRegionBorders
 
@@ -479,7 +479,7 @@ KLMSegmentationRegion::PrintRegionInfo()
     std::cout << "Border Ptr :" << (*tempVectorIt) << "( " << region1label << " - " << region2label << " )"
               << " Lambda = " << (*tempVectorIt)->GetLambda() << std::endl;
 
-    tempVectorIt++;
+    ++tempVectorIt;
   } // end for
 
   std::cout << "------------------------------" << std::endl;

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -135,7 +135,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
         InputPixelType value = bit.GetPixel(i);
         if (Math::ExactlyEquals(value, m_ForegroundValue))
         {
-          count++;
+          ++count;
         }
       }
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
@@ -124,14 +124,14 @@ VotingBinaryHoleFillingImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
           InputPixelType value = bit.GetPixel(i);
           if (value == foregroundValue)
           {
-            count++;
+            ++count;
           }
         }
 
         if (count >= birthThreshold)
         {
           it.Set(static_cast<OutputPixelType>(foregroundValue));
-          numberOfPixelsChanged++;
+          ++numberOfPixelsChanged;
         }
         else
         {

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -130,7 +130,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
         InputPixelType value = bit.GetPixel(i);
         if (value == m_ForegroundValue)
         {
-          count++;
+          ++count;
         }
       }
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
@@ -68,7 +68,7 @@ VotingBinaryIterativeHoleFillingImageFilter<TInputImage>::GenerateData()
     filter->SetInput(input);
     filter->Update();
 
-    m_CurrentNumberOfIterations++;
+    ++m_CurrentNumberOfIterations;
     progress.CompletedPixel(); // not really a pixel but an iteration
     this->InvokeEvent(IterationEvent());
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -267,7 +267,7 @@ public:
       ProcessNormals();
     }
 
-    m_RefitIteration++;
+    ++m_RefitIteration;
   }
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
@@ -55,7 +55,7 @@ LevelSetDomainPartitionImage<TImage>::PopulateListDomain()
       {
         identifierList.push_back(i);
       }
-      i++;
+      ++i;
     }
     lIt.Set(identifierList);
   }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -116,12 +116,12 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GreyScalarBoundary(LabelledI
       Index3D[i]--;
       neighbors[j] = static_cast<LabelType>(m_InputImage->GetPixel(Index3D)[rgb]);
       Index3D[i]++;
-      j++;
+      ++j;
 
       Index3D[i]++;
       neighbors[j] = static_cast<LabelType>(m_InputImage->GetPixel(Index3D)[rgb]);
       Index3D[i]--;
-      j++;
+      ++j;
     }
 
     for (auto & sign : signs)
@@ -146,10 +146,10 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GreyScalarBoundary(LabelledI
           const auto difference = static_cast<LabelType>(itk::Math::abs(m_LowPoint[rgb] - neighbors[i]));
           if (difference < m_BoundaryGradient)
           {
-            numx++;
+            ++numx;
             x += neighbors[i];
             signs[i]++;
-            change++;
+            ++change;
           }
         }
       }
@@ -163,10 +163,10 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GreyScalarBoundary(LabelledI
           const auto difference = static_cast<LabelType>(itk::Math::abs(m_LowPoint[rgb] - neighbors[i]));
           if (difference > m_BoundaryGradient)
           {
-            numx--;
+            --numx;
             x -= neighbors[i];
             signs[i]--;
-            change++;
+            ++change;
           }
         }
       }
@@ -265,7 +265,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
   {
     if (f[j] == m_ObjectLabel)
     {
-      k++;
+      ++k;
     }
   }
 
@@ -406,7 +406,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
   {
     if ((f[j] == labelledPixel) != changeflag)
     {
-      changenum++;
+      ++changenum;
       changeflag = !changeflag;
     }
 
@@ -420,7 +420,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
       {
         res -= 1.0;
       }
-      simnum++;
+      ++simnum;
     }
   }
 
@@ -497,7 +497,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GenerateData()
     ++outImageIt;
   }
 
-  m_RecursiveNumber++;
+  ++m_RecursiveNumber;
 }
 
 template <typename TInputImage, typename TClassifiedImage>
@@ -533,7 +533,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::MinimizeFunctional()
     {
       GibbsTotalEnergy(randomPixel); // minimized f_2;
     }
-    m_Temp++;
+    ++m_Temp;
   }
 #endif
 }
@@ -607,7 +607,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
     }
     labelledImageIt.Set(pixLabel);
 
-    i++;
+    ++i;
     ++labelledImageIt;
     ++inputImageIt;
     ++mediumImageIt;
@@ -653,11 +653,11 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
       if (LabelRegion(i, ++l, label) > m_ClusterSize)
       {
         valid_region_counter[k] = l;
-        k++;
+        ++k;
       }
     }
 
-    i++;
+    ++i;
     ++labelledImageIt;
   }
 
@@ -670,7 +670,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
     j = 0;
     while ((m_Region[i] != valid_region_counter[j]) && (j < k))
     {
-      j++;
+      ++j;
     }
 
     if (j == k)
@@ -678,7 +678,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
       label = labelledImageIt.Get();
       labelledImageIt.Set(1 - label);
     }
-    i++;
+    ++i;
     ++labelledImageIt;
   }
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -183,7 +183,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         sumOfSquares += neighborhoodSumOfSquares;
         ++num;
       }
-      si++;
+      ++si;
     }
 
     if (num == 0)
@@ -215,7 +215,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         sumOfSquares += value * value;
         ++num;
       }
-      si++;
+      ++si;
     }
 
     if (num == 0)
@@ -251,7 +251,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         highestSeedIntensity = seedIntensity;
       }
     }
-    si++;
+    ++si;
   }
 
   // Adjust lower and upper to always contain the seed's intensity, otherwise,

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -251,7 +251,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       {
         const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si));
         seedIntensitySum += value;
-        si++;
+        ++si;
       }
 
       if (Math::NotExactlyEquals(seedIntensitySum, NumericTraits<InputRealType>::ZeroValue()))
@@ -316,7 +316,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       {
         const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si));
         seedIntensitySum += value;
-        si++;
+        ++si;
       }
 
       if (Math::NotExactlyEquals(seedIntensitySum, NumericTraits<InputRealType>::ZeroValue()))
@@ -375,7 +375,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si1));
     seed1IntensitySum += value;
-    si1++;
+    ++si1;
   }
   typename SeedsContainerType::const_iterator si2 = m_Seeds2.begin();
   typename SeedsContainerType::const_iterator li2 = m_Seeds2.end();
@@ -383,7 +383,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si2));
     seed2IntensitySum += value;
-    si2++;
+    ++si2;
   }
   if (Math::NotAlmostEquals(seed1IntensitySum, m_ReplaceValue * m_Seeds1.size()) ||
       Math::NotExactlyEquals(seed2IntensitySum, NumericTraits<InputRealType>::ZeroValue()))

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -178,7 +178,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         }
       }
     }
-    si++;
+    ++si;
   }
 
   if (seed_cnt == 0)
@@ -223,7 +223,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         m_Multiplier = distance;
       }
     }
-    si++;
+    ++si;
   }
 
   // Finally setup the eventually modified multiplier. That is actually the

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -139,7 +139,7 @@ void
 VoronoiDiagram2DGenerator<TCoordRepType>::AddOneSeed(PointType inputSeed)
 {
   m_Seeds.push_back(inputSeed);
-  m_NumberOfSeeds++;
+  ++m_NumberOfSeeds;
 }
 
 template <typename TCoordRepType>
@@ -247,22 +247,22 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
   corner[0][0] = m_Pxmin;
   corner[0][1] = m_Pymin;
   cornerID[0] = m_Nvert;
-  m_Nvert++;
+  ++m_Nvert;
   m_OutputVD->AddVert(corner[0]);
   corner[1][0] = m_Pxmin;
   corner[1][1] = m_Pymax;
   cornerID[1] = m_Nvert;
-  m_Nvert++;
+  ++m_Nvert;
   m_OutputVD->AddVert(corner[1]);
   corner[2][0] = m_Pxmax;
   corner[2][1] = m_Pymax;
   cornerID[2] = m_Nvert;
-  m_Nvert++;
+  ++m_Nvert;
   m_OutputVD->AddVert(corner[2]);
   corner[3][0] = m_Pxmax;
   corner[3][1] = m_Pymin;
   cornerID[3] = m_Nvert;
-  m_Nvert++;
+  ++m_Nvert;
   m_OutputVD->AddVert(corner[3]);
 
   std::list<EdgeInfo>                    buildEdges;
@@ -285,7 +285,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
     auto     maxStop = static_cast<int>(rawEdges[i].size());
     while (!(rawEdges[i].empty()))
     {
-      maxStop--;
+      --maxStop;
       curr = rawEdges[i].front();
       rawEdges[i].pop_front();
       frontbnd = Pointonbnd(front[0]);
@@ -519,7 +519,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::deletePQ(FortuneHalfEdge * task)
       last = last->m_Next;
     }
     last->m_Next = (task->m_Next);
-    m_PQcount--;
+    --m_PQcount;
     task->m_Vert = nullptr;
   }
 }
@@ -739,7 +739,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::bisect(FortuneEdge * answer, FortuneSi
     answer->m_C /= dy;
   }
   answer->m_Edgenbr = m_Nedges;
-  m_Nedges++;
+  ++m_Nedges;
   Point<int, 2> outline;
   outline[0] = answer->m_Reg[0]->m_Sitenbr;
   outline[1] = answer->m_Reg[1]->m_Sitenbr;
@@ -812,7 +812,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::getPQmin() -> FortuneHalfEdge *
   FortuneHalfEdge * curr = m_PQHash[m_PQmin].m_Next;
 
   m_PQHash[m_PQmin].m_Next = curr->m_Next;
-  m_PQcount--;
+  --m_PQcount;
   return (curr);
 }
 
@@ -989,7 +989,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::clip_line(FortuneEdge * task)
   else
   {
     newInfo.m_LeftID = m_Nvert;
-    m_Nvert++;
+    ++m_Nvert;
     PointType newv;
     newv[0] = x1;
     newv[1] = y1;
@@ -1003,7 +1003,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::clip_line(FortuneEdge * task)
   else
   {
     newInfo.m_RightID = m_Nvert;
-    m_Nvert++;
+    ++m_Nvert;
     PointType newv;
     newv[0] = x2;
     newv[1] = y2;
@@ -1124,11 +1124,11 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
 
       bisect(&(Edgepool[Edgeid]), findSite, currentSite);
       newEdge = &(Edgepool[Edgeid]);
-      Edgeid++;
+      ++Edgeid;
 
       createHalfEdge(&(HEpool[HEid]), newEdge, 0);
       newHE = &(HEpool[HEid]);
-      HEid++;
+      ++HEid;
 
       insertEdgeList(leftHalfEdge, newHE);
 
@@ -1139,13 +1139,13 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
       {
         deletePQ(leftHalfEdge);
         insertPQ(leftHalfEdge, meetSite, dist(meetSite, currentSite));
-        Siteid++;
+        ++Siteid;
       }
 
       leftHalfEdge = newHE;
       createHalfEdge(&(HEpool[HEid]), newEdge, 1);
       newHE = &(HEpool[HEid]);
-      HEid++;
+      ++HEid;
 
       insertEdgeList(leftHalfEdge, newHE);
 
@@ -1153,14 +1153,14 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
       meetSite = &(Sitepool[Siteid]);
       if ((meetSite->m_Sitenbr) == -5)
       {
-        Siteid++;
+        ++Siteid;
         insertPQ(newHE, meetSite, dist(meetSite, currentSite));
       }
       if (i < m_SeedSites.size())
       {
         currentSite = &(m_SeedSites[i]);
       }
-      i++;
+      ++i;
     }
     else if (m_PQcount != 0)
     {
@@ -1175,7 +1175,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
 
       newVert = leftHalfEdge->m_Vert;
       newVert->m_Sitenbr = m_Nvert;
-      m_Nvert++;
+      ++m_Nvert;
       m_OutputVD->AddVert(newVert->m_Coord);
 
       makeEndPoint(leftHalfEdge->m_Edge, leftHalfEdge->m_RorL, newVert);
@@ -1195,11 +1195,11 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
 
       bisect(&(Edgepool[Edgeid]), findSite, topSite);
       newEdge = &(Edgepool[Edgeid]);
-      Edgeid++;
+      ++Edgeid;
 
       createHalfEdge(&(HEpool[HEid]), newEdge, saveBool);
       newHE = &(HEpool[HEid]);
-      HEid++;
+      ++HEid;
 
       insertEdgeList(left2HalfEdge, newHE);
       makeEndPoint(newEdge, 1 - saveBool, newVert);
@@ -1209,7 +1209,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
 
       if ((meetSite->m_Sitenbr) == -5)
       {
-        Siteid++;
+        ++Siteid;
         deletePQ(left2HalfEdge);
         insertPQ(left2HalfEdge, meetSite, dist(meetSite, findSite));
       }
@@ -1218,7 +1218,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
       meetSite = &(Sitepool[Siteid]);
       if ((meetSite->m_Sitenbr) == -5)
       {
-        Siteid++;
+        ++Siteid;
         insertPQ(newHE, meetSite, dist(meetSite, findSite));
       }
     }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -160,14 +160,14 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Ta
     {
       if (ait.Get())
       {
-        num++;
+        ++num;
         currp = static_cast<float>(iit.Get());
         addp += currp;
         addpp += currp * currp;
       }
       else
       {
-        numb++;
+        ++numb;
         currp = static_cast<float>(iit.Get());
         addb += currp;
       }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -200,7 +200,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   auto vsize = static_cast<int>(vertlist.size());
   while (vsize > 2)
   {
-    vsize--;
+    --vsize;
     if (RorL)
     {
       vertlist.pop_back();
@@ -389,7 +389,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       if (bnd)
       {
         m_Label[i] = 2;
-        m_NumberOfBoundary++;
+        ++m_NumberOfBoundary;
       }
     }
   }
@@ -462,7 +462,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     }
     while ((m_NumberOfSeedsToAdded != 0) && ok)
     {
-      count++;
+      ++count;
       m_VDGenerator->AddSeeds(m_NumberOfSeedsToAdded, m_SeedsToAdded.begin());
       m_LastStepSeeds = m_NumberOfSeeds;
       m_NumberOfSeeds += m_NumberOfSeedsToAdded;
@@ -498,7 +498,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       m_LastStepSeeds = m_NumberOfSeeds;
       m_NumberOfSeeds += m_NumberOfSeedsToAdded;
       this->RunSegmentOneStep();
-      i++;
+      ++i;
       this->UpdateProgress(static_cast<float>(i) / static_cast<float>(m_Steps));
     }
   }
@@ -750,7 +750,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   auto vsize = static_cast<int>(vertlist.size());
   while (vsize > 2)
   {
-    vsize--;
+    --vsize;
     if (RorL)
     {
       vertlist.pop_back();
@@ -905,19 +905,19 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 
   if (x1 == static_cast<int>(m_Size[0]))
   {
-    x1--;
+    --x1;
   }
   if (x2 == static_cast<int>(m_Size[0]))
   {
-    x2--;
+    --x2;
   }
   if (y1 == static_cast<int>(m_Size[1]))
   {
-    y1--;
+    --y1;
   }
   if (y2 == static_cast<int>(m_Size[1]))
   {
-    y2--;
+    --y2;
   }
 
   int       dx = x1 - x2;
@@ -1028,19 +1028,19 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 
   if (x1 == static_cast<int>(m_Size[0]))
   {
-    x1--;
+    --x1;
   }
   if (x2 == static_cast<int>(m_Size[0]))
   {
-    x2--;
+    --x2;
   }
   if (y1 == static_cast<int>(m_Size[1]))
   {
-    y1--;
+    --y1;
   }
   if (y2 == static_cast<int>(m_Size[1]))
   {
-    y2--;
+    --y2;
   }
   int       dx = x1 - x2;
   int       adx = (dx > 0) ? dx : -dx;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -194,7 +194,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TestHomogeneity(In
     {
       ok = false;
     }
-    j++;
+    ++j;
   }
 
   if (ok)
@@ -278,7 +278,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
       currp = iit.Get();
       if (ait.Get())
       {
-        objnum++;
+        ++objnum;
         for (k = 0; k < 6; ++k)
         {
           objaddp[k] += currp[k];
@@ -287,7 +287,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
       }
       else
       {
-        bkgnum++;
+        ++bkgnum;
         for (k = 0; k < 6; ++k)
         {
           bkgaddp[k] += currp[k];

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -222,7 +222,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
         // If we found an unlabeled minimum,
         // Set the LabelForRegion, and increment CurrentLabel
         LabelForRegion = CurrentLabel;
-        CurrentLabel++;
+        ++CurrentLabel;
       }
       if (MinimumNeighborClass > 1)
       {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -85,7 +85,7 @@ Relabeler<TScalar, TImageDimension>::GenerateData()
   while (it != tree->End() && (*it).saliency <= mergeLimit)
   {
     eqT->Add((*it).from, (*it).to);
-    it++;
+    ++it;
   }
 
   SegmenterType::RelabelImage(output, output->GetRequestedRegion(), eqT);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -36,7 +36,7 @@ SegmentTable<TScalar>::PruneEdgeLists(ScalarType maximum_saliency)
     {
       if ((e->height - (*it).second.min) > maximum_saliency)
       { // dump the rest of the list, assumes list is sorted
-        e++;
+        ++e;
         (*it).second.edge_list.erase(e, (*it).second.edge_list.end());
         break; // through with this segment
       }

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -137,7 +137,7 @@ SegmentTreeGenerator<TScalar>::MergeEquivalencies()
       counter = 0;
     }
 
-    counter++;
+    ++counter;
   }
 }
 
@@ -221,7 +221,7 @@ SegmentTreeGenerator<TScalar>::ExtractMergeHierarchy(SegmentTableTypePointer seg
 
   while ((!heap->Empty()) && (topMerge.saliency <= threshold))
   {
-    counter++;            // Every so often we should eliminate
+    ++counter;            // Every so often we should eliminate
     if (counter == 10000) // all the recursion in our records
     {                     // of which segments have merged.
       counter = 0;
@@ -343,14 +343,14 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
       edgeTEMPi = edgeTOi;
-      edgeTEMPi++;
+      ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;
       continue;
     }
     if (seen_table.find(labelFROM) != seen_table.end() || labelFROM == TO)
     {
-      edgeFROMi++;
+      ++edgeFROMi;
       continue;
     }
 
@@ -369,12 +369,12 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
     {
       to_seg->edge_list.insert(edgeTOi, *edgeFROMi);
       seen_table.insert(HashMapType::value_type(labelFROM, true));
-      edgeFROMi++;
+      ++edgeFROMi;
     }
     else
     {
       seen_table.insert(HashMapType::value_type(labelTO, true));
-      edgeTOi++;
+      ++edgeTOi;
     }
   }
 
@@ -384,7 +384,7 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
     labelFROM = eqT->RecursiveLookup(edgeFROMi->label);
     if (seen_table.find(labelFROM) != seen_table.end() || labelFROM == TO)
     {
-      edgeFROMi++;
+      ++edgeFROMi;
     }
     else
     {
@@ -394,7 +394,7 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
       }
       to_seg->edge_list.push_back(*edgeFROMi);
       seen_table.insert(HashMapType::value_type(labelFROM, true));
-      edgeFROMi++;
+      ++edgeFROMi;
     }
   }
 
@@ -405,7 +405,7 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
       edgeTEMPi = edgeTOi;
-      edgeTEMPi++;
+      ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;
     }
@@ -416,7 +416,7 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
         edgeTOi->label = labelTO;
       }
       seen_table.insert(HashMapType::value_type(labelTO, true));
-      edgeTOi++;
+      ++edgeTOi;
     }
   }
 
@@ -481,14 +481,14 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
       edgeTEMPi = edgeTOi;
-      edgeTEMPi++;
+      ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;
       continue;
     }
     if (seen_table.find(labelFROM) != seen_table.end() || labelFROM == TO)
     {
-      edgeFROMi++;
+      ++edgeFROMi;
       continue;
     }
 
@@ -507,12 +507,12 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     {
       to_seg->edge_list.insert(edgeTOi, *edgeFROMi);
       seen_table.insert(HashMapType::value_type(labelFROM, true));
-      edgeFROMi++;
+      ++edgeFROMi;
     }
     else
     {
       seen_table.insert(HashMapType::value_type(labelTO, true));
-      edgeTOi++;
+      ++edgeTOi;
     }
   }
 
@@ -522,7 +522,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     labelFROM = eqT->RecursiveLookup(edgeFROMi->label);
     if (seen_table.find(labelFROM) != seen_table.end() || labelFROM == TO)
     {
-      edgeFROMi++;
+      ++edgeFROMi;
     }
     else
     {
@@ -532,7 +532,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
       }
       to_seg->edge_list.push_back(*edgeFROMi);
       seen_table.insert(HashMapType::value_type(labelFROM, true));
-      edgeFROMi++;
+      ++edgeFROMi;
     }
   }
 
@@ -543,7 +543,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
       edgeTEMPi = edgeTOi;
-      edgeTEMPi++;
+      ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;
     }
@@ -554,7 +554,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
         edgeTOi->label = labelTO;
       }
       seen_table.insert(HashMapType::value_type(labelTO, true));
-      edgeTOi++;
+      ++edgeTOi;
     }
   }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -538,7 +538,7 @@ Segmenter<TInputImage>::AnalyzeBoundaryFlow(InputImageTypePointer thresholdImage
             tempFlatRegion.is_on_boundary = true;
             flatRegions[m_CurrentLabel] = tempFlatRegion;
 
-            m_CurrentLabel++;
+            ++m_CurrentLabel;
           }
         }
         else // Is cPos the path of steepest descent?
@@ -589,7 +589,7 @@ Segmenter<TInputImage>::AnalyzeBoundaryFlow(InputImageTypePointer thresholdImage
                 break;
               }
             }
-            m_CurrentLabel++;
+            ++m_CurrentLabel;
           }
         }
 
@@ -664,14 +664,14 @@ Segmenter<TInputImage>::GenerateConnectivity()
     stride = it.GetStride(d);
     m_Connectivity.index[i] = nCenter - stride;
     m_Connectivity.direction[i][d] = -1;
-    i++;
+    ++i;
   }
   for (d = 0; d < static_cast<int>(ImageDimension); ++d)
   {
     stride = it.GetStride(d);
     m_Connectivity.index[i] = nCenter + stride;
     m_Connectivity.direction[i][d] = 1;
-    i++;
+    ++i;
   }
 }
 

--- a/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
@@ -41,7 +41,7 @@ OneWayEquivalencyTable::Add(unsigned long a, unsigned long b)
 //  while (it != this->End() )
 //    {
 //      std::cout << (*it).first << " = " << (*it).second << std::endl;
-//      it++;
+//      ++it;
 //    }
 //}
 
@@ -53,7 +53,7 @@ OneWayEquivalencyTable::Flatten()
   while (it != this->End())
   {
     (*it).second = this->RecursiveLookup((*it).first);
-    it++;
+    ++it;
   }
 }
 

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -155,7 +155,7 @@ ImageToVideoFilter<TInputImage, TOutputVideoStream>::GenerateOutputInformation()
     {
       outputSpacing.SetElement(outputIdx, inputSpacing[inputIdx]);
       outputOrigin.SetElement(outputIdx, inputOrigin[inputIdx]);
-      outputIdx++;
+      ++outputIdx;
     }
   }
   this->GetOutput()->SetAllFramesSpacing(outputSpacing);

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -76,7 +76,7 @@ FileListVideoIO ::SplitFileNames(const std::string & fileList)
     // Move past the delimiter
     if (pos != std::string::npos)
     {
-      pos++;
+      ++pos;
     }
     len -= pos;
   }
@@ -220,7 +220,7 @@ FileListVideoIO::Read(void * buffer)
   // Move on to the next frame
   if (m_CurrentFrame < m_FrameTotal - 1)
   {
-    m_CurrentFrame++;
+    ++m_CurrentFrame;
   }
 }
 
@@ -356,7 +356,7 @@ FileListVideoIO::Write(const void * buffer)
   // Move to the next frame
   if (m_CurrentFrame < m_FrameTotal - 1)
   {
-    m_CurrentFrame++;
+    ++m_CurrentFrame;
   }
 }
 


### PR DESCRIPTION
Followed common C++ guidelines, including:

Google C++ Style Guide: "Use the prefix form (++i) of the increment and
decrement operators unless you need postfix semantics."
https://google.github.io/styleguide/cppguide.html#Preincrement_and_Predecrement

Herb Sutter, Andrei Alexandrescu - C++ Coding Standards: 101 Rules,
Guidelines, and Best Practices: "Prefer the canonical form of ++ and --.
Prefer calling the prefix forms"
https://www.oreilly.com/library/view/c-coding-standards/0321113586/ch29.html

Follow-up to pull request #2493 commit f81578bbb6242032b611d7e3e4dca3b7557fbbe0 "STYLE: Replace postfix by prefix increment in `for` loops in Core/Common"
