### PR TITLE
`VectorNeighborhoodInnerProduct`: Move pixel retrieval out of its inner loops and zero-initialize its `sum` by `{}`

### DIFF
--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
@@ -26,17 +26,9 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &           
                                                    const ConstNeighborhoodIterator<TImage> & it,
                                                    const OperatorType &                      op) const
 {
-  PixelType    sum;
-  unsigned int j;
+  PixelType sum{};
 
-  typename OperatorType::ConstIterator o_it;
-
-  for (j = 0; j < VectorDimension; ++j)
-  {
-    sum[j] = NumericTraits<ScalarValueType>::ZeroValue();
-  }
-
-  o_it = op.Begin();
+  typename OperatorType::ConstIterator       o_it = op.Begin();
   const typename OperatorType::ConstIterator op_end = op.End();
 
   const auto start = static_cast<unsigned int>(s.start());
@@ -45,7 +37,7 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &           
   {
     const auto & neighborPixel = it.GetPixel(i);
 
-    for (j = 0; j < VectorDimension; ++j)
+    for (unsigned int j = 0; j < VectorDimension; ++j)
     {
       sum[j] += *o_it * neighborPixel[j];
     }
@@ -60,17 +52,9 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &       s,
                                                    const NeighborhoodType & it,
                                                    const OperatorType &     op) const
 {
-  PixelType    sum;
-  unsigned int j;
+  PixelType sum{};
 
-  typename OperatorType::ConstIterator o_it;
-
-  for (j = 0; j < VectorDimension; ++j)
-  {
-    sum[j] = NumericTraits<ScalarValueType>::ZeroValue();
-  }
-
-  o_it = op.Begin();
+  typename OperatorType::ConstIterator       o_it = op.Begin();
   const typename OperatorType::ConstIterator op_end = op.End();
 
   const auto start = static_cast<unsigned int>(s.start());
@@ -79,7 +63,7 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &       s,
   {
     const auto & neighborPixel = it[i];
 
-    for (j = 0; j < VectorDimension; ++j)
+    for (unsigned int j = 0; j < VectorDimension; ++j)
     {
       sum[j] += *o_it * neighborPixel[j];
     }

--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
@@ -43,9 +43,11 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &           
   const auto stride = static_cast<unsigned int>(s.stride());
   for (unsigned int i = start; o_it < op_end; i += stride, ++o_it)
   {
+    const auto & neighborPixel = it.GetPixel(i);
+
     for (j = 0; j < VectorDimension; ++j)
     {
-      sum[j] += *o_it * (it.GetPixel(i))[j];
+      sum[j] += *o_it * neighborPixel[j];
     }
   }
 
@@ -75,9 +77,11 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &       s,
   const auto stride = static_cast<unsigned int>(s.stride());
   for (unsigned int i = start; o_it < op_end; i += stride, ++o_it)
   {
+    const auto & neighborPixel = it[i];
+
     for (j = 0; j < VectorDimension; ++j)
     {
-      sum[j] += *o_it * it[i][j];
+      sum[j] += *o_it * neighborPixel[j];
     }
   }
 


### PR DESCRIPTION
Moved the retrieval of neighbor pixels out of the inner `for` loops of both `VectorNeighborhoodInnerProduct<TImage>::operator()` overloads. A reduction of more than 8 % of the duration of `itkSyNPointSetRegistrationTest` was observed, running a Visual Studio 2019 Release build.

Used `{}` to zero-initialize the local `sum` variables, instead of having a `for` loop to assign zero to each element.

Initialized `o_it` directly at its begin value, avoiding an extra assignment.


