### PR TITLE
ENH: Clamp `STAPLEImageFilter` maximum iterations

### DIFF
--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
@@ -204,7 +204,7 @@ public:
   /** Set/Get the maximum number of iterations after which the STAPLE algorithm
    *  will be considered to have converged.  In general this SHOULD NOT be set and
    *  the algorithm should be allowed to converge on its own. */
-  itkSetMacro(MaximumIterations, unsigned int);
+  itkSetClampMacro(MaximumIterations, unsigned int, 1, NumericTraits<unsigned int>::max());
   itkGetConstMacro(MaximumIterations, unsigned int);
 
   /** Scales the estimated prior probability that a pixel will be inside the


### PR DESCRIPTION
Clamp `STAPLEImageFilter` maximum iterations to avoid setting a 0 value, and thus giving rise dynamic memory defects when querying about non-existing vector indices for the sensitivity and specifity.

Related to commit 5b5d85e.

Fixes #3644.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)