### PR TITLE
ENH: Bump TubeTK to v1.3.1

### DIFF
--- a/Modules/Remote/TubeTK.remote.cmake
+++ b/Modules/Remote/TubeTK.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(TubeTK
   "http://www.tubetk.org"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTubeTK.git
-  GIT_TAG ac8ce8baee1dcabca5d32c3d42922aed458f8f79
+  GIT_TAG v1.3.1
   )


### PR DESCRIPTION
TubeTK has been updated to use
  - ITK5.3rc4.post2
  and
  - MinimalPathExtraction1.2.2