### PR TITLE
ENH: Improve LabelOverlapMeasuresImageFilter

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
@@ -226,6 +226,13 @@ public:
   /** Get the false positive error for the specified individual label. */
   RealType GetFalsePositiveError(LabelType) const;
 
+  /** Get the false discovery rate over all labels. */
+  RealType
+  GetFalseDiscoveryRate() const;
+
+  /** Get the false discovery rate for the specified individual label. */
+  RealType GetFalseDiscoveryRate(LabelType) const;
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<LabelType>));

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -91,14 +91,14 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::AfterThreadedGenerateData()
       }
 
       // Accumulate the information from this thread
-      (*mapIt).second.m_Source += (*threadIt).second.m_Source;
-      (*mapIt).second.m_Target += (*threadIt).second.m_Target;
-      (*mapIt).second.m_Union += (*threadIt).second.m_Union;
-      (*mapIt).second.m_Intersection += (*threadIt).second.m_Intersection;
-      (*mapIt).second.m_SourceComplement += (*threadIt).second.m_SourceComplement;
-      (*mapIt).second.m_TargetComplement += (*threadIt).second.m_TargetComplement;
-    } // end of thread map iterator loop
-  }   // end of thread loop
+      (*mapIt).second.m_Source += (*threadIt).second.m_Source; // segmentation which will be compared (TP+FP)
+      (*mapIt).second.m_Target += (*threadIt).second.m_Target; // Ground Truth segmentation (TP+FN)
+      (*mapIt).second.m_Union += (*threadIt).second.m_Union;   // (TP+FN+FP)
+      (*mapIt).second.m_Intersection += (*threadIt).second.m_Intersection;         //(TP)
+      (*mapIt).second.m_SourceComplement += (*threadIt).second.m_SourceComplement; //(FP)
+      (*mapIt).second.m_TargetComplement += (*threadIt).second.m_TargetComplement; //(FN)
+    }                                                                              // end of thread map iterator loop
+  }                                                                                // end of thread loop
 }
 
 template <typename TLabelImage>
@@ -375,6 +375,9 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> R
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
+
+  auto nVox = this->GetInput(0)->GetLargestPossibleRegion().GetNumberOfPixels(); // TP+FP+FN+TN
+
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
@@ -382,8 +385,9 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> R
     {
       continue;
     }
-    numerator += static_cast<RealType>((*mapIt).second.m_SourceComplement);
-    denominator += static_cast<RealType>((*mapIt).second.m_Source);
+    auto nComplementIntersection = nVox - (*mapIt).second.m_Union;                                      // TN
+    numerator += static_cast<RealType>((*mapIt).second.m_SourceComplement);                             // FP
+    denominator += static_cast<RealType>((*mapIt).second.m_SourceComplement + nComplementIntersection); // FP+TN
   }
 
   if (Math::ExactlyEquals(denominator, 0.0))
@@ -399,6 +403,62 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> R
 template <typename TLabelImage>
 auto
 LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType label) const -> RealType
+{
+  auto nVox = this->GetInput(0)->GetLargestPossibleRegion().GetNumberOfPixels(); // TP+FP+FN+TN
+  auto mapIt = this->m_LabelSetMeasures.find(label);
+  if (mapIt == this->m_LabelSetMeasures.end())
+  {
+    itkWarningMacro("Label " << label << " not found.");
+    return 0.0;
+  }
+
+  RealType value;
+  if (Math::ExactlyEquals((*mapIt).second.m_Source, 0.0))
+  {
+    value = NumericTraits<RealType>::max();
+  }
+  else
+  {
+    auto nComplementIntersection = nVox - (*mapIt).second.m_Union; // TN
+
+    value = static_cast<RealType>((*mapIt).second.m_SourceComplement) /
+            static_cast<RealType>((*mapIt).second.m_SourceComplement + nComplementIntersection);
+  }
+
+  return value;
+}
+
+
+template <typename TLabelImage>
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseDiscoveryRate() const -> RealType
+{
+  RealType numerator = 0.0;
+  RealType denominator = 0.0;
+  for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
+  {
+    // Do not include the background in the final value.
+    if ((*mapIt).first == NumericTraits<LabelType>::ZeroValue())
+    {
+      continue;
+    }
+    numerator += static_cast<RealType>((*mapIt).second.m_SourceComplement); // FP
+    denominator += static_cast<RealType>((*mapIt).second.m_Source);         // FP+TP
+  }
+
+  if (Math::ExactlyEquals(denominator, 0.0))
+  {
+    return NumericTraits<RealType>::max();
+  }
+  else
+  {
+    return (numerator / denominator);
+  }
+}
+
+template <typename TLabelImage>
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseDiscoveryRate(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
@@ -416,7 +476,6 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType la
   {
     value = static_cast<RealType>((*mapIt).second.m_SourceComplement) / static_cast<RealType>((*mapIt).second.m_Source);
   }
-
   return value;
 }
 

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -48,7 +48,7 @@ LabelOverlapMeasures(int, char * argv[])
   std::cout << "All Labels" << std::endl;
   std::cout << std::setw(10) << "   " << std::setw(17) << "Total" << std::setw(17) << "Union (jaccard)" << std::setw(17)
             << "Mean (dice)" << std::setw(17) << "Volume sim." << std::setw(17) << "False negative" << std::setw(17)
-            << "False positive" << std::endl;
+            << "False positive" << std::setw(17) << "False discovery" << std::endl;
   std::cout << std::setw(10) << "   ";
   std::cout << std::setw(17) << filter->GetTotalOverlap();
   std::cout << std::setw(17) << filter->GetUnionOverlap();
@@ -56,12 +56,13 @@ LabelOverlapMeasures(int, char * argv[])
   std::cout << std::setw(17) << filter->GetVolumeSimilarity();
   std::cout << std::setw(17) << filter->GetFalseNegativeError();
   std::cout << std::setw(17) << filter->GetFalsePositiveError();
+  std::cout << std::setw(17) << filter->GetFalseDiscoveryRate();
   std::cout << std::endl;
 
   std::cout << "Individual Labels" << std::endl;
   std::cout << std::setw(10) << "Label" << std::setw(17) << "Target" << std::setw(17) << "Union (jaccard)"
             << std::setw(17) << "Mean (dice)" << std::setw(17) << "Volume sim." << std::setw(17) << "False negative"
-            << std::setw(17) << "False positive" << std::endl;
+            << std::setw(17) << "False positive" << std::setw(17) << "False discovery" << std::endl;
 
   typename FilterType::MapType                 labelMap = filter->GetLabelSetMeasures();
   typename FilterType::MapType::const_iterator it;
@@ -82,6 +83,7 @@ LabelOverlapMeasures(int, char * argv[])
     std::cout << std::setw(17) << filter->GetVolumeSimilarity(label);
     std::cout << std::setw(17) << filter->GetFalseNegativeError(label);
     std::cout << std::setw(17) << filter->GetFalsePositiveError(label);
+    std::cout << std::setw(17) << filter->GetFalseDiscoveryRate(label);
     std::cout << std::endl;
   }
 
@@ -134,6 +136,15 @@ LabelOverlapMeasures(int, char * argv[])
   {
     std::cout << "Error in label " << static_cast<itk::NumericTraits<PixelType>::PrintType>(label) << ": ";
     std::cout << "Expected false positive error: " << expectedValue << ", but got " << result << std::endl;
+    std::cout << "Test failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  result = filter->GetFalseDiscoveryRate(label);
+  if (itk::Math::NotAlmostEquals(expectedValue, result))
+  {
+    std::cout << "Error in label " << static_cast<itk::NumericTraits<PixelType>::PrintType>(label) << ": ";
+    std::cout << "Expected false discovery rate: " << expectedValue << ", but got " << result << std::endl;
     std::cout << "Test failed" << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Add definition of false discovery rate
Separate FalsePositiveError with FPR and FDR
Indicate members of the confusion matrix in code comments
Support test for GetFalseDiscoveryRate() function

From @Joeycho. Closes #3490.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)