### PR TITLE
PERF: Use smaller (16x16) images in KullbackLeibler metric test

### DIFF
--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -52,7 +52,7 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
     ImageDimension = MovingImageType::ImageDimension
   };
 
-  MovingImageType::SizeType   size = { { 100, 100 } };
+  MovingImageType::SizeType   size = { { 16, 16 } };
   MovingImageType::IndexType  index = { { 0, 0 } };
   MovingImageType::RegionType region;
   region.SetSize(size);


### PR DESCRIPTION
The `KullbackLeiblerCompareHistogramImageToImageMetric` test appeared to be the most time consuming test of ITK's test framework, taking more than 9 seconds on Windows, on GitHub Actions. Originally it had test images of 100 x 100 pixels, with commit de0f47aee76c3ee69504c5663ba284e32ba03e44 "Tests for the CompareHistogramImageToImageMetric class and the KullbackLieblerCompareHistogramImageToImageMetric class", Luis Ibanez (@luisibanez), 29 Dec 2003. However, the same code coverage may be achieved with images of 16 x 16.

---
Current top 25 of most time consuming tests (on GitHub Actions running Windows): https://github.com/InsightSoftwareConsortium/ITK/pull/3702#issuecomment-1295786873