### PR TITLE
STYLE: Declare `NormalVariateGenerator::m_Vec1` as fixed array

### DIFF
--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -142,17 +142,19 @@ private:
   double m_Scale;
   double m_Rscale;
   double m_Rcons;
-  int    m_ELEN;
-  int    m_LEN;
-  int    m_LMASK;
-  int    m_TLEN;
+
+  static constexpr int m_ELEN{ 7 };
+  // LEN must be 2 ** ELEN
+  static constexpr int m_LEN{ 128 };
+  static constexpr int m_LMASK{ 4 * (m_LEN - 1) };
+  static constexpr int m_TLEN{ 8 * m_LEN };
 
   int   m_Gaussfaze;
   int * m_Gausssave;
 
   double m_GScale;
 
-  int *  m_Vec1;
+  int    m_Vec1[m_TLEN];
   int    m_Nslew;
   int    m_Irs;
   int    m_Lseed;

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -28,20 +28,12 @@ NormalVariateGenerator::NormalVariateGenerator()
   m_Scale = 30000000.0;
   m_Rscale = 1.0 / m_Scale;
   m_Rcons = 1.0 / (2.0 * 1024.0 * 1024.0 * 1024.0);
-  m_ELEN = 7; /*  LEN must be 2 ** ELEN       */
-  m_LEN = 128;
-  m_LMASK = (4 * (m_LEN - 1));
-  m_TLEN = (8 * m_LEN);
-  m_Vec1 = new int[m_TLEN];
 
   m_Gausssave = nullptr;
   this->Initialize(0);
 }
 
-NormalVariateGenerator::~NormalVariateGenerator()
-{
-  delete[] m_Vec1;
-}
+NormalVariateGenerator::~NormalVariateGenerator() = default;
 
 void
 NormalVariateGenerator::PrintSelf(std::ostream & os, Indent indent) const


### PR DESCRIPTION
Declared the private (internal) NormalVariateGenerator data member `m_Vec1` as
a fixed-size C-style array, instead of a raw pointer to dynamically allocated
memory.

Declared the private data members `m_ELEN`, `m_LEN`, `m_LMASK`, and `m_TLEN`
`static constexpr`, to ensure compile-time evaluation.

Defaulted the destructor of `NormalVariateGenerator`.

Following C++ Core Guidelines, April 10, 2022, "Prefer scoped objects, don’t
heap-allocate unnecessarily",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily