### PR TITLE
COMP: Fix compile error on Visual Studio 2017

### DIFF
--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -343,7 +343,7 @@ private:
   TWindowFunction m_WindowFunction;
 
   /** Size of the offset table */
-  static constexpr unsigned int m_OffsetTableSize{ Math::UnsignedPower(m_WindowSize, ImageDimension) };
+  static constexpr unsigned int m_OffsetTableSize = Math::UnsignedPower(m_WindowSize, ImageDimension);
 
   /** The offset array, used to keep a list of relevant
    * offsets in the neihborhoodIterator */


### PR DESCRIPTION
The full error message is:

```log
M:\Dashboard\ITK\Modules\Core\ImageFunction\include\itkWindowedSincInterpolateImageFunction.h(346): error C2397: conversion from 'TReturnType' to 'const unsigned int' requires a narrowing conversion [M:\Dashboard\ITK-build\Modules\Core\Common\test\ITKCommon1TestDriver.vcxproj]

M:\Dashboard\ITK\Modules\Core\Common\test\itkPhasedArray3DSpecialCoordinatesImageTest.cxx(96): note: see reference to class template instantiation 'itk::WindowedSincInterpolateImageFunction<Image,3,itk::Function::HammingWindowFunction<3,double,double>,itk::ZeroFluxNeumannBoundaryCondition<TInputImage,TInputImage>,double>' being compiled
```
Dashboard build: https://open.cdash.org/viewBuildError.php?buildid=8124742

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
