### PR TITLE
STYLE: Replace `(*p).member` with `p->member`

### DIFF
--- a/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
@@ -105,19 +105,19 @@ itkVtkConnectedComponentImageFilterTest(int argc, char * argv[])
   auto it = filterContainer.begin();
   for (it = filterContainer.begin(); it != filterContainer.end(); ++it)
   {
-    (*it).second->SetInsideValue(255);
-    (*it).second->SetOutsideValue(0);
-    (*it).second->SetNumberOfHistogramBins(256);
-    (*it).second->SetInput(reader->GetOutput());
-    (*it).second->Update();
+    it->second->SetInsideValue(255);
+    it->second->SetOutsideValue(0);
+    it->second->SetNumberOfHistogramBins(256);
+    it->second->SetInput(reader->GetOutput());
+    it->second->Update();
 
     auto connected = ConnectedComponentImageFilterType::New();
-    connected->SetInput((*it).second->GetOutput());
+    connected->SetInput(it->second->GetOutput());
 
     auto rgbFilter = RGBFilterType::New();
     rgbFilter->SetInput(connected->GetOutput());
     std::stringstream desc;
-    desc << (*it).first << " threshold = " << (*it).second->GetThreshold();
+    desc << it->first << " threshold = " << it->second->GetThreshold();
     viewer.AddRGBImage(rgbFilter->GetOutput(), true, desc.str());
   }
 

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
@@ -190,7 +190,7 @@ public:
   Print(std::ostream & os) const
   {
     // This prints the object pointed to by the pointer
-    (*m_Pointer).Print(os);
+    m_Pointer->Print(os);
     return m_Pointer;
   }
 

--- a/Modules/Core/Common/include/itkAutoPointer.h
+++ b/Modules/Core/Common/include/itkAutoPointer.h
@@ -205,7 +205,7 @@ public:
   /*  ObjectType *Print (std::ostream& os) const
       {
       // This prints the object pointed to by the pointer
-      (*m_Pointer).Print(os);
+      m_Pointer->Print(os);
       os << "Owner: " << m_IsOwner << std::endl;
       return m_Pointer;
       }

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -193,7 +193,7 @@ public:
         auto pos = m_UserDefined.find(id);
         if (pos != m_UserDefined.end())
         {
-          return (*pos).second;
+          return pos->second;
         }
       }
       return nullptr;

--- a/Modules/Core/Common/include/itkCommand.h
+++ b/Modules/Core/Common/include/itkCommand.h
@@ -124,7 +124,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))(caller, event);
+      (m_This->*(m_MemberFunction))(caller, event);
     }
   }
 
@@ -134,7 +134,7 @@ public:
   {
     if (m_ConstMemberFunction)
     {
-      ((*m_This).*(m_ConstMemberFunction))(caller, event);
+      (m_This->*(m_ConstMemberFunction))(caller, event);
     }
   }
 
@@ -195,7 +195,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))(event);
+      (m_This->*(m_MemberFunction))(event);
     }
   }
 
@@ -205,7 +205,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))(event);
+      (m_This->*(m_MemberFunction))(event);
     }
   }
 
@@ -263,7 +263,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))();
+      (m_This->*(m_MemberFunction))();
     }
   }
 
@@ -272,7 +272,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))();
+      (m_This->*(m_MemberFunction))();
     }
   }
 
@@ -330,7 +330,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))();
+      (m_This->*(m_MemberFunction))();
     }
   }
 
@@ -339,7 +339,7 @@ public:
   {
     if (m_MemberFunction)
     {
-      ((*m_This).*(m_MemberFunction))();
+      (m_This->*(m_MemberFunction))();
     }
   }
 

--- a/Modules/Core/Common/include/itkEquivalencyTable.h
+++ b/Modules/Core/Common/include/itkEquivalencyTable.h
@@ -100,7 +100,7 @@ public:
     }
     else
     {
-      return (*result).second;
+      return result->second;
     }
   }
 

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -39,7 +39,7 @@ typename ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifi
 ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::GetLocation(
   const ElementWrapperPointerType & element) const
 {
-  return ((*element).GetLocation(*element));
+  return (element->GetLocation(*element));
 }
 // -----------------------------------------------------------------------------
 
@@ -50,7 +50,7 @@ ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::SetL
   ElementWrapperPointerType &   element,
   const ElementIdentifierType & identifier)
 {
-  (*element).SetLocation(*element, identifier);
+  element->SetLocation(*element, identifier);
 }
 // -----------------------------------------------------------------------------
 
@@ -61,7 +61,7 @@ ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::is_l
   const ElementWrapperPointerType & element1,
   const ElementWrapperPointerType & element2) const
 {
-  return ((*element1).is_less((*element1), (*element2)));
+  return (element1->is_less((*element1), (*element2)));
 }
 // -----------------------------------------------------------------------------
 
@@ -72,7 +72,7 @@ ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::is_g
   const ElementWrapperPointerType & element1,
   const ElementWrapperPointerType & element2) const
 {
-  return ((*element1).is_greater((*element1), (*element2)));
+  return (element1->is_greater((*element1), (*element2)));
 }
 // -----------------------------------------------------------------------------
 

--- a/Modules/Core/Common/include/itkSmartPointer.h
+++ b/Modules/Core/Common/include/itkSmartPointer.h
@@ -169,7 +169,7 @@ public:
     else
     {
       // This prints the object pointed to by the pointer
-      (*m_Pointer).Print(os);
+      m_Pointer->Print(os);
     }
     return m_Pointer;
   }

--- a/Modules/Core/Common/include/itkSmartPointerForwardReference.hxx
+++ b/Modules/Core/Common/include/itkSmartPointerForwardReference.hxx
@@ -156,7 +156,7 @@ T *
 SmartPointerForwardReference<T>::Print(std::ostream & os) const
 {
   // This prints the object pointed to by the pointer
-  (*m_Pointer).Print(os);
+  m_Pointer->Print(os);
   return m_Pointer;
 }
 

--- a/Modules/Core/Common/include/itkWeakPointer.h
+++ b/Modules/Core/Common/include/itkWeakPointer.h
@@ -145,7 +145,7 @@ public:
     else
     {
       // This prints the object pointed to by the pointer
-      (*m_Pointer).Print(os);
+      m_Pointer->Print(os);
     }
     return m_Pointer;
   }

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -99,7 +99,7 @@ EquivalencyTable::AddAndFlatten(unsigned long a, unsigned long b)
 //  ConstIterator it = this->Begin();
 //  while (it != this->End() )
 //    {
-//      std::cout << (*it).first << " = " << (*it).second << std::endl;
+//      std::cout << it->first << " = " << it->second << std::endl;
 //      ++it;
 //    }
 //}
@@ -111,7 +111,7 @@ EquivalencyTable::Flatten()
 
   while (it != this->End())
   {
-    (*it).second = this->RecursiveLookup((*it).second);
+    it->second = this->RecursiveLookup(it->second);
     ++it;
   }
 }
@@ -127,7 +127,7 @@ EquivalencyTable::RecursiveLookup(const unsigned long a) const
 
   while ((it = m_HashMap.find(ans)) != hashEnd)
   {
-    ans = (*it).second;
+    ans = it->second;
     if (ans == a)
     {
       return last_ans; // about to cycle again.

--- a/Modules/Core/Common/src/itkLoggerManager.cxx
+++ b/Modules/Core/Common/src/itkLoggerManager.cxx
@@ -72,7 +72,7 @@ LoggerManager::SetPriorityLevel(PriorityLevelEnum level)
 
   while (itr != this->m_LoggerSet.end())
   {
-    (*itr).second->SetPriorityLevel(level);
+    itr->second->SetPriorityLevel(level);
     ++itr;
   }
 }
@@ -84,7 +84,7 @@ LoggerManager::SetLevelForFlushing(PriorityLevelEnum level)
 
   while (itr != this->m_LoggerSet.end())
   {
-    (*itr).second->SetLevelForFlushing(level);
+    itr->second->SetLevelForFlushing(level);
     ++itr;
   }
 }
@@ -96,7 +96,7 @@ LoggerManager::AddLogOutput(OutputType * output)
 
   while (itr != this->m_LoggerSet.end())
   {
-    (*itr).second->AddLogOutput(output);
+    itr->second->AddLogOutput(output);
     ++itr;
   }
 }
@@ -108,7 +108,7 @@ LoggerManager::Write(PriorityLevelEnum level, std::string const & content)
 
   while (itr != this->m_LoggerSet.end())
   {
-    (*itr).second->Write(level, content);
+    itr->second->Write(level, content);
     ++itr;
   }
 }
@@ -120,7 +120,7 @@ LoggerManager::Flush()
 
   while (itr != this->m_LoggerSet.end())
   {
-    (*itr).second->Flush();
+    itr->second->Flush();
     ++itr;
   }
 }

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -46,8 +46,8 @@ MetaDataDictionary::Print(std::ostream & os) const
   os << "Dictionary use_count: " << m_Dictionary.use_count() << std::endl;
   for (MetaDataDictionaryMapType::const_iterator it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
   {
-    os << (*it).first << "  ";
-    (*it).second->Print(os);
+    os << it->first << "  ";
+    it->second->Print(os);
   }
 }
 
@@ -102,7 +102,7 @@ MetaDataDictionary::GetKeys() const
 
   for (MetaDataDictionaryMapType::const_iterator it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
   {
-    ans.push_back((*it).first);
+    ans.push_back(it->first);
   }
 
   return ans;

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -782,9 +782,9 @@ ObjectFactoryBase::CreateObject(const char * itkclassname)
 
   for (auto i = start; i != end; ++i)
   {
-    if (i != m_OverrideMap->end() && (*i).second.m_EnabledFlag)
+    if (i != m_OverrideMap->end() && i->second.m_EnabledFlag)
     {
-      return (*i).second.m_CreateObject->CreateObject();
+      return i->second.m_CreateObject->CreateObject();
     }
   }
   return nullptr;
@@ -800,9 +800,9 @@ ObjectFactoryBase::CreateAllObject(const char * itkclassname)
 
   for (auto i = start; i != end; ++i)
   {
-    if (i != m_OverrideMap->end() && (*i).second.m_EnabledFlag)
+    if (i != m_OverrideMap->end() && i->second.m_EnabledFlag)
     {
-      created.push_back((*i).second.m_CreateObject->CreateObject());
+      created.push_back(i->second.m_CreateObject->CreateObject());
     }
   }
   return created;
@@ -819,9 +819,9 @@ ObjectFactoryBase::SetEnableFlag(bool flag, const char * className, const char *
 
   for (auto i = start; i != end; ++i)
   {
-    if ((*i).second.m_OverrideWithName == subclassName)
+    if (i->second.m_OverrideWithName == subclassName)
     {
-      (*i).second.m_EnabledFlag = flag;
+      i->second.m_EnabledFlag = flag;
     }
   }
 }
@@ -837,9 +837,9 @@ ObjectFactoryBase::GetEnableFlag(const char * className, const char * subclassNa
 
   for (auto i = start; i != end; ++i)
   {
-    if ((*i).second.m_OverrideWithName == subclassName)
+    if (i->second.m_OverrideWithName == subclassName)
     {
-      return (*i).second.m_EnabledFlag;
+      return i->second.m_EnabledFlag;
     }
   }
   return false;
@@ -856,7 +856,7 @@ ObjectFactoryBase::Disable(const char * className)
 
   for (auto i = start; i != end; ++i)
   {
-    (*i).second.m_EnabledFlag = false;
+    i->second.m_EnabledFlag = false;
   }
 }
 

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -36,7 +36,7 @@ ImageBoundaryFaceCalculatorTest(TImage *                          image,
   {
     std::cout << "Number of pixels : " << fit->GetNumberOfPixels() << std::endl;
     std::cout << *fit << std::endl;
-    if (!region.IsInside(*fit) && (*fit).GetNumberOfPixels() > 0)
+    if (!region.IsInside(*fit) && fit->GetNumberOfPixels() > 0)
     {
       std::cerr << "face region is outside of requestToProcessRegion " << std::endl;
       return false;

--- a/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
+++ b/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
@@ -67,7 +67,7 @@ itkSparseFieldLayerTest(int, char *[])
     i = 3999;
     while (cit != layer->End())
     {
-      if ((*cit).value != i || cit->value != i)
+      if (cit->value != i || cit->value != i)
         return EXIT_FAILURE;
       ++cit;
       --i;
@@ -77,10 +77,10 @@ itkSparseFieldLayerTest(int, char *[])
     i = 3999;
     while (it != layer->End())
     {
-      if ((*it).value != i || it->value != i)
+      if (it->value != i || it->value != i)
         return EXIT_FAILURE;
-      (*it).value = 32567;
-      if ((*it).value != 32567 || it->value != 32567)
+      it->value = 32567;
+      if (it->value != 32567 || it->value != 32567)
         return EXIT_FAILURE;
       ++it;
       --i;

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -46,7 +46,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint(const DTIT
   auto                  it = fields.begin();
   while (it != fields.end())
   {
-    this->AddField((*it).first.c_str(), (*it).second);
+    this->AddField(it->first.c_str(), it->second);
     ++it;
   }
   for (unsigned int i = 0; i < 6; ++i)
@@ -102,9 +102,9 @@ DTITubeSpatialObjectPoint<TPointDimension>::SetField(const char * name, float va
 
   while (it != m_Fields.end())
   {
-    if (!strcmp((*it).first.c_str(), itksys::SystemTools::LowerCase(name).c_str()))
+    if (!strcmp(it->first.c_str(), itksys::SystemTools::LowerCase(name).c_str()))
     {
-      (*it).second = value;
+      it->second = value;
     }
     ++it;
   }
@@ -154,9 +154,9 @@ DTITubeSpatialObjectPoint<TPointDimension>::GetField(const char * name) const
 
   while (it != m_Fields.end())
   {
-    if (!strcmp((*it).first.c_str(), itksys::SystemTools::LowerCase(name).c_str()))
+    if (!strcmp(it->first.c_str(), itksys::SystemTools::LowerCase(name).c_str()))
     {
-      return (*it).second;
+      return it->second;
     }
     ++it;
   }
@@ -189,7 +189,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObject
     auto                  it = fields.begin();
     while (it != fields.end())
     {
-      this->AddField((*it).first.c_str(), (*it).second);
+      this->AddField(it->first.c_str(), it->second);
       ++it;
     }
     for (unsigned int i = 0; i < 6; ++i)

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -73,7 +73,7 @@ LineSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) co
       bool match = true;
       for (unsigned int i = 0; i < TDimension; ++i)
       {
-        if (!Math::AlmostEquals((*it).GetPositionInObjectSpace()[i], point[i]))
+        if (!Math::AlmostEquals(it->GetPositionInObjectSpace()[i], point[i]))
         {
           match = false;
           break;

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -103,13 +103,13 @@ MetaBlobConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*it).GetRed();
-    pnt->m_Color[1] = (*it).GetGreen();
-    pnt->m_Color[2] = (*it).GetBlue();
-    pnt->m_Color[3] = (*it).GetAlpha();
+    pnt->m_Color[0] = it->GetRed();
+    pnt->m_Color[1] = it->GetGreen();
+    pnt->m_Color[2] = it->GetBlue();
+    pnt->m_Color[3] = it->GetAlpha();
 
     Blob->GetPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -147,27 +147,27 @@ MetaContourConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
   {
     auto * pnt = new ContourControlPnt(VDimension);
 
-    pnt->m_Id = (*itCP).GetId();
+    pnt->m_Id = itCP->GetId();
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*itCP).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = itCP->GetPositionInObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_XPicked[d] = (*itCP).GetPickedPointInObjectSpace()[d];
+      pnt->m_XPicked[d] = itCP->GetPickedPointInObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V[d] = (*itCP).GetNormalInObjectSpace()[d];
+      pnt->m_V[d] = itCP->GetNormalInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*itCP).GetRed();
-    pnt->m_Color[1] = (*itCP).GetGreen();
-    pnt->m_Color[2] = (*itCP).GetBlue();
-    pnt->m_Color[3] = (*itCP).GetAlpha();
+    pnt->m_Color[0] = itCP->GetRed();
+    pnt->m_Color[1] = itCP->GetGreen();
+    pnt->m_Color[2] = itCP->GetBlue();
+    pnt->m_Color[3] = itCP->GetAlpha();
 
     contourMO->GetControlPoints().push_back(pnt);
   }
@@ -187,16 +187,16 @@ MetaContourConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
   {
     auto * pnt = new ContourInterpolatedPnt(VDimension);
 
-    pnt->m_Id = (*itI).GetId();
+    pnt->m_Id = itI->GetId();
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*itI).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = itI->GetPositionInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*itI).GetRed();
-    pnt->m_Color[1] = (*itI).GetGreen();
-    pnt->m_Color[2] = (*itI).GetBlue();
-    pnt->m_Color[3] = (*itI).GetAlpha();
+    pnt->m_Color[0] = itI->GetRed();
+    pnt->m_Color[1] = itI->GetGreen();
+    pnt->m_Color[2] = itI->GetBlue();
+    pnt->m_Color[3] = itI->GetAlpha();
 
     contourMO->GetInterpolatedPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -79,13 +79,13 @@ MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
     while (extraIt != metaFields.end())
     {
       // Do not add the optional fields
-      if (((*extraIt).first != "r") && ((*extraIt).first != "v1x") && ((*extraIt).first != "v1y") &&
-          ((*extraIt).first != "v1z") && ((*extraIt).first != "v2x") && ((*extraIt).first != "v2y") &&
-          ((*extraIt).first != "v2z") && ((*extraIt).first != "tx") && ((*extraIt).first != "ty") &&
-          ((*extraIt).first != "tz") && ((*extraIt).first != "red") && ((*extraIt).first != "green") &&
-          ((*extraIt).first != "blue") && ((*extraIt).first != "alpha") && ((*extraIt).first != "id"))
+      if ((extraIt->first != "r") && (extraIt->first != "v1x") && (extraIt->first != "v1y") &&
+          (extraIt->first != "v1z") && (extraIt->first != "v2x") && (extraIt->first != "v2y") &&
+          (extraIt->first != "v2z") && (extraIt->first != "tx") && (extraIt->first != "ty") &&
+          (extraIt->first != "tz") && (extraIt->first != "red") && (extraIt->first != "green") &&
+          (extraIt->first != "blue") && (extraIt->first != "alpha") && (extraIt->first != "id"))
       {
-        pnt.AddField((*extraIt).first.c_str(), (*extraIt).second);
+        pnt.AddField(extraIt->first.c_str(), extraIt->second);
       }
       ++extraIt;
     }
@@ -203,12 +203,12 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
   for (it = DTITubeSO->GetPoints().begin(); it != DTITubeSO->GetPoints().end(); ++it)
   {
     // Optional fields (written only if not default values)
-    if ((*it).GetId() != -1)
+    if (it->GetId() != -1)
     {
       writeID = true;
     }
 
-    if ((*it).GetRadiusInObjectSpace() != 0.0f)
+    if (it->GetRadiusInObjectSpace() != 0.0f)
     {
       writeRadius = true;
     }
@@ -216,27 +216,27 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     unsigned int d;
     for (d = 0; d < VDimension; ++d)
     {
-      if (Math::NotExactlyEquals((*it).GetNormal1InObjectSpace()[d], 0))
+      if (Math::NotExactlyEquals(it->GetNormal1InObjectSpace()[d], 0))
       {
         writeNormal1 = true;
       }
-      if (Math::NotExactlyEquals((*it).GetNormal2InObjectSpace()[d], 0))
+      if (Math::NotExactlyEquals(it->GetNormal2InObjectSpace()[d], 0))
       {
         writeNormal2 = true;
       }
-      if (Math::NotExactlyEquals((*it).GetTangentInObjectSpace()[d], 0))
+      if (Math::NotExactlyEquals(it->GetTangentInObjectSpace()[d], 0))
       {
         writeTangent = true;
       }
     }
 
     // write the color if changed
-    if (((*it).GetRed() != 1.0) || ((*it).GetGreen() != 0.0) || ((*it).GetBlue() != 0.0))
+    if ((it->GetRed() != 1.0) || (it->GetGreen() != 0.0) || (it->GetBlue() != 0.0))
     {
       writeColor = true;
     }
 
-    if ((*it).GetAlpha() != 1.0)
+    if (it->GetAlpha() != 1.0)
     {
       writeAlpha = true;
     }
@@ -249,74 +249,74 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
-    const DTITubePnt::FieldListType & metaFields = (*it).GetFields();
+    const DTITubePnt::FieldListType & metaFields = it->GetFields();
     auto                              extraIt = metaFields.begin();
     while (extraIt != metaFields.end())
     {
-      pnt->AddField((*extraIt).first.c_str(), (*extraIt).second);
+      pnt->AddField(extraIt->first.c_str(), extraIt->second);
       ++extraIt;
     }
 
     for (unsigned int d = 0; d < 6; ++d)
     {
-      pnt->m_TensorMatrix[d] = (*it).GetTensorMatrix()[d];
+      pnt->m_TensorMatrix[d] = it->GetTensorMatrix()[d];
     }
 
     // Optional fields (written only if not default values)
     if (writeID)
     {
-      pnt->AddField("id", (*it).GetId());
+      pnt->AddField("id", it->GetId());
     }
 
     if (writeRadius)
     {
-      pnt->AddField("r", (*it).GetRadiusInObjectSpace());
+      pnt->AddField("r", it->GetRadiusInObjectSpace());
     }
 
     if (writeNormal1)
     {
-      pnt->AddField("v1x", (*it).GetNormal1InObjectSpace()[0]);
-      pnt->AddField("v1y", (*it).GetNormal1InObjectSpace()[1]);
+      pnt->AddField("v1x", it->GetNormal1InObjectSpace()[0]);
+      pnt->AddField("v1y", it->GetNormal1InObjectSpace()[1]);
       if (VDimension == 3)
       {
-        pnt->AddField("v1z", (*it).GetNormal1InObjectSpace()[2]);
+        pnt->AddField("v1z", it->GetNormal1InObjectSpace()[2]);
       }
     }
 
     if (writeNormal2)
     {
-      pnt->AddField("v2x", (*it).GetNormal2InObjectSpace()[0]);
-      pnt->AddField("v2y", (*it).GetNormal2InObjectSpace()[1]);
+      pnt->AddField("v2x", it->GetNormal2InObjectSpace()[0]);
+      pnt->AddField("v2y", it->GetNormal2InObjectSpace()[1]);
       if (VDimension == 3)
       {
-        pnt->AddField("v2z", (*it).GetNormal2InObjectSpace()[2]);
+        pnt->AddField("v2z", it->GetNormal2InObjectSpace()[2]);
       }
     }
 
     if (writeTangent)
     {
-      pnt->AddField("tx", (*it).GetTangentInObjectSpace()[0]);
-      pnt->AddField("ty", (*it).GetTangentInObjectSpace()[1]);
+      pnt->AddField("tx", it->GetTangentInObjectSpace()[0]);
+      pnt->AddField("ty", it->GetTangentInObjectSpace()[1]);
       if (VDimension == 3)
       {
-        pnt->AddField("tz", (*it).GetTangentInObjectSpace()[2]);
+        pnt->AddField("tz", it->GetTangentInObjectSpace()[2]);
       }
     }
 
     // write the color if changed
     if (writeColor)
     {
-      pnt->AddField("red", (*it).GetRed());
-      pnt->AddField("green", (*it).GetGreen());
-      pnt->AddField("blue", (*it).GetBlue());
+      pnt->AddField("red", it->GetRed());
+      pnt->AddField("green", it->GetGreen());
+      pnt->AddField("blue", it->GetBlue());
     }
 
     if (writeAlpha)
     {
-      pnt->AddField("alpha", (*it).GetAlpha());
+      pnt->AddField("alpha", it->GetAlpha());
     }
 
     tube->GetPoints().push_back(pnt);

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -102,13 +102,13 @@ MetaLandmarkConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObject
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*it).GetRed();
-    pnt->m_Color[1] = (*it).GetGreen();
-    pnt->m_Color[2] = (*it).GetBlue();
-    pnt->m_Color[3] = (*it).GetAlpha();
+    pnt->m_Color[0] = it->GetRed();
+    pnt->m_Color[1] = it->GetGreen();
+    pnt->m_Color[2] = it->GetBlue();
+    pnt->m_Color[3] = it->GetAlpha();
     landmarkMO->GetPoints().push_back(pnt);
   }
 

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -115,21 +115,21 @@ MetaLineConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
     for (unsigned int n = 0; n < VDimension - 1; ++n)
     {
       for (unsigned int d = 0; d < VDimension; ++d)
       {
-        pnt->m_V[n][d] = ((*it).GetNormalInObjectSpace(n))[d];
+        pnt->m_V[n][d] = (it->GetNormalInObjectSpace(n))[d];
       }
     }
 
-    pnt->m_Color[0] = (*it).GetRed();
-    pnt->m_Color[1] = (*it).GetGreen();
-    pnt->m_Color[2] = (*it).GetBlue();
-    pnt->m_Color[3] = (*it).GetAlpha();
+    pnt->m_Color[0] = it->GetRed();
+    pnt->m_Color[1] = it->GetGreen();
+    pnt->m_Color[2] = it->GetBlue();
+    pnt->m_Color[3] = it->GetAlpha();
 
     lineMO->GetPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -107,18 +107,18 @@ MetaSurfaceConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V[d] = (*it).GetNormalInObjectSpace()[d];
+      pnt->m_V[d] = it->GetNormalInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*it).GetRed();
-    pnt->m_Color[1] = (*it).GetGreen();
-    pnt->m_Color[2] = (*it).GetBlue();
-    pnt->m_Color[3] = (*it).GetAlpha();
+    pnt->m_Color[0] = it->GetRed();
+    pnt->m_Color[1] = it->GetGreen();
+    pnt->m_Color[2] = it->GetBlue();
+    pnt->m_Color[3] = it->GetAlpha();
 
     surfaceMO->GetPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -141,24 +141,24 @@ MetaTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = it->GetPositionInObjectSpace()[d];
     }
 
-    pnt->m_ID = (*it).GetId();
-    pnt->m_R = (*it).GetRadiusInObjectSpace();
-    pnt->m_Alpha1 = (*it).GetAlpha1();
-    pnt->m_Alpha2 = (*it).GetAlpha2();
-    pnt->m_Alpha3 = (*it).GetAlpha3();
-    pnt->m_Medialness = (*it).GetMedialness();
-    pnt->m_Branchness = (*it).GetBranchness();
-    pnt->m_Ridgeness = (*it).GetRidgeness();
-    pnt->m_Curvature = (*it).GetCurvature();
-    pnt->m_Levelness = (*it).GetLevelness();
-    pnt->m_Roundness = (*it).GetRoundness();
-    pnt->m_Intensity = (*it).GetIntensity();
+    pnt->m_ID = it->GetId();
+    pnt->m_R = it->GetRadiusInObjectSpace();
+    pnt->m_Alpha1 = it->GetAlpha1();
+    pnt->m_Alpha2 = it->GetAlpha2();
+    pnt->m_Alpha3 = it->GetAlpha3();
+    pnt->m_Medialness = it->GetMedialness();
+    pnt->m_Branchness = it->GetBranchness();
+    pnt->m_Ridgeness = it->GetRidgeness();
+    pnt->m_Curvature = it->GetCurvature();
+    pnt->m_Levelness = it->GetLevelness();
+    pnt->m_Roundness = it->GetRoundness();
+    pnt->m_Intensity = it->GetIntensity();
 
-    auto iter = (*it).GetTagScalarDictionary().begin();
-    while (iter != (*it).GetTagScalarDictionary().end())
+    auto iter = it->GetTagScalarDictionary().begin();
+    while (iter != it->GetTagScalarDictionary().end())
     {
       pnt->AddField(iter->first.c_str(), iter->second);
       ++iter;
@@ -166,23 +166,23 @@ MetaTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V1[d] = (*it).GetNormal1InObjectSpace()[d];
+      pnt->m_V1[d] = it->GetNormal1InObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V2[d] = (*it).GetNormal2InObjectSpace()[d];
+      pnt->m_V2[d] = it->GetNormal2InObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_T[d] = (*it).GetTangentInObjectSpace()[d];
+      pnt->m_T[d] = it->GetTangentInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*it).GetRed();
-    pnt->m_Color[1] = (*it).GetGreen();
-    pnt->m_Color[2] = (*it).GetBlue();
-    pnt->m_Color[3] = (*it).GetAlpha();
+    pnt->m_Color[0] = it->GetRed();
+    pnt->m_Color[1] = it->GetGreen();
+    pnt->m_Color[2] = it->GetBlue();
+    pnt->m_Color[3] = it->GetAlpha();
 
     tubeMO->GetPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -154,24 +154,24 @@ MetaVesselTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObje
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_X[d] = (*i).GetPositionInObjectSpace()[d];
+      pnt->m_X[d] = i->GetPositionInObjectSpace()[d];
     }
 
-    pnt->m_ID = (*i).GetId();
-    pnt->m_R = (*i).GetRadiusInObjectSpace();
-    pnt->m_Alpha1 = (*i).GetAlpha1();
-    pnt->m_Alpha2 = (*i).GetAlpha2();
-    pnt->m_Alpha3 = (*i).GetAlpha3();
-    pnt->m_Medialness = (*i).GetMedialness();
-    pnt->m_Branchness = (*i).GetBranchness();
-    pnt->m_Ridgeness = (*i).GetRidgeness();
-    pnt->m_Curvature = (*i).GetCurvature();
-    pnt->m_Levelness = (*i).GetLevelness();
-    pnt->m_Roundness = (*i).GetRoundness();
-    pnt->m_Intensity = (*i).GetIntensity();
+    pnt->m_ID = i->GetId();
+    pnt->m_R = i->GetRadiusInObjectSpace();
+    pnt->m_Alpha1 = i->GetAlpha1();
+    pnt->m_Alpha2 = i->GetAlpha2();
+    pnt->m_Alpha3 = i->GetAlpha3();
+    pnt->m_Medialness = i->GetMedialness();
+    pnt->m_Branchness = i->GetBranchness();
+    pnt->m_Ridgeness = i->GetRidgeness();
+    pnt->m_Curvature = i->GetCurvature();
+    pnt->m_Levelness = i->GetLevelness();
+    pnt->m_Roundness = i->GetRoundness();
+    pnt->m_Intensity = i->GetIntensity();
 
-    auto iter = (*i).GetTagScalarDictionary().begin();
-    while (iter != (*i).GetTagScalarDictionary().end())
+    auto iter = i->GetTagScalarDictionary().begin();
+    while (iter != i->GetTagScalarDictionary().end())
     {
       pnt->AddField(iter->first.c_str(), iter->second);
       ++iter;
@@ -179,23 +179,23 @@ MetaVesselTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObje
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V1[d] = (*i).GetNormal1InObjectSpace()[d];
+      pnt->m_V1[d] = i->GetNormal1InObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_V2[d] = (*i).GetNormal2InObjectSpace()[d];
+      pnt->m_V2[d] = i->GetNormal2InObjectSpace()[d];
     }
 
     for (unsigned int d = 0; d < VDimension; ++d)
     {
-      pnt->m_T[d] = (*i).GetTangentInObjectSpace()[d];
+      pnt->m_T[d] = i->GetTangentInObjectSpace()[d];
     }
 
-    pnt->m_Color[0] = (*i).GetRed();
-    pnt->m_Color[1] = (*i).GetGreen();
-    pnt->m_Color[2] = (*i).GetBlue();
-    pnt->m_Color[3] = (*i).GetAlpha();
+    pnt->m_Color[0] = i->GetRed();
+    pnt->m_Color[1] = i->GetGreen();
+    pnt->m_Color[2] = i->GetBlue();
+    pnt->m_Color[3] = i->GetAlpha();
 
     vesselTubeMO->GetPoints().push_back(pnt);
   }

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -105,7 +105,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInObje
   double                 closestPointDistance = NumericTraits<double>::max();
   while (it != itend)
   {
-    typename SpatialObjectPoint<TDimension>::PointType curpos = (*it).GetPositionInObjectSpace();
+    typename SpatialObjectPoint<TDimension>::PointType curpos = it->GetPositionInObjectSpace();
     double                                             curdistance = curpos.EuclideanDistanceTo(point);
     if (curdistance < closestPointDistance)
     {
@@ -135,7 +135,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInWorl
   double                 closestPointDistance = NumericTraits<double>::max();
   while (it != itend)
   {
-    typename SpatialObjectPoint<TDimension>::PointType curpos = (*it).GetPositionInWorldSpace();
+    typename SpatialObjectPoint<TDimension>::PointType curpos = it->GetPositionInWorldSpace();
     double                                             curdistance = curpos.EuclideanDistanceTo(point);
     if (curdistance < closestPointDistance)
     {
@@ -167,14 +167,14 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingB
     return;
   }
 
-  PointType pt = (*it).GetPositionInObjectSpace();
+  PointType pt = it->GetPositionInObjectSpace();
 
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pt);
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pt);
   ++it;
   while (it != end)
   {
-    this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint((*it).GetPositionInObjectSpace());
+    this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint(it->GetPositionInObjectSpace());
     ++it;
   }
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -102,7 +102,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
   {
     // Try to find 3 points close to the corresponding point
     SurfacePointType pt = *it;
-    PointType        pos = (*it).GetPositionInObjectSpace();
+    PointType        pos = it->GetPositionInObjectSpace();
 
     std::list<int> badId;
     unsigned int   identifier[3];
@@ -149,7 +149,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
           continue;
         }
 
-        PointType pos2 = (*it2).GetPositionInObjectSpace();
+        PointType pos2 = it2->GetPositionInObjectSpace();
         float     distance = pos2.EuclideanDistanceTo(pos);
 
         // Check that the point is not the same as some previously defined
@@ -224,7 +224,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
           normal[0] = coa / absvec;
           normal[1] = cob / absvec;
           normal[2] = coc / absvec;
-          (*it).SetNormalInObjectSpace(normal);
+          it->SetNormalInObjectSpace(normal);
         }
       }
       else
@@ -243,7 +243,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
           CovariantVectorType normal;
           normal[0] = coa / absvec;
           normal[1] = cob / absvec;
-          (*it).SetNormalInObjectSpace(normal);
+          it->SetNormalInObjectSpace(normal);
         }
       }
     } while ((Math::AlmostEquals(absvec, 0.0)) && (badId.size() < this->m_Points.size() - 1));

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -206,8 +206,8 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
     while (it2 != end)
     {
       // Check if the point is on the normal plane
-      PointType a = (*it).GetPositionInObjectSpace();
-      PointType b = (*it2).GetPositionInObjectSpace();
+      PointType a = it->GetPositionInObjectSpace();
+      PointType b = it2->GetPositionInObjectSpace();
 
       if (!m_EndRounded)
       {
@@ -245,8 +245,8 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
 
         double lambdaMin = 0;
         double lambdaMax = 1;
-        double lambdaMinR = (*it).GetRadiusInObjectSpace();
-        double lambdaMaxR = (*it2).GetRadiusInObjectSpace();
+        double lambdaMinR = it->GetRadiusInObjectSpace();
+        double lambdaMaxR = it2->GetRadiusInObjectSpace();
         if (m_EndRounded || !withinEndCap)
         {
           lambdaMin = -(lambdaMinR / B);

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -93,7 +93,7 @@ itkBlobSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetPositionInObjectSpace()[d], i + d))
+      if (itk::Math::NotExactlyEquals(it->GetPositionInObjectSpace()[d], i + d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
@@ -139,24 +139,24 @@ itkBlobSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetBlue(), i))
+      if (itk::Math::NotExactlyEquals(it->GetBlue(), i))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*it).GetGreen(), i + 1))
-      {
-        std::cout << "[FAILED]" << std::endl;
-        return EXIT_FAILURE;
-      }
-
-      if (itk::Math::NotExactlyEquals((*it).GetRed(), i + 2))
+      if (itk::Math::NotExactlyEquals(it->GetGreen(), i + 1))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*it).GetAlpha(), i + 3))
+      if (itk::Math::NotExactlyEquals(it->GetRed(), i + 2))
+      {
+        std::cout << "[FAILED]" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      if (itk::Math::NotExactlyEquals(it->GetAlpha(), i + 3))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
@@ -69,7 +69,7 @@ itkCastSpatialObjectFilterTest(int, char *[])
 
   std::unique_ptr<TubeListType> tList(caster->GetTubes());
 
-  TubeType::Pointer tListTube = (*tList).begin()->GetPointer();
+  TubeType::Pointer tListTube = tList->begin()->GetPointer();
 
   bool found = false;
   if (!strcmp(tListTube->GetTypeName().c_str(), "TubeSpatialObject"))
@@ -88,9 +88,9 @@ itkCastSpatialObjectFilterTest(int, char *[])
     {
       for (unsigned int d = 0; d < 3; ++d)
       {
-        if (itk::Math::NotAlmostEquals((*pnt).GetPositionInWorldSpace()[d], value * tListTube->GetId()))
+        if (itk::Math::NotAlmostEquals(pnt->GetPositionInWorldSpace()[d], value * tListTube->GetId()))
         {
-          std::cout << " [FAILED] (Position is: " << (*pnt).GetPositionInWorldSpace()[d]
+          std::cout << " [FAILED] (Position is: " << pnt->GetPositionInWorldSpace()[d]
                     << " expected : " << value * tListTube->GetId() << " ) " << std::endl;
           return EXIT_FAILURE;
         }

--- a/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
@@ -87,7 +87,7 @@ itkLandmarkSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetPositionInObjectSpace()[d], i + d))
+      if (itk::Math::NotExactlyEquals(it->GetPositionInObjectSpace()[d], i + d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
@@ -133,24 +133,24 @@ itkLandmarkSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetBlue(), i))
+      if (itk::Math::NotExactlyEquals(it->GetBlue(), i))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*it).GetGreen(), i + 1))
-      {
-        std::cout << "[FAILED]" << std::endl;
-        return EXIT_FAILURE;
-      }
-
-      if (itk::Math::NotExactlyEquals((*it).GetRed(), i + 2))
+      if (itk::Math::NotExactlyEquals(it->GetGreen(), i + 1))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*it).GetAlpha(), i + 3))
+      if (itk::Math::NotExactlyEquals(it->GetRed(), i + 2))
+      {
+        std::cout << "[FAILED]" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      if (itk::Math::NotExactlyEquals(it->GetAlpha(), i + 3))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -91,19 +91,19 @@ itkLineSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetPositionInWorldSpace()[d], i + d))
+      if (itk::Math::NotExactlyEquals(it->GetPositionInWorldSpace()[d], i + d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals(((*it).GetNormalInObjectSpace(0))[d], d))
+      if (itk::Math::NotExactlyEquals((it->GetNormalInObjectSpace(0))[d], d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals(((*it).GetNormalInObjectSpace(1))[d], 2 * d))
+      if (itk::Math::NotExactlyEquals((it->GetNormalInObjectSpace(1))[d], 2 * d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -289,7 +289,7 @@ itkNewMetaObjectTypeTest(int, char *[])
       delete mySceneChildren;
       return EXIT_FAILURE;
     }
-    DummyType::Pointer p = dynamic_cast<DummyType *>((*obj).GetPointer());
+    DummyType::Pointer p = dynamic_cast<DummyType *>(obj->GetPointer());
     if (p.IsNull())
     {
       std::cout << "Unable to downcast child SpatialObject to DummySpatialObject"

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -130,83 +130,83 @@ itkSpatialObjectDuplicatorTest(int, char *[])
     {
       for (unsigned int d = 0; d < 3; ++d)
       {
-        if (itk::Math::NotAlmostEquals((*jdti).GetPositionInWorldSpace()[d], value * dtiTube_copy->GetId()))
+        if (itk::Math::NotAlmostEquals(jdti->GetPositionInWorldSpace()[d], value * dtiTube_copy->GetId()))
         {
-          std::cout << " [FAILED] (Position is: " << (*jdti).GetPositionInWorldSpace()[d]
+          std::cout << " [FAILED] (Position is: " << jdti->GetPositionInWorldSpace()[d]
                     << " expected : " << value * dtiTube_copy->GetId() << " ) " << std::endl;
           return EXIT_FAILURE;
         }
       }
       // Testing the color of the tube points
-      if (itk::Math::NotExactlyEquals((*jdti).GetRed(), value))
+      if (itk::Math::NotExactlyEquals(jdti->GetRed(), value))
       {
-        std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jdti).GetRed() << " instead of " << value
+        std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << jdti->GetRed() << " instead of " << value
                   << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*jdti).GetGreen(), value + 1))
+      if (itk::Math::NotExactlyEquals(jdti->GetGreen(), value + 1))
       {
-        std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jdti).GetGreen() << " instead of "
+        std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << jdti->GetGreen() << " instead of "
                   << value + 1 << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*jdti).GetBlue(), value + 2))
+      if (itk::Math::NotExactlyEquals(jdti->GetBlue(), value + 2))
       {
-        std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jdti).GetBlue() << " instead of "
-                  << value + 2 << std::endl;
-        return EXIT_FAILURE;
-      }
-
-      if (itk::Math::NotExactlyEquals((*jdti).GetAlpha(), value + 3))
-      {
-        std::cout << " [FAILED] : Alpha : found " << (*jdti).GetAlpha() << " instead of " << value + 3 << std::endl;
-        return EXIT_FAILURE;
-      }
-
-      if (itk::Math::NotExactlyEquals(
-            (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::FA), value))
-      {
-        std::cout << " [FAILED] : FA : found " << (*jdti).GetField("FA") << " instead of " << value << std::endl;
-        return EXIT_FAILURE;
-      }
-      if (itk::Math::NotExactlyEquals(
-            (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::ADC), value * 2))
-      {
-        std::cout << " [FAILED] : ADC : found " << (*jdti).GetField("ADC") << " instead of " << value * 2 << std::endl;
-        return EXIT_FAILURE;
-      }
-      if (itk::Math::NotExactlyEquals(
-            (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::GA), value * 3))
-      {
-        std::cout << " [FAILED] : GA : found " << (*jdti).GetField("FA") << " instead of " << value * 3 << std::endl;
-        return EXIT_FAILURE;
-      }
-      if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda1"), value * 4))
-      {
-        std::cout << " [FAILED] : GetLambda1 : found " << (*jdti).GetField("Lambda1") << " instead of " << value * 4
+        std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << jdti->GetBlue() << " instead of " << value + 2
                   << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda2"), value * 5))
+
+      if (itk::Math::NotExactlyEquals(jdti->GetAlpha(), value + 3))
       {
-        std::cout << " [FAILED] : GetLambda2 : found " << (*jdti).GetField("Lambda2") << " instead of " << value * 5
+        std::cout << " [FAILED] : Alpha : found " << jdti->GetAlpha() << " instead of " << value + 3 << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      if (itk::Math::NotExactlyEquals(
+            jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::FA), value))
+      {
+        std::cout << " [FAILED] : FA : found " << jdti->GetField("FA") << " instead of " << value << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (itk::Math::NotExactlyEquals(
+            jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::ADC), value * 2))
+      {
+        std::cout << " [FAILED] : ADC : found " << jdti->GetField("ADC") << " instead of " << value * 2 << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (itk::Math::NotExactlyEquals(
+            jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::GA), value * 3))
+      {
+        std::cout << " [FAILED] : GA : found " << jdti->GetField("FA") << " instead of " << value * 3 << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda1"), value * 4))
+      {
+        std::cout << " [FAILED] : GetLambda1 : found " << jdti->GetField("Lambda1") << " instead of " << value * 4
                   << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda3"), value * 6))
+      if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda2"), value * 5))
       {
-        std::cout << " [FAILED] : GetLambda3 : found " << (*jdti).GetField("Lambda3") << " instead of " << value * 6
+        std::cout << " [FAILED] : GetLambda2 : found " << jdti->GetField("Lambda2") << " instead of " << value * 5
+                  << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda3"), value * 6))
+      {
+        std::cout << " [FAILED] : GetLambda3 : found " << jdti->GetField("Lambda3") << " instead of " << value * 6
                   << std::endl;
         return EXIT_FAILURE;
       }
       int ind;
       for (ind = 0; ind < 6; ++ind)
       {
-        if (itk::Math::NotExactlyEquals((*jdti).GetTensorMatrix()[ind], ind))
+        if (itk::Math::NotExactlyEquals(jdti->GetTensorMatrix()[ind], ind))
         {
-          std::cout << " [FAILED] : GetTensorMatrix : found " << (*jdti).GetTensorMatrix()[ind] << " instead of " << ind
+          std::cout << " [FAILED] : GetTensorMatrix : found " << jdti->GetTensorMatrix()[ind] << " instead of " << ind
                     << std::endl;
           return EXIT_FAILURE;
         }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -84,19 +84,19 @@ itkSurfaceSpatialObjectTest(int, char *[])
   {
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::NotExactlyEquals((*it).GetPositionInWorldSpace()[d], i + d))
+      if (itk::Math::NotExactlyEquals(it->GetPositionInWorldSpace()[d], i + d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*it).GetNormalInObjectSpace()[d], d))
+      if (itk::Math::NotExactlyEquals(it->GetNormalInObjectSpace()[d], d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*it).GetNormalInWorldSpace()[d], d))
+      if (itk::Math::NotExactlyEquals(it->GetNormalInWorldSpace()[d], d))
       {
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -910,8 +910,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
   auto iter = slabs.begin();
   while (iter != slabs.end())
   {
-    coordFirst2 = (*iter).GetIndex()[m_SlicingDirection];
-    coordLast2 = coordFirst2 + static_cast<IndexValueType>((*iter).GetSize()[m_SlicingDirection]) - 1;
+    coordFirst2 = iter->GetIndex()[m_SlicingDirection];
+    coordLast2 = coordFirst2 + static_cast<IndexValueType>(iter->GetSize()[m_SlicingDirection]) - 1;
 
     if (coordFirst > coordFirst2)
     {

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
@@ -88,7 +88,7 @@ VnlInverse1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
         outputIt.GoToBeginOfLine();
         while (!outputIt.IsAtEndOfLine())
         {
-          outputIt.Set((*outputBufferIt).real() / vectorSize);
+          outputIt.Set(outputBufferIt->real() / vectorSize);
           ++outputIt;
           ++outputBufferIt;
         }

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -610,10 +610,10 @@ OrientImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   axes = m_CodeToString.find(m_DesiredCoordinateOrientation);
   os << indent << "Desired Coordinate Orientation: " << static_cast<long>(this->GetDesiredCoordinateOrientation())
-     << " (" << (*axes).second << ")" << std::endl;
+     << " (" << axes->second << ")" << std::endl;
   axes = m_CodeToString.find(m_GivenCoordinateOrientation);
   os << indent << "Given Coordinate Orientation: " << static_cast<long>(this->GetGivenCoordinateOrientation()) << " ("
-     << (*axes).second << ")" << std::endl;
+     << axes->second << ")" << std::endl;
   os << indent << "Use Image Direction: " << m_UseImageDirection << std::endl;
   os << indent << "Permute Axes: " << m_PermuteOrder << std::endl;
   os << indent << "Flip Axes: " << m_FlipAxes << std::endl;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -68,7 +68,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::MergeMap(MapType & m1, Map
     {
 
 
-      typename MapType::mapped_type & labelStats = (*m1It).second;
+      typename MapType::mapped_type & labelStats = m1It->second;
 
       // accumulate the information from this thread
       labelStats.m_Count += m2_value.second.m_Count;
@@ -296,7 +296,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType 
   }
   else
   {
-    return (*mapIt).second.m_Minimum;
+    return mapIt->second.m_Minimum;
   }
 }
 
@@ -314,7 +314,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType 
   }
   else
   {
-    return (*mapIt).second.m_Maximum;
+    return mapIt->second.m_Maximum;
   }
 }
 
@@ -332,7 +332,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType lab
   }
   else
   {
-    return (*mapIt).second.m_Mean;
+    return mapIt->second.m_Mean;
   }
 }
 
@@ -350,7 +350,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType labe
   }
   else
   {
-    return (*mapIt).second.m_Sum;
+    return mapIt->second.m_Sum;
   }
 }
 
@@ -368,7 +368,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType la
   }
   else
   {
-    return (*mapIt).second.m_Sigma;
+    return mapIt->second.m_Sigma;
   }
 }
 
@@ -386,7 +386,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType
   }
   else
   {
-    return (*mapIt).second.m_Variance;
+    return mapIt->second.m_Variance;
   }
 }
 
@@ -405,7 +405,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelT
   }
   else
   {
-    return (*mapIt).second.m_BoundingBox;
+    return mapIt->second.m_BoundingBox;
   }
 }
 
@@ -454,7 +454,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType la
   }
   else
   {
-    return (*mapIt).second.m_Count;
+    return mapIt->second.m_Count;
   }
 }
 
@@ -480,18 +480,18 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType l
     RealType total = 0;
 
     // count bins until just over half the distribution is counted
-    while (total <= ((*mapIt).second.m_Count / 2) && (bin < m_NumBins[0]))
+    while (total <= (mapIt->second.m_Count / 2) && (bin < m_NumBins[0]))
     {
       index[0] = bin;
-      total += (*mapIt).second.m_Histogram->GetFrequency(index);
+      total += mapIt->second.m_Histogram->GetFrequency(index);
       ++bin;
     }
     --bin;
     index[0] = bin;
 
     // return center of bin range
-    RealType lowRange = (*mapIt).second.m_Histogram->GetBinMin(0, bin);
-    RealType highRange = (*mapIt).second.m_Histogram->GetBinMax(0, bin);
+    RealType lowRange = mapIt->second.m_Histogram->GetBinMin(0, bin);
+    RealType highRange = mapIt->second.m_Histogram->GetBinMax(0, bin);
     median = lowRange + (highRange - lowRange) / 2;
     return median;
   }
@@ -512,7 +512,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetHistogram(LabelPixelTyp
   else
   {
     // this will be zero if histograms have not been enabled
-    return (*mapIt).second.m_Histogram;
+    return mapIt->second.m_Histogram;
   }
 }
 

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -69,12 +69,12 @@ LabelOverlapMeasures(int, char * argv[])
   int                                          label = 0;
   for (it = labelMap.begin(); it != labelMap.end(); ++it)
   {
-    if ((*it).first == 0)
+    if (it->first == 0)
     {
       continue;
     }
 
-    label = (*it).first;
+    label = it->first;
 
     std::cout << std::setw(10) << label;
     std::cout << std::setw(17) << filter->GetTargetOverlap(label);

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -282,7 +282,7 @@ LabelMap<TLabelObject>::AddPixel(const LabelObjectContainerIterator & it,
   if (it != m_LabelObjectContainer.end())
   {
     // the label already exist - add the pixel to it
-    (*it).second->AddIndex(idx);
+    it->second->AddIndex(idx);
     this->Modified();
   }
   else
@@ -353,7 +353,7 @@ LabelMap<TLabelObject>::SetLine(const IndexType & idx, const LengthType & length
   if (it != m_LabelObjectContainer.end())
   {
     // the label already exist - add the pixel to it
-    (*it).second->AddLine(idx, length);
+    it->second->AddLine(idx, length);
     this->Modified();
   }
   else

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -590,17 +590,17 @@ ContourExtractor2DImageFilter<TInputImage>::FillOutputs(
     // mark output as modified
     if (m_ReverseContourOrientation)
     {
-      ContourConstIterator itC{ (*it).cend() };
+      ContourConstIterator itC{ it->cend() };
       do
       {
         --itC;
         path->push_back(*itC);
-      } while (itC != (*it).cbegin());
+      } while (itC != it->cbegin());
     }
     else
     {
-      ContourConstIterator itC{ (*it).cbegin() };
-      while (itC != (*it).cend())
+      ContourConstIterator itC{ it->cbegin() };
+      while (itC != it->cend())
       {
         path->push_back(*itC);
         ++itC;

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -103,7 +103,7 @@ RegularExpressionSeriesFileNames::GetFileNames()
   std::vector<std::pair<std::string, std::string>>::iterator siter;
   for (siter = sortedBySubMatch.begin(); siter != sortedBySubMatch.end(); ++siter)
   {
-    m_FileNames.push_back((*siter).first);
+    m_FileNames.push_back(siter->first);
   }
 
   return m_FileNames;

--- a/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
@@ -51,7 +51,7 @@ itkArchetypeSeriesFileNamesTest(int argc, char * argv[])
     std::cout << "List of returned filenames: " << std::endl;
     for (nit = names.begin(); nit != names.end(); ++nit)
     {
-      std::cout << "File: " << (*nit).c_str() << std::endl;
+      std::cout << "File: " << nit->c_str() << std::endl;
     }
 
     std::cout << fit;

--- a/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
@@ -76,7 +76,7 @@ itkNumericSeriesFileNamesTest(int, char *[])
                 << " and may have been truncated." << std::endl;
       return EXIT_FAILURE;
     }
-    std::cout << "File: " << (*nit).c_str() << std::endl;
+    std::cout << "File: " << nit->c_str() << std::endl;
   }
 
   // Exercise the PrintSelf method to print the filenames for coverage purposes

--- a/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
@@ -57,7 +57,7 @@ itkRegularExpressionSeriesFileNamesTest(int argc, char * argv[])
   std::cout << "Normal Sort--------" << std::endl;
   for (nit = names.begin(); nit != names.end(); ++nit)
   {
-    std::cout << "File: " << (*nit).c_str() << std::endl;
+    std::cout << "File: " << nit->c_str() << std::endl;
   }
 
   // Show only those files with numbers in the names
@@ -73,7 +73,7 @@ itkRegularExpressionSeriesFileNamesTest(int argc, char * argv[])
   std::cout << "Numeric sort on only files with numbers in the names--------" << std::endl;
   for (nit = names.begin(); nit != names.end(); ++nit)
   {
-    std::cout << "File: " << (*nit).c_str() << std::endl;
+    std::cout << "File: " << nit->c_str() << std::endl;
   }
 
 
@@ -92,7 +92,7 @@ itkRegularExpressionSeriesFileNamesTest(int argc, char * argv[])
             << std::endl;
   for (nit = names.begin(); nit != names.end(); ++nit)
   {
-    std::cout << "File: " << (*nit).c_str() << std::endl;
+    std::cout << "File: " << nit->c_str() << std::endl;
   }
 
   // Show only those files with numbers in the names followed by other
@@ -109,7 +109,7 @@ itkRegularExpressionSeriesFileNamesTest(int argc, char * argv[])
             << std::endl;
   for (nit = names.begin(); nit != names.end(); ++nit)
   {
-    std::cout << "File: " << (*nit).c_str() << std::endl;
+    std::cout << "File: " << nit->c_str() << std::endl;
   }
 
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1226,19 +1226,19 @@ MINCImageIO::WriteImageInformation()
   for (MetaDataDictionary::ConstIterator it = thisDic.Begin(); it != thisDic.End(); ++it)
   {
     // don't store some internal ITK junk
-    if ((*it).first == "ITK_InputFilterName" || (*it).first == "NRRD_content" || (*it).first == "NRRD_centerings[0]" ||
-        (*it).first == "NRRD_centerings[1]" || (*it).first == "NRRD_centerings[2]" ||
-        (*it).first == "NRRD_centerings[3]" || (*it).first == "NRRD_kinds[0]" || (*it).first == "NRRD_kinds[1]" ||
-        (*it).first == "NRRD_kinds[2]" || (*it).first == "NRRD_kinds[3]" || (*it).first == "NRRD_space")
+    if (it->first == "ITK_InputFilterName" || it->first == "NRRD_content" || it->first == "NRRD_centerings[0]" ||
+        it->first == "NRRD_centerings[1]" || it->first == "NRRD_centerings[2]" || it->first == "NRRD_centerings[3]" ||
+        it->first == "NRRD_kinds[0]" || it->first == "NRRD_kinds[1]" || it->first == "NRRD_kinds[2]" ||
+        it->first == "NRRD_kinds[3]" || it->first == "NRRD_space")
       continue;
 
-    const char *         d = strchr((*it).first.c_str(), ':');
-    MetaDataObjectBase * bs = (*it).second;
+    const char *         d = strchr(it->first.c_str(), ':');
+    MetaDataObjectBase * bs = it->second;
     const char *         tname = bs->GetMetaDataObjectTypeName();
 
     if (d)
     {
-      std::string var((*it).first.c_str(), d - (*it).first.c_str());
+      std::string var(it->first.c_str(), d - it->first.c_str());
       std::string att(d + 1);
 
       // VF:THIS is not good OO style at all :(
@@ -1286,7 +1286,7 @@ MINCImageIO::WriteImageInformation()
         itkDebugMacro(<< "Unsupported metadata type:" << tname);
       }
     }
-    else if ((*it).first == "history")
+    else if (it->first == "history")
     {
       const std::string & tmp = dynamic_cast<MetaDataObject<std::string> *>(bs)->GetMetaDataObjectValue();
       miset_attr_values(this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", tmp.length() + 1, tmp.c_str());

--- a/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
@@ -32,7 +32,7 @@ ConvertPixelBuffer<InputPixelType, Array<T>, OutputConvertTraits>::Convert(Input
 
   while (inputData != endInput)
   {
-    (*outputData).SetSize(inputNumberOfComponents);
+    outputData->SetSize(inputNumberOfComponents);
     for (int ii = 0; ii < inputNumberOfComponents; ++ii)
     {
       OutputConvertTraits::SetNthComponent(ii, *outputData, static_cast<T>(*inputData++));

--- a/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
@@ -33,7 +33,7 @@ ConvertPixelBuffer<InputPixelType, VariableLengthVector<T>, OutputConvertTraits>
 
   while (inputData != endInput)
   {
-    (*outputData).SetSize(inputNumberOfComponents);
+    outputData->SetSize(inputNumberOfComponents);
     for (int ii = 0; ii < inputNumberOfComponents; ++ii)
     {
       OutputConvertTraits::SetNthComponent(ii, *outputData, static_cast<T>(*inputData++));

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -661,7 +661,7 @@ MetaImageIO ::WriteImageInformation()
 
     // Rolling this back out so that the tests pass.
     // The meta image AddUserField requires control of the memory space.
-    m_MetaImage.AddUserField((*keyIt).c_str(), MET_STRING, static_cast<int>(value.size()), value.c_str(), true, -1);
+    m_MetaImage.AddUserField(keyIt->c_str(), MET_STRING, static_cast<int>(value.size()), value.c_str(), true, -1);
   }
 }
 

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -958,9 +958,9 @@ NrrdImageIO::Write(const void * buffer)
   const char *                             keyField, *field;
   for (keyIt = keys.begin(); keyIt != keys.end(); ++keyIt)
   {
-    if (!strncmp(KEY_PREFIX, (*keyIt).c_str(), strlen(KEY_PREFIX)))
+    if (!strncmp(KEY_PREFIX, keyIt->c_str(), strlen(KEY_PREFIX)))
     {
-      keyField = (*keyIt).c_str() + strlen(KEY_PREFIX);
+      keyField = keyIt->c_str() + strlen(KEY_PREFIX);
       // only of one of these can succeed
       field = airEnumStr(nrrdField, nrrdField_thicknesses);
       if (!strncmp(keyField, field, strlen(field)))
@@ -1067,7 +1067,7 @@ NrrdImageIO::Write(const void * buffer)
       // not a NRRD field packed into meta data; just a regular key/value
       std::string value;
       ExposeMetaData<std::string>(thisDic, *keyIt, value);
-      nrrdKeyValueAdd(nrrd, (*keyIt).c_str(), value.c_str());
+      nrrdKeyValueAdd(nrrd, keyIt->c_str(), value.c_str());
     }
   }
 

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -244,13 +244,13 @@ PolygonGroupSpatialObjectXMLFileWriter::WriteFile()
   {
     WriteStartElement("POLYGON", output);
     output << std::endl;
-    auto * curstrand = dynamic_cast<PolygonSpatialObjectType *>((*it).GetPointer());
+    auto * curstrand = dynamic_cast<PolygonSpatialObjectType *>(it->GetPointer());
     PolygonSpatialObjectType::PolygonPointListType & polygonPoints = curstrand->GetPoints();
     auto                                             pointIt = polygonPoints.begin();
     auto                                             pointItEnd = polygonPoints.end();
     while (pointIt != pointItEnd)
     {
-      PolygonSpatialObjectType::PointType curpoint = (*pointIt).GetPositionInObjectSpace();
+      PolygonSpatialObjectType::PointType curpoint = pointIt->GetPositionInObjectSpace();
       WriteStartElement("POINT", output);
       output << curpoint[0] << " " << curpoint[1] << " " << curpoint[2];
       WriteEndElement("POINT", output);

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
@@ -85,8 +85,8 @@ testPolygonGroupEquivalence(PolygonGroup3DPointer & p1, PolygonGroup3DPointer & 
       delete children2;
       return EXIT_FAILURE;
     }
-    auto * curstrand1 = dynamic_cast<Polygon3DType *>((*it1).GetPointer());
-    auto * curstrand2 = dynamic_cast<Polygon3DType *>((*it2).GetPointer());
+    auto * curstrand1 = dynamic_cast<Polygon3DType *>(it1->GetPointer());
+    auto * curstrand2 = dynamic_cast<Polygon3DType *>(it2->GetPointer());
 
     Polygon3DType::PolygonPointListType & points1 = curstrand1->GetPoints();
     Polygon3DType::PolygonPointListType & points2 = curstrand2->GetPoints();
@@ -106,8 +106,8 @@ testPolygonGroupEquivalence(PolygonGroup3DPointer & p1, PolygonGroup3DPointer & 
         delete children2;
         return EXIT_FAILURE;
       }
-      Polygon3DType::PointType curpoint1 = (*pointIt1).GetPositionInWorldSpace();
-      Polygon3DType::PointType curpoint2 = (*pointIt2).GetPositionInWorldSpace();
+      Polygon3DType::PointType curpoint1 = pointIt1->GetPositionInWorldSpace();
+      Polygon3DType::PointType curpoint2 = pointIt2->GetPositionInWorldSpace();
       if (curpoint1 != curpoint2)
       {
         // Just a silly test to make sure that the positions returned are valid

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -470,63 +470,63 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     {
       found = true;
       unsigned int value = 0;
-      for (j = dynamic_cast<TubeType *>((*obj).GetPointer())->GetPoints().begin();
-           j != dynamic_cast<TubeType *>((*obj).GetPointer())->GetPoints().end();
+      for (j = dynamic_cast<TubeType *>(obj->GetPointer())->GetPoints().begin();
+           j != dynamic_cast<TubeType *>(obj->GetPointer())->GetPoints().end();
            j++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*j).GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
+          if (itk::Math::NotExactlyEquals(j->GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
           {
-            std::cout << " [FAILED] (Position is: " << (*j).GetPositionInObjectSpace()[d]
+            std::cout << " [FAILED] (Position is: " << j->GetPositionInObjectSpace()[d]
                       << " expected : " << value * (*obj)->GetId() << " ) " << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
         }
         // Testing the color of the tube points
-        if (itk::Math::NotExactlyEquals((*j).GetRed(), value))
+        if (itk::Math::NotExactlyEquals(j->GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*j).GetRed() << " instead of " << value
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << j->GetRed() << " instead of " << value
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*j).GetGreen(), value + 1))
+        if (itk::Math::NotExactlyEquals(j->GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*j).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << j->GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*j).GetBlue(), value + 2))
+        if (itk::Math::NotExactlyEquals(j->GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*j).GetBlue() << " instead of "
-                    << value + 2 << std::endl;
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << j->GetBlue() << " instead of " << value + 2
+                    << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*j).GetAlpha(), value + 3))
+        if (itk::Math::NotExactlyEquals(j->GetAlpha(), value + 3))
         {
-          std::cout << " [FAILED] : Alpha : found " << (*j).GetAlpha() << " instead of " << value + 3 << std::endl;
+          std::cout << " [FAILED] : Alpha : found " << j->GetAlpha() << " instead of " << value + 3 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
         // Testing the dictionary of the tube points
-        if (itk::Math::NotExactlyEquals((*j).GetTagScalarValue("var1"), value * (*obj)->GetId()))
+        if (itk::Math::NotExactlyEquals(j->GetTagScalarValue("var1"), value * (*obj)->GetId()))
         {
-          std::cout << " [FAILED] : TagScalarDictionary::var1 : found " << (*j).GetTagScalarValue("var1")
+          std::cout << " [FAILED] : TagScalarDictionary::var1 : found " << j->GetTagScalarValue("var1")
                     << " instead of " << value * (*obj)->GetId() << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*j).GetTagScalarValue("var2"), value * (*obj)->GetId()))
+        if (itk::Math::NotExactlyEquals(j->GetTagScalarValue("var2"), value * (*obj)->GetId()))
         {
-          std::cout << " [FAILED] : TagScalarDictionary::var1 : found " << (*j).GetTagScalarValue("var2")
+          std::cout << " [FAILED] : TagScalarDictionary::var1 : found " << j->GetTagScalarValue("var2")
                     << " instead of " << value * (*obj)->GetId() << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -561,87 +561,87 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     {
       found = true;
       unsigned int value = 0;
-      for (jv = dynamic_cast<VesselTubeType *>((*obj).GetPointer())->GetPoints().begin();
-           jv != dynamic_cast<VesselTubeType *>((*obj).GetPointer())->GetPoints().end();
+      for (jv = dynamic_cast<VesselTubeType *>(obj->GetPointer())->GetPoints().begin();
+           jv != dynamic_cast<VesselTubeType *>(obj->GetPointer())->GetPoints().end();
            jv++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*jv).GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
+          if (itk::Math::NotExactlyEquals(jv->GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
           {
-            std::cout << " [FAILED] (Position is: " << (*jv).GetPositionInObjectSpace()[d]
+            std::cout << " [FAILED] (Position is: " << jv->GetPositionInObjectSpace()[d]
                       << " expected : " << value * (*obj)->GetId() << " ) " << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
         }
         // Testing the color of the tube points
-        if (itk::Math::NotExactlyEquals((*jv).GetRed(), value))
+        if (itk::Math::NotExactlyEquals(jv->GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jv).GetRed() << " instead of " << value
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << jv->GetRed() << " instead of " << value
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jv).GetGreen(), value + 1))
+        if (itk::Math::NotExactlyEquals(jv->GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jv).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << jv->GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jv).GetBlue(), value + 2))
+        if (itk::Math::NotExactlyEquals(jv->GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jv).GetBlue() << " instead of "
-                    << value + 2 << std::endl;
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << jv->GetBlue() << " instead of " << value + 2
+                    << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jv).GetAlpha(), value + 3))
+        if (itk::Math::NotExactlyEquals(jv->GetAlpha(), value + 3))
         {
-          std::cout << " [FAILED] : Alpha : found " << (*jv).GetAlpha() << " instead of " << value + 3 << std::endl;
+          std::cout << " [FAILED] : Alpha : found " << jv->GetAlpha() << " instead of " << value + 3 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetRidgeness(), value * 1))
+        if (itk::Math::NotExactlyEquals(jv->GetRidgeness(), value * 1))
         {
-          std::cout << " [FAILED] : Ridgeness : found " << (*jv).GetRidgeness() << " instead of " << value * 1
+          std::cout << " [FAILED] : Ridgeness : found " << jv->GetRidgeness() << " instead of " << value * 1
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetMedialness(), value * 2))
+        if (itk::Math::NotExactlyEquals(jv->GetMedialness(), value * 2))
         {
-          std::cout << " [FAILED] : Medialness : found " << (*jv).GetMedialness() << " instead of " << value * 2
+          std::cout << " [FAILED] : Medialness : found " << jv->GetMedialness() << " instead of " << value * 2
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetBranchness(), value * 3))
+        if (itk::Math::NotExactlyEquals(jv->GetBranchness(), value * 3))
         {
-          std::cout << " [FAILED] : Branchness : found " << (*jv).GetBranchness() << " instead of " << value * 3
+          std::cout << " [FAILED] : Branchness : found " << jv->GetBranchness() << " instead of " << value * 3
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetAlpha1(), value * 1))
+        if (itk::Math::NotExactlyEquals(jv->GetAlpha1(), value * 1))
         {
-          std::cout << " [FAILED] : Alpha1 : found " << (*jv).GetAlpha1() << " instead of " << value * 1 << std::endl;
+          std::cout << " [FAILED] : Alpha1 : found " << jv->GetAlpha1() << " instead of " << value * 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetAlpha2(), value * 2))
+        if (itk::Math::NotExactlyEquals(jv->GetAlpha2(), value * 2))
         {
-          std::cout << " [FAILED] : Alpha2 : found " << (*jv).GetAlpha2() << " instead of " << value * 2 << std::endl;
+          std::cout << " [FAILED] : Alpha2 : found " << jv->GetAlpha2() << " instead of " << value * 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jv).GetAlpha3(), value * 3))
+        if (itk::Math::NotExactlyEquals(jv->GetAlpha3(), value * 3))
         {
-          std::cout << " [FAILED] : Alpha3 : found " << (*jv).GetAlpha3() << " instead of " << value * 3 << std::endl;
+          std::cout << " [FAILED] : Alpha3 : found " << jv->GetAlpha3() << " instead of " << value * 3 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
@@ -674,91 +674,90 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     {
       found = true;
       unsigned int value = 0;
-      for (jdti = dynamic_cast<DTITubeType *>((*obj).GetPointer())->GetPoints().begin();
-           jdti != dynamic_cast<DTITubeType *>((*obj).GetPointer())->GetPoints().end();
+      for (jdti = dynamic_cast<DTITubeType *>(obj->GetPointer())->GetPoints().begin();
+           jdti != dynamic_cast<DTITubeType *>(obj->GetPointer())->GetPoints().end();
            jdti++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*jdti).GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
+          if (itk::Math::NotExactlyEquals(jdti->GetPositionInObjectSpace()[d], value * (*obj)->GetId()))
           {
-            std::cout << " [FAILED] (Position is: " << (*jdti).GetPositionInObjectSpace()[d]
+            std::cout << " [FAILED] (Position is: " << jdti->GetPositionInObjectSpace()[d]
                       << " expected : " << value * (*obj)->GetId() << " ) " << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
         }
         // Testing the color of the tube points
-        if (itk::Math::NotExactlyEquals((*jdti).GetRed(), value))
+        if (itk::Math::NotExactlyEquals(jdti->GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jdti).GetRed() << " instead of " << value
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << jdti->GetRed() << " instead of " << value
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jdti).GetGreen(), value + 1))
+        if (itk::Math::NotExactlyEquals(jdti->GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jdti).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << jdti->GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jdti).GetBlue(), value + 2))
+        if (itk::Math::NotExactlyEquals(jdti->GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jdti).GetBlue() << " instead of "
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << jdti->GetBlue() << " instead of "
                     << value + 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jdti).GetAlpha(), value + 3))
+        if (itk::Math::NotExactlyEquals(jdti->GetAlpha(), value + 3))
         {
-          std::cout << " [FAILED] : Alpha : found " << (*jdti).GetAlpha() << " instead of " << value + 3 << std::endl;
+          std::cout << " [FAILED] : Alpha : found " << jdti->GetAlpha() << " instead of " << value + 3 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
         if (itk::Math::NotExactlyEquals(
-              (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::FA), value + 1))
+              jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::FA), value + 1))
         {
-          std::cout << " [FAILED] : FA : found " << (*jdti).GetField("FA") << " instead of " << value + 1 << std::endl;
+          std::cout << " [FAILED] : FA : found " << jdti->GetField("FA") << " instead of " << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
         if (itk::Math::NotExactlyEquals(
-              (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::ADC), value * 2))
+              jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::ADC), value * 2))
         {
-          std::cout << " [FAILED] : ADC : found " << (*jdti).GetField("ADC") << " instead of " << value * 2
-                    << std::endl;
+          std::cout << " [FAILED] : ADC : found " << jdti->GetField("ADC") << " instead of " << value * 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
         if (itk::Math::NotExactlyEquals(
-              (*jdti).GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::GA), value * 3))
+              jdti->GetField(itk::DTITubeSpatialObjectPointEnums::DTITubeSpatialObjectPointField::GA), value * 3))
         {
-          std::cout << " [FAILED] : GA : found " << (*jdti).GetField("FA") << " instead of " << value * 3 << std::endl;
+          std::cout << " [FAILED] : GA : found " << jdti->GetField("FA") << " instead of " << value * 3 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda1"), value * 4))
+        if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda1"), value * 4))
         {
-          std::cout << " [FAILED] : GetLambda1 : found " << (*jdti).GetField("Lambda1") << " instead of " << value * 4
+          std::cout << " [FAILED] : GetLambda1 : found " << jdti->GetField("Lambda1") << " instead of " << value * 4
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda2"), value * 5))
+        if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda2"), value * 5))
         {
-          std::cout << " [FAILED] : GetLambda2 : found " << (*jdti).GetField("Lambda2") << " instead of " << value * 5
+          std::cout << " [FAILED] : GetLambda2 : found " << jdti->GetField("Lambda2") << " instead of " << value * 5
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jdti).GetField("Lambda3"), value * 6))
+        if (itk::Math::NotExactlyEquals(jdti->GetField("Lambda3"), value * 6))
         {
-          std::cout << " [FAILED] : GetLambda3 : found " << (*jdti).GetField("Lambda3") << " instead of " << value * 6
+          std::cout << " [FAILED] : GetLambda3 : found " << jdti->GetField("Lambda3") << " instead of " << value * 6
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -766,10 +765,10 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
         int ind;
         for (ind = 0; ind < 6; ++ind)
         {
-          if (itk::Math::NotExactlyEquals((*jdti).GetTensorMatrix()[ind], ind))
+          if (itk::Math::NotExactlyEquals(jdti->GetTensorMatrix()[ind], ind))
           {
-            std::cout << " [FAILED] : GetTensorMatrix : found " << (*jdti).GetTensorMatrix()[ind] << " instead of "
-                      << ind << std::endl;
+            std::cout << " [FAILED] : GetTensorMatrix : found " << jdti->GetTensorMatrix()[ind] << " instead of " << ind
+                      << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -801,7 +800,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     {
       for (unsigned int jj = 0; jj < 3; ++jj)
       {
-        if (dynamic_cast<EllipseType *>((*obj).GetPointer())->GetRadiusInObjectSpace()[jj] != 9.0)
+        if (dynamic_cast<EllipseType *>(obj->GetPointer())->GetRadiusInObjectSpace()[jj] != 9.0)
         {
           std::cout << " [FAILED]" << std::endl;
           delete mySceneChildren;
@@ -827,7 +826,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
   {
     if (!strcmp((*obj)->GetTypeName().c_str(), "ImageSpatialObject"))
     {
-      const itkImageType * constImage = dynamic_cast<const ImageType *>((*obj).GetPointer())->GetImage();
+      const itkImageType * constImage = dynamic_cast<const ImageType *>(obj->GetPointer())->GetImage();
       if (constImage == nullptr)
       {
         std::cerr << "dynamic_cast failed." << std::endl;
@@ -857,7 +856,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     if (!strcmp((*obj)->GetTypeName().c_str(), "ImageMaskSpatialObject"))
     {
       maskFound = true;
-      itkImageMaskType::ConstPointer constImage = dynamic_cast<const ImageMaskType *>((*obj).GetPointer())->GetImage();
+      itkImageMaskType::ConstPointer constImage = dynamic_cast<const ImageMaskType *>(obj->GetPointer())->GetImage();
       itk::ImageRegionConstIteratorWithIndex<itkImageMaskType> it(constImage, constImage->GetLargestPossibleRegion());
       for (unsigned char i = 0; !it.IsAtEnd(); i++, ++it)
       {
@@ -890,46 +889,46 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     if (!strcmp((*obj)->GetTypeName().c_str(), "BlobSpatialObject"))
     {
       unsigned int value = 0;
-      for (pit = dynamic_cast<BlobType *>((*obj).GetPointer())->GetPoints().begin();
-           pit != dynamic_cast<BlobType *>((*obj).GetPointer())->GetPoints().end();
+      for (pit = dynamic_cast<BlobType *>(obj->GetPointer())->GetPoints().begin();
+           pit != dynamic_cast<BlobType *>(obj->GetPointer())->GetPoints().end();
            pit++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*pit).GetPositionInObjectSpace()[d], value))
+          if (itk::Math::NotExactlyEquals(pit->GetPositionInObjectSpace()[d], value))
           {
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
           // Testing the color of the tube points
-          if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
+          if (itk::Math::NotExactlyEquals(pit->GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << pit->GetRed() << " instead of " << value
                       << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
+          if (itk::Math::NotExactlyEquals(pit->GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << pit->GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
+          if (itk::Math::NotExactlyEquals(pit->GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << pit->GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetAlpha(), value + 3))
+          if (itk::Math::NotExactlyEquals(pit->GetAlpha(), value + 3))
           {
-            std::cout << " [FAILED] : Alpha : found " << (*pit).GetAlpha() << " instead of " << value + 3 << std::endl;
+            std::cout << " [FAILED] : Alpha : found " << pit->GetAlpha() << " instead of " << value + 3 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -950,56 +949,56 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     if (!strcmp((*obj)->GetTypeName().c_str(), "SurfaceSpatialObject"))
     {
       unsigned int value = 0;
-      for (pit = dynamic_cast<SurfaceType *>((*obj).GetPointer())->GetPoints().begin();
-           pit != dynamic_cast<SurfaceType *>((*obj).GetPointer())->GetPoints().end();
+      for (pit = dynamic_cast<SurfaceType *>(obj->GetPointer())->GetPoints().begin();
+           pit != dynamic_cast<SurfaceType *>(obj->GetPointer())->GetPoints().end();
            pit++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*pit).GetPositionInObjectSpace()[d], value))
+          if (itk::Math::NotExactlyEquals(pit->GetPositionInObjectSpace()[d], value))
           {
-            std::cout << (*pit).GetPositionInObjectSpace()[d] << "!=" << value << std::endl;
+            std::cout << pit->GetPositionInObjectSpace()[d] << "!=" << value << std::endl;
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetNormalInObjectSpace()[d], d))
+          if (itk::Math::NotExactlyEquals(pit->GetNormalInObjectSpace()[d], d))
           {
-            std::cout << "Normal : " << (*pit).GetNormalInObjectSpace()[d] << std::endl;
+            std::cout << "Normal : " << pit->GetNormalInObjectSpace()[d] << std::endl;
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
           // Testing the color of the tube points
-          if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
+          if (itk::Math::NotExactlyEquals(pit->GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << pit->GetRed() << " instead of " << value
                       << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
+          if (itk::Math::NotExactlyEquals(pit->GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << pit->GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
+          if (itk::Math::NotExactlyEquals(pit->GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << pit->GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetAlpha(), value + 3))
+          if (itk::Math::NotExactlyEquals(pit->GetAlpha(), value + 3))
           {
-            std::cout << " [FAILED] : Alpha : found " << (*pit).GetAlpha() << " instead of " << value + 3 << std::endl;
+            std::cout << " [FAILED] : Alpha : found " << pit->GetAlpha() << " instead of " << value + 3 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -1019,27 +1018,27 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     if (!strcmp((*obj)->GetTypeName().c_str(), "LineSpatialObject"))
     {
       unsigned int value = 0;
-      for (pit = dynamic_cast<LineType *>((*obj).GetPointer())->GetPoints().begin();
-           pit != dynamic_cast<LineType *>((*obj).GetPointer())->GetPoints().end();
+      for (pit = dynamic_cast<LineType *>(obj->GetPointer())->GetPoints().begin();
+           pit != dynamic_cast<LineType *>(obj->GetPointer())->GetPoints().end();
            pit++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*pit).GetPositionInObjectSpace()[d], value))
+          if (itk::Math::NotExactlyEquals(pit->GetPositionInObjectSpace()[d], value))
           {
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals(((*pit).GetNormalInObjectSpace(0))[d], d))
+          if (itk::Math::NotExactlyEquals((pit->GetNormalInObjectSpace(0))[d], d))
           {
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals(((*pit).GetNormalInObjectSpace(1))[d], 2 * d))
+          if (itk::Math::NotExactlyEquals((pit->GetNormalInObjectSpace(1))[d], 2 * d))
           {
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
@@ -1047,33 +1046,33 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           }
 
           // Testing the color of the tube points
-          if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
+          if (itk::Math::NotExactlyEquals(pit->GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << pit->GetRed() << " instead of " << value
                       << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
+          if (itk::Math::NotExactlyEquals(pit->GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << pit->GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
+          if (itk::Math::NotExactlyEquals(pit->GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << pit->GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*pit).GetAlpha(), value + 3))
+          if (itk::Math::NotExactlyEquals(pit->GetAlpha(), value + 3))
           {
-            std::cout << " [FAILED] : Alpha : found " << (*pit).GetAlpha() << " instead of " << value + 3 << std::endl;
+            std::cout << " [FAILED] : Alpha : found " << pit->GetAlpha() << " instead of " << value + 3 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -1093,13 +1092,13 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     if (!strcmp((*obj)->GetTypeName().c_str(), "LandmarkSpatialObject"))
     {
       unsigned int value = 0;
-      for (pit = dynamic_cast<LandmarkType *>((*obj).GetPointer())->GetPoints().begin();
-           pit != dynamic_cast<LandmarkType *>((*obj).GetPointer())->GetPoints().end();
+      for (pit = dynamic_cast<LandmarkType *>(obj->GetPointer())->GetPoints().begin();
+           pit != dynamic_cast<LandmarkType *>(obj->GetPointer())->GetPoints().end();
            pit++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if (itk::Math::NotExactlyEquals((*pit).GetPositionInObjectSpace()[d], value))
+          if (itk::Math::NotExactlyEquals(pit->GetPositionInObjectSpace()[d], value))
           {
             std::cout << " [FAILED]" << std::endl;
             delete mySceneChildren;
@@ -1117,42 +1116,42 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
   {
     if (!strcmp((*obj)->GetTypeName().c_str(), "ContourSpatialObject"))
     {
-      if (!dynamic_cast<ContourType *>((*obj).GetPointer())->GetIsClosed())
+      if (!dynamic_cast<ContourType *>(obj->GetPointer())->GetIsClosed())
       {
         std::cout << "The contour should be closed" << std::endl;
         delete mySceneChildren;
         return EXIT_FAILURE;
       }
 
-      if (dynamic_cast<ContourType *>((*obj).GetPointer())->GetControlPoints().begin()->GetPositionInObjectSpace()[2] !=
+      if (dynamic_cast<ContourType *>(obj->GetPointer())->GetControlPoints().begin()->GetPositionInObjectSpace()[2] !=
             0 &&
-          dynamic_cast<ContourType *>((*obj).GetPointer())->GetOrientationInObjectSpace() != 2)
+          dynamic_cast<ContourType *>(obj->GetPointer())->GetOrientationInObjectSpace() != 2)
       {
         std::cout << "The contour should have display orientation == 2 instead of"
-                  << dynamic_cast<ContourType *>((*obj).GetPointer())->GetOrientationInObjectSpace() << std::endl;
+                  << dynamic_cast<ContourType *>(obj->GetPointer())->GetOrientationInObjectSpace() << std::endl;
         delete mySceneChildren;
         return EXIT_FAILURE;
       }
 
-      if (dynamic_cast<ContourType *>((*obj).GetPointer())->GetAttachedToSlice() != 50)
+      if (dynamic_cast<ContourType *>(obj->GetPointer())->GetAttachedToSlice() != 50)
       {
         std::cout << "The contour should be attached to slice 50 instead of"
-                  << dynamic_cast<ContourType *>((*obj).GetPointer())->GetAttachedToSlice() << std::endl;
+                  << dynamic_cast<ContourType *>(obj->GetPointer())->GetAttachedToSlice() << std::endl;
         delete mySceneChildren;
         return EXIT_FAILURE;
       }
       ContourType::ContourPointListType::const_iterator ctrl;
       int                                               value = 0;
 
-      for (ctrl = dynamic_cast<ContourType *>((*obj).GetPointer())->GetControlPoints().begin();
-           ctrl != dynamic_cast<ContourType *>((*obj).GetPointer())->GetControlPoints().end();
+      for (ctrl = dynamic_cast<ContourType *>(obj->GetPointer())->GetControlPoints().begin();
+           ctrl != dynamic_cast<ContourType *>(obj->GetPointer())->GetControlPoints().end();
            ctrl++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if ((*ctrl).GetId() != value)
+          if (ctrl->GetId() != value)
           {
-            std::cout << "Control ID [FAILED]" << (*ctrl).GetId() << " v.s. " << value << std::endl;
+            std::cout << "Control ID [FAILED]" << ctrl->GetId() << " v.s. " << value << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -1170,7 +1169,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
               (d == 2 && itk::Math::NotExactlyEquals(ctrl->GetPickedPointInObjectSpace()[d], -value) &&
                itk::Math::NotExactlyEquals(ctrl->GetPickedPointInObjectSpace()[d], 0)))
           {
-            std::cout << "Picked Point [FAILED]" << (*ctrl).GetPickedPointInObjectSpace() << " v.s. " << -value
+            std::cout << "Picked Point [FAILED]" << ctrl->GetPickedPointInObjectSpace() << " v.s. " << -value
                       << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -1184,32 +1183,30 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           }
 
           // Testing the color of the tube points
-          if (itk::Math::NotExactlyEquals((*ctrl).GetRed(), value))
+          if (itk::Math::NotExactlyEquals(ctrl->GetRed(), value))
           {
-            std::cout << " [FAILED] : CRed : found " << (*ctrl).GetRed() << " instead of " << value << std::endl;
+            std::cout << " [FAILED] : CRed : found " << ctrl->GetRed() << " instead of " << value << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*ctrl).GetGreen(), value + 1))
+          if (itk::Math::NotExactlyEquals(ctrl->GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : CGreen : found " << (*ctrl).GetGreen() << " instead of " << value + 1
-                      << std::endl;
+            std::cout << " [FAILED] : CGreen : found " << ctrl->GetGreen() << " instead of " << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*ctrl).GetBlue(), value + 2))
+          if (itk::Math::NotExactlyEquals(ctrl->GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : CBlue : found " << (*ctrl).GetBlue() << " instead of " << value + 2 << std::endl;
+            std::cout << " [FAILED] : CBlue : found " << ctrl->GetBlue() << " instead of " << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*ctrl).GetAlpha(), value + 3))
+          if (itk::Math::NotExactlyEquals(ctrl->GetAlpha(), value + 3))
           {
-            std::cout << " [FAILED] : CAlpha : found " << (*ctrl).GetAlpha() << " instead of " << value + 3
-                      << std::endl;
+            std::cout << " [FAILED] : CAlpha : found " << ctrl->GetAlpha() << " instead of " << value + 3 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
@@ -1219,22 +1216,22 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
       ContourType::ContourPointListType::const_iterator inter;
       value = 0;
-      for (inter = dynamic_cast<ContourType *>((*obj).GetPointer())->GetPoints().begin();
-           inter != dynamic_cast<ContourType *>((*obj).GetPointer())->GetPoints().end();
+      for (inter = dynamic_cast<ContourType *>(obj->GetPointer())->GetPoints().begin();
+           inter != dynamic_cast<ContourType *>(obj->GetPointer())->GetPoints().end();
            inter++)
       {
         for (unsigned int d = 0; d < 3; ++d)
         {
-          if ((*inter).GetId() != value)
+          if (inter->GetId() != value)
           {
             std::cout << "Interpolated ID [FAILED]" << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if ((d != 2 && itk::Math::NotExactlyEquals((*inter).GetPositionInObjectSpace()[d], value)) ||
-              (d == 2 && itk::Math::NotExactlyEquals((*inter).GetPositionInObjectSpace()[d], 0) &&
-               itk::Math::NotExactlyEquals((*inter).GetPositionInObjectSpace()[d], value)))
+          if ((d != 2 && itk::Math::NotExactlyEquals(inter->GetPositionInObjectSpace()[d], value)) ||
+              (d == 2 && itk::Math::NotExactlyEquals(inter->GetPositionInObjectSpace()[d], 0) &&
+               itk::Math::NotExactlyEquals(inter->GetPositionInObjectSpace()[d], value)))
           {
             std::cout << "Interpolated Position [FAILED]" << std::endl;
             delete mySceneChildren;
@@ -1242,32 +1239,30 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           }
 
           // Testing the color of the tube points
-          if (itk::Math::NotExactlyEquals((*inter).GetRed(), value))
+          if (itk::Math::NotExactlyEquals(inter->GetRed(), value))
           {
-            std::cout << " [FAILED] : IRed : found " << (*inter).GetRed() << " instead of " << value << std::endl;
+            std::cout << " [FAILED] : IRed : found " << inter->GetRed() << " instead of " << value << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*inter).GetGreen(), value + 1))
+          if (itk::Math::NotExactlyEquals(inter->GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : IGreen : found " << (*inter).GetGreen() << " instead of " << value + 1
-                      << std::endl;
+            std::cout << " [FAILED] : IGreen : found " << inter->GetGreen() << " instead of " << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*inter).GetBlue(), value + 2))
+          if (itk::Math::NotExactlyEquals(inter->GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : IBlue : found " << (*inter).GetBlue() << " instead of " << value + 2 << std::endl;
+            std::cout << " [FAILED] : IBlue : found " << inter->GetBlue() << " instead of " << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
-          if (itk::Math::NotExactlyEquals((*inter).GetAlpha(), value + 3))
+          if (itk::Math::NotExactlyEquals(inter->GetAlpha(), value + 3))
           {
-            std::cout << " [FAILED] : IAlpha : found " << (*inter).GetAlpha() << " instead of " << value + 3
-                      << std::endl;
+            std::cout << " [FAILED] : IAlpha : found " << inter->GetAlpha() << " instead of " << value + 3 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }

--- a/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
+++ b/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
@@ -165,7 +165,7 @@ CompositeTransformIOHelperTemplate<TParametersValueType>::BuildTransformList(con
   const typename CompositeType::TransformQueueType & transforms = composite->GetTransformQueue();
   for (auto it = transforms.begin(); it != transforms.end(); ++it)
   {
-    const auto *          curTransform = static_cast<const TransformType *>((*it).GetPointer());
+    const auto *          curTransform = static_cast<const TransformType *>(it->GetPointer());
     ConstTransformPointer curPtr = curTransform;
     this->m_TransformList.push_back(curPtr);
   }
@@ -201,7 +201,7 @@ CompositeTransformIOHelperTemplate<TParametersValueType>::InternalSetTransformLi
   ++it; // skip the composite transform
   for (; it != transformList.end(); ++it)
   {
-    auto * component = static_cast<ComponentTransformType *>((*it).GetPointer());
+    auto * component = static_cast<ComponentTransformType *>(it->GetPointer());
     composite->AddTransform(component);
   }
   return 1;

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -172,7 +172,7 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
   if (firstTransformName.find("CompositeTransform") != std::string::npos)
   {
     typename TransformListType::const_iterator tit = ioTransformList.begin();
-    typename TransformType::Pointer            composite = (*tit).GetPointer();
+    typename TransformType::Pointer            composite = tit->GetPointer();
 
     // CompositeTransformIOHelperTemplate knows how to assign to the composite
     // transform's internal list
@@ -185,7 +185,7 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
   {
     for (auto it = ioTransformList.begin(); it != ioTransformList.end(); ++it)
     {
-      this->m_TransformList.push_back((*it).GetPointer());
+      this->m_TransformList.push_back(it->GetPointer());
     }
   }
 }

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -450,7 +450,7 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
 
     for (typename ConstTransformListType::const_iterator it = transformList.begin(); it != end; ++it, ++count)
     {
-      this->WriteOneTransform(count, (*it).GetPointer());
+      this->WriteOneTransform(count, it->GetPointer());
     }
     this->m_H5File->close();
   }

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -321,7 +321,7 @@ MINCTransformIOTemplate<TParametersValueType>::Write()
   int serial = 0;
   for (typename ConstTransformListType::const_iterator it = transformList.begin(); it != end; ++it, ++count)
   {
-    this->WriteOneTransform(count, (*it).GetPointer(), xfm, xfm_file_base.c_str(), serial);
+    this->WriteOneTransform(count, it->GetPointer(), xfm, xfm_file_base.c_str(), serial);
   }
 
   VIO_General_transform transform = xfm.back();

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -210,7 +210,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     // Update the geometry values.
 
     // LABEL
-    (*mapIt).second.m_Label = label;
+    mapIt->second.m_Label = label;
 
     // BOUNDING BOX
     // The bounding box is defined in (min, max) pairs, such as
@@ -219,24 +219,24 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     for (unsigned int i = 0; i < (2 * ImageDimension); i += 2)
     {
       // Update min
-      if ((*mapIt).second.m_BoundingBox[i] > index[i / 2])
+      if (mapIt->second.m_BoundingBox[i] > index[i / 2])
       {
-        (*mapIt).second.m_BoundingBox[i] = index[i / 2];
+        mapIt->second.m_BoundingBox[i] = index[i / 2];
       }
       // Update max
-      if ((*mapIt).second.m_BoundingBox[i + 1] < index[i / 2])
+      if (mapIt->second.m_BoundingBox[i + 1] < index[i / 2])
       {
-        (*mapIt).second.m_BoundingBox[i + 1] = index[i / 2];
+        mapIt->second.m_BoundingBox[i + 1] = index[i / 2];
       }
     }
 
     // VOLUME
-    (*mapIt).second.m_ZeroOrderMoment++;
+    mapIt->second.m_ZeroOrderMoment++;
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       // FIRST ORDER RAW MOMENTS
-      (*mapIt).second.m_FirstOrderRawMoments[i] += index[i];
+      mapIt->second.m_FirstOrderRawMoments[i] += index[i];
     }
 
     // SECOND ORDER RAW MOMENTS
@@ -249,14 +249,14 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       // symmetric.
       for (unsigned int j = 0; j < ImageDimension; ++j)
       {
-        (*mapIt).second.m_SecondOrderRawMoments(i, j) += index[i] * index[j];
+        mapIt->second.m_SecondOrderRawMoments(i, j) += index[i] * index[j];
       }
     }
 
     if (m_CalculatePixelIndices == true)
     {
       // Pixel location list
-      (*mapIt).second.m_PixelIndices.push_back(index);
+      mapIt->second.m_PixelIndices.push_back(index);
     }
 
     ++labelIt;
@@ -288,12 +288,12 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       index = it.GetIndex();
 
       // INTEGRATED PIXEL VALUE
-      (*mapIt).second.m_Sum += value;
+      mapIt->second.m_Sum += value;
 
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         // FIRST ORDER WEIGHTED RAW MOMENTS
-        (*mapIt).second.m_FirstOrderWeightedRawMoments[i] += index[i] * (typename LabelIndexType::IndexValueType)value;
+        mapIt->second.m_FirstOrderWeightedRawMoments[i] += index[i] * (typename LabelIndexType::IndexValueType)value;
       }
 
       ++it;
@@ -326,32 +326,32 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
   for (mapIt = m_LabelGeometryMapper.begin(); mapIt != m_LabelGeometryMapper.end(); ++mapIt)
   {
     // Update the bounding box measurements.
-    (*mapIt).second.m_BoundingBoxVolume = 1;
+    mapIt->second.m_BoundingBoxVolume = 1;
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      (*mapIt).second.m_BoundingBoxSize[i] =
-        (*mapIt).second.m_BoundingBox[2 * i + 1] - (*mapIt).second.m_BoundingBox[2 * i] + 1;
-      (*mapIt).second.m_BoundingBoxVolume = (*mapIt).second.m_BoundingBoxVolume * (*mapIt).second.m_BoundingBoxSize[i];
+      mapIt->second.m_BoundingBoxSize[i] =
+        mapIt->second.m_BoundingBox[2 * i + 1] - mapIt->second.m_BoundingBox[2 * i] + 1;
+      mapIt->second.m_BoundingBoxVolume = mapIt->second.m_BoundingBoxVolume * mapIt->second.m_BoundingBoxSize[i];
     }
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       // Normalize the centroid sum by the count to get the centroid.
-      (*mapIt).second.m_Centroid[i] =
-        static_cast<typename LabelPointType::ValueType>((*mapIt).second.m_FirstOrderRawMoments[i]) /
-        (*mapIt).second.m_ZeroOrderMoment;
+      mapIt->second.m_Centroid[i] =
+        static_cast<typename LabelPointType::ValueType>(mapIt->second.m_FirstOrderRawMoments[i]) /
+        mapIt->second.m_ZeroOrderMoment;
 
       // This is the weighted sum.  It only calculates correctly if
       // the intensity image is defined.
       if (!intensityImage)
       {
-        (*mapIt).second.m_WeightedCentroid[i] = 0.0;
+        mapIt->second.m_WeightedCentroid[i] = 0.0;
       }
       else
       {
-        (*mapIt).second.m_WeightedCentroid[i] =
-          static_cast<typename LabelPointType::ValueType>((*mapIt).second.m_FirstOrderWeightedRawMoments[i]) /
-          (*mapIt).second.m_Sum;
+        mapIt->second.m_WeightedCentroid[i] =
+          static_cast<typename LabelPointType::ValueType>(mapIt->second.m_FirstOrderWeightedRawMoments[i]) /
+          mapIt->second.m_Sum;
       }
     }
 
@@ -362,8 +362,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         normalizedSecondOrderCentralMoments(i, j) =
-          ((*mapIt).second.m_SecondOrderRawMoments(i, j)) / ((*mapIt).second.m_ZeroOrderMoment) -
-          (*mapIt).second.m_Centroid[i] * (*mapIt).second.m_Centroid[j];
+          (mapIt->second.m_SecondOrderRawMoments(i, j)) / (mapIt->second.m_ZeroOrderMoment) -
+          mapIt->second.m_Centroid[i] * mapIt->second.m_Centroid[j];
         // We need to add to the second order moment the second order
         // moment of a pixel.  This can be derived analytically.
         if (i == j)
@@ -386,34 +386,34 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       eigenvectors.set_column(i, eig.get_eigenvector(i));
       eigenvalues[i] = eig.get_eigenvalue(i);
     }
-    (*mapIt).second.m_Eigenvalues = eigenvalues;
-    (*mapIt).second.m_Eigenvectors = eigenvectors;
+    mapIt->second.m_Eigenvalues = eigenvalues;
+    mapIt->second.m_Eigenvectors = eigenvectors;
 
     itk::FixedArray<float, ImageDimension> axesLength;
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       axesLength[i] = 4 * std::sqrt(eigenvalues[i]);
     }
-    (*mapIt).second.m_AxesLength = axesLength;
+    mapIt->second.m_AxesLength = axesLength;
 
     // The following three features are currently only meaningful in 2D.
-    (*mapIt).second.m_Eccentricity =
+    mapIt->second.m_Eccentricity =
       std::sqrt((eigenvalues[ImageDimension - 1] - eigenvalues[0]) / eigenvalues[ImageDimension - 1]);
-    (*mapIt).second.m_Elongation = axesLength[ImageDimension - 1] / axesLength[0];
+    mapIt->second.m_Elongation = axesLength[ImageDimension - 1] / axesLength[0];
     RealType orientation =
       std::atan2(eig.get_eigenvector(ImageDimension - 1)[1], eig.get_eigenvector(ImageDimension - 1)[0]);
     // Change the orientation from being between -pi to pi to being from 0 to pi.
     // We can add pi because the orientation of the major axis is symmetric about the origin.
-    (*mapIt).second.m_Orientation = orientation < 0.0 ? orientation + itk::Math::pi : orientation;
+    mapIt->second.m_Orientation = orientation < 0.0 ? orientation + itk::Math::pi : orientation;
 
     if (m_CalculateOrientedBoundingBox == true)
     {
       // Calculate the oriented bounding box using the eigenvectors.
-      CalculateOrientedBoundingBoxVertices(eig, (*mapIt).second);
+      CalculateOrientedBoundingBoxVertices(eig, mapIt->second);
     }
     if (m_CalculateOrientedLabelRegions == true)
     {
-      CalculateOrientedImage<TLabelImage, TIntensityImage>(eig, (*mapIt).second, true, this->GetInput());
+      CalculateOrientedImage<TLabelImage, TIntensityImage>(eig, mapIt->second, true, this->GetInput());
     }
     if (m_CalculateOrientedIntensityRegions == true)
     {
@@ -421,11 +421,11 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       // intensity regions cannot be calculated.
       if (this->GetIntensityInput())
       {
-        CalculateOrientedImage<TLabelImage, TIntensityImage>(eig, (*mapIt).second, false, this->GetIntensityInput());
+        CalculateOrientedImage<TLabelImage, TIntensityImage>(eig, mapIt->second, false, this->GetIntensityInput());
       }
     }
 
-    m_AllLabels.push_back((*mapIt).first);
+    m_AllLabels.push_back(mapIt->first);
   }
 }
 
@@ -589,7 +589,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetPixelIndices(LabelPix
   }
   else
   {
-    return (*mapIt).second.m_PixelIndices;
+    return mapIt->second.m_PixelIndices;
   }
 }
 
@@ -607,7 +607,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetVolume(LabelPixelType
   }
   else
   {
-    return (*mapIt).second.m_ZeroOrderMoment;
+    return mapIt->second.m_ZeroOrderMoment;
   }
 }
 
@@ -625,7 +625,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetIntegratedIntensity(L
   }
   else
   {
-    return (*mapIt).second.m_Sum;
+    return mapIt->second.m_Sum;
   }
 }
 
@@ -645,7 +645,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelTy
   }
   else
   {
-    return (*mapIt).second.m_Centroid;
+    return mapIt->second.m_Centroid;
   }
 }
 
@@ -666,7 +666,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetWeightedCentroid(Labe
   }
   else
   {
-    return (*mapIt).second.m_WeightedCentroid;
+    return mapIt->second.m_WeightedCentroid;
   }
 }
 
@@ -685,7 +685,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvalues(LabelPixe
   }
   else
   {
-    return (*mapIt).second.m_Eigenvalues;
+    return mapIt->second.m_Eigenvalues;
   }
 }
 
@@ -704,7 +704,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvectors(LabelPix
   }
   else
   {
-    return (*mapIt).second.m_Eigenvectors;
+    return mapIt->second.m_Eigenvectors;
   }
 }
 
@@ -724,7 +724,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixel
   }
   else
   {
-    return (*mapIt).second.m_AxesLength;
+    return mapIt->second.m_AxesLength;
   }
 }
 
@@ -760,7 +760,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEccentricity(LabelPix
   }
   else
   {
-    return (*mapIt).second.m_Eccentricity;
+    return mapIt->second.m_Eccentricity;
   }
 }
 
@@ -778,7 +778,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetElongation(LabelPixel
   }
   else
   {
-    return (*mapIt).second.m_Elongation;
+    return mapIt->second.m_Elongation;
   }
 }
 
@@ -796,7 +796,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientation(LabelPixe
   }
   else
   {
-    return (*mapIt).second.m_Orientation;
+    return mapIt->second.m_Orientation;
   }
 }
 
@@ -816,7 +816,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixe
   }
   else
   {
-    return (*mapIt).second.m_BoundingBox;
+    return mapIt->second.m_BoundingBox;
   }
 }
 
@@ -834,7 +834,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxVolume(Lab
   }
   else
   {
-    return (*mapIt).second.m_BoundingBoxVolume;
+    return mapIt->second.m_BoundingBoxVolume;
   }
 }
 
@@ -854,7 +854,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(Label
   }
   else
   {
-    return (*mapIt).second.m_BoundingBoxSize;
+    return mapIt->second.m_BoundingBoxSize;
   }
 }
 
@@ -876,7 +876,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVe
   }
   else
   {
-    return (*mapIt).second.m_OrientedBoundingBoxVertices;
+    return mapIt->second.m_OrientedBoundingBoxVertices;
   }
 }
 
@@ -895,7 +895,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVo
   }
   else
   {
-    return (*mapIt).second.m_OrientedBoundingBoxVolume;
+    return mapIt->second.m_OrientedBoundingBoxVolume;
   }
 }
 
@@ -919,7 +919,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxSi
   }
   else
   {
-    return (*mapIt).second.m_OrientedBoundingBoxSize;
+    return mapIt->second.m_OrientedBoundingBoxSize;
   }
 }
 
@@ -940,7 +940,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxOr
   }
   else
   {
-    return (*mapIt).second.m_OrientedBoundingBoxOrigin;
+    return mapIt->second.m_OrientedBoundingBoxOrigin;
   }
 }
 
@@ -959,7 +959,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRotationMatrix(LabelP
   }
   else
   {
-    return (*mapIt).second.m_RotationMatrix;
+    return mapIt->second.m_RotationMatrix;
   }
 }
 
@@ -1012,7 +1012,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedLabelImage(La
   }
   else
   {
-    return (*mapIt).second.m_OrientedLabelImage;
+    return mapIt->second.m_OrientedLabelImage;
   }
 }
 
@@ -1030,7 +1030,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedIntensityImag
   }
   else
   {
-    return (*mapIt).second.m_OrientedIntensityImage;
+    return mapIt->second.m_OrientedIntensityImage;
   }
 }
 
@@ -1046,21 +1046,21 @@ LabelGeometryImageFilter<TImage, TLabelImage>::PrintSelf(std::ostream & os, Inde
   for (mapIt = m_LabelGeometryMapper.begin(); mapIt != m_LabelGeometryMapper.end(); ++mapIt)
   {
     using LabelPrintType = typename NumericTraits<LabelPixelType>::PrintType;
-    os << indent << "Label[" << (LabelPrintType)((*mapIt).second.m_Label) << "]: ";
-    os << "\t Volume: " << (*mapIt).second.m_ZeroOrderMoment;
-    os << "\t Integrated Intensity: " << (*mapIt).second.m_Sum;
-    os << "\t Centroid: " << (*mapIt).second.m_Centroid;
-    os << "\t Weighted Centroid: " << (*mapIt).second.m_WeightedCentroid;
-    os << "\t Axes Length: " << (*mapIt).second.m_AxesLength;
-    os << "\t Eccentricity: " << (*mapIt).second.m_Eccentricity;
-    os << "\t Elongation: " << (*mapIt).second.m_Elongation;
-    os << "\t Orientation: " << (*mapIt).second.m_Orientation;
-    os << "\t Bounding box: " << (*mapIt).second.m_BoundingBox;
-    os << "\t Bounding box volume: " << (*mapIt).second.m_BoundingBoxVolume;
-    os << "\t Bounding box size: " << (*mapIt).second.m_BoundingBoxSize;
+    os << indent << "Label[" << (LabelPrintType)(mapIt->second.m_Label) << "]: ";
+    os << "\t Volume: " << mapIt->second.m_ZeroOrderMoment;
+    os << "\t Integrated Intensity: " << mapIt->second.m_Sum;
+    os << "\t Centroid: " << mapIt->second.m_Centroid;
+    os << "\t Weighted Centroid: " << mapIt->second.m_WeightedCentroid;
+    os << "\t Axes Length: " << mapIt->second.m_AxesLength;
+    os << "\t Eccentricity: " << mapIt->second.m_Eccentricity;
+    os << "\t Elongation: " << mapIt->second.m_Elongation;
+    os << "\t Orientation: " << mapIt->second.m_Orientation;
+    os << "\t Bounding box: " << mapIt->second.m_BoundingBox;
+    os << "\t Bounding box volume: " << mapIt->second.m_BoundingBoxVolume;
+    os << "\t Bounding box size: " << mapIt->second.m_BoundingBoxSize;
     // Oriented bounding box verticies
-    os << "\t Oriented bounding box volume: " << (*mapIt).second.m_OrientedBoundingBoxVolume;
-    os << "\t Oriented bounding box size: " << (*mapIt).second.m_OrientedBoundingBoxSize;
+    os << "\t Oriented bounding box volume: " << mapIt->second.m_OrientedBoundingBoxVolume;
+    os << "\t Oriented bounding box size: " << mapIt->second.m_OrientedBoundingBoxSize;
     // Rotation matrix
     os << std::endl;
     os << "\t Calculate oriented intensity regions: " << m_CalculateOrientedIntensityRegions;

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -494,7 +494,7 @@ RobustSolver<VDimension>::UnselectLandmarks(unsigned int nUnselected)
 
   for (it = loadVector.begin(); it <= nth; ++it)
   {
-    auto * landmark = dynamic_cast<LoadNoisyLandmark *>((*it).GetPointer());
+    auto * landmark = dynamic_cast<LoadNoisyLandmark *>(it->GetPointer());
     itkAssertInDebugAndIgnoreInReleaseMacro(landmark != nullptr);
 
     landmark->SetOutlier(true);

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -67,8 +67,8 @@ ParticleSwarmOptimizerBase::SetInitialSwarm(const SwarmType & initialSwarm)
     // check that the dimensions of the swarm data are consistent
     for (auto it = initialSwarm.begin(); it != initialSwarm_END; ++it)
     {
-      if ((*it).m_CurrentParameters.GetSize() != n || (*it).m_CurrentVelocity.GetSize() != n ||
-          (*it).m_BestParameters.GetSize() != n)
+      if (it->m_CurrentParameters.GetSize() != n || it->m_CurrentVelocity.GetSize() != n ||
+          it->m_BestParameters.GetSize() != n)
       {
         itkExceptionMacro(<< "inconsistent dimensions in swarm data");
       }
@@ -156,7 +156,7 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
   for (it = this->m_ParameterBounds.begin(); it != end; ++it)
-    os << " [" << (*it).first << ", " << (*it).second << "]";
+    os << " [" << it->first << ", " << it->second << "]";
   os << " ]\n";
   os << indent << "Parameters' convergence tolerance: " << this->m_ParametersConvergenceTolerance;
   os << "\n";

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -460,11 +460,11 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageIndexes(FixedImag
     // Get sampled index
     FixedImageIndexType index = m_FixedImageIndexes[i];
     // Translate index to point
-    m_FixedImage->TransformIndexToPhysicalPoint(index, (*iter).point);
+    m_FixedImage->TransformIndexToPhysicalPoint(index, iter->point);
 
     // Get sampled fixed image value
-    (*iter).value = m_FixedImage->GetPixel(index);
-    (*iter).valueIndex = 0;
+    iter->value = m_FixedImage->GetPixel(index);
+    iter->valueIndex = 0;
 
     ++iter;
   }
@@ -516,9 +516,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
         SizeValueType count = 0;
         while (iter != end)
         {
-          (*iter).point = samples[count].point;
-          (*iter).value = samples[count].value;
-          (*iter).valueIndex = 0;
+          iter->point = samples[count].point;
+          iter->value = samples[count].value;
+          iter->valueIndex = 0;
           ++count;
           if (count >= samplesFound)
           {
@@ -559,10 +559,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
       }
 
       // Translate index to point
-      (*iter).point = inputPoint;
+      iter->point = inputPoint;
       // Get sampled fixed image value
-      (*iter).value = randIter.Get();
-      (*iter).valueIndex = 0;
+      iter->value = randIter.Get();
+      iter->valueIndex = 0;
 
       ++samplesFound;
       ++randIter;
@@ -578,10 +578,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
       // Get sampled index
       FixedImageIndexType index = randIter.GetIndex();
       // Translate index to point
-      m_FixedImage->TransformIndexToPhysicalPoint(index, (*iter).point);
+      m_FixedImage->TransformIndexToPhysicalPoint(index, iter->point);
       // Get sampled fixed image value
-      (*iter).value = randIter.Get();
-      (*iter).valueIndex = 0;
+      iter->value = randIter.Get();
+      iter->valueIndex = 0;
 
       // Jump to random position
       ++randIter;
@@ -648,10 +648,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
       }
 
       // Translate index to point
-      (*iter).point = inputPoint;
+      iter->point = inputPoint;
       // Get sampled fixed image value
-      (*iter).value = regionIter.Get();
-      (*iter).valueIndex = 0;
+      iter->value = regionIter.Get();
+      iter->valueIndex = 0;
 
       ++regionIter;
       if (regionIter.IsAtEnd())
@@ -669,10 +669,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
       FixedImageIndexType index = regionIter.GetIndex();
 
       // Translate index to point
-      m_FixedImage->TransformIndexToPhysicalPoint(index, (*iter).point);
+      m_FixedImage->TransformIndexToPhysicalPoint(index, iter->point);
       // Get sampled fixed image value
-      (*iter).value = regionIter.Get();
-      (*iter).valueIndex = 0;
+      iter->value = regionIter.Get();
+      iter->valueIndex = 0;
 
       ++regionIter;
       if (regionIter.IsAtEnd())

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -339,7 +339,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeFix
   {
     // Determine parzen window arguments (see eqn 6 of Mattes paper [2]).
     const PDFValueType windowTerm =
-      static_cast<PDFValueType>((*iter).value) / this->m_FixedImageBinSize - this->m_FixedImageNormalizedMin;
+      static_cast<PDFValueType>(iter->value) / this->m_FixedImageBinSize - this->m_FixedImageNormalizedMin;
     auto pindex = static_cast<OffsetValueType>(windowTerm);
 
     // Make sure the extreme values are in valid bins
@@ -356,7 +356,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeFix
       }
     }
 
-    (*iter).valueIndex = pindex;
+    iter->valueIndex = pindex;
   }
 }
 

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -135,12 +135,12 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
     // Get sampled index
     FixedImageIndexType index = randIter.GetIndex();
     // Get sampled fixed image value
-    (*iter).FixedImageValue = randIter.Get();
+    iter->FixedImageValue = randIter.Get();
     // Translate index to point
-    this->m_FixedImage->TransformIndexToPhysicalPoint(index, (*iter).FixedImagePointValue);
+    this->m_FixedImage->TransformIndexToPhysicalPoint(index, iter->FixedImagePointValue);
 
     // If not inside the fixed mask, ignore the point
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace((*iter).FixedImagePointValue))
+    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(iter->FixedImagePointValue))
     {
       ++randIter; // jump to another random position
       continue;
@@ -157,7 +157,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
       }
     }
 
-    MovingImagePointType mappedPoint = this->m_Transform->TransformPoint((*iter).FixedImagePointValue);
+    MovingImagePointType mappedPoint = this->m_Transform->TransformPoint(iter->FixedImagePointValue);
 
     // If the transformed point after transformation does not lie within the
     // MovingImageMask, skip it.
@@ -173,13 +173,13 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
     // will need bounds checking.. So keep this anyway.
     if (this->m_Interpolator->IsInsideBuffer(mappedPoint))
     {
-      (*iter).MovingImageValue = this->m_Interpolator->Evaluate(mappedPoint);
+      iter->MovingImageValue = this->m_Interpolator->Evaluate(mappedPoint);
       this->m_NumberOfPixelsCounted++;
       allOutside = false;
     }
     else
     {
-      (*iter).MovingImageValue = 0;
+      iter->MovingImageValue = 0;
     }
 
     // Jump to random position
@@ -237,10 +237,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const P
       double valueFixed;
       double valueMoving;
 
-      valueFixed = ((*biter).FixedImageValue - (*aiter).FixedImageValue) / m_FixedImageStandardDeviation;
+      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = ((*biter).MovingImageValue - (*aiter).MovingImageValue) / m_MovingImageStandardDeviation;
+      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
       dSumFixed += valueFixed;
@@ -331,7 +331,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
   for (aiter = m_SampleA.begin(), aditer = sampleADerivatives.begin(); aiter != aend; ++aiter, ++aditer)
   {
     /** FIXME: is there a way to avoid the extra copying step? */
-    this->CalculateDerivatives((*aiter).FixedImagePointValue, tempDeriv, jacobian);
+    this->CalculateDerivatives(aiter->FixedImagePointValue, tempDeriv, jacobian);
     (*aditer) = tempDeriv;
   }
 
@@ -349,10 +349,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
       double valueFixed;
       double valueMoving;
 
-      valueFixed = ((*biter).FixedImageValue - (*aiter).FixedImageValue) / m_FixedImageStandardDeviation;
+      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = ((*biter).MovingImageValue - (*aiter).MovingImageValue) / m_MovingImageStandardDeviation;
+      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
       dDenominatorMoving += valueMoving;
@@ -375,7 +375,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
     }
 
     /** get the image derivative for this B sample */
-    this->CalculateDerivatives((*biter).FixedImagePointValue, derivB, jacobian);
+    this->CalculateDerivatives(biter->FixedImagePointValue, derivB, jacobian);
 
     SumType totalWeight;
     for (aiter = m_SampleA.begin(), aditer = sampleADerivatives.begin(); aiter != aend; ++aiter, ++aditer)
@@ -386,17 +386,17 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
       double weightJoint;
       double weight;
 
-      valueFixed = ((*biter).FixedImageValue - (*aiter).FixedImageValue) / m_FixedImageStandardDeviation;
+      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = ((*biter).MovingImageValue - (*aiter).MovingImageValue) / m_MovingImageStandardDeviation;
+      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
       weightMoving = valueMoving / dDenominatorMoving.GetSum();
       weightJoint = valueMoving * valueFixed / dDenominatorJoint.GetSum();
 
       weight = (weightMoving - weightJoint);
-      weight *= (*biter).MovingImageValue - (*aiter).MovingImageValue;
+      weight *= biter->MovingImageValue - aiter->MovingImageValue;
 
       totalWeight += weight;
       derivative -= (*aditer) * weight;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -174,7 +174,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
     {
       idx[0] = i;
-      (*PixelPool).push_back(idx);
+      PixelPool->push_back(idx);
     }
     idx[1] = idx[1] + 1;
   }
@@ -188,7 +188,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
-        (*PixelPool).push_back(idx);
+        PixelPool->push_back(idx);
       }
       endx += rightDx;
       beginx += leftDx;
@@ -275,7 +275,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
         for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
         {
           idx[0] = i;
-          (*PixelPool).push_back(idx);
+          PixelPool->push_back(idx);
         }
         endx += rightDx;
         beginx += leftDx;
@@ -333,7 +333,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
-        (*PixelPool).push_back(idx);
+        PixelPool->push_back(idx);
       }
       endx += rightDx;
       beginx += leftDx;

--- a/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
@@ -94,7 +94,7 @@ public:
     }
     else
     {
-      return (*result).second;
+      return result->second;
     }
   }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -82,9 +82,9 @@ Relabeler<TScalar, TImageDimension>::GenerateData()
   this->UpdateProgress(0.5);
 
   it = tree->Begin();
-  while (it != tree->End() && (*it).saliency <= mergeLimit)
+  while (it != tree->End() && it->saliency <= mergeLimit)
   {
-    eqT->Add((*it).from, (*it).to);
+    eqT->Add(it->from, it->to);
     ++it;
   }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -127,7 +127,7 @@ public:
     }
     else
     {
-      return &((*result).second);
+      return &(result->second);
     }
   }
 
@@ -144,7 +144,7 @@ public:
     }
     else
     {
-      return &((*result).second);
+      return &(result->second);
     }
   }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -32,12 +32,12 @@ SegmentTable<TScalar>::PruneEdgeLists(ScalarType maximum_saliency)
   typename edge_list_t::iterator e;
   for (it = this->Begin(); it != this->End(); ++it)
   {
-    for (e = (*it).second.edge_list.begin(); e != (*it).second.edge_list.end(); ++e)
+    for (e = it->second.edge_list.begin(); e != it->second.edge_list.end(); ++e)
     {
-      if ((e->height - (*it).second.min) > maximum_saliency)
+      if ((e->height - it->second.min) > maximum_saliency)
       { // dump the rest of the list, assumes list is sorted
         ++e;
-        (*it).second.edge_list.erase(e, (*it).second.edge_list.end());
+        it->second.edge_list.erase(e, it->second.edge_list.end());
         break; // through with this segment
       }
     }
@@ -52,7 +52,7 @@ SegmentTable<TScalar>::SortEdgeLists()
 
   for (it = this->Begin(); it != this->End(); ++it)
   {
-    (*it).second.edge_list.sort();
+    it->second.edge_list.sort();
   }
 }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -128,7 +128,7 @@ SegmentTreeGenerator<TScalar>::MergeEquivalencies()
 
   for (it = eqTable->Begin(); it != eqTable->End(); ++it)
   {
-    MergeSegments(segTable, m_MergedSegmentsTable, (*it).first, (*it).second); // Merge first INTO second.
+    MergeSegments(segTable, m_MergedSegmentsTable, it->first, it->second); // Merge first INTO second.
     // deletes first
     if ((counter % 10000) == 0)
     {
@@ -161,7 +161,7 @@ SegmentTreeGenerator<TScalar>::CompileMergeList(SegmentTableTypePointer segments
 
   for (segment_ptr = segments->Begin(); segment_ptr != segments->End(); ++segment_ptr)
   {
-    labelFROM = (*segment_ptr).first;
+    labelFROM = segment_ptr->first;
 
     // Must take into account any equivalencies that have already been
     // recorded.
@@ -170,18 +170,18 @@ SegmentTreeGenerator<TScalar>::CompileMergeList(SegmentTableTypePointer segments
       // This is to defend against the referencing below.  This was causing an assert error.
       itkGenericExceptionMacro(<< "CompileMergeList:: An unexpected and fatal error has occurred.");
     }
-    labelTO = m_MergedSegmentsTable->RecursiveLookup((*segment_ptr).second.edge_list.front().label);
+    labelTO = m_MergedSegmentsTable->RecursiveLookup(segment_ptr->second.edge_list.front().label);
     while (labelTO == labelFROM) // Pop off any bogus merges with ourself
     {                            // that may have been left in this list.
-      (*segment_ptr).second.edge_list.pop_front();
-      labelTO = m_MergedSegmentsTable->RecursiveLookup((*segment_ptr).second.edge_list.front().label);
+      segment_ptr->second.edge_list.pop_front();
+      labelTO = m_MergedSegmentsTable->RecursiveLookup(segment_ptr->second.edge_list.front().label);
     }
 
     // Add this merge to our list if its saliency is below
     // the threshold.
     tempMerge.from = labelFROM;
     tempMerge.to = labelTO;
-    tempMerge.saliency = (*segment_ptr).second.edge_list.front().height - (*segment_ptr).second.min;
+    tempMerge.saliency = segment_ptr->second.edge_list.front().height - segment_ptr->second.min;
     if (tempMerge.saliency < threshold)
     {
       mergeList->PushBack(tempMerge);

--- a/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
@@ -40,7 +40,7 @@ OneWayEquivalencyTable::Add(unsigned long a, unsigned long b)
 //  ConstIterator it = this->Begin();
 //  while (it != this->End() )
 //    {
-//      std::cout << (*it).first << " = " << (*it).second << std::endl;
+//      std::cout << it->first << " = " << it->second << std::endl;
 //      ++it;
 //    }
 //}
@@ -52,7 +52,7 @@ OneWayEquivalencyTable::Flatten()
 
   while (it != this->End())
   {
-    (*it).second = this->RecursiveLookup((*it).first);
+    it->second = this->RecursiveLookup(it->first);
     ++it;
   }
 }
@@ -68,7 +68,7 @@ OneWayEquivalencyTable::RecursiveLookup(const unsigned long a) const
 
   while ((it = m_HashMap.find(ans)) != hashEnd)
   {
-    ans = (*it).second;
+    ans = it->second;
     if (ans == a)
     {
       return last_ans; // about to cycle again.


### PR DESCRIPTION
Simplified code by using the arrow operator, instead of using parentheses, asterisk and dot operators.

Did so by replacing the regular expression `\(\*(\w+)\)\.` with `$1->`, followed by a few manual fixes.

Somewhat complementary to pull request #3505, "Replace all occurrences of `(&x)->Print` with `x.Print`"
