### PR TITLE
Make `itk::Object` implementation more private, more hidden, more const

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -38,8 +38,6 @@
 
 namespace itk
 {
-// Forward reference because of private implementation
-class SubjectImplementation;
 // Forward reference because of circular dependencies
 class ITK_FORWARD_EXPORT Command;
 
@@ -271,6 +269,9 @@ private:
 
   /** Global object debug flag. */
   static bool * m_GlobalWarningDisplay;
+
+  // Forward reference because of private implementation
+  class SubjectImplementation;
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -56,7 +56,7 @@ public:
 };
 } // namespace
 
-class ITKCommon_HIDDEN SubjectImplementation
+class ITKCommon_HIDDEN Object::SubjectImplementation
 {
 public:
   SubjectImplementation() { m_Count = 0; }
@@ -117,7 +117,7 @@ private:
 };
 
 unsigned long
-SubjectImplementation::AddObserver(const EventObject & event, Command * cmd)
+Object::SubjectImplementation::AddObserver(const EventObject & event, Command * cmd)
 {
   const unsigned long tag{ m_Count };
   m_Observers.emplace_back(cmd, event.MakeObject(), tag);
@@ -126,7 +126,7 @@ SubjectImplementation::AddObserver(const EventObject & event, Command * cmd)
 }
 
 void
-SubjectImplementation::RemoveObserver(unsigned long tag)
+Object::SubjectImplementation::RemoveObserver(unsigned long tag)
 {
   for (auto i = m_Observers.begin(); i != m_Observers.end(); ++i)
   {
@@ -140,14 +140,14 @@ SubjectImplementation::RemoveObserver(unsigned long tag)
 }
 
 void
-SubjectImplementation::RemoveAllObservers()
+Object::SubjectImplementation::RemoveAllObservers()
 {
   m_Observers.clear();
   m_ListModified = true;
 }
 
 void
-SubjectImplementation::InvokeEvent(const EventObject & event, Object * self)
+Object::SubjectImplementation::InvokeEvent(const EventObject & event, Object * self)
 {
   // While an event is being invoked, it's possible to remove
   // observers, or another event to be invoked. All methods which
@@ -162,7 +162,7 @@ SubjectImplementation::InvokeEvent(const EventObject & event, Object * self)
 }
 
 void
-SubjectImplementation::InvokeEvent(const EventObject & event, const Object * self)
+Object::SubjectImplementation::InvokeEvent(const EventObject & event, const Object * self)
 {
   SaveRestoreListModified save(this);
 
@@ -172,9 +172,9 @@ SubjectImplementation::InvokeEvent(const EventObject & event, const Object * sel
 
 template <typename TObject>
 void
-SubjectImplementation::InvokeEventRecursion(const EventObject &                     event,
-                                            TObject *                               self,
-                                            std::list<Observer>::reverse_iterator & i)
+Object::SubjectImplementation::InvokeEventRecursion(const EventObject &                     event,
+                                                    TObject *                               self,
+                                                    std::list<Observer>::reverse_iterator & i)
 {
   // This method recursively visits the list of observers in reverse
   // order so that on the last recursion the first observer can be
@@ -215,7 +215,7 @@ SubjectImplementation::InvokeEventRecursion(const EventObject &                 
 }
 
 Command *
-SubjectImplementation::GetCommand(unsigned long tag)
+Object::SubjectImplementation::GetCommand(unsigned long tag)
 {
   for (auto & observer : m_Observers)
   {
@@ -228,7 +228,7 @@ SubjectImplementation::GetCommand(unsigned long tag)
 }
 
 bool
-SubjectImplementation::HasObserver(const EventObject & event) const
+Object::SubjectImplementation::HasObserver(const EventObject & event) const
 {
   for (const auto & observer : m_Observers)
   {
@@ -242,7 +242,7 @@ SubjectImplementation::HasObserver(const EventObject & event) const
 }
 
 bool
-SubjectImplementation::PrintObservers(std::ostream & os, Indent indent) const
+Object::SubjectImplementation::PrintObservers(std::ostream & os, Indent indent) const
 {
   if (m_Observers.empty())
   {

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -88,7 +88,7 @@ public:
 
   bool m_ListModified{ false };
 
-protected:
+private:
   // RAII of ListModified state to ensure exception safety
   struct SaveRestoreListModified
   {
@@ -111,7 +111,6 @@ protected:
   void
   InvokeEventRecursion(const EventObject & event, TObject * self, std::list<Observer>::reverse_iterator & i);
 
-private:
   std::list<Observer> m_Observers;
   unsigned long       m_Count;
 };

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -109,7 +109,7 @@ private:
 
   template <typename TObject>
   void
-  InvokeEventRecursion(const EventObject & event, TObject * self, std::list<Observer>::reverse_iterator & i);
+  InvokeEventRecursion(const EventObject & event, TObject * self, std::list<Observer>::const_reverse_iterator & i);
 
   std::list<Observer> m_Observers;
   unsigned long       m_Count;
@@ -156,7 +156,7 @@ Object::SubjectImplementation::InvokeEvent(const EventObject & event, Object * s
 
   SaveRestoreListModified save(this);
 
-  auto i = m_Observers.rbegin();
+  auto i = m_Observers.crbegin();
   InvokeEventRecursion(event, self, i);
 }
 
@@ -165,15 +165,15 @@ Object::SubjectImplementation::InvokeEvent(const EventObject & event, const Obje
 {
   SaveRestoreListModified save(this);
 
-  auto i = m_Observers.rbegin();
+  auto i = m_Observers.crbegin();
   InvokeEventRecursion(event, self, i);
 }
 
 template <typename TObject>
 void
-Object::SubjectImplementation::InvokeEventRecursion(const EventObject &                     event,
-                                                    TObject *                               self,
-                                                    std::list<Observer>::reverse_iterator & i)
+Object::SubjectImplementation::InvokeEventRecursion(const EventObject &                           event,
+                                                    TObject *                                     self,
+                                                    std::list<Observer>::const_reverse_iterator & i)
 {
   // This method recursively visits the list of observers in reverse
   // order so that on the last recursion the first observer can be
@@ -216,7 +216,7 @@ Object::SubjectImplementation::InvokeEventRecursion(const EventObject &         
 Command *
 Object::SubjectImplementation::GetCommand(unsigned long tag)
 {
-  for (auto & observer : m_Observers)
+  for (const auto & observer : m_Observers)
   {
     if (observer.m_Tag == tag)
     {

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -40,6 +40,8 @@ itkGetGlobalValueMacro(Object, bool, GlobalWarningDisplay, true);
 
 bool * Object::m_GlobalWarningDisplay;
 
+namespace
+{
 class ITKCommon_HIDDEN Observer
 {
 public:
@@ -52,6 +54,7 @@ public:
   std::unique_ptr<const EventObject> m_Event;
   unsigned long                      m_Tag;
 };
+} // namespace
 
 class ITKCommon_HIDDEN SubjectImplementation
 {


### PR DESCRIPTION
- Moved `Observer` into an unnamed namespace
- Made `SubjectImplementation` a private nested type of itk::Object
- Made protected `SubjectImplementation` members private
- Made iteration over observers "const"