### PR TITLE
COMP: Fix uninitialized vector warnings

### DIFF
--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -96,7 +96,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m;
+    MeasurementVectorType m{};
 
     if (MeasurementVectorTraits::IsResizable(m))
     {

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -66,7 +66,7 @@ public:
     // If the default constructor creates a vector of
     // length zero, we assume that it is resizable,
     // otherwise that is a pretty useless measurement vector.
-    TVectorType             m;
+    TVectorType             m{};
     MeasurementVectorLength len = NumericTraits<TVectorType>::GetLength(m);
 
     return (len == 0);

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -92,7 +92,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m;
+    MeasurementVectorType m{};
 
     if (MeasurementVectorTraits::IsResizable(m))
     {

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -116,7 +116,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m;
+    MeasurementVectorType m{};
 
     if (MeasurementVectorTraits::IsResizable(m))
     {


### PR DESCRIPTION
Fix uninitialized vector warnings.

Fixes:
```
Modules/Numerics/Statistics/include/itkDistanceMetric.h:101:45:
warning: 'm' may be used uninitialized [-Wmaybe-uninitialized]
```

and
```
Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h:70:72:
warning: 'm' may be used uninitialized [-Wmaybe-uninitialized]
```

and
```
Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h:97:45:
warning: 'm' may be used uninitialized [-Wmaybe-uninitialized]
```

and
```
Modules/Numerics/Statistics/include/itkSample.h:121:45:
warning: 'm' may be used uninitialized [-Wmaybe-uninitialized]
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8240358

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)