### PR TITLE
BUG: Fix variable typo `MultiphaseDenseFiniteDifferenceImageFilter` test

### DIFF
--- a/Modules/Nonunit/Review/test/itkMultiphaseDenseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseDenseFiniteDifferenceImageFilterTest.cxx
@@ -112,7 +112,7 @@ itkMultiphaseDenseFiniteDifferenceImageFilterTest(int, char *[])
 
   unsigned int reinitializeCounter = 1;
   filter->SetReinitializeCounter(reinitializeCounter);
-  ITK_TEST_SET_GET_VALUE(reinitializeCounter, flter->GetReinitializeCounter());
+  ITK_TEST_SET_GET_VALUE(reinitializeCounter, filter->GetReinitializeCounter());
 
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
Fix variable spelling mistake in `Review` module
`itk::MultiphaseDenseFiniteDifferenceImageFilter` class test file.

Fixes:
```
/Nonunit/Review/test/itkMultiphaseDenseFiniteDifferenceImageFilterTest.cxx:115:47:
error: use of undeclared identifier 'flter'; did you mean 'filter'?
  ITK_TEST_SET_GET_VALUE(reinitializeCounter, flter->GetReinitializeCounter());
                                              ^~~~~
                                              filter
```

introduced in commit 669a39c.

Raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=8135692

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)