### PR TITLE
ENH: Enable building HL library for the bundled HDF5

### DIFF
--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -41,23 +41,23 @@ endif()
 
   if(BUILD_SHARED_LIBS)
     if (TARGET hdf5-shared)
-      set(ITKHDF5_LIBRARIES hdf5_cpp-shared hdf5-shared)
+      set(ITKHDF5_LIBRARIES hdf5_cpp-shared hdf5-shared hdf5_hl-shared)
     elseif(TARGET hdf5::hdf5-shared)
-      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp-shared hdf5::hdf5-shared)
+      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp-shared hdf5::hdf5-shared hdf5::hdf5_hl-shared)
     elseif(TARGET hdf5::hdf5)
-      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp hdf5::hdf5)
+      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp hdf5::hdf5 hdf5::hdf5_hl)
     else()
-      set(ITKHDF5_LIBRARIES ${HDF5_C_SHARED_LIBRARY} ${HDF5_CXX_SHARED_LIBRARY} ${HDF5_CXX_LIBRARY_NAMES} ${HDF5_LIBRARIES})
+      set(ITKHDF5_LIBRARIES ${HDF5_C_SHARED_LIBRARY} ${HDF5_CXX_SHARED_LIBRARY} ${HDF5_CXX_LIBRARY_NAMES} ${HDF5_HL_SHARED_LIBRARY} ${HDF5_LIBRARIES})
     endif()
   else()
     if (TARGET hdf5-static)
-      set(ITKHDF5_LIBRARIES hdf5_cpp-static hdf5-static)
+      set(ITKHDF5_LIBRARIES hdf5_cpp-static hdf5-static hdf5_hl-static)
     elseif(TARGET hdf5::hdf5-static)
-      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp-static hdf5::hdf5-static)
+      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp-static hdf5::hdf5-static hdf5::hdf5_hl-static)
     elseif(TARGET hdf5::hdf5)
-      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp hdf5::hdf5)
+      set(ITKHDF5_LIBRARIES hdf5::hdf5_cpp hdf5::hdf5 hdf5::hdf5_hl)
     else()
-      set(ITKHDF5_LIBRARIES ${HDF5_C_STATIC_LIBRARY} ${HDF5_CXX_STATIC_LIBRARY} ${HDF5_CXX_LIBRARY_NAMES} ${HDF5_LIBRARIES})
+      set(ITKHDF5_LIBRARIES ${HDF5_C_STATIC_LIBRARY} ${HDF5_CXX_STATIC_LIBRARY} ${HDF5_CXX_LIBRARY_NAMES} ${HDF5_HL_STATIC_LIBRARY} ${HDF5_LIBRARIES})
     endif()
   endif()
 
@@ -66,7 +66,7 @@ endif()
   )
   set(ITKHDF5_SYSTEM_INCLUDE_DIRS
     ${HDF5_INCLUDE_DIR}
-    ${HDF5_INCLUDE_DIR_CPP}
+    ${HDF5_INCLUDE_DIR_HL}
     ${HDF5_INCLUDE_DIRS}
     ${HDF5_INCLUDE_DIR_CPP}
     )
@@ -75,12 +75,16 @@ endif()
 else()
   set(ITKHDF5_INCLUDE_DIRS
     ${ITKHDF5_SOURCE_DIR}/src
+    ${ITKHDF5_SOURCE_DIR}/src/itkhdf5/src
+    ${ITKHDF5_SOURCE_DIR}/src/itkhdf5/hl/src
     ${ITKHDF5_BINARY_DIR}/src
+    ${ITKHDF5_BINARY_DIR}/src/itkhdf5/src
+    ${ITKHDF5_BINARY_DIR}/src/itkhdf5/hl/src
     )
   if(BUILD_SHARED_LIBS)
-    set(ITKHDF5_LIBRARIES hdf5_cpp-shared hdf5-shared)
+    set(ITKHDF5_LIBRARIES hdf5_cpp-shared hdf5-shared hdf5_hl-shared)
   else()
-    set(ITKHDF5_LIBRARIES hdf5_cpp-static hdf5-static)
+    set(ITKHDF5_LIBRARIES hdf5_cpp-static hdf5-static hdf5_hl-static)
   endif()
 endif()
 

--- a/Modules/ThirdParty/HDF5/src/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(HDF5_INSTALL_INCLUDE_DIR ${ITKHDF5_INSTALL_INCLUDE_DIR}/itkhdf5)
 # Configure HDF5 privately so its options do not appear to the user.
 set(HDF5_ALLOW_EXTERNAL_SUPPORT OFF CACHE INTERNAL "Allow External Library Building")
 set(HDF5_BUILD_CPP_LIB ON CACHE INTERNAL "Build HDF5 C++ Library")
-set(HDF5_BUILD_HL_LIB OFF CACHE INTERNAL "Build HIGH Level HDF5 Library")
+set(HDF5_BUILD_HL_LIB ON CACHE INTERNAL "Build High Level HDF5 Library")
 set(HDF5_DISABLE_COMPILER_WARNINGS OFF CACHE INTERNAL "Disable HDF5 warnings")
 set(HDF5_ENABLE_CODESTACK OFF CACHE INTERNAL "Enable the function stack tracing (for developer debugging).")
 set(HDF5_ENABLE_COVERAGE OFF CACHE INTERNAL "Enable code coverage for Libraries and Programs")
@@ -101,6 +101,7 @@ endif()
 foreach(lib
     hdf5
     hdf5_cpp
+    hdf5_hl
     )
   itk_module_target(${lib}${target_extension} NO_INSTALL)
 endforeach()


### PR DESCRIPTION
This is needed by netCDF, which is needed for Zarr support.
