### PR TITLE
COMP: Missing "\ingroup ITKMesh" doxygen setting

### DIFF
--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
@@ -36,18 +36,10 @@
 
 namespace itk
 {
-/**  \class TriangleMeshCurvatureCalculator
- * \brief
- * Calculator to compute curvature of a triangle mesh. Set the input triangle mesh and the
- * required curvature type first. Default curvature type is Gauss. After computing curvature the result
- * can be obtained using the getter method. It throws exception if the input mesh is not set.
- * The implementation is the same as in VTK.
- * \ingroup ITKMesh
- */
-
 /** \class TriangleMeshCurvatureCalculatorEnum
  * \brief Different modes of operation. Currently only Gaussian curvature is supported.
  * Using enum for future extension to Mean, Max and Min curvature.
+ * \ingroup ITKMesh
  */
 class TriangleMeshCurvatureCalculatorEnums
 {
@@ -64,6 +56,14 @@ public:
 extern ITKMesh_EXPORT std::ostream &
                       operator<<(std::ostream & out, const TriangleMeshCurvatureCalculatorEnums::Curvatures value);
 
+/**  \class TriangleMeshCurvatureCalculator
+ * \brief
+ * Calculator to compute curvature of a triangle mesh. Set the input triangle mesh and the
+ * required curvature type first. Default curvature type is Gauss. After computing curvature the result
+ * can be obtained using the getter method. It throws exception if the input mesh is not set.
+ * The implementation is the same as in VTK.
+ * \ingroup ITKMesh
+ */
 template <typename TInputMesh>
 class ITK_TEMPLATE_EXPORT TriangleMeshCurvatureCalculator : public Object
 {


### PR DESCRIPTION
"\ingroup ITKMesh" not set in class TriangleMeshCurvatureCalculatorEnum.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
