### PR TITLE
ENH: Switch Azure Pipelines Linux environment version

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   steps:
     - checkout: self
       clean: true
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y python3-venv
         sudo python3 -m pip install --upgrade setuptools
-        sudo python3 -m pip install scikit-ci-addons
+        sudo python3 -m pip install lxml scikit-ci-addons
       displayName: 'Install dependencies'
 
     - bash: |
@@ -85,7 +85,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   steps:
     - checkout: self
       clean: true
@@ -103,7 +103,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y python3-venv
         sudo python3 -m pip install --upgrade setuptools
-        sudo python3 -m pip install scikit-ci-addons
+        sudo python3 -m pip install lxml scikit-ci-addons
       displayName: 'Install dependencies'
 
     - bash: |

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
Switch Azure Pipelines Linux environment version to `ubuntu-20.04`.

Fixes:
```
Warning
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest),
or ubuntu-22.04 instead.
For more details see https://github.com/actions/virtual-environments/issues/6002
```

reported for example at:
https://dev.azure.com/itkrobotlinux/ITK.Linux/_build/results?buildId=8765&view=results

Install the `lxml` Python package. Fixes:
```
/usr/bin/bash --noprofile --norc /home/vsts/work/_temp/5d2d781b-9e71-4c0a-ab4d-2837ae79d6f9.sh
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/anyci/ctest_junit_formatter.py", line 4, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```

reported for example at:
https://dev.azure.com/itkrobotlinux/ITK.Linux/_build/results?buildId=8794&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=5494183b-801e-5084-3b4b-5451c6a14ee1&l=17

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)