### PR TITLE
STYLE: Use `{}` instead of dummy as `NumericTraits::GetLength` argument

### DIFF
--- a/Modules/Core/Common/include/itkImage.hxx
+++ b/Modules/Core/Common/include/itkImage.hxx
@@ -147,8 +147,7 @@ Image<TPixel, VImageDimension>::GetNumberOfComponentsPerPixel() const
 {
   // use the GetLength() method which works with variable length arrays,
   // to make it work with as much pixel types as possible
-  const auto p = PixelType();
-  return NumericTraits<PixelType>::GetLength(p);
+  return NumericTraits<PixelType>::GetLength({});
 }
 
 

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
@@ -27,8 +27,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 ComposeImageFilter<TInputImage, TOutputImage>::ComposeImageFilter()
 {
-  OutputPixelType p;
-  int             nbOfComponents = NumericTraits<OutputPixelType>::GetLength(p);
+  int nbOfComponents = NumericTraits<OutputPixelType>::GetLength({});
   nbOfComponents = std::max(1, nbOfComponents); // require at least one input
   this->SetNumberOfRequiredInputs(nbOfComponents);
   this->DynamicMultiThreadingOn();

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -95,8 +95,7 @@ CovarianceSampleFilter<TSample>::GetMeasurementVectorSize() const -> Measurement
   }
 
   // Test if the Vector type knows its length
-  MeasurementVectorType     vector;
-  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(vector);
+  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength({});
 
   if (measurementVectorSize)
   {

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -114,8 +114,7 @@ public:
     else
     {
       // If this is a non-resizable vector type
-      MeasurementVectorType     m3;
-      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength(m3);
+      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength({});
       // and the new length is different from the default one, then throw an
       // exception
       if (defaultLength != s)

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
@@ -28,11 +28,9 @@ DistanceMetric<TVector>::DistanceMetric()
 {
   // If the measurement vector type is non-resizable type,
   // initialize the vector size to it.
-  MeasurementVectorType vector;
-
   if (!MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
   {
-    MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength(vector);
+    MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength({});
 
     this->m_MeasurementVectorSize = defaultLength;
     this->m_Origin.SetSize(this->m_MeasurementVectorSize);

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -92,12 +92,11 @@ ImageToListSampleFilter<TImage, TMaskImage>::GetMeasurementVectorSize() const
     itkExceptionMacro("Input image has not been set yet");
   }
 
-  MeasurementVectorType m;
-  unsigned int          measurementVectorSize;
+  unsigned int measurementVectorSize;
 
   if (!MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
   {
-    measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(m);
+    measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength({});
   }
   else
   {

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -97,8 +97,7 @@ MeanSampleFilter<TSample>::GetMeasurementVectorSize() const -> MeasurementVector
   }
 
   // Test if the Vector type knows its length
-  MeasurementVectorType     vector;
-  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(vector);
+  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength({});
 
   if (measurementVectorSize)
   {

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -66,8 +66,7 @@ public:
     // If the default constructor creates a vector of
     // length zero, we assume that it is resizable,
     // otherwise that is a pretty useless measurement vector.
-    TVectorType             m{};
-    MeasurementVectorLength len = NumericTraits<TVectorType>::GetLength(m);
+    MeasurementVectorLength len = NumericTraits<TVectorType>::GetLength({});
 
     return (len == 0);
   }

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -110,8 +110,7 @@ public:
     else
     {
       // If this is a non-resizable vector type
-      MeasurementVectorType     m3;
-      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength(m3);
+      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength({});
       // and the new length is different from the default one, then throw an
       // exception
       if (defaultLength != s)

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -144,8 +144,7 @@ public:
     else
     {
       // If this is a non-resizable vector type
-      MeasurementVectorType     m3;
-      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength(m3);
+      MeasurementVectorSizeType defaultLength = NumericTraits<MeasurementVectorType>::GetLength({});
       // and the new length is different from the default one, then throw an
       // exception
       if (defaultLength != s)

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -100,8 +100,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::GetMeasurementVectorSize() c
   }
 
   // Test if the Vector type knows its length
-  MeasurementVectorType     vector;
-  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(vector);
+  MeasurementVectorSizeType measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength({});
 
   if (measurementVectorSize)
   {


### PR DESCRIPTION
It appears unnecessary to use a local variable as function argument of `NumericTraits::GetLength(const T &)`, when this local variable is a "dummy", that is only just default-initialized, or initialized by `T()` or `{}`.

This commit removes such local "dummy" variables, and passes `{}` to those `NumericTraits::GetLength` calls that had such a dummy as argument.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3710 commit be8cb4233b6510f436333213b7cac7c9ab7c07a7
"STYLE: Use `{}` as `MeasurementVectorTraits::IsResizable` argument"