### PR TITLE
STYLE: Allocate `Directory::m_Internal` without `new`

### DIFF
--- a/Modules/Core/Common/include/itkDirectory.h
+++ b/Modules/Core/Common/include/itkDirectory.h
@@ -80,7 +80,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  ::itksys::Directory * m_Internal;
+  ::itksys::Directory m_Internal;
 }; // End Class: Directory
 } // end namespace itk
 

--- a/Modules/Core/Common/src/itkDirectory.cxx
+++ b/Modules/Core/Common/src/itkDirectory.cxx
@@ -22,18 +22,12 @@ namespace itk
 /**
  *
  */
-Directory::Directory()
-{
-  m_Internal = new itksys::Directory;
-}
+Directory::Directory() = default;
 
 /**
  *
  */
-Directory::~Directory()
-{
-  delete m_Internal;
-}
+Directory::~Directory() = default;
 
 /**
  *
@@ -42,13 +36,13 @@ void
 Directory::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Directory for: " << m_Internal->GetPath() << "\n";
+  os << indent << "Directory for: " << m_Internal.GetPath() << "\n";
   os << indent << "Contains the following files:\n";
   indent = indent.GetNextIndent();
-  unsigned long numFiles = m_Internal->GetNumberOfFiles();
+  unsigned long numFiles = m_Internal.GetNumberOfFiles();
   for (unsigned long i = 0; i < numFiles; ++i)
   {
-    os << indent << m_Internal->GetFile(i) << "\n";
+    os << indent << m_Internal.GetFile(i) << "\n";
   }
 }
 
@@ -58,7 +52,7 @@ Directory::PrintSelf(std::ostream & os, Indent indent) const
 bool
 Directory::Load(const char * dir)
 {
-  return static_cast<bool>(m_Internal->Load(dir));
+  return static_cast<bool>(m_Internal.Load(dir));
 }
 
 /**
@@ -67,7 +61,7 @@ Directory::Load(const char * dir)
 std::vector<std::string>::size_type
 Directory::GetNumberOfFiles()
 {
-  return m_Internal->GetNumberOfFiles();
+  return m_Internal.GetNumberOfFiles();
 }
 
 /**
@@ -76,6 +70,6 @@ Directory::GetNumberOfFiles()
 const char *
 Directory::GetFile(unsigned int index)
 {
-  return m_Internal->GetFile(index);
+  return m_Internal.GetFile(index);
 }
 } // end namespace itk


### PR DESCRIPTION
Removed the extra heap allocation for the internal data of `Directory`, and "defaulted" its default-constructor and destructor.