### PR TITLE
COMP: Remove deprecated uses of vxl for LEGACY ITK

### DIFF
--- a/Modules/ThirdParty/VNL/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/CMakeLists.txt
@@ -23,6 +23,11 @@ else()
 
   # ITKv5 no longer supports legacy method signatures for VNL
   set(VNL_CONFIG_LEGACY_METHODS     OFF CACHE BOOL "Whether backward-compatibility methods are provided by vnl." FORCE )
+  if(ITK_LEGACY_REMOVE OR ITK_FUTURE_LEGACY_REMOVE)
+    set(VXL_USE_HISTORICAL_IMPLICIT_CONVERSIONS OFF CACHE BOOL "Allow default deprecated implicit conversions." FORCE )
+  else()
+    set(VXL_USE_HISTORICAL_IMPLICIT_CONVERSIONS ON  CACHE BOOL "Allow default deprecated implicit conversions." FORCE )
+  endif()
   set(VXL_BUILD_CORE_NUMERICS       ON  CACHE BOOL "VXL configuration for ITK" FORCE )
   set(VXL_BUILD_CORE_NUMERICS_ONLY  ON  CACHE BOOL "VXL configuration for ITK" FORCE ) #This hides other VXL core options from CMake
   set(VXL_NO_EXPORT                 ON  CACHE BOOL "VXL configuration for ITK" FORCE )


### PR DESCRIPTION
When ITK specifies removing support for LEGACY code uses, then VXL should also remove support.

This patch sets "VXL_USE_HISTORICAL_IMPLICIT_CONVERSIONS=OFF" when ITK_LEGACY_REMOVE or ITK_LEGACY_FUTURE_REMOVE is requested.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
