### PR TITLE
Add `make_unique_for_overwrite` from C++20, and replace `new T[n]` with `make_unique_for_overwrite<T[]>(n)` calls

### DIFF
--- a/Modules/Core/Common/include/itkMakeUniqueForOverwrite.h
+++ b/Modules/Core/Common/include/itkMakeUniqueForOverwrite.h
@@ -1,0 +1,81 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkMakeUniqueForOverwrite_h
+#define itkMakeUniqueForOverwrite_h
+
+#include <memory> // For unique_ptr.
+
+#if __cplusplus < 202002L
+
+#  include <type_traits> // For remove_extent_t, false_type, etc.
+
+namespace itk
+{
+
+// Namespace of implementation details (not part of the public ITK interface).
+namespace MakeUniqueForOverwriteImplDetail
+{
+
+// `is_unbounded_array` implementation for C++14/C++17. From C++20, `std::is_unbounded_array` is preferred.
+template <typename>
+struct is_unbounded_array : std::false_type
+{};
+
+template <typename T>
+struct is_unbounded_array<T[]> : std::true_type
+{};
+
+} // namespace MakeUniqueForOverwriteImplDetail
+
+
+/** `make_unique_for_overwrite` implementation for C++14/C++17, specifically for dynamically sized ("unbounded")
+ * arrays. From C++20, `std::make_unique_for_overwrite` is preferred.
+ *
+ * Example (mind the square brackets):
+   \code
+     using ElementType = int;
+     size_t numberOfElements{ 42 };
+
+     // Create a buffer that may be used to store the specified number of elements.
+     auto buffer = make_unique_for_overwrite<ElementType[]>(numberOfElements);
+   \endcode
+ *
+ */
+template <typename TUnboundedArray>
+auto
+make_unique_for_overwrite(const size_t numberOfElements)
+{
+  // The template argument must be something like `ElementType[]`, having an empty pair of square brackets.
+  static_assert(MakeUniqueForOverwriteImplDetail::is_unbounded_array<TUnboundedArray>::value,
+                "The specified template argument must be an unbounded array type!");
+  return std::unique_ptr<TUnboundedArray>(new std::remove_extent_t<TUnboundedArray>[numberOfElements]);
+}
+
+} // namespace itk
+
+#else
+
+namespace itk
+{
+using ::std::make_unique_for_overwrite;
+}
+
+#endif
+
+#endif // itkMakeUniqueForOverwrite_h

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -26,6 +26,7 @@
  *
  *=========================================================================*/
 #include "itkWin32OutputWindow.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -91,7 +92,7 @@ Win32OutputWindow::DisplayText(const char * text)
   }
 
   /** Create a buffer big enough to hold the entire text */
-  char * buffer = new char[strlen(text) + 1];
+  const auto buffer = make_unique_for_overwrite<char[]>(strlen(text) + 1);
 
   /** Start at the beginning */
   const char * NewLinePos = text;
@@ -109,14 +110,13 @@ Win32OutputWindow::DisplayText(const char * text)
     else
     {
       int len = NewLinePos - text;
-      strncpy(buffer, text, len);
+      strncpy(buffer.get(), text, len);
       buffer[len] = 0;
       text = NewLinePos + 1;
-      Win32OutputWindow::AddText(buffer);
+      Win32OutputWindow::AddText(buffer.get());
       Win32OutputWindow::AddText("\r\n");
     }
   }
-  delete[] buffer;
 }
 
 /** Add some text to the EDIT control. */

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkXMLFileOutputWindow.h"
+#include "itkMakeUniqueForOverwrite.h"
 #include <fstream>
 #include <cstring>
 
@@ -64,18 +65,16 @@ XMLFileOutputWindow::DisplayTag(const char * text)
 void
 XMLFileOutputWindow::DisplayXML(const char * tag, const char * text)
 {
-  char * xmlText;
-
   if (!text)
   {
     return;
   }
 
   // allocate enough room for the worst case
-  xmlText = new char[strlen(text) * 6 + 1];
+  const auto xmlText = make_unique_for_overwrite<char[]>(strlen(text) * 6 + 1);
 
   const char * s = text;
-  char *       x = xmlText;
+  char *       x = xmlText.get();
   *x = '\0';
 
   // replace all special characters
@@ -127,13 +126,12 @@ XMLFileOutputWindow::DisplayXML(const char * tag, const char * text)
   {
     this->Initialize();
   }
-  *m_Stream << "<" << tag << ">" << xmlText << "</" << tag << ">" << std::endl;
+  *m_Stream << "<" << tag << ">" << xmlText.get() << "</" << tag << ">" << std::endl;
 
   if (m_Flush)
   {
     m_Stream->flush();
   }
-  delete[] xmlText;
 }
 
 void

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -638,6 +638,7 @@ set(ITKCommonGTests
       itkImageRegionGTest.cxx
       itkIndexGTest.cxx
       itkIndexRangeGTest.cxx
+      itkMakeUniqueForOverwriteGTest.cxx
       itkMatrixGTest.cxx
       itkMersenneTwisterRandomVariateGeneratorGTest.cxx
       itkNeighborhoodAllocatorGTest.cxx

--- a/Modules/Core/Common/test/itkMakeUniqueForOverwriteGTest.cxx
+++ b/Modules/Core/Common/test/itkMakeUniqueForOverwriteGTest.cxx
@@ -1,0 +1,43 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkMakeUniqueForOverwrite.h"
+#include <gtest/gtest.h>
+#include <numeric> // For iota.
+
+
+// Tests that `make_unique_for_overwrite` creates an array of the specified dynamic size, whose elements can all be
+// written to.
+TEST(MakeUniqueForOverwrite, CreatesAnArrayThatCanBeWrittenTo)
+{
+  for (std::size_t numberOfElements = 1; numberOfElements < 4; ++numberOfElements)
+  {
+    const auto data = itk::make_unique_for_overwrite<int[]>(numberOfElements);
+    ASSERT_NE(data, nullptr);
+
+    // Write the values { 0, 1, ... , N-1 }.
+    std::iota(data.get(), data.get() + numberOfElements, 0);
+
+    // Check that each value is correctly written to the corresponding element.
+    for (std::size_t i = 0; i < numberOfElements; ++i)
+    {
+      EXPECT_EQ(data[i], i);
+    }
+  }
+}

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkGiplImageIO.h"
 #include "itkByteSwapper.h"
+#include "itkMakeUniqueForOverwrite.h"
 #include <iostream>
 #include "itk_zlib.h"
 
@@ -1049,33 +1050,31 @@ GiplImageIO ::Write(const void * buffer)
     // Swap bytes if necessary
     if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
     {
-      auto * tempBuffer = new char[numberOfBytes];
-      memcpy(tempBuffer, buffer, numberOfBytes);
-      SwapBytesIfNecessary(tempBuffer, numberOfComponents);
+      const auto tempBuffer = make_unique_for_overwrite<char[]>(numberOfBytes);
+      memcpy(tempBuffer.get(), buffer, numberOfBytes);
+      SwapBytesIfNecessary(tempBuffer.get(), numberOfComponents);
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, tempBuffer, numberOfBytes);
+        gzwrite(m_Internal->m_GzFile, tempBuffer.get(), numberOfBytes);
       }
       else
       {
-        m_Ofstream.write(tempBuffer, numberOfBytes);
+        m_Ofstream.write(tempBuffer.get(), numberOfBytes);
       }
-      delete[] tempBuffer;
     }
     else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
-      auto * tempBuffer = new char[numberOfBytes];
-      memcpy(tempBuffer, buffer, numberOfBytes);
-      SwapBytesIfNecessary(tempBuffer, numberOfComponents);
+      const auto tempBuffer = make_unique_for_overwrite<char[]>(numberOfBytes);
+      memcpy(tempBuffer.get(), buffer, numberOfBytes);
+      SwapBytesIfNecessary(tempBuffer.get(), numberOfComponents);
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, tempBuffer, numberOfBytes);
+        gzwrite(m_Internal->m_GzFile, tempBuffer.get(), numberOfBytes);
       }
       else
       {
-        m_Ofstream.write(tempBuffer, numberOfBytes);
+        m_Ofstream.write(tempBuffer.get(), numberOfBytes);
       }
-      delete[] tempBuffer;
     }
     else
     {

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkNumericSeriesFileNames.h"
+#include "itkMakeUniqueForOverwrite.h"
 #include <cstdio>
 
 namespace itk
@@ -55,19 +56,17 @@ NumericSeriesFileNames::GetFileNames()
                                                                                 // absurdly long integer string.
     }
     OffsetValueType bufflen = nchars + 1;
-    auto *          temp = new char[bufflen];
-    OffsetValueType result = snprintf(temp, bufflen, m_SeriesFormat.c_str(), i);
+    const auto      temp = make_unique_for_overwrite<char[]>(bufflen);
+    OffsetValueType result = snprintf(temp.get(), bufflen, m_SeriesFormat.c_str(), i);
     if (result < 0 || result >= bufflen)
     {
       std::stringstream message_cache;
       message_cache << "The filename is too long for temp buffer."
-                    << " Truncated form: " << temp << "." << std::endl
+                    << " Truncated form: " << temp.get() << "." << std::endl
                     << "nchars: " << nchars << " bufflen: " << bufflen << " result: " << result;
-      delete[] temp;
       itkExceptionMacro(<< message_cache.str());
     }
-    std::string fileName(temp);
-    delete[] temp;
+    std::string fileName(temp.get());
     m_FileNames.push_back(fileName);
   }
   return m_FileNames;

--- a/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
+++ b/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkImageIOBase.h"
 #include "itkByteSwapper.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace
 {
@@ -34,19 +35,17 @@ _WriteRawBytesAfterSwappingUtility(const void *         buffer,
   const itk::SizeValueType numberOfPixels = numberOfBytes / (sizeof(TStrongType));
   if (byteOrder == itk::IOByteOrderEnum::LittleEndian && InternalByteSwapperType::SystemIsBigEndian())
   {
-    auto * tempBuffer = new TStrongType[numberOfPixels];
-    memcpy((char *)tempBuffer, buffer, numberOfBytes);
-    InternalByteSwapperType::SwapRangeFromSystemToLittleEndian((TStrongType *)tempBuffer, numberOfComponents);
-    file.write((char *)tempBuffer, numberOfBytes);
-    delete[] tempBuffer;
+    const auto tempBuffer = itk::make_unique_for_overwrite<TStrongType[]>(numberOfPixels);
+    memcpy(tempBuffer.get(), buffer, numberOfBytes);
+    InternalByteSwapperType::SwapRangeFromSystemToLittleEndian(tempBuffer.get(), numberOfComponents);
+    file.write(reinterpret_cast<char *>(tempBuffer.get()), numberOfBytes);
   }
   else if (byteOrder == itk::IOByteOrderEnum::BigEndian && InternalByteSwapperType::SystemIsLittleEndian())
   {
-    auto * tempBuffer = new TStrongType[numberOfPixels];
-    memcpy((char *)tempBuffer, buffer, numberOfBytes);
-    InternalByteSwapperType::SwapRangeFromSystemToBigEndian((TStrongType *)tempBuffer, numberOfComponents);
-    file.write((char *)tempBuffer, numberOfBytes);
-    delete[] tempBuffer;
+    const auto tempBuffer = itk::make_unique_for_overwrite<TStrongType[]>(numberOfPixels);
+    memcpy(tempBuffer.get(), buffer, numberOfBytes);
+    InternalByteSwapperType::SwapRangeFromSystemToBigEndian(tempBuffer.get(), numberOfComponents);
+    file.write(reinterpret_cast<char *>(tempBuffer.get()), numberOfBytes);
   }
   else
   {

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -27,6 +27,7 @@
  *=========================================================================*/
 #include "itkLSMImageIO.h"
 #include "itkByteSwapper.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "itk_tiff.h"
 
@@ -301,16 +302,15 @@ LSMImageIO::Write(const void * buffer)
     {
       // if number of scalar components is greater than 3, that means we assume
       // there is alpha.
-      uint16_t extra_samples = scomponents - 3;
-      auto *   sample_info = new uint16_t[scomponents - 3];
+      uint16_t   extra_samples = scomponents - 3;
+      const auto sample_info = make_unique_for_overwrite<uint16_t[]>(scomponents - 3);
       sample_info[0] = EXTRASAMPLE_ASSOCALPHA;
       int cc;
       for (cc = 1; cc < scomponents - 3; ++cc)
       {
         sample_info[cc] = EXTRASAMPLE_UNSPECIFIED;
       }
-      TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info);
-      delete[] sample_info;
+      TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info.get());
     }
 
     uint16_t compression;

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -23,6 +23,7 @@
 #include "itkMetaDataObject.h"
 #include "itkArray.h"
 #include "itkPrintHelper.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "itk_minc2.h"
 
@@ -691,14 +692,13 @@ MINCImageIO::ReadImageInformation()
   size_t minc_history_length = 0;
   if (miget_attr_length(this->m_MINCPImpl->m_Volume, "", "history", &minc_history_length) == MI_NOERROR)
   {
-    auto * minc_history = new char[minc_history_length + 1];
+    const auto minc_history = make_unique_for_overwrite<char[]>(minc_history_length + 1);
     if (miget_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", minc_history_length + 1, minc_history) ==
+          this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", minc_history_length + 1, minc_history.get()) ==
         MI_NOERROR)
     {
-      EncapsulateMetaData<std::string>(thisDic, "history", std::string(minc_history));
+      EncapsulateMetaData<std::string>(thisDic, "history", std::string(minc_history.get()));
     }
-    delete[] minc_history;
   }
 
   if (this->m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
@@ -794,14 +794,13 @@ MINCImageIO::ReadImageInformation()
             {
               case MI_TYPE_STRING:
               {
-                auto * tmp = new char[att_length + 1];
+                const auto tmp = make_unique_for_overwrite<char[]>(att_length + 1);
                 if (miget_attr_values(
-                      this->m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length + 1, tmp) ==
+                      this->m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length + 1, tmp.get()) ==
                     MI_NOERROR)
                 {
-                  EncapsulateMetaData<std::string>(thisDic, entry_key, std::string(tmp));
+                  EncapsulateMetaData<std::string>(thisDic, entry_key, std::string(tmp.get()));
                 }
-                delete[] tmp;
               }
               break;
               case MI_TYPE_FLOAT:

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkFreeSurferAsciiMeshIO.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "itksys/SystemTools.hxx"
 
@@ -166,7 +167,7 @@ FreeSurferAsciiMeshIO ::ReadCells(void * buffer)
   m_InputFile.precision(12);
   SizeValueType          index = 0;
   constexpr unsigned int numberOfCellPoints = 3;
-  auto *                 data = new unsigned int[this->m_NumberOfCells * numberOfCellPoints];
+  const auto             data = make_unique_for_overwrite<unsigned int[]>(this->m_NumberOfCells * numberOfCellPoints);
   float                  value;
 
   for (SizeValueType id = 0; id < this->m_NumberOfCells; ++id)
@@ -179,8 +180,7 @@ FreeSurferAsciiMeshIO ::ReadCells(void * buffer)
   }
 
   this->WriteCellsBuffer(
-    data, static_cast<unsigned int *>(buffer), CellGeometryEnum::TRIANGLE_CELL, 3, this->m_NumberOfCells);
-  delete[] data;
+    data.get(), static_cast<unsigned int *>(buffer), CellGeometryEnum::TRIANGLE_CELL, 3, this->m_NumberOfCells);
 
   CloseFile();
 }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -19,6 +19,7 @@
 #include "itkFreeSurferBinaryMeshIO.h"
 
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -243,14 +244,15 @@ void
 FreeSurferBinaryMeshIO ::ReadCells(void * buffer)
 {
   constexpr unsigned int numberOfCellPoints = 3;
-  auto *                 data = new itk::uint32_t[this->m_NumberOfCells * numberOfCellPoints];
+  const auto             data = make_unique_for_overwrite<itk::uint32_t[]>(this->m_NumberOfCells * numberOfCellPoints);
 
-  m_InputFile.read(reinterpret_cast<char *>(data), this->m_NumberOfCells * numberOfCellPoints * sizeof(itk::uint32_t));
-  itk::ByteSwapper<itk::uint32_t>::SwapRangeFromSystemToBigEndian(data, this->m_NumberOfCells * numberOfCellPoints);
+  m_InputFile.read(reinterpret_cast<char *>(data.get()),
+                   this->m_NumberOfCells * numberOfCellPoints * sizeof(itk::uint32_t));
+  itk::ByteSwapper<itk::uint32_t>::SwapRangeFromSystemToBigEndian(data.get(),
+                                                                  this->m_NumberOfCells * numberOfCellPoints);
 
   this->WriteCellsBuffer(
-    data, static_cast<unsigned int *>(buffer), CellGeometryEnum::TRIANGLE_CELL, 3, this->m_NumberOfCells);
-  delete[] data;
+    data.get(), static_cast<unsigned int *>(buffer), CellGeometryEnum::TRIANGLE_CELL, 3, this->m_NumberOfCells);
 
   CloseFile();
 }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -19,6 +19,7 @@
 #include "itkOBJMeshIO.h"
 #include "itkNumericTraits.h"
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 #include <locale>
 #include <vector>
 
@@ -251,7 +252,7 @@ OBJMeshIO ::ReadCells(void * buffer)
   OpenFile();
 
   // Read and analyze the first line in the file
-  auto *        data = new long[this->m_CellBufferSize - this->m_NumberOfCells];
+  const auto    data = make_unique_for_overwrite<long[]>(this->m_CellBufferSize - this->m_NumberOfCells);
   SizeValueType index = 0;
 
   std::string line;
@@ -294,10 +295,10 @@ OBJMeshIO ::ReadCells(void * buffer)
 
   CloseFile();
 
-  this->WriteCellsBuffer(data, static_cast<long *>(buffer), CellGeometryEnum::POLYGON_CELL, this->m_NumberOfCells);
+  this->WriteCellsBuffer(
+    data.get(), static_cast<long *>(buffer), CellGeometryEnum::POLYGON_CELL, this->m_NumberOfCells);
   // this->WriteCellsBuffer(data, static_cast<unsigned int *>(buffer),
   // CellGeometryEnum::TRIANGLE_CELL, 3, this->m_NumberOfCells);
-  delete[] data;
 }
 
 void

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -19,6 +19,7 @@
 #include "itkVTKPolyDataMeshIO.h"
 
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <double-conversion/string-to-double.h>
 
@@ -985,10 +986,10 @@ VTKPolyDataMeshIO ::ReadCellsBufferAsBINARY(std::ifstream & inputFile, void * bu
     return;
   }
 
-  auto * inputBuffer = new unsigned int[this->m_CellBufferSize - this->m_NumberOfCells];
-  void * pv = inputBuffer;
-  auto * startBuffer = static_cast<char *>(pv);
-  auto * outputBuffer = static_cast<unsigned int *>(buffer);
+  const auto inputBuffer = make_unique_for_overwrite<unsigned int[]>(this->m_CellBufferSize - this->m_NumberOfCells);
+  void *     pv = inputBuffer.get();
+  auto *     startBuffer = static_cast<char *>(pv);
+  auto *     outputBuffer = static_cast<unsigned int *>(buffer);
 
   std::string          line;
   MetaDataDictionary & metaDic = this->GetMetaDataDictionary();
@@ -1051,11 +1052,6 @@ VTKPolyDataMeshIO ::ReadCellsBufferAsBINARY(std::ifstream & inputFile, void * bu
       startBuffer += numberOfPolygonIndices * sizeof(unsigned int);
       outputBuffer += (numberOfPolygonIndices + numberOfPolygons) * sizeof(unsigned int);
     }
-  }
-
-  if (this->m_CellBufferSize)
-  {
-    delete[] inputBuffer;
   }
 }
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -20,6 +20,7 @@
 #include "itkTIFFReaderInternal.h"
 #include "itksys/SystemTools.hxx"
 #include "itkMetaDataObject.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "itk_tiff.h"
 
@@ -674,15 +675,14 @@ TIFFImageIO::InternalWrite(const void * buffer)
     {
       // if number of scalar components is greater than 3, that means we assume
       // there is alpha.
-      uint16_t extra_samples = scomponents - 3;
-      auto *   sample_info = new uint16_t[scomponents - 3];
+      uint16_t   extra_samples = scomponents - 3;
+      const auto sample_info = make_unique_for_overwrite<uint16_t[]>(scomponents - 3);
       sample_info[0] = EXTRASAMPLE_ASSOCALPHA;
       for (uint16_t cc = 1; cc < scomponents - 3; ++cc)
       {
         sample_info[cc] = EXTRASAMPLE_UNSPECIFIED;
       }
-      TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info);
-      delete[] sample_info;
+      TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info.get());
     }
 
     uint16_t compression;

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -19,6 +19,7 @@
 #include "itkByteSwapper.h"
 
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 
 
 namespace itk
@@ -816,43 +817,41 @@ VTKImageIO::WriteBufferAsASCII(std::ostream &              os,
   }
 }
 
-#define WriteVTKImageBinaryBlockMACRO(storageType)                                                                \
-  {                                                                                                               \
-    const ImageIOBase::BufferSizeType numbytes =                                                                  \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInBytes());                                      \
-    const ImageIOBase::BufferSizeType numberImageComponents =                                                     \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInComponents());                                 \
-    const bool    isSymmetricSecondRankTensor = (this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR); \
-    storageType * tempmemory = new storageType[numberImageComponents];                                            \
-    memcpy(tempmemory, buffer, numbytes);                                                                         \
-    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents);                  \
-    /* write the image */                                                                                         \
-    if (isSymmetricSecondRankTensor)                                                                              \
-    {                                                                                                             \
-      this->WriteSymmetricTensorBufferAsBinary(file, tempmemory, numbytes);                                       \
-    }                                                                                                             \
-    else                                                                                                          \
-    {                                                                                                             \
-      if (!this->WriteBufferAsBinary(file, tempmemory, numbytes))                                                 \
-      {                                                                                                           \
-        itkExceptionMacro(<< "Could not write file: " << m_FileName);                                             \
-      }                                                                                                           \
-    }                                                                                                             \
-    delete[] tempmemory;                                                                                          \
+#define WriteVTKImageBinaryBlockMACRO(storageType)                                                             \
+  {                                                                                                            \
+    const ImageIOBase::BufferSizeType numbytes =                                                               \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInBytes());                                   \
+    const ImageIOBase::BufferSizeType numberImageComponents =                                                  \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInComponents());                              \
+    const bool isSymmetricSecondRankTensor = (this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR); \
+    const auto tempmemory = make_unique_for_overwrite<storageType[]>(numberImageComponents);                   \
+    memcpy(tempmemory.get(), buffer, numbytes);                                                                \
+    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory.get(), numberImageComponents);         \
+    /* write the image */                                                                                      \
+    if (isSymmetricSecondRankTensor)                                                                           \
+    {                                                                                                          \
+      this->WriteSymmetricTensorBufferAsBinary(file, tempmemory.get(), numbytes);                              \
+    }                                                                                                          \
+    else                                                                                                       \
+    {                                                                                                          \
+      if (!this->WriteBufferAsBinary(file, tempmemory.get(), numbytes))                                        \
+      {                                                                                                        \
+        itkExceptionMacro(<< "Could not write file: " << m_FileName);                                          \
+      }                                                                                                        \
+    }                                                                                                          \
   }
 
-#define StreamWriteVTKImageBinaryBlockMACRO(storageType)                                         \
-  {                                                                                              \
-    const ImageIOBase::BufferSizeType numbytes =                                                 \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInBytes());                  \
-    const ImageIOBase::BufferSizeType numberImageComponents =                                    \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInComponents());             \
-    storageType * tempmemory = new storageType[numberImageComponents];                           \
-    memcpy(tempmemory, buffer, numbytes);                                                        \
-    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents); \
-    /* write the image */                                                                        \
-    this->StreamWriteBufferAsBinary(file, tempmemory);                                           \
-    delete[] tempmemory;                                                                         \
+#define StreamWriteVTKImageBinaryBlockMACRO(storageType)                                               \
+  {                                                                                                    \
+    const ImageIOBase::BufferSizeType numbytes =                                                       \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInBytes());                        \
+    const ImageIOBase::BufferSizeType numberImageComponents =                                          \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInComponents());                   \
+    const auto tempmemory = make_unique_for_overwrite<storageType[]>(numberImageComponents);           \
+    memcpy(tempmemory.get(), buffer, numbytes);                                                        \
+    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory.get(), numberImageComponents); \
+    /* write the image */                                                                              \
+    this->StreamWriteBufferAsBinary(file, tempmemory.get());                                           \
   }
 
 void

--- a/Modules/IO/XML/src/itkXMLFile.cxx
+++ b/Modules/IO/XML/src/itkXMLFile.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkXMLFile.h"
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 #include <fstream>
 #include "expat.h"
 
@@ -86,9 +87,9 @@ XMLReaderBase::parse()
   // Default stream parser just reads a block at a time.
   std::streamsize filesize = itksys::SystemTools::FileLength(m_Filename.c_str());
 
-  auto * buffer = new char[filesize];
+  const auto buffer = make_unique_for_overwrite<char[]>(filesize);
 
-  inputstream.read(buffer, filesize);
+  inputstream.read(buffer.get(), filesize);
 
   if (static_cast<std::streamsize>(inputstream.gcount()) != filesize)
   {
@@ -96,8 +97,7 @@ XMLReaderBase::parse()
     exception.SetDescription("File Read Error");
     throw exception;
   }
-  const auto result = XML_Parse(Parser, buffer, inputstream.gcount(), false);
-  delete[] buffer;
+  const auto result = XML_Parse(Parser, buffer.get(), inputstream.gcount(), false);
   if (!result)
   {
     ExceptionObject exception(__FILE__, __LINE__);


### PR DESCRIPTION
Replaced `new T[n]` with `make_unique_for_overwrite<T[]>(n)` in code that basically looks like: 

    auto * data = new T[n];
    Do things...
    delete [] data;

Doing so fixes some potential memory leaks, when the things being done before the `delete [] data` might throw an exception.

`make_unique_for_overwrite` is introduced with C++20: https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique It is hereby mimicked for dynamic array allocation as `itk::make_unique_for_overwrite` 