### PR TITLE
BUG: Remove unintended `<<` concatenation of literal words in messages and test output

### DIFF
--- a/Modules/Core/Common/include/itkDomainThreader.hxx
+++ b/Modules/Core/Common/include/itkDomainThreader.hxx
@@ -82,8 +82,8 @@ DomainThreader<TDomainPartitioner, TAssociate>::DetermineNumberOfWorkUnitsUsed()
 
   if (this->m_NumberOfWorkUnitsUsed > numberOfWorkUnits)
   {
-    itkExceptionMacro("A subclass of ThreadedDomainPartitioner::PartitionDomain"
-                      << "returned more subdomains than were requested");
+    itkExceptionMacro(
+      "A subclass of ThreadedDomainPartitioner::PartitionDomain returned more subdomains than were requested");
   }
 }
 

--- a/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
@@ -59,8 +59,8 @@ itkMemoryProbesCollecterBaseTest(int, char *[])
   std::cout << " Total Value " << probe.GetTotal() << std::endl;
   if (total == 0)
   {
-    std::cout << "WARNING: Total memory usage should be greater than zero"
-              << "Memory Probes do not work on this platform" << std::endl;
+    std::cout << "WARNING: Total memory usage should be greater than zero. Memory Probes do not work on this platform"
+              << std::endl;
     delete[] buf;
     return EXIT_SUCCESS;
   }

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
@@ -49,9 +49,8 @@ VnlComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
     if (!VnlFFTCommon::IsDimensionSizeLegal(imageSize[ii]))
     {
       itkExceptionMacro(<< "Cannot compute FFT of image with size " << imageSize
-                        << ". VnlComplexToComplexFFTImageFilter operates "
-                        << "only on images whose size in each dimension has"
-                        << "only a combination of 2,3, and 5 as prime factors.");
+                        << ". VnlComplexToComplexFFTImageFilter operates only on images whose size in each dimension "
+                           "has only a combination of 2,3, and 5 as prime factors.");
     }
   }
 

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
@@ -53,9 +53,8 @@ VnlForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     if (!VnlFFTCommon::IsDimensionSizeLegal(inputSize[i]))
     {
       itkExceptionMacro(<< "Cannot compute FFT of image with size " << inputSize
-                        << ". VnlForwardFFTImageFilter operates "
-                        << "only on images whose size in each dimension has"
-                        << "only a combination of 2,3, and 5 as prime factors.");
+                        << ". VnlForwardFFTImageFilter operates only on images whose size in each dimension has only a "
+                           "combination of 2,3, and 5 as prime factors.");
     }
     vectorSize *= inputSize[i];
   }

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -56,9 +56,8 @@ VnlHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Generate
     if (!VnlFFTCommon::IsDimensionSizeLegal(outputSize[i]))
     {
       itkExceptionMacro(<< "Cannot compute FFT of image with size " << outputSize
-                        << ". VnlHalfHermitianToRealInverseFFTImageFilter operates "
-                        << "only on images whose size in each dimension has"
-                        << "only a combination of 2,3, and 5 as prime factors.");
+                        << ". VnlHalfHermitianToRealInverseFFTImageFilter operates only on images whose size in each "
+                           "dimension has only a combination of 2,3, and 5 as prime factors.");
     }
     vectorSize *= outputSize[i];
   }

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.hxx
@@ -55,9 +55,8 @@ VnlInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     if (!VnlFFTCommon::IsDimensionSizeLegal(outputSize[i]))
     {
       itkExceptionMacro(<< "Cannot compute FFT of image with size " << outputSize
-                        << ". VnlInverseFFTImageFilter operates "
-                        << "only on images whose size in each dimension has"
-                        << "only a combination of 2,3, and 5 as prime factors.");
+                        << ". VnlInverseFFTImageFilter operates only on images whose size in each dimension has only a "
+                           "combination of 2,3, and 5 as prime factors.");
     }
     vectorSize *= outputSize[i];
   }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -66,10 +66,8 @@ itkResampleImageTest2Streaming(int argc, char * argv[])
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
-    std::cerr << "inputImage referenceImage "
-              << "resampledImageLinear resampledImageNonLinear "
-              << "resampledImageLinearNearestExtrapolate"
-              << "resampledImageNonLinearNearestExtrapolate";
+    std::cerr << "inputImage referenceImage resampledImageLinear resampledImageNonLinear "
+                 "resampledImageLinearNearestExtrapolate resampledImageNonLinearNearestExtrapolate";
     std::cerr << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/test/itkStatisticsRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsRelabelLabelMapFilterTest1.cxx
@@ -32,8 +32,8 @@ itkStatisticsRelabelLabelMapFilterTest1(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input feature output"
-              << "background reverseOrdering attribute" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " input feature output background reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
@@ -31,12 +31,8 @@ itkRenyiEntropyMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage:" << std::endl;
-    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile"
-              << " maskImageFile"
-              << " outputImageFile"
-              << " maskOutput"
-              << " maskValue"
-              << "expectedThreshold" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+              << " inputImageFile maskImageFile outputImageFile maskOutput maskValue expectedThreshold" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -58,14 +58,12 @@ CSVFileReaderBase::PrepareForParsing()
 
   if (this->m_UseStringDelimiterCharacter && !(this->m_HasRowHeaders || this->m_HasColumnHeaders))
   {
-    itkWarningMacro(<< " Use string delimiter has been set to on"
-                    << "but row and/or column headers indicators are off!");
+    itkWarningMacro(<< " Use string delimiter has been set to on but row and/or column headers indicators are off!");
   }
 
   if (this->m_UseStringDelimiterCharacter && this->m_FieldDelimiterCharacter == this->m_StringDelimiterCharacter)
   {
-    itkExceptionMacro(<< "The same character has been set for the string"
-                      << "delimiter and the field delimiter character!");
+    itkExceptionMacro(<< "The same character has been set for the string delimiter and the field delimiter character!");
   }
 }
 

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -146,8 +146,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   }
   if (!caught)
   {
-    std::cerr << "An exception should have been caught here as the filename does"
-              << "not exist! Test fails." << std::endl;
+    std::cerr << "An exception should have been caught here as the filename does not exist! Test fails." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
@@ -74,14 +74,13 @@ itkCSVNumericObjectFileWriterTest(int argc, char * argv[])
   {
     caught = true;
     std::cerr << "Exception caught!" << std::endl;
-    std::cerr << "This is an expected exception as there is no input"
-              << "file provided." << std::endl;
+    std::cerr << "This is an expected exception as there is no input file provided." << std::endl;
     std::cerr << exp << std::endl;
   }
   if (!caught)
   {
-    std::cerr << "An exception should have been caught here as there"
-              << "is no input file provided. Test fails." << std::endl;
+    std::cerr << "An exception should have been caught here as there is no input file provided. Test fails."
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -104,8 +103,8 @@ itkCSVNumericObjectFileWriterTest(int argc, char * argv[])
   }
   if (!caught)
   {
-    std::cerr << "An exception should have been caught here as there is no"
-              << "input object to write out. Test fails." << std::endl;
+    std::cerr << "An exception should have been caught here as there is no input object to write out. Test fails."
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -330,8 +330,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::EnlargeOutputRequestedRegion(
     // DataObject::PropagateRequestedRegion() has an exception
     // specification
     std::ostringstream message;
-    message << "ImageIO returns IO region that does not fully contain the requested region"
-            << "Requested region: " << imageRequestedRegion << "StreamableRegion region: " << streamableRegion;
+    message << "ImageIO returns IO region that does not fully contain the requested region. Requested region: "
+            << imageRequestedRegion << "StreamableRegion region: " << streamableRegion;
     InvalidRequestedRegionError e(__FILE__, __LINE__);
     e.SetLocation(ITK_LOCATION);
     e.SetDescription(message.str().c_str());

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -242,8 +242,8 @@ ImageFileWriter<TInputImage>::Write()
   // largest region or not.
   if (!largestIORegion.IsInside(pasteIORegion))
   {
-    itkExceptionMacro(<< "Largest possible region does not fully contain requested paste IO region"
-                      << "Paste IO region: " << pasteIORegion << "Largest possible region: " << largestRegion);
+    itkExceptionMacro(<< "Largest possible region does not fully contain requested paste IO region. Paste IO region: "
+                      << pasteIORegion << "Largest possible region: " << largestRegion);
   }
 
   // Determine the actual number of divisions of the input. This is determined
@@ -270,8 +270,9 @@ ImageFileWriter<TInputImage>::Write()
     // largest region or not.
     if (!pasteIORegion.IsInside(streamIORegion))
     {
-      itkExceptionMacro(<< "ImageIO returns streamable region that is not fully contain in paste IO region"
-                        << "Paste IO region: " << pasteIORegion << "Streamable region: " << streamIORegion);
+      itkExceptionMacro(
+        << "ImageIO returns streamable region that is not fully contain in paste IO region. Paste IO region: "
+        << pasteIORegion << "Streamable region: " << streamIORegion);
     }
 
     InputImageRegionType streamRegion;

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -141,9 +141,7 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFile"
-              << " outputFile"
-              << "compression"
-              << "[JPEGQuality]" << std::endl;
+              << " outputFile compression [JPEGQuality]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
@@ -243,8 +243,9 @@ itkMahalanobisDistanceMetricTest(int, char *[])
   try
   {
     distance->Evaluate(measurementSingleComponent, measurementSingleComponent3);
-    std::cerr << "Attempting to compute distance between unequal size measurement vectors"
-              << "Exception should have been thrown: " << std::endl;
+    std::cerr
+      << "Attempting to compute distance between unequal size measurement vectors. Exception should have been thrown: "
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excpt)

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -251,8 +251,8 @@ itkImageClassifierFilterTest(int argc, char * argv[])
   try
   {
     filter->Update();
-    std::cerr << "Attempting to run a classification without setting"
-              << "decision rule, should throw an exception" << std::endl;
+    std::cerr << "Attempting to run a classification without setting decision rule, should throw an exception"
+              << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
@@ -187,8 +187,8 @@ itkSampleClassifierFilterTest1(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Attempting to run a classification without setting"
-              << "decision rule, should throw an exception" << std::endl;
+    std::cerr << "Attempting to run a classification without setting decision rule, should throw an exception"
+              << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest3.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest3.cxx
@@ -179,8 +179,8 @@ itkSampleClassifierFilterTest3(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Exception should be thrown since weight array has size different"
-              << "from the number of classes set" << std::endl;
+    std::cerr << "Exception should be thrown since weight array has size different from the number of classes set"
+              << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -774,8 +774,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedAlloc
   // Throw an exception if we don't have enough layers.
   if (m_Data[ThreadId].m_Layers.size() < 3)
   {
-    itkExceptionMacro(<< "Not enough layers have been allocated for the sparse"
-                      << "field. Requires at least one layer.");
+    itkExceptionMacro(<< "Not enough layers have been allocated for the sparse field. Requires at least one layer.");
   }
 
   // Layers used as buffers for transferring pixels during load balancing


### PR DESCRIPTION
Avoided unintended concatenations, like "PartitionDomainreturned", "hasonly", "regionRequested", "regionPaste", and "sparsefield", which appeared in exception and warning messages, when inserting multiple literal strings consecutively into an output stream. Separated those concatenated words either by a single space character, or by a period _and_ a space (whichever is appropriate).