### PR TITLE
ENH: Support reading a mesh of non-3D points from a .vtk PolyData file

### DIFF
--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -524,6 +524,8 @@ template <typename TOutputMesh, typename ConvertPointPixelTraits, typename Conve
 void
 MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::GenerateData()
 {
+  m_MeshIO->SetPointDimension(OutputPointDimension);
+
   typename TOutputMesh::Pointer output = this->GetOutput();
 
   // Test if the file exists and if it can be opened.

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -343,7 +343,6 @@ VTKPolyDataMeshIO ::ReadMeshInformation()
 
       // Get number of Points
       ss >> this->m_NumberOfPoints;
-      this->m_PointDimension = 3; // vtk only support 3 dimensional points
 
       // Get point component type
       StringType pointType;

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
@@ -33,6 +33,15 @@
 
 namespace
 {
+template <unsigned int VDimension>
+auto
+MakePointOfIncreasingCoordValues()
+{
+  itk::Point<float, VDimension> point;
+  std::iota(point.begin(), point.end(), 1.0f);
+  return point;
+}
+
 
 // Expects that VTKPolyDataMeshIO supports writing points, and then reading them back losslessly. (When a NaN coordinate
 // value is written, a NaN coordinate value is expected to be read back.)
@@ -160,5 +169,20 @@ TEST(VTKPolyDataMeshIO, SupportWriteAndReadOfNaNCoordValues)
       "VTKPolyDataMeshIOGTest_SupportWriteAndReadOfNaNCoordValues.vtk",
       { itk::MakeFilled<PointType>(std::numeric_limits<CoordRepType>::quiet_NaN()) },
       writeAsBinary);
+  }
+}
+
+
+// Tests that a mesh of any `PointDimension` > 1 is properly written and read back, not just 3D (the default).
+TEST(VTKPolyDataMeshIO, SupportsPointDimensionsGreaterThanOne)
+{
+  for (const bool writeAsBinary : { false, true })
+  {
+    Expect_lossless_writing_and_reading_of_points<itk::Mesh<int, 2>>(
+      "VTKPolyDataMeshIOGTest_Supports2D.vtk", { MakePointOfIncreasingCoordValues<2>() }, writeAsBinary);
+    Expect_lossless_writing_and_reading_of_points<itk::Mesh<int, 3>>(
+      "VTKPolyDataMeshIOGTest_Supports3D.vtk", { MakePointOfIncreasingCoordValues<3>() }, writeAsBinary);
+    Expect_lossless_writing_and_reading_of_points<itk::Mesh<int, 4>>(
+      "VTKPolyDataMeshIOGTest_Supports4D.vtk", { MakePointOfIncreasingCoordValues<4>() }, writeAsBinary);
   }
 }


### PR DESCRIPTION
`itk::MeshFileWriter` does allow writing non-3D points to a .vtk file, so it
appears both reasonable and useful for `itk::MeshFileReader` to allow reading
those points back.

Implemented by setting the PointDimension within MeshFileReader::GenerateData(),
and tested by GTest `VTKPolyDataMeshIO.SupportsAnyPointDimensionGreaterThanZero`.

Related to issue https://github.com/slicersalt/ITKShape/issues/8 "Add 2D mesh support" by Matt McCormick (@thewtex).
