### PR TITLE
STYLE: Make OverRideMap, ObjectFactoryBasePrivate private nested classes

### DIFF
--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -56,10 +56,6 @@ namespace itk
  * \ingroup ITKCommon
  */
 
-// Forward reference because of private implementation
-class OverRideMap;
-class ObjectFactoryBasePrivate;
-
 class ITKCommon_EXPORT ObjectFactoryBase : public Object
 {
 public:
@@ -271,6 +267,10 @@ protected:
   ~ObjectFactoryBase() override;
 
 private:
+  // Forward reference because of private implementation
+  class OverRideMap;
+  class ObjectFactoryBasePrivate;
+
   /** Set/Get the pointer to ObjectFactoryBasePrivate.
    * No concurrent thread safe. */
   static void

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -94,7 +94,7 @@ namespace itk
  *
  */
 
-class ObjectFactoryBasePrivate : public LightObject
+class ObjectFactoryBase::ObjectFactoryBasePrivate : public LightObject
 {
 public:
   ~ObjectFactoryBasePrivate() override
@@ -114,8 +114,8 @@ public:
   bool            m_StrictVersionChecking{ false };
 };
 
-ObjectFactoryBasePrivate *
-ObjectFactoryBase::GetPimplGlobalsPointer()
+auto
+ObjectFactoryBase::GetPimplGlobalsPointer() -> ObjectFactoryBasePrivate *
 {
   const auto                 deleteLambda = []() { m_PimplGlobals->UnRegister(); };
   ObjectFactoryBasePrivate * globalInstance =
@@ -141,10 +141,8 @@ using StringOverMapType = std::multimap<std::string, ObjectFactoryBase::Override
 /** \class OverRideMap
  * \brief Internal implementation class for ObjectFactorBase.
  */
-class OverRideMap : public StringOverMapType
-{
-public:
-};
+class ObjectFactoryBase::OverRideMap : public StringOverMapType
+{};
 
 /**
  * Make possible for application developers to demand an exact match
@@ -925,5 +923,5 @@ ObjectFactoryBase::GetLibraryPath()
   return m_LibraryPath.c_str();
 }
 
-ObjectFactoryBasePrivate * ObjectFactoryBase::m_PimplGlobals;
+ObjectFactoryBase::ObjectFactoryBasePrivate * ObjectFactoryBase::m_PimplGlobals;
 } // end namespace itk


### PR DESCRIPTION
Moved the forward-declaration of both `OverRideMap` and `ObjectFactoryBasePrivate` into the class definition of `ObjectFactoryBase`, as they are just part of the internal private implementation of `ObjectFactoryBase`.

Follow-up to commit 4c0526e4abd40b0157ad05645a8b32aab8d9e733, "STYLE: Make `SubjectImplementation` a private nested type of itk::Object".