### PR TITLE
COMP: Suppress uninitialed variable warning

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -211,7 +211,7 @@ private:
   void
   TransformOutputPixel(ImageRegionIterator<T> & it)
   {
-    OutputPixelType         correctedGradient;
+    OutputPixelType         correctedGradient{};
     const OutputPixelType & gradient = it.Get();
 
     const unsigned int nComponents = NumericTraits<OutputPixelType>::GetLength(gradient) / ImageDimension;


### PR DESCRIPTION
ITK/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx: In member function ‘GenerateData’:
ITK/Modules/Core/Common/include/itkDefaultPixelAccessor.h:72:5: warning: ‘MEM[(const struct CovariantVector &)&correctedGradient + 12]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   72 |     output = input;
      |     ^
ITK/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h:214:29: note: ‘MEM[(const struct CovariantVector &)&correctedGradient + 12]’ was declared here
  214 |     OutputPixelType         correctedGradient;
      |                             ^

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
