### PR TITLE
STYLE: Method local variables should not have `m_` prefix

### DIFF
--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -100,9 +100,9 @@ public:
   ~ObjectFactoryBasePrivate() override
   {
     itk::ObjectFactoryBase::UnRegisterAllFactories();
-    for (auto & m_InternalFactorie : m_InternalFactories)
+    for (auto & internalFactory : m_InternalFactories)
     {
-      m_InternalFactorie->UnRegister();
+      internalFactory->UnRegister();
     }
   }
 

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -388,9 +388,9 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   if (this->GetDebug())
   {
     SizeValueType count = 0;
-    for (const auto & m_RegionSize : m_RegionSizes)
+    for (const auto & regionSize : m_RegionSizes)
     {
-      count += m_RegionSize;
+      count += regionSize;
     }
     itkDebugMacro(<< "Total #of cells accounted for: " << count);
     itkDebugMacro(<< "Extracted " << output->GetNumberOfCells() << " cells");

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -209,40 +209,40 @@ GDCMSeriesFileNames::GetOutputFileNames()
   if (!m_InputFileNames.empty())
   {
     bool hasExtension = false;
-    for (const auto & m_InputFileName : m_InputFileNames)
+    for (const auto & inputFileName : m_InputFileNames)
     {
       // look for extension ".dcm" and ".DCM"
-      std::string::size_type dcmPos = m_InputFileName.rfind(".dcm");
-      if ((dcmPos != std::string::npos) && (dcmPos == m_InputFileName.length() - 4))
+      std::string::size_type dcmPos = inputFileName.rfind(".dcm");
+      if ((dcmPos != std::string::npos) && (dcmPos == inputFileName.length() - 4))
       {
         hasExtension = true;
       }
       else
       {
-        dcmPos = m_InputFileName.rfind(".DCM");
-        if ((dcmPos != std::string::npos) && (dcmPos == m_InputFileName.length() - 4))
+        dcmPos = inputFileName.rfind(".DCM");
+        if ((dcmPos != std::string::npos) && (dcmPos == inputFileName.length() - 4))
         {
           hasExtension = true;
         }
       }
 
       // look for extension ".dicom" and ".DICOM"
-      std::string::size_type dicomPos = m_InputFileName.rfind(".dicom");
-      if ((dicomPos != std::string::npos) && (dicomPos == m_InputFileName.length() - 6))
+      std::string::size_type dicomPos = inputFileName.rfind(".dicom");
+      if ((dicomPos != std::string::npos) && (dicomPos == inputFileName.length() - 6))
       {
         hasExtension = true;
       }
       else
       {
-        dicomPos = m_InputFileName.rfind(".DICOM");
-        if ((dicomPos != std::string::npos) && (dicomPos == m_InputFileName.length() - 6))
+        dicomPos = inputFileName.rfind(".DICOM");
+        if ((dicomPos != std::string::npos) && (dicomPos == inputFileName.length() - 6))
         {
           hasExtension = true;
         }
       }
 
       // construct a filename, adding an extension if necessary
-      std::string filename = m_OutputDirectory + itksys::SystemTools::GetFilenameName(m_InputFileName);
+      std::string filename = m_OutputDirectory + itksys::SystemTools::GetFilenameName(inputFileName);
       if (!hasExtension)
       {
         // input filename has no extension, add a ".dcm"


### PR DESCRIPTION
Method local variables should not have `m_` prefix.  That prefix is reserved for class member variables.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)