### PR TITLE
Add `DataObject::UpdateSource()`, replacing `GetSource()->Update()` calls

### DIFF
--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -333,6 +333,10 @@ public:
   DataObjectPointerArraySizeType
   GetSourceOutputIndex() const;
 
+  /** Does an Update() of its source, if it has one. Does nothing, otherwise. */
+  void
+  UpdateSource() const;
+
   /** Restore the data object to its initial state. This means releasing
    * memory. */
   virtual void

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -268,6 +268,17 @@ DataObject::GetSourceOutputIndex() const
   return m_Source->MakeIndexFromOutputName(m_SourceOutputName);
 }
 
+void
+DataObject::UpdateSource() const
+{
+  const auto source = this->GetSource();
+
+  if (source)
+  {
+    source->Update();
+  }
+}
+
 //----------------------------------------------------------------------------
 void
 DataObject::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -40,14 +40,8 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::InitializeT
   }
 
   // If images come from filters, then update those filters.
-  if (m_FixedImage->GetSource())
-  {
-    m_FixedImage->GetSource()->Update();
-  }
-  if (m_MovingImage->GetSource())
-  {
-    m_MovingImage->GetSource()->Update();
-  }
+  m_FixedImage->UpdateSource();
+  m_MovingImage->UpdateSource();
 
   InputPointType   rotationCenter;
   OutputVectorType translationVector;

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -65,10 +65,7 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
   }
 
   // If the image is provided by a source, update the source.
-  if (m_TrainingMovingImage->GetSource())
-  {
-    m_TrainingMovingImage->GetSource()->Update();
-  }
+  m_TrainingMovingImage->UpdateSource();
 
   if (!m_TrainingFixedImage)
   {
@@ -76,10 +73,7 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
   }
 
   // If the image is provided by a source, update the source.
-  if (m_TrainingFixedImage->GetSource())
-  {
-    m_TrainingFixedImage->GetSource()->Update();
-  }
+  m_TrainingFixedImage->UpdateSource();
 
   if (m_TrainingFixedImageRegion.GetNumberOfPixels() == 0)
   {

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -256,16 +256,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
 
   // If the image is provided by a source, update the source.
-  if (m_MovingImage->GetSource())
-  {
-    m_MovingImage->GetSource()->Update();
-  }
+  m_MovingImage->UpdateSource();
 
   // If the image is provided by a source, update the source.
-  if (m_FixedImage->GetSource())
-  {
-    m_FixedImage->GetSource()->Update();
-  }
+  m_FixedImage->UpdateSource();
 
   // The use of FixedImageIndexes and the use of FixedImageRegion
   // are mutually exclusive, so they should not both be checked.

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -73,10 +73,7 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::Initialize()
   }
 
   // If the image is provided by a source, update the source.
-  if (m_FixedImage->GetSource())
-  {
-    m_FixedImage->GetSource()->Update();
-  }
+  m_FixedImage->UpdateSource();
 
   m_Interpolator->SetInputImage(m_FixedImage);
 

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -78,16 +78,10 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::Initialize()
   }
 
   // If the image is provided by a source, update the source.
-  if (m_MovingImage->GetSource())
-  {
-    m_MovingImage->GetSource()->Update();
-  }
+  m_MovingImage->UpdateSource();
 
   // If the point set is provided by a source, update the source.
-  if (m_FixedPointSet->GetSource())
-  {
-    m_FixedPointSet->GetSource()->Update();
-  }
+  m_FixedPointSet->UpdateSource();
 
   m_Interpolator->SetInputImage(m_MovingImage);
 

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
@@ -64,16 +64,10 @@ PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initialize()
   }
 
   // If the PointSet is provided by a source, update the source.
-  if (m_MovingPointSet->GetSource())
-  {
-    m_MovingPointSet->GetSource()->Update();
-  }
+  m_MovingPointSet->UpdateSource();
 
   // If the point set is provided by a source, update the source.
-  if (m_FixedPointSet->GetSource())
-  {
-    m_FixedPointSet->GetSource()->Update();
-  }
+  m_FixedPointSet->UpdateSource();
 }
 
 /** PrintSelf */

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -108,16 +108,10 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   }
 
   // If the image is provided by a source, update the source.
-  if (this->m_MovingImage->GetSource())
-  {
-    this->m_MovingImage->GetSource()->Update();
-  }
+  this->m_MovingImage->UpdateSource();
 
   // If the image is provided by a source, update the source.
-  if (this->m_FixedImage->GetSource())
-  {
-    this->m_FixedImage->GetSource()->Update();
-  }
+  this->m_FixedImage->UpdateSource();
 
   /* If a virtual image has not been set or created,
    * create one from fixed image settings */

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -79,16 +79,10 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   }
 
   // If the PointSet is provided by a source, update the source.
-  if (this->m_MovingPointSet->GetSource())
-  {
-    this->m_MovingPointSet->GetSource()->Update();
-  }
+  this->m_MovingPointSet->UpdateSource();
 
   // If the point set is provided by a source, update the source.
-  if (this->m_FixedPointSet->GetSource())
-  {
-    this->m_FixedPointSet->GetSource()->Update();
-  }
+  this->m_FixedPointSet->UpdateSource();
 
   // Check for virtual domain if needed.
   // With local-support transforms we need a virtual domain in


### PR DESCRIPTION
`DataObject::UpdateSource()` offers a more efficient, more concise alternative to the following common pattern:

    if (x->GetSource())
    {
      x->GetSource()->Update();
    }

Calling `DataObject::UpdateSource()` instead is more efficient, because it internally calls `DataObject::GetSource()` just once, instead of twice.

Replaced all (15) occurrences of the pattern with  `x->UpdateSource()` calls.

Follow-up to pull request #3602 "Each `UpdateOutputInformation()` member function should call `GetSource()` just once"