### PR TITLE
BUG: fixed memory leak in Nifti IO

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -2310,12 +2310,11 @@ NiftiImageIO ::Write(const void * buffer)
     this->m_NiftiImage->data = static_cast<void *>(nifti_buf);
     const int nifti_write_status = nifti_image_write_status(this->m_NiftiImage);
     this->m_NiftiImage->data = nullptr; // if left pointing to data buffer
+    delete[] nifti_buf;
     if (nifti_write_status)
     {
       itkExceptionMacro(<< "ERROR: nifti library failed to write image" << this->GetFileName());
     }
-
-    delete[] nifti_buf;
   }
 }
 


### PR DESCRIPTION
Should fix the small regression after
https://github.com/InsightSoftwareConsortium/ITK/commit/63590b85bbe5016ecb863a27007ce22979c27bc9


![Screenshot 2022-08-12 at 01-02-04 Insight Dynamic Analysis](https://user-images.githubusercontent.com/1494580/184257852-32267468-f3b3-4725-b9f6-db98a5f03f49.png)

https://open.cdash.org/viewDynamicAnalysisFile.php?id=9648918
https://open.cdash.org/viewDynamicAnalysisFile.php?id=9648919
https://open.cdash.org/viewDynamicAnalysisFile.php?id=9648921
https://open.cdash.org/viewDynamicAnalysisFile.php?id=9648923
https://open.cdash.org/viewDynamicAnalysisFile.php?id=9648924

CC   @hjmjohnson 




