### PR TITLE
STYLE: Declare lambda's created for Singleton `const`, but non-static

### DIFF
--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -44,11 +44,11 @@
   {                                                                                                 \
     if (m_##VarName == nullptr)                                                                     \
     {                                                                                               \
-      static auto setLambda = [](void * a) {                                                        \
+      const auto setLambda = [](void * a) {                                                         \
         delete m_##VarName;                                                                         \
         m_##VarName = static_cast<Type *>(a);                                                       \
       };                                                                                            \
-      static auto deleteLambda = []() {                                                             \
+      const auto deleteLambda = []() {                                                              \
         delete m_##VarName;                                                                         \
         m_##VarName = nullptr;                                                                      \
       };                                                                                            \

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -129,7 +129,7 @@ public:
 ObjectFactoryBasePrivate *
 ObjectFactoryBase::GetPimplGlobalsPointer()
 {
-  static auto                deleteLambda = []() { m_PimplGlobals->UnRegister(); };
+  const auto                 deleteLambda = []() { m_PimplGlobals->UnRegister(); };
   ObjectFactoryBasePrivate * globalInstance =
     Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", SynchronizeObjectFactoryBase, deleteLambda);
   if (globalInstance != m_PimplGlobals)


### PR DESCRIPTION
The lifetime of lambda's passed as argument to the function `Singleton<T>` does not need to be extended beyond the function call, as these arguments directly get converted to `std::function` objects.