### PR TITLE
STYLE: Declare `RGBGibbsPriorFilter` data members as `unique_ptr<T[]>`

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -23,6 +23,8 @@
 
 #include "itkMRFImageFilter.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 /**
@@ -194,7 +196,7 @@ public:
 
 protected:
   RGBGibbsPriorFilter();
-  ~RGBGibbsPriorFilter() override;
+  ~RGBGibbsPriorFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -237,13 +239,13 @@ private:
 
   typename ClassifierType::Pointer m_ClassifierPtr;
 
-  unsigned int m_BoundaryGradient{ 7 }; /** the threshold for the existence of a
-                                       boundary. */
-  double      m_BoundaryWeight{ 1 };    /** weight for H_1 */
-  double      m_GibbsPriorWeight{ 1 };  /** weight for H_2 */
-  int         m_StartRadius{ 10 };      /** define the start region of the object. */
-  int         m_RecursiveNumber{ 0 };   /** number of SA iterations. */
-  LabelType * m_LabelStatus{ nullptr }; /** array for the state of each pixel. */
+  unsigned int m_BoundaryGradient{ 7 };                  /** the threshold for the existence of a
+                                                        boundary. */
+  double                       m_BoundaryWeight{ 1 };    /** weight for H_1 */
+  double                       m_GibbsPriorWeight{ 1 };  /** weight for H_2 */
+  int                          m_StartRadius{ 10 };      /** define the start region of the object. */
+  int                          m_RecursiveNumber{ 0 };   /** number of SA iterations. */
+  std::unique_ptr<LabelType[]> m_LabelStatus{ nullptr }; /** array for the state of each pixel. */
 
   InputImagePointer m_MediumImage; /** the medium image to store intermedium
                                      result */
@@ -261,8 +263,8 @@ private:
   InputPixelType m_LowPoint;         /** the point give lowest value of H-1 in
                                        neighbor. */
 
-  unsigned short * m_Region{ nullptr };      /** for region erase. */
-  unsigned short * m_RegionCount{ nullptr }; /** for region erase. */
+  std::unique_ptr<unsigned short[]> m_Region{ nullptr };      /** for region erase. */
+  std::unique_ptr<unsigned short[]> m_RegionCount{ nullptr }; /** for region erase. */
 
   /** weights for different clique configuration. */
   double m_CliqueWeight_1{ 0.0 }; /** weight for cliques that v/h smooth boundary */

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -43,14 +43,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RGBGibbsPriorFilter()
   m_StartPoint.Fill(0);
 }
 
-template <typename TInputImage, typename TClassifiedImage>
-RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::~RGBGibbsPriorFilter()
-{
-  delete[] m_Region;
-  delete[] m_RegionCount;
-  delete[] m_LabelStatus;
-}
-
 /* Set the labelled image. */
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -87,7 +79,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::Allocate()
   m_ImageDepth = inputImageSize[2];
 
   const unsigned int numberOfPixels = m_ImageWidth * m_ImageHeight * m_ImageDepth;
-  m_LabelStatus = new LabelType[numberOfPixels];
+  m_LabelStatus = make_unique_for_overwrite<LabelType[]>(numberOfPixels);
   for (unsigned int index = 0; index < numberOfPixels; ++index)
   {
     m_LabelStatus[index] = 1;
@@ -623,11 +615,8 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
 {
   const unsigned int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
 
-  delete[] m_Region;
-  m_Region = new unsigned short[size];
-
-  delete[] m_RegionCount;
-  m_RegionCount = new unsigned short[size];
+  m_Region = make_unique_for_overwrite<unsigned short[]>(size);
+  m_RegionCount = make_unique_for_overwrite<unsigned short[]>(size);
 
   const auto valid_region_counter = make_unique_for_overwrite<unsigned short[]>(size);
 


### PR DESCRIPTION
Declared m_LabelStatus, m_Region, and m_RegionCount as `unique_ptr<T[]>`, which improved exception-safety. Defaulted the destructor of `RGBGibbsPriorFilter`.