### PR TITLE
COMP: Set `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE` in wrapping modules

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -60,6 +60,10 @@ else()
     if(ITK_BINARY_DIR)
       itk_download_attempt_check(CastXML)
     endif()
+    cmake_policy(PUSH)
+    if(POLICY CMP0135)
+      cmake_policy(SET CMP0135 NEW)
+    endif()
     ExternalProject_Add(castxml
       URL ${_castxml_url}
       URL_HASH SHA512=${_castxml_hash}
@@ -67,6 +71,7 @@ else()
       BUILD_COMMAND ""
       INSTALL_COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/castxml-prefix/src/castxml" "${CMAKE_CURRENT_BINARY_DIR}/castxml"
       )
+    cmake_policy(POP)
     set(CASTXML_EXECUTABLE ${castxml_ep})
     set(CASTXML_EXECUTABLE ${castxml_ep} CACHE FILEPATH "castxml executable." FORCE)
   # Build from source

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -138,6 +138,11 @@ else()
               install
         )
       endif()
+      if(${CMAKE_VERSION} VERSION_LESS 3.24)
+        set(download_extract_timestamp_flag)
+      else()
+        set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+      endif()
       set(pcre_hash "abac4c4f9df9e61d7d7761a9c50843882611752e1df0842a54318f358c28f5953025eba2d78997d21ee690756b56cc9f1c04a5ed591dd60654cc78ba16d9ecfb")
       ExternalProject_Add(PCRE
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
@@ -148,6 +153,7 @@ else()
           --prefix=${CMAKE_CURRENT_BINARY_DIR}/PCRE
           --enable-shared=no
         ${extra_external_project_commands}
+        ${download_extract_timestamp_flag}
         )
 
       # swig uses bison find it by cmake and pass it down
@@ -240,6 +246,11 @@ message(STATUS \"Swig configure successfully completed.\")
         )
       endif()
 
+      if(${CMAKE_VERSION} VERSION_LESS 3.24)
+        set(download_extract_timestamp_flag)
+      else()
+        set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+      endif()
       ExternalProject_Add(swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
         URL_HASH SHA512=${swig_hash}
@@ -247,6 +258,7 @@ message(STATUS \"Swig configure successfully completed.\")
           ${extra_swig_configure_env} ${CMAKE_COMMAND} -P "${_swig_configure_script}"
         ${extra_external_project_commands}
         DEPENDS PCRE
+        ${download_extract_timestamp_flag}
         )
     endif()
 


### PR DESCRIPTION
Set `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE`: the timestamps of the
extracted files will reflect the timestamps in the archive.

Configure/autoconf based projects like SWIG and PCRE have timestamped
files for their auto configuration dependencies. Thus, they depend on
the timestamps of the extracted files, and the external projects require
setting `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE` to build robustly.

Set the `CMP0135` policy to `NEW` for the CastXML CMake-based project.

Suppresses CMake warnings in wrapping modules.

Fixes:
```
CMake Warning (dev) at /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:4170 (_ep_add_download_command)
  Wrapping/Generators/SwigInterface/CMakeLists.txt:142 (ExternalProject_Add)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found BISON: /usr/bin/bison (found version "3.5.1")
CMake Warning (dev) at /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:4170 (_ep_add_download_command)
  Wrapping/Generators/SwigInterface/CMakeLists.txt:243 (ExternalProject_Add)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.24/Modules/ExternalProject.cmake:4170 (_ep_add_download_command)
  Wrapping/Generators/CastXML/CMakeLists.txt:63 (ExternalProject_Add)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

raised for example in:
https://open.cdash.org/build/8245525/configure

Related documentation:
https://cmake.org/cmake/help/latest/module/ExternalProject.html?highlight=download_extract_timestamp
https://cmake.org/cmake/help/latest/policy/CMP0135.html

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)