### PR TITLE
BUG: Add GitHub Action permissions for the labeller

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
     - uses: srvaroa/labeler@v0.8


### PR DESCRIPTION
Attempt to enable the pull request labeler to work on forked pull
requests.

Background:

- https://github.com/actions/labeler/issues/12
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
