### PR TITLE
STYLE: Rename nested ObjectFactoryBase type OverRideMap to `OverrideMap`

### DIFF
--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -268,7 +268,7 @@ protected:
 
 private:
   // Forward reference because of private implementation
-  class OverRideMap;
+  class OverrideMap;
   class ObjectFactoryBasePrivate;
 
   /** Set/Get the pointer to ObjectFactoryBasePrivate.
@@ -277,7 +277,7 @@ private:
   SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate);
   itkGetGlobalDeclarationMacro(ObjectFactoryBasePrivate, PimplGlobals);
 
-  const std::unique_ptr<OverRideMap> m_OverrideMap;
+  const std::unique_ptr<OverrideMap> m_OverrideMap;
 
   /** Initialize the static list of Factories. */
   static void

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -127,8 +127,7 @@ ObjectFactoryBase::GetPimplGlobalsPointer() -> ObjectFactoryBasePrivate *
   return m_PimplGlobals;
 }
 
-
-/** \class StringOverMap
+/** \class OverrideMap
  * \brief Internal implementation class for ObjectFactorBase.
  *
  * Create a sub class to shrink the size of the symbols
@@ -136,12 +135,7 @@ ObjectFactoryBase::GetPimplGlobalsPointer() -> ObjectFactoryBasePrivate *
  * and a pointer member can be used.  This avoids other
  * classes including <map> and getting long symbol warnings.
  */
-using StringOverMapType = std::multimap<std::string, ObjectFactoryBase::OverrideInformation>;
-
-/** \class OverRideMap
- * \brief Internal implementation class for ObjectFactorBase.
- */
-class ObjectFactoryBase::OverRideMap : public StringOverMapType
+class ObjectFactoryBase::OverrideMap : public std::multimap<std::string, OverrideInformation>
 {};
 
 /**
@@ -485,7 +479,7 @@ ObjectFactoryBase::ReHash()
  * initialize class members
  */
 ObjectFactoryBase::ObjectFactoryBase()
-  : m_OverrideMap{ std::make_unique<OverRideMap>() }
+  : m_OverrideMap{ std::make_unique<OverrideMap>() }
 {
   m_LibraryHandle = nullptr;
   m_LibraryDate = 0;
@@ -731,7 +725,7 @@ ObjectFactoryBase::RegisterOverride(const char *               classOverride,
   info.m_EnabledFlag = enableFlag;
   info.m_CreateObject = createFunction;
 
-  m_OverrideMap->insert(OverRideMap::value_type(classOverride, info));
+  m_OverrideMap->insert(OverrideMap::value_type(classOverride, info));
 }
 
 LightObject::Pointer


### PR DESCRIPTION
The uppercase 'R' in the identifier `OverRideMap` appears unusual. Note that this nested type is just a private implementation detail, so this change does not affect of the API.

Also removed the internal type alias `StringOverMap`, which was only used once.