### PR TITLE
Use `unique_ptr` internally in the implementation of `itk::Object`

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -34,6 +34,7 @@
 #include "itkSingletonMacro.h"
 
 #include <functional>
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -273,7 +274,8 @@ private:
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */
-  SubjectImplementation * m_SubjectImplementation{ nullptr };
+  std::unique_ptr<SubjectImplementation> m_SubjectImplementation{ nullptr };
+
   /**
    * Implementation for holding Object MetaData
    * @see itk::MetaDataDictionary
@@ -281,7 +283,7 @@ private:
    * @see itk::MetaDataObject
    * This is only allocated if used.
    */
-  mutable MetaDataDictionary * m_MetaDataDictionary{ nullptr };
+  mutable std::unique_ptr<MetaDataDictionary> m_MetaDataDictionary{ nullptr };
 
   std::string m_ObjectName;
 };

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -27,6 +27,7 @@
  *=========================================================================*/
 #include "itkCommand.h"
 #include <algorithm>
+#include <memory> // For unique_ptr.
 
 #include "itkSingleton.h"
 
@@ -47,16 +48,10 @@ public:
     , m_Event(event)
     , m_Tag(tag)
   {}
-  virtual ~Observer();
-  Command::Pointer    m_Command;
-  const EventObject * m_Event;
-  unsigned long       m_Tag;
+  Command::Pointer                   m_Command;
+  std::unique_ptr<const EventObject> m_Event;
+  unsigned long                      m_Tag;
 };
-/* Create Out-of-line Definition */
-Observer::~Observer()
-{
-  delete m_Event;
-}
 
 class ITKCommon_HIDDEN SubjectImplementation
 {
@@ -248,7 +243,7 @@ SubjectImplementation::HasObserver(const EventObject & event) const
 {
   for (auto observer : m_Observers)
   {
-    const EventObject * e = observer->m_Event;
+    const EventObject * e = observer->m_Event.get();
     if (e->CheckEvent(&event))
     {
       return true;
@@ -267,7 +262,7 @@ SubjectImplementation::PrintObservers(std::ostream & os, Indent indent) const
 
   for (auto observer : m_Observers)
   {
-    const EventObject * e = observer->m_Event;
+    const EventObject * e = observer->m_Event.get();
     const Command *     c = observer->m_Command;
     os << indent << e->GetEventName() << "(" << c->GetNameOfClass();
     if (!c->GetObjectName().empty())

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -478,7 +478,7 @@ Object::AddObserver(const EventObject & event, Command * cmd)
 {
   if (!this->m_SubjectImplementation)
   {
-    this->m_SubjectImplementation = new SubjectImplementation;
+    this->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
   }
   return this->m_SubjectImplementation->AddObserver(event, cmd);
 }
@@ -489,7 +489,7 @@ Object::AddObserver(const EventObject & event, Command * cmd) const
   if (!this->m_SubjectImplementation)
   {
     auto * me = const_cast<Self *>(this);
-    me->m_SubjectImplementation = new SubjectImplementation;
+    me->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
   }
   return this->m_SubjectImplementation->AddObserver(event, cmd);
 }
@@ -583,8 +583,6 @@ Object::Object()
 Object::~Object()
 {
   itkDebugMacro(<< "Destructing!");
-  delete m_SubjectImplementation;
-  delete m_MetaDataDictionary;
 }
 
 /**
@@ -611,7 +609,7 @@ Object::GetMetaDataDictionary()
 {
   if (m_MetaDataDictionary == nullptr)
   {
-    m_MetaDataDictionary = new MetaDataDictionary;
+    m_MetaDataDictionary = std::make_unique<MetaDataDictionary>();
   }
   return *m_MetaDataDictionary;
 }
@@ -621,7 +619,7 @@ Object::GetMetaDataDictionary() const
 {
   if (m_MetaDataDictionary == nullptr)
   {
-    m_MetaDataDictionary = new MetaDataDictionary;
+    m_MetaDataDictionary = std::make_unique<MetaDataDictionary>();
   }
   return *m_MetaDataDictionary;
 }
@@ -631,7 +629,7 @@ Object::SetMetaDataDictionary(const MetaDataDictionary & rhs)
 {
   if (m_MetaDataDictionary == nullptr)
   {
-    m_MetaDataDictionary = new MetaDataDictionary(rhs);
+    m_MetaDataDictionary = std::make_unique<MetaDataDictionary>(rhs);
     return;
   }
   *m_MetaDataDictionary = rhs;
@@ -642,7 +640,7 @@ Object::SetMetaDataDictionary(MetaDataDictionary && rrhs)
 {
   if (m_MetaDataDictionary == nullptr)
   {
-    m_MetaDataDictionary = new MetaDataDictionary(std::move(rrhs));
+    m_MetaDataDictionary = std::make_unique<MetaDataDictionary>(std::move(rrhs));
     return;
   }
   *m_MetaDataDictionary = std::move(rrhs);


### PR DESCRIPTION
- Declared the observers of `itk::Object` as list of `Observer` objects (instead of a list of raw pointers).
- Declared both `m_SubjectImplementation` and `m_MetaDataDictionary` as an `std::unique_ptr`.
- Declared `Observer::m_Event` as unique_ptr 
