### PR TITLE
BUG: Fix `itk::STAPLEImageFilter` test argument order

### DIFF
--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -31,7 +31,7 @@ itk_add_test(NAME itkSTAPLEImageFilterTest
   COMMAND ITKImageCompareTestDriver
 --compare DATA{${ITK_DATA_ROOT}/Baseline/Algorithms/STAPLEImageFilterTest.mha}
           ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha
-itkSTAPLEImageFilterTest 2 ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha 255 0.5 100 DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png})
+itkSTAPLEImageFilterTest 2 ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha 255 100 0.5 DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png})
 itk_add_test(NAME itkTestingComparisonImageFilterTest
       COMMAND ITKImageCompareTestDriver
       --compare DATA{Input/itkTestingComparisonImageFilterTest.png}


### PR DESCRIPTION
Fix `itk::STAPLEImageFilter` test argument order.

Set the `maximumIterations` and `confidenceWeight` arguments to the
wrong order in commit aa76dfb, which made it so that `maximumIterations`
was being set to 0, which in turn caused the code coverage to drop.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)