### PR TITLE
ENH: Add MetaDataObject Python wrapping with Matrix

### DIFF
--- a/Modules/Core/Common/wrapping/itkMetaDataObject.wrap
+++ b/Modules/Core/Common/wrapping/itkMetaDataObject.wrap
@@ -1,5 +1,6 @@
 itk_wrap_include("itkArray.h")
 itk_wrap_include("<vector>")
+itk_wrap_include("itkMatrix.h")
 
 itk_wrap_class("itk::MetaDataObject" POINTER)
   itk_wrap_template("D" "double")
@@ -17,4 +18,6 @@ itk_wrap_class("itk::MetaDataObject" POINTER)
   itk_wrap_template("vectorD" "std::vector< double >")
   itk_wrap_template("vectorvectorF" "std::vector< std::vector< float > >")
   itk_wrap_template("vectorvectorD" "std::vector< std::vector< double > >")
+  itk_wrap_template("matrixD33" "itk::Matrix< double, 3, 3 >")
+  itk_wrap_template("matrixF44" "itk::Matrix< float, 4, 4 >")
 itk_end_wrap_class()

--- a/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
@@ -30,4 +30,9 @@ md["double"] = 10.0
 print(md["double"])
 
 # Required for "NRRD_measurement frame"
-itk.MetaDataObject[itk.vector[itk.vector[itk.D]]].New()
+md1 = itk.MetaDataObject[itk.vector[itk.vector[itk.D]]].New()
+print(md1)
+
+# Required for "qto_xyz" metadata
+md2 = itk.MetaDataObject[itk.Matrix[itk.F, 4, 4]].New()
+print(md2)


### PR DESCRIPTION
Needed to convert image to xarray. Dict method on image fails without these wrappings.

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
