### PR TITLE
COMP: Fix typo (compile error) in `PhilipsRECImageIO` constructor

### DIFF
--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -387,11 +387,14 @@ PhilipsRECImageIO::PhilipsRECImageIO()
   // Start out with file byte order == system byte order
   // this will be changed if we're reading a file to whatever
   // the file actually contains.
-  iff(ByteSwapper<int>::SystemIsBigEndian())
+  if (ByteSwapper<int>::SystemIsBigEndian())
   {
     this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::BigEndian;
   }
-  else { this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::LittleEndian; }
+  else
+  {
+    this->m_MachineByteOrder = this->m_ByteOrder = IOByteOrderEnum::LittleEndian;
+  }
   this->m_SliceIndex = new SliceIndexType();
 }
 


### PR DESCRIPTION
Fixed a compile error, which appeared when enabling `Module_ITKIOPhilipsREC`:

> itkPhilipsRECImageIO.cxx(390,3): error C3861: 'iff': identifier not found

This obvious typo was introduced with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3664 commit 2b1b5312fadf1a156882d06dc2e7c6b2a2290044 "STYLE: Remove space between class and member names (follow-up)", and reported by Bradley Lowekamp (@blowekamp).