### PR TITLE
Remove unreachable code from GE5ImageIO and use unique_ptr

### DIFF
--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -255,22 +255,12 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   if (pixelHdrFlag)
   {
     buffer = new char[imageHdr.GENESIS_IH_img_l_exam];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for exam header!");
-    }
     f.seekg(imageHdr.GENESIS_IH_img_p_exam, std::ios::beg);
     f.read(buffer, imageHdr.GENESIS_IH_img_l_exam);
   }
   else
   {
     buffer = new char[GENESIS_EX_HDR_LEN];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for exam header!");
-    }
     f.seekg(GENESIS_EX_HDR_START, std::ios::beg);
     f.read(buffer, GENESIS_EX_HDR_LEN);
   }
@@ -314,22 +304,12 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   if (pixelHdrFlag)
   {
     buffer = new char[imageHdr.GENESIS_IH_img_l_series];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for series header!");
-    }
     f.seekg(imageHdr.GENESIS_IH_img_p_series, std::ios::beg);
     f.read(buffer, imageHdr.GENESIS_IH_img_l_series);
   }
   else
   {
     buffer = new char[GENESIS_SE_HDR_LEN];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for series header!");
-    }
     f.seekg(GENESIS_SE_HDR_START);
     f.read(buffer, GENESIS_SE_HDR_LEN);
   }
@@ -351,11 +331,6 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   if (pixelHdrFlag)
   {
     buffer = new char[imageHdr.GENESIS_IH_img_l_image];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for MR header!");
-    }
     // Now seek to the MR header and read the data into the buffer.
     f.seekg(imageHdr.GENESIS_IH_img_p_image, std::ios::beg);
     f.read(buffer, imageHdr.GENESIS_IH_img_l_image);
@@ -363,11 +338,6 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   else
   {
     buffer = new char[GENESIS_MR_HDR_LEN];
-    if (buffer == nullptr)
-    {
-      f.close();
-      itkExceptionMacro("GE5ImageIO:Unable to allocate memory for MR header!");
-    }
     f.seekg(GENESIS_IM_HDR_START, std::ios::beg);
     f.read(buffer, GENESIS_MR_HDR_LEN);
   }

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -513,8 +513,8 @@ GE5ImageIO::ModifyImageInformation()
     ++it;
     std::string file2 = (*it)->GetImageFileName();
 
-    GEImageHeader * hdr1 = this->ReadHeader(file1.c_str());
-    GEImageHeader * hdr2 = this->ReadHeader(file2.c_str());
+    const std::unique_ptr<const GEImageHeader> hdr1{ this->ReadHeader(file1.c_str()) };
+    const std::unique_ptr<const GEImageHeader> hdr2{ this->ReadHeader(file2.c_str()) };
 
     float origin1[3], origin2[3];
     origin1[0] = hdr1->tlhcR;
@@ -535,10 +535,6 @@ GE5ImageIO::ModifyImageInformation()
                                                (origin1[2] - origin2[2]) * (origin1[2] - origin2[2]));
 
     this->SetSpacing(2, distanceBetweenTwoSlices);
-
-    // Cleanup
-    delete hdr1;
-    delete hdr2;
   }
   else
   // If there is only one slice, the use its origin


### PR DESCRIPTION
`GE5ImageIO::ReadHeader` appeared to have unreachable code in `if`-clauses like this:

    buffer = new char[N];
    if (buffer == nullptr)
    {
      f.close();
      itkExceptionMacro("GE5ImageIO:Unable to allocate memory...!");
    }

This pull request proposes to remove those unreachable lines of code, and replace locally declared raw pointers by `unique_ptr`, in GE5ImageIO.