### PR TITLE
PERF: Remove unnecessary computations and parallelize function.

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -165,6 +165,7 @@ public:
   using PointSetPointer = typename PointSetType::Pointer;
   using PointDataType = typename PointSetType::PixelType;
   using PointDataContainerType = typename PointSetType::PointDataContainer;
+  using PointDataContainerPointer = typename PointDataContainerType::Pointer;
 
   /** Other type alias. */
   using RealType = float;
@@ -318,10 +319,6 @@ private:
   void
   RefineControlPointLattice();
 
-  /** Determine the residuals after fitting to one level. */
-  void
-  UpdatePointSet();
-
   /** This function is not used as it requires an evaluation of all
    * (SplineOrder+1)^ImageDimensions B-spline weights for each evaluation. */
   void
@@ -334,6 +331,10 @@ private:
   /** Function used to generate the sampled B-spline object quickly. */
   void
   ThreadedGenerateDataForReconstruction(const RegionType &, ThreadIdType);
+
+  /** Update the input point set values with the residuals after fitting to a level. */
+  void
+  ThreadedGenerateDataForUpdatePointSetValues(const RegionType &, ThreadIdType);
 
   /** Sub-function used by GenerateOutputImageFast() to generate the sampled
    * B-spline object quickly. */
@@ -368,8 +369,7 @@ private:
 
   vnl_matrix<RealType> m_RefinedLatticeCoefficients[ImageDimension];
 
-  typename PointDataContainerType::Pointer m_InputPointData;
-  typename PointDataContainerType::Pointer m_OutputPointData;
+  PointDataContainerPointer m_InputPointData;
 
   typename KernelType::Pointer m_Kernel[ImageDimension];
 
@@ -383,6 +383,7 @@ private:
 
   RealType m_BSplineEpsilon{ static_cast<RealType>(1e-3) };
   bool     m_IsFittingComplete{ false };
+  bool     m_DoUpdatePointSetValues{ false };
 };
 } // end namespace itk
 


### PR DESCRIPTION
H/t to @NitramNimod and @chrisadamsonmcri for pointing out the computational bottleneck that precipitated this contribution.  Further discussion is [here.](https://github.com/ANTsX/ANTs/issues/1017)

Two improvements:

1) Eliminate unnecessary calls to UpdatePointSet()
2) Multi-thread UpdatePointSet() (Now called ThreadedGenerateDataForUpdatePointSetValues()).

For single-level approximation, no calls to UpdatePointSet are needed.  This effects well-used code (e.g., N4 bias field correction) so I want to be cautious in submitting but the computational improvements should be relatively significant.  For @thewtex , this would affect your B-spline image gradient module so please take a look if you have time.  

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)


