### PR TITLE
STYLE: Declare WindowedSincInterpolateImageFunction data as fixed arrays

### DIFF
--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -21,6 +21,7 @@
 #include "itkConstNeighborhoodIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkInterpolateImageFunction.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -326,8 +327,8 @@ public:
   }
 
 protected:
-  WindowedSincInterpolateImageFunction();
-  ~WindowedSincInterpolateImageFunction() override;
+  WindowedSincInterpolateImageFunction() = default;
+  ~WindowedSincInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -336,20 +337,20 @@ private:
   using IteratorType = ConstNeighborhoodIterator<ImageType, TBoundaryCondition>;
 
   // Constant to store twice the radius
-  static const unsigned int m_WindowSize;
+  static constexpr unsigned int m_WindowSize{ 2 * VRadius };
 
   /** The function object, used to compute window */
   TWindowFunction m_WindowFunction;
 
+  /** Size of the offset table */
+  static constexpr unsigned int m_OffsetTableSize{ Math::UnsignedPower(m_WindowSize, ImageDimension) };
+
   /** The offset array, used to keep a list of relevant
    * offsets in the neihborhoodIterator */
-  unsigned int * m_OffsetTable;
-
-  /** Size of the offset table */
-  unsigned int m_OffsetTableSize;
+  unsigned int m_OffsetTable[m_OffsetTableSize];
 
   /** Index into the weights array for each offset */
-  unsigned int ** m_WeightOffsetTable;
+  unsigned int m_WeightOffsetTable[m_OffsetTableSize][ImageDimension];
 
   /** The sinc function */
   inline double

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -45,62 +45,6 @@ template <unsigned int VRadius, typename TInput, typename TOutput>
 const double BlackmanWindowFunction<VRadius, TInput, TOutput>::m_Factor2 = 2.0 * itk::Math::pi / VRadius;
 } // end namespace Function
 
-/** Window size constant */
-template <typename TInputImage,
-          unsigned int VRadius,
-          typename TWindowFunction,
-          typename TBoundaryCondition,
-          typename TCoordRep>
-const unsigned int
-  WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
-    m_WindowSize = VRadius << 1;
-
-/** Constructor */
-template <typename TInputImage,
-          unsigned int VRadius,
-          typename TWindowFunction,
-          typename TBoundaryCondition,
-          typename TCoordRep>
-WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
-  WindowedSincInterpolateImageFunction()
-{
-  // Compute the offset table size
-  m_OffsetTableSize = 1;
-  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
-  {
-    m_OffsetTableSize *= m_WindowSize;
-  }
-
-  // Allocate the offset table
-  m_OffsetTable = new unsigned int[m_OffsetTableSize];
-
-  // Allocate the weights tables
-  m_WeightOffsetTable = new unsigned int *[m_OffsetTableSize];
-  for (unsigned int i = 0; i < m_OffsetTableSize; ++i)
-  {
-    m_WeightOffsetTable[i] = new unsigned int[ImageDimension];
-  }
-}
-
-/** Destructor */
-template <typename TInputImage,
-          unsigned int VRadius,
-          typename TWindowFunction,
-          typename TBoundaryCondition,
-          typename TCoordRep>
-WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
-  ~WindowedSincInterpolateImageFunction()
-{
-  // Clear the offset table
-  delete[] m_OffsetTable;
-
-  // Clear the weights tables
-  for (unsigned int i = 0; i < m_OffsetTableSize; ++i)
-  {
-    delete[] m_WeightOffsetTable[i];
-  }
-  delete[] m_WeightOffsetTable;
-}
 
 template <typename TInputImage,
           unsigned int VRadius,


### PR DESCRIPTION
Declared the private (internal) WindowedSincInterpolateImageFunction data
members `m_WeightOffsetTable` and `m_WeightOffsetTable` as fixed-size C-style
arrays, instead of raw pointers to dynamically allocated memory.

Declared the private data members `m_WindowSize` and `m_OffsetTableSize` both
`static constexpr`, to ensure compile-time evaluation.

Defaulted the default-constructor and destructor of
`WindowedSincInterpolateImageFunction`, as they now no longer need to
explicitly manage the internal data.

Following C++ Core Guidelines, April 10, 2022, "Prefer scoped objects, don’t
heap-allocate unnecessarily",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily

Somewhat similar to pull request #3564 "STYLE: Declare Ellipsoid SpatialFunction orientations as a fixed matrix"