### PR TITLE
BUG: Use absolute module path PyCapsule_Import

### DIFF
--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -7,6 +7,8 @@ import collections
 from sys import version_info as _version_info
 if _version_info < (3, 7, 0):
     raise RuntimeError("Python 3.7 or later required")
+
+from . import _ITKCommonPython
 %}
 
 //By including pyabc.i and using the -py3 command line option when calling SWIG,

--- a/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
+++ b/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
@@ -67,7 +67,7 @@ static void ** _ITKCommonPython_API;
 static int
 import__ITKCommonPython()
 {
-  _ITKCommonPython_API = (void **)PyCapsule_Import("_ITKCommonPython._C_API", 0);
+  _ITKCommonPython_API = (void **)PyCapsule_Import("itk._ITKCommonPython._C_API", 0);
   return (_ITKCommonPython_API != NULL) ? 0 : -1;
 }
 

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -1489,7 +1489,10 @@ import collections
 from sys import version_info as _version_info
 if _version_info < (3, 7, 0):
     raise RuntimeError("Python 3.7 or later required")
+
+from . import _ITKCommonPython
 %}
+
 """
                 )
                 # Also, release the GIL

--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -293,7 +293,7 @@ _ITKCommonPython_API[_ITKCommonPython_GetGlobalSingletonIndex_NUM] = (void *)_IT
 
 /* Create a Capsule containing the API pointer array's address */
 PyObject * cAPIObject = PyCapsule_New((void *)_ITKCommonPython_API,
-\"_ITKCommonPython._C_API\", NULL);
+\"itk._ITKCommonPython._C_API\", NULL);
 
 if(cAPIObject != NULL)
 {


### PR DESCRIPTION
Addresses:

```
ImportError: PyCapsule_Import could not import module "_ITKCommonPython"
```

That can occur when unpickling for Dask, for example.

According to the `PyCapsule_Import` documentation, internally it calls
`PyImport_ImportModule`. According to the `PyImport_ImportModule`
documentation, this requires the absolute path -- we add the `itk.`
prefix.

In most other contexts, the `_ITKCommonPython` module is likely to
already be imported. Since `_ITKCommonPython` gets loaded via
PyImport_ImportModule, it is not registered with the ITK lazy loading
module system, so we add `from . import _ITKCommon`.
