### PR TITLE
STYLE: Declare Ellipsoid SpatialFunction orientations as a fixed matrix

### DIFF
--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.h
@@ -82,7 +82,7 @@ public:
 
 protected:
   EllipsoidInteriorExteriorSpatialFunction();
-  ~EllipsoidInteriorExteriorSpatialFunction() override;
+  ~EllipsoidInteriorExteriorSpatialFunction() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -95,7 +95,7 @@ private:
   InputType m_Axes;
 
   /** The orientation vectors (must be orthogonal) of the ellipsoid axes. */
-  double ** m_Orientations;
+  OrientationType m_Orientations{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -25,24 +25,8 @@ namespace itk
 template <unsigned int VDimension, typename TInput>
 EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::EllipsoidInteriorExteriorSpatialFunction()
 {
-  m_Orientations = nullptr;
   m_Axes.Fill(1.0f);   // Lengths of ellipsoid axes.
   m_Center.Fill(0.0f); // Origin of ellipsoid
-}
-
-template <unsigned int VDimension, typename TInput>
-EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::~EllipsoidInteriorExteriorSpatialFunction()
-{
-  unsigned int i;
-
-  if (m_Orientations)
-  {
-    for (i = 0; i < VDimension; ++i)
-    {
-      delete[] m_Orientations[i];
-    }
-    delete[] m_Orientations;
-  }
 }
 
 template <unsigned int VDimension, typename TInput>
@@ -84,31 +68,8 @@ template <unsigned int VDimension, typename TInput>
 void
 EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::SetOrientations(const OrientationType & orientations)
 {
-  unsigned int i, j;
-
-  // Initialize orientation vectors.
-  if (m_Orientations)
-  {
-    for (i = 0; i < VDimension; ++i)
-    {
-      delete[] m_Orientations[i];
-    }
-    delete[] m_Orientations;
-  }
-  m_Orientations = new double *[VDimension];
-  for (i = 0; i < VDimension; ++i)
-  {
-    m_Orientations[i] = new double[VDimension];
-  }
-
   // Set orientation vectors (must be orthogonal).
-  for (i = 0; i < VDimension; ++i)
-  {
-    for (j = 0; j < VDimension; ++j)
-    {
-      m_Orientations[i][j] = orientations[i][j];
-    }
-  }
+  m_Orientations = orientations;
 }
 
 template <unsigned int VDimension, typename TInput>
@@ -121,17 +82,14 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ost
 
   os << indent << "Lengths of Ellipsoid Axes: " << m_Axes << std::endl;
   os << indent << "Origin of Ellipsoid: " << m_Center << std::endl;
-  if (m_Orientations)
+  os << indent << "Orientations: " << std::endl;
+  for (i = 0; i < VDimension; ++i)
   {
-    os << indent << "Orientations: " << std::endl;
-    for (i = 0; i < VDimension; ++i)
+    for (j = 0; j < VDimension; ++j)
     {
-      for (j = 0; j < VDimension; ++j)
-      {
-        os << indent << indent << m_Orientations[i][j] << " ";
-      }
-      os << std::endl;
+      os << indent << indent << m_Orientations[i][j] << " ";
     }
+    os << std::endl;
   }
 }
 } // end namespace itk


### PR DESCRIPTION
Declared the private (internal) EllipsoidInteriorExteriorSpatialFunction data
member `m_Orientations` as a `vnl_matrix_fixed`, instead of a raw pointer to
dynamically allocated memory.

Defaulted the `EllipsoidInteriorExteriorSpatialFunction` destructor, as it now
no longer needs to `delete` internal data pointers anymore.

Following C++ Core Guidelines, April 10, 2022, "Prefer scoped objects, don’t
heap-allocate unnecessarily",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily