### PR TITLE
ENH: Test `itk::ImageFileReader` image IO to requested region mismatch

### DIFF
--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -7,6 +7,7 @@ itkConstrainedValueDifferenceImageFilterTest.cxx
 itkSimilarityIndexImageFilterTest.cxx
 itkSTAPLEImageFilterTest.cxx
 itkTestingComparisonImageFilterTest.cxx
+itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
 )
 
 CreateTestDriver(ITKImageCompare  "${ITKImageCompare-Test_LIBRARIES}" "${ITKImageCompareTests}")
@@ -37,4 +38,9 @@ itk_add_test(NAME itkTestingComparisonImageFilterTest
       --compare DATA{Input/itkTestingComparisonImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png
     itkTestingComparisonImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cake_easy.png} DATA{${ITK_DATA_ROOT}/Input/cake_hard.png} ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png 0 10 1 1647 11 66 16.2999 26846
+)
+itk_add_test(NAME itkImageFileReaderIOToRequestedRegionMismatchTest
+      COMMAND ITKImageCompareTestDriver
+      itkImageFileReaderIOToRequestedRegionMismatchTest
+      DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png}DATA{${ITK_DATA_ROOT}/Input/BinaryImageWithVariousShapes01.png}
 )

--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -29,15 +29,24 @@ itk_add_test(NAME itkConstrainedValueDifferenceImageFilterTest
 itk_add_test(NAME itkSimilarityIndexImageFilterTest
       COMMAND ITKImageCompareTestDriver itkSimilarityIndexImageFilterTest)
 itk_add_test(NAME itkSTAPLEImageFilterTest
-  COMMAND ITKImageCompareTestDriver
---compare DATA{${ITK_DATA_ROOT}/Baseline/Algorithms/STAPLEImageFilterTest.mha}
-          ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha
-itkSTAPLEImageFilterTest 2 ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha 255 0.5 100 DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png})
+      COMMAND ITKImageCompareTestDriver
+    --compare DATA{${ITK_DATA_ROOT}/Baseline/Algorithms/STAPLEImageFilterTest.mha}
+              ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha
+    itkSTAPLEImageFilterTest
+    2 ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha 255 0.5 100
+    DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png}
+    DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png}
+    DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png}
+    DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png}
+)
 itk_add_test(NAME itkTestingComparisonImageFilterTest
       COMMAND ITKImageCompareTestDriver
       --compare DATA{Input/itkTestingComparisonImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png
-    itkTestingComparisonImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cake_easy.png} DATA{${ITK_DATA_ROOT}/Input/cake_hard.png} ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png 0 10 1 1647 11 66 16.2999 26846
+    itkTestingComparisonImageFilterTest
+    DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
+    DATA{${ITK_DATA_ROOT}/Input/cake_hard.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png 0 10 1 1647 11 66 16.2999 26846
 )
 itk_add_test(NAME itkImageFileReaderIOToRequestedRegionMismatchTest
       COMMAND ITKImageCompareTestDriver

--- a/Modules/Filtering/ImageCompare/test/itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
@@ -1,0 +1,58 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkSTAPLEImageFilter.h"
+#include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
+
+
+int
+itkImageFileReaderIOToRequestedRegionMismatchTest(int argc, char * argv[])
+{
+  if (argc < 3)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "file1 file2 ... fileN" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  constexpr unsigned int Dimension = 2;
+
+  using InputImageType = itk::Image<unsigned short, Dimension>;
+  using OutputImageType = itk::Image<double, Dimension>;
+
+  using STAPLEImageFilterType = itk::STAPLEImageFilter<InputImageType, OutputImageType>;
+  auto stapleImageFilter = STAPLEImageFilterType::New();
+
+  typename itk::ImageFileReader<InputImageType>::Pointer reader;
+  for (int i = 1; i < argc; ++i)
+  {
+    // Instantiate a new reader for each image
+    reader = itk::ImageFileReader<InputImageType>::New();
+
+    reader->SetFileName(argv[i]);
+    stapleImageFilter->SetInput(itk::Math::CastWithRangeCheck<unsigned int>(i - 1), reader->GetOutput());
+  }
+
+  // Expect an image region to requested region size mismatch exception
+  ITK_TRY_EXPECT_EXCEPTION(stapleImageFilter->Update());
+
+
+  std::cout << "Test finished." << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Test `itk::ImageFileReader` image IO to requested region mismatch exception.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)