### PR TITLE
Replace all occurrences of `(&x)->Print` with `x.Print`

### DIFF
--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -107,7 +107,7 @@ protected:
 inline std::ostream &
 operator<<(std::ostream & os, const EventObject & e)
 {
-  (&e)->Print(os);
+  e.Print(os);
   return os;
 }
 

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -140,7 +140,7 @@ private:
 inline std::ostream &
 operator<<(std::ostream & os, const ExceptionObject & e)
 {
-  (&e)->Print(os);
+  e.Print(os);
   return os;
 }
 

--- a/Modules/Core/Common/test/itkByteSwapTest.cxx
+++ b/Modules/Core/Common/test/itkByteSwapTest.cxx
@@ -117,7 +117,7 @@ itkByteSwapTest(int, char *[])
   catch (const itk::ExceptionObject & err)
   {
     std::cout << "Caught unsigned long exception size is: " << sizeof(unsigned long) << std::endl;
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
   }
 
 
@@ -142,7 +142,7 @@ itkByteSwapTest(int, char *[])
   catch (const itk::ExceptionObject & err)
   {
     std::cout << "Caught unsigned long long exception size is: " << sizeof(unsigned long long) << std::endl;
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
   }
 
   try
@@ -166,7 +166,7 @@ itkByteSwapTest(int, char *[])
   catch (const itk::ExceptionObject & err)
   {
     std::cout << "Caught float exception size is: " << sizeof(float) << std::endl;
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 
@@ -191,7 +191,7 @@ itkByteSwapTest(int, char *[])
   catch (const itk::ExceptionObject & err)
   {
     std::cout << "Good catch! Caught double exception size is: " << sizeof(double) << std::endl;
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   // we failed to throw an exception for the double swap (once it's implemented, this should return 0

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -191,7 +191,7 @@ itkSliceIteratorTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return 2;
   }
 

--- a/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
@@ -184,7 +184,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   try
@@ -193,7 +193,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   try
@@ -202,7 +202,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   try
@@ -211,7 +211,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   try
@@ -220,7 +220,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   try
@@ -229,7 +229,7 @@ itkVariableSizeMatrixTest(int, char *[])
   }
   catch (const itk::ExceptionObject & e)
   {
-    (&e)->Print(std::cout);
+    e.Print(std::cout);
   }
 
   std::cout << "[PASSED]" << std::endl;

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
@@ -52,7 +52,7 @@ itkCurvatureAnisotropicDiffusionImageFilterTest(int itkNotUsed(argc), char * itk
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -56,7 +56,7 @@ itkGradientAnisotropicDiffusionImageFilterTest(int itkNotUsed(argc), char * itkN
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
@@ -88,7 +88,7 @@ itkVectorAnisotropicDiffusionImageFilterTest(int itkNotUsed(argc), char * itkNot
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
@@ -130,7 +130,7 @@ itkIsoContourDistanceImageFilterTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 
@@ -164,7 +164,7 @@ itkIsoContourDistanceImageFilterTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
@@ -49,7 +49,7 @@ itkBilateralImageFilterTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageFilterBase/test/itkNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkNeighborhoodOperatorImageFilterTest.cxx
@@ -55,7 +55,7 @@ itkNeighborhoodOperatorImageFilterTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageFilterBase/test/itkVectorNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkVectorNeighborhoodOperatorImageFilterTest.cxx
@@ -57,7 +57,7 @@ itkVectorNeighborhoodOperatorImageFilterTest(int itkNotUsed(argc), char * itkNot
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
@@ -135,7 +135,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
@@ -126,7 +126,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -124,7 +124,7 @@ itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -187,7 +187,7 @@ itkNarrowBandImageFilterBaseTest(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & err)
   {
-    (&err)->Print(std::cerr);
+    err.Print(std::cerr);
     std::cout << "Test failed." << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Aims to simplify the code.
