### PR TITLE
COMP: ARM Eigen copying an object of non-trivial type

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/arch/NEON/PacketMath.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/arch/NEON/PacketMath.h
@@ -1668,7 +1668,7 @@ template<> EIGEN_STRONG_INLINE Packet4f pload<Packet4f>(const float* from)
 template<> EIGEN_STRONG_INLINE Packet4c pload<Packet4c>(const int8_t* from)
 {
   Packet4c res;
-  memcpy(&res, from, sizeof(Packet4c));
+  memcpy((void *)&res, from, sizeof(Packet4c));
   return res;
 }
 template<> EIGEN_STRONG_INLINE Packet8c pload<Packet8c>(const int8_t* from)
@@ -1678,7 +1678,7 @@ template<> EIGEN_STRONG_INLINE Packet16c pload<Packet16c>(const int8_t* from)
 template<> EIGEN_STRONG_INLINE Packet4uc pload<Packet4uc>(const uint8_t* from)
 {
   Packet4uc res;
-  memcpy(&res, from, sizeof(Packet4uc));
+  memcpy((void *)&res, from, sizeof(Packet4uc));
   return res;
 }
 template<> EIGEN_STRONG_INLINE Packet8uc pload<Packet8uc>(const uint8_t* from)
@@ -1713,7 +1713,7 @@ template<> EIGEN_STRONG_INLINE Packet4f ploadu<Packet4f>(const float* from)
 template<> EIGEN_STRONG_INLINE Packet4c ploadu<Packet4c>(const int8_t* from)
 {
   Packet4c res;
-  memcpy(&res, from, sizeof(Packet4c));
+  memcpy((void *)&res, from, sizeof(Packet4c));
   return res;
 }
 template<> EIGEN_STRONG_INLINE Packet8c ploadu<Packet8c>(const int8_t* from)
@@ -1723,7 +1723,7 @@ template<> EIGEN_STRONG_INLINE Packet16c ploadu<Packet16c>(const int8_t* from)
 template<> EIGEN_STRONG_INLINE Packet4uc ploadu<Packet4uc>(const uint8_t* from)
 {
   Packet4uc res;
-  memcpy(&res, from, sizeof(Packet4uc));
+  memcpy((void *)&res, from, sizeof(Packet4uc));
   return res;
 }
 template<> EIGEN_STRONG_INLINE Packet8uc ploadu<Packet8uc>(const uint8_t* from)


### PR DESCRIPTION
Addresses:

  Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/src/Core/arch/NEON/PacketMath.h:1671:9: warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘Eigen::internal::Packet4c’ {aka ‘struct Eigen::internal::eigen_packet_wrapper<int, 2>’} from an array of ‘const int8_t’ {aka ‘const signed char’} [-Wclass-memaccess]

with GCC 11.2.0 on ARM/Linux.

Explicit cast to void * to indicate that the call was intentional.

Upstream update expected with next Eigen upgrade, discussed:
https://gitlab.kitware.com/phcerdan/eigen/-/issues/3.
