### PR TITLE
STYLE: Remove const_cast, make `Object::m_SubjectImplementation` mutable

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -151,6 +151,11 @@ public:
    * and an itk::Command to execute. It returns an unsigned long tag
    * which can be used later to remove the event or retrieve the
    * command.
+   *
+   * \note This member function is overloaded for const and non-const,
+   * just for backward compatibility. Removing the non-const overload
+   * appears to break the use of SWIG %pythonprepend in
+   * ITK/Wrapping/Generators/Python/PyBase/pyBase.i
    */
   unsigned long
   AddObserver(const EventObject & event, Command *);
@@ -275,7 +280,7 @@ private:
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */
-  std::unique_ptr<SubjectImplementation> m_SubjectImplementation;
+  mutable std::unique_ptr<SubjectImplementation> m_SubjectImplementation;
 
   /**
    * Implementation for holding Object MetaData

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -459,11 +459,8 @@ Object::GetGlobalWarningDisplay()
 unsigned long
 Object::AddObserver(const EventObject & event, Command * cmd)
 {
-  if (!this->m_SubjectImplementation)
-  {
-    this->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
-  }
-  return this->m_SubjectImplementation->AddObserver(event, cmd);
+  const auto & thisAsConst = *this;
+  return thisAsConst.AddObserver(event, cmd);
 }
 
 unsigned long
@@ -471,8 +468,7 @@ Object::AddObserver(const EventObject & event, Command * cmd) const
 {
   if (!this->m_SubjectImplementation)
   {
-    auto * me = const_cast<Self *>(this);
-    me->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
+    this->m_SubjectImplementation = std::make_unique<SubjectImplementation>();
   }
   return this->m_SubjectImplementation->AddObserver(event, cmd);
 }


### PR DESCRIPTION
Removed the `const_cast` from the const overload of `Object::AddObserver`, and removed duplicate code by having the non-const overload call the const overload.

Following C++ Core Guidelines, September 23, 2022, "Don’t cast away const", at http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es50-dont-cast-away-const

Added a note on why the non-const overload is still there.

----

This pull request partially supersedes #3636 "STYLE: Remove non-const overload of `Object::AddObserver`, add `mutable`" (but it does not remove the overload).