### PR TITLE
DOC: updated comment for ITK_FUTURE_LEGACY_REMOVE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ cmake_dependent_option(ITK_LEGACY_REMOVE
 # These ITK_FUTURE_LEGACY_REMOVE are another level of granularity for
 # which backwards compatible features we want to maintain.
 cmake_dependent_option(ITK_FUTURE_LEGACY_REMOVE
-      "Completely remove compilation of code which will become deprecated by default in ITKv5." OFF
+      "Completely remove compilation of code which will become deprecated by default in ITKv6." OFF
       "ITK_LEGACY_REMOVE" OFF)
 cmake_dependent_option(ITK_LEGACY_SILENT
       "Silence all legacy code messages when ITK_LEGACY_REMOVE:BOOL=OFF." OFF


### PR DESCRIPTION
Changed _ITKv5_ to _ITKv6_ in cmake comment for ITK_FUTURE_LEGACY_REMOVE.
