### PR TITLE
BUG:  Copy input data instead of overwriting.

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -332,9 +332,9 @@ private:
   void
   ThreadedGenerateDataForReconstruction(const RegionType &, ThreadIdType);
 
-  /** Update the input point set values with the residuals after fitting to a level. */
+  /** Update the residuals for multi-level fitting. */
   void
-  ThreadedGenerateDataForUpdatePointSetValues(const RegionType &, ThreadIdType);
+  ThreadedGenerateDataForUpdatingResidualValues(const RegionType &, ThreadIdType);
 
   /** Sub-function used by GenerateOutputImageFast() to generate the sampled
    * B-spline object quickly. */
@@ -369,7 +369,7 @@ private:
 
   vnl_matrix<RealType> m_RefinedLatticeCoefficients[ImageDimension];
 
-  PointDataContainerPointer m_InputPointData;
+  PointDataContainerPointer m_ResidualPointSetValues;
 
   typename KernelType::Pointer m_Kernel[ImageDimension];
 
@@ -383,7 +383,7 @@ private:
 
   RealType m_BSplineEpsilon{ static_cast<RealType>(1e-3) };
   bool     m_IsFittingComplete{ false };
-  bool     m_DoUpdatePointSetValues{ false };
+  bool     m_DoUpdateResidualValues{ false };
 };
 } // end namespace itk
 


### PR DESCRIPTION
Follow-up to the [related pull-request](https://github.com/InsightSoftwareConsortium/ITK/pull/3681).  This corrects a long-standing minor bug (minor in the sense that it was probably not encountered much, if at all with normal usage).  Instead of overwriting the input point data in the case of multi-level fitting, this copies the input data for processing.   

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

