### PR TITLE
STYLE: Rethrow caught exceptions just by `throw;` without argument

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -114,7 +114,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::GenerateData()
   {
     Superclass::GenerateData();
   }
-  catch (const ProcessAborted & exc)
+  catch (const ProcessAborted &)
   {
     // process was aborted, clean up the state of the filter
     // (most of the cleanup will have already been done by the
@@ -122,7 +122,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::GenerateData()
 
     // restore the original stopping value
     this->SetStoppingValue(stoppingValue);
-    throw exc;
+    throw;
   }
 
   // restore the original stopping value

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
@@ -183,7 +183,7 @@ CSVNumericObjectFileWriter<TValue, VRows, VColumns>::Write()
     std::cerr << "Exception caught! " << std::endl;
     std::cerr << exp << std::endl;
     outputStream.close();
-    throw exp;
+    throw;
   }
   catch (...)
   {

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -52,7 +52,7 @@ public:
       {
         std::cout << "Caught an exception: " << std::endl;
         std::cout << err << " " << __FILE__ << " " << __LINE__ << std::endl;
-        throw err;
+        throw;
       }
       catch (...)
       {

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -88,7 +88,7 @@ GradientDescentOptimizer::ResumeOptimization()
     {
       m_CostFunction->GetValueAndDerivative(this->GetCurrentPosition(), m_Value, m_Gradient);
     }
-    catch (const ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       // An exception has occurred.
       // Terminate immediately.
@@ -97,7 +97,7 @@ GradientDescentOptimizer::ResumeOptimization()
       StopOptimization();
 
       // Pass exception to caller
-      throw err;
+      throw;
     }
 
     if (m_Stop)

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -110,7 +110,7 @@ RegularStepGradientDescentBaseOptimizer::ResumeOptimization()
       m_StopConditionDescription << "Cost function error after " << m_CurrentIteration << " iterations. "
                                  << excp.GetDescription();
       this->StopOptimization();
-      throw excp;
+      throw;
     }
 
     if (m_Stop)

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -228,14 +228,14 @@ SPSAOptimizer::AdvanceOneStep()
   {
     this->ComputeGradient(currentPosition, m_Gradient);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // An exception has occurred.
     // Terminate immediately.
     m_StopCondition = StopConditionSPSAOptimizerEnum::MetricError;
     StopOptimization();
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   /** Compute the gain a_k */

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -89,13 +89,13 @@ ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::A
     /* Pass gradient to transform and let it do its own updating. */
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";
     this->StopOptimization();
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   this->InvokeEvent(IterationEvent());

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -82,13 +82,13 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Adv
     /* Pass gradient to transform and let it do its own updating */
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";
     this->StopOptimization();
     // Pass exception to caller
-    throw err;
+    throw;
   }
   this->InvokeEvent(IterationEvent());
 }

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -98,14 +98,14 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
       // proper size, no new allocation is done.
       this->m_Metric->GetValueAndDerivative(this->m_CurrentMetricValue, this->m_Gradient);
     }
-    catch (const ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::COSTFUNCTION_ERROR;
       this->m_StopConditionDescription << "Metric error during optimization";
       this->StopOptimization();
 
       // Pass exception to caller
-      throw err;
+      throw;
     }
 
     // Check if optimization has been stopped externally.
@@ -175,14 +175,14 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::AdvanceOneSte
     // Pass gradient to transform and let it do its own updating
     this->m_Metric->UpdateTransformParameters(this->m_Gradient);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";
     this->StopOptimization();
 
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   this->InvokeEvent(IterationEvent());

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -206,13 +206,13 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::ResumeOptimizat
       itkDebugMacro(" combine-grad ");
       this->m_OptimizersList[0]->GetModifiableMetric()->UpdateTransformParameters(this->m_Gradient);
     }
-    catch (const ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
       this->m_StopConditionDescription << "UpdateTransformParameters error";
       this->StopOptimization();
       // Pass exception to caller
-      throw err;
+      throw;
     }
     this->InvokeEvent(IterationEvent());
     /* Update and check iteration count */

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -165,14 +165,14 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::AdvanceOneStep()
     /* Pass gradient to transform and let it do its own updating */
     this->m_Metric->UpdateTransformParameters(this->m_NewtonStep);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";
     this->StopOptimization();
 
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   this->InvokeEvent(IterationEvent());

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
@@ -159,14 +159,14 @@ RegularStepGradientDescentOptimizerv4<TInternalComputationValueType>::AdvanceOne
     // Pass gradient to transform and let it do its own updating
     this->m_Metric->UpdateTransformParameters(this->m_Gradient, factor);
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::UPDATE_PARAMETERS_ERROR;
     this->m_StopConditionDescription << "UpdateTransformParameters error";
     this->StopOptimization();
 
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   this->InvokeEvent(IterationEvent());

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -217,14 +217,14 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::StartOptimization()
     // do the optimization
     m_Optimizer->StartOptimization();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // An error has occurred in the optimization.
     // Update the parameters
     m_LastTransformParameters = m_Optimizer->GetCurrentPosition();
 
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   // get the results
@@ -266,12 +266,12 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
     // initialize the interconnects between components
     this->Initialize();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     m_LastTransformParameters = empty;
 
     // pass exception to caller
-    throw err;
+    throw;
   }
 
   this->StartOptimization();

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -124,10 +124,10 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Gener
     // Initialize the interconnects between components
     this->Initialize();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   try
@@ -135,13 +135,13 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Gener
     // Do the optimization
     m_Optimizer->StartOptimization();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // An error has occurred in the optimization.
     // Update the parameters
     m_LastTransformParameters = m_Optimizer->GetCurrentPosition();
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   // Get the results

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -350,13 +350,13 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData(
       // initialize the interconnects between components
       this->Initialize();
     }
-    catch (const ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       m_LastTransformParameters = ParametersType(1);
       m_LastTransformParameters.Fill(0.0f);
 
       // pass exception to caller
-      throw err;
+      throw;
     }
 
     try
@@ -364,14 +364,14 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData(
       // do the optimization
       m_Optimizer->StartOptimization();
     }
-    catch (const ExceptionObject & err)
+    catch (const ExceptionObject &)
     {
       // An error has occurred in the optimization.
       // Update the parameters
       m_LastTransformParameters = m_Optimizer->GetCurrentPosition();
 
       // Pass exception to caller
-      throw err;
+      throw;
     }
 
     // get the results

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -116,13 +116,13 @@ PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GenerateData()
   {
     this->Initialize();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     m_LastTransformParameters = ParametersType(1);
     m_LastTransformParameters.Fill(0.0f);
 
     // Pass the exception to the caller
-    throw err;
+    throw;
   }
 
   // Do the optimization
@@ -130,14 +130,14 @@ PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GenerateData()
   {
     m_Optimizer->StartOptimization();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // An error has occurred in the optimization.
     // Update the parameters
     m_LastTransformParameters = m_Optimizer->GetCurrentPosition();
 
     // Pass the exception to the caller
-    throw err;
+    throw;
   }
 
   // Get the results

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -110,13 +110,13 @@ PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GenerateD
   {
     this->Initialize();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     m_LastTransformParameters = ParametersType(1);
     m_LastTransformParameters.Fill(0.0f);
 
     // Pass the  exception to the caller
-    throw err;
+    throw;
   }
 
   // Do the optimization
@@ -124,14 +124,14 @@ PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GenerateD
   {
     m_Optimizer->StartOptimization();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // An error has occurred in the optimization.
     // Update the parameters
     m_LastTransformParameters = m_Optimizer->GetCurrentPosition();
 
     // Pass the exception to the caller
-    throw err;
+    throw;
   }
 
   // Get the results

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -104,10 +104,10 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
   {
     kmeansFilter->Update();
   }
-  catch (const ExceptionObject & err)
+  catch (const ExceptionObject &)
   {
     // Pass exception to caller
-    throw err;
+    throw;
   }
 
   typename KMeansFilterType::ParametersType estimatedMeans = kmeansFilter->GetFinalMeans(); // mean of each class

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -352,12 +352,12 @@ TemporalProcessObject::UpdateOutputData(DataObject * itkNotUsed(output))
     }
     this->GenerateData();
   }
-  catch (const ProcessAborted & excp)
+  catch (const ProcessAborted &)
   {
     this->InvokeEvent(AbortEvent());
     this->ResetPipeline();
     this->RestoreInputReleaseDataFlags();
-    throw excp;
+    throw;
   }
   catch (...)
   {


### PR DESCRIPTION
Following C++ Core Guidelines, April 10, 2022, which says:

> To rethrow a caught exception use `throw;` not `throw e;`

At https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference

Found by the regular expression, `catch \(const [^\s]+ & (\w+)\).+  throw \1;`