### PR TITLE
ENH: Fix the `Documentation` PR title identification

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_impact_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_impact_report.md
@@ -1,6 +1,6 @@
 ---
 name: "Documentation Impact Report \U0001F4D6"
-labels: area:Documentation
+labels: type:Documentation
 about: "File a documentation report to improve documentation in ITK"
 ---
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@ type:Compiler:
 type:Bug:
   title: "^BUG:.*"
 
-area:Documentation:
+type:Documentation:
   title: "^DOC:.*"
 
 type:Enhancement:


### PR DESCRIPTION
Fix the `Documentation`PR title identification: avoid having two entries for the `area:Documentation` label, and use the newly created `type:Documentation` for the PR title regex.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)