### PR TITLE
Attribute morphology consolidation

### DIFF
--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -26,23 +26,11 @@ namespace itk
  * \class AreaClosingImageFilter
  * \brief Morphological closing by attributes
  *
- * This is the base class for morphology attribute
- * operations. Attribute openings remove blobs according to criteria
- * such as area. When applied to grayscale images it has the effect of
- * trimming peaks based on area while leaving the rest of the image
- * unchanged. It is possible to use attributes besides area, but no
- * others are implemented yet. This filter uses some dodgy coding
- * practices - most notably copying the image data to a linear buffer
- * to allow direct implementation of the published algorithm. It
- * should therefore be quite a good candidate to carry out tests of
- * itk iterator performance with randomish access patterns.
- *
- * This filter is implemented using the method of Wilkinson, "A
- * comparison of algorithms for Connected set openings and Closings",
- * A. Meijster and M. H. Wilkinson, PAMI, vol 24, no. 4, April 2002.
- * Attempts at implementing the method from ISMM 2000 are also
- * included, but operation appears incorrect. Check the ifdefs if you
- * are interested.
+ * Attribute closing remove blobs according to criteria
+ * such as area. When applied to grayscale images they have the effect of
+ * filling valleys (regions darker than their surroundings)
+ * based on area while leaving the rest of the image
+ * unchanged.
  *
  * This code was contributed in the Insight Journal paper
  *

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -27,23 +27,11 @@ namespace itk
  * \class AreaOpeningImageFilter
  * \brief Morphological opening by attributes
  *
- * This is the base class for morphology attribute
- * operations. Attribute openings remove blobs according to criteria
- * such as area. When applied to grayscale images it has the effect of
- * trimming peaks based on area while leaving the rest of the image
- * unchanged. It is possible to use attributes besides area, but no
- * others are implemented yet. This filter uses some dodgy coding
- * practices - most notably copying the image data to a linear buffer
- * to allow direct implementation of the published algorithm. It
- * should therefore be quite a good candidate to carry out tests of
- * itk iterator performance with randomish access patterns.
- *
- * This filter is implemented using the method of Wilkinson, "A
- * comparison of algorithms for Connected set openings and Closings",
- * A. Meijster and M. H. Wilkinson, PAMI, vol 24, no. 4, April 2002.
- * Attempts at implementing the method from ISMM 2000 are also
- * included, but operation appears incorrect. Check the ifdefs if you
- * are interested.
+ * Attribute openings remove blobs according to criteria
+ * such as area. When applied to grayscale images they have the effect of
+ * trimming peaks (regions brighter than their surrounings)
+ * based on area while leaving the rest of the image
+ * unchanged.
  *
  * This code was contributed in the Insight Journal paper
  *

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -21,8 +21,6 @@
 #include "itkImageToImageFilter.h"
 #include <vector>
 
-#define PAMI
-
 namespace itk
 {
 /**
@@ -211,7 +209,6 @@ private:
     }
   };
 
-#ifdef PAMI
   // version from PAMI. Note - using the AuxData array rather than the
   // parent array to store area
   void
@@ -259,8 +256,6 @@ private:
       }
     }
   }
-
-#endif
 };
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -188,9 +188,7 @@ private:
 
   GreyAndPos *      m_SortPixels;
   OffsetValueType * m_Parent;
-#ifndef PAMI
-  bool * m_Processed;
-#endif
+
   // This is a bit ugly, but I can't see an easy way around
   InputPixelType * m_Raw;
 
@@ -258,75 +256,6 @@ private:
       else
       {
         m_AuxData[p] = m_Lambda;
-      }
-    }
-  }
-
-#else
-  // version from ISMM paper
-  void
-  MakeSet(OffsetValueType x)
-  {
-    m_Parent[x] = ACTIVE;
-    m_AuxData[x] = m_AttributeValuePerPixel;
-  }
-
-  void
-  Link(OffsetValueType x, OffsetValueType y)
-  {
-    if ((m_Parent[y] == ACTIVE) && (m_Parent[x] == ACTIVE))
-    {
-      // should be a call to MergeAuxData
-      m_AuxData[y] = m_AuxData[x] + m_AuxData[y];
-      m_AuxData[x] = -m_AttributeValuePerPixel;
-    }
-    else if (m_Parent[x] == ACTIVE)
-    {
-      m_AuxData[x] = -m_AttributeValuePerPixel;
-    }
-    else
-    {
-      m_AuxData[y] = -m_AttributeValuePerPixel;
-      m_Parent[y] = INACTIVE;
-    }
-    m_Parent[x] = y;
-  }
-
-  OffsetValueType
-  FindRoot(OffsetValueType x)
-  {
-    if (m_Parent[x] >= 0)
-    {
-      m_Parent[x] = FindRoot(m_Parent[x]);
-      return (m_Parent[x]);
-    }
-    else
-    {
-      return (x);
-    }
-  }
-
-  bool
-  Equiv(OffsetValueType x, OffsetValueType y)
-  {
-    return ((m_Raw[x] == m_Raw[y]) || (m_Parent[x] == ACTIVE));
-  }
-
-  void
-  Union(OffsetValueType n, OffsetValueType p)
-  {
-    OffsetValueType r = FindRoot(n);
-
-    if (r != p)
-    {
-      if (Equiv(r, p))
-      {
-        Link(r, p);
-      }
-      else if (m_Parent[p] == ACTIVE)
-      {
-        m_Parent[p] = INACTIVE;
-        m_AuxData[p] = -m_AttributeValuePerPixel;
       }
     }
   }

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -30,22 +30,15 @@ namespace itk
  * \brief Morphological opening by attributes
  *
  * This is the base class for morphology attribute
- * operations. Attribute openings remove blobs according to criteria
- * such as area. When applied to grayscale images it has the effect of
- * trimming peaks based on area while leaving the rest of the image
- * unchanged. It is possible to use attributes besides area, but no
- * others are implemented yet. This filter uses some dodgy coding
- * practices - most notably copying the image data to a linear buffer
- * to allow direct implementation of the published algorithm. It
- * should therefore be quite a good candidate to carry out tests of
- * itk iterator performance with randomish access patterns.
+ * operations. Attribute operations remove blobs according to criteria
+ * such as area. Attribute openings remove bright regions that meet the
+ * attribute criteria (i.e. regions less than a user specified area or
+ * volume) while attribute closings fill dark regions that meet the
+ * attribute criteria.
  *
  * This filter is implemented using the method of Wilkinson, "A
  * comparison of algorithms for Connected set openings and Closings",
  * A. Meijster and M. H. Wilkinson, PAMI, vol 24, no. 4, April 2002.
- * Attempts at implementing the method from ISMM 2000 are also
- * included, but operation appears incorrect. Check the ifdefs if you
- * are interested.
  *
  * This code was contributed in the Insight Journal paper
  *

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -133,7 +133,6 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
 
   // the core algorithm
   // process first pixel
-#ifdef PAMI
   MakeSet(m_SortPixels[0].Pos);
   // m_Processed[0] = true;
   for (SizeValueType k = 1; k < buffsize; ++k)
@@ -174,7 +173,6 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
     }
     progress.CompletedPixel();
   }
-#endif
 
   // resolving phase
   // copy pixels back
@@ -185,7 +183,6 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
   // fill Raw - worry about iteration details later.
   // We aren't filling m_Parent, as suggested in the paper, because it
   // is an integer array. We want this to work with float types
-#ifdef PAMI
   // write the new image to Raw - note that we aren't putting the
   // result in parent
   for (pos = buffsize - 1; pos >= 0; --pos)
@@ -203,7 +200,6 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
     progress.CompletedPixel();
   }
 
-#endif
 
   delete[] m_Raw;
   delete[] m_SortPixels;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->




STYLE: Documentation and removal of code hidden by macros

This PR consolidates documentation between parent and child classes - previously the child
classes had copies of the parent documentation.

The PAMI macro has been removed. Originally there were two versions
of the code from consecutive publications of the algorithm. The
non PAMI code was incorrect and retained for historical purposes only.

PERF: Used stl::stable_sort instead of standard sort of a class containing
both offset and pixel intensity. This slightly reduces RAM use.

Changes suggested as a result of:

@zivy SimpleITK/SimpleITK#1656

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Updated API documentation (or API not changed)

<!-- **Thanks for contributing to ITK!** -->
