### PR TITLE
STYLE: Use `std::make_unique<T[]>` to zero-initialize the elements

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -57,7 +57,7 @@ template <typename TMatrix, typename TVector, typename TEigenMatrix>
 unsigned int
 SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesLegacy(const TMatrix & A, TVector & D) const
 {
-  const auto workArea1 = make_unique_for_overwrite<double[]>(m_Dimension);
+  const auto workArea1 = std::make_unique<double[]>(m_Dimension);
 
   // Copy the input matrix
   const auto inputMatrix = make_unique_for_overwrite<double[]>(m_Dimension * m_Dimension);
@@ -68,7 +68,6 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesLegacy
   for (unsigned int row = 0; row < m_Dimension; ++row)
   {
     dVector[row] = D[row];
-    workArea1[row] = 0;
 
     for (unsigned int col = 0; col < m_Dimension; ++col)
     {
@@ -94,8 +93,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   TVector &       EigenValues,
   TEigenMatrix &  EigenVectors) const
 {
-  const auto workArea1 = make_unique_for_overwrite<double[]>(m_Dimension);
-  const auto workArea2 = make_unique_for_overwrite<double[]>(m_Dimension * m_Dimension);
+  const auto workArea1 = std::make_unique<double[]>(m_Dimension);
+  const auto workArea2 = std::make_unique<double[]>(m_Dimension * m_Dimension);
 
   // Copy the input matrix
   const auto inputMatrix = make_unique_for_overwrite<double[]>(m_Dimension * m_Dimension);
@@ -106,11 +105,9 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   for (unsigned int row = 0; row < m_Dimension; ++row)
   {
     dVector[row] = EigenValues[row];
-    workArea1[row] = 0;
 
     for (unsigned int col = 0; col < m_Dimension; ++col)
     {
-      workArea2[k] = 0;
       inputMatrix[k++] = A(row, col);
     }
   }

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -82,12 +82,11 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
   const unsigned int numberOfPoints = inputMesh->GetNumberOfPoints();
 
   const auto K = make_unique_for_overwrite<double[]>(numberOfPoints);
-  const auto dA = make_unique_for_overwrite<double[]>(numberOfPoints);
+  const auto dA = std::make_unique<double[]>(numberOfPoints);
   double     pi2 = itk::Math::twopi;
   for (unsigned int k = 0; k < numberOfPoints; ++k)
   {
     K[k] = pi2;
-    dA[k] = 0.0;
   }
 
   CellsContainerConstPointer  outCells = inputMesh->GetCells();

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 #include "itkMath.h"
-#include "itkMakeUniqueForOverwrite.h"
+#include <memory> // For make_unique.
 
 namespace itk
 {
@@ -184,11 +184,7 @@ HistogramToTextureFeaturesFilter<THistogram>::ComputeMeansAndVariances(double & 
 
   // Initialize everything
   typename HistogramType::SizeValueType binsPerAxis = inputHistogram->GetSize(0);
-  const auto                            marginalSums = make_unique_for_overwrite<double[]>(binsPerAxis);
-  for (double * ms_It = marginalSums.get(); ms_It < marginalSums.get() + binsPerAxis; ++ms_It)
-  {
-    *ms_It = 0;
-  }
+  const auto                            marginalSums = std::make_unique<double[]>(binsPerAxis);
   pixelMean = 0;
 
   typename RelativeFrequencyContainerType::const_iterator rFreqIterator = m_RelativeFrequencyContainer.begin();

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -146,7 +146,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
   this->m_FeatureMeans->clear();
   this->m_FeatureStandardDeviations->clear();
   const auto tempFeatureMeans = make_unique_for_overwrite<double[]>(numFeatures);
-  const auto tempFeatureDevs = make_unique_for_overwrite<double[]>(numFeatures);
+  const auto tempFeatureDevs = std::make_unique<double[]>(numFeatures);
 
   /*Compute incremental mean and SD, a la Knuth, "The  Art of Computer
     Programming, Volume 2: Seminumerical Algorithms",  section 4.2.2.
@@ -162,7 +162,6 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
   for (featureNum = 0; featureNum < numFeatures; ++featureNum)
   {
     tempFeatureMeans[featureNum] = features[0][featureNum];
-    tempFeatureDevs[featureNum] = 0;
   }
   // Run through the recurrence (k = 2 ... N)
   for (offsetNum = 1; offsetNum < numOffsets; ++offsetNum)

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -615,18 +615,16 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
 {
   const unsigned int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
 
-  m_Region = make_unique_for_overwrite<unsigned short[]>(size);
+  m_Region = std::make_unique<unsigned short[]>(size);
   m_RegionCount = make_unique_for_overwrite<unsigned short[]>(size);
 
-  const auto valid_region_counter = make_unique_for_overwrite<unsigned short[]>(size);
+  const auto valid_region_counter = std::make_unique<unsigned short[]>(size);
 
   LabelledImageRegionIterator labelledImageIt(m_LabelledImage, m_LabelledImage->GetBufferedRegion());
 
   for (unsigned int r = 0; r < size; ++r)
   {
-    m_Region[r] = 0;
     m_RegionCount[r] = 1;
-    valid_region_counter[r] = 0;
   }
 
   LabelType i = NumericTraits<LabelType>::ZeroValue();


### PR DESCRIPTION
Replaced `make_unique_for_overwrite<T[]>` calls with `std::make_unique<T[]>`, whenever the elements of the allocated buffer need to be zero-initialized. Removed "post-initializations" which did assign zero to these elements.