### PR TITLE
STYLE: Use `unique_ptr` for `OrthogonalSwath2DPathFilter` data members

### DIFF
--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
@@ -21,6 +21,8 @@
 #include "itkPathAndImageToPathFilter.h"
 #include "itkOrthogonallyCorrected2DParametricPath.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 /**
@@ -87,8 +89,8 @@ public:
   using SizeType = typename ImageType::SizeType;
 
 protected:
-  OrthogonalSwath2DPathFilter();
-  ~OrthogonalSwath2DPathFilter() override;
+  OrthogonalSwath2DPathFilter() = default;
+  ~OrthogonalSwath2DPathFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -131,16 +133,16 @@ private:
     return m_MeritValues[(x * rows * rows) + (f * rows) + (l)];
   }
 
-  int * m_StepValues; // best y=error coordinate @ x of image for (0,F) ->
-                      // (x+1,L)
-  double * m_MeritValues;
+  std::unique_ptr<int[]> m_StepValues{ nullptr }; // best y=error coordinate @ x of image for (0,F) ->
+                                                  // (x+1,L)
+  std::unique_ptr<double[]> m_MeritValues{ nullptr };
 
-  int * m_OptimumStepsValues; // best step (e value)
-                              // sequence for a
-                              // closed path
-  OrthogonalCorrectionTablePointer m_FinalOffsetValues;
+  std::unique_ptr<int[]> m_OptimumStepsValues{ nullptr }; // best step (e value)
+                                                          // sequence for a
+                                                          // closed path
+  OrthogonalCorrectionTablePointer m_FinalOffsetValues{ OrthogonalCorrectionTableType::New() };
 
-  SizeType m_SwathSize;
+  SizeType m_SwathSize{ { 0 } };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -23,34 +23,6 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
-template <typename TParametricPath, typename TSwathMeritImage>
-OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::OrthogonalSwath2DPathFilter()
-{
-  SizeType size;
-
-  // Initialize the member variables
-  size[0] = 0;
-  size[1] = 0;
-  m_SwathSize = size;
-  m_StepValues = nullptr;
-  m_MeritValues = nullptr;
-  m_OptimumStepsValues = nullptr;
-  m_FinalOffsetValues = OrthogonalCorrectionTableType::New();
-}
-
-/**
- * Destructor
- */
-template <typename TParametricPath, typename TSwathMeritImage>
-OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::~OrthogonalSwath2DPathFilter()
-{
-  delete[] m_StepValues;
-  delete[] m_MeritValues;
-  delete[] m_OptimumStepsValues;
-}
 
 /**
  * GenerateData Performs the reflection
@@ -64,12 +36,9 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
 
   // Re-initialize the member variables
   m_SwathSize = swathMeritImage->GetLargestPossibleRegion().GetSize();
-  delete[] m_StepValues;
-  delete[] m_MeritValues;
-  delete[] m_OptimumStepsValues;
-  m_StepValues = new int[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]];
-  m_MeritValues = new double[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]];
-  m_OptimumStepsValues = new int[m_SwathSize[0]];
+  m_StepValues.reset(new int[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]]);
+  m_MeritValues.reset(new double[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]]);
+  m_OptimumStepsValues.reset(new int[m_SwathSize[0]]);
   m_FinalOffsetValues->Initialize();
 
   // Perform the remaining calculations; use dynamic programming
@@ -196,9 +165,9 @@ void
 OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "StepValues:  " << m_StepValues << std::endl;
-  os << indent << "MeritValues:  " << m_MeritValues << std::endl;
-  os << indent << "OptimumStepsValues:  " << m_OptimumStepsValues << std::endl;
+  os << indent << "StepValues:  " << m_StepValues.get() << std::endl;
+  os << indent << "MeritValues:  " << m_MeritValues.get() << std::endl;
+  os << indent << "OptimumStepsValues:  " << m_OptimumStepsValues.get() << std::endl;
   os << indent << "FinalOffsetValues:  " << m_FinalOffsetValues << std::endl;
 }
 


### PR DESCRIPTION
Also "defaulted" both its default-constructor and its destructor. Made use of
modern C++ in-class data member initialization.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2897
commit 3c6f2984df2085f3465edd0c941ab222834fccca
"STYLE: Use `unique_ptr` for `ImageToImageMetric` data members"