### PR TITLE
ENH: Increase coverage for `itk::ImageRegistrationMethodv4`

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
@@ -208,6 +208,8 @@ PerformSimpleImageRegistration2(int argc, char * argv[])
     RegistrationType::MetricSamplingStrategyEnum::RANDOM;
   double rigidSamplingPercentage = 0.20;
   rigidRegistration->SetMetricSamplingStrategy(rigidSamplingStrategy);
+  ITK_TEST_SET_GET_VALUE(rigidSamplingStrategy, rigidRegistration->GetMetricSamplingStrategy());
+
   rigidRegistration->SetMetricSamplingPercentage(rigidSamplingPercentage);
 
   using RigidScalesEstimatorType = itk::RegistrationParameterScalesFromPhysicalShift<MIMetricType>;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
@@ -21,6 +21,7 @@
 #include "itkAffineTransform.h"
 #include "itkEuclideanDistancePointSetToPointSetMetricv4.h"
 #include "itkRegistrationParameterScalesFromPhysicalShift.h"
+#include "itkTestingMacros.h"
 
 template <typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -212,8 +213,13 @@ itkSimplePointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
   using AffineRegistrationType = itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
   auto affineSimple = AffineRegistrationType::New();
   affineSimple->SetObjectName("affineSimple");
+
   affineSimple->SetFixedPointSet(fixedPoints);
+  ITK_TEST_SET_GET_VALUE(fixedPoints, affineSimple->GetFixedPointSet());
+
   affineSimple->SetMovingPointSet(movingPoints);
+  ITK_TEST_SET_GET_VALUE(movingPoints, affineSimple->GetMovingPointSet());
+
   affineSimple->SetInitialTransform(transform);
   affineSimple->SetMetric(metric);
   affineSimple->SetOptimizer(optimizer);


### PR DESCRIPTION
Increase coverage for `itk::ImageRegistrationMethodv4`:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Test other getter methods by serializing the data to the standard output.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)