### PR TITLE
DOC: fix typos in Modules/Filtering

### DIFF
--- a/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
@@ -122,7 +122,7 @@ itkAntiAliasBinaryImageFilterTest(int argc, char * argv[])
   antialiaser->GetMaximumRMSError();
 
 
-  // Generally a good idea to set this value as a safeguard against infinte
+  // Generally a good idea to set this value as a safeguard against infinite
   // loops if the MaximumRMSError has been set too low.
   antialiaser->SetNumberOfIterations(100);
 

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
@@ -117,7 +117,7 @@ public:
   itkSetMacro(SlicingDirection, int);
   itkGetConstReferenceMacro(SlicingDirection, int);
 
-  /** Compute the average values of mininum intensity pixels for each slice and
+  /** Compute the average values of minimum intensity pixels for each slice and
    * compare the average values with overall averages. */
   void
   GenerateSlabRegions();

--- a/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
@@ -86,7 +86,7 @@ itkMRIBiasFieldCorrectionFilterTest(int, char *[])
   classSigmas[0] = 10.0;
   classSigmas[1] = 20.0;
 
-  // creats a normal random variate generator
+  // creates a normal random variate generator
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =
     itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
 

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -337,7 +337,7 @@ itkN4BiasFieldCorrectionImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  // Exercise the objet's basic methods outside the templated test helper to
+  // Exercise the object's basic methods outside the templated test helper to
   // avoid the Superclass name not being found.
   constexpr unsigned int ImageDimension = 2;
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -175,7 +175,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::ComputeThinImage()
           // seven 8-neighbors valued 1.  Having only one such
           // neighbor implies that p1 is the end point of a skeleton
           // stroke and obviously should not be deleted.  Deleting p1
-          // if it has seven such neighbos would cause erosion into a region.
+          // if it has seven such neighbors would cause erosion into a region.
           PixelType numberOfOnNeighbors = p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
 
           if (numberOfOnNeighbors > 1 && numberOfOnNeighbors < 7)

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
@@ -58,7 +58,7 @@ itkBinaryMorphologicalClosingImageFilterTest(int argc, char * argv[])
   auto filter = FilterType::New();
   filter->SetInput(reader->GetOutput());
   filter->SetKernel(ball);
-  // test the default attribute values, and exercise the accesors
+  // test the default attribute values, and exercise the accessors
   if (!filter->GetSafeBorder())
   {
     std::cerr << "Wrong SafeBorder default value" << std::endl;

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -179,7 +179,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
         // Compute the normalized correlation at this pixel.  The
         // template has already been normalized to mean zero and norm 1.
         // This simplifies the calculation to being just the correlation
-        // of the image neighborhod with the template, normalized by a
+        // of the image neighborhood with the template, normalized by a
         // function of the image neighborhood.
         sum = 0.0;
         sumOfSquares = 0.0;

--- a/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
@@ -106,7 +106,7 @@ itkFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & excep)
   {
-    std::cerr << "Exception catched !" << std::endl;
+    std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;
   }
 

--- a/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
@@ -117,7 +117,7 @@ itkMaskedFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & excep)
   {
-    std::cerr << "Exception catched !" << std::endl;
+    std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;
   }
 

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -97,7 +97,7 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                          neighborhoodScales[i] * neighborhoodScales[j];
     }
 
-    // accumlate the gradient magnitude squared
+    // accumulate the gradient magnitude squared
     magnitudeSqr += itk::Math::sqr(static_cast<double>(firstderiv[i]));
   }
 
@@ -126,7 +126,7 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
     update += temp * itk::Math::sqr(static_cast<double>(firstderiv[i]));
   }
 
-  // accumlate -2 * dx * dy * dxy terms
+  // accumulate -2 * dx * dy * dxy terms
   for (i = 0; i < ImageDimension; ++i)
   {
     for (j = i + 1; j < ImageDimension; ++j)

--- a/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
@@ -63,7 +63,7 @@ public:
  * \brief Deconvolve an image using the Landweber deconvolution
  * algorithm.
  *
- * This filter implements the Landweber deconvolution algorthim as
+ * This filter implements the Landweber deconvolution algorithm as
  * defined in Bertero M and Boccacci P, "Introduction to Inverse
  * Problems in Imaging", 1998. The algorithm assumes that the input
  * image has been formed by a linear shift-invariant system with a

--- a/Modules/Filtering/DiffusionTensorImage/itk-module.cmake
+++ b/Modules/Filtering/DiffusionTensorImage/itk-module.cmake
@@ -1,4 +1,4 @@
-set(DOCUMENTATION "This module contains classes intended to generate or procees
+set(DOCUMENTATION "This module contains classes intended to generate or process
 diffusion tensor images. In particular you will find here the filter that
 computes a tensor image from a set of gradient images.")
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -49,7 +49,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldT
   // Setup and assign parameter helper. This will hold the displacement field
   // for access through the common OptimizerParameters interface.
   auto * helper = new OptimizerParametersHelperType;
-  // After assigning this, m_Parametes will manage this,
+  // After assigning this, m_Parameters will manage this,
   // deleting when appropriate.
   this->m_Parameters.SetHelper(helper);
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
@@ -28,7 +28,7 @@ namespace itk
 
 /** \class GaussianSmoothingOnUpdateDisplacementFieldTransform
  * \brief Modifies the UpdateTransformParameters method
- * to peform a Gaussian smoothing of the
+ * to perform a Gaussian smoothing of the
  * displacement field after adding the update array.
  *
  * This class is the same as \c DisplacementFieldTransform, except

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
@@ -25,7 +25,7 @@ namespace itk
 
 /** \class GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform
  * \brief Modifies the UpdateTransformParameters method
- * to peform a Gaussian smoothing of the
+ * to perform a Gaussian smoothing of the
  * velocity field after adding the update array.
  *
  * This class is the same as \c TimeVaryingVelocityFieldTransform, except

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
@@ -109,7 +109,7 @@ itkDisplacementFieldTransformCloneTest(int, char *[])
   if (!originalIt.IsAtEnd() || !cloneIt.IsAtEnd())
   {
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Displacment field size mismatch" << std::endl;
+    std::cerr << "Displacement field size mismatch" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -82,7 +82,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   // std::cout << "params *before* SmoothDisplacementFieldGauss: " << std::endl
   //          << params << std::endl;
   params = displacementTransform->GetParameters();
-  // std::cout << "field->GetPixelContainter *after* Smooth: "
+  // std::cout << "field->GetPixelContainer *after* Smooth: "
   //          << field->GetPixelContainer() << std::endl;
   /* We should see 0's on all boundaries from the smoothing routine */
   unsigned int linelength = dimLength * dimensions;

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -77,7 +77,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   // std::cout << "params *before* SmoothDisplacementFieldGauss: " << std::endl
   //          << params << std::endl;
   params = displacementTransform->GetParameters();
-  // std::cout << "field->GetPixelContainter *after* Smooth: "
+  // std::cout << "field->GetPixelContainer *after* Smooth: "
   //          << field->GetPixelContainer() << std::endl;
   /* We should see 0's on all boundaries from the smoothing routine */
   unsigned int linelength = dimLength * dimensions;

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -99,7 +99,7 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
 
   // Since the tested transform is upsampling by a factor of two, the
   // size of the inverse field should be twice the size of the input
-  // field. All other geomtry parameters are the same.
+  // field. All other geometry parameters are the same.
   filter->SetOutputSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, filter->GetOutputSpacing());
 

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  * resulting in completely incorrect (read: zero-valued) output.
  *
  * The distances computed by this filter are Chamfer distances, which are only
- * an approximation to Euclidian distances, and are not as exact approximations
+ * an approximation to Euclidean distances, and are not as exact approximations
  * as those calculated by the DanielssonDistanceMapImageFilter. On the other hand,
  * this filter is faster.
  *

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -315,7 +315,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataBa
     ComputeValue(inNeigIt, outNeigIt, center, stride);
 
     ++bandIt;
-  } // Band iteratior
+  } // Band iterator
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -61,7 +61,7 @@ struct FFTImageFilterTraits
  *
  * FFTImageFilterFactory can be used for making an FFT implementation
  * class available through object factory initialization if the class
- * meets certain critera:
+ * meets certain criteria:
  * - the FFT implementation class must be able to be templated over
  *   the pattern
  *   <TInput<PixelType, Dimension>, TOutput<PixelType, Dimension>

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -109,7 +109,7 @@ FFTWHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::BeforeT
   {
     // complex<double> and double[2] types are compatible memory layouts.
     // The reinterpret_cast is used here to
-    // make the "C" fftw libary compatible with the c++ complex<double>.
+    // make the "C" fftw library compatible with the c++ complex<double>.
     std::copy_n(
       inputPtr->GetBufferPointer(), totalInputSize, reinterpret_cast<typename InputImageType::PixelType *>(in));
   }

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -385,7 +385,7 @@ FFTWGlobalConfiguration ::FFTWGlobalConfiguration()
     }
     else
     {
-      // In the abscence of explicit specification, point to
+      // In the absence of explicit specification, point to
       // the DefaultFilenameGenerator for creating the name
       auto * DefaultFilenameGenerator = new HardwareWisdomFilenameGenerator;
       this->m_WisdomFilenameGenerator = DefaultFilenameGenerator;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
@@ -106,7 +106,7 @@ FastMarchingBase<TInput, TOutput>::Initialize(OutputDomainType * oDomain)
   this->InitializeOutput(oDomain);
 
   // By setting the output domain to the stopping criterion, we enable funky
-  // criterion based on informations extracted from it
+  // criterion based on information extracted from it
   m_StoppingCriterion->SetDomain(oDomain);
 }
 // -----------------------------------------------------------------------------

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -271,7 +271,7 @@ protected:
       SizeValueType availableNumberOfTargets = m_TargetPoints->Size();
       if (targetModeMinPoints > availableNumberOfTargets)
       {
-        itkExceptionMacro(<< "Not enought target points: Available: " << availableNumberOfTargets
+        itkExceptionMacro(<< "Not enough target points: Available: " << availableNumberOfTargets
                           << "; Requested: " << targetModeMinPoints);
       }
     }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -25,7 +25,7 @@
  * and does not exercise the base class filter. The process of testing
  * the running of the filter is delegated to other tests.
  * @tparam VDimension
- * @return EXIT_SUCCESS if all test passs, EXIT_FAILURE otherwise
+ * @return EXIT_SUCCESS if all test pass, EXIT_FAILURE otherwise
  */
 template <unsigned int VDimension>
 static int

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -33,7 +33,7 @@ namespace itk
  * the size of the N+1'th dimension of the output is same as the number of
  * the inputs. The spacing and the origin (where the first input is placed)
  * for the N+1'th dimension is specified in this filter. The output image
- * informations for the first N dimensions are taken from the first input.
+ * information for the first N dimensions are taken from the first input.
  * Note that all the inputs should have the same information.
  *
  * \ingroup GeometricTransform

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
@@ -161,7 +161,7 @@ itkJoinSeriesImageFilterTest(int, char *[])
   OutputImageType::Pointer output = streamingImage->GetOutput();
 
 
-  // Check the informations
+  // Check the information
   if (output->GetLargestPossibleRegion() != expectedRegion)
   {
     std::cout << "LargestPossibleRegion mismatch" << std::endl;

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -214,7 +214,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()
   m_GaussianFilter->SetVariance(m_Variance);
   m_GaussianFilter->SetMaximumError(m_MaximumError);
   m_GaussianFilter->SetInput(input);
-  // Modify to force excution, due to grafting complications
+  // Modify to force execution, due to grafting complications
   m_GaussianFilter->Modified();
   m_GaussianFilter->Update();
   this->UpdateProgress(0.01f);

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -106,7 +106,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->SetBufferedRegion(output->GetRequestedRegion());
   output->Allocate();
 
-  // Create an internal image to protect the input image's metdata
+  // Create an internal image to protect the input image's metadata
   // (e.g. RequestedRegion). The StreamingImageFilter changes the
   // requested region as poart of its normal provessing.
   auto localInput = TInputImage::New();

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -158,7 +158,7 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   // initialize output image
   //
   // NOTE: We intentionally don't allocate the output image here,
-  // because the cast image filter will either run inplace, or alloate
+  // because the cast image filter will either run inplace, or allocate
   // the output there. The requested region has already been set in
   // ImageToImageFilter::GenerateInputImageFilter.
   typename TOutputImage::Pointer outputImage(this->GetOutput());

--- a/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
@@ -50,7 +50,7 @@ itkHessianToObjectnessMeasureImageFilterTest(int argc, char * argv[])
 
   using HessianImageType = GaussianImageFilterType::OutputImageType;
 
-  // Delcare the type of objectness measure image filter
+  // Declare the type of objectness measure image filter
 
   using ObjectnessFilterType = itk::HessianToObjectnessMeasureImageFilter<HessianImageType, ImageType>;
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -548,7 +548,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
       std::cout << "Failure for circle #" << i << std::endl;
       std::cout << "Expected center: [" << center[i][0] << ", " << center[i][1] << "], found [" << centerResult[i][0]
                 << ", " << centerResult[i][1] << "]" << std::endl;
-      std::cout << "Excpected radius: " << radius[i] << ", found " << radiusResult[i] << std::endl;
+      std::cout << "Expected radius: " << radius[i] << ", found " << radiusResult[i] << std::endl;
       success = false;
     }
     else

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -23,7 +23,7 @@
 #include "itkTestingMacros.h"
 
 /**
- * This program looks for straight lines whithin an image
+ * This program looks for straight lines within an image
  * It uses the ITK HoughTransform2DLinesImageFilter.
  * - Read the image.
  * - Apply a gradient and thresholding functions.

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
@@ -66,7 +66,7 @@ namespace itk
  * to consider that the histogram will never be empty.
  *
  * One histogram is created for each thread by the method NewHistogram().
- * The NewHistogram() method can be overriden to pass some parameters to the
+ * The NewHistogram() method can be overridden to pass some parameters to the
  * histogram.
  *
  * The neighborhood is defined by a structuring element, and must a

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
@@ -69,7 +69,7 @@ namespace itk
  * to consider that the histogram will never be empty.
  *
  * One histogram is created for each thread by the method NewHistogram().
- * The NewHistogram() method can be overriden to pass some parameters to the
+ * The NewHistogram() method can be overridden to pass some parameters to the
  * histogram.
  *
  * The neighborhood is defined by a structuring element, and must a

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
@@ -97,7 +97,7 @@ itkFrequencyBandImageFilterTest(int argc, char * argv[])
   }
   else
   {
-    std::cerr << "Unkown string: " + evenOrOddInput + " . Use Even or Odd." << std::endl;
+    std::cerr << "Unknown string: " + evenOrOddInput + " . Use Even or Odd." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -208,7 +208,7 @@ compareAllTypesOfIterators(typename TImageType::Pointer image, double difference
   // Compare full and hermitian
   // Hermitian saves memory, but at the cost of less precision
   // in the reconstruction (forward + inverse == original_image)
-  // This is the minimun threshold for the comparison between
+  // This is the minimum threshold for the comparison between
   // original and reconstructed image to be equal (without any extra band filter).
   bool fullAndHermitian = compareImages<ImageType>(filteredHermitianImage, filteredImage, differenceHermitianThreshold);
   EXPECT_TRUE(fullAndHermitian);

--- a/Modules/Filtering/ImageFusion/wrapping/CMakeLists.txt
+++ b/Modules/Filtering/ImageFusion/wrapping/CMakeLists.txt
@@ -1,6 +1,6 @@
 itk_wrap_module(ITKImageFusion)
 
-# Save default includes so they can be reseted afterwards
+# Save default includes so they can be reset afterwards
 set(tmp_default_includes ${WRAPPER_DEFAULT_INCLUDE})
 
 # Add itkStatisticsLabelObject.h, it is not automatically detected

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -98,7 +98,7 @@ itkVectorGradientMagnitudeImageFilterTest3(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  // this verifies that the pipeline was executed as expected allong
+  // this verifies that the pipeline was executed as expected along
   // with correct region propagation and output information
   if (!monitor2->VerifyAllInputCanStream(4))
   {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -55,7 +55,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostrea
 }
 
 /**
- * Intializes the Pyramid Spline Filter parameters for an "l2" filter
+ * Initializes the Pyramid Spline Filter parameters for an "l2" filter
  */
 template <typename TInputImage, typename TOutputImage>
 void

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
@@ -29,7 +29,7 @@ namespace itk
  * PermuateAxesImageFilter permutes the image axes according to a
  * user specified order. The permutation order is set via method
  * SetOrder( order ) where the input is an array of ImageDimension
- * number of unsigned int. The elements of the array must be a rearrangment
+ * number of unsigned int. The elements of the array must be a rearrangement
  * of the numbers from 0 to ImageDimension - 1.
  *
  * The i-th axis of the output image corresponds with the order[i]-th

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -146,7 +146,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   {
     offsetIndex[i] = inputIndex[i] - outputIndex[i] * m_ShrinkFactors[i];
     // It is plausible that due to small amounts of loss of numerical
-    // precision that the offset it negaive, this would cause sampling
+    // precision that the offset it negative, this would cause sampling
     // out of out region, this is insurance against that possibility
     offsetIndex[i] = std::max(zeroOffset, offsetIndex[i]);
   }
@@ -226,7 +226,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   {
     offsetIndex[i] = inputIndex[i] - outputIndex[i] * m_ShrinkFactors[i];
     // It is plausible that due to small amounts of loss of numerical
-    // precision that the offset it negaive, this would cause sampling
+    // precision that the offset it negative, this would cause sampling
     // out of out region, this is insurance against that possibility
     offsetIndex[i] = std::max(zeroOffset, offsetIndex[i]);
   }

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -49,7 +49,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
     }
   }
 
-  // assemple pipeline
+  // assemble pipeline
   using InputMonitorFilterType = itk::PipelineMonitorImageFilter<InputImageType>;
   auto monitor1 = InputMonitorFilterType::New();
   monitor1->SetInput(sourceImage);

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
@@ -21,7 +21,7 @@
  *  Accessors
  *
  *  The example shows how an Adaptor can be used to
- *  get acces only to thered component of an RGBPixel image
+ *  get access only to the red component of an RGBPixel image
  *  giving the appearance of being just a 'float' image
  *
  *  That will allow to pass the red component of this

--- a/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
@@ -21,7 +21,7 @@
 #include "itkCommand.h"
 
 
-// The following classe is used to support callbacks
+// The following class is used to support callbacks
 // on the filter in the pipeline that follows later
 class ShowProgressObject
 {

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -57,7 +57,7 @@ GetFirstPixelFromFilterOutput(const TPixel inputPixel)
 
 
 // Test if the resample image filter has a valid output region defined
-// A common mistake is to use SetReferenceIamge without setting UseReferenceIamgeOn
+// A common mistake is to use SetReferenceImage without setting UseReferenceImageOn
 // which results in the default output image size of 0,0,0.
 template <typename TPixel>
 TPixel

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
@@ -82,7 +82,7 @@ itkShrinkImageStreamingTest(int, char *[])
   streamer->Update();
 
 
-  // this verifies that the pipeline was executed as expected allong
+  // this verifies that the pipeline was executed as expected along
   // with correct region propagation and output information
   if (!monitor2->VerifyAllInputCanStream(numberOfStreamDivisions))
   {

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -425,7 +425,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
     lowerBound.Fill(minHistogramValidValue);
     upperBound.Fill(maxHistogramValidValue);
 
-    // Initialize with equally spaced bins withing the valid region.
+    // Initialize with equally spaced bins within the valid region.
     histogram->Initialize(size, lowerBound, upperBound);
 
     // Now expand the first and last bin to represent the true reference image range

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -303,7 +303,7 @@ protected:
  *\class SymmetricEigenAnalysisFixedDimensionImageFilter
  * \brief Computes the eigen-values of every input symmetric matrix pixel.
  *
- * SymmetricEigenAnalysisImageFilter applies pixel-wise the invokation for
+ * SymmetricEigenAnalysisImageFilter applies pixel-wise the invocation for
  * computing the eigen-values and eigen-vectors of the symmetric matrix
  * corresponding to every input pixel.
  *

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -74,7 +74,7 @@ srcPattern(unsigned long offset)
 namespace
 {
 
-// The following classe is used to support callbacks
+// The following class is used to support callbacks
 // on the filter in the pipeline that follows later
 class ShowProgressObject
 {

--- a/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
@@ -21,7 +21,7 @@
  *  NthElementPixelAccessor
  *
  *  The example shows how an Adaptor can be used to
- *  get acces only to the Nth component of a vector image
+ *  get access only to the Nth component of a vector image
  *  giving the appearance of being just a 'float' image
  *
  *  That will allow to pass the Nth component of this

--- a/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
@@ -175,7 +175,7 @@ itkChangeLabelImageFilterTest(int, char *[])
 
   if (pass)
   {
-    std::cout << "Test passsed. " << std::endl;
+    std::cout << "Test passed. " << std::endl;
     return EXIT_SUCCESS;
   }
   else

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -362,7 +362,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
 
   // Calculate the principal shape variations
   //
-  // m_EigenVectors capture the principal shape variantions
+  // m_EigenVectors capture the principal shape variations
   // m_EigenValues capture the relative weight of each variation
   // Multiply original image vetors with the eigenVectorsOfInnerProductMatrix
   // to derive the principal shapes.
@@ -396,7 +396,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
   m_EigenValues = (eigenVectors_eigenValues.D).diagonal();
 
   // Flip the eigen values since the eigen vectors output
-  // is ordered in decending order of their corresponding eigen values.
+  // is ordered in descending order of their corresponding eigen values.
   m_EigenValues.flip();
 
   // Normalize the eigen values

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
@@ -56,7 +56,7 @@ itkHistogramToProbabilityImageFilterTest2(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
+    std::cerr << "Problem encountered while reading image file : " << argv[1] << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
@@ -94,7 +94,7 @@ AttributeUniqueLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
     IndexType         idx = l.line.GetIndex();
     // NOTE: VS 7,8,9 seem to contain a bug where if the next line is
     // accessed with l.labelObject, the results will be erroneous. I
-    // have not been able to find anly reason for this.
+    // have not been able to find any reason for this.
     //
     // EXERCISE EXTREME CAUTION WHEN EDITING THE NEXT 2 LINES
     const typename LabelObjectType::LabelType             lLabel = pq.top().labelObject->GetLabel();

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -64,7 +64,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  // Call a method that can be overriden by a subclass to allocate
+  // Call a method that can be overridden by a subclass to allocate
   // memory for the filter's outputs
   this->AllocateOutputs();
   this->SetupLineOffsets(false);

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
@@ -118,14 +118,14 @@ public:
 
   /**
    * Set/Get whether the maximum Feret diameter should be computed or not. The
-   * defaut value is false, because of the high computation time required.
+   * default value is false, because of the high computation time required.
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
   itkBooleanMacro(ComputeFeretDiameter);
 
   /**
-   * Set/Get whether the perimeter should be computed or not. The defaut value
+   * Set/Get whether the perimeter should be computed or not. The default value
    * is false, because of the high computation time required.
    */
   itkSetMacro(ComputePerimeter, bool);

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
@@ -102,14 +102,14 @@ public:
 
   /**
    * Set/Get whether the maximum Feret diameter should be computed or not. The
-   * defaut value is false, because of the high computation time required.
+   * default value is false, because of the high computation time required.
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
   itkBooleanMacro(ComputeFeretDiameter);
 
   /**
-   * Set/Get whether the perimeter should be computed or not. The defaut value
+   * Set/Get whether the perimeter should be computed or not. The default value
    * is false, because of the high computation time required.
    */
   itkSetMacro(ComputePerimeter, bool);

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -233,7 +233,7 @@ public:
 
   /**
    * Add a label object to the image. If a label object already has the label,
-   * it is overriden.
+   * it is overridden.
    */
   void
   AddLabelObject(LabelObjectType * labelObject);

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -313,7 +313,7 @@ LabelObject<TLabel, VImageDimension>::Optimize()
     typename Functor::LabelObjectLineComparator<LineType> comparator;
     std::sort(lineContainer.begin(), lineContainer.end(), comparator);
 
-    // then check the lines consistancy
+    // then check the lines consistency
     // we'll proceed line index by line index
     IndexType  currentIdx = lineContainer.begin()->GetIndex();
     LengthType currentLength = lineContainer.begin()->GetLength();

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
@@ -94,7 +94,7 @@ LabelObjectLine<VImageDimension>::IsNextIndex(const IndexType & idx) const
 
 /**
  * This function just calls the
- * header/self/trailer print methods, which can be overriden by
+ * header/self/trailer print methods, which can be overridden by
  * subclasses.
  */
 template <unsigned int VImageDimension>

--- a/Modules/Filtering/LabelMap/wrapping/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/wrapping/CMakeLists.txt
@@ -11,7 +11,7 @@ set(WRAPPER_SUBMODULE_ORDER
   itkChangeRegionLabelMapFilter
 )
 
-# Save default includes so they can be reseted afterwards
+# Save default includes so they can be reset afterwards
 set(tmp_default_includes ${WRAPPER_DEFAULT_INCLUDE})
 
 # Add itkStatisticsLabelObject.h, it is not automatically detected

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -239,7 +239,7 @@ AnchorErodeDilateLine<TInputPix, TCompare>::StartLine(std::vector<TInputPix> & b
     ++currentP;
     if (Compare(inbuffer[currentP], Extreme))
     {
-      // Found a new extrem
+      // Found a new extreme
       Extreme = inbuffer[currentP];
       ++outLeftP;
       buffer[outLeftP] = Extreme;

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -189,7 +189,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
     ++currentP;
     if (Compare2(buffer[currentP], Extreme))
     {
-      // Found a new extrem
+      // Found a new extreme
       endP = currentP;
       for (unsigned int PP = outLeftP + 1; PP < endP; ++PP)
       {

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
@@ -29,7 +29,7 @@ namespace itk
  * This class defines a Neighborhood whose elements are either on or off
  * depending on whether they are the face connected neighbors of the
  * neighborhood center when the radii are all 1.
- * The neighorhood is a cross for any size radius.
+ * The neighborhood is a cross for any size radius.
  * By default, the Neighborhood is defined to be of radii 1
  * (i.e. 3x3x...).
  * This can be changed explicitly using the SetRadius() method.

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
@@ -33,7 +33,7 @@ namespace itk
  * erosion.  The opening by reconstruction of an image "f" is defined
  * as:
  *
- *   OpeningByReconstruction(f) = DilationByRecontruction(f, Erosion(f)).
+ *   OpeningByReconstruction(f) = DilationByReconstruction(f, Erosion(f)).
  *
  * Opening by reconstruction not only removes structures destroyed by
  * the erosion, but also levels down the contrast of the brightest

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -199,7 +199,7 @@ DoFace(typename TImage::ConstPointer             input,
           typename TImage::PixelType V2 = rExtBuffer[l];
           pixbuffer[j] = m_TF(V1, V2);
         }
-        // line end -- involves reseting the end of the reverse
+        // line end -- involves resetting the end of the reverse
         // extreme array
         for (unsigned int j = size - 2; (j > 0) && (j >= (size - KernLen - 1)); j--)
         {

--- a/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
@@ -125,7 +125,7 @@ itkDoubleThresholdImageFilterTest(int argc, char * argv[])
   }
   if (thresholds[0] <= thresholds[1] && thresholds[1] <= thresholds[2] && thresholds[2] <= thresholds[3])
   {
-    std::cerr << "Values inputed as Threshold meet the requirement" << std::endl;
+    std::cerr << "Values inputted as Threshold meet the requirement" << std::endl;
   }
   else
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -190,12 +190,12 @@ ComputeAreaError(const SEType & k, unsigned int thickness)
   float expectedInnerForegroundArea;
   if (thickness == 0)
   {
-    // Circle/Ellipse has no inner area to subract.
+    // Circle/Ellipse has no inner area to subtract.
     expectedInnerForegroundArea = 0;
   }
   else
   {
-    // Annulus does have inner area to subract.
+    // Annulus does have inner area to subtract.
     expectedInnerForegroundArea = 1;
   }
   if (SEType::NeighborhoodDimension == 2)

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -115,7 +115,7 @@ itkFlatStructuringElementTest2(int argc, char * argv[])
   FSEType              flatStructure = FSEType::FromImage(testImgBool);
   ImageUCType::Pointer imgFromStructure = GetImage(flatStructure);
 
-  // Write result from GetImage for comparisson with input image
+  // Write result from GetImage for comparison with input image
 
   using WriterType = itk::ImageFileWriter<ImageUCType>;
   auto writer = WriterType::New();

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -102,7 +102,7 @@ itkShapedIteratorFromStructuringElementTest(int, char *[])
   }
   if (!caught)
   {
-    std::cout << "Faile to catch expected exception." << std::endl;
+    std::cout << "Failed to catch expected exception." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
@@ -28,5 +28,5 @@ elif argv[1] == "Box":
     print("Box")
     strel = itk.FlatStructuringElement[2].Box(int(argv[2]))
 else:
-    print("invalid arguement: " + argv[1])
+    print("invalid argument: " + argv[1])
     exit(1)

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -101,7 +101,7 @@ ContourExtractor2DImageFilter<TInputImage>::CreateSingleContour(InputPixelType  
   // 6 7 8
   // We are interested only in the square of 4,5,7,8 which is the 2x2 square
   // with the center pixel at the top-left. So we only activate the
-  // coresponding offsets, and only query pixels 4, 5, 7, and 8 with the
+  // corresponding offsets, and only query pixels 4, 5, 7, and 8 with the
   // iterator's GetPixel method.
 
   const InputOffsetType none{ { 0, 0 } };

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -180,7 +180,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateData()
   {
     index = outputIt.GetIndex();
 
-    // what position along the path coresponds to this column of the swath?
+    // what position along the path corresponds to this column of the swath?
     pathInput =
       inputPathPtr->StartOfInput() + static_cast<double>(inputPathPtr->EndOfInput() - inputPathPtr->StartOfInput()) *
                                        static_cast<double>(index[0]) / static_cast<double>(m_Size[0]);
@@ -188,7 +188,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateData()
     // What is the orghogonal offset from the path in the input image for this
     // particular index in the output swath image?
     // Vertically centered swath pixels lie on the path in the input image.
-    orthogonalOffset = index[1] - static_cast<int>(m_Size[1] / 2); // use signed arithmatic
+    orthogonalOffset = index[1] - static_cast<int>(m_Size[1] / 2); // use signed arithmetic
 
     // Make continousIndex point to the source pixel in the input image
     continousIndex = inputPathPtr->Evaluate(pathInput);

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -144,7 +144,7 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
       }
     }
   }
-  // end of tripple for-loop covering x & F & L
+  // end of triple for-loop covering x & F & L
 
   // Find the best starting and ending points (F & L) for the path
   int    bestF = 0, bestL = 0;

--- a/Modules/Filtering/Path/include/itkParametricPath.h
+++ b/Modules/Filtering/Path/include/itkParametricPath.h
@@ -67,7 +67,7 @@ public:
 
   /** Standard class type aliases. */
   using Self = ParametricPath;
-  /** All paths must be mapable to index space */
+  /** All paths must be mappable to index space */
   using ContinuousIndexType = ContinuousIndex<SpacePrecisionType, VDimension>;
   using Superclass = Path<double, ContinuousIndexType, VDimension>;
 

--- a/Modules/Filtering/Path/include/itkPath.h
+++ b/Modules/Filtering/Path/include/itkPath.h
@@ -32,7 +32,7 @@ namespace itk
  * path, it maps a 1D parameter (such as time or arc length, etc) to an index
  * (or possibly an offset or a point) in ND space.  This mapping is done via the
  * abstract Evaluate() method, which must be overridden in all instantiable
- * subclasses. The only geometric requirement for a gerneral path is that it be
+ * subclasses. The only geometric requirement for a general path is that it be
  * continuous. A path may be open or closed, and may cross itself several
  * times.  A classic application of this class is the representation of contours
  * in 2D images using chaincodes or freeman codes.  Another use of a path is to
@@ -74,7 +74,7 @@ public:
   /** Output type */
   using OutputType = TOutput;
 
-  /** All paths must be mapable to index space */
+  /** All paths must be mappable to index space */
   using IndexType = Index<VDimension>;
   using OffsetType = Offset<VDimension>;
 

--- a/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
@@ -146,9 +146,9 @@ itkOrthogonalSwath2DPathFilterTest(int, char *[])
   auto smoothFilter = SmoothFilterType::New();
   smoothFilter->SetInput(castFilter->GetOutput());
   double gaussianVariance = 1.0;
-  // We want a fast 3x3 kernel. A Gausian operator will not truncate its kernel
+  // We want a fast 3x3 kernel. A Gaussian operator will not truncate its kernel
   // width to any less than a 5x5 kernel (kernel width of 3 for 1 center pixel +
-  // 2 edge pixels). However, a Gausian operator always uses at least a 3x3
+  // 2 edge pixels). However, a Gaussian operator always uses at least a 3x3
   // kernel, and so setting the maximum error to 1.0 (no limit) will make it
   // stop growing the kernel at the desired 3x3 size.
   double maxError = 0.9;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -74,7 +74,7 @@ public:
 };
 
 /** \class InverseEuclideanDistanceMatrixCoefficients
- * \brief Compute a matrix filed with the inverse of the euclidian distance
+ * \brief Compute a matrix filed with the inverse of the euclidean distance
  *        wherever two vertices are connected by an edge.
  * \note  Belongs to the parameterisation package.
  * \note  See paper: ...

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -157,7 +157,7 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->SetBufferedRegion(output->GetRequestedRegion());
   output->Allocate();
 
-  // Create an internal image to protect the input image's metdata
+  // Create an internal image to protect the input image's metadata
   // (e.g. RequestedRegion). The StreamingImageFilter changes the
   // requested region as part of its normal processing.
   auto localInput = TInputImage::New();

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -172,7 +172,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->SetBufferedRegion(output->GetRequestedRegion());
   output->Allocate();
 
-  // Create an internal image to protect the input image's metdata
+  // Create an internal image to protect the input image's metadata
   // (e.g. RequestedRegion). The StreamingImageFilter changes the
   // requested region as part of its normal processing.
   auto localInput = TInputImage::New();

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkDiscreteGaussianImageFilterTest(int argc, char * argv[])
   array.Fill(0.04);
   filter->SetMaximumError(array.GetDataPointer());
 
-  // Set the value ofthe standard deviation of the Gaussian used for smoothing
+  // Set the value of the standard deviation of the Gaussian used for smoothing
   FilterType::SigmaArrayType::ValueType sigmaValue = 1.0;
   FilterType::SigmaArrayType            sigma;
   sigma.Fill(sigmaValue);

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -138,7 +138,7 @@ itkSmoothingRecursiveGaussianImageFilterTest(int argc, char * argv[])
   bool normalizeAcrossScale = std::stoi(argv[3]);
   ITK_TEST_SET_GET_BOOLEAN(filter, NormalizeAcrossScale, normalizeAcrossScale);
 
-  // Set the value ofthe standard deviation of the Gaussian used for smoothing
+  // Set the value of the standard deviation of the Gaussian used for smoothing
   SmoothingRecursiveGaussianImageFilterType::SigmaArrayType::ValueType sigmaValue = std::stod(argv[4]);
   SmoothingRecursiveGaussianImageFilterType::SigmaArrayType            sigma;
   sigma.Fill(sigmaValue);

--- a/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
@@ -29,7 +29,7 @@ itk.ImageFileReader.IUC2.New(FileName=argv[1])
 itk.MedianImageFilter.IUC2IUC2.New(Radius=eval(argv[3]))
 itk.CastImageFilter.IUC2IUC2.New()
 
-# stop the auto_pipeline and test that the next (imcompatible) filter is not
+# stop the auto_pipeline and test that the next (incompatible) filter is not
 # automatically connected, and restart the auto pipeline
 p.Stop()
 itk.CastImageFilter.IF2IF2.New()

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -218,7 +218,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   //
   // The "volatile" modifier is used here for preventing the variable from
   // being kept in 80 bit FPU registers when using 32-bit x86 processors with
-  // SSE instructions disabled. A case that arised in the Debian 32-bits
+  // SSE instructions disabled. A case that arose in the Debian 32-bits
   // distribution.
   //
 #ifndef ITK_COMPILER_SUPPORTS_SSE2_32
@@ -259,7 +259,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
     //
     // The "volatile" modifier is used here for preventing the variable from
     // being kept in 80 bit FPU registers when using 32-bit x86 processors with
-    // SSE instructions disabled. A case that arised in the Debian 32-bits
+    // SSE instructions disabled. A case that arose in the Debian 32-bits
     // distribution.
     //
 #ifndef ITK_COMPILER_SUPPORTS_SSE2_32


### PR DESCRIPTION
Found via `codespell -q 3 -S ./Modules/ThirdParty,./Documentation/ReleaseNotes -L ans,ba,boun,childrens,developpement,dum,fiter,inout,ist,nd,normaly,numer,ot,positionn,pullrequest,reson,serie,te,unser`

Signed-off-by: luz paz <luzpaz@github.com>

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
