### PR TITLE
DOC: Fix ITK class namespace spelling in `Core` group description

### DIFF
--- a/CMake/ITKGroups.cmake
+++ b/CMake/ITKGroups.cmake
@@ -17,7 +17,7 @@ set(group_list
 set(Core_documentation "This group of modules contain the toolkit framework used
 by other modules.  There are common base classes for data objects and process
 objects, basic data structures such as itk::Image, itk::Mesh, itk::QuadEdgeMesh, and
-ik::SpatialObject, and common functionality for operations such as finite
+itk::SpatialObject, and common functionality for operations such as finite
 differences, image adaptors, or image transforms.")
 
 set(Compatibility_documentation "This group contains modules that ease the transition to ITKv4 and Deprecated classes.")


### PR DESCRIPTION
Fix ITK class namespace spelling in `Core` group description.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)