### PR TITLE
WIP: Remove non-const overload of `Object::AddObserver`, add `mutable`

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -153,8 +153,6 @@ public:
    * command.
    */
   unsigned long
-  AddObserver(const EventObject & event, Command *);
-  unsigned long
   AddObserver(const EventObject & event, Command *) const;
 
   /** \brief A convenient method to add an C++ lambda function as an observer.
@@ -275,7 +273,7 @@ private:
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */
-  std::unique_ptr<SubjectImplementation> m_SubjectImplementation;
+  mutable std::unique_ptr<SubjectImplementation> m_SubjectImplementation;
 
   /**
    * Implementation for holding Object MetaData

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -457,22 +457,11 @@ Object::GetGlobalWarningDisplay()
 }
 
 unsigned long
-Object::AddObserver(const EventObject & event, Command * cmd)
-{
-  if (!this->m_SubjectImplementation)
-  {
-    this->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
-  }
-  return this->m_SubjectImplementation->AddObserver(event, cmd);
-}
-
-unsigned long
 Object::AddObserver(const EventObject & event, Command * cmd) const
 {
   if (!this->m_SubjectImplementation)
   {
-    auto * me = const_cast<Self *>(this);
-    me->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
+    this->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
   }
   return this->m_SubjectImplementation->AddObserver(event, cmd);
 }


### PR DESCRIPTION
Declared m_SubjectImplementation `mutable` (just like m_MetaDataDictionary), in order to avoid a `const_cast<Self *>` in the `const` overload of `Object::AddObserver`. Removed the non-const overload, as it is semantically just the same as the `const` overload.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3634 commit ebddf08ba028480af3b6ef0c214172e65f6e4f78
"STYLE: Remove `const` overload of `SubjectImplementation::AddObserver`"