### PR TITLE
ENH: Increase `itk::FastMarchingImageFilter` coverage

### DIFF
--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -161,13 +161,24 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
   ITK_TEST_SET_GET_BOOLEAN(adaptor, IsForbiddenImageBinaryMask, isForbiddenImageBinaryMask);
 
   adaptor->SetAliveImage(aliveImage.GetPointer());
-  adaptor->SetAliveValue(0.0);
+  ITK_TEST_SET_GET_VALUE(aliveImage.GetPointer(), adaptor->GetAliveImage());
+
+  typename AdaptorType::OutputPixelType aliveValue = 0.0;
+  adaptor->SetAliveValue(aliveValue);
+  ITK_TEST_SET_GET_VALUE(aliveValue, adaptor->GetAliveValue());
 
   adaptor->SetTrialImage(trialImage.GetPointer());
-  adaptor->SetTrialValue(1.0);
+  ITK_TEST_SET_GET_VALUE(trialImage.GetPointer(), adaptor->GetTrialImage());
+
+  typename AdaptorType::OutputPixelType trialValue = 1.0;
+  adaptor->SetTrialValue(trialValue);
+  ITK_TEST_SET_GET_VALUE(trialValue, adaptor->GetTrialValue());
 
   adaptor->SetForbiddenImage(maskImage.GetPointer());
+  ITK_TEST_SET_GET_VALUE(maskImage.GetPointer(), adaptor->GetForbiddenImage());
+
   adaptor->Update();
+
 
   marcher->SetForbiddenPoints(adaptor->GetForbiddenPoints());
   ITK_TEST_SET_GET_VALUE(adaptor->GetForbiddenPoints(), marcher->GetForbiddenPoints());

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -177,7 +177,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
   adaptor->SetForbiddenImage(maskImage.GetPointer());
   ITK_TEST_SET_GET_VALUE(maskImage.GetPointer(), adaptor->GetForbiddenImage());
 
-  adaptor->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(adaptor->Update());
 
 
   marcher->SetForbiddenPoints(adaptor->GetForbiddenPoints());


### PR DESCRIPTION
- ENH: Increase `itk::FastMarchingImageFilter` coverage
- STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)