### PR TITLE
BUG: `Object::InvokeEvent` should not use a dangling Observer pointer

### DIFF
--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -221,11 +221,16 @@ SubjectImplementation::InvokeEventRecursion(const EventObject &                 
     // save observer
     const Observer * o = *i;
 
+    // Save its tag, before the observer could /possibly/ be removed.
+    const unsigned long tag{ o->m_Tag };
+
     if (o->m_Event->CheckEvent(&event))
     {
       InvokeEventRecursion(event, self, ++i);
 
-      if (!m_ListModified || std::find(m_Observers.begin(), m_Observers.end(), o) != m_Observers.end())
+      const auto hasSameTag = [tag](const Observer * const observer) { return observer->m_Tag == tag; };
+
+      if (!m_ListModified || std::any_of(m_Observers.begin(), m_Observers.end(), hasSameTag))
       {
         o->m_Command->Execute(self, event);
       }


### PR DESCRIPTION
`SubjectImplementation::InvokeEventRecursion` (an internal helper function of
`Object::InvokeEvent`) tried to "find" a *possibly* dangling pointer `o` in its
list of `Observer` pointers.

It appears more secure to check if an observer is still in the list by
comparing its tag to the tags of the other observers.

----

FYI A dangling `Observer` pointer `o` actually occurs when running the test function `testDeleteObserverDuringEvent()` from [CommandObserverObjectTest](https://github.com/InsightSoftwareConsortium/ITK/blob/2f2b29cbbe3fe91474933e0194db8d581d5b3247/Modules/Core/Common/test/itkCommandObserverObjectTest.cxx), while executing the following line of code:

https://github.com/InsightSoftwareConsortium/ITK/blob/2f2b29cbbe3fe91474933e0194db8d581d5b3247/Modules/Core/Common/test/itkCommandObserverObjectTest.cxx#L101

Which triggers calling the callback function `onUserRemove`:

https://github.com/InsightSoftwareConsortium/ITK/blob/2f2b29cbbe3fe91474933e0194db8d581d5b3247/Modules/Core/Common/test/itkCommandObserverObjectTest.cxx#L67-L72
