### PR TITLE
Fix exception message

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -107,8 +107,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   const ReferenceImageBaseType * const referenceImage = this->GetReferenceImage();
   if (this->m_Size[0] == 0 && referenceImage && !m_UseReferenceImage)
   {
-    itkExceptionMacro("Output image size is zero in all dimensions.  Consider using SetUseReferenceImageOn()."
-                      "to define the resample output from the ReferenceImage.");
+    itkExceptionMacro("Output image size is zero in all dimensions.  Consider using UseReferenceImageOn()."
+                      "or SetUseReferenceImage(true) to define the resample output from the ReferenceImage.");
   }
 }
 


### PR DESCRIPTION
    The suggested member function does not exist.  Use one of the two
    available member functions to suggest the correct behavior for
    using the reference image information.