### PR TITLE
DOC: Fix miscellaneous Doxygen warnings

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
@@ -47,7 +47,7 @@ namespace itk
  * For this identifier, a slice means 2D image data which is extracted from
  * the input image along one of three axes \f$(x, y, z)\f$. Users can specify
  * the slicing axis using the SetSlicingDirection(int dimension) member, where
- * the \p dimension variable follows the convention \f{X, Y, Z} : {0, 1, 2}\f$.
+ * the \p dimension variable follows the convention \f${X, Y, Z} : {0, 1, 2}\f$.
  *
  * The identification scheme used works according to the following steps:
  *   -# Users should specify how many pixels per slice the identifier

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
@@ -55,7 +55,7 @@ public:
   /*-------- This part of the interfaces deals with reading data. ----- */
 
   /** Determine if the file can be read with this MeshIO implementation.
-   * \param FileNameToRead The name of the file to test for reading.
+   * \param fileName The name of the file to test for reading.
    * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
    * \return Returns true if this MeshIO can read the file specified.
    */

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -152,7 +152,7 @@ public:
   //-------- This part of the interfaces deals with writing data. -----
 
   /** Determine if the file can be written with this ImageIO implementation.
-   * \param fileName The name of the file to test for writing.
+   * \param FileNameToWrite The name of the file to test for writing.
    * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToWrite
    * \return Returns true if this ImageIO can write the file specified.
    */


### PR DESCRIPTION
Fix miscellaneous Doxygen warnings.

Fixes:
```
Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h:161:
warning:
Reached end of file while still inside a (nested) comment.
Nesting level 1 (probable line reference: 27)

Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h:64:
warning:
End of comment block while inside formula.
```

and
```
Modules/IO/NIFTI/include/itkNiftiImageIO.h:162:
warning:
argument 'fileName' of command @param is not found in the argument list of itk::NiftiImageIO::CanWriteFile(const char *FileNameToWrite)

Modules/IO/NIFTI/include/itkNiftiImageIO.h:168:
warning:
The following parameters of itk::NiftiImageIO::CanWriteFile(const char *FileNameToWrite) are not documented:
parameter 'FileNameToWrite'

Modules/IO/NIFTI/include/itkNiftiImageIO.h:162:
warning:
argument 'fileName' of command @param is not found in the argument list of itk::NiftiImageIO::CanWriteFile(const char *FileNameToWrite)
```

and
```
Modules/IO/MeshOBJ/include/itkOBJMeshIO.h:57:
warning:
argument 'FileNameToRead' of command @param is not found in the argument list of itk::OBJMeshIO::CanReadFile(const char *fileName)
```

Reported in:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=8175572

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)