### PR TITLE
STYLE: Make unique_ptr by make_unique_for_overwrite, instead of new T[]

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -27,6 +27,7 @@
  *=========================================================================*/
 #ifndef itkByteSwapper_hxx
 #define itkByteSwapper_hxx
+#include "itkMakeUniqueForOverwrite.h"
 #include <algorithm> // For swap.
 #include <memory>
 #include <cstring>
@@ -301,7 +302,7 @@ ByteSwapper<T>::SwapWrite2Range(const void * ptr, BufferSizeType num, OStreamTyp
   {
     chunkSize = num;
   }
-  const std::unique_ptr<char[]> cpy(new char[chunkSize * 2]);
+  const auto cpy = make_unique_for_overwrite<char[]>(chunkSize * 2);
   while (num)
   {
     memcpy(cpy.get(), ptr, chunkSize * 2);
@@ -355,7 +356,7 @@ ByteSwapper<T>::SwapWrite4Range(const void * ptr, BufferSizeType num, OStreamTyp
   {
     chunkSize = num;
   }
-  const std::unique_ptr<char[]> cpy(new char[chunkSize * 4]);
+  const auto cpy = make_unique_for_overwrite<char[]>(chunkSize * 4);
 
   while (num)
   {
@@ -412,7 +413,7 @@ ByteSwapper<T>::SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamTyp
   {
     chunkSize = num;
   }
-  const std::unique_ptr<char[]> cpy(new char[chunkSize * 8]);
+  const auto cpy = make_unique_for_overwrite<char[]>(chunkSize * 8);
 
   while (num)
   {

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -30,7 +30,7 @@
 #ifndef itkTriangleMeshCurvatureCalculator_hxx
 #define itkTriangleMeshCurvatureCalculator_hxx
 
-#include <memory> // For unique_ptr
+#include "itkMakeUniqueForOverwrite.h"
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 #include "vnl/vnl_cross.h"
@@ -81,9 +81,9 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
 
   const unsigned int numberOfPoints = inputMesh->GetNumberOfPoints();
 
-  const std::unique_ptr<double[]> K(new double[numberOfPoints]);
-  const std::unique_ptr<double[]> dA(new double[numberOfPoints]);
-  double                          pi2 = itk::Math::twopi;
+  const auto K = make_unique_for_overwrite<double[]>(numberOfPoints);
+  const auto dA = make_unique_for_overwrite<double[]>(numberOfPoints);
+  double     pi2 = itk::Math::twopi;
   for (unsigned int k = 0; k < numberOfPoints; ++k)
   {
     K[k] = pi2;

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkObjectFactory.h"
 #include "itkImageLinearIteratorWithIndex.h"
-#include <memory> // For unique_ptr
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -281,9 +281,9 @@ RecursiveSeparableImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerat
 
   const SizeValueType ln = region.GetSize(this->m_Direction);
 
-  const std::unique_ptr<RealType[]> inps(new RealType[ln]);
-  const std::unique_ptr<RealType[]> outs(new RealType[ln]);
-  const std::unique_ptr<RealType[]> scratch(new RealType[ln]);
+  const auto inps = make_unique_for_overwrite<RealType[]>(ln);
+  const auto outs = make_unique_for_overwrite<RealType[]>(ln);
+  const auto scratch = make_unique_for_overwrite<RealType[]>(ln);
 
   inputIterator.GoToBegin();
   outputIterator.GoToBegin();

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -20,8 +20,8 @@
 
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
+#include "itkMakeUniqueForOverwrite.h"
 
-#include <memory> // For unique_ptr.
 #include <numeric>
 #include <functional>
 
@@ -141,8 +141,8 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   }
 
   // allocate accumulate line
-  const size_t                                 ln = outputRegionForThread.GetSize(0);
-  const std::unique_ptr<AccumulatePixelType[]> accBuffer(new AccumulatePixelType[ln]);
+  const size_t ln = outputRegionForThread.GetSize(0);
+  const auto   accBuffer = make_unique_for_overwrite<AccumulatePixelType[]>(ln);
 
   // convert the shrink factor for convenient multiplication
   typename TOutputImage::SizeType factorSize;

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -21,6 +21,7 @@
 #include "itkArray.h"
 #include "itksys/SystemTools.hxx"
 #include "itk_H5Cpp.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <algorithm>
 
@@ -482,8 +483,8 @@ HDF5ImageIO ::WriteDirections(const std::string & path, const std::vector<std::v
   hsize_t dim[2];
   dim[1] = dir.size();
   dim[0] = dir[0].size();
-  const std::unique_ptr<double[]> buf(new double[dim[0] * dim[1]]);
-  unsigned int                    k(0);
+  const auto   buf = make_unique_for_overwrite<double[]>(dim[0] * dim[1]);
+  unsigned int k(0);
   for (unsigned int i = 0; i < dim[1]; ++i)
   {
     for (unsigned int j = 0; j < dim[0]; ++j)
@@ -520,7 +521,7 @@ HDF5ImageIO ::ReadDirections(const std::string & path)
   H5::FloatType dirType = dirSet.getFloatType();
   if (dirType.getSize() == sizeof(double))
   {
-    const std::unique_ptr<double[]> buf(new double[dim[0] * dim[1]]);
+    const auto buf = make_unique_for_overwrite<double[]>(dim[0] * dim[1]);
     dirSet.read(buf.get(), H5::PredType::NATIVE_DOUBLE);
     int k = 0;
     for (unsigned int i = 0; i < dim[1]; ++i)
@@ -534,7 +535,7 @@ HDF5ImageIO ::ReadDirections(const std::string & path)
   }
   else
   {
-    const std::unique_ptr<float[]> buf(new float[dim[0] * dim[1]]);
+    const auto buf = make_unique_for_overwrite<float[]>(dim[0] * dim[1]);
     dirSet.read(buf.get(), H5::PredType::NATIVE_FLOAT);
     int k = 0;
     for (unsigned int i = 0; i < dim[1]; ++i)
@@ -728,8 +729,8 @@ HDF5ImageIO ::ReadImageInformation()
     // by comparing the size of the Directions matrix with the
     // reported # of dimensions in the voxel dataset
     {
-      hsize_t                          nDims = imageSpace.getSimpleExtentNdims();
-      const std::unique_ptr<hsize_t[]> Dims(new hsize_t[nDims]);
+      hsize_t    nDims = imageSpace.getSimpleExtentNdims();
+      const auto Dims = make_unique_for_overwrite<hsize_t[]>(nDims);
       imageSpace.getSimpleExtentDims(Dims.get());
       if (nDims > this->GetNumberOfDimensions())
       {
@@ -925,9 +926,9 @@ HDF5ImageIO ::SetupStreaming(H5::DataSpace * imageSpace, H5::DataSpace * slabSpa
 
   const int HDFDim(this->GetNumberOfDimensions() + (numComponents > 1 ? 1 : 0));
 
-  const std::unique_ptr<hsize_t[]> offset(new hsize_t[HDFDim]);
-  const std::unique_ptr<hsize_t[]> HDFSize(new hsize_t[HDFDim]);
-  const int                        limit = regionToRead.GetImageDimension();
+  const auto offset = make_unique_for_overwrite<hsize_t[]>(HDFDim);
+  const auto HDFSize = make_unique_for_overwrite<hsize_t[]>(HDFDim);
+  const int  limit = regionToRead.GetImageDimension();
   //
   // fastest moving dimension is intra-voxel
   // index
@@ -1066,7 +1067,7 @@ HDF5ImageIO ::WriteImageInformation()
     int numDims = this->GetNumberOfDimensions();
     // HDF5 dimensions listed slowest moving first, ITK are fastest
     // moving first.
-    std::unique_ptr<hsize_t[]> dims(new hsize_t[numDims + (numComponents == 1 ? 0 : 1)]);
+    auto dims = make_unique_for_overwrite<hsize_t[]>(numDims + (numComponents == 1 ? 0 : 1));
 
     for (int i(0), j(numDims - 1); i < numDims; i++, j--)
     {
@@ -1278,7 +1279,7 @@ HDF5ImageIO ::Write(const void * buffer)
     int numDims = this->GetNumberOfDimensions();
     // HDF5 dimensions listed slowest moving first, ITK are fastest
     // moving first.
-    const std::unique_ptr<hsize_t[]> dims(new hsize_t[numDims + (numComponents == 1 ? 0 : 1)]);
+    const auto dims = make_unique_for_overwrite<hsize_t[]>(numDims + (numComponents == 1 ? 0 : 1));
 
     for (int i(0), j(numDims - 1); i < numDims; i++, j--)
     {

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -26,7 +26,7 @@
 #include "itkMetaDataObject.h"
 
 #include "itksys/SystemTools.hxx"
-#include <memory> // For unique_ptr
+#include "itkMakeUniqueForOverwrite.h"
 #include <fstream>
 
 namespace itk
@@ -399,7 +399,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
                   << ConvertPixelTraits::GetNumberOfComponents() << " m_ImageIO->NumComponents "
                   << m_ImageIO->GetNumberOfComponents());
 
-    const std::unique_ptr<char[]> loadBuffer(new char[sizeOfActualIORegion]);
+    const auto loadBuffer = make_unique_for_overwrite<char[]>(sizeOfActualIORegion);
     m_ImageIO->Read(static_cast<void *>(loadBuffer.get()));
 
     // See note below as to why the buffered region is needed and
@@ -417,7 +417,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
 
     OutputImagePixelType * outputBuffer = output->GetPixelContainer()->GetBufferPointer();
 
-    const std::unique_ptr<char[]> loadBuffer(new char[sizeOfActualIORegion]);
+    const auto loadBuffer = make_unique_for_overwrite<char[]>(sizeOfActualIORegion);
     m_ImageIO->Read(static_cast<void *>(loadBuffer.get()));
 
     // we use std::copy_n here as it should be optimized to memcpy for

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -104,8 +104,8 @@ MINCImageIO::Read(void * buffer)
   const unsigned int nDims = this->GetNumberOfDimensions();
   const unsigned int nComp = this->GetNumberOfComponents();
 
-  const std::unique_ptr<misize_t[]> start(new misize_t[nDims + (nComp > 1 ? 1 : 0)]);
-  const std::unique_ptr<misize_t[]> count(new misize_t[nDims + (nComp > 1 ? 1 : 0)]);
+  const auto start = make_unique_for_overwrite<misize_t[]>(nDims + (nComp > 1 ? 1 : 0));
+  const auto count = make_unique_for_overwrite<misize_t[]>(nDims + (nComp > 1 ? 1 : 0));
 
   for (unsigned int i = 0; i < nDims; ++i)
   {
@@ -1363,8 +1363,8 @@ MINCImageIO::Write(const void * buffer)
   const unsigned int nComp = this->GetNumberOfComponents();
   size_t             buffer_length = 1;
 
-  const std::unique_ptr<misize_t[]> start(new misize_t[nDims + (nComp > 1 ? 1 : 0)]);
-  const std::unique_ptr<misize_t[]> count(new misize_t[nDims + (nComp > 1 ? 1 : 0)]);
+  const auto start = make_unique_for_overwrite<misize_t[]>(nDims + (nComp > 1 ? 1 : 0));
+  const auto count = make_unique_for_overwrite<misize_t[]>(nDims + (nComp > 1 ? 1 : 0));
 
   for (unsigned int i = 0; i < nDims; ++i)
   {

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -27,9 +27,9 @@
 #include "itkPixelTraits.h"
 
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
-#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -346,8 +346,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
 {
   typename TOutputMesh::Pointer output = this->GetOutput();
 
-  const std::unique_ptr<OutputPointPixelType[]> outputPointDataBuffer(
-    new OutputPointPixelType[m_MeshIO->GetNumberOfPointPixels()]);
+  const auto outputPointDataBuffer =
+    make_unique_for_overwrite<OutputPointPixelType[]>(m_MeshIO->GetNumberOfPointPixels());
 
   if ((m_MeshIO->GetPointPixelComponentType() !=
        MeshIOBase::MapComponentType<typename ConvertPointPixelTraits::ComponentType>::CType) ||
@@ -362,10 +362,9 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
                   << "ConvertPointPixelTraits::NumberOfComponents " << ConvertPointPixelTraits::GetNumberOfComponents()
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfPointPixelComponents());
 
-    const std::unique_ptr<char[]> inputPointDataBuffer(
-      new char[m_MeshIO->GetNumberOfPointPixelComponents() *
-               m_MeshIO->GetComponentSize(m_MeshIO->GetPointPixelComponentType()) *
-               m_MeshIO->GetNumberOfPointPixels()]);
+    const auto inputPointDataBuffer = make_unique_for_overwrite<char[]>(
+      m_MeshIO->GetNumberOfPointPixelComponents() * m_MeshIO->GetComponentSize(m_MeshIO->GetPointPixelComponentType()) *
+      m_MeshIO->GetNumberOfPointPixels());
     m_MeshIO->ReadPointData(static_cast<void *>(inputPointDataBuffer.get()));
 
     this->ConvertPointPixelBuffer(
@@ -389,8 +388,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
 {
   typename TOutputMesh::Pointer output = this->GetOutput();
 
-  const std::unique_ptr<OutputCellPixelType[]> outputCellDataBuffer(
-    new OutputCellPixelType[m_MeshIO->GetNumberOfCellPixels()]);
+  const auto outputCellDataBuffer = make_unique_for_overwrite<OutputCellPixelType[]>(m_MeshIO->GetNumberOfCellPixels());
 
   if ((m_MeshIO->GetCellPixelComponentType() !=
        MeshIOBase::MapComponentType<typename ConvertCellPixelTraits::ComponentType>::CType) ||
@@ -405,9 +403,9 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
                   << "ConvertCellPixelTraits::NumberOfComponents " << ConvertCellPixelTraits::GetNumberOfComponents()
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfCellPixelComponents());
 
-    const std::unique_ptr<char[]> inputCellDataBuffer(
-      new char[m_MeshIO->GetNumberOfCellPixelComponents() *
-               m_MeshIO->GetComponentSize(m_MeshIO->GetCellPixelComponentType()) * m_MeshIO->GetNumberOfCellPixels()]);
+    const auto inputCellDataBuffer = make_unique_for_overwrite<char[]>(
+      m_MeshIO->GetNumberOfCellPixelComponents() * m_MeshIO->GetComponentSize(m_MeshIO->GetCellPixelComponentType()) *
+      m_MeshIO->GetNumberOfCellPixels());
     m_MeshIO->ReadCellData(static_cast<void *>(inputCellDataBuffer.get()));
 
     this->ConvertCellPixelBuffer(
@@ -825,7 +823,7 @@ template <typename T>
 void
 MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::ReadPointsUsingMeshIO()
 {
-  const std::unique_ptr<T[]> buffer(new T[m_MeshIO->GetNumberOfPoints() * OutputPointDimension]);
+  const auto buffer = make_unique_for_overwrite<T[]>(m_MeshIO->GetNumberOfPoints() * OutputPointDimension);
   m_MeshIO->ReadPoints(buffer.get());
   Self::ReadPoints(buffer.get());
 }
@@ -836,7 +834,7 @@ template <typename T>
 void
 MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::ReadCellsUsingMeshIO()
 {
-  const std::unique_ptr<T[]> buffer(new T[m_MeshIO->GetCellBufferSize()]);
+  const auto buffer = make_unique_for_overwrite<T[]>(m_MeshIO->GetCellBufferSize());
   m_MeshIO->ReadCells(buffer.get());
   Self::ReadCells(buffer.get());
 }

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
@@ -141,7 +141,7 @@ protected:
   {
     constexpr itk::uint32_t numberOfCellPoints = 3;
 
-    const std::unique_ptr<itk::uint32_t[]> data(new itk::uint32_t[this->m_NumberOfCells * numberOfCellPoints]);
+    const auto data = make_unique_for_overwrite<itk::uint32_t[]>(this->m_NumberOfCells * numberOfCellPoints);
 
     ReadCellsBuffer(buffer, data.get());
     itk::ByteSwapper<itk::uint32_t>::SwapWriteRangeFromSystemToBigEndian(

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -18,6 +18,7 @@
 #include "itkPNGImageIO.h"
 #include "itk_png.h"
 #include "itksys/SystemTools.hxx"
+#include "itkMakeUniqueForOverwrite.h"
 #include <string>
 #include <csetjmp>
 
@@ -233,9 +234,9 @@ PNGImageIO::Read(void * buffer)
   // update the info now that we have defined the filters
   png_read_update_info(png_ptr, info_ptr);
 
-  auto                               rowbytes = static_cast<SizeValueType>(png_get_rowbytes(png_ptr, info_ptr));
-  auto *                             tempImage = static_cast<unsigned char *>(buffer);
-  const std::unique_ptr<png_bytep[]> row_pointers(new png_bytep[height]);
+  auto       rowbytes = static_cast<SizeValueType>(png_get_rowbytes(png_ptr, info_ptr));
+  auto *     tempImage = static_cast<unsigned char *>(buffer);
+  const auto row_pointers = make_unique_for_overwrite<png_bytep[]>(height);
   for (unsigned int ui = 0; ui < height; ++ui)
   {
     row_pointers[ui] = tempImage + rowbytes * ui;
@@ -681,7 +682,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
     png_set_swap(png_ptr);
 #endif
   }
-  const std::unique_ptr<png_bytep[]> row_pointers(new png_bytep[height]);
+  const auto row_pointers = make_unique_for_overwrite<png_bytep[]>(height);
 
   {
     const int                      rowInc = width * numComp * bitDepth / 8;

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -24,6 +24,7 @@
 #include "itkCompositeTransform.h"
 #include "itkCompositeTransformIOHelper.h"
 #include "itkVersion.h"
+#include "itkMakeUniqueForOverwrite.h"
 #include <sstream>
 
 namespace itk
@@ -183,7 +184,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string 
 
   if (ParamType.getSize() == sizeof(double))
   {
-    const std::unique_ptr<double[]> buf(new double[dim]);
+    const auto buf = make_unique_for_overwrite<double[]>(dim);
     paramSet.read(buf.get(), H5::PredType::NATIVE_DOUBLE);
     for (unsigned int i = 0; i < dim; ++i)
     {
@@ -192,7 +193,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string 
   }
   else
   {
-    const std::unique_ptr<float[]> buf(new float[dim]);
+    const auto buf = make_unique_for_overwrite<float[]>(dim);
     paramSet.read(buf.get(), H5::PredType::NATIVE_FLOAT);
     for (unsigned int i = 0; i < dim; ++i)
     {
@@ -230,7 +231,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadFixedParameters(const std::st
 
   if (ParamType.getSize() == sizeof(double))
   {
-    const std::unique_ptr<double[]> buf(new double[dim]);
+    const auto buf = make_unique_for_overwrite<double[]>(dim);
     paramSet.read(buf.get(), H5::PredType::NATIVE_DOUBLE);
     for (unsigned int i = 0; i < dim; ++i)
     {
@@ -239,7 +240,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadFixedParameters(const std::st
   }
   else
   {
-    const std::unique_ptr<float[]> buf(new float[dim]);
+    const auto buf = make_unique_for_overwrite<float[]>(dim);
     paramSet.read(buf.get(), H5::PredType::NATIVE_FLOAT);
     for (unsigned int i = 0; i < dim; ++i)
     {


### PR DESCRIPTION
Initialized existing `unique_ptr<T[]>` variables by `make_unique_for_overwrite`,
instead of by `new T[]`, using the following regular expression in Visual Studio:

 - Find: `std::unique_ptr<(.+)\[\]> (\w+)\(new \1\[(.+)\]\);`
 - Replace with: `auto $2 = make_unique_for_overwrite<$1[]>($3);`

Aims to make code of previous `unique_ptr` use cases consistent with more
recent commits, including:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3596
commit a9bd57036c8ee3bb7325332ccd8b80c99e6375ae
"STYLE: More make_unique_for_overwrite, less delete[], on local variables"