### PR TITLE
STYLE: Let Operator Fill allocate temp_slice on the stack, without `new`

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -43,10 +43,9 @@ template <typename TPixel, unsigned int TDimension, typename TAllocator>
 void
 AnnulusOperator<TPixel, TDimension, TAllocator>::Fill(const CoefficientVector & coeff)
 {
-  auto * temp_slice = new std::slice(0, coeff.size(), 1);
+  const std::slice temp_slice(0, coeff.size(), 1);
 
-  typename Self::SliceIteratorType data(this, *temp_slice);
-  delete temp_slice;
+  typename Self::SliceIteratorType data(this, temp_slice);
 
   auto it = coeff.begin();
 

--- a/Modules/Core/Common/include/itkImageKernelOperator.hxx
+++ b/Modules/Core/Common/include/itkImageKernelOperator.hxx
@@ -87,14 +87,12 @@ ImageKernelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVecto
   // Initialize all coefficients to zero
   this->InitializeToZero();
 
-  std::slice *                               temp_slice;
   typename CoefficientVector::const_iterator it;
 
-  temp_slice = new std::slice(0, coeff.size(), 1);
+  const std::slice temp_slice(0, coeff.size(), 1);
   it = coeff.begin();
 
-  typename Superclass::SliceIteratorType data(this, *temp_slice);
-  delete temp_slice;
+  typename Superclass::SliceIteratorType data(this, temp_slice);
 
   // Copy the coefficients into the neighborhood, truncating them if there
   // are too many.

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -49,11 +49,9 @@ LaplacianOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector 
 {
   typename Superclass::CoefficientVector::const_iterator it;
 
-  std::slice * temp_slice;
-  temp_slice = new std::slice(0, coeff.size(), 1);
+  const std::slice temp_slice(0, coeff.size(), 1);
 
-  typename Self::SliceIteratorType data(this, *temp_slice);
-  delete temp_slice;
+  typename Self::SliceIteratorType data(this, temp_slice);
 
   it = coeff.begin();
 

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
@@ -122,21 +122,21 @@ NeighborhoodOperator<TPixel, VDimension, TAllocator>::FillCenteredDirectional(co
   const int sizediff = (static_cast<int>(size) - static_cast<int>(coeff.size())) >> 1;
 
   // Create a slice iterator centered in the neighborhood.
-  std::slice *                               temp_slice;
+  std::slice                                 temp_slice;
   typename CoefficientVector::const_iterator it;
   if (sizediff >= 0)
   {
-    temp_slice = new std::slice(start + sizediff * stride, coeff.size(), stride);
+    temp_slice = std::slice(start + sizediff * stride, coeff.size(), stride);
     it = coeff.begin();
   }
   else
   {
-    temp_slice = new std::slice(start, size, stride);
+    temp_slice = std::slice(start, size, stride);
     it = coeff.begin() - sizediff;
   }
 
-  SliceIteratorType data(this, *temp_slice);
-  delete temp_slice;
+
+  SliceIteratorType data(this, temp_slice);
 
   // Copy the coefficients into the neighborhood, truncating them if there
   // are too many.


### PR DESCRIPTION
Might speed up the "Fill" member functions of AnnulusOperator, ImageKernelOperator, LaplacianOperator, and NeighborhoodOperator.