### PR TITLE
ENH: Switch Azure Pipelines macOS environment version

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: macOS-10.15
+    vmImage: macos-11
   steps:
     - checkout: self
       clean: true

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: macOS-10.15
+    vmImage: macos-11
   steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
Switch Azure Pipelines macOS environment version to `macos-11`.

Fixes:
```
Warning
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead.
For more details see https://github.com/actions/virtual-environments/issues/5583
```

reported for example at:
https://dev.azure.com/itkrobotmacos/ITK.macOS/_build/results?buildId=8641&view=results

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)