### PR TITLE
ENH: Bump MinimalPathExtraction module to v1.2.2

### DIFF
--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(MinimalPathExtraction
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG v1.2.1
+  GIT_TAG v1.2.2
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(MinimalPathExtraction
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG 72ef4ad37a341f6c5f1b0fe1c10e454a27980309
+  GIT_TAG v1.2.1
   )


### PR DESCRIPTION
# What's Changed in v1.2.2
* BUG: It is .post2, not -post2, for ITK 5.3 rc4 in setup.py
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/94

# What's Changed in v1.2.1
* COMP: Remove inclusion of .hxx files as headers by @hjmjohnson in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/86
* COMP: Modules need updated version of ITK by @hjmjohnson in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/87
* BUG: Set FastMarching targets prior to reach mode by @aylward in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/90
* ENH: Bump ITK and replace http with https using script by @tbirdso in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/89
* ENH: Update Python package for itk-5.3rc4 by @thewtex in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/88
* ENH: Bump ITK to v5.3rc04(.post2) by @aylward in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/93

* @tbirdso made their first contribution in
* https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/pull/89

**Full Changelog**:
https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/compare/v1.2.0...v1.2.1
