### PR TITLE
DOC: Fix typos in Modules/Numerics

### DIFF
--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -119,7 +119,7 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
 
 /**
  *   Make Output
- * \todo Verify that MakeOutput is createing the right type of objects
+ * \todo Verify that MakeOutput is creating the right type of objects
  *  this could be the cause of the reinterpret_cast bug in this class
  */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>

--- a/Modules/Numerics/FEM/include/itkFEMElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementBase.h
@@ -329,7 +329,7 @@ public:
    *     a
    *
    * where (rho c) is constant (element density), which is here assumed to be
-   * equal to one. If this is not the case, this function must be overriden in
+   * equal to one. If this is not the case, this function must be overridden in
    * a derived class. Implementation is similar to GetStiffnessMatrix.
    */
   virtual void
@@ -706,7 +706,7 @@ public:
    * equal to number of unknowns that we want to solve for at each point
    * within an element.
    *
-   * \note This function must be overriden in all derived classes.
+   * \note This function must be overridden in all derived classes.
    */
   virtual unsigned int
   GetNumberOfDegreesOfFreedomPerNode() const = 0;

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.h
@@ -65,7 +65,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ElementStd, TBaseClass);
 
-  // FIXME: Add concept cheking for TBaseClass, and TPointClass
+  // FIXME: Add concept checking for TBaseClass, and TPointClass
 
   // Repeat type alias and enums from parent class
 

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -60,7 +60,7 @@ public:
 
 /**
  * \class FEMExceptionIO
- * \brief Base class for all IO exception's that can occur within FEM classe.
+ * \brief Base class for all IO exception's that can occur within FEM classes.
  *
  * This class is normally used when reading or writing objects from/to stream.
  * \ingroup ITKFEM

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
@@ -339,7 +339,7 @@ public:
 
   /**
    * Set ??
-   * \param i smalles jacobian eigenvalue estimate
+   * \param i smallest jacobian eigenvalue estimate
    */
   void
   SetSmallestJacobiEigenvalueEstimate(double i)

--- a/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
@@ -38,7 +38,7 @@ namespace fem
  *
  * Ultimately, when assembling the right hand side of the master equation (master force vector)
  * the Element's Fe() member function is called with the pointer to the LoadElement class that is
- * prescribed on that element. Fe() function shuld dynamically cast this pointer to specific
+ * prescribed on that element. Fe() function should dynamically cast this pointer to specific
  * load class, which it can handle and return the element's force vector.
  * \ingroup ITKFEM
  */

--- a/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
@@ -38,7 +38,7 @@ namespace fem
  * special properties or constants.
  *
  * Material base class doesn't define any data member.
- * Everything useful is stored in derived clases. This class
+ * Everything useful is stored in derived classes. This class
  * is here just to group all material classes together and access
  * them via this base class.
  * \ingroup ITKFEM

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -391,7 +391,7 @@ FEMObject<VDimension>::GenerateGFN()
                                         // all
                                         // elements
   {
-    // Add the elemens in the nodes list of elements
+    // Add the elements in the nodes list of elements
     // FIXME: should be removed once Mesh is there
     Element::Pointer el = this->GetElement(e);
     unsigned int     Npts = el->GetNumberOfNodes();

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
@@ -312,7 +312,7 @@ protected:
   RescaleLandmarkStiffnessMatrix(double oldPointTensorPonderation);
 
   /**
-   * Calculate KU, which will  be added on the righ hand side to reach
+   * Calculate KU, which will  be added on the right hand side to reach
    * the effect of zeroing mesh energy
    */
   void

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -1045,7 +1045,7 @@ RobustSolver<VDimension>::InitializeInterpolationGrid()
     // Step over all points within the region
     for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
     {
-      // Note: Iteratior is guarantied to be within image, since the
+      // Note: Iterator is guaranteed to be within image, since the
       // elements with BB outside are skipped before.
       this->m_InterpolationGrid->TransformIndexToPhysicalPoint(iter.GetIndex(), pt);
       for (FEMIndexType d = 0; d < NumberOfDimensions; ++d)

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -137,7 +137,7 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
 
   // set the interpolation grid of the FEMSolver
   // note that let the interpolation grid be same with the deformation field
-  // in order to accelarate the generation of the deformation field.
+  // in order to accelerate the generation of the deformation field.
   this->m_FEMSolver->SetOrigin(this->m_Origin);
   this->m_FEMSolver->SetSpacing(this->m_Spacing);
   RegionType region;

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -252,7 +252,7 @@ public:
    * Returns pointer to interpolation grid, which is an itk::Image of pointers
    * to Element objects. Normally you would use physical coordinates to get
    * specific points (pointers to elements) from the image. You can then
-   * use the Elemenet::InterpolateSolution member function on the returned
+   * use the Element::InterpolateSolution member function on the returned
    * element to obtain the solution at this point.
    *
    * \note Physical coordinates in an image correspond to the global
@@ -341,7 +341,7 @@ protected:
    * Copy the element stiffness matrix into the correct position in the
    * master stiffness matrix. Since more complex Solver classes may need to
    * assemble many matrices and may also do some funky stuff to them, this
-   * function is and can be overriden in a derived solver class.
+   * function is and can be overridden in a derived solver class.
    */
   virtual void
   AssembleElementMatrix(Element::Pointer e);
@@ -351,7 +351,7 @@ protected:
    * correct position in the master stiffness matrix. Since more
    * complex Solver classes may need to assemble many matrices and may
    * also do some funky stuff to them, this function is virtual and
-   * can be overriden in a derived solver class.
+   * can be overridden in a derived solver class.
    */
   virtual void
   AssembleLandmarkContribution(Element::ConstPointer e, float);
@@ -386,7 +386,7 @@ protected:
   void
   DecomposeK();
 
-  /** Solve for the displacement vector u. May be overriden in derived
+  /** Solve for the displacement vector u. May be overridden in derived
    * classes. */
   virtual void
   RunSolver();

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -723,7 +723,7 @@ Solver<VDimension>::InitializeInterpolationGrid(const InterpolationGridSizeType 
 
   // Set the interpolation grid (image) size, origin and spacing
   // from the given vectors, so that physical point of v1 is (0,0,0) and
-  // phisical point v2 is (size[0],size[1],size[2]).
+  // physical point v2 is (size[0],size[1],size[2]).
   InterpolationGridSizeType image_size;
   image_size.Fill(1);
   for (unsigned int i = 0; i < FEMDimension; ++i)
@@ -856,7 +856,7 @@ Solver<VDimension>::FillInterpolationGrid()
     // Step over all points within the region
     for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
     {
-      // Note: Iteratior is guarantied to be within image, since the
+      // Note: Iterator is guaranteed to be within image, since the
       //       elements with BB outside are skipped before.
       m_InterpolationGrid->TransformIndexToPhysicalPoint(iter.GetIndex(), pt);
       for (unsigned int d = 0; d < NumberOfDimensions; ++d)
@@ -907,7 +907,7 @@ template <unsigned int VDimension>
 const Element *
 Solver<VDimension>::GetElementAtPoint(const VectorType & pt) const
 {
-  // Add zeros to the end of physical point if necesarry
+  // Add zeros to the end of physical point if necessary
   Point<Float, FEMDimension> pp;
   for (unsigned int i = 0; i < FEMDimension; ++i)
   {

--- a/Modules/Numerics/FEM/include/itpack.h
+++ b/Modules/Numerics/FEM/include/itpack.h
@@ -616,7 +616,7 @@ extern "C"
    * \param nn order of the matrix
    * \param m number of smallest eigenvalues desired
    * \param isw positive definite flag (0 = not pd, 1 = pd)
-   * \param ierr error flag (601 = interates not monotone increasing, 602 = not really pd)
+   * \param ierr error flag (601 = iterates not monotone increasing, 602 = not really pd)
    */
   extern int
   eqrt1s_(doublereal * d__, doublereal * e2, integer * nn, integer * m, integer * isw, integer * ierr);

--- a/Modules/Numerics/FEM/src/dsrc2c.c
+++ b/Modules/Numerics/FEM/src/dsrc2c.c
@@ -5955,7 +5955,7 @@ perror_(integer *    n,
   /*          W      WORKSPACE VECTOR */
   /*          DIGIT1 OUTPUT: MEASURE OF ACCURACY OF STOPPING TEST (= DIGTT1 */
   /*          DIGIT2 OUTPUT: MEASURE OF ACCURACY OF SOLUTION (= DIGTT2) */
-  /*          IDGTS   PARAMETER CONTROLING LEVEL OF OUTPUT (= IDGTTS) */
+  /*          IDGTS   PARAMETER CONTROLLING LEVEL OF OUTPUT (= IDGTTS) */
   /*                    IF IDGTS < 1 OR IDGTS > 4, THEN NO OUTPUT. */
   /*                            = 1, THEN NUMBER OF DIGITS IS PRINTED, PRO- */
   /*                                 VIDED LEVEL .GE. 1 */

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -183,10 +183,10 @@ void
 Element::GetMassMatrix(MatrixType & Me) const
 {
   /*
-   * If the function is not overriden, we compute consistent mass matrix
+   * If the function is not overridden, we compute consistent mass matrix
    * by integrating the shape functions over the element domain. The element
    * density is assumed one. If this is not the case, the GetMassMatrix in a
-   * derived class must be overriden and the Me matrix corrected accordingly.
+   * derived class must be overridden and the Me matrix corrected accordingly.
    */
   Me = MatrixType(this->GetNumberOfDegreesOfFreedom(), this->GetNumberOfDegreesOfFreedom(), 0.0);
 

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
@@ -79,7 +79,7 @@ LinearSystemWrapperItpack::InitializeMatrix(unsigned int matrixIndex)
       __FILE__, __LINE__, "LinearSystemWrapperItpack::InitializeMatrix", "Maximum number of non zeros not set");
   }
 
-  // allocate if necessay
+  // allocate if necessary
   if (m_Matrices == nullptr)
   {
     m_Matrices = new MatrixHolder(m_NumberOfMatrices);
@@ -125,7 +125,7 @@ LinearSystemWrapperItpack::InitializeVector(unsigned int vectorIndex)
       __FILE__, __LINE__, "LinearSystemWrapperItpack::InitializeVector", "m_Vectors", vectorIndex);
   }
 
-  /* allocate if necessay */
+  /* allocate if necessary */
   if (m_Vectors == nullptr)
   {
     m_Vectors = new VectorHolder(m_NumberOfVectors);
@@ -173,7 +173,7 @@ LinearSystemWrapperItpack::InitializeSolution(unsigned int solutionIndex)
       __FILE__, __LINE__, "LinearSystemWrapperItpack::InitializeSolution", "m_Solutions", solutionIndex);
   }
 
-  // allocate if necessay
+  // allocate if necessary
   if (m_Solutions == nullptr)
   {
     m_Solutions = new VectorHolder(m_NumberOfSolutions);

--- a/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
@@ -114,7 +114,7 @@ LoadGravConst::ApplyLoad(Element::ConstPointer element, Element::VectorType & Fe
     {
       force[d] = force_tmp[d];
     }
-    // Claculate the equivalent nodal loads
+    // Calculate the equivalent nodal loads
     for (unsigned int n = 0; n < Nnodes; ++n)
     {
       for (unsigned int d = 0; d < Ndofs; ++d)

--- a/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
@@ -57,7 +57,7 @@ itkFEMRobustSolverTest(int, char *[])
   /** Solver type alias suppot */
   using SolverType = itk::fem::RobustSolver<DataDimension>;
 
-  /** FEMObject type alias suppport */
+  /** FEMObject type alias support */
   using FEMObjectType = itk::fem::FEMObject<DataDimension>;
 
   /** FEM element type alias support */
@@ -217,10 +217,10 @@ itkFEMRobustSolverTest(int, char *[])
   // displacement associated with the feature point on the bottorm boundary
   displacement0[0] = 1.0;
   displacement0[1] = 1.0;
-  // displacement assoaiate with the feature point inside the element
+  // displacement associated with the feature point inside the element
   displacement1[0] = 1.0;
   displacement1[1] = 1.0;
-  // displacement associated with the fature point, coincidentally being the node of the mesh
+  // displacement associated with the feature point, coincidentally being the node of the mesh
   displacement2[0] = 1.0;
   displacement2[1] = 1.0;
   // displacement associated with the feature point on the right boundary

--- a/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
@@ -114,7 +114,7 @@ itkFEMScatteredDataPointSetToImageFilterTest(int, char *[])
   filter->SetInput(featurePoints);
 
   // Set the parameters for a rectilinear mesh.
-  // Ingore this setting if users provide a mesh
+  // Ignore this setting if users provide a mesh
   DeformationFieldType::SpacingType elementSpacing;
   elementSpacing[0] = 2.0;
   elementSpacing[1] = 2.0;

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
@@ -33,7 +33,7 @@ namespace itk
  * \f$ G(x) = \frac{1}{{\sigma \sqrt {2\pi } }}e^{ - \frac{{\left( {x -
  * \mu } \right)^2 }}{{2\sigma ^2 }}} \f$.
  * The Cumulative Gaussian, is acquired by integrating G(x) then scaling and
- * offseting it by the lower asymptotes \f$ I_1 \f$ and upper \f$ I_2 \f$:
+ * offsetting it by the lower asymptotes \f$ I_1 \f$ and upper \f$ I_2 \f$:
  * \f$ C\left( x \right) = I_1  + \frac{{I_2  - I_1 }}{2}\left( {1 +
  * erf\left( {\frac{{x - \mu }}{{\sigma \sqrt 2 }}} \right)} \right) \f$, where
  * \f$ C\left( { - \infty } \right) = I_1 \f$ and

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
@@ -143,7 +143,7 @@ private:
   MeasureType *
   ExtendGaussian(MeasureType * originalArray, MeasureType * extendedArray, int startingPointForInsertion);
 
-  /** Recalulate the parameters of the extended Gaussian array. */
+  /** Recalculate the parameters of the extended Gaussian array. */
   MeasureType *
   RecalculateExtendedArrayFromGaussianParameters(MeasureType * originalArray,
                                                  MeasureType * extendedArray,

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -224,7 +224,7 @@ CumulativeGaussianOptimizer::RecalculateExtendedArrayFromGaussianParameters(Meas
 {
   // From the Gaussian parameters stored with the extendedArray,
   // recalculate the extended portion of the extendedArray,
-  // leaving the inserted original array unchaged.
+  // leaving the inserted original array unchanged.
   double mean = m_ComputedMean;
   double sd = m_ComputedStandardDeviation;
   double amplitude = m_ComputedAmplitude;
@@ -350,7 +350,7 @@ CumulativeGaussianOptimizer::VerticalBestShift(MeasureType * originalArray, Meas
   //     Let B = the new array.
   //     Let n = the number of elements in each array (note they must be the
   // same).
-  //     We want to mimimize sum(((Bi+c) - (Ai))^2).
+  //     We want to minimize sum(((Bi+c) - (Ai))^2).
   //     So we take the derivative with respect to c and equate this derivative
   // to 0.
   //     d/dc sum(((Bi+c) - (Ai))^2) dc = 0

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -78,7 +78,7 @@ MultipleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparame
 
   measures = this->m_CostFunction->GetValue(parameters);
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   m_CachedValue = measures;
   m_CachedCurrentParameters = parameters;
@@ -145,7 +145,7 @@ MultipleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
 
   this->ConvertExternalToInternalGradient(externalGradient, *g);
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   // Note that m_CachedDerivative is already loaded in the GetDerivative()
   // above.

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -248,7 +248,7 @@ ParticleSwarmOptimizerBase::StartOptimization()
     // buffer with m_NumberOfGenerationsWithMinimalImprovement+1
     // elements. the optimizer has converged if: (a) the difference
     // between the first and last elements currently in the ring buffer
-    // is less than the user specificed threshold. and (b) the particles
+    // is less than the user-specified threshold. and (b) the particles
     // are close enough to the best particle.
     if (this->m_IterationIndex >= m_NumberOfGenerationsWithMinimalImprovement)
     {
@@ -281,7 +281,7 @@ ParticleSwarmOptimizerBase::StartOptimization()
 
   this->m_StopConditionDescription << GetNameOfClass() << ": ";
   if (converged)
-    this->m_StopConditionDescription << "successfuly converged after " << m_IterationIndex << " iterations";
+    this->m_StopConditionDescription << "successfully converged after " << m_IterationIndex << " iterations";
   else
     this->m_StopConditionDescription << "terminated after " << m_IterationIndex << " iterations";
   InvokeEvent(EndEvent());

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -315,7 +315,7 @@ PowellOptimizer::BracketedLineOptimize(double           ax,
         q = -q; /* p        */
       }
 
-      /* Chec if x+p/q falls in [a,b] and  not too close to a and b
+      /* Check if x+p/q falls in [a,b] and  not too close to a and b
            and isn't too large */
       if (itk::Math::abs(p) < itk::Math::abs(new_step * q) && p > q * (a - x + 2 * tolerance1) &&
           p < q * (b - x - 2 * tolerance1))
@@ -359,7 +359,7 @@ PowellOptimizer::BracketedLineOptimize(double           ax,
         a = x;
       }
 
-      /* assing the best approximation to x */
+      /* assign the best approximation to x */
       v = w;
       w = x;
       x = t;

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -286,7 +286,7 @@ SPSAOptimizer::Compute_c(SizeValueType k) const
  * ********************** GenerateDelta *************************
  *
  * This function generates a perturbation vector delta.
- * Currently the elements are drawn from a bernouilli
+ * Currently the elements are drawn from a bernoulli
  * distribution. (+- 1)
  */
 

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -83,7 +83,7 @@ SingleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparamete
     value *= -1.0;
   }
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   m_CachedValue = value;
   m_CachedCurrentParameters = parameters;
@@ -120,7 +120,7 @@ SingleValuedVnlCostFunctionAdaptor ::gradf(const InternalParametersType & inpara
   m_CostFunction->GetDerivative(parameters, m_CachedDerivative);
   this->ConvertExternalToInternalGradient(m_CachedDerivative, gradient);
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   // Note that m_CachedDerivative is already loaded in the GetDerivative()
   // above.
@@ -166,7 +166,7 @@ SingleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
     {
       *fun = static_cast<InternalMeasureType>(-measure);
     }
-    // Notify observers. This is used for overcoming the limitaion of VNL
+    // Notify observers. This is used for overcoming the limitation of VNL
     // optimizers of not providing callbacks per iteration.
     // Note that m_CachedDerivative is already loaded in the GetDerivative()
     // above.

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -351,7 +351,7 @@ PSOTest3()
   itkOptimizer->SetInertiaCoefficient(inertiaCoefficient);
   if (itk::Math::abs(itkOptimizer->GetInertiaCoefficient() - inertiaCoefficient))
   {
-    std::cerr << "Error in Set/Get method for inertia coefficent parameter";
+    std::cerr << "Error in Set/Get method for inertia coefficient parameter";
     return EXIT_FAILURE;
   }
 
@@ -359,7 +359,7 @@ PSOTest3()
   itkOptimizer->SetPersonalCoefficient(personalCoefficient);
   if (itk::Math::abs(itkOptimizer->GetPersonalCoefficient() - personalCoefficient))
   {
-    std::cerr << "Error in Set/Get method for personal coefficent parameter";
+    std::cerr << "Error in Set/Get method for personal coefficient parameter";
     return EXIT_FAILURE;
   }
 
@@ -367,7 +367,7 @@ PSOTest3()
   itkOptimizer->SetGlobalCoefficient(gobalCoefficient);
   if (itk::Math::abs(itkOptimizer->GetGlobalCoefficient() - gobalCoefficient))
   {
-    std::cerr << "Error in Set/Get method for gobal coefficent parameter";
+    std::cerr << "Error in Set/Get method for global coefficient parameter";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -216,7 +216,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ModifyGradien
   // Loop over the range. It is inclusive.
   for (IndexValueType j = subrange[0]; j <= subrange[1]; ++j)
   {
-    // scales is checked during StartOptmization for values <=
+    // scales is checked during StartOptimization for values <=
     // machine epsilon.
     // Take the modulo of the index to handle gradients from transforms
     // with local support. The gradient array stores the gradient of local

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -492,7 +492,7 @@ protected:
                  int                   k,
                  int                   ls);
 
-  //** Function evalation callback from libLBFGS frowrad to instance */
+  //** Function evaluation callback from libLBFGS forward to instance */
   static PrecisionType
   EvaluateCostCallback(void *                instance,
                        const PrecisionType * x,

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -74,7 +74,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
      * if first applied transform is DisplacementFieldTransform */
     this->VerifyDisplacementFieldSizeAndPhysicalSpace();
 
-    /* Verify virtual image pixel type is scalar. This effects the calcualtion
+    /* Verify virtual image pixel type is scalar. This effects the calculation
      * of offsets in ComputeParameterOffsetFromVirtualIndex().
      * NOTE:  Can this be checked at compile time? ConceptChecking has a
      * HasPixelTraits class, but looks like it just verifies that type T

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -309,7 +309,7 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
         q = -q; /* p        */
       }
 
-      /* Chec if x+p/q falls in [a,b] and  not too close to a and b
+      /* Check if x+p/q falls in [a,b] and  not too close to a and b
            and isn't too large */
       if (itk::Math::abs(p) < itk::Math::abs(new_step * q) && p > q * (a - x + 2 * tolerance1) &&
           p < q * (b - x - 2 * tolerance1))
@@ -353,7 +353,7 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
         a = x;
       }
 
-      /* assing the best approximation to x */
+      /* assign the best approximation to x */
       v = w;
       w = x;
       x = t;

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -79,7 +79,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::StartOptimization
     if (this->m_MaximumNewtonStepSizeInPhysicalUnits <= NumericTraits<TInternalComputationValueType>::epsilon())
     {
       // Newton step size might be bigger than one voxel spacing.
-      // emperically, we set it to 1~5 voxel spacings.
+      // empirically, we set it to 1~5 voxel spacings.
       this->m_MaximumNewtonStepSizeInPhysicalUnits = 3.0 * this->m_ScalesEstimator->EstimateMaximumStepSize();
     }
   }

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
@@ -207,7 +207,7 @@ RegularStepGradientDescentOptimizerv4<TInternalComputationValueType>::ModifyGrad
   // Loop over the range. It is inclusive.
   for (IndexValueType j = subrange[0]; j <= subrange[1]; ++j)
   {
-    // Scale is checked during StartOptmization for values <=
+    // Scale is checked during StartOptimization for values <=
     // machine epsilon.
     // Take the modulo of the index to handle gradients from transforms
     // with local support. The gradient array stores the gradient of local

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
@@ -28,8 +28,8 @@ namespace itk
  * \brief This class is a base for a CostFunction that returns a
  * single value.
  *
- * This class differs from the SingleValuedCostFunction in that it is fine
- * tunned for managing very large numbers of parameters. For example, to be
+ * This class differs from the SingleValuedCostFunction in that it is fine-
+ * tuned for managing very large numbers of parameters. For example, to be
  * used in conditions where the number of parameters is in the range of
  * thousands or even millions. Due to the large number of parameters, the API
  * of this class avoids any copying of the parameters array, and of the classes

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -60,7 +60,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::f(const InternalParametersType & inparame
   this->m_ObjectMetric->SetParameters(parameters);
   auto value = static_cast<InternalMeasureType>(m_ObjectMetric->GetValue());
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   m_CachedValue = value;
   this->ReportIteration(FunctionEvaluationIterationEvent());
@@ -97,7 +97,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::gradf(const InternalParametersType & inpa
   // This will also scale gradient by user scales
   this->ConvertExternalToInternalGradient(m_CachedDerivative, gradient);
 
-  // Notify observers. This is used for overcoming the limitaion of VNL
+  // Notify observers. This is used for overcoming the limitation of VNL
   // optimizers of not providing callbacks per iteration.
   // Note that m_CachedDerivative is already loaded in the GetDerivative()
   // above.
@@ -134,7 +134,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::compute(const InternalParametersType & x,
   if (fun) // paranoids have longer lives...
   {
     *fun = static_cast<InternalMeasureType>(measure);
-    // Notify observers. This is used for overcoming the limitaion of VNL
+    // Notify observers. This is used for overcoming the limitation of VNL
     // optimizers of not providing callbacks per iteration.
     // Note that m_CachedDerivative is already loaded in the GetDerivative()
     // above.

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -150,7 +150,7 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
   catch (const itk::ExceptionObject & e)
   {
     std::cout << "Exception thrown ! " << std::endl;
-    std::cout << "An error ocurred during Optimization:" << std::endl;
+    std::cout << "An error occurred during Optimization:" << std::endl;
     std::cout << e.GetLocation() << std::endl;
     std::cout << e.GetDescription() << std::endl;
     std::cout << e.what() << std::endl;

--- a/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
@@ -57,10 +57,10 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** InstanceIdenfitifer type alias */
+  /** InstanceIdentifer type alias */
   using InstanceIdentifier = MeasurementVectorTraits::InstanceIdentifier;
 
-  /** Absoluate Frequency type alias */
+  /** Absolute Frequency type alias */
   using AbsoluteFrequencyType = MeasurementVectorTraits::AbsoluteFrequencyType;
 
   /** Absolute Total frequency type */

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -102,7 +102,7 @@ public:
     {
       // then this is a resizable vector type
       //
-      // if the new size is the same as the previou size, just return
+      // if the new size is the same as the previous size, just return
       if (s == this->m_MeasurementVectorSize)
       {
         return;

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -113,7 +113,7 @@ protected:
 
   /** method to randomly generate an integer in the closed range
    * [0, upperBound]
-   * usign a gaussian selection method. */
+   * using a gaussian selection method. */
   RandomIntType
   GetIntegerVariate(RandomIntType lowerBound, RandomIntType upperBound, RandomIntType mean) override;
 

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
@@ -66,7 +66,7 @@ extern ITKStatistics_EXPORT std::ostream &
  * or related class).
  *
  * The features calculated are as follows (where \f$ g(i, j) \f$ is the element in
- * cell i, j of a a normalized GLCM):
+ * cell i, j of a normalized GLCM):
  *
  * "Energy" \f$ = f_1 = \sum_{i,j}g(i, j)^2 \f$
  *
@@ -114,7 +114,7 @@ extern ITKStatistics_EXPORT std::ostream &
  * Haralick, R.M. 1979. Statistical and Structural Approaches to Texture.
  * Proceedings of the IEEE, 67:786-804.
  *
- * R.W. Conners and C.A. Harlow. A Theoretical Comaprison of Texture Algorithms.
+ * R.W. Conners and C.A. Harlow. A Theoretical Comparison of Texture Algorithms.
  * IEEE Transactions on Pattern Analysis and Machine Intelligence,  2:204-222, 1980.
  *
  * R.W. Conners, M.M. Trivedi, and C.A. Harlow. Segmentation of a High-Resolution

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -107,7 +107,7 @@ struct ITK_TEMPLATE_EXPORT KdTreeNode
   Right() const = 0;
 
   /**
-   * Returs the number of measurement vectors under this node including
+   * Returns the number of measurement vectors under this node including
    * its children
    */
   virtual unsigned int
@@ -121,7 +121,7 @@ struct ITK_TEMPLATE_EXPORT KdTreeNode
   virtual void
   GetCentroid(CentroidType &) = 0;
 
-  /** Retuns the instance identifier of the index-th measurement vector */
+  /** Returns the instance identifier of the index-th measurement vector */
   virtual InstanceIdentifier GetInstanceIdentifier(InstanceIdentifier) const = 0;
 
   /** Add an instance to this node */
@@ -195,7 +195,7 @@ struct ITK_TEMPLATE_EXPORT KdTreeNonterminalNode : public KdTreeNode<TSample>
   }
 
   /**
-   * Returs the number of measurement vectors under this node including
+   * Returns the number of measurement vectors under this node including
    * its children
    */
   unsigned int
@@ -710,7 +710,7 @@ public:
   }
 
   /** Returns the measurement vector identified by the instance
-   * identifier that is an identifier defiend for the input sample */
+   * identifier that is an identifier defined for the input sample */
   const MeasurementVectorType &
   GetMeasurementVector(InstanceIdentifier id) const
   {

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -403,7 +403,7 @@ template <typename TKdTree>
 auto
 KdTreeBasedKmeansEstimator<TKdTree>::GetOutput() const -> const MembershipFunctionVectorObjectType *
 {
-  // INSERT CHECKS if all the required inputs are set and optmization has been
+  // INSERT CHECKS if all the required inputs are set and optimization has been
   // run.
   unsigned int                   numberOfClasses = m_Parameters.size() / m_MeasurementVectorSize;
   MembershipFunctionVectorType & membershipFunctionsVector = m_MembershipFunctionsObject->Get();

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -81,7 +81,7 @@ public:
   using InternalDataContainerType = std::vector<MeasurementVectorType>;
 
   /** Resize the container. Using Resize() and then SetMeasurementVector() is
-   * about nine times faster than usign PushBack() continuously. Which means that
+   * about nine times faster than using PushBack() continuously. Which means that
    * whenever the total number of Measurement vectors is known, the users
    * should prefer calling Resize() first and then set the values by calling
    * SetMeasurementVector(). On the other hand, if the number of measurement

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -98,7 +98,7 @@ public:
     {
       // then this is a resizable vector type
       //
-      // if the new size is the same as the previou size, just return
+      // if the new size is the same as the previous size, just return
       if (s == this->m_MeasurementVectorSize)
       {
         return;

--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -36,7 +36,7 @@ namespace Statistics
  * You should run Initialize() function before call GetNormalVariate()
  * function.
  *
- * The followings are original comments.
+ * The following are original comments.
  *
  *  Revision date 31 May 1996
  *      This is a revised version of the algorithm described in
@@ -68,7 +68,7 @@ namespace Statistics
  * and three variables used in the macro.
  *        Read below for calling conventions.
  *
- * THIS CODE ASSUMES TWO'S-COMPLEMENT 32-BIT INTEGER ARITHMATIC.  IT ALSO
+ * THIS CODE ASSUMES TWO'S-COMPLEMENT 32-BIT INTEGER ARITHMETIC.  IT ALSO
  * ASSUMES THE 'C' COMPILER COMPILES THE LEFT-SHIFT OPERATOR "<<" AS A LOGICAL
  * SHIFT, DISCARDING THE SIGN DIGIT AND SHIFTING IN ZEROS ON THE RIGHT, SO
  * " X << 1" IS EQUIVALENT TO " X+X ".   IT ALSO ASSUMES THE RIGHT-SHIFT

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -122,7 +122,7 @@ public:
     {
       // then this is a resizable vector type
       //
-      // if the new size is the same as the previou size, just return
+      // if the new size is the same as the previous size, just return
       if (s == this->m_MeasurementVectorSize)
       {
         return;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
@@ -257,7 +257,7 @@ protected:
 
   /**
    * Normalize the direction of the offset before it is applied.
-   * The last non-zero dimension of the offest has to be positive in order
+   * The last non-zero dimension of the offset has to be positive in order
    * to match to scanning order of the iterator. Only the sign is changed.
    * For example, the input offset (-1, 0) will be normalized as
    * (1, 0).

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -87,7 +87,7 @@ namespace Statistics
  * Haralick, R.M. 1979. Statistical and Structural Approaches to Texture.
  * Proceedings of the IEEE, 67:786-804.
  *
- * R.W. Conners and C.A. Harlow. A Theoretical Comaprison of Texture Algorithms.
+ * R.W. Conners and C.A. Harlow. A Theoretical Comparison of Texture Algorithms.
  * IEEE Transactions on Pattern Analysis and Machine Intelligence,  2:204-222, 1980.
  *
  * R.W. Conners, M.M. Trivedi, and C.A. Harlow. Segmentation of a High-Resolution

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -154,18 +154,18 @@ ChiSquareDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   //
   //   0 iterations, error = 10^-1  at 1 degree of freedom
   //   3 iterations, error = 10^-11 at 1 degree of freedom
-  //  10 iterations, erorr = 10^-13 at 1 degree of freedom
-  //  20 iterations, erorr = 10^-13 at 1 degree of freedom
+  //  10 iterations, error = 10^-13 at 1 degree of freedom
+  //  20 iterations, error = 10^-13 at 1 degree of freedom
   //
   //   0 iterations, error = 10^-1  at 11 degrees of freedom
   //   3 iterations, error = 10^-8  at 11 degrees of freedom
-  //  10 iterations, erorr = 10^-13 at 11 degrees of freedom
-  //  20 iterations, erorr = 10^-13 at 11 degrees of freedom
+  //  10 iterations, error = 10^-13 at 11 degrees of freedom
+  //  20 iterations, error = 10^-13 at 11 degrees of freedom
   //
   //   0 iterations, error = 10^-1  at 100 degrees of freedom
   //   3 iterations, error = 10^-9  at 100 degrees of freedom
-  //  10 iterations, erorr = 10^-10 at 100 degrees of freedom
-  //  20 iterations, erorr = 10^-9  at 100 degrees of freedom
+  //  10 iterations, error = 10^-10 at 100 degrees of freedom
+  //  20 iterations, error = 10^-9  at 100 degrees of freedom
 
   // We are trying to find the zero of
   //

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -193,11 +193,11 @@ TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   //
   //   0 iterations, error = 1      at 1 degree of freedom
   //   3 iterations, error = 10^-10 at 1 degree of freedom
-  // 100 iterations, erorr = 10^-12 at 1 degree of freedom
+  // 100 iterations, error = 10^-12 at 1 degree of freedom
   //
   //   0 iterations, error = 10^-2  at 11 degrees of freedom
   //   3 iterations, error = 10^-11 at 11 degrees of freedom
-  // 100 iterations, erorr = 10^-12 at 11 degrees of freedom
+  // 100 iterations, error = 10^-12 at 11 degrees of freedom
   //
   //
   // We are trying to find the zero of

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
@@ -99,7 +99,7 @@ itkDistanceMetricTest(int, char *[])
     std::cerr << "Exception thrown: " << excpt << std::endl;
   }
 
-  // try re-setting the measurement vector size to the same value, no exceptins should be
+  // try re-setting the measurement vector size to the same value, no exceptions should be
   // thrown
   try
   {

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
@@ -91,7 +91,7 @@ itkDistanceMetricTest2(int, char *[])
     return EXIT_FAILURE;
   }
 
-  // try re-setting the measurement vector size to the same value, no exceptins should be
+  // try re-setting the measurement vector size to the same value, no exceptions should be
   // thrown
   try
   {

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
@@ -304,7 +304,7 @@ itkHistogramToTextureFeaturesFilterTest(int, char *[])
   if (filter->GetFeature(itk::Statistics::HistogramToTextureFeaturesFilterEnums::TextureFeature::InvalidFeatureName))
   {
     std::cerr << "Error: " << std::endl;
-    std::cerr << "GetFeature() is returing non-zero feature value: "
+    std::cerr << "GetFeature() is returning non-zero feature value: "
               << "for invalid feature request" << std::endl;
     passed = false;
   }

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -105,7 +105,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   bool        pass = true;
   std::string whereFail = "";
 
-  // creats an image and allocate memory
+  // creates an image and allocate memory
   auto image = ImageType::New();
 
   ImageType::SizeType size;
@@ -126,7 +126,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   auto sample = SampleType::New();
   sample->SetImage(image);
 
-  // creates a Subsample obeject using the ImageToListSampleAdaptor object
+  // creates a Subsample object using the ImageToListSampleAdaptor object
   auto subsample = SubsampleType::New();
   subsample->SetSample(sample);
 
@@ -134,7 +134,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   // refVector
   std::vector<int> refVector;
 
-  // creats a subsample with all instances in the image
+  // creates a subsample with all instances in the image
   subsample->InitializeWithAllInstances();
 
   // InsertSort algorithm test
@@ -159,7 +159,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
     whereFail = "HeapSort";
   }
 
-  // IntospectiveSort algortihm test
+  // IntospectiveSort algorithm test
   resetData(image, refVector);
   itk::Statistics::Algorithm::IntrospectiveSort<SubsampleType>(subsample, testDimension, 0, subsample->Size(), 16);
   if (!isSortedOrderCorrect(refVector, subsample))

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -22,7 +22,7 @@
 #include "itkTestingMacros.h"
 #include <fstream>
 
-// Testing the weighed centroid Kd tree generator using varaiable length vector
+// Testing the weighed centroid Kd tree generator using variable length vector
 // sample
 int
 itkWeightedCentroidKdTreeGeneratorTest9(int argc, char * argv[])


### PR DESCRIPTION
Found via `codespell -q 3 -S ./Modules/ThirdParty,./Documentation/ReleaseNotes -L ans,ba,boun,childrens,developpement,dum,fiter,inout,ist,nd,normaly,numer,ot,positionn,pullrequest,reson,serie,te,unser`

Signed-off-by: luz paz <luzpaz@github.com>
