### PR TITLE
STYLE: Replace pointers initialized by `new T[N]` with fixed arrays

### DIFF
--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -65,7 +65,7 @@ itkVariableLengthVectorTest(int, char *[])
   }
 
   {
-    auto * d = new double[3];
+    double d[3];
     d[0] = 0.1;
     d[1] = 0.2;
     d[2] = 0.3;
@@ -283,8 +283,6 @@ itkVariableLengthVectorTest(int, char *[])
       //    x.FastAssign(ref4);
       // is an invalid instruction: Indeed FastAssign preconditions are not met.
     }
-
-    delete[] d;
   }
 
 

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -92,15 +92,13 @@ MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
 
     pnt.SetPositionInObjectSpace(point);
 
-    auto * tensor = new float[6];
+    float tensor[6];
 
     for (unsigned int ii = 0; ii < 6; ++ii)
     {
       tensor[ii] = (*it2)->m_TensorMatrix[ii];
     }
     pnt.SetTensorMatrix(tensor);
-
-    delete[] tensor;
 
     // This attribute is optional
     if (Math::NotExactlyEquals((*it2)->GetField("r"), -1))

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -73,7 +73,7 @@ MetaEllipseConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
 
   auto * ellipseMO = new EllipseMetaObjectType(VDimension);
 
-  auto * radii = new float[VDimension];
+  float radii[VDimension];
 
   for (unsigned int i = 0; i < VDimension; ++i)
   {
@@ -92,7 +92,6 @@ MetaEllipseConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
                    ellipseSO->GetProperty().GetBlue(),
                    ellipseSO->GetProperty().GetAlpha());
 
-  delete[] radii;
   return ellipseMO;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -258,13 +258,12 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
 
   metaScene->BinaryData(m_BinaryPoints);
 
-  auto * spacing = new float[VDimension];
+  float spacing[VDimension];
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     spacing[i] = 1;
   }
   metaScene->ElementSpacing(spacing);
-  delete[] spacing;
 
   using ListType = typename SpatialObjectType::ChildrenConstListType;
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -86,7 +86,7 @@ itkSpatialObjectDuplicatorTest(int, char *[])
     p.AddField("Lambda1", 4 * i);
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
-    auto * v = new float[6];
+    float v[6];
     // this is only for testing
     // the tensor matrix should be definite positive
     // in the real case
@@ -95,7 +95,6 @@ itkSpatialObjectDuplicatorTest(int, char *[])
       v[k] = k;
     }
     p.SetTensorMatrix(v);
-    delete[] v;
     list3.push_back(p);
   }
 

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -98,11 +98,10 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft_c2r(2, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -116,12 +115,11 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft_c2r(3, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -199,11 +197,10 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft_r2c(2, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -217,12 +214,11 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft_r2c(3, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -302,11 +298,10 @@ public:
               int           threads = 1,
               bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft(2, sizes, in, out, sign, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -321,12 +316,11 @@ public:
               int           threads = 1,
               bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft(3, sizes, in, out, sign, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -440,11 +434,10 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft_c2r(2, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -458,12 +451,11 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft_c2r(3, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -541,11 +533,10 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft_r2c(2, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -559,12 +550,11 @@ public:
                   int           threads = 1,
                   bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft_r2c(3, sizes, in, out, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -643,11 +633,10 @@ public:
               int           threads = 1,
               bool          canDestroyInput = false)
   {
-    auto * sizes = new int[2];
+    int sizes[2];
     sizes[0] = nx;
     sizes[1] = ny;
     PlanType plan = Plan_dft(2, sizes, in, out, sign, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 
@@ -662,12 +651,11 @@ public:
               int           threads = 1,
               bool          canDestroyInput = false)
   {
-    auto * sizes = new int[3];
+    int sizes[3];
     sizes[0] = nx;
     sizes[1] = ny;
     sizes[2] = nz;
     PlanType plan = Plan_dft(3, sizes, in, out, sign, flags, threads, canDestroyInput);
-    delete[] sizes;
     return plan;
   }
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -107,7 +107,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
 
   // Steps is used to keep track of the order in which the line
   // iterator passes over the various dimensions.
-  auto * Steps = new int[ImageDimension];
+  int Steps[ImageDimension];
 
   for (i = 0; i < ImageDimension; ++i)
   {
@@ -170,7 +170,6 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
     }
     progress.Completed(outputRegionForThread.GetSize()[0]);
   }
-  delete[] Steps;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel, typename THistogram>

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -197,7 +197,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
 
   // Steps is used to keep track of the order in which the line
   // iterator passes over the various dimensions.
-  auto * Steps = new int[ImageDimension];
+  int Steps[ImageDimension];
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -277,7 +277,6 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
       }
     }
   }
-  delete[] Steps;
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage, typename TKernel, typename THistogram>

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -119,7 +119,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     p.AddField("Lambda1", 4 * i);
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
-    auto * v = new float[6];
+    float v[6];
     // this is only for testing
     // the tensor matrix should be definite positive
     // in the real case
@@ -128,7 +128,6 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
       v[k] = k;
     }
     p.SetTensorMatrix(v);
-    delete[] v;
     list3.push_back(p);
   }
 


### PR DESCRIPTION
Changed the type of local variables that were declared as pointer and
initialized by `new T[N]`, to the corresponding fixed size C-style array type,
`T[N]`. Removed the corresponding `delete []` statements.

Cases found by the following regular expressions:

    new \w+\[\d\]
    new \w+\[V\w+\]
    new \w+\[\w*Dimension\]

Aims to increase code readability, and may (possibly) improve the run-time
performance.

Following C++ Core Guidelines, April 10, 2022, "Prefer scoped objects, don’t
heap-allocate unnecessarily",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily