### PR TITLE
Remove unused local dynamically allocated `double[]` buffers from Segmentation module 

### DIFF
--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -399,9 +399,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
 {
   // itkDebugMacro(<<"Start nearest_neighbor_search_basic()");
 
-  double     bestdistortion, tempdistortion, diff;
-  int        bestcodeword;
-  const auto tempVec = make_unique_for_overwrite<double[]>(m_VectorDimension);
+  double bestdistortion, tempdistortion, diff;
+  int    bestcodeword;
 
   // unused: double *centroidVecTemp = ( double * ) new double[m_VectorDimension];
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -556,8 +556,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
   LabelledImageIndexType offsetIndex3D;
   offsetIndex3D.Fill(0);
 
-  const auto dist = make_unique_for_overwrite<double[]>(m_NumberOfClasses);
-
   const unsigned int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
   const unsigned int frame = m_ImageWidth * m_ImageHeight;
   const unsigned int rowsize = m_ImageWidth;


### PR DESCRIPTION
Might slightly speedup the code.

Note that those two local buffers were already there before `make_unique_for_overwrite` was introduced. 