### PR TITLE
STYLE: More make_unique_for_overwrite, less delete[], on local variables

### DIFF
--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -22,6 +22,7 @@
 
 #include "itkNeighborhoodIterator.h"
 #include "itkImageRegionIterator.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -104,7 +105,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   NeighborhoodIterator<TInputImage> it(r, this->GetOutput(), m_RegionToProcess);
 
   const unsigned int center_voxel = it.Size() / 2;
-  auto *             neighbor_type = new int[it.Size()];
+  const auto         neighbor_type = make_unique_for_overwrite<int[]>(it.Size());
   int                i;
   unsigned int       n;
   float              val[ImageDimension];
@@ -263,7 +264,6 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
       }
     }
   }
-  delete[] neighbor_type;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
@@ -22,6 +22,7 @@
 #include "itkNeighborhoodInnerProduct.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkDerivativeOperator.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -147,10 +148,10 @@ GPUScalarAnisotropicDiffusionFunction<TImage>::GPUCalculateAverageGradientMagnit
   kernelManager->LaunchKernel(kernelHandle, ImageDim, globalSize, localSize);
 
   // Read back intermediate sums from GPU and compute final value
-  double sum = 0;
-  auto * intermSum = new float[bufferSize];
+  double     sum = 0;
+  const auto intermSum = make_unique_for_overwrite<float[]>(bufferSize);
 
-  this->m_AnisotropicDiffusionFunctionGPUBuffer->SetCPUBufferPointer(intermSum);
+  this->m_AnisotropicDiffusionFunctionGPUBuffer->SetCPUBufferPointer(intermSum.get());
   this->m_AnisotropicDiffusionFunctionGPUBuffer->SetCPUDirtyFlag(true); //
                                                                         // CPU
                                                                         // is
@@ -166,8 +167,6 @@ GPUScalarAnisotropicDiffusionFunction<TImage>::GPUCalculateAverageGradientMagnit
   }
 
   this->SetAverageGradientMagnitudeSquared(static_cast<double>(sum / static_cast<double>(numPixel)));
-
-  delete[] intermSum;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkSTAPLEImageFilter_hxx
 
 #include "itkImageScanlineIterator.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -58,13 +59,13 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Record the number of input files.
   number_of_input_files = this->GetNumberOfIndexedInputs();
 
-  auto * D_it = new IteratorType[number_of_input_files];
+  const auto D_it = make_unique_for_overwrite<IteratorType[]>(number_of_input_files);
 
-  auto * p = new double[number_of_input_files]; // sensitivity
-  auto * q = new double[number_of_input_files]; // specificity
+  const auto p = make_unique_for_overwrite<double[]>(number_of_input_files); // sensitivity
+  const auto q = make_unique_for_overwrite<double[]>(number_of_input_files); // specificity
 
-  auto * last_q = new double[number_of_input_files];
-  auto * last_p = new double[number_of_input_files];
+  const auto last_q = make_unique_for_overwrite<double[]>(number_of_input_files);
+  const auto last_p = make_unique_for_overwrite<double[]>(number_of_input_files);
 
   for (i = 0; i < number_of_input_files; ++i)
   {
@@ -250,12 +251,6 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
     m_Specificity.push_back(q[i]);
   }
   m_ElapsedIterations = iter;
-
-  delete[] q;
-  delete[] p;
-  delete[] last_q;
-  delete[] last_p;
-  delete[] D_it;
 }
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -23,8 +23,10 @@
 #include "itkMeshConvertPixelTraits.h"
 #include "itkMeshIOFactory.h"
 #include "itkObjectFactoryBase.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "vnl/vnl_vector.h"
+
 
 namespace itk
 {
@@ -248,10 +250,10 @@ MeshFileWriter<TInputMesh>::WritePoints()
 
   itkDebugMacro(<< "Writing points: " << m_FileName);
   SizeValueType pointsBufferSize = input->GetNumberOfPoints() * TInputMesh::PointDimension;
-  auto *        buffer = new typename TInputMesh::PointType::ValueType[pointsBufferSize];
-  CopyPointsToBuffer(buffer);
-  m_MeshIO->WritePoints(buffer);
-  delete[] buffer;
+  using ValueType = typename TInputMesh::PointType::ValueType;
+  const auto buffer = make_unique_for_overwrite<ValueType[]>(pointsBufferSize);
+  CopyPointsToBuffer(buffer.get());
+  m_MeshIO->WritePoints(buffer.get());
 }
 
 template <typename TInputMesh>
@@ -261,10 +263,10 @@ MeshFileWriter<TInputMesh>::WriteCells()
   itkDebugMacro(<< "Writing cells: " << m_FileName);
 
   SizeValueType cellsBufferSize = m_MeshIO->GetCellBufferSize();
-  auto *        buffer = new typename TInputMesh::PointIdentifier[cellsBufferSize];
-  CopyCellsToBuffer(buffer);
-  m_MeshIO->WriteCells(buffer);
-  delete[] buffer;
+  using PointIdentifierType = typename TInputMesh::PointIdentifier;
+  const auto buffer = make_unique_for_overwrite<PointIdentifierType[]>(cellsBufferSize);
+  CopyCellsToBuffer(buffer.get());
+  m_MeshIO->WriteCells(buffer.get());
 }
 
 template <typename TInputMesh>
@@ -282,10 +284,9 @@ MeshFileWriter<TInputMesh>::WritePointData()
                                         input->GetPointData()->Begin().Value());
 
     using ValueType = typename itk::NumericTraits<typename TInputMesh::PixelType>::ValueType;
-    auto * buffer = new ValueType[numberOfComponents];
-    CopyPointDataToBuffer(buffer);
-    m_MeshIO->WritePointData(buffer);
-    delete[] buffer;
+    const auto buffer = make_unique_for_overwrite<ValueType[]>(numberOfComponents);
+    CopyPointDataToBuffer(buffer.get());
+    m_MeshIO->WritePointData(buffer.get());
   }
 }
 
@@ -304,10 +305,9 @@ MeshFileWriter<TInputMesh>::WriteCellData()
                                        input->GetCellData()->Begin().Value());
 
     using ValueType = typename itk::NumericTraits<typename TInputMesh::CellPixelType>::ValueType;
-    auto * buffer = new ValueType[numberOfComponents];
-    CopyCellDataToBuffer(buffer);
-    m_MeshIO->WriteCellData(buffer);
-    delete[] buffer;
+    const auto buffer = make_unique_for_overwrite<ValueType[]>(numberOfComponents);
+    CopyCellDataToBuffer(buffer.get());
+    m_MeshIO->WriteCellData(buffer.get());
   }
 }
 

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -34,6 +34,7 @@
 #include "itkVector.h"
 #include "itkNumberToString.h"
 #include "itkCommonEnums.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <string>
 #include <complex>
@@ -686,7 +687,7 @@ protected:
     }
     else
     {
-      auto * data = new TOutput[numberOfComponents];
+      const auto data = make_unique_for_overwrite<TOutput[]>(numberOfComponents);
       for (SizeValueType ii = 0; ii < numberOfComponents; ++ii)
       {
         data[ii] = static_cast<TOutput>(buffer[ii]);
@@ -694,15 +695,14 @@ protected:
 
       if (m_ByteOrder == IOByteOrderEnum::BigEndian && itk::ByteSwapper<TOutput>::SystemIsLittleEndian())
       {
-        itk::ByteSwapper<TOutput>::SwapRangeFromSystemToBigEndian(data, numberOfComponents);
+        itk::ByteSwapper<TOutput>::SwapRangeFromSystemToBigEndian(data.get(), numberOfComponents);
       }
       else if (m_ByteOrder == IOByteOrderEnum::LittleEndian && itk::ByteSwapper<TOutput>::SystemIsBigEndian())
       {
-        itk::ByteSwapper<TOutput>::SwapRangeFromSystemToLittleEndian(data, numberOfComponents);
+        itk::ByteSwapper<TOutput>::SwapRangeFromSystemToLittleEndian(data.get(), numberOfComponents);
       }
 
-      outputFile.write(reinterpret_cast<char *>(data), numberOfComponents);
-      delete[] data;
+      outputFile.write(reinterpret_cast<char *>(data.get()), numberOfComponents);
     }
   }
 

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
@@ -21,6 +21,7 @@
 #include "ITKIOMeshFreeSurferExport.h"
 
 #include "itkMeshIOBase.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
 
@@ -135,9 +136,9 @@ protected:
     constexpr unsigned int numberOfCellPoints = 3;
     SizeValueType          index = 0;
 
-    auto * data = new T[this->m_NumberOfCells * numberOfCellPoints];
+    const auto data = make_unique_for_overwrite<T[]>(this->m_NumberOfCells * numberOfCellPoints);
 
-    ReadCellsBuffer(buffer, data);
+    ReadCellsBuffer(buffer, data.get());
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {
@@ -147,7 +148,6 @@ protected:
       }
       outputFile << label << '\n';
     }
-    delete[] data;
   }
 
   /** Read cells from a data buffer, used when writting cells */

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
@@ -23,6 +23,7 @@
 #include "itkByteSwapper.h"
 #include "itkMeshIOBase.h"
 #include "itkIntTypes.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
 
@@ -119,7 +120,7 @@ protected:
   void
   WritePoints(T * buffer, std::ofstream & outputFile)
   {
-    auto * data = new float[this->m_NumberOfPoints * this->m_PointDimension];
+    const auto data = make_unique_for_overwrite<float[]>(this->m_NumberOfPoints * this->m_PointDimension);
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfPoints; ++ii)
     {
@@ -130,8 +131,7 @@ protected:
     }
 
     itk::ByteSwapper<float>::SwapWriteRangeFromSystemToBigEndian(
-      data, this->m_NumberOfPoints * this->m_PointDimension, &outputFile);
-    delete[] data;
+      data.get(), this->m_NumberOfPoints * this->m_PointDimension, &outputFile);
   }
 
   /** Write cells to utput stream */
@@ -141,13 +141,11 @@ protected:
   {
     constexpr itk::uint32_t numberOfCellPoints = 3;
 
-    auto * data = new itk::uint32_t[this->m_NumberOfCells * numberOfCellPoints];
+    const std::unique_ptr<itk::uint32_t[]> data(new itk::uint32_t[this->m_NumberOfCells * numberOfCellPoints]);
 
-    ReadCellsBuffer(buffer, data);
+    ReadCellsBuffer(buffer, data.get());
     itk::ByteSwapper<itk::uint32_t>::SwapWriteRangeFromSystemToBigEndian(
-      data, this->m_NumberOfCells * numberOfCellPoints, &outputFile);
-
-    delete[] data;
+      data.get(), this->m_NumberOfCells * numberOfCellPoints, &outputFile);
   }
 
   /** Read cells from a data buffer, used when writting mesh */
@@ -174,15 +172,14 @@ protected:
   void
   WritePointData(T * buffer, std::ofstream & outputFile)
   {
-    auto * data = new float[this->m_NumberOfPointPixels];
+    const auto data = make_unique_for_overwrite<float[]>(this->m_NumberOfPointPixels);
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfPointPixels; ++ii)
     {
       data[ii] = static_cast<float>(buffer[ii]);
     }
 
-    itk::ByteSwapper<float>::SwapWriteRangeFromSystemToBigEndian(data, this->m_NumberOfPointPixels, &outputFile);
-    delete[] data;
+    itk::ByteSwapper<float>::SwapWriteRangeFromSystemToBigEndian(data.get(), this->m_NumberOfPointPixels, &outputFile);
   }
 
 protected:

--- a/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
+++ b/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
@@ -21,6 +21,7 @@
 #include "ITKIOMeshOFFExport.h"
 
 #include "itkMeshIOBase.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
 
@@ -182,12 +183,10 @@ protected:
   void
   WriteCellsAsBinary(TInput * buffer, std::ofstream & outputFile)
   {
-    auto * data = new TOutput[m_CellBufferSize - this->m_NumberOfCells];
+    const auto data = make_unique_for_overwrite<TOutput[]>(m_CellBufferSize - this->m_NumberOfCells);
 
-    ReadCellsBuffer(buffer, data);
-    WriteBufferAsBinary<TOutput>(data, outputFile, m_CellBufferSize - this->m_NumberOfCells);
-
-    delete[] data;
+    ReadCellsBuffer(buffer, data.get());
+    WriteBufferAsBinary<TOutput>(data.get(), outputFile, m_CellBufferSize - this->m_NumberOfCells);
   }
 
 protected:

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -24,6 +24,7 @@
 #include "itkMeshIOBase.h"
 #include "itkVectorContainer.h"
 #include "itkNumberToString.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
 #include <vector>
@@ -596,11 +597,11 @@ protected:
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfVertexIndices", numberOfVertexIndices);
       outputFile << "VERTICES " << numberOfVertices << " " << numberOfVertexIndices << '\n';
-      auto * data = new unsigned int[numberOfVertexIndices];
-      ReadCellsBuffer(buffer, data);
-      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(data, numberOfVertexIndices, &outputFile);
+      const auto data = make_unique_for_overwrite<unsigned int[]>(numberOfVertexIndices);
+      ReadCellsBuffer(buffer, data.get());
+      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(
+        data.get(), numberOfVertexIndices, &outputFile);
       outputFile << "\n";
-      delete[] data;
     }
 
     /** Write lines */
@@ -641,7 +642,7 @@ protected:
       EncapsulateMetaData<unsigned int>(metaDic, "numberOfLineIndices", numberOfLineIndices);
 
       outputFile << "LINES " << numberOfLines << " " << numberOfLineIndices << '\n';
-      auto *        data = new unsigned int[numberOfLineIndices];
+      const auto    data = make_unique_for_overwrite<unsigned int[]>(numberOfLineIndices);
       unsigned long outputIndex = 0;
       for (SizeValueType ii = 0; ii < polylines->Size(); ++ii)
       {
@@ -653,9 +654,8 @@ protected:
         }
       }
 
-      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(data, numberOfLineIndices, &outputFile);
+      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(data.get(), numberOfLineIndices, &outputFile);
       outputFile << "\n";
-      delete[] data;
     }
 
     /** Write polygons */
@@ -665,11 +665,11 @@ protected:
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfPolygonIndices", numberOfPolygonIndices);
       outputFile << "POLYGONS " << numberOfPolygons << " " << numberOfPolygonIndices << '\n';
-      auto * data = new unsigned int[numberOfPolygonIndices];
-      ReadCellsBuffer(buffer, data);
-      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(data, numberOfPolygonIndices, &outputFile);
+      const auto data = make_unique_for_overwrite<unsigned int[]>(numberOfPolygonIndices);
+      ReadCellsBuffer(buffer, data.get());
+      itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(
+        data.get(), numberOfPolygonIndices, &outputFile);
       outputFile << "\n";
-      delete[] data;
     }
   }
 
@@ -1100,15 +1100,13 @@ protected:
   {
     outputFile << numberOfPixelComponents << "\n";
     SizeValueType numberOfElements = numberOfPixelComponents * numberOfPixels;
-    auto *        data = new unsigned char[numberOfElements];
+    const auto    data = make_unique_for_overwrite<unsigned char[]>(numberOfElements);
     for (SizeValueType ii = 0; ii < numberOfElements; ++ii)
     {
       data[ii] = static_cast<unsigned char>(buffer[ii]);
     }
 
-    outputFile.write(reinterpret_cast<char *>(data), numberOfElements);
-
-    delete[] data;
+    outputFile.write(reinterpret_cast<char *>(data.get()), numberOfElements);
     outputFile << "\n";
     return;
   }

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -183,8 +184,8 @@ HistogramToTextureFeaturesFilter<THistogram>::ComputeMeansAndVariances(double & 
 
   // Initialize everything
   typename HistogramType::SizeValueType binsPerAxis = inputHistogram->GetSize(0);
-  auto *                                marginalSums = new double[binsPerAxis];
-  for (double * ms_It = marginalSums; ms_It < marginalSums + binsPerAxis; ++ms_It)
+  const auto                            marginalSums = make_unique_for_overwrite<double[]>(binsPerAxis);
+  for (double * ms_It = marginalSums.get(); ms_It < marginalSums.get() + binsPerAxis; ++ms_It)
   {
     *ms_It = 0;
   }
@@ -242,8 +243,6 @@ HistogramToTextureFeaturesFilter<THistogram>::ComputeMeansAndVariances(double & 
     pixelVariance += (index[0] - pixelMean) * (index[0] - pixelMean) * frequency;
     ++rFreqIterator;
   }
-
-  delete[] marginalSums;
 }
 
 template <typename THistogram>

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNeighborhood.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -144,8 +145,8 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
   // Now get the mean and deviaton of each feature across the offsets.
   this->m_FeatureMeans->clear();
   this->m_FeatureStandardDeviations->clear();
-  auto * tempFeatureMeans = new double[numFeatures];
-  auto * tempFeatureDevs = new double[numFeatures];
+  const auto tempFeatureMeans = make_unique_for_overwrite<double[]>(numFeatures);
+  const auto tempFeatureDevs = make_unique_for_overwrite<double[]>(numFeatures);
 
   /*Compute incremental mean and SD, a la Knuth, "The  Art of Computer
     Programming, Volume 2: Seminumerical Algorithms",  section 4.2.2.
@@ -196,8 +197,6 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
     itkDynamicCastInDebugMode<FeatureValueVectorDataObjectType *>(this->ProcessObject::GetOutput(1));
   standardDeviationOutputObject->Set(this->m_FeatureStandardDeviations);
 
-  delete[] tempFeatureMeans;
-  delete[] tempFeatureDevs;
   for (size_t i = 0; i < numOffsets; ++i)
   {
     delete[] features[i];

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -18,6 +18,8 @@
 #ifndef itkImageKmeansModelEstimator_hxx
 #define itkImageKmeansModelEstimator_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
+
 
 namespace itk
 {
@@ -397,9 +399,9 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
 {
   // itkDebugMacro(<<"Start nearest_neighbor_search_basic()");
 
-  double bestdistortion, tempdistortion, diff;
-  int    bestcodeword;
-  auto * tempVec = (double *)new double[m_VectorDimension];
+  double     bestdistortion, tempdistortion, diff;
+  int        bestcodeword;
+  const auto tempVec = make_unique_for_overwrite<double[]>(m_VectorDimension);
 
   // unused: double *centroidVecTemp = ( double * ) new double[m_VectorDimension];
 
@@ -510,8 +512,6 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
   // Normalize the distortions
   *distortion /= static_cast<double>(totalNumVecsInInput);
 
-  delete[] tempVec;
-
   // Check for bizarre errors
   if (*distortion < 0.0)
   {
@@ -523,8 +523,8 @@ template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SplitCodewords(int currentSize, int numDesired, int scale)
 {
-  auto * newCodebookData = (double *)new double[m_VectorDimension];
-  auto * inCodebookData = (double *)new double[m_VectorDimension];
+  const auto newCodebookData = make_unique_for_overwrite<double[]>(m_VectorDimension);
+  const auto inCodebookData = make_unique_for_overwrite<double[]>(m_VectorDimension);
 
   for (int i = 0; i < numDesired; ++i)
   {
@@ -533,16 +533,13 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SplitCodewords(int 
       inCodebookData[j] = m_Codebook[i][j];
     }
 
-    Perturb(inCodebookData, scale, newCodebookData);
+    Perturb(inCodebookData.get(), scale, newCodebookData.get());
 
     for (unsigned int j = 0; j < m_VectorDimension; ++j)
     {
       m_Codebook[i + currentSize][j] = newCodebookData[j];
     }
   }
-
-  delete[] inCodebookData;
-  delete[] newCodebookData;
 }
 
 template <typename TInputImage, typename TMembershipFunction>

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -36,10 +37,10 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   using LabelType = unsigned short;
 
-  auto *    equivalenceTable = new LabelType[NumericTraits<LabelType>::max()];
-  LabelType label = 0;
-  LabelType maxLabel = 0;
-  SizeType  size;
+  const auto equivalenceTable = make_unique_for_overwrite<LabelType[]>(NumericTraits<LabelType>::max());
+  LabelType  label = 0;
+  LabelType  maxLabel = 0;
+  SizeType   size;
 
   typename ListType::iterator iter;
 
@@ -158,8 +159,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
     }
   }
 
-  auto * flags = new unsigned char[NumericTraits<LabelType>::max()];
-  memset(flags, 0, maxLabel + 1);
+  const auto flags = make_unique_for_overwrite<unsigned char[]>(NumericTraits<LabelType>::max());
+  memset(flags.get(), 0, maxLabel + 1);
   for (iter = m_Seeds.begin(); iter != m_Seeds.end(); ++iter)
   {
     const IndexType currentIndex = *iter;
@@ -188,8 +189,6 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
       ot.Set(flags[static_cast<LabelType>(ot.Get())]);
     }
   }
-  delete[] equivalenceTable;
-  delete[] flags;
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkLabelVotingImageFilter.h"
 
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -236,14 +237,14 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
   const size_t numberOfInputs = this->GetNumberOfInputs();
 
   // create and initialize all input image iterators
-  auto * it = new InputConstIteratorType[numberOfInputs];
+  const auto it = make_unique_for_overwrite<InputConstIteratorType[]>(numberOfInputs);
   for (size_t k = 0; k < numberOfInputs; ++k)
   {
     it[k] = InputConstIteratorType(this->GetInput(k), output->GetRequestedRegion());
   }
 
   // allocate array for pixel class weights
-  auto * W = new WeightsType[this->m_TotalLabelCount];
+  const auto W = make_unique_for_overwrite<WeightsType[]>(this->m_TotalLabelCount);
 
   unsigned int iteration = 0;
   for (; (!this->m_HasMaximumNumberOfIterations) || (iteration < this->m_MaximumNumberOfIterations); ++iteration)
@@ -413,9 +414,6 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
   }
 
   m_ElapsedNumberOfIterations = iteration;
-
-  delete[] W;
-  delete[] it;
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef itkRGBGibbsPriorFilter_hxx
 #define itkRGBGibbsPriorFilter_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
+
 #include <cstdlib>
 #include <cstdio>
 #include <ctime>
@@ -562,7 +564,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
   LabelledImageIndexType offsetIndex3D;
   offsetIndex3D.Fill(0);
 
-  auto * dist = new double[m_NumberOfClasses];
+  const auto dist = make_unique_for_overwrite<double[]>(m_NumberOfClasses);
 
   const unsigned int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
   const unsigned int frame = m_ImageWidth * m_ImageHeight;
@@ -612,8 +614,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
     ++inputImageIt;
     ++mediumImageIt;
   }
-
-  delete[] dist;
 }
 
 /* Remove the tiny bias inside the object region. */
@@ -629,7 +629,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
   delete[] m_RegionCount;
   m_RegionCount = new unsigned short[size];
 
-  auto * valid_region_counter = new unsigned short[size];
+  const auto valid_region_counter = make_unique_for_overwrite<unsigned short[]>(size);
 
   LabelledImageRegionIterator labelledImageIt(m_LabelledImage, m_LabelledImage->GetBufferedRegion());
 
@@ -681,8 +681,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
     ++i;
     ++labelledImageIt;
   }
-
-  delete[] valid_region_counter;
 }
 
 template <typename TInputImage, typename TClassifiedImage>

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include "vnl/vnl_sample.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -224,7 +225,7 @@ template <typename TCoordRepType>
 void
 VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
 {
-  auto * rawEdges = new EdgeInfoDQ[m_NumberOfSeeds];
+  const auto rawEdges = make_unique_for_overwrite<EdgeInfoDQ[]>(m_NumberOfSeeds);
 
   m_OutputVD->Reset();
 
@@ -417,8 +418,6 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
     m_OutputVD->BuildEdge(i);
   }
   m_OutputVD->InsertCells();
-
-  delete[] rawEdges;
 }
 
 template <typename TCoordRepType>

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -20,6 +20,7 @@
 #define itkVideoFileReader_hxx
 
 #include "itkConvertPixelBuffer.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 
 namespace itk
@@ -231,15 +232,14 @@ VideoFileReader<TOutputVideoStream>::TemporalStreamingGenerateData()
   if (this->m_PixelConversionNeeded)
   {
     // Set up temporary buffer for reading
-    size_t bufferSize = m_VideoIO->GetImageSizeInBytes();
-    auto * loadBuffer = new char[bufferSize];
+    size_t     bufferSize = m_VideoIO->GetImageSizeInBytes();
+    const auto loadBuffer = make_unique_for_overwrite<char[]>(bufferSize);
 
     // Read into a temporary buffer
-    this->m_VideoIO->Read(static_cast<void *>(loadBuffer));
+    this->m_VideoIO->Read(static_cast<void *>(loadBuffer.get()));
 
     // Convert the buffer into the output buffer location
-    this->DoConvertBuffer(static_cast<void *>(loadBuffer), frameNum);
-    delete[] loadBuffer;
+    this->DoConvertBuffer(static_cast<void *>(loadBuffer.get()), frameNum);
   }
   else
   {


### PR DESCRIPTION
Replaced `new T[n]` with `make_unique_for_overwrite<T[]>(n)` calls, for the
initialization of local variables in ITK library files (*.h, *.hxx), and
removed the corresponding `delete[]` statements.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3590
commit 15d09d6c756b46b4d1c296d8bb13b85f82654ef9
"STYLE: Replace `new T[n]` with `make_unique_for_overwrite` in cxx files"