### PR TITLE
STYLE: Remove space between class and member names (follow-up)

### DIFF
--- a/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
@@ -22,14 +22,14 @@ namespace itk
 /**
  * The hexahedron's topology data: Edges.
  */
-const int HexahedronCellTopology ::m_Edges[12][2] = { { 0, 1 }, { 1, 2 }, { 3, 2 }, { 0, 3 }, { 4, 5 }, { 5, 6 },
-                                                      { 7, 6 }, { 4, 7 }, { 0, 4 }, { 1, 5 }, { 3, 7 }, { 2, 6 } };
+const int HexahedronCellTopology::m_Edges[12][2] = { { 0, 1 }, { 1, 2 }, { 3, 2 }, { 0, 3 }, { 4, 5 }, { 5, 6 },
+                                                     { 7, 6 }, { 4, 7 }, { 0, 4 }, { 1, 5 }, { 3, 7 }, { 2, 6 } };
 
 /**
  * The hexahedron's topology data: Faces.
  */
-const int HexahedronCellTopology ::m_Faces[6][4] = { { 0, 4, 7, 3 }, { 1, 2, 6, 5 }, { 0, 1, 5, 4 },
-                                                     { 3, 7, 6, 2 }, { 0, 3, 2, 1 }, { 4, 5, 6, 7 } };
+const int HexahedronCellTopology::m_Faces[6][4] = { { 0, 4, 7, 3 }, { 1, 2, 6, 5 }, { 0, 1, 5, 4 },
+                                                    { 3, 7, 6, 2 }, { 0, 3, 2, 1 }, { 4, 5, 6, 7 } };
 
 HexahedronCellTopology::HexahedronCellTopology() = default;
 

--- a/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * The triangle's topology data: Edges
  */
-const int QuadraticTriangleCellTopology ::m_Edges[3][3] = { { 0, 4, 1 }, { 1, 5, 2 }, { 2, 3, 0 } };
+const int QuadraticTriangleCellTopology::m_Edges[3][3] = { { 0, 4, 1 }, { 1, 5, 2 }, { 2, 3, 0 } };
 
 QuadraticTriangleCellTopology::QuadraticTriangleCellTopology() = default;
 

--- a/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * The quadrilateral's topology data: Edges.
  */
-const int QuadrilateralCellTopology ::m_Edges[4][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 0 } };
+const int QuadrilateralCellTopology::m_Edges[4][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 0 } };
 
 QuadrilateralCellTopology::QuadrilateralCellTopology() = default;
 

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -438,7 +438,7 @@ SmapsData_2_6::GetStackUsage()
 
 /**              ---            VMMapData               ---              **/
 
-VMMapData_10_2 ::VMMapData_10_2() = default;
+VMMapData_10_2::VMMapData_10_2() = default;
 
 VMMapData_10_2::~VMMapData_10_2() = default;
 

--- a/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
@@ -22,12 +22,12 @@ namespace itk
 /**
  * The tetrahedron's topology data: Faces
  */
-const int TetrahedronCellTopology ::m_Faces[4][3] = { { 0, 1, 3 }, { 1, 2, 3 }, { 2, 0, 3 }, { 0, 2, 1 } };
+const int TetrahedronCellTopology::m_Faces[4][3] = { { 0, 1, 3 }, { 1, 2, 3 }, { 2, 0, 3 }, { 0, 2, 1 } };
 
 /**
  * The tetrahedron's topology data: Faces
  */
-const int TetrahedronCellTopology ::m_Edges[6][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 }, { 0, 3 }, { 1, 3 }, { 2, 3 } };
+const int TetrahedronCellTopology::m_Edges[6][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 }, { 0, 3 }, { 1, 3 }, { 2, 3 } };
 
 TetrahedronCellTopology::TetrahedronCellTopology() = default;
 

--- a/Modules/Core/Common/src/itkTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTriangleCellTopology.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * The triangle's topology data: Edges
  */
-const int TriangleCellTopology ::m_Edges[3][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 } };
+const int TriangleCellTopology::m_Edges[3][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 } };
 
 TriangleCellTopology::TriangleCellTopology() = default;
 

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -26,7 +26,7 @@ namespace itk
 /**
  * Prompting off by default
  */
-XMLFileOutputWindow ::XMLFileOutputWindow() = default;
+XMLFileOutputWindow::XMLFileOutputWindow() = default;
 
 XMLFileOutputWindow::~XMLFileOutputWindow() = default;
 

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -372,7 +372,7 @@ HardwareWisdomFilenameGenerator::GetUseSteppingCode() const
 }
 
 
-FFTWGlobalConfiguration ::FFTWGlobalConfiguration()
+FFTWGlobalConfiguration::FFTWGlobalConfiguration()
   : m_WisdomCacheBase("")
 {
   { // Configure default method for creating WISDOM_CACHE files

--- a/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
+++ b/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
@@ -21,13 +21,13 @@
 namespace itk
 {
 ChainCodePath2D::OutputType
-ChainCodePath2D ::Evaluate(const InputType & input) const
+ChainCodePath2D::Evaluate(const InputType & input) const
 {
   return DecodeOffset(m_Chain2D[input]);
 }
 
 ChainCodePath2D::IndexType
-ChainCodePath2D ::EvaluateToIndex(const InputType & input) const
+ChainCodePath2D::EvaluateToIndex(const InputType & input) const
 {
   IndexType index = GetStart();
 
@@ -41,7 +41,7 @@ ChainCodePath2D ::EvaluateToIndex(const InputType & input) const
 }
 
 ChainCodePath2D::OffsetType
-ChainCodePath2D ::IncrementInput(InputType & input) const
+ChainCodePath2D::IncrementInput(InputType & input) const
 {
   if (input < NumberOfSteps())
   {
@@ -54,7 +54,7 @@ ChainCodePath2D ::IncrementInput(InputType & input) const
 }
 
 std::string
-ChainCodePath2D ::GetChainCodeAsString() const
+ChainCodePath2D::GetChainCodeAsString() const
 {
   std::string printableChain;
 
@@ -72,7 +72,7 @@ ChainCodePath2D ::GetChainCodeAsString() const
 }
 
 /** Constructor */
-ChainCodePath2D ::ChainCodePath2D()
+ChainCodePath2D::ChainCodePath2D()
 {
   // Most of the work is done in the parent constructor.
 
@@ -129,7 +129,7 @@ ChainCodePath2D::~ChainCodePath2D() = default;
 
 /** Standard "PrintSelf" method */
 void
-ChainCodePath2D ::PrintSelf(std::ostream & os, Indent indent) const
+ChainCodePath2D::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Chain code 2D:  " << GetChainCodeAsString() << std::endl;

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -97,7 +97,7 @@ DCMTKSequence::SetDcmSequenceOfItems(DcmSequenceOfItems * seq)
 }
 
 int
-DCMTKSequence ::card() const
+DCMTKSequence::card() const
 {
   return this->m_DcmSequenceOfItems->card();
 }

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -65,7 +65,7 @@ DCMTKImageIO::DCMTKImageIO()
 }
 
 void
-DCMTKImageIO ::SetLogLevel(LogLevelEnum level)
+DCMTKImageIO::SetLogLevel(LogLevelEnum level)
 {
   switch (level)
   {
@@ -96,7 +96,7 @@ DCMTKImageIO ::SetLogLevel(LogLevelEnum level)
 }
 
 DCMTKImageIO::LogLevelEnum
-DCMTKImageIO ::GetLogLevel() const
+DCMTKImageIO::GetLogLevel() const
 {
   dcmtk::log4cplus::Logger rootLogger = dcmtk::log4cplus::Logger::getRoot();
   switch (rootLogger.getLogLevel())
@@ -247,7 +247,7 @@ DCMTKImageIO::CanWriteFile(const char * itkNotUsed(name))
 }
 
 void
-DCMTKImageIO ::OpenDicomImage()
+DCMTKImageIO::OpenDicomImage()
 {
   if (this->m_DImage != nullptr)
   {
@@ -271,7 +271,7 @@ DCMTKImageIO ::OpenDicomImage()
 
 //------------------------------------------------------------------------------
 void
-DCMTKImageIO ::Read(void * buffer)
+DCMTKImageIO::Read(void * buffer)
 {
   this->OpenDicomImage();
   if (m_DImage->getStatus() != EIS_Normal)
@@ -307,7 +307,7 @@ DCMTKImageIO ::Read(void * buffer)
 }
 
 void
-DCMTKImageIO ::ReorderRGBValues(void * buffer, const void * data, size_t count, unsigned int voxel_size)
+DCMTKImageIO::ReorderRGBValues(void * buffer, const void * data, size_t count, unsigned int voxel_size)
 {
   switch (this->m_ComponentType)
   {
@@ -510,12 +510,12 @@ DCMTKImageIO::ReadImageInformation()
 }
 
 void
-DCMTKImageIO ::WriteImageInformation()
+DCMTKImageIO::WriteImageInformation()
 {}
 
 /** */
 void
-DCMTKImageIO ::Write(const void * buffer)
+DCMTKImageIO::Write(const void * buffer)
 {
   (void)(buffer);
 }

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -26,7 +26,7 @@
 
 namespace itk
 {
-DCMTKSeriesFileNames ::DCMTKSeriesFileNames()
+DCMTKSeriesFileNames::DCMTKSeriesFileNames()
 {
   m_InputDirectory = "";
   m_OutputDirectory = "";

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -345,7 +345,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
 }
 
 float
-GE4ImageIO ::MvtSunf(int numb)
+GE4ImageIO::MvtSunf(int numb)
 {
   constexpr auto signbit = 020000000000U;
   constexpr auto dmantissa = 077777777U;

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -41,7 +41,7 @@ GE5ImageIO::~GE5ImageIO()
 }
 
 int
-GE5ImageIO ::CheckGE5xImages(char const * const imageFileTemplate, std::string & reason)
+GE5ImageIO::CheckGE5xImages(char const * const imageFileTemplate, std::string & reason)
 {
   //
   // Does it exist?

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -612,7 +612,7 @@ GiplImageIO::ReadImageInformation()
 }
 
 void
-GiplImageIO ::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
+GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
 {
   switch (m_ComponentType)
   {
@@ -696,14 +696,14 @@ GiplImageIO ::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
 }
 
 void
-GiplImageIO ::WriteImageInformation()
+GiplImageIO::WriteImageInformation()
 {
   // not possible to write a Gipl file
 }
 
 /** The write function is not implemented */
 void
-GiplImageIO ::Write(const void * buffer)
+GiplImageIO::Write(const void * buffer)
 {
   CheckExtension(m_FileName.c_str());
 

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -50,7 +50,7 @@ HDF5ImageIO::~HDF5ImageIO()
 }
 
 void
-HDF5ImageIO ::PrintSelf(std::ostream & os, Indent indent) const
+HDF5ImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   // just prints out the pointer value.
@@ -262,7 +262,7 @@ doesAttrExist(const H5::H5Object & object, const char * const name)
 } // namespace
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const bool value)
+HDF5ImageIO::WriteScalar(const std::string & path, const bool value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -284,7 +284,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const bool value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const long value)
+HDF5ImageIO::WriteScalar(const std::string & path, const long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -307,7 +307,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const long value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long value)
+HDF5ImageIO::WriteScalar(const std::string & path, const unsigned long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -330,7 +330,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const long long value)
+HDF5ImageIO::WriteScalar(const std::string & path, const long long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -352,7 +352,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const long long value)
 }
 
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long long value)
+HDF5ImageIO::WriteScalar(const std::string & path, const unsigned long long value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -375,7 +375,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const unsigned long long val
 
 template <typename TScalar>
 void
-HDF5ImageIO ::WriteScalar(const std::string & path, const TScalar & value)
+HDF5ImageIO::WriteScalar(const std::string & path, const TScalar & value)
 {
   hsize_t       numScalars(1);
   H5::DataSpace scalarSpace(1, &numScalars);
@@ -387,7 +387,7 @@ HDF5ImageIO ::WriteScalar(const std::string & path, const TScalar & value)
 
 template <typename TScalar>
 TScalar
-HDF5ImageIO ::ReadScalar(const std::string & DataSetName)
+HDF5ImageIO::ReadScalar(const std::string & DataSetName)
 {
   hsize_t       dim[1];
   H5::DataSet   scalarSet = this->m_H5File->openDataSet(DataSetName);
@@ -413,7 +413,7 @@ HDF5ImageIO ::ReadScalar(const std::string & DataSetName)
 
 
 void
-HDF5ImageIO ::WriteString(const std::string & path, const std::string & value)
+HDF5ImageIO::WriteString(const std::string & path, const std::string & value)
 {
   hsize_t       numStrings(1);
   H5::DataSpace strSpace(1, &numStrings);
@@ -424,14 +424,14 @@ HDF5ImageIO ::WriteString(const std::string & path, const std::string & value)
 }
 
 void
-HDF5ImageIO ::WriteString(const std::string & path, const char * s)
+HDF5ImageIO::WriteString(const std::string & path, const char * s)
 {
   std::string _s(s);
   WriteString(path, _s);
 }
 
 std::string
-HDF5ImageIO ::ReadString(const std::string & path)
+HDF5ImageIO::ReadString(const std::string & path)
 {
   std::string   rval;
   hsize_t       numStrings(1);
@@ -445,7 +445,7 @@ HDF5ImageIO ::ReadString(const std::string & path)
 
 template <typename TScalar>
 void
-HDF5ImageIO ::WriteVector(const std::string & path, const std::vector<TScalar> & vec)
+HDF5ImageIO::WriteVector(const std::string & path, const std::vector<TScalar> & vec)
 {
   hsize_t       dim(vec.size());
   H5::DataSpace vecSpace(1, &dim);
@@ -457,7 +457,7 @@ HDF5ImageIO ::WriteVector(const std::string & path, const std::vector<TScalar> &
 
 template <typename TScalar>
 std::vector<TScalar>
-HDF5ImageIO ::ReadVector(const std::string & DataSetName)
+HDF5ImageIO::ReadVector(const std::string & DataSetName)
 {
   std::vector<TScalar> vec;
   hsize_t              dim[1];
@@ -478,7 +478,7 @@ HDF5ImageIO ::ReadVector(const std::string & DataSetName)
 }
 
 void
-HDF5ImageIO ::WriteDirections(const std::string & path, const std::vector<std::vector<double>> & dir)
+HDF5ImageIO::WriteDirections(const std::string & path, const std::vector<std::vector<double>> & dir)
 {
   hsize_t dim[2];
   dim[1] = dir.size();
@@ -501,7 +501,7 @@ HDF5ImageIO ::WriteDirections(const std::string & path, const std::vector<std::v
 }
 
 std::vector<std::vector<double>>
-HDF5ImageIO ::ReadDirections(const std::string & path)
+HDF5ImageIO::ReadDirections(const std::string & path)
 {
   std::vector<std::vector<double>> rval;
   H5::DataSet                      dirSet = this->m_H5File->openDataSet(path);
@@ -553,10 +553,10 @@ HDF5ImageIO ::ReadDirections(const std::string & path)
 
 template <typename TType>
 void
-HDF5ImageIO ::StoreMetaData(MetaDataDictionary * metaDict,
-                            const std::string &  HDFPath,
-                            const std::string &  name,
-                            unsigned long        numElements)
+HDF5ImageIO::StoreMetaData(MetaDataDictionary * metaDict,
+                           const std::string &  HDFPath,
+                           const std::string &  name,
+                           unsigned long        numElements)
 {
   if (numElements == 1)
   {
@@ -579,7 +579,7 @@ HDF5ImageIO ::StoreMetaData(MetaDataDictionary * metaDict,
 }
 
 bool
-HDF5ImageIO ::CanWriteFile(const char * name)
+HDF5ImageIO::CanWriteFile(const char * name)
 {
   return this->HasSupportedWriteExtension(name);
 }
@@ -588,7 +588,7 @@ HDF5ImageIO ::CanWriteFile(const char * name)
 // HDF5 Header.  Some code is redundant with ReadImageInformation
 // a StateMachine could provide a better implementation
 bool
-HDF5ImageIO ::CanReadFile(const char * FileNameToRead)
+HDF5ImageIO::CanReadFile(const char * FileNameToRead)
 {
   // HDF5 is overly verbose in complaining that
   //     a file does not exist.
@@ -632,7 +632,7 @@ HDF5ImageIO ::CanReadFile(const char * FileNameToRead)
 }
 
 void
-HDF5ImageIO ::ResetToInitialState()
+HDF5ImageIO::ResetToInitialState()
 {
   // close the H5 File
   {
@@ -661,7 +661,7 @@ HDF5ImageIO ::ResetToInitialState()
 }
 
 void
-HDF5ImageIO ::ReadImageInformation()
+HDF5ImageIO::ReadImageInformation()
 {
   try
   {
@@ -916,7 +916,7 @@ HDF5ImageIO ::ReadImageInformation()
 }
 
 void
-HDF5ImageIO ::SetupStreaming(H5::DataSpace * imageSpace, H5::DataSpace * slabSpace)
+HDF5ImageIO::SetupStreaming(H5::DataSpace * imageSpace, H5::DataSpace * slabSpace)
 {
   ImageIORegion            regionToRead = this->GetIORegion();
   ImageIORegion::SizeType  size = regionToRead.GetSize();
@@ -958,7 +958,7 @@ HDF5ImageIO ::SetupStreaming(H5::DataSpace * imageSpace, H5::DataSpace * slabSpa
 }
 
 void
-HDF5ImageIO ::Read(void * buffer)
+HDF5ImageIO::Read(void * buffer)
 {
   ImageIORegion            regionToRead = this->GetIORegion();
   ImageIORegion::SizeType  size = regionToRead.GetSize();
@@ -974,7 +974,7 @@ HDF5ImageIO ::Read(void * buffer)
 
 template <typename TType>
 bool
-HDF5ImageIO ::WriteMeta(const std::string & name, MetaDataObjectBase * metaObjBase)
+HDF5ImageIO::WriteMeta(const std::string & name, MetaDataObjectBase * metaObjBase)
 {
   auto * metaObj = dynamic_cast<MetaDataObject<TType> *>(metaObjBase);
   if (metaObj == nullptr)
@@ -988,7 +988,7 @@ HDF5ImageIO ::WriteMeta(const std::string & name, MetaDataObjectBase * metaObjBa
 
 template <typename TType>
 bool
-HDF5ImageIO ::WriteMetaArray(const std::string & name, MetaDataObjectBase * metaObjBase)
+HDF5ImageIO::WriteMetaArray(const std::string & name, MetaDataObjectBase * metaObjBase)
 {
   using MetaDataArrayObject = MetaDataObject<Array<TType>>;
   auto * metaObj = dynamic_cast<MetaDataArrayObject *>(metaObjBase);
@@ -1010,7 +1010,7 @@ HDF5ImageIO ::WriteMetaArray(const std::string & name, MetaDataObjectBase * meta
  * appropriate header information.
  */
 void
-HDF5ImageIO ::WriteImageInformation()
+HDF5ImageIO::WriteImageInformation()
 {
   //
   // guard so that image information is only written once
@@ -1270,7 +1270,7 @@ HDF5ImageIO ::WriteImageInformation()
  * Write the image Information before writing data
  */
 void
-HDF5ImageIO ::Write(const void * buffer)
+HDF5ImageIO::Write(const void * buffer)
 {
   this->WriteImageInformation();
   try
@@ -1329,7 +1329,7 @@ HDF5ImageIO ::Write(const void * buffer)
 //
 // GetHeaderSize -- return 0
 ImageIOBase::SizeType
-HDF5ImageIO ::GetHeaderSize() const
+HDF5ImageIO::GetHeaderSize() const
 {
   return 0;
 }

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -293,7 +293,7 @@ IPLCommonImageIO::SortImageListByNameDescend()
  *
  */
 void
-IPLCommonImageIO ::WriteImageInformation()
+IPLCommonImageIO::WriteImageInformation()
 {
   RAISE_EXCEPTION();
 }
@@ -302,17 +302,13 @@ IPLCommonImageIO ::WriteImageInformation()
  *
  */
 void
-IPLCommonImageIO ::Write(const void *)
+IPLCommonImageIO::Write(const void *)
 {
   RAISE_EXCEPTION();
 }
 
 int
-IPLCommonImageIO ::GetStringAt(std::ifstream & f,
-                               std::streamoff  Offset,
-                               char *          buf,
-                               size_t          amount,
-                               bool            throw_exception)
+IPLCommonImageIO::GetStringAt(std::ifstream & f, std::streamoff Offset, char * buf, size_t amount, bool throw_exception)
 {
   f.seekg(Offset, std::ios::beg);
   if (f.fail())
@@ -341,7 +337,7 @@ IPLCommonImageIO ::GetStringAt(std::ifstream & f,
 }
 
 int
-IPLCommonImageIO ::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, bool throw_exception)
+IPLCommonImageIO::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, bool throw_exception)
 {
   int tmp;
 
@@ -357,7 +353,7 @@ IPLCommonImageIO ::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, 
 }
 
 int
-IPLCommonImageIO ::GetShortAt(std::ifstream & f, std::streamoff Offset, short * ip, bool throw_exception)
+IPLCommonImageIO::GetShortAt(std::ifstream & f, std::streamoff Offset, short * ip, bool throw_exception)
 {
   short tmp;
 
@@ -373,7 +369,7 @@ IPLCommonImageIO ::GetShortAt(std::ifstream & f, std::streamoff Offset, short * 
 }
 
 int
-IPLCommonImageIO ::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * ip, bool throw_exception)
+IPLCommonImageIO::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * ip, bool throw_exception)
 {
   float tmp;
 
@@ -389,7 +385,7 @@ IPLCommonImageIO ::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * 
 }
 
 int
-IPLCommonImageIO ::GetDoubleAt(std::ifstream & f, std::streamoff Offset, double * ip, bool throw_exception)
+IPLCommonImageIO::GetDoubleAt(std::ifstream & f, std::streamoff Offset, double * ip, bool throw_exception)
 {
   double tmp;
 
@@ -415,7 +411,7 @@ IPLCommonImageIO::hdr2Short(char * hdr)
 }
 
 int
-IPLCommonImageIO ::hdr2Int(char * hdr)
+IPLCommonImageIO::hdr2Int(char * hdr)
 {
   int intValue;
 
@@ -425,7 +421,7 @@ IPLCommonImageIO ::hdr2Int(char * hdr)
 }
 
 float
-IPLCommonImageIO ::hdr2Float(char * hdr)
+IPLCommonImageIO::hdr2Float(char * hdr)
 {
   float floatValue;
 
@@ -436,7 +432,7 @@ IPLCommonImageIO ::hdr2Float(char * hdr)
 }
 
 double
-IPLCommonImageIO ::hdr2Double(char * hdr)
+IPLCommonImageIO::hdr2Double(char * hdr)
 {
   double doubleValue;
 
@@ -447,15 +443,15 @@ IPLCommonImageIO ::hdr2Double(char * hdr)
 }
 
 int
-IPLCommonImageIO ::AddElementToList(char const * const filename,
-                                    const float        sliceLocation,
-                                    const int          offset,
-                                    const int          XDim,
-                                    const int          YDim,
-                                    const float        XRes,
-                                    const float        YRes,
-                                    const int          Key1,
-                                    const int          Key2)
+IPLCommonImageIO::AddElementToList(char const * const filename,
+                                   const float        sliceLocation,
+                                   const int          offset,
+                                   const int          XDim,
+                                   const int          YDim,
+                                   const float        XRes,
+                                   const float        YRes,
+                                   const int          Key1,
+                                   const int          Key2)
 {
   if (m_FilenameList->NumFiles() == 0)
   {
@@ -484,19 +480,19 @@ IPLCommonImageIO ::AddElementToList(char const * const filename,
 }
 
 void
-IPLCommonImageIO ::sortImageListAscend()
+IPLCommonImageIO::sortImageListAscend()
 {
   m_FilenameList->sortImageListAscend();
 }
 
 void
-IPLCommonImageIO ::sortImageListDescend()
+IPLCommonImageIO::sortImageListDescend()
 {
   m_FilenameList->sortImageListDescend();
 }
 
 int
-IPLCommonImageIO ::statTimeToAscii(void * clock, char * timeString, int len)
+IPLCommonImageIO::statTimeToAscii(void * clock, char * timeString, int len)
 {
 
   auto               tclock = (time_t) * ((int *)clock);

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -701,7 +701,7 @@ JPEG2000ImageIO::CanWriteFile(const char * filename)
 }
 
 void
-JPEG2000ImageIO ::WriteImageInformation()
+JPEG2000ImageIO::WriteImageInformation()
 {
   itkDebugMacro(<< "WriteImageInformation()");
 
@@ -735,7 +735,7 @@ JPEG2000ImageIO ::WriteImageInformation()
  *
  */
 void
-JPEG2000ImageIO ::Write(const void * buffer)
+JPEG2000ImageIO::Write(const void * buffer)
 {
   itkDebugMacro(<< "Write() " << this->GetNumberOfComponents());
 
@@ -1064,7 +1064,7 @@ JPEG2000ImageIO::GetHeaderSize() const
  * smaller than the LargestPossibleRegion and greater or equal to the
 RequestedRegion */
 ImageIORegion
-JPEG2000ImageIO ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
+JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
 {
   itkDebugMacro(<< "JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion()");
   itkDebugMacro(<< "Requested region = " << requestedRegion);
@@ -1090,9 +1090,9 @@ JPEG2000ImageIO ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIOR
 }
 
 void
-JPEG2000ImageIO ::ComputeRegionInTileBoundaries(unsigned int    dimension,
-                                                SizeValueType   tileSize,
-                                                ImageIORegion & streamableRegion) const
+JPEG2000ImageIO::ComputeRegionInTileBoundaries(unsigned int    dimension,
+                                               SizeValueType   tileSize,
+                                               ImageIORegion & streamableRegion) const
 {
   SizeValueType  requestedSize = streamableRegion.GetSize(dimension);
   IndexValueType requestedIndex = streamableRegion.GetIndex(dimension);
@@ -1121,7 +1121,7 @@ JPEG2000ImageIO ::ComputeRegionInTileBoundaries(unsigned int    dimension,
 }
 
 bool
-JPEG2000ImageIO ::CanStreamWrite()
+JPEG2000ImageIO::CanStreamWrite()
 {
   // we currently can't stream write for now...
   return false;

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -269,7 +269,7 @@ MRCImageIO::InternalReadImageInformation(std::ifstream & file)
 }
 
 void
-MRCImageIO ::Read(void * buffer)
+MRCImageIO::Read(void * buffer)
 {
   std::ifstream file;
 
@@ -469,7 +469,7 @@ MRCImageIO::WriteImageInformation(const void * buffer)
 }
 
 void
-MRCImageIO ::UpdateHeaderWithMinMaxMean(const void * bufferBegin)
+MRCImageIO::UpdateHeaderWithMinMaxMean(const void * bufferBegin)
 {
   // fixed types defined by header
   const MRCHeaderObject::Header & header = m_MRCHeader->GetHeader();
@@ -540,7 +540,7 @@ MRCImageIO ::UpdateHeaderWithMinMaxMean(const void * bufferBegin)
 }
 
 void
-MRCImageIO ::Write(const void * buffer)
+MRCImageIO::Write(const void * buffer)
 {
   if (this->RequestedToStream())
   {

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-BYUMeshIO ::BYUMeshIO()
+BYUMeshIO::BYUMeshIO()
   : m_PartId(NumericTraits<SizeValueType>::max())
   , m_FirstCellId(NumericTraits<SizeValueType>::OneValue())
   , m_LastCellId(NumericTraits<SizeValueType>::max())
@@ -33,7 +33,7 @@ BYUMeshIO ::BYUMeshIO()
 BYUMeshIO::~BYUMeshIO() = default;
 
 bool
-BYUMeshIO ::CanReadFile(const char * fileName)
+BYUMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -49,7 +49,7 @@ BYUMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-BYUMeshIO ::CanWriteFile(const char * fileName)
+BYUMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".byu")
   {
@@ -60,7 +60,7 @@ BYUMeshIO ::CanWriteFile(const char * fileName)
 }
 
 void
-BYUMeshIO ::ReadMeshInformation()
+BYUMeshIO::ReadMeshInformation()
 {
   // Define input file stream and attach it to input file
   std::ifstream inputFile;
@@ -178,7 +178,7 @@ BYUMeshIO ::ReadMeshInformation()
 }
 
 void
-BYUMeshIO ::ReadPoints(void * buffer)
+BYUMeshIO::ReadPoints(void * buffer)
 {
   // Define input file stream and attach it to input file
   std::ifstream inputFile;
@@ -216,7 +216,7 @@ BYUMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-BYUMeshIO ::ReadCells(void * buffer)
+BYUMeshIO::ReadCells(void * buffer)
 {
   // Define input file stream and attach it to input file
   std::ifstream inputFile;
@@ -270,15 +270,15 @@ BYUMeshIO ::ReadCells(void * buffer)
 }
 
 void
-BYUMeshIO ::ReadPointData(void * itkNotUsed(buffer))
+BYUMeshIO::ReadPointData(void * itkNotUsed(buffer))
 {}
 
 void
-BYUMeshIO ::ReadCellData(void * itkNotUsed(buffer))
+BYUMeshIO::ReadCellData(void * itkNotUsed(buffer))
 {}
 
 void
-BYUMeshIO ::WriteMeshInformation()
+BYUMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -309,7 +309,7 @@ BYUMeshIO ::WriteMeshInformation()
 }
 
 void
-BYUMeshIO ::WritePoints(void * buffer)
+BYUMeshIO::WritePoints(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -417,7 +417,7 @@ BYUMeshIO ::WritePoints(void * buffer)
 }
 
 void
-BYUMeshIO ::WriteCells(void * buffer)
+BYUMeshIO::WriteCells(void * buffer)
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -513,19 +513,19 @@ BYUMeshIO ::WriteCells(void * buffer)
 }
 
 void
-BYUMeshIO ::WritePointData(void * itkNotUsed(buffer))
+BYUMeshIO::WritePointData(void * itkNotUsed(buffer))
 {}
 
 void
-BYUMeshIO ::WriteCellData(void * itkNotUsed(buffer))
+BYUMeshIO::WriteCellData(void * itkNotUsed(buffer))
 {}
 
 void
-BYUMeshIO ::Write()
+BYUMeshIO::Write()
 {}
 
 void
-BYUMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+BYUMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
@@ -28,7 +28,7 @@ BYUMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 
-BYUMeshIOFactory ::BYUMeshIOFactory()
+BYUMeshIOFactory::BYUMeshIOFactory()
 {
   this->RegisterOverride("itkMeshIOBase", "itkBYUMeshIO", "BYU Mesh IO", true, CreateObjectFunction<BYUMeshIO>::New());
 }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-FreeSurferAsciiMeshIO ::FreeSurferAsciiMeshIO()
+FreeSurferAsciiMeshIO::FreeSurferAsciiMeshIO()
 {
   this->AddSupportedWriteExtension(".fsa");
 }
@@ -31,7 +31,7 @@ FreeSurferAsciiMeshIO ::FreeSurferAsciiMeshIO()
 FreeSurferAsciiMeshIO::~FreeSurferAsciiMeshIO() = default;
 
 bool
-FreeSurferAsciiMeshIO ::CanReadFile(const char * fileName)
+FreeSurferAsciiMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -47,7 +47,7 @@ FreeSurferAsciiMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-FreeSurferAsciiMeshIO ::CanWriteFile(const char * fileName)
+FreeSurferAsciiMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".fsa")
   {
@@ -58,7 +58,7 @@ FreeSurferAsciiMeshIO ::CanWriteFile(const char * fileName)
 }
 
 void
-FreeSurferAsciiMeshIO ::OpenFile()
+FreeSurferAsciiMeshIO::OpenFile()
 {
   if (this->m_FileName.empty())
   {
@@ -79,7 +79,7 @@ FreeSurferAsciiMeshIO ::OpenFile()
 }
 
 void
-FreeSurferAsciiMeshIO ::CloseFile()
+FreeSurferAsciiMeshIO::CloseFile()
 {
   if (m_InputFile.is_open())
   {
@@ -88,7 +88,7 @@ FreeSurferAsciiMeshIO ::CloseFile()
 }
 
 void
-FreeSurferAsciiMeshIO ::ReadMeshInformation()
+FreeSurferAsciiMeshIO::ReadMeshInformation()
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -140,7 +140,7 @@ FreeSurferAsciiMeshIO ::ReadMeshInformation()
 }
 
 void
-FreeSurferAsciiMeshIO ::ReadPoints(void * buffer)
+FreeSurferAsciiMeshIO::ReadPoints(void * buffer)
 {
   // Number of data array
   auto * data = static_cast<float *>(buffer);
@@ -161,7 +161,7 @@ FreeSurferAsciiMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-FreeSurferAsciiMeshIO ::ReadCells(void * buffer)
+FreeSurferAsciiMeshIO::ReadCells(void * buffer)
 {
   // Get cell buffer
   m_InputFile.precision(12);
@@ -186,15 +186,15 @@ FreeSurferAsciiMeshIO ::ReadCells(void * buffer)
 }
 
 void
-FreeSurferAsciiMeshIO ::ReadPointData(void * itkNotUsed(buffer))
+FreeSurferAsciiMeshIO::ReadPointData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferAsciiMeshIO ::ReadCellData(void * itkNotUsed(buffer))
+FreeSurferAsciiMeshIO::ReadCellData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferAsciiMeshIO ::WriteMeshInformation()
+FreeSurferAsciiMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -222,7 +222,7 @@ FreeSurferAsciiMeshIO ::WriteMeshInformation()
 }
 
 void
-FreeSurferAsciiMeshIO ::WritePoints(void * buffer)
+FreeSurferAsciiMeshIO::WritePoints(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -333,7 +333,7 @@ FreeSurferAsciiMeshIO ::WritePoints(void * buffer)
 }
 
 void
-FreeSurferAsciiMeshIO ::WriteCells(void * buffer)
+FreeSurferAsciiMeshIO::WriteCells(void * buffer)
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -432,19 +432,19 @@ FreeSurferAsciiMeshIO ::WriteCells(void * buffer)
 }
 
 void
-FreeSurferAsciiMeshIO ::WritePointData(void * itkNotUsed(buffer))
+FreeSurferAsciiMeshIO::WritePointData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferAsciiMeshIO ::WriteCellData(void * itkNotUsed(buffer))
+FreeSurferAsciiMeshIO::WriteCellData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferAsciiMeshIO ::Write()
+FreeSurferAsciiMeshIO::Write()
 {}
 
 void
-FreeSurferAsciiMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+FreeSurferAsciiMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-FreeSurferBinaryMeshIO ::FreeSurferBinaryMeshIO()
+FreeSurferBinaryMeshIO::FreeSurferBinaryMeshIO()
 
 {
   this->AddSupportedWriteExtension(".fsb");
@@ -33,7 +33,7 @@ FreeSurferBinaryMeshIO ::FreeSurferBinaryMeshIO()
 FreeSurferBinaryMeshIO::~FreeSurferBinaryMeshIO() = default;
 
 bool
-FreeSurferBinaryMeshIO ::CanReadFile(const char * fileName)
+FreeSurferBinaryMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -50,7 +50,7 @@ FreeSurferBinaryMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-FreeSurferBinaryMeshIO ::CanWriteFile(const char * fileName)
+FreeSurferBinaryMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".fsb" &&
       itksys::SystemTools::GetFilenameLastExtension(fileName) != ".fcv")
@@ -62,7 +62,7 @@ FreeSurferBinaryMeshIO ::CanWriteFile(const char * fileName)
 }
 
 void
-FreeSurferBinaryMeshIO ::OpenFile()
+FreeSurferBinaryMeshIO::OpenFile()
 {
   if (this->m_FileName.empty())
   {
@@ -83,7 +83,7 @@ FreeSurferBinaryMeshIO ::OpenFile()
 }
 
 void
-FreeSurferBinaryMeshIO ::CloseFile()
+FreeSurferBinaryMeshIO::CloseFile()
 {
   if (m_InputFile.is_open())
   {
@@ -92,7 +92,7 @@ FreeSurferBinaryMeshIO ::CloseFile()
 }
 
 void
-FreeSurferBinaryMeshIO ::ReadMeshInformation()
+FreeSurferBinaryMeshIO::ReadMeshInformation()
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -228,7 +228,7 @@ FreeSurferBinaryMeshIO ::ReadMeshInformation()
 }
 
 void
-FreeSurferBinaryMeshIO ::ReadPoints(void * buffer)
+FreeSurferBinaryMeshIO::ReadPoints(void * buffer)
 {
   OpenFile();
   m_InputFile.seekg(m_FilePosition, std::ios::beg);
@@ -241,7 +241,7 @@ FreeSurferBinaryMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::ReadCells(void * buffer)
+FreeSurferBinaryMeshIO::ReadCells(void * buffer)
 {
   constexpr unsigned int numberOfCellPoints = 3;
   const auto             data = make_unique_for_overwrite<itk::uint32_t[]>(this->m_NumberOfCells * numberOfCellPoints);
@@ -258,7 +258,7 @@ FreeSurferBinaryMeshIO ::ReadCells(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::ReadPointData(void * buffer)
+FreeSurferBinaryMeshIO::ReadPointData(void * buffer)
 {
   OpenFile();
   m_InputFile.seekg(m_FilePosition, std::ios::beg);
@@ -272,11 +272,11 @@ FreeSurferBinaryMeshIO ::ReadPointData(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::ReadCellData(void * itkNotUsed(buffer))
+FreeSurferBinaryMeshIO::ReadCellData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferBinaryMeshIO ::WriteMeshInformation()
+FreeSurferBinaryMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -327,7 +327,7 @@ FreeSurferBinaryMeshIO ::WriteMeshInformation()
 }
 
 void
-FreeSurferBinaryMeshIO ::WritePoints(void * buffer)
+FreeSurferBinaryMeshIO::WritePoints(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -435,7 +435,7 @@ FreeSurferBinaryMeshIO ::WritePoints(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::WriteCells(void * buffer)
+FreeSurferBinaryMeshIO::WriteCells(void * buffer)
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -531,7 +531,7 @@ FreeSurferBinaryMeshIO ::WriteCells(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::WritePointData(void * buffer)
+FreeSurferBinaryMeshIO::WritePointData(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -639,15 +639,15 @@ FreeSurferBinaryMeshIO ::WritePointData(void * buffer)
 }
 
 void
-FreeSurferBinaryMeshIO ::WriteCellData(void * itkNotUsed(buffer))
+FreeSurferBinaryMeshIO::WriteCellData(void * itkNotUsed(buffer))
 {}
 
 void
-FreeSurferBinaryMeshIO ::Write()
+FreeSurferBinaryMeshIO::Write()
 {}
 
 void
-FreeSurferBinaryMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+FreeSurferBinaryMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -26,7 +26,7 @@
 
 namespace itk
 {
-OBJMeshIO ::OBJMeshIO()
+OBJMeshIO::OBJMeshIO()
 {
   this->AddSupportedWriteExtension(".obj");
 }
@@ -34,7 +34,7 @@ OBJMeshIO ::OBJMeshIO()
 OBJMeshIO::~OBJMeshIO() = default;
 
 bool
-OBJMeshIO ::CanReadFile(const char * fileName)
+OBJMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -50,7 +50,7 @@ OBJMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-OBJMeshIO ::CanWriteFile(const char * fileName)
+OBJMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".obj")
   {
@@ -61,7 +61,7 @@ OBJMeshIO ::CanWriteFile(const char * fileName)
 }
 
 void
-OBJMeshIO ::OpenFile()
+OBJMeshIO::OpenFile()
 {
   if (this->m_FileName.empty())
   {
@@ -90,7 +90,7 @@ OBJMeshIO ::OpenFile()
 }
 
 void
-OBJMeshIO ::CloseFile()
+OBJMeshIO::CloseFile()
 {
   if (m_InputFile.is_open())
   {
@@ -99,7 +99,7 @@ OBJMeshIO ::CloseFile()
 }
 
 bool
-OBJMeshIO ::SplitLine(const std::string & line, std::string & type, std::string & content)
+OBJMeshIO::SplitLine(const std::string & line, std::string & type, std::string & content)
 {
   std::locale                 loc;
   std::string::const_iterator start = line.begin();
@@ -127,7 +127,7 @@ OBJMeshIO ::SplitLine(const std::string & line, std::string & type, std::string 
 }
 
 void
-OBJMeshIO ::ReadMeshInformation()
+OBJMeshIO::ReadMeshInformation()
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -213,7 +213,7 @@ OBJMeshIO ::ReadMeshInformation()
 }
 
 void
-OBJMeshIO ::ReadPoints(void * buffer)
+OBJMeshIO::ReadPoints(void * buffer)
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -246,7 +246,7 @@ OBJMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-OBJMeshIO ::ReadCells(void * buffer)
+OBJMeshIO::ReadCells(void * buffer)
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -302,7 +302,7 @@ OBJMeshIO ::ReadCells(void * buffer)
 }
 
 void
-OBJMeshIO ::ReadPointData(void * buffer)
+OBJMeshIO::ReadPointData(void * buffer)
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -335,11 +335,11 @@ OBJMeshIO ::ReadPointData(void * buffer)
 }
 
 void
-OBJMeshIO ::ReadCellData(void * itkNotUsed(buffer))
+OBJMeshIO::ReadCellData(void * itkNotUsed(buffer))
 {}
 
 void
-OBJMeshIO ::WriteMeshInformation()
+OBJMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -479,7 +479,7 @@ OBJMeshIO::WritePoints(void * buffer)
 }
 
 void
-OBJMeshIO ::WriteCells(void * buffer)
+OBJMeshIO::WriteCells(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -576,7 +576,7 @@ OBJMeshIO ::WriteCells(void * buffer)
 }
 
 void
-OBJMeshIO ::WritePointData(void * buffer)
+OBJMeshIO::WritePointData(void * buffer)
 {
   // Point data must be vector
   if (!m_UpdatePointData || m_NumberOfPointPixelComponents != m_PointDimension)
@@ -691,15 +691,15 @@ OBJMeshIO ::WritePointData(void * buffer)
 }
 
 void
-OBJMeshIO ::WriteCellData(void * itkNotUsed(buffer))
+OBJMeshIO::WriteCellData(void * itkNotUsed(buffer))
 {}
 
 void
-OBJMeshIO ::Write()
+OBJMeshIO::Write()
 {}
 
 void
-OBJMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+OBJMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
@@ -27,7 +27,7 @@ void
 OBJMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
-OBJMeshIOFactory ::OBJMeshIOFactory()
+OBJMeshIOFactory::OBJMeshIOFactory()
 {
   this->RegisterOverride("itkMeshIOBase", "itkOBJMeshIO", "OBJ Mesh IO", true, CreateObjectFunction<OBJMeshIO>::New());
 }

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-OFFMeshIO ::OFFMeshIO()
+OFFMeshIO::OFFMeshIO()
 {
   this->AddSupportedWriteExtension(".off");
   this->SetByteOrderToBigEndian();
@@ -34,7 +34,7 @@ OFFMeshIO ::OFFMeshIO()
 OFFMeshIO::~OFFMeshIO() = default;
 
 bool
-OFFMeshIO ::CanReadFile(const char * fileName)
+OFFMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -50,7 +50,7 @@ OFFMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-OFFMeshIO ::CanWriteFile(const char * fileName)
+OFFMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".off")
   {
@@ -61,7 +61,7 @@ OFFMeshIO ::CanWriteFile(const char * fileName)
 }
 
 void
-OFFMeshIO ::OpenFile()
+OFFMeshIO::OpenFile()
 {
   if (this->m_FileName.empty())
   {
@@ -86,7 +86,7 @@ OFFMeshIO ::OpenFile()
 }
 
 void
-OFFMeshIO ::CloseFile()
+OFFMeshIO::CloseFile()
 {
   if (m_InputFile.is_open())
   {
@@ -95,7 +95,7 @@ OFFMeshIO ::CloseFile()
 }
 
 void
-OFFMeshIO ::ReadMeshInformation()
+OFFMeshIO::ReadMeshInformation()
 {
   // Define input file stream and attach it to input file
   OpenFile();
@@ -260,7 +260,7 @@ OFFMeshIO ::ReadMeshInformation()
 }
 
 void
-OFFMeshIO ::ReadPoints(void * buffer)
+OFFMeshIO::ReadPoints(void * buffer)
 {
   // Set file position to points start position
   m_InputFile.seekg(m_PointsStartPosition, std::ios::beg);
@@ -282,7 +282,7 @@ OFFMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-OFFMeshIO ::ReadCells(void * buffer)
+OFFMeshIO::ReadCells(void * buffer)
 {
   const auto data = make_unique_for_overwrite<itk::uint32_t[]>(this->m_CellBufferSize - this->m_NumberOfCells);
 
@@ -314,15 +314,15 @@ OFFMeshIO ::ReadCells(void * buffer)
 }
 
 void
-OFFMeshIO ::ReadPointData(void * itkNotUsed(buffer))
+OFFMeshIO::ReadPointData(void * itkNotUsed(buffer))
 {}
 
 void
-OFFMeshIO ::ReadCellData(void * itkNotUsed(buffer))
+OFFMeshIO::ReadCellData(void * itkNotUsed(buffer))
 {}
 
 void
-OFFMeshIO ::WriteMeshInformation()
+OFFMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -383,7 +383,7 @@ OFFMeshIO ::WriteMeshInformation()
 }
 
 void
-OFFMeshIO ::WritePoints(void * buffer)
+OFFMeshIO::WritePoints(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -594,7 +594,7 @@ OFFMeshIO ::WritePoints(void * buffer)
 }
 
 void
-OFFMeshIO ::WriteCells(void * buffer)
+OFFMeshIO::WriteCells(void * buffer)
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -802,19 +802,19 @@ OFFMeshIO ::WriteCells(void * buffer)
 }
 
 void
-OFFMeshIO ::WritePointData(void * itkNotUsed(buffer))
+OFFMeshIO::WritePointData(void * itkNotUsed(buffer))
 {}
 
 void
-OFFMeshIO ::WriteCellData(void * itkNotUsed(buffer))
+OFFMeshIO::WriteCellData(void * itkNotUsed(buffer))
 {}
 
 void
-OFFMeshIO ::Write()
+OFFMeshIO::Write()
 {}
 
 void
-OFFMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+OFFMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
@@ -27,7 +27,7 @@ void
 OFFMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
-OFFMeshIOFactory ::OFFMeshIOFactory()
+OFFMeshIOFactory::OFFMeshIOFactory()
 {
   this->RegisterOverride("itkMeshIOBase", "itkOFFMeshIO", "OFF Mesh IO", true, CreateObjectFunction<OFFMeshIO>::New());
 }

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -82,7 +82,7 @@ ReadFloatingPointsAsASCII(std::ifstream &        inputFile,
 
 
 // Constructor
-VTKPolyDataMeshIO ::VTKPolyDataMeshIO()
+VTKPolyDataMeshIO::VTKPolyDataMeshIO()
 {
   this->AddSupportedWriteExtension(".vtk");
   this->m_ByteOrder = IOByteOrderEnum::BigEndian;
@@ -102,7 +102,7 @@ VTKPolyDataMeshIO::~VTKPolyDataMeshIO() = default;
 
 
 int
-VTKPolyDataMeshIO ::GetNextLine(std::ifstream & ifs, std::string & line, bool lowerCase, SizeValueType count)
+VTKPolyDataMeshIO::GetNextLine(std::ifstream & ifs, std::string & line, bool lowerCase, SizeValueType count)
 {
   // The terminal condition for this recursive calls
   if (count > 5)
@@ -136,7 +136,7 @@ VTKPolyDataMeshIO ::GetNextLine(std::ifstream & ifs, std::string & line, bool lo
 
 
 bool
-VTKPolyDataMeshIO ::CanReadFile(const char * fileName)
+VTKPolyDataMeshIO::CanReadFile(const char * fileName)
 {
   if (!itksys::SystemTools::FileExists(fileName, true))
   {
@@ -173,7 +173,7 @@ VTKPolyDataMeshIO ::CanReadFile(const char * fileName)
 }
 
 bool
-VTKPolyDataMeshIO ::CanWriteFile(const char * fileName)
+VTKPolyDataMeshIO::CanWriteFile(const char * fileName)
 {
   if (itksys::SystemTools::GetFilenameLastExtension(fileName) != ".vtk")
   {
@@ -247,7 +247,7 @@ VTKPolyDataMeshIO::GetComponentTypeFromString(const std::string & pointType)
 }
 
 void
-VTKPolyDataMeshIO ::ReadMeshInformation()
+VTKPolyDataMeshIO::ReadMeshInformation()
 {
   std::ifstream inputFile;
 
@@ -811,7 +811,7 @@ VTKPolyDataMeshIO ::ReadMeshInformation()
   }
 
 void
-VTKPolyDataMeshIO ::ReadPoints(void * buffer)
+VTKPolyDataMeshIO::ReadPoints(void * buffer)
 {
   std::ifstream inputFile;
 
@@ -865,7 +865,7 @@ VTKPolyDataMeshIO ::ReadPoints(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::ReadCells(void * buffer)
+VTKPolyDataMeshIO::ReadCells(void * buffer)
 {
   std::ifstream inputFile;
 
@@ -977,7 +977,7 @@ VTKPolyDataMeshIO::ReadCellsBufferAsASCII(std::ifstream & inputFile, void * buff
 }
 
 void
-VTKPolyDataMeshIO ::ReadCellsBufferAsBINARY(std::ifstream & inputFile, void * buffer)
+VTKPolyDataMeshIO::ReadCellsBufferAsBINARY(std::ifstream & inputFile, void * buffer)
 {
   if (!this->m_CellBufferSize)
   {
@@ -1054,7 +1054,7 @@ VTKPolyDataMeshIO ::ReadCellsBufferAsBINARY(std::ifstream & inputFile, void * bu
 }
 
 void
-VTKPolyDataMeshIO ::ReadPointData(void * buffer)
+VTKPolyDataMeshIO::ReadPointData(void * buffer)
 {
   std::ifstream inputFile;
 
@@ -1108,7 +1108,7 @@ VTKPolyDataMeshIO ::ReadPointData(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::ReadCellData(void * buffer)
+VTKPolyDataMeshIO::ReadCellData(void * buffer)
 {
   std::ifstream inputFile;
 
@@ -1162,7 +1162,7 @@ VTKPolyDataMeshIO ::ReadCellData(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::WriteMeshInformation()
+VTKPolyDataMeshIO::WriteMeshInformation()
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -1282,7 +1282,7 @@ VTKPolyDataMeshIO ::WriteMeshInformation()
   }
 
 void
-VTKPolyDataMeshIO ::WritePoints(void * buffer)
+VTKPolyDataMeshIO::WritePoints(void * buffer)
 {
   // Check file name
   if (this->m_FileName.empty())
@@ -1417,7 +1417,7 @@ VTKPolyDataMeshIO ::WritePoints(void * buffer)
   }
 
 void
-VTKPolyDataMeshIO ::WriteCells(void * buffer)
+VTKPolyDataMeshIO::WriteCells(void * buffer)
 {
   if (this->m_FileName.empty())
   {
@@ -1471,7 +1471,7 @@ VTKPolyDataMeshIO ::WriteCells(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::WritePointData(void * buffer)
+VTKPolyDataMeshIO::WritePointData(void * buffer)
 {
   // check file name
   if (this->m_FileName.empty())
@@ -1526,7 +1526,7 @@ VTKPolyDataMeshIO ::WritePointData(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::WriteCellData(void * buffer)
+VTKPolyDataMeshIO::WriteCellData(void * buffer)
 {
   if (this->m_FileName.empty())
   {
@@ -1579,11 +1579,11 @@ VTKPolyDataMeshIO ::WriteCellData(void * buffer)
 }
 
 void
-VTKPolyDataMeshIO ::Write()
+VTKPolyDataMeshIO::Write()
 {}
 
 void
-VTKPolyDataMeshIO ::PrintSelf(std::ostream & os, Indent indent) const
+VTKPolyDataMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
@@ -29,7 +29,7 @@ VTKPolyDataMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 
-VTKPolyDataMeshIOFactory ::VTKPolyDataMeshIOFactory()
+VTKPolyDataMeshIOFactory::VTKPolyDataMeshIOFactory()
 {
   this->RegisterOverride(
     "itkMeshIOBase", "itkVTKPolyDataMeshIO", "VTK Polydata IO", true, CreateObjectFunction<VTKPolyDataMeshIO>::New());

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -509,7 +509,7 @@ MetaImageIO::CanWriteFile(const char * name)
 }
 
 void
-MetaImageIO ::WriteImageInformation()
+MetaImageIO::WriteImageInformation()
 {
 
   MetaDataDictionary & metaDict = this->GetMetaDataDictionary();
@@ -665,7 +665,7 @@ MetaImageIO ::WriteImageInformation()
  *
  */
 void
-MetaImageIO ::Write(const void * buffer)
+MetaImageIO::Write(const void * buffer)
 {
   const unsigned int numberOfDimensions = this->GetNumberOfDimensions();
 
@@ -1111,7 +1111,7 @@ MetaImageIO ::Write(const void * buffer)
  * smaller than the LargestPossibleRegion and greater or equal to the
  * RequestedRegion */
 ImageIORegion
-MetaImageIO ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
+MetaImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
 {
   //
   // The default implementations determines that the streamable region is

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -422,7 +422,7 @@ SymMatDim(int count)
 }
 
 ImageIORegion
-NiftiImageIO ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
+NiftiImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
 {
   return requestedRegion;
 }
@@ -468,7 +468,7 @@ NiftiImageIO::~NiftiImageIO()
 }
 
 void
-NiftiImageIO ::PrintSelf(std::ostream & os, Indent indent) const
+NiftiImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -481,7 +481,7 @@ NiftiImageIO ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 bool
-NiftiImageIO ::CanWriteFile(const char * FileNameToWrite)
+NiftiImageIO::CanWriteFile(const char * FileNameToWrite)
 {
   const bool ValidFileNameFound = nifti_is_complete_filename(FileNameToWrite) > 0;
 
@@ -810,7 +810,7 @@ NiftiImageIO::DetermineFileType(const char * FileNameToRead)
 // Nifti Header.  Some code is redundant with ReadImageInformation
 // a StateMachine could provide a better implementation
 bool
-NiftiImageIO ::CanReadFile(const char * FileNameToRead)
+NiftiImageIO::CanReadFile(const char * FileNameToRead)
 {
   // is_nifti_file returns
   //      == 2 for a nifti file (header+data in 2 files)
@@ -1006,7 +1006,7 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
 }
 
 void
-NiftiImageIO ::ReadImageInformation()
+NiftiImageIO::ReadImageInformation()
 {
   const int image_FTYPE = is_nifti_file(this->GetFileName());
   if (image_FTYPE == 0)
@@ -1388,7 +1388,7 @@ mat44_transpose(const mat44 & in)
 } // namespace
 
 void
-NiftiImageIO ::WriteImageInformation()
+NiftiImageIO::WriteImageInformation()
 {
   //
   //
@@ -2213,7 +2213,7 @@ NiftiImageIO::SetNIfTIOrientationFromImageIO(unsigned short origdims, unsigned s
 }
 
 void
-NiftiImageIO ::Write(const void * buffer)
+NiftiImageIO::Write(const void * buffer)
 {
   // Write the image Information before writing data
   this->WriteImageInformation();

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -387,14 +387,11 @@ PhilipsRECImageIO::PhilipsRECImageIO()
   // Start out with file byte order == system byte order
   // this will be changed if we're reading a file to whatever
   // the file actually contains.
-  if (ByteSwapper<int>::SystemIsBigEndian())
+  iff(ByteSwapper<int>::SystemIsBigEndian())
   {
     this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::BigEndian;
   }
-  else
-  {
-    this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::LittleEndian;
-  }
+  else { this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::LittleEndian; }
   this->m_SliceIndex = new SliceIndexType();
 }
 

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -622,7 +622,7 @@ VoxBoCUBImageIO::ReadImageInformation()
 }
 
 void
-VoxBoCUBImageIO ::WriteImageInformation()
+VoxBoCUBImageIO::WriteImageInformation()
 {
   if (m_Writer == nullptr)
   {
@@ -738,7 +738,7 @@ VoxBoCUBImageIO ::WriteImageInformation()
 
 /** The write function is not implemented */
 void
-VoxBoCUBImageIO ::Write(const void * buffer)
+VoxBoCUBImageIO::Write(const void * buffer)
 {
   m_Writer = CreateWriter(m_FileName.c_str());
   WriteImageInformation();
@@ -786,7 +786,7 @@ VoxBoCUBImageIO::CheckExtension(const char * filename, bool & isCompressed)
 }
 
 void
-VoxBoCUBImageIO ::InitializeOrientationMap()
+VoxBoCUBImageIO::InitializeOrientationMap()
 {
   m_OrientationMap["RIP"] = SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_RIP;
   m_OrientationMap["LIP"] = SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_LIP;
@@ -845,7 +845,7 @@ VoxBoCUBImageIO ::InitializeOrientationMap()
 }
 
 void
-VoxBoCUBImageIO ::SwapBytesIfNecessary(void * buffer, BufferSizeType numberOfBytes)
+VoxBoCUBImageIO::SwapBytesIfNecessary(void * buffer, BufferSizeType numberOfBytes)
 {
   if (m_ComponentType == IOComponentEnum::CHAR)
   {

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 namespace fem
 {
-const double Element2DC0LinearTriangular ::trigGaussRuleInfo[6][7][4] = {
+const double Element2DC0LinearTriangular::trigGaussRuleInfo[6][7][4] = {
   { // order=0, never used
     { 0.0 } },
   { // order=1

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -26,7 +26,7 @@ namespace itk
 {
 namespace fem
 {
-const Element3DC0LinearTriangular::Float Element3DC0LinearTriangular ::trigGaussRuleInfo[6][7][4] = {
+const Element3DC0LinearTriangular::Float Element3DC0LinearTriangular::trigGaussRuleInfo[6][7][4] = {
   { // order=0, never used
     { 0.0 } },
   { // order=1

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 const double FRPR_TINY = 1e-20;
 
-FRPROptimizer ::FRPROptimizer()
+FRPROptimizer::FRPROptimizer()
 {
   m_UseUnitLengthGradient = false;
   m_OptimizationType = OptimizationEnum::PolakRibiere;

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -52,7 +52,7 @@ private:
 /**
  * Constructor
  */
-LBFGSBOptimizer ::LBFGSBOptimizer()
+LBFGSBOptimizer::LBFGSBOptimizer()
 
 {
   m_LowerBound = InternalBoundValueType(0);
@@ -356,14 +356,14 @@ LBFGSBOptimizer::StartOptimization()
  */
 
 /** Create with a reference to the ITK object */
-LBFGSBOptimizerHelper ::LBFGSBOptimizerHelper(vnl_cost_function & f, LBFGSBOptimizer * const itkObj)
+LBFGSBOptimizerHelper::LBFGSBOptimizerHelper(vnl_cost_function & f, LBFGSBOptimizer * const itkObj)
   : vnl_lbfgsb(f)
   , m_ItkObj(itkObj)
 {}
 
 /** Handle new iteration event */
 bool
-LBFGSBOptimizerHelper ::report_iter()
+LBFGSBOptimizerHelper::report_iter()
 {
   Superclass::report_iter();
 

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -24,7 +24,7 @@ namespace itk
 /**
  * Constructor
  */
-LBFGSOptimizer ::LBFGSOptimizer()
+LBFGSOptimizer::LBFGSOptimizer()
 {
   m_OptimizerInitialized = false;
   m_VnlOptimizer = nullptr;

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -51,7 +51,7 @@ MultipleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
 
 /**  Delegate computation of the value to the CostFunction. */
 void
-MultipleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparameters, InternalMeasureType & measures)
+MultipleValuedVnlCostFunctionAdaptor::f(const InternalParametersType & inparameters, InternalMeasureType & measures)
 {
   if (!this->m_CostFunction)
   {
@@ -87,8 +87,8 @@ MultipleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparame
 
 /**  Delegate computation of the gradient to the costfunction.  */
 void
-MultipleValuedVnlCostFunctionAdaptor ::gradf(const InternalParametersType & inparameters,
-                                             InternalDerivativeType &       gradient)
+MultipleValuedVnlCostFunctionAdaptor::gradf(const InternalParametersType & inparameters,
+                                            InternalDerivativeType &       gradient)
 {
   if (!this->m_CostFunction)
   {
@@ -119,9 +119,9 @@ MultipleValuedVnlCostFunctionAdaptor ::gradf(const InternalParametersType & inpa
 
 /**  Delegate computation of value and gradient to the costfunction.     */
 void
-MultipleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
-                                               InternalMeasureType *          ff,
-                                               InternalDerivativeType *       g)
+MultipleValuedVnlCostFunctionAdaptor::compute(const InternalParametersType & x,
+                                              InternalMeasureType *          ff,
+                                              InternalDerivativeType *       g)
 {
   // delegate the computation to the CostFunction
   DerivativeType externalGradient;

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -24,7 +24,7 @@ namespace itk
 /**
  * ************************* Constructor ************************
  */
-SPSAOptimizer ::SPSAOptimizer()
+SPSAOptimizer::SPSAOptimizer()
 
 {
   m_CurrentIteration = 0;

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -53,7 +53,7 @@ SingleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
 
 /**  Delegate computation of the value to the CostFunction. */
 SingleValuedVnlCostFunctionAdaptor::InternalMeasureType
-SingleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparameters)
+SingleValuedVnlCostFunctionAdaptor::f(const InternalParametersType & inparameters)
 {
   if (!m_CostFunction)
   {
@@ -94,8 +94,8 @@ SingleValuedVnlCostFunctionAdaptor ::f(const InternalParametersType & inparamete
 
 /**  Delegate computation of the gradient to the costfunction.  */
 void
-SingleValuedVnlCostFunctionAdaptor ::gradf(const InternalParametersType & inparameters,
-                                           InternalDerivativeType &       gradient)
+SingleValuedVnlCostFunctionAdaptor::gradf(const InternalParametersType & inparameters,
+                                          InternalDerivativeType &       gradient)
 {
   if (!m_CostFunction)
   {
@@ -130,9 +130,9 @@ SingleValuedVnlCostFunctionAdaptor ::gradf(const InternalParametersType & inpara
 
 /**  Delegate computation of value and gradient to the costfunction.     */
 void
-SingleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
-                                             InternalMeasureType *          fun,
-                                             InternalDerivativeType *       g)
+SingleValuedVnlCostFunctionAdaptor::compute(const InternalParametersType & x,
+                                            InternalMeasureType *          fun,
+                                            InternalDerivativeType *       g)
 {
   // delegate the computation to the CostFunction
   ParametersType parameters(x.size());

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 
 
-AmoebaOptimizerv4 ::AmoebaOptimizerv4()
+AmoebaOptimizerv4::AmoebaOptimizerv4()
   : m_InitialSimplexDelta(1)
 {
   this->m_NumberOfIterations = 500;
@@ -42,14 +42,14 @@ AmoebaOptimizerv4::~AmoebaOptimizerv4()
 
 
 const std::string
-AmoebaOptimizerv4 ::GetStopConditionDescription() const
+AmoebaOptimizerv4::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();
 }
 
 
 void
-AmoebaOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
+AmoebaOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "ParametersConvergenceTolerance: " << this->m_ParametersConvergenceTolerance << std::endl;
@@ -60,7 +60,7 @@ AmoebaOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
 
 
 vnl_amoeba *
-AmoebaOptimizerv4 ::GetOptimizer() const
+AmoebaOptimizerv4::GetOptimizer() const
 {
   return this->m_VnlOptimizer;
 }
@@ -75,7 +75,7 @@ AmoebaOptimizerv4::SetInitialSimplexDelta(ParametersType initialSimplexDelta, bo
 
 
 void
-AmoebaOptimizerv4 ::SetMetric(MetricType * metric)
+AmoebaOptimizerv4::SetMetric(MetricType * metric)
 {
   this->m_Metric = metric;
 
@@ -114,7 +114,7 @@ AmoebaOptimizerv4 ::SetMetric(MetricType * metric)
 
 
 void
-AmoebaOptimizerv4 ::StartOptimization(bool /* doOnlyInitialization */)
+AmoebaOptimizerv4::StartOptimization(bool /* doOnlyInitialization */)
 {
   // Perform some verification, check scales,
   // pass settings to cost-function adaptor.
@@ -250,7 +250,7 @@ AmoebaOptimizerv4 ::StartOptimization(bool /* doOnlyInitialization */)
 
 
 void
-AmoebaOptimizerv4 ::ValidateSettings()
+AmoebaOptimizerv4::ValidateSettings()
 {
   // if we got here it is safe to get the number of parameters the cost
   // function expects

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -42,13 +42,13 @@ protected:
 };
 
 /** Create with a reference to the ITK object */
-LBFGSBOptimizerHelperv4 ::LBFGSBOptimizerHelperv4(vnl_cost_function & f, LBFGSBOptimizerv4 * const itkObj)
+LBFGSBOptimizerHelperv4::LBFGSBOptimizerHelperv4(vnl_cost_function & f, LBFGSBOptimizerv4 * const itkObj)
   : Superclass::LBFGSOptimizerBaseHelperv4(f, itkObj)
 {}
 
 /** Handle new iteration event */
 bool
-LBFGSBOptimizerHelperv4 ::report_iter()
+LBFGSBOptimizerHelperv4::report_iter()
 {
   const bool ret = Superclass::report_iter();
   m_ItkObj->m_InfinityNormOfProjectedGradient = this->get_inf_norm_projected_gradient();
@@ -56,7 +56,7 @@ LBFGSBOptimizerHelperv4 ::report_iter()
 }
 //-------------------------------------------------------------------------
 
-LBFGSBOptimizerv4 ::LBFGSBOptimizerv4()
+LBFGSBOptimizerv4::LBFGSBOptimizerv4()
   : m_InitialPosition(0)
   , m_LowerBound(0)
   , m_UpperBound(0)
@@ -66,7 +66,7 @@ LBFGSBOptimizerv4 ::LBFGSBOptimizerv4()
 LBFGSBOptimizerv4::~LBFGSBOptimizerv4() = default;
 
 void
-LBFGSBOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
+LBFGSBOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -93,7 +93,7 @@ LBFGSBOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-LBFGSBOptimizerv4 ::SetScales(const ScalesType &)
+LBFGSBOptimizerv4::SetScales(const ScalesType &)
 {
   itkWarningMacro(<< "LBFGSB optimizer does not support scaling. All scales are set to one.");
   m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
@@ -102,14 +102,14 @@ LBFGSBOptimizerv4 ::SetScales(const ScalesType &)
 }
 
 void
-LBFGSBOptimizerv4 ::SetInitialPosition(const ParametersType & param)
+LBFGSBOptimizerv4::SetInitialPosition(const ParametersType & param)
 {
   m_InitialPosition = param;
   this->Modified();
 }
 
 void
-LBFGSBOptimizerv4 ::SetLowerBound(const BoundValueType & value)
+LBFGSBOptimizerv4::SetLowerBound(const BoundValueType & value)
 {
   this->m_LowerBound = value;
   if (m_OptimizerInitialized)
@@ -120,7 +120,7 @@ LBFGSBOptimizerv4 ::SetLowerBound(const BoundValueType & value)
 }
 
 void
-LBFGSBOptimizerv4 ::SetUpperBound(const BoundValueType & value)
+LBFGSBOptimizerv4::SetUpperBound(const BoundValueType & value)
 {
   this->m_UpperBound = value;
   if (m_OptimizerInitialized)
@@ -131,7 +131,7 @@ LBFGSBOptimizerv4 ::SetUpperBound(const BoundValueType & value)
 }
 
 void
-LBFGSBOptimizerv4 ::SetBoundSelection(const BoundSelectionType & value)
+LBFGSBOptimizerv4::SetBoundSelection(const BoundSelectionType & value)
 {
   m_BoundSelection = value;
   if (m_OptimizerInitialized)
@@ -142,7 +142,7 @@ LBFGSBOptimizerv4 ::SetBoundSelection(const BoundSelectionType & value)
 }
 
 void
-LBFGSBOptimizerv4 ::SetCostFunctionConvergenceFactor(double value)
+LBFGSBOptimizerv4::SetCostFunctionConvergenceFactor(double value)
 {
   if (value < 0.0)
   {
@@ -158,7 +158,7 @@ LBFGSBOptimizerv4 ::SetCostFunctionConvergenceFactor(double value)
 }
 
 void
-LBFGSBOptimizerv4 ::SetMaximumNumberOfCorrections(unsigned int value)
+LBFGSBOptimizerv4::SetMaximumNumberOfCorrections(unsigned int value)
 {
   m_MaximumNumberOfCorrections = value;
   if (m_OptimizerInitialized)
@@ -169,7 +169,7 @@ LBFGSBOptimizerv4 ::SetMaximumNumberOfCorrections(unsigned int value)
 }
 
 void
-LBFGSBOptimizerv4 ::SetMetric(MetricType * metric)
+LBFGSBOptimizerv4::SetMetric(MetricType * metric)
 {
   Superclass::SetMetric(metric);
 
@@ -193,7 +193,7 @@ LBFGSBOptimizerv4 ::SetMetric(MetricType * metric)
 }
 
 void
-LBFGSBOptimizerv4 ::StartOptimization(bool /*doOnlyInitialization*/)
+LBFGSBOptimizerv4::StartOptimization(bool /*doOnlyInitialization*/)
 {
   // Perform some verification, check scales,
   // pass settings to cost-function adaptor.

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
@@ -21,12 +21,12 @@
 
 namespace itk
 {
-LBFGSOptimizerv4 ::LBFGSOptimizerv4() = default;
+LBFGSOptimizerv4::LBFGSOptimizerv4() = default;
 
 LBFGSOptimizerv4::~LBFGSOptimizerv4() = default;
 
 void
-LBFGSOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
+LBFGSOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "LineSearchAccuracy: " << m_LineSearchAccuracy << std::endl;
@@ -39,7 +39,7 @@ LBFGSOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-LBFGSOptimizerv4 ::VerboseOn()
+LBFGSOptimizerv4::VerboseOn()
 {
   if (m_Verbose == true)
   {
@@ -56,7 +56,7 @@ LBFGSOptimizerv4 ::VerboseOn()
 }
 
 void
-LBFGSOptimizerv4 ::VerboseOff()
+LBFGSOptimizerv4::VerboseOff()
 {
   if (m_Verbose == false)
   {
@@ -73,7 +73,7 @@ LBFGSOptimizerv4 ::VerboseOff()
 }
 
 void
-LBFGSOptimizerv4 ::SetLineSearchAccuracy(double f)
+LBFGSOptimizerv4::SetLineSearchAccuracy(double f)
 {
   if (Math::ExactlyEquals(f, m_LineSearchAccuracy))
   {
@@ -90,7 +90,7 @@ LBFGSOptimizerv4 ::SetLineSearchAccuracy(double f)
 }
 
 void
-LBFGSOptimizerv4 ::SetDefaultStepLength(double f)
+LBFGSOptimizerv4::SetDefaultStepLength(double f)
 {
   if (Math::ExactlyEquals(f, m_DefaultStepLength))
   {
@@ -107,7 +107,7 @@ LBFGSOptimizerv4 ::SetDefaultStepLength(double f)
 }
 
 void
-LBFGSOptimizerv4 ::SetMetric(MetricType * metric)
+LBFGSOptimizerv4::SetMetric(MetricType * metric)
 {
   Superclass::SetMetric(metric);
 
@@ -127,7 +127,7 @@ LBFGSOptimizerv4 ::SetMetric(MetricType * metric)
 }
 
 void
-LBFGSOptimizerv4 ::StartOptimization(bool /* doOnlyInitialization */)
+LBFGSOptimizerv4::StartOptimization(bool /* doOnlyInitialization */)
 {
   // Perform some verification, check scales,
   // pass settings to cost-function adaptor.

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-SingleValuedNonLinearVnlOptimizerv4 ::SingleValuedNonLinearVnlOptimizerv4()
+SingleValuedNonLinearVnlOptimizerv4::SingleValuedNonLinearVnlOptimizerv4()
 {
   this->m_CostFunctionAdaptor = nullptr;
   this->m_Command = CommandType::New();
@@ -39,7 +39,7 @@ SingleValuedNonLinearVnlOptimizerv4::~SingleValuedNonLinearVnlOptimizerv4()
 }
 
 void
-SingleValuedNonLinearVnlOptimizerv4 ::StartOptimization(bool doOnlyInitialization)
+SingleValuedNonLinearVnlOptimizerv4::StartOptimization(bool doOnlyInitialization)
 {
   // Perform some verification, check scales.
   Superclass::StartOptimization(doOnlyInitialization);
@@ -65,7 +65,7 @@ SingleValuedNonLinearVnlOptimizerv4 ::StartOptimization(bool doOnlyInitializatio
 }
 
 void
-SingleValuedNonLinearVnlOptimizerv4 ::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
+SingleValuedNonLinearVnlOptimizerv4::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
   if (this->m_CostFunctionAdaptor == adaptor)
   {
@@ -83,25 +83,25 @@ SingleValuedNonLinearVnlOptimizerv4 ::SetCostFunctionAdaptor(CostFunctionAdaptor
 }
 
 const SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizerv4 ::GetCostFunctionAdaptor() const
+SingleValuedNonLinearVnlOptimizerv4::GetCostFunctionAdaptor() const
 {
   return this->m_CostFunctionAdaptor;
 }
 
 SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizerv4 ::GetCostFunctionAdaptor()
+SingleValuedNonLinearVnlOptimizerv4::GetCostFunctionAdaptor()
 {
   return this->m_CostFunctionAdaptor;
 }
 
 SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizerv4 ::GetNonConstCostFunctionAdaptor() const
+SingleValuedNonLinearVnlOptimizerv4::GetNonConstCostFunctionAdaptor() const
 {
   return this->m_CostFunctionAdaptor;
 }
 
 void
-SingleValuedNonLinearVnlOptimizerv4 ::IterationReport(const EventObject & event)
+SingleValuedNonLinearVnlOptimizerv4::IterationReport(const EventObject & event)
 {
   const CostFunctionAdaptorType * adaptor = this->GetCostFunctionAdaptor();
 
@@ -112,7 +112,7 @@ SingleValuedNonLinearVnlOptimizerv4 ::IterationReport(const EventObject & event)
 }
 
 void
-SingleValuedNonLinearVnlOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
+SingleValuedNonLinearVnlOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Cached Derivative: " << this->m_CachedDerivative << std::endl;

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-SingleValuedVnlCostFunctionAdaptorv4 ::SingleValuedVnlCostFunctionAdaptorv4(unsigned int spaceDimension)
+SingleValuedVnlCostFunctionAdaptorv4::SingleValuedVnlCostFunctionAdaptorv4(unsigned int spaceDimension)
   : vnl_cost_function(spaceDimension)
 {
   m_ScalesInitialized = false;
@@ -29,14 +29,14 @@ SingleValuedVnlCostFunctionAdaptorv4 ::SingleValuedVnlCostFunctionAdaptorv4(unsi
 }
 
 void
-SingleValuedVnlCostFunctionAdaptorv4 ::SetScales(const ScalesType & scales)
+SingleValuedVnlCostFunctionAdaptorv4::SetScales(const ScalesType & scales)
 {
   m_Scales = scales;
   m_ScalesInitialized = true;
 }
 
 SingleValuedVnlCostFunctionAdaptorv4::InternalMeasureType
-SingleValuedVnlCostFunctionAdaptorv4 ::f(const InternalParametersType & inparameters)
+SingleValuedVnlCostFunctionAdaptorv4::f(const InternalParametersType & inparameters)
 {
   if (!m_ObjectMetric)
   {
@@ -69,8 +69,8 @@ SingleValuedVnlCostFunctionAdaptorv4 ::f(const InternalParametersType & inparame
 }
 
 void
-SingleValuedVnlCostFunctionAdaptorv4 ::gradf(const InternalParametersType & inparameters,
-                                             InternalDerivativeType &       gradient)
+SingleValuedVnlCostFunctionAdaptorv4::gradf(const InternalParametersType & inparameters,
+                                            InternalDerivativeType &       gradient)
 {
   if (!m_ObjectMetric)
   {
@@ -105,9 +105,9 @@ SingleValuedVnlCostFunctionAdaptorv4 ::gradf(const InternalParametersType & inpa
 }
 
 void
-SingleValuedVnlCostFunctionAdaptorv4 ::compute(const InternalParametersType & x,
-                                               InternalMeasureType *          fun,
-                                               InternalDerivativeType *       g)
+SingleValuedVnlCostFunctionAdaptorv4::compute(const InternalParametersType & x,
+                                              InternalMeasureType *          fun,
+                                              InternalDerivativeType *       g)
 {
   // delegate the computation to the ObjectMetric
   ParametersType parameters(x.size());
@@ -144,8 +144,8 @@ SingleValuedVnlCostFunctionAdaptorv4 ::compute(const InternalParametersType & x,
 }
 
 void
-SingleValuedVnlCostFunctionAdaptorv4 ::ConvertExternalToInternalGradient(const DerivativeType &   input,
-                                                                         InternalDerivativeType & output) const
+SingleValuedVnlCostFunctionAdaptorv4::ConvertExternalToInternalGradient(const DerivativeType &   input,
+                                                                        InternalDerivativeType & output) const
 {
   // Convert external derivative measures into internal type
   const unsigned int size = input.GetSize();
@@ -163,7 +163,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::ConvertExternalToInternalGradient(const D
 }
 
 void
-SingleValuedVnlCostFunctionAdaptorv4 ::ReportIteration(const EventObject & event) const
+SingleValuedVnlCostFunctionAdaptorv4::ReportIteration(const EventObject & event) const
 {
   // This method reports iterations events. It is intended to
   // help monitoring the progress of the optimization process.
@@ -171,7 +171,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::ReportIteration(const EventObject & event
 }
 
 unsigned long
-SingleValuedVnlCostFunctionAdaptorv4 ::AddObserver(const EventObject & event, Command * command) const
+SingleValuedVnlCostFunctionAdaptorv4::AddObserver(const EventObject & event, Command * command) const
 {
   // Connects a Command/Observer to the internal reporter class.
   // This is useful for reporting iteration event to potential observers.
@@ -179,7 +179,7 @@ SingleValuedVnlCostFunctionAdaptorv4 ::AddObserver(const EventObject & event, Co
 }
 
 const SingleValuedVnlCostFunctionAdaptorv4::ParametersType &
-SingleValuedVnlCostFunctionAdaptorv4 ::GetCachedCurrentParameters() const
+SingleValuedVnlCostFunctionAdaptorv4::GetCachedCurrentParameters() const
 {
   // Return the cached value of the parameters used for computing the function.
   return this->m_ObjectMetric->GetParameters();

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -73,7 +73,7 @@ ChiSquareDistribution::GetDegreesOfFreedom() const
 }
 
 double
-ChiSquareDistribution ::PDF(double x, SizeValueType degreesOfFreedom)
+ChiSquareDistribution::PDF(double x, SizeValueType degreesOfFreedom)
 {
   auto   dof = static_cast<double>(degreesOfFreedom);
   double dofon2 = 0.5 * dof;
@@ -88,7 +88,7 @@ ChiSquareDistribution ::PDF(double x, SizeValueType degreesOfFreedom)
 }
 
 double
-ChiSquareDistribution ::PDF(double x, const ParametersType & p)
+ChiSquareDistribution::PDF(double x, const ParametersType & p)
 {
   if (p.GetSize() != 1)
   {
@@ -99,7 +99,7 @@ ChiSquareDistribution ::PDF(double x, const ParametersType & p)
 }
 
 double
-ChiSquareDistribution ::CDF(double x, SizeValueType degreesOfFreedom)
+ChiSquareDistribution::CDF(double x, SizeValueType degreesOfFreedom)
 {
   // Based on Abramowitz and Stegun 26.4.19 which relates the
   // cumulative of the chi-square to incomplete (and complete) gamma
@@ -116,7 +116,7 @@ ChiSquareDistribution ::CDF(double x, SizeValueType degreesOfFreedom)
 }
 
 double
-ChiSquareDistribution ::CDF(double x, const ParametersType & p)
+ChiSquareDistribution::CDF(double x, const ParametersType & p)
 {
   if (p.GetSize() != 1)
   {

--- a/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
@@ -21,28 +21,28 @@ namespace itk
 {
 namespace Statistics
 {
-DenseFrequencyContainer2 ::DenseFrequencyContainer2()
+DenseFrequencyContainer2::DenseFrequencyContainer2()
 {
   m_FrequencyContainer = FrequencyContainerType::New();
   m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
 }
 
 void
-DenseFrequencyContainer2 ::Initialize(SizeValueType length)
+DenseFrequencyContainer2::Initialize(SizeValueType length)
 {
   m_FrequencyContainer->Reserve(length);
   this->SetToZero();
 }
 
 void
-DenseFrequencyContainer2 ::SetToZero()
+DenseFrequencyContainer2::SetToZero()
 {
   m_FrequencyContainer->Fill(NumericTraits<AbsoluteFrequencyType>::ZeroValue());
   m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
 }
 
 bool
-DenseFrequencyContainer2 ::SetFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
+DenseFrequencyContainer2::SetFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
 {
   if (id >= m_FrequencyContainer->Size())
   {
@@ -55,7 +55,7 @@ DenseFrequencyContainer2 ::SetFrequency(const InstanceIdentifier id, const Absol
 }
 
 DenseFrequencyContainer2::AbsoluteFrequencyType
-DenseFrequencyContainer2 ::GetFrequency(const InstanceIdentifier id) const
+DenseFrequencyContainer2::GetFrequency(const InstanceIdentifier id) const
 {
   if (id >= m_FrequencyContainer->Size())
   {
@@ -65,7 +65,7 @@ DenseFrequencyContainer2 ::GetFrequency(const InstanceIdentifier id) const
 }
 
 bool
-DenseFrequencyContainer2 ::IncreaseFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
+DenseFrequencyContainer2::IncreaseFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
 {
   if (id >= m_FrequencyContainer->Size())
   {
@@ -78,7 +78,7 @@ DenseFrequencyContainer2 ::IncreaseFrequency(const InstanceIdentifier id, const 
 }
 
 void
-DenseFrequencyContainer2 ::PrintSelf(std::ostream & os, Indent indent) const
+DenseFrequencyContainer2::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -151,13 +151,13 @@ GaussianDistribution::SetVariance(double variance)
 }
 
 double
-GaussianDistribution ::PDF(double x)
+GaussianDistribution::PDF(double x)
 {
   return itk::Math::one_over_sqrt2pi * std::exp(-0.5 * x * x);
 }
 
 double
-GaussianDistribution ::PDF(double x, double mean, double variance)
+GaussianDistribution::PDF(double x, double mean, double variance)
 {
   double xminusmean = x - mean;
 
@@ -165,7 +165,7 @@ GaussianDistribution ::PDF(double x, double mean, double variance)
 }
 
 double
-GaussianDistribution ::PDF(double x, const ParametersType & p)
+GaussianDistribution::PDF(double x, const ParametersType & p)
 {
   // verify the parameter vector length
   if (p.GetSize() == 2)
@@ -180,13 +180,13 @@ GaussianDistribution ::PDF(double x, const ParametersType & p)
 }
 
 double
-GaussianDistribution ::CDF(double x)
+GaussianDistribution::CDF(double x)
 {
   return 0.5 * (vnl_erf(itk::Math::sqrt1_2 * x) + 1.0);
 }
 
 double
-GaussianDistribution ::CDF(double x, double mean, double variance)
+GaussianDistribution::CDF(double x, double mean, double variance)
 {
   // convert to zero mean unit variance
   double u = (x - mean) / std::sqrt(variance);
@@ -195,7 +195,7 @@ GaussianDistribution ::CDF(double x, double mean, double variance)
 }
 
 double
-GaussianDistribution ::CDF(double x, const ParametersType & p)
+GaussianDistribution::CDF(double x, const ParametersType & p)
 {
   if (p.GetSize() != 2)
   {

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -21,18 +21,18 @@ namespace itk
 {
 namespace Statistics
 {
-SparseFrequencyContainer2 ::SparseFrequencyContainer2()
+SparseFrequencyContainer2::SparseFrequencyContainer2()
 {
   m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
 }
 
-void SparseFrequencyContainer2 ::Initialize(SizeValueType)
+void SparseFrequencyContainer2::Initialize(SizeValueType)
 {
   this->SetToZero();
 }
 
 void
-SparseFrequencyContainer2 ::SetToZero()
+SparseFrequencyContainer2::SetToZero()
 {
   auto iter = m_FrequencyContainer.begin();
   auto end = m_FrequencyContainer.end();
@@ -45,7 +45,7 @@ SparseFrequencyContainer2 ::SetToZero()
 }
 
 bool
-SparseFrequencyContainer2 ::SetFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
+SparseFrequencyContainer2::SetFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
 {
   // No need to test for bounds because in a map container the
   // element is allocated if the key doesn't exist yet
@@ -57,7 +57,7 @@ SparseFrequencyContainer2 ::SetFrequency(const InstanceIdentifier id, const Abso
 }
 
 SparseFrequencyContainer2::AbsoluteFrequencyType
-SparseFrequencyContainer2 ::GetFrequency(const InstanceIdentifier id) const
+SparseFrequencyContainer2::GetFrequency(const InstanceIdentifier id) const
 {
   auto iter = m_FrequencyContainer.find(id);
 
@@ -72,7 +72,7 @@ SparseFrequencyContainer2 ::GetFrequency(const InstanceIdentifier id) const
 }
 
 bool
-SparseFrequencyContainer2 ::IncreaseFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
+SparseFrequencyContainer2::IncreaseFrequency(const InstanceIdentifier id, const AbsoluteFrequencyType value)
 {
   // No need to test for bounds because in a map container the
   // element is allocated if the key doesn't exist yet
@@ -84,7 +84,7 @@ SparseFrequencyContainer2 ::IncreaseFrequency(const InstanceIdentifier id, const
 }
 
 void
-SparseFrequencyContainer2 ::PrintSelf(std::ostream & os, Indent indent) const
+SparseFrequencyContainer2::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -30,7 +30,7 @@ namespace itk
 {
 namespace Statistics
 {
-TDistribution ::TDistribution()
+TDistribution::TDistribution()
 {
   m_Parameters = ParametersType(1);
   m_Parameters[0] = 1.0;
@@ -74,7 +74,7 @@ TDistribution::GetDegreesOfFreedom() const
 }
 
 double
-TDistribution ::PDF(double x, SizeValueType degreesOfFreedom)
+TDistribution::PDF(double x, SizeValueType degreesOfFreedom)
 {
   auto   dof = static_cast<double>(degreesOfFreedom);
   double dofplusoneon2 = 0.5 * (dof + 1.0);
@@ -88,7 +88,7 @@ TDistribution ::PDF(double x, SizeValueType degreesOfFreedom)
 }
 
 double
-TDistribution ::PDF(double x, const ParametersType & p)
+TDistribution::PDF(double x, const ParametersType & p)
 {
   if (p.GetSize() != 1)
   {
@@ -99,7 +99,7 @@ TDistribution ::PDF(double x, const ParametersType & p)
 }
 
 double
-TDistribution ::CDF(double x, SizeValueType degreesOfFreedom)
+TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
 {
   double bx;
   double pin, qin;
@@ -145,7 +145,7 @@ TDistribution ::CDF(double x, SizeValueType degreesOfFreedom)
 }
 
 double
-TDistribution ::CDF(double x, const ParametersType & p)
+TDistribution::CDF(double x, const ParametersType & p)
 {
   if (p.GetSize() != 1)
   {

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-KLMSegmentationBorder ::KLMSegmentationBorder()
+KLMSegmentationBorder::KLMSegmentationBorder()
 {
   m_Lambda = 0.0;
   m_Region1 = nullptr;

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-KLMSegmentationRegion ::KLMSegmentationRegion()
+KLMSegmentationRegion::KLMSegmentationRegion()
 {
   m_MeanRegionIntensity = 0;
 }

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -56,7 +56,7 @@ FileListVideoIO::SetFileName(const char * fileList)
 }
 
 std::vector<std::string>
-FileListVideoIO ::SplitFileNames(const std::string & fileList)
+FileListVideoIO::SplitFileNames(const std::string & fileList)
 {
   std::vector<std::string> out;
 
@@ -464,7 +464,7 @@ FileListVideoIO::ResetMembers()
 }
 
 bool
-FileListVideoIO ::VerifyExtensions(const std::vector<std::string> & fileList) const
+FileListVideoIO::VerifyExtensions(const std::vector<std::string> & fileList) const
 {
   for (size_t i = 1; i < fileList.size(); ++i)
   {


### PR DESCRIPTION
Removed spaces between class and member names, that were
accidentally introduced with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1191
commit 2074c2f9e5ed3f087d0e2059f8e0e8992fcad7ef "STYLE: Enforce ITK style
defined by .clang-format".

Using bash commands like:

    find . \( -iname *.cxx \) -exec perl -pi -w -e 's/([A-Z]\w+) \:\:(\w)/$1::$2/g;' {} \;

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2096
commit 734d6f84d728b343baae5ef66643a5568a5a30c7 "STYLE: Remove space between
class and member names in C++ source files"