### PR TITLE
ENH: Update remote modules using the script

### DIFF
--- a/Modules/Remote/AdaptiveDenoising.remote.cmake
+++ b/Modules/Remote/AdaptiveDenoising.remote.cmake
@@ -56,5 +56,5 @@ itk_fetch_module(AdaptiveDenoising
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/ntustison/ITKAdaptiveDenoising.git
-  GIT_TAG 674218fae611184d4168bd0c7b027f1a0d1a8a18
+  GIT_TAG 24825c8d246e941334f47968553f0ae388851f0c
 )

--- a/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(AnalyzeObjectLabelMap
   "AnalyzeObjectLabelMap plugin for ITK. From Insight Journal article with handle: https://www.insight-journal.org/browse/publication/178"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG 6501909759a0de4ba99905d0f8e36005150f444a
+  GIT_TAG e6a8291f6066c4f0e732d422c3cdb0a5644f2ce6
   )

--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -63,5 +63,5 @@ itk_fetch_module(AnisotropicDiffusionLBR
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG 66a74d2fc9584ff22a42b4beacb0dd9bc9e71d23
+  GIT_TAG d46aab0e0c8f02b89eaa0420e61970559177683f
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(BSplineGradient
   "Approximate an image's gradient from a b-spline fit to its intensity."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG ba1417c320c75ba0987e8a6cb12d9bb8a3f47365
+  GIT_TAG f5d1205837509e962afe853ec3e31e25bfb0feab
 )

--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -48,5 +48,5 @@ It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG 4cef62a2f426df1784cd4984e18f31c005b4c71c
+  GIT_TAG 5a6ee6c0cef727d8a6c39b3333af0fced0611dee
   )

--- a/Modules/Remote/BoneEnhancement.remote.cmake
+++ b/Modules/Remote/BoneEnhancement.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(BoneEnhancement
   "Various filters for enhancing cortical bones in quantitative computed tomography."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBoneEnhancement.git
-  GIT_TAG 68e550f7ba8dd6bc467d3d86aac463302b22dffd
+  GIT_TAG 658b9cb31f7216f604dfd35b187bd1ae80fd7506
 )

--- a/Modules/Remote/BoneMorphometry.remote.cmake
+++ b/Modules/Remote/BoneMorphometry.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(BoneMorphometry
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
-  GIT_TAG 391e5bcc5c57209447bf5b2f3a77ba59d3edfe57
+  GIT_TAG e68bd5b9274d448f0888acef5abf5ccdeb27b3b8
 )

--- a/Modules/Remote/Cleaver.remote.cmake
+++ b/Modules/Remote/Cleaver.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(Cleaver
   "ITK module wrapping Cleaver functionalities used for MultiMaterial Tetrahedral Meshing."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SCIInstitute/ITKCleaver.git
-  GIT_TAG b1cec7c0d4a90927c051d61d20d623cf0f587ad5
+  GIT_TAG a12f62a7f7f5329525f1ab0b22823bb8aa8a2df0
   )

--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -68,5 +68,5 @@ And the related:
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 6b0961120ec8aa03153ecab034d2f4dd192ef190
+  GIT_TAG 3e049175b5a8a60015451b9c34198cb410f17004
   )

--- a/Modules/Remote/CudaCommon.remote.cmake
+++ b/Modules/Remote/CudaCommon.remote.cmake
@@ -41,5 +41,5 @@ itk_fetch_module(CudaCommon
   "Framework for processing images with Cuda."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/ITKCudaCommon.git
-  GIT_TAG 2999fc30f6a8acfe8c94e9e79318a1a68439324e
+  GIT_TAG 4745a97e07496e214c1ee10ec278dcae56b010b4
 )

--- a/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
+++ b/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(FixedPointInverseDisplacementField
   "Computes the inverse of a displacement field."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField.git
-  GIT_TAG b540bb41bc01313396093dfb078b1a74187d5cc9
+  GIT_TAG e38e8a3c5af0ffc6ee208e44b805b817d9836ab2
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(GenericLabelInterpolator
   "A generic interpolator for multi-label images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG d804834d5af635241cb92ab0ef2197d6e4f4e50c
+  GIT_TAG 2f3768110ffe160c00c533a1450a49a16f4452d9
   )

--- a/Modules/Remote/GrowCut.remote.cmake
+++ b/Modules/Remote/GrowCut.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(GrowCut
 "ITKGrowCut segments a 3D image from user-provided foreground and background seeds."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKGrowCut.git
-  GIT_TAG 7e9959f46bf40fe23d9ae30364055ae29e6059d0
+  GIT_TAG 21d982afd15047173108d39643adfba3ba7ca0a9
   )

--- a/Modules/Remote/HASI.remote.cmake
+++ b/Modules/Remote/HASI.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(HASI
 "High-throughput Applications for Skeletal Imaging."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/HASI.git
-  GIT_TAG 0f50ab50d6fb532f4276ca88b244dd3c000a0155
+  GIT_TAG 35e0a2bb13c4febf360282aa1fc1fd8f13305af0
   )

--- a/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
+++ b/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(HigherOrderAccurateGradient
   https://www.insight-journal.org/browse/publication/775"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient.git
-  GIT_TAG b57ee45519e88b88bd46d5b8390b029f290311d9
+  GIT_TAG 0a40f5c99ca21ef4b9cbf2b47b1be149046905e6
   )

--- a/Modules/Remote/IOFDF.remote.cmake
+++ b/Modules/Remote/IOFDF.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(IOFDF
   "FDFImageIO plugin for ITK. Authors Gleen Pierce/Nick Tustison/Kent Williams"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIOFDF.git
-  GIT_TAG 0a170137bac5c5728f0b0e5134de269eb390ad62
+  GIT_TAG 79695870f4d2416b257db733624a3e8bfc38391d
   )

--- a/Modules/Remote/IOMeshSTL.remote.cmake
+++ b/Modules/Remote/IOMeshSTL.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(IOMeshSTL
   the STL (STereoLithography) file format. https://www.insight-journal.org/browse/publication/913"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIOMeshSTL.git
-  GIT_TAG 7841c1360990dac8cf6f4440b765b6b6aff73cc2
+  GIT_TAG 764773647490f2c8da48b5bea2ad4ea91c911915
   )

--- a/Modules/Remote/IOMeshSWC.remote.cmake
+++ b/Modules/Remote/IOMeshSWC.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(IOMeshSWC
   "Read meshes from SWC files, a format for representing neuron morphology."
   MODULE_COMPLIANCE_LEVEL 4
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIOMeshSWC.git
-  GIT_TAG 60a61652e6b87f66f7771c9c69dc76504c2471b8
+  GIT_TAG 212b3678780b5b6ab27ae17ea68072ec5a088156
   )

--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(IOScanco
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKIOScanco.git
-  GIT_TAG f56c97b76ae26103e017eeaeebd6153af1223ff0
+  GIT_TAG ed97d302e67571d95eea1a49cebad4a4d31399fd
 )

--- a/Modules/Remote/IOTransformDCMTK.remote.cmake
+++ b/Modules/Remote/IOTransformDCMTK.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(IOTransformDCMTK
   files. See https://www.insight-journal.org/browse/publication/923"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIOTransformDCMTK.git
-  GIT_TAG 649da7a2dc71a6d89ccdf7d3123906d0ae7c72dc
+  GIT_TAG e97e0e8c27809eea1834dd534a47fc06168e3e45
   )

--- a/Modules/Remote/IsotropicWavelets.remote.cmake
+++ b/Modules/Remote/IsotropicWavelets.remote.cmake
@@ -53,5 +53,5 @@ Cerdan, P.H. \"Steerable Isotropic Wavelets for Multiscale and Phase Analysis\".
   # Upstream repository was transferred from phcerdan to InsightSoftwareConsortium
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets.git
-  GIT_TAG 0f901b815b67cc80480d66ad5841af4a8e669734
+  GIT_TAG b63d8d55f146d194b665e3599d5a154054d052e9
 )

--- a/Modules/Remote/LabelErodeDilate.remote.cmake
+++ b/Modules/Remote/LabelErodeDilate.remote.cmake
@@ -52,5 +52,5 @@ itk_fetch_module(LabelErodeDilate
   MODULE_COMPLIANCE_LEVEL 2
   #UPSTREAM_GIT_REPOSITORY
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate.git
-  GIT_TAG 9cab6d555b5052f9e04714323755713ee05bf2db
+  GIT_TAG af2525c2f2d45d43989dfcdd9b9587a0f9c8a03e
   )

--- a/Modules/Remote/LesionSizingToolkit.remote.cmake
+++ b/Modules/Remote/LesionSizingToolkit.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(LesionSizingToolkit
   "Framework for determining the sizes of lesions in medical images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/LesionSizingToolkit.git
-  GIT_TAG c1a84175c73319e70083e44abedb655ca85d5c57
+  GIT_TAG 58b95e8f54e8f270b2b221c519f7a49c2086bb11
   )

--- a/Modules/Remote/MGHIO.remote.cmake
+++ b/Modules/Remote/MGHIO.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(MGHIO
   "MGHIO ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkMGHImageIO.git
-  GIT_TAG b5b0d48e43335c8ae60f4441cc8ac2d9cafbfdb9
+  GIT_TAG 4b2e7bd514d3759b6903b75c71d593d061b6e6a3
   )

--- a/Modules/Remote/MeshNoise.remote.cmake
+++ b/Modules/Remote/MeshNoise.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(MeshNoise
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMeshNoise.git
-  GIT_TAG 95cf5854e848e4c0f2d17eb2991e7606bdb5b955
+  GIT_TAG a01fae4f1d637eb6d4a183d940b9ce79970db14e
   )

--- a/Modules/Remote/MeshToPolyData.remote.cmake
+++ b/Modules/Remote/MeshToPolyData.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(MeshToPolyData
 "Convert an ITK Mesh to a data structure compatible with vtkPolyData."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMeshToPolyData.git
-  GIT_TAG a8f6f9c95523acbf6a2505c4fae1c35260e032eb
+  GIT_TAG f2140a34bec87aecae2f64937d4c1172d4c1763d
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(MinimalPathExtraction
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG v1.2.3
+  GIT_TAG b83fdc9d726552e0d4b5044c5ad593c29fb76f1a
   )

--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(Montage
 "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG d4d7e4a35e7882896cd1b671c9922934ee7a5930
+  GIT_TAG 21f8eb99ae350f4c0d271da149fea2adeda7d6e1
   )

--- a/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
+++ b/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
@@ -57,5 +57,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKMorphologicalContourInterpolation.git
-  GIT_TAG e518b40cc863a7be4d986469decc52d3f60f14b8
+  GIT_TAG dbe1d9e53a2b9ed595cdda530cb7e863c1b95c20
   )

--- a/Modules/Remote/MultipleImageIterator.remote.cmake
+++ b/Modules/Remote/MultipleImageIterator.remote.cmake
@@ -56,5 +56,5 @@ Schaerer J. \"A MultipleImageIterator for iterating over multiple images simulta
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/MultipleImageIterator.git
-  GIT_TAG 15712259fed4a7f3b7d8171fd8f6c393df380a50
+  GIT_TAG 046e70f43f56ac1a0e32e083fb1fe1d1379a1f73
   )

--- a/Modules/Remote/ParabolicMorphology.remote.cmake
+++ b/Modules/Remote/ParabolicMorphology.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(ParabolicMorphology
   https://www.insight-journal.org/browse/publication/228"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKParabolicMorphology.git
-  GIT_TAG 18d15dedd4de3886d0bf5529ffb48720d6de32ff
+  GIT_TAG 2c6aa18ff5415b320bf9d85dae6b1cf68c099d55
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -58,5 +58,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG f9a8dc22b67ec63eee023c0734fc7aa5f119356a
+  GIT_TAG 950921a642a720867c00c92c548312a4939da917
   )

--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -54,5 +54,5 @@ https://www.insight-journal.org/browse/publication/846
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKPhaseSymmetry.git
-  GIT_TAG 0b6993c4f7d1d48db110d145f6f2b22c84e5f2dd
+  GIT_TAG 4d9cba2d0529e29500c11fd25ac9c4c808a0279b
   )

--- a/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
+++ b/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
@@ -51,5 +51,5 @@ A more detailed description can be found in the Insight Journal article:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKPrincipalComponentsAnalysis.git
-  GIT_TAG d4877819abc8a921a5cefee864a52324a2542721
+  GIT_TAG 2f8d8bffb37fca8875a674465af5e3d902432f30
   )

--- a/Modules/Remote/RLEImage.remote.cmake
+++ b/Modules/Remote/RLEImage.remote.cmake
@@ -52,5 +52,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKRLEImage.git
-  GIT_TAG e18b8daa31be436e1163888183cab36e5f4a5f05
+  GIT_TAG 0c7971981a38bc3191f8e36ccee1fe483d9dd2e3
   )

--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -41,5 +41,5 @@ itk_fetch_module(RTK
   "Reconstruction Toolkit (RTK) https://www.openrtk.org/"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG d5112fc4bba7eb07c4556169ac652d088fc29fdf
+  GIT_TAG cd65ca6079dc3f55e00b75adbbb868779dca0005
 )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(SCIFIO
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/scifio/scifio-imageio.git
-  GIT_TAG 42b30ee7d50ef6c91e0d3153f400b62bc114b2f7
+  GIT_TAG 1054ece893ee072bdb8124c45ce207de00af280f
   )

--- a/Modules/Remote/Shape.remote.cmake
+++ b/Modules/Remote/Shape.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(Shape
   ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM)."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SlicerSALT/ITKShape.git
-  GIT_TAG 918041aa5508996a7ca044d509e48583cb74f2ba
+  GIT_TAG 67373b34a20116698b4d3617dc5c2edf9be6e2cc
 )

--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(SimpleITKFilters
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG f885603b630619a20155c03a5baca2f684b9a6a7
+  GIT_TAG 877b9be442e36b9dee9d9e251bb1107acc6eed56
   )

--- a/Modules/Remote/SkullStrip.remote.cmake
+++ b/Modules/Remote/SkullStrip.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(SkullStrip
   "A class to perform automatic skull-stripping for neuroimage analysis."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSkullStrip.git
-  GIT_TAG 9afa0491f5fa5fbeba8ca44edc0a0fb2712087b5
+  GIT_TAG da5821af3e2fe8f4c2d881d4fd961b17d0684b3e
   )

--- a/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
+++ b/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(SmoothingRecursiveYvvGaussianFilter
   MODULE_COMPLIANCE_LEVEL 2
   #UPSTREAM_REPO GIT_REPOSITORY ${git_protocol}://github.com/Inria-Asclepios/SmoothingRecursiveYvvGaussianFilter
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.git
-  GIT_TAG 389754f659b47f05bf7b75f76de2500ce1f9428c
+  GIT_TAG f6bd553266aa1c1c3cdebc9033fd3b21f1f734c4
   )

--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(SphinxExamples
   "This module builds the examples found at https://itk.org/ITKExamples/"
   MODULE_COMPLIANCE_LEVEL 5
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSphinxExamples.git
-  GIT_TAG 3ac107a7a1e9b884a3d2e7636b923d5c4cfcbf3f
+  GIT_TAG ffdabca2f41e91a062b6b616f300f55ef088eddc
   )

--- a/Modules/Remote/SplitComponents.remote.cmake
+++ b/Modules/Remote/SplitComponents.remote.cmake
@@ -49,5 +49,5 @@ itk::Image of, for example, itk::Vector, itk::CovariantVector, or
 itk::SymmetricSecondRankTensor. https://www.insight-journal.org/browse/publication/774"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSplitComponents.git
-  GIT_TAG 3dfd5775ec5702428d6319091e58990e9fe1e42d
+  GIT_TAG 697e9552f6d4d6c56e7ef4c767b020973d902539
   )

--- a/Modules/Remote/Strain.remote.cmake
+++ b/Modules/Remote/Strain.remote.cmake
@@ -55,5 +55,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKStrain.git
-  GIT_TAG 4fd046c85556c3514b436652002539573ce25125
+  GIT_TAG 0e2f894e70243d46a4bab40a533a491a23a0f796
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -50,5 +50,5 @@ See the following Insight Journal's publication:
   https://www.insight-journal.org/browse/publication/831"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG cb71f215dc8e35c5052e542082e14486d76d39fa
+  GIT_TAG 6e30c49f7ef9a5b4854bff39834f9d7e181130aa
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -56,5 +56,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG 8ff51060a2b2bda7b2e1068908afce266ea71b3f
+  GIT_TAG b75d9daf50b16da0cec92a6f620426122489bd38
   )

--- a/Modules/Remote/Thickness3D.remote.cmake
+++ b/Modules/Remote/Thickness3D.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(Thickness3D
   "Tools for 3D thickness measurement"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKThickness3D.git
-  GIT_TAG 6830cadf76194acf8394308efd8c043acd561369
+  GIT_TAG cc8c9602cb7a7538bfd9f55515d9ab4cf0b04cdd
 )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -51,5 +51,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG fe6a530857bdb573ce8a138651b3f369a4110a3d
+  GIT_TAG 1dda823f15c8e190ddcd9354f388af01f8b07b08
 )

--- a/Modules/Remote/TubeTK.remote.cmake
+++ b/Modules/Remote/TubeTK.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(TubeTK
   "http://www.tubetk.org"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTubeTK.git
-  GIT_TAG v1.3.2
+  GIT_TAG 88fe752151e3160d0708b50e4f730dd3b8e03113
   )

--- a/Modules/Remote/TwoProjectionRegistration.remote.cmake
+++ b/Modules/Remote/TwoProjectionRegistration.remote.cmake
@@ -61,5 +61,5 @@ Wu, J. \"ITK-Based Implementation of Two-Projection 2D/3D Registration Method wi
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTwoProjectionRegistration.git
-  GIT_TAG 8e775982245ab59710b1ce9d49cd8f06c7e74377
+  GIT_TAG 2cf7d9522031c613a3edcdcd76aee2896536672e
   )

--- a/Modules/Remote/Ultrasound.remote.cmake
+++ b/Modules/Remote/Ultrasound.remote.cmake
@@ -62,5 +62,5 @@ https://dx.doi.org/10.1109/ISBI.2016.7493437
 https://pdfs.semanticscholar.org/6bcd/1e7adbc24e15c928a7ad5af77bbd5da29c30.pdf"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKUltrasound.git
-  GIT_TAG 2443abe29ae44799a5e189fb66c7b8b7a044dcdf
+  GIT_TAG 6f126b84d9a6511c695c197330800c5612fced93
   )

--- a/Modules/Remote/VariationalRegistration.remote.cmake
+++ b/Modules/Remote/VariationalRegistration.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(VariationalRegistration
   "A module to perform variational image registration. https://www.insight-journal.org/browse/publication/917"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKVariationalRegistration.git
-  GIT_TAG f9db4b9a0149e3b0164dd524af124f0827c04b78
+  GIT_TAG 7634013fa2b661eda81d79e52b804f669ec0ce79
   )

--- a/Modules/Remote/VkFFTBackend.remote.cmake
+++ b/Modules/Remote/VkFFTBackend.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(VkFFTBackend
 "ITK FFT accelerated backends using the VkFFT library for Vulkan/CUDA/HIP/OpenCL compatibility."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKVkFFTBackend.git
-  GIT_TAG bce0b1cec6d4af7de9ed3d462c0a255cf0029c06
+  GIT_TAG f5e0a5f93bf9c88698d95ef2cb24f086bd4e1334
 )

--- a/Modules/Remote/WebAssemblyInterface.remote.cmake
+++ b/Modules/Remote/WebAssemblyInterface.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(WebAssemblyInterface
   "The itk-wasm WebAssemblyInterface module provides tools to a) build C/C++ code to WebAssembly-compatible processing pipelines, b) bridge local filesystems, JavaScript/Typescript data structures, and traditional file formats, c) transfer data efficiently in and out of the WebAssembly runtime."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itk-wasm.git
-  GIT_TAG 802f937a97b4cd702f6e171f54e76665ac8df50d
+  GIT_TAG 80f0354caf375e26549864c5155b0484b59b8f05
   )


### PR DESCRIPTION
We have not updated remotes in a while. Trying to fix `/home/dzenan/Dashboards/Tests/ITK/Modules/Remote/Cuberille/include/itkCuberilleImageToMeshFilter.h:9: error: Header mismatch: ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) : Utilities/KWStyle/ITKHeader.h` and other similar errors from https://open.cdash.org/test/789368467.
