### PR TITLE
 Declare metric "per thread" data members as `unique_ptr<T[]>`, remove `mutable`

### DIFF
--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -360,7 +360,7 @@ private:
   // See
   //   https://thetweaker.wordpress.com/2010/05/05/stdvector-of-aligned-elements/
   //   https://connect.microsoft.com/VisualStudio/feedback/details/692988
-  mutable AlignedMMIMetricPerThreadStruct * m_MMIMetricPerThreadVariables;
+  AlignedMMIMetricPerThreadStruct * m_MMIMetricPerThreadVariables;
 #endif
 
   bool         m_UseExplicitPDFDerivatives{ true };

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -24,6 +24,7 @@
 #include "itkBSplineDerivativeKernelFunction.h"
 #include "itkArray2D.h"
 
+#include <memory> // For unique_ptr.
 #include <mutex>
 
 
@@ -259,7 +260,7 @@ public:
 
 protected:
   MattesMutualInformationImageToImageMetric();
-  ~MattesMutualInformationImageToImageMetric() override;
+  ~MattesMutualInformationImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -360,7 +361,7 @@ private:
   // See
   //   https://thetweaker.wordpress.com/2010/05/05/stdvector-of-aligned-elements/
   //   https://connect.microsoft.com/VisualStudio/feedback/details/692988
-  AlignedMMIMetricPerThreadStruct * m_MMIMetricPerThreadVariables;
+  std::unique_ptr<AlignedMMIMetricPerThreadStruct[]> m_MMIMetricPerThreadVariables;
 #endif
 
   bool         m_UseExplicitPDFDerivatives{ true };

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -22,6 +22,7 @@
 #include "itkImageIterator.h"
 #include "itkMath.h"
 #include "itkStatisticsImageFilter.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include "vnl/vnl_vector.h"
 #include "vnl/vnl_c_vector.h"
@@ -44,12 +45,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MattesMutu
   this->m_WithinThreadPreProcess = true;
   this->m_WithinThreadPostProcess = false;
   this->m_ComputeGradient = false;
-}
-
-template <typename TFixedImage, typename TMovingImage>
-MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::~MattesMutualInformationImageToImageMetric()
-{
-  delete[] this->m_MMIMetricPerThreadVariables;
 }
 
 template <typename TFixedImage, typename TMovingImage>
@@ -217,8 +212,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
    */
   this->m_MovingImageMarginalPDF.resize(m_NumberOfHistogramBins, 0.0F);
 
-  delete[] this->m_MMIMetricPerThreadVariables;
-  this->m_MMIMetricPerThreadVariables = new AlignedMMIMetricPerThreadStruct[this->m_NumberOfWorkUnits];
+  this->m_MMIMetricPerThreadVariables =
+    make_unique_for_overwrite<AlignedMMIMetricPerThreadStruct[]>(this->m_NumberOfWorkUnits);
 
   {
     const int binRange = this->m_NumberOfHistogramBins / this->m_NumberOfWorkUnits;

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
@@ -22,6 +22,8 @@
 #include "itkPoint.h"
 #include "itkIndex.h"
 
+#include <memory> // For unique_ptr.
+
 
 namespace itk
 {
@@ -104,7 +106,7 @@ public:
 
 protected:
   MeanSquaresImageToImageMetric();
-  ~MeanSquaresImageToImageMetric() override;
+  ~MeanSquaresImageToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -130,7 +132,7 @@ private:
   };
 
   itkAlignedTypedef(64, PerThreadS, AlignedPerThreadType);
-  AlignedPerThreadType * m_PerThread;
+  std::unique_ptr<AlignedPerThreadType[]> m_PerThread;
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageIterator.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -33,7 +34,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeanSquaresImageToImag
 {
   this->SetComputeGradient(true);
 
-  m_PerThread = nullptr;
   this->m_WithinThreadPreProcess = false;
   this->m_WithinThreadPostProcess = false;
 
@@ -41,13 +41,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeanSquaresImageToImag
   //  in the fixed image.
   //  This should be fixed in ITKv4 so that this metric behaves as the others.
   this->SetUseAllPixels(true);
-}
-
-template <typename TFixedImage, typename TMovingImage>
-MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::~MeanSquaresImageToImageMetric()
-{
-  delete[] m_PerThread;
-  m_PerThread = nullptr;
 }
 
 /**
@@ -70,9 +63,7 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   this->Superclass::Initialize();
   this->Superclass::MultiThreadingInitialize();
 
-  delete[] m_PerThread;
-
-  m_PerThread = new AlignedPerThreadType[this->m_NumberOfWorkUnits];
+  m_PerThread = make_unique_for_overwrite<AlignedPerThreadType[]>(this->m_NumberOfWorkUnits);
 
   for (ThreadIdType workUnitID = 0; workUnitID < this->m_NumberOfWorkUnits; ++workUnitID)
   {

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -147,7 +147,7 @@ private:
                     PaddedCorrelationMetricValueDerivativePerThreadStruct,
                     AlignedCorrelationMetricValueDerivativePerThreadStruct);
   /* per thread variables for correlation and its derivatives */
-  mutable AlignedCorrelationMetricValueDerivativePerThreadStruct * m_CorrelationMetricValueDerivativePerThreadVariables;
+  AlignedCorrelationMetricValueDerivativePerThreadStruct * m_CorrelationMetricValueDerivativePerThreadVariables;
 
   /** Internal pointer to the metric object in use by this threader.
    *  This will avoid costly dynamic casting in tight loops. */

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -20,6 +20,8 @@
 
 #include "itkImageToImageMetricv4GetValueAndDerivativeThreader.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 
@@ -73,7 +75,7 @@ public:
 
 protected:
   CorrelationImageToImageMetricv4GetValueAndDerivativeThreader();
-  ~CorrelationImageToImageMetricv4GetValueAndDerivativeThreader() override;
+  ~CorrelationImageToImageMetricv4GetValueAndDerivativeThreader() override = default;
 
   /** Overload: Resize and initialize per thread objects:
    *    number of valid points
@@ -147,7 +149,8 @@ private:
                     PaddedCorrelationMetricValueDerivativePerThreadStruct,
                     AlignedCorrelationMetricValueDerivativePerThreadStruct);
   /* per thread variables for correlation and its derivatives */
-  AlignedCorrelationMetricValueDerivativePerThreadStruct * m_CorrelationMetricValueDerivativePerThreadVariables;
+  std::unique_ptr<AlignedCorrelationMetricValueDerivativePerThreadStruct[]>
+    m_CorrelationMetricValueDerivativePerThreadVariables;
 
   /** Internal pointer to the metric object in use by this threader.
    *  This will avoid costly dynamic casting in tight loops. */

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -18,6 +18,8 @@
 #ifndef itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader_hxx
 #define itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
+
 
 namespace itk
 {
@@ -30,16 +32,6 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   : m_CorrelationMetricValueDerivativePerThreadVariables(nullptr)
   , m_CorrelationAssociate(nullptr)
 {}
-
-
-template <typename TDomainPartitioner, typename TImageToImageMetric, typename TCorrelationMetric>
-CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
-  TDomainPartitioner,
-  TImageToImageMetric,
-  TCorrelationMetric>::~CorrelationImageToImageMetricv4GetValueAndDerivativeThreader()
-{
-  delete[] m_CorrelationMetricValueDerivativePerThreadVariables;
-}
 
 
 template <typename TDomainPartitioner, typename TImageToImageMetric, typename TCorrelationMetric>
@@ -62,9 +54,8 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
 
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
   // set size
-  delete[] m_CorrelationMetricValueDerivativePerThreadVariables;
   m_CorrelationMetricValueDerivativePerThreadVariables =
-    new AlignedCorrelationMetricValueDerivativePerThreadStruct[numWorkUnitsUsed];
+    make_unique_for_overwrite<AlignedCorrelationMetricValueDerivativePerThreadStruct[]>(numWorkUnitsUsed);
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
     this->m_CorrelationMetricValueDerivativePerThreadVariables[i].fdm.SetSize(globalDerivativeSize);

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
@@ -132,7 +132,7 @@ private:
                     PaddedCorrelationMetricPerThreadStruct,
                     AlignedCorrelationMetricPerThreadStruct);
   /* per thread variables for correlation and its derivatives */
-  mutable AlignedCorrelationMetricPerThreadStruct * m_CorrelationMetricPerThreadVariables;
+  AlignedCorrelationMetricPerThreadStruct * m_CorrelationMetricPerThreadVariables;
 
   /** Internal pointer to the metric object in use by this threader.
    *  This will avoid costly dynamic casting in tight loops. */

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
@@ -20,6 +20,8 @@
 
 #include "itkImageToImageMetricv4GetValueAndDerivativeThreader.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 
@@ -73,7 +75,7 @@ public:
 
 protected:
   CorrelationImageToImageMetricv4HelperThreader();
-  ~CorrelationImageToImageMetricv4HelperThreader() override;
+  ~CorrelationImageToImageMetricv4HelperThreader() override = default;
 
   /** Overload: Resize and initialize per thread objects. */
   void
@@ -132,7 +134,7 @@ private:
                     PaddedCorrelationMetricPerThreadStruct,
                     AlignedCorrelationMetricPerThreadStruct);
   /* per thread variables for correlation and its derivatives */
-  AlignedCorrelationMetricPerThreadStruct * m_CorrelationMetricPerThreadVariables;
+  std::unique_ptr<AlignedCorrelationMetricPerThreadStruct[]> m_CorrelationMetricPerThreadVariables;
 
   /** Internal pointer to the metric object in use by this threader.
    *  This will avoid costly dynamic casting in tight loops. */

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
@@ -18,6 +18,7 @@
 #ifndef itkCorrelationImageToImageMetricv4HelperThreader_hxx
 #define itkCorrelationImageToImageMetricv4HelperThreader_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -31,14 +32,6 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
 
 
 template <typename TDomainPartitioner, typename TImageToImageMetric, typename TCorrelationMetric>
-CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageMetric, TCorrelationMetric>::
-  ~CorrelationImageToImageMetricv4HelperThreader()
-{
-  delete[] m_CorrelationMetricPerThreadVariables;
-}
-
-
-template <typename TDomainPartitioner, typename TImageToImageMetric, typename TCorrelationMetric>
 void
 CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageMetric, TCorrelationMetric>::
   BeforeThreadedExecution()
@@ -49,8 +42,8 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
   this->m_CorrelationAssociate = dynamic_cast<TCorrelationMetric *>(this->m_Associate);
 
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
-  delete[] this->m_CorrelationMetricPerThreadVariables;
-  this->m_CorrelationMetricPerThreadVariables = new AlignedCorrelationMetricPerThreadStruct[numWorkUnitsUsed];
+  this->m_CorrelationMetricPerThreadVariables =
+    make_unique_for_overwrite<AlignedCorrelationMetricPerThreadStruct[]>(numWorkUnitsUsed);
 
   //---------------------------------------------------------------
   // Set initial values.

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -191,7 +191,7 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedGetValueAndDerivativePerThreadStruct,
                     AlignedGetValueAndDerivativePerThreadStruct);
-  mutable AlignedGetValueAndDerivativePerThreadStruct * m_GetValueAndDerivativePerThreadVariables;
+  AlignedGetValueAndDerivativePerThreadStruct * m_GetValueAndDerivativePerThreadVariables;
 
   /** Cached values to avoid call overhead.
    *  These will only be set once threading has been started. */

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -21,6 +21,8 @@
 #include "itkDomainThreader.h"
 #include "itkCompensatedSummation.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 
@@ -95,7 +97,7 @@ public:
 
 protected:
   ImageToImageMetricv4GetValueAndDerivativeThreaderBase();
-  ~ImageToImageMetricv4GetValueAndDerivativeThreaderBase() override;
+  ~ImageToImageMetricv4GetValueAndDerivativeThreaderBase() override = default;
 
   /** Resize and initialize per thread objects. */
   void
@@ -191,7 +193,7 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedGetValueAndDerivativePerThreadStruct,
                     AlignedGetValueAndDerivativePerThreadStruct);
-  AlignedGetValueAndDerivativePerThreadStruct * m_GetValueAndDerivativePerThreadVariables;
+  std::unique_ptr<AlignedGetValueAndDerivativePerThreadStruct[]> m_GetValueAndDerivativePerThreadVariables;
 
   /** Cached values to avoid call overhead.
    *  These will only be set once threading has been started. */

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
@@ -19,6 +19,7 @@
 #define itkImageToImageMetricv4GetValueAndDerivativeThreaderBase_hxx
 
 #include "itkNumericTraits.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -30,13 +31,6 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
   , m_CachedNumberOfParameters(0)
   , m_CachedNumberOfLocalParameters(0)
 {}
-
-template <typename TDomainPartitioner, typename TImageToImageMetricv4>
-ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImageToImageMetricv4>::
-  ~ImageToImageMetricv4GetValueAndDerivativeThreaderBase()
-{
-  delete[] m_GetValueAndDerivativePerThreadVariables;
-}
 
 template <typename TDomainPartitioner, typename TImageToImageMetricv4>
 void
@@ -52,8 +46,8 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
 
   /* Per-thread results */
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
-  delete[] m_GetValueAndDerivativePerThreadVariables;
-  this->m_GetValueAndDerivativePerThreadVariables = new AlignedGetValueAndDerivativePerThreadStruct[numWorkUnitsUsed];
+  this->m_GetValueAndDerivativePerThreadVariables =
+    make_unique_for_overwrite<AlignedGetValueAndDerivativePerThreadStruct[]>(numWorkUnitsUsed);
 
   if (this->m_Associate->GetComputeDerivative())
   {

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
@@ -21,6 +21,8 @@
 #include "itkDomainThreader.h"
 #include "itkImage.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 
@@ -65,7 +67,7 @@ public:
 
 protected:
   JointHistogramMutualInformationComputeJointPDFThreaderBase();
-  ~JointHistogramMutualInformationComputeJointPDFThreaderBase() override;
+  ~JointHistogramMutualInformationComputeJointPDFThreaderBase() override = default;
 
   /** Create the \c m_JointPDFPerThread's. */
   void
@@ -92,7 +94,7 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedJointHistogramMIPerThreadStruct,
                     AlignedJointHistogramMIPerThreadStruct);
-  AlignedJointHistogramMIPerThreadStruct * m_JointHistogramMIPerThreadVariables;
+  std::unique_ptr<AlignedJointHistogramMIPerThreadStruct[]> m_JointHistogramMIPerThreadVariables;
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkImageRegionIterator.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -31,20 +32,13 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
 {}
 
 template <typename TDomainPartitioner, typename TJointHistogramMetric>
-JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, TJointHistogramMetric>::
-  ~JointHistogramMutualInformationComputeJointPDFThreaderBase()
-{
-  delete[] this->m_JointHistogramMIPerThreadVariables;
-}
-
-template <typename TDomainPartitioner, typename TJointHistogramMetric>
 void
 JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
                                                            TJointHistogramMetric>::BeforeThreadedExecution()
 {
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
-  delete[] this->m_JointHistogramMIPerThreadVariables;
-  this->m_JointHistogramMIPerThreadVariables = new AlignedJointHistogramMIPerThreadStruct[numWorkUnitsUsed];
+  this->m_JointHistogramMIPerThreadVariables =
+    make_unique_for_overwrite<AlignedJointHistogramMIPerThreadStruct[]>(numWorkUnitsUsed);
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
     if (this->m_JointHistogramMIPerThreadVariables[i].JointHistogram.IsNull())

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
@@ -20,6 +20,8 @@
 
 #include "itkImageToImageMetricv4GetValueAndDerivativeThreader.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 
@@ -79,7 +81,7 @@ public:
 
 protected:
   JointHistogramMutualInformationGetValueAndDerivativeThreader();
-  ~JointHistogramMutualInformationGetValueAndDerivativeThreader() override;
+  ~JointHistogramMutualInformationGetValueAndDerivativeThreader() override = default;
 
   using JointHistogramType = Image<SizeValueType, 2>;
 
@@ -122,7 +124,7 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedJointHistogramMIPerThreadStruct,
                     AlignedJointHistogramMIPerThreadStruct);
-  AlignedJointHistogramMIPerThreadStruct * m_JointHistogramMIPerThreadVariables;
+  std::unique_ptr<AlignedJointHistogramMIPerThreadStruct[]> m_JointHistogramMIPerThreadVariables;
 
 private:
   /** Internal pointer to the metric object in use by this threader.

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -18,6 +18,7 @@
 #ifndef itkJointHistogramMutualInformationGetValueAndDerivativeThreader_hxx
 #define itkJointHistogramMutualInformationGetValueAndDerivativeThreader_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -30,16 +31,6 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   : m_JointHistogramMIPerThreadVariables(nullptr)
   , m_JointAssociate(nullptr)
 {}
-
-
-template <typename TDomainPartitioner, typename TImageToImageMetric, typename TJointHistogramMetric>
-JointHistogramMutualInformationGetValueAndDerivativeThreader<
-  TDomainPartitioner,
-  TImageToImageMetric,
-  TJointHistogramMetric>::~JointHistogramMutualInformationGetValueAndDerivativeThreader()
-{
-  delete[] this->m_JointHistogramMIPerThreadVariables;
-}
 
 
 template <typename TDomainPartitioner, typename TImageToImageMetric, typename TJointHistogramMetric>
@@ -58,8 +49,8 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<TDomainPartitioner,
   }
 
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
-  delete[] this->m_JointHistogramMIPerThreadVariables;
-  this->m_JointHistogramMIPerThreadVariables = new AlignedJointHistogramMIPerThreadStruct[numWorkUnitsUsed];
+  this->m_JointHistogramMIPerThreadVariables =
+    make_unique_for_overwrite<AlignedJointHistogramMIPerThreadStruct[]>(numWorkUnitsUsed);
 
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {


### PR DESCRIPTION
Declared registration metric "per thread" data members as `unique_ptr<T[]>` (similar to pull request #3613 and #3614), and removed `mutable` keywords from their declarations.