### PR TITLE
STYLE: Remove `const` overload of `SubjectImplementation::AddObserver`

### DIFF
--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -67,9 +67,6 @@ public:
   unsigned long
   AddObserver(const EventObject & event, Command * cmd);
 
-  unsigned long
-  AddObserver(const EventObject & event, Command * cmd) const;
-
   void
   RemoveObserver(unsigned long tag);
 
@@ -136,17 +133,6 @@ SubjectImplementation::AddObserver(const EventObject & event, Command * cmd)
 
   m_Observers.push_back(ptr);
   ++m_Count;
-  return ptr->m_Tag;
-}
-
-unsigned long
-SubjectImplementation::AddObserver(const EventObject & event, Command * cmd) const
-{
-  auto * ptr = new Observer(cmd, event.MakeObject(), m_Count);
-  auto * me = const_cast<SubjectImplementation *>(this);
-
-  me->m_Observers.push_back(ptr);
-  me->m_Count++;
   return ptr->m_Tag;
 }
 


### PR DESCRIPTION
`SubjectImplementation` is an internal (hidden) helper class of `itk::Object`, which only uses the non-const overload of `SubjectImplementation::AddObserver`.

Removing this unused overload reduces maintenance.

----
Ubuntu2004 Coverage 8 appears to indicate that indeed, the `const` overload of `SubjectImplementation::AddObserver` was not covered: https://open.cdash.org/viewCoverageFile.php?buildid=8162114&fileid=52190897 (line 143-150) @jhlegarreta Can you please confirm that, Jon? 