### PR TITLE
ENH: Pin Python version in non-Python Azure pipelines

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -42,6 +42,11 @@ jobs:
           if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
         displayName: Checkout pull request HEAD
 
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.9'
+          architecture: 'x64'
+
       - script: |
           pip3 install ninja
           pip3 install --upgrade setuptools

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -24,6 +24,11 @@ jobs:
         fi
       displayName: 'Checkout pull request HEAD'
 
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.9'
+        architecture: 'x64'
+
     - bash: |
         set -x
         sudo pip3 install ninja

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -24,6 +24,11 @@ jobs:
         fi
       displayName: Checkout pull request HEAD
 
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.9'
+        architecture: 'x64'
+
     - bash: |
         set -x
         sudo python3 -m pip install ninja

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -22,10 +22,15 @@ jobs:
         if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
       displayName: Checkout pull request HEAD
 
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.9'
+        architecture: 'x64'
+
     - script: |
         pip3 install ninja
         pip3 install --upgrade setuptools
-        pip3 install scikit-ci-addons
+        pip3 install scikit-ci-addons lxml
       displayName: 'Install dependencies'
 
     - script: |


### PR DESCRIPTION
Pin Python version in non-Python Azure pipelines so that the required Python package versions used match those used in the Azure pipelines testing the Python wrapping.

Additionally, install the `lxml` Python package explicitly in the
Windows build.

Addresses:
```
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\anyci\ctest_junit_formatter.py", line 4, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```

raised in:
https://dev.azure.com/itkrobotwindow/ITK.Windows/_build/results?buildId=9122&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=3f67303d-caa6-535b-2055-750b67f1a4bf&l=17

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)