### PR TITLE
STYLE: Use `{}` as `MeasurementVectorTraits::IsResizable` argument

### DIFF
--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -96,9 +96,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m{};
-
-    if (MeasurementVectorTraits::IsResizable(m))
+    if (MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
     {
       // then this is a resizable vector type
       //

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
@@ -30,7 +30,7 @@ DistanceMetric<TVector>::DistanceMetric()
   // initialize the vector size to it.
   MeasurementVectorType vector;
 
-  if (!MeasurementVectorTraits::IsResizable(vector))
+  if (!MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
   {
     MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength(vector);
 

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -95,7 +95,7 @@ ImageToListSampleFilter<TImage, TMaskImage>::GetMeasurementVectorSize() const
   MeasurementVectorType m;
   unsigned int          measurementVectorSize;
 
-  if (!MeasurementVectorTraits::IsResizable(m))
+  if (!MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
   {
     measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(m);
   }

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -92,9 +92,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m{};
-
-    if (MeasurementVectorTraits::IsResizable(m))
+    if (MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
     {
       // then this is a resizable vector type
       //

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -116,9 +116,7 @@ public:
   SetMeasurementVectorSize(MeasurementVectorSizeType s)
   {
     // Test whether the vector type is resizable or not
-    MeasurementVectorType m{};
-
-    if (MeasurementVectorTraits::IsResizable(m))
+    if (MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
     {
       // then this is a resizable vector type
       //


### PR DESCRIPTION
It appears unnecessary to use a local variable as function argument of
 `IsResizable(const TVectorType &)`. In three cases, such a local variable
could simply be removed.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3707 commit d81a02cc23e08a4ddaa3a3c4468f2093cbf9cf5a "COMP: Fix uninitialized vector warnings" by Jon Haitz Legarreta Gorroño (@jhlegarreta).
