### PR TITLE
Update nifti clib 2022-09-19 (8f7ecce7)

### DIFF
--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1.h
@@ -13,8 +13,8 @@
 
  */
 
-#ifndef _NIFTI_HEADER_
-#define _NIFTI_HEADER_
+#ifndef NIFTI1_HEADER
+#define NIFTI1_HEADER
 
 /*****************************************************************************
       ** This file defines the "NIFTI-1" header format.               **
@@ -1525,4 +1525,4 @@ typedef struct { unsigned char r,g,b; } rgb_byte ;
 #endif
 /*=================*/
 
-#endif /* _NIFTI_HEADER_ */
+#endif /* NIFTI1_HEADER */

--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.c
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.c
@@ -1,5 +1,6 @@
-#define _NIFTI1_IO_C_
+#define NIFTI1_IO_C
 
+#include <assert.h>
 #include "nifti1_io.h"   /* typedefs, prototypes, macros, etc. */
 #include "nifti1_io_version.h"
 
@@ -193,7 +194,7 @@ static char const * const gni_history[] =
   "\n",
   "1.3  09 Feb 2005 [rickr]\n"
   "   - nifti1.h: added doxygen comments for extension structs\n"
-  "   - nifti1_io.h: put most #defines in #ifdef _NIFTI1_IO_C_ block\n"
+  "   - nifti1_io.h: put most #defines in #ifdef NIFTI1_IO_C block\n"
   "   - added a doxygen-style description to every exported function\n"
   "   - added doxygen-style comments within some functions\n"
   "   - re-exported many znzFile functions that I had made static\n"
@@ -472,7 +473,7 @@ void nifti_disp_lib_hist( void )
 *//*--------------------------------------------------------------------*/
 void nifti_disp_lib_version( void )
 {
-   printf("%s, compiled %s\n", gni_version, __DATE__);
+   printf("%s\n", gni_version);
 }
 
 
@@ -2104,6 +2105,7 @@ void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod )
      case -2: i = NIFTI_A2P ; break ;
      case  3: i = NIFTI_I2S ; break ;
      case -3: i = NIFTI_S2I ; break ;
+     default: assert(0) ; break ;
    }
 
    switch( jbest*qbest ){
@@ -2113,6 +2115,7 @@ void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod )
      case -2: j = NIFTI_A2P ; break ;
      case  3: j = NIFTI_I2S ; break ;
      case -3: j = NIFTI_S2I ; break ;
+     default: assert(0) ; break ;
    }
 
    switch( kbest*rbest ){
@@ -2122,6 +2125,7 @@ void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod )
      case -2: k = NIFTI_A2P ; break ;
      case  3: k = NIFTI_I2S ; break ;
      case -3: k = NIFTI_S2I ; break ;
+     default: assert(0) ; break ;
    }
 
    *icod = i ; *jcod = j ; *kcod = k ;
@@ -5608,7 +5612,7 @@ int nifti_copy_extensions(nifti_image * nim_dest, const nifti_image * nim_src)
     and the bytes used for the data.  Each esize also needs to be a
     multiple of 16, so it may be greater than the sum of its 3 parts.
 *//*--------------------------------------------------------------------*/
-int nifti_extension_size(nifti_image *nim)
+static int nifti_extension_size(nifti_image *nim)
 {
    int c, size = 0;
 
@@ -6969,7 +6973,7 @@ int nifti_read_subregion_image( nifti_image * nim,
   znzFile fp;                   /* file to read */
   int i,j,k,l,m,n;              /* indices for dims */
   long int bytes = 0;           /* total # bytes read */
-  int total_alloc_size;         /* size of buffer allocation */
+  size_t total_alloc_size;      /* size of buffer allocation */
   char *readptr;                /* where in *data to read next */
   int strides[7];               /* strides between dimensions */
   int collapsed_dims[8];        /* for read_collapsed_image */
@@ -7065,8 +7069,8 @@ int nifti_read_subregion_image( nifti_image * nim,
     if(g_opts.debug > 1)
       {
       fprintf(stderr,"allocation of %d bytes failed\n",total_alloc_size);
-      return -1;
       }
+    return -1;
     }
 
   /* point to start of data buffer as char * */

--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.h
@@ -3,8 +3,8 @@
            - Written by Bob Cox, SSCC NIMH
            - Revisions by Rick Reynolds, SSCC NIMH
  */
-#ifndef _NIFTI_IO_HEADER_
-#define _NIFTI_IO_HEADER_
+#ifndef NIFTI1_IO_HEADER
+#define NIFTI1_IO_HEADER
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -502,9 +502,9 @@ int    valid_nifti_extensions(const nifti_image *nim);
 #define NIFTI_MAX_FTYPE       3    /* this should match the maximum code */
 
 /*------------------------------------------------------------------------*/
-/*-- the rest of these apply only to nifti1_io.c, check for _NIFTI1_IO_C_ */
+/*-- the rest of these apply only to nifti1_io.c, check for NIFTI1_IO_C */
 /*                                                    Feb 9, 2005 [rickr] */
-#ifdef _NIFTI1_IO_C_
+#ifdef NIFTI1_IO_C
 
 typedef struct {
     int debug;               /*!< debug level for status reports  */
@@ -554,7 +554,7 @@ typedef struct {
 
 #define LNI_MAX_NIA_EXT_LEN 100000  /* consider a longer extension invalid */
 
-#endif  /* _NIFTI1_IO_C_ section */
+#endif  /* NIFTI1_IO_C section */
 /*------------------------------------------------------------------------*/
 
 /*=================*/
@@ -563,4 +563,4 @@ typedef struct {
 #endif
 /*=================*/
 
-#endif /* _NIFTI_IO_HEADER_ */
+#endif /* NIFTI1_IO_HEADER */

--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_tool.c
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_tool.c
@@ -165,7 +165,6 @@ static int  g_debug = 1;
 #include <string.h>
 #include <stdint.h>
 
-#define _NIFTI_TOOL_C_
 #include "nifti1_io.h"
 #include "nifti1_tool.h"
 
@@ -1734,9 +1733,8 @@ int use_full(const char * prog )
    "  ------------------------------\n"
    "\n"
    "  R. Reynolds\n"
-   "  compiled: %s\n"
    "  %s\n\n",
-   __DATE__, g_version );
+   g_version );
 
    return 1;
 }
@@ -3391,8 +3389,6 @@ const char * field_type_str( int type )
 
    return "DT_UNKNOWN";  /* for DT_UNKNOWN, or as an else */
 }
-
-#define NT_MAX_DT_STR_LEN 14
 
 /*----------------------------------------------------------------------
  * display the contents of all of the field structures

--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_tool.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_tool.h
@@ -1,5 +1,5 @@
-#ifndef _NIFTI_TOOL_H_
-#define _NIFTI_TOOL_H_
+#ifndef NIFTI1_TOOL_H
+#define NIFTI1_TOOL_H
 
 #define NT_CMD_LEN 2048
 
@@ -160,4 +160,4 @@ nifti_1_header * nt_read_header(nt_opts * opts, const char * fname, int * swappe
                                 int check);
 
 
-#endif  /* _NIFTI_TOOL_H_ */
+#endif  /* NIFTI1_TOOL_H */

--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti_tester001.c
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti_tester001.c
@@ -7,7 +7,7 @@ enum NIFTITEST_BOOL {
   NIFTITEST_FALSE=0
 };
 
-void _PrintTest(const int line,const char * message,const int FailureOccured, const enum NIFTITEST_BOOL isFatal,int *ErrorAccum)
+static void PrintTest_eng(const int line,const char * message,const int FailureOccured, const enum NIFTITEST_BOOL isFatal,int *ErrorAccum)
 {
   if(FailureOccured==NIFTITEST_TRUE)  /* This line can be commented out for a more verbose output */
     {
@@ -24,9 +24,9 @@ void _PrintTest(const int line,const char * message,const int FailureOccured, co
     }
   }
 #define PrintTest(message,failure,isfailure,errorcount) \
-  _PrintTest(__LINE__,message,failure,isfailure,errorcount)
+  PrintTest_eng(__LINE__,message,failure,isfailure,errorcount)
 
-nifti_image * generate_reference_image( const char * write_image_filename , int * const Errors)
+static nifti_image * generate_reference_image( const char * write_image_filename , int * const Errors)
 {
   nifti_1_header reference_header;
   memset(&reference_header,0,sizeof(reference_header));
@@ -117,7 +117,7 @@ nifti_image * generate_reference_image( const char * write_image_filename , int 
 }
 
 
-void compare_reference_image_values(nifti_image const * const reference_image, nifti_image const * const reloaded_image, int * const Errors)
+static void compare_reference_image_values(nifti_image const * const reference_image, nifti_image const * const reloaded_image, int * const Errors)
 {
   if( ! reference_image  || ! reference_image->data )
   {

--- a/Modules/ThirdParty/NIFTI/src/nifti/znzlib/znzlib.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/znzlib/znzlib.h
@@ -1,5 +1,5 @@
-#ifndef _ZNZLIB_H_
-#define _ZNZLIB_H_
+#ifndef ZNZLIB_H
+#define ZNZLIB_H
 
 /*
 znzlib.h  (zipped or non-zipped library)


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

---

Update nifti clib:
```
8f7ecce Fix reading subregions of large files
36e8df3 Renamed private _PrintTest to PrintTest_eng
a2d25c4 Removed use of __DATE__ to allow for reproducible builds
53d64db Fixed some -Wconditional-uninitialized with an assert
2012da3 Fixed all -Wunused-macros warnings
4e800b8 Fixed all but one -Wmissing-prototypes warnings
d05a71e Fixed all clang -Wreserved-id-macro warnings
376161c Removed used _NIFTI_TOOL_C_ defines to fix -Wreserved-id-macro some warnings
```

Fixes  #3625

<!-- **Thanks for contributing to ITK!** -->
