### PR TITLE
BUG: Add permissions to apply clang format action

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   clang-format:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          fetch-depth: 0
     - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master


### PR DESCRIPTION
Attempt to enable the pull request clang format action to work on forked pull
requests.

Background:

- https://github.com/actions/labeler/issues/12
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

