### PR TITLE
STYLE: Change Over/UnderFlow to Over/Underflow

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -555,9 +555,9 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin|Linux")
   itk_add_test(NAME itkFloatingPointExceptionsTest2 COMMAND ITKCommon1TestDriver
     itkFloatingPointExceptionsTest ZeroDivByZero)
   itk_add_test(NAME itkFloatingPointExceptionsTest3 COMMAND ITKCommon1TestDriver
-    itkFloatingPointExceptionsTest FPOverFlow)
+    itkFloatingPointExceptionsTest FPOverflow)
   itk_add_test(NAME itkFloatingPointExceptionsTest4 COMMAND ITKCommon1TestDriver
-    itkFloatingPointExceptionsTest FPUnderFlow)
+    itkFloatingPointExceptionsTest FPUnderflow)
 
   set_tests_properties(
     itkFloatingPointExceptionsTest1

--- a/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
@@ -82,7 +82,7 @@ itkFloatingPointExceptionsTest(int argc, char * argv[])
       std::cout.flush();
     }
   }
-  if (testName == "FPOverFlow")
+  if (testName == "FPOverflow")
   {
     std::cout << "Testing floating point overflow" << std::endl;
     std::cout.flush();
@@ -103,7 +103,7 @@ itkFloatingPointExceptionsTest(int argc, char * argv[])
       std::cout.flush();
     }
   }
-  if (testName == "FPUnderFlow")
+  if (testName == "FPUnderflow")
   {
     std::cout << "Testing floating point underflow" << std::endl;
     std::cout.flush();


### PR DESCRIPTION
"OverFlow" and "UnderFlow" should not have capital "F" characters.
