### PR TITLE
STYLE: Replace `reset(new T[n])` with make_unique_for_overwrite<T[]>(n)

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -60,7 +60,7 @@ public:
   /** Defaulted destructor */
   ~NeighborhoodAllocator() = default;
 
-  /** Allocates memory using new() */
+  /** Allocates memory. */
   void
   Allocate(unsigned int n)
   {
@@ -68,7 +68,7 @@ public:
     m_ElementCount = n;
   }
 
-  /** Deallocates memory using delete[](). */
+  /** Deallocates memory. */
   void
   Deallocate()
   {
@@ -79,7 +79,7 @@ public:
   /** Copy constructor. */
   NeighborhoodAllocator(const Self & other)
     : m_ElementCount(other.m_ElementCount)
-    , m_Data(new TPixel[other.m_ElementCount])
+    , m_Data(make_unique_for_overwrite<TPixel[]>(other.m_ElementCount))
   {
     std::copy_n(other.m_Data.get(), m_ElementCount, m_Data.get());
   }

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #ifndef itkNeighborhoodAllocator_h
 #define itkNeighborhoodAllocator_h
+#include "itkMakeUniqueForOverwrite.h"
 #include <algorithm>
 #include <iostream>
 #include <memory>
@@ -63,7 +64,7 @@ public:
   void
   Allocate(unsigned int n)
   {
-    m_Data.reset(new TPixel[n]);
+    m_Data = make_unique_for_overwrite<TPixel[]>(n);
     m_ElementCount = n;
   }
 
@@ -158,7 +159,7 @@ public:
     if (n != m_ElementCount)
     {
       *this = NeighborhoodAllocator();
-      m_Data.reset(new TPixel[n]);
+      m_Data = make_unique_for_overwrite<TPixel[]>(n);
       m_ElementCount = n;
     }
   }

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkOrthogonalSwath2DPathFilter_hxx
 #define itkOrthogonalSwath2DPathFilter_hxx
 
+#include "itkMakeUniqueForOverwrite.h"
 #include "itkMath.h"
 #include "itkNumericTraits.h"
 
@@ -36,9 +37,9 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
 
   // Re-initialize the member variables
   m_SwathSize = swathMeritImage->GetLargestPossibleRegion().GetSize();
-  m_StepValues.reset(new int[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]]);
-  m_MeritValues.reset(new double[m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]]);
-  m_OptimumStepsValues.reset(new int[m_SwathSize[0]]);
+  m_StepValues = make_unique_for_overwrite<int[]>(m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]);
+  m_MeritValues = make_unique_for_overwrite<double[]>(m_SwathSize[0] * m_SwathSize[1] * m_SwathSize[1]);
+  m_OptimumStepsValues = make_unique_for_overwrite<int[]>(m_SwathSize[0]);
   m_FinalOffsetValues->Initialize();
 
   // Perform the remaining calculations; use dynamic programming

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -21,6 +21,7 @@
 #include "itkMetaDataObject.h"
 #include "itkIOCommon.h"
 #include "itkByteSwapper.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 #include <fstream>
 #include <memory> // For unique_ptr.
@@ -246,7 +247,7 @@ MRCImageIO::InternalReadImageInformation(std::ifstream & file)
 
   this->OpenFileForReading(file, m_FileName);
 
-  buffer.reset(new char[m_MRCHeader->GetHeaderSize()]);
+  buffer = make_unique_for_overwrite<char[]>(m_MRCHeader->GetHeaderSize());
   if (!this->ReadBufferAsBinary(file, static_cast<void *>(buffer.get()), m_MRCHeader->GetHeaderSize()))
   {
     itkExceptionMacro(<< "Header Read failed: Wanted " << m_MRCHeader->GetHeaderSize() << " bytes, but read "
@@ -259,7 +260,7 @@ MRCImageIO::InternalReadImageInformation(std::ifstream & file)
     itkExceptionMacro(<< "Unrecognized header");
   }
 
-  buffer.reset(new char[m_MRCHeader->GetExtendedHeaderSize()]);
+  buffer = make_unique_for_overwrite<char[]>(m_MRCHeader->GetExtendedHeaderSize());
   if (!this->ReadBufferAsBinary(file, static_cast<void *>(buffer.get()), m_MRCHeader->GetExtendedHeaderSize()))
   {
     itkExceptionMacro(<< "Extended Header Read failed.");

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageRandomConstIteratorWithIndex.h"
 #include "itkMath.h"
+#include "itkMakeUniqueForOverwrite.h"
 
 namespace itk
 {
@@ -305,10 +306,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
 {
   this->SetNumberOfWorkUnits(m_NumberOfWorkUnits);
 
-  m_ThreaderNumberOfMovingImageSamples.reset(new unsigned int[m_NumberOfWorkUnits - 1]);
+  m_ThreaderNumberOfMovingImageSamples = make_unique_for_overwrite<unsigned int[]>(m_NumberOfWorkUnits - 1);
 
   // Allocate the array of transform clones to be used in every thread
-  m_ThreaderTransform.reset(new TransformPointer[m_NumberOfWorkUnits - 1]);
+  m_ThreaderTransform = make_unique_for_overwrite<TransformPointer[]>(m_NumberOfWorkUnits - 1);
   for (ThreadIdType ithread = 0; ithread < m_NumberOfWorkUnits - 1; ++ithread)
   {
     this->m_ThreaderTransform[ithread] = this->m_Transform->Clone();
@@ -422,8 +423,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     }
     else
     {
-      this->m_ThreaderBSplineTransformWeights.reset(new BSplineTransformWeightsType[m_NumberOfWorkUnits - 1]);
-      this->m_ThreaderBSplineTransformIndices.reset(new BSplineTransformIndexArrayType[m_NumberOfWorkUnits - 1]);
+      this->m_ThreaderBSplineTransformWeights =
+        make_unique_for_overwrite<BSplineTransformWeightsType[]>(m_NumberOfWorkUnits - 1);
+      this->m_ThreaderBSplineTransformIndices =
+        make_unique_for_overwrite<BSplineTransformIndexArrayType[]>(m_NumberOfWorkUnits - 1);
     }
 
     for (unsigned int j = 0; j < FixedImageDimension; ++j)


### PR DESCRIPTION
Replaced `\.reset\(new (\w+)\[(.+)\]\);` with ` = make_unique_for_overwrite<$1[]>($2);`, using regular expressions in Visual Studio 2019.

Following C++ Core Guidelines, September 23, 2022, "Avoid calling `new` and `delete` explicitly", from http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-newdelete