### PR TITLE
ENH: Improve LabelOverlapMeasuresImageFilter

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
@@ -226,6 +226,13 @@ public:
   /** Get the false positive error for the specified individual label. */
   RealType GetFalsePositiveError(LabelType) const;
 
+  /** Get the false discovery rate over all labels. */
+  RealType
+  GetFalseDiscoveryRate() const;
+
+  /** Get the false discovery rate for the specified individual label. */
+  RealType GetFalseDiscoveryRate(LabelType) const;
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<LabelType>));


### PR DESCRIPTION
Add definition of false discovery rate
Separate FalsePositiveError with FPR and FDR
Indicate members of the confusion matrix in code comments

From @Joeycho. Closes #3490.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
