### PR TITLE
COMP: Work around GCC <= 9.1 "error: invalid application of ‘sizeof’..."

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -274,7 +274,7 @@ private:
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */
-  std::unique_ptr<SubjectImplementation> m_SubjectImplementation{ nullptr };
+  std::unique_ptr<SubjectImplementation> m_SubjectImplementation;
 
   /**
    * Implementation for holding Object MetaData


### PR DESCRIPTION
Worked around a GCC bug which produced the following error:

> unique_ptr.h:79:16: error: invalid application of ‘sizeof’ to incomplete type

The issue https://github.com/InsightSoftwareConsortium/ITK/issues/3643 "Compilation fails with GCC 8.4." was reported by Max Aehle  (@maxaehle). The GCC bug appears to be fixed with GCC 9.2.

The workaround (removing "`{ nullptr }`") was also suggested by Max Aehle.

Closes #3643