### PR TITLE
Each `UpdateOutputInformation()` member function should call `GetSource()` just once

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -213,9 +213,11 @@ template <unsigned int VImageDimension>
 void
 ImageBase<VImageDimension>::UpdateOutputInformation()
 {
-  if (this->GetSource())
+  const auto source = this->GetSource();
+
+  if (source)
   {
-    this->GetSource()->UpdateOutputInformation();
+    source->UpdateOutputInformation();
   }
   else
   {

--- a/Modules/Core/Common/include/itkPointSet.hxx
+++ b/Modules/Core/Common/include/itkPointSet.hxx
@@ -277,10 +277,7 @@ template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 void
 PointSet<TPixelType, VDimension, TMeshTraits>::UpdateOutputInformation()
 {
-  if (this->GetSource())
-  {
-    this->GetSource()->UpdateOutputInformation();
-  }
+  this->Superclass::UpdateOutputInformation();
 
   // Now we should know what our largest possible region is. If our
   // requested region was not set yet, (or has been set to something

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -311,10 +311,11 @@ DataObject::Update()
 void
 DataObject::UpdateOutputInformation()
 {
+  const auto source = this->GetSource();
 
-  if (this->GetSource())
+  if (source)
   {
-    this->GetSource()->UpdateOutputInformation();
+    source->UpdateOutputInformation();
   }
 }
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -1157,9 +1157,11 @@ template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::UpdateOutputInformation()
 {
-  if (this->GetSource())
+  const auto source = this->GetSource();
+
+  if (source)
   {
-    this->GetSource()->UpdateOutputInformation();
+    source->UpdateOutputInformation();
   }
   // If we don't have a source, then let's make our Image
   // span our buffer

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -168,10 +168,7 @@ template <typename TInput, unsigned int VDimension, typename TOutput, typename T
 void
 LevelSetBase<TInput, VDimension, TOutput, TDomain>::UpdateOutputInformation()
 {
-  if (this->GetSource())
-  {
-    this->GetSource()->UpdateOutputInformation();
-  }
+  this->Superclass::UpdateOutputInformation();
 
   // Now we should know what our largest possible region is. If our
   // requested region was not set yet, (or has been set to something


### PR DESCRIPTION
When calling `GetSource()` twice on the same data object, debug output may appear duplicated, and it may cause unnecessary reference counting (both up and down) of the source object.

For clarification, the debug output may come from the `itkDebugMacro` call inside `DataObject::GetSource()`, and the reference counting comes from converting m_Source to a `SmartPointer`, here:
https://github.com/InsightSoftwareConsortium/ITK/blob/c1839700a9d28946d1313caf91795e4ce160eb13/Modules/Core/Common/src/itkDataObject.cxx#L247-L252