### PR TITLE
ENH: Use `itkPrintSelfObjectMacro` to print objects that can be null

### DIFF
--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -89,12 +89,10 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
   os << indent << "MaximumUpdateStepLength: ";
   os << m_MaximumUpdateStepLength << std::endl;
 
-  os << indent << "MovingImageIterpolator: ";
-  os << m_MovingImageInterpolator.GetPointer() << std::endl;
-  os << indent << "FixedImageGradientCalculator: ";
-  os << m_FixedImageGradientCalculator.GetPointer() << std::endl;
-  os << indent << "MappedMovingImageGradientCalculator: ";
-  os << m_MappedMovingImageGradientCalculator.GetPointer() << std::endl;
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+  itkPrintSelfObjectMacro(FixedImageGradientCalculator);
+  itkPrintSelfObjectMacro(MappedMovingImageGradientCalculator);
+
   os << indent << "DenominatorThreshold: ";
   os << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: ";

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -84,30 +84,21 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseGradientType: ";
-  os << m_UseGradientType << std::endl;
-  os << indent << "MaximumUpdateStepLength: ";
-  os << m_MaximumUpdateStepLength << std::endl;
+  os << indent << "UseGradientType: " << m_UseGradientType << std::endl;
+  os << indent << "MaximumUpdateStepLength: " << m_MaximumUpdateStepLength << std::endl;
 
   itkPrintSelfObjectMacro(MovingImageInterpolator);
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MappedMovingImageGradientCalculator);
 
-  os << indent << "DenominatorThreshold: ";
-  os << m_DenominatorThreshold << std::endl;
-  os << indent << "IntensityDifferenceThreshold: ";
-  os << m_IntensityDifferenceThreshold << std::endl;
+  os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 
-  os << indent << "Metric: ";
-  os << m_Metric << std::endl;
-  os << indent << "SumOfSquaredDifference: ";
-  os << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: ";
-  os << m_NumberOfPixelsProcessed << std::endl;
-  os << indent << "RMSChange: ";
-  os << m_RMSChange << std::endl;
-  os << indent << "SumOfSquaredChange: ";
-  os << m_SumOfSquaredChange << std::endl;
+  os << indent << "Metric: " << m_Metric << std::endl;
+  os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
+  os << indent << "NumberOfPixelsProcessed: " << m_NumberOfPixelsProcessed << std::endl;
+  os << indent << "RMSChange: " << m_RMSChange << std::endl;
+  os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }
 
 /**

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -32,16 +32,16 @@ void
 MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "HasLabelForUndecidedPixels = " << this->m_HasLabelForUndecidedPixels << std::endl;
+  os << indent << "HasLabelForUndecidedPixels: " << this->m_HasLabelForUndecidedPixels << std::endl;
   using OutputPixelPrintType = typename NumericTraits<OutputPixelType>::PrintType;
-  os << indent << "LabelForUndecidedPixels = " << static_cast<OutputPixelPrintType>(this->m_LabelForUndecidedPixels)
+  os << indent << "LabelForUndecidedPixels: " << static_cast<OutputPixelPrintType>(this->m_LabelForUndecidedPixels)
      << std::endl;
-  os << indent << "HasPriorProbabilities = " << this->m_PriorProbabilities << std::endl;
-  os << indent << "PriorProbabilities = " << this->m_PriorProbabilities << std::endl;
-  os << indent << "HasMaximumNumberOfIterations = " << this->m_HasMaximumNumberOfIterations << std::endl;
-  os << indent << "MaximumNumberOfIterations = " << this->m_MaximumNumberOfIterations << std::endl;
-  os << indent << "m_ElapsedNumberOfIterations = " << m_ElapsedNumberOfIterations << std::endl;
-  os << indent << "TerminationUpdateThreshold = " << this->m_TerminationUpdateThreshold << std::endl;
+  os << indent << "HasPriorProbabilities: " << this->m_PriorProbabilities << std::endl;
+  os << indent << "PriorProbabilities: " << this->m_PriorProbabilities << std::endl;
+  os << indent << "HasMaximumNumberOfIterations: " << this->m_HasMaximumNumberOfIterations << std::endl;
+  os << indent << "MaximumNumberOfIterations: " << this->m_MaximumNumberOfIterations << std::endl;
+  os << indent << "ElapsedNumberOfIterations: " << m_ElapsedNumberOfIterations << std::endl;
+  os << indent << "TerminationUpdateThreshold: " << this->m_TerminationUpdateThreshold << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TWeights>


### PR DESCRIPTION
- ENH: Use `itkPrintSelfObjectMacro` to print objects that can be null
- STYLE: Improve style in `PrintSelf` methods

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)