### PR TITLE
Remove backslash (+ indent) from string literals in tests

### DIFF
--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -76,11 +76,8 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " splineOrder";
-    std::cerr << " splinePoles(e.g. 0.12753,-0.48673,0.76439,\
-                 [0.12753,-0.48673,0.76439],\
-                 \"[0.12753 -0.48673 0.76439]\",\
-                 \"(0.12753 -0.48673 0.76439)\", or\
-                 \"0.12753 -0.48673 0.76439\")";
+    std::cerr << " splinePoles(e.g. 0.12753,-0.48673,0.76439, [0.12753,-0.48673,0.76439], \"[0.12753 -0.48673 "
+                 "0.76439]\", \"(0.12753 -0.48673 0.76439)\", or \"0.12753 -0.48673 0.76439\")";
     std::cerr << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -178,8 +178,7 @@ itkResampleImageTest2Streaming(int argc, char * argv[])
   writer2->SetNumberOfStreamDivisions(8);
   ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());
 
-  std::cout << "We demanded splitting into 8 pieces for streaming, \
-but faked non-linearity should disable streaming."
+  std::cout << "We demanded splitting into 8 pieces for streaming, but faked non-linearity should disable streaming."
             << std::endl;
   if (monitor->VerifyInputFilterExecutedStreaming(8))
   {

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
@@ -80,9 +80,9 @@ itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest(int argc, c
     if (itk::Math::NotAlmostEquals(otsuCalculator->GetThreshold(), otsuMultipleCalculator->GetOutput()[0]))
     {
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in itk::OtsuThresholdCalculator::GetThreshold() or \
-                 itk::OtsuMultipleThresholdsCalculator::GetOutput()"
-                << std::endl;
+      std::cerr
+        << "Error in itk::OtsuThresholdCalculator::GetThreshold() or itk::OtsuMultipleThresholdsCalculator::GetOutput()"
+        << std::endl;
       std::cout << "Computed Otsu threshold: " << otsuCalculator->GetThreshold()
                 << " is different from computed Otsu multiple threshold: " << otsuMultipleCalculator->GetOutput()[0]
                 << std::endl;

--- a/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
@@ -104,9 +104,9 @@ itkBMPImageIOTest3(int argc, char * argv[])
     if (it1.Value() != it2.Value())
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "An image stored in a lower-left bitmap is different than \
-                   the same image stored in an upper-left bitmap."
-                << std::endl;
+      std::cout
+        << "An image stored in a lower-left bitmap is different than the same image stored in an upper-left bitmap."
+        << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
@@ -106,9 +106,9 @@ itkBMPImageIOTest4(int argc, char * argv[])
     if (!(it1.Value() == it2.Value()))
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "An image stored in a lower-left bitmap is different than \
-                   the same image stored in an upper-left bitmap."
-                << std::endl;
+      std::cout
+        << "An image stored in a lower-left bitmap is different than the same image stored in an upper-left bitmap."
+        << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
@@ -141,9 +141,9 @@ itkBMPImageIOTest5(int argc, char * argv[])
     if (it1.Value() != it2.Value())
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "An image stored in a lower-left bitmap is different than \
-                   the same image stored in an upper-left bitmap."
-                << std::endl;
+      std::cout
+        << "An image stored in a lower-left bitmap is different than the same image stored in an upper-left bitmap."
+        << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
@@ -93,9 +93,7 @@ itkCovarianceSampleFilterTest(int, char *[])
   try
   {
     covarianceFilter->Update();
-    std::cerr << "Exception should have been thrown since \
-                 Update() is invoked without setting an input "
-              << std::endl;
+    std::cerr << "Exception should have been thrown since Update() is invoked without setting an input " << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -107,9 +105,7 @@ itkCovarianceSampleFilterTest(int, char *[])
 
   if (covarianceFilter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr if the input \
-                     has not been set"
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr if the input has not been set" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -138,9 +134,8 @@ itkCovarianceSampleFilterTest(int, char *[])
   if ((itk::Math::abs(mean[0] - mean2[0]) > epsilon) || (itk::Math::abs(mean[1] - mean2[1]) > epsilon) ||
       (itk::Math::abs(mean[2] - mean2[2]) > epsilon))
   {
-    std::cerr << "Mean parameter value retrieved using GetMean() and the decorator\
-                  are not the same:: "
-              << mean << "," << mean2 << std::endl;
+    std::cerr << "Mean parameter value retrieved using GetMean() and the decorator are not the same:: " << mean << ","
+              << mean2 << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -170,9 +165,9 @@ itkCovarianceSampleFilterTest(int, char *[])
       (itk::Math::abs(meanCalculatedUsingMeanSampleFilter[1] - mean[1]) > epsilon) ||
       (itk::Math::abs(meanCalculatedUsingMeanSampleFilter[2] - mean[2]) > epsilon))
   {
-    std::cerr << "Mean calculated using the MeanSampleFilter is different from\
-                 the one calculated using the covariance filter "
-              << std::endl;
+    std::cerr
+      << "Mean calculated using the MeanSampleFilter is different from the one calculated using the covariance filter "
+      << std::endl;
     std::cerr << "Mean computed with covariance filter = " << mean << std::endl;
     std::cerr << "Mean computed with mean filter = " << meanCalculatedUsingMeanSampleFilter << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
+++ b/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
@@ -68,16 +68,14 @@ itkDenseFrequencyContainer2Test(int, char *[])
 
     if (container->SetFrequency(binOutOfBound, frequency))
     {
-      std::cerr << "SetFrequency() method should have returned false boolean\
-                    since the bin index is out of bound \n"
+      std::cerr << "SetFrequency() method should have returned false boolean since the bin index is out of bound \n"
                 << std::endl;
       return EXIT_FAILURE;
     }
 
     if (container->GetFrequency(binOutOfBound) != itk::NumericTraits<AbsoluteFrequencyType>::ZeroValue())
     {
-      std::cerr << "GetFrequency() method should have returned zero frequency\
-                    since the bin index is out of bound \n"
+      std::cerr << "GetFrequency() method should have returned zero frequency since the bin index is out of bound \n"
                 << std::endl;
       return EXIT_FAILURE;
     }
@@ -125,9 +123,9 @@ itkDenseFrequencyContainer2Test(int, char *[])
 
     if (container->IncreaseFrequency(binOutOfBound, frequency))
     {
-      std::cerr << "IncreaseFrequency() method should have returned a false boolean\
-                    since the bin index is out of bound \n"
-                << std::endl;
+      std::cerr
+        << "IncreaseFrequency() method should have returned a false boolean since the bin index is out of bound \n"
+        << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
@@ -63,9 +63,9 @@ itkDistanceToCentroidMembershipFunctionTest(int, char *[])
   {
     MeasurementVectorSizeType measurementVector2 = MeasurementVectorSize + 1;
     function->SetMeasurementVectorSize(measurementVector2);
-    std::cerr << "Exception should have been thrown since we are trying to resize\
-                  non-resizeable measurement vector type "
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since we are trying to resize non-resizeable measurement vector type "
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
@@ -59,9 +59,7 @@ itkImageToListSampleAdaptorTestTemplate()
   {
     // purposely call Size() method prematurely in order to trigger an exception.
     sample->Size();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -71,9 +69,7 @@ itkImageToListSampleAdaptorTestTemplate()
   {
     // purposely call GetTotalFrequency() method prematurely in order to trigger an exception.
     sample->GetTotalFrequency();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -83,9 +79,7 @@ itkImageToListSampleAdaptorTestTemplate()
   try
   {
     typename ImageToListSampleAdaptorType::MeasurementVectorType m = sample->GetMeasurementVector(0);
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet "
-              << m << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet " << m << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -95,9 +89,7 @@ itkImageToListSampleAdaptorTestTemplate()
   try
   {
     typename ImageToListSampleAdaptorType::ImageConstPointer image = sample->GetImage();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -108,9 +100,7 @@ itkImageToListSampleAdaptorTestTemplate()
   {
     // purposely call GetFrequency() method prematurely in order to trigger an exception.
     sample->GetFrequency(0);
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -138,8 +138,7 @@ itkImageToListSampleFilterTest(int, char *[])
   try
   {
     filter->Update();
-    failureMeassage = "Exception should have been thrown since \
-                    Update() is invoked without setting an input ";
+    failureMeassage = "Exception should have been thrown since Update() is invoked without setting an input ";
     pass = false;
   }
   catch (const itk::ExceptionObject & excp)
@@ -152,15 +151,13 @@ itkImageToListSampleFilterTest(int, char *[])
   if (filter->GetInput() != nullptr)
   {
     pass = false;
-    failureMeassage = "GetInput() should return nullptr if the input \
-                     has not been set";
+    failureMeassage = "GetInput() should return nullptr if the input has not been set";
   }
 
   if (filter->GetMaskImage() != nullptr)
   {
     pass = false;
-    failureMeassage = "GetMaskImage() should return nullptr if mask image \
-                     has not been set";
+    failureMeassage = "GetMaskImage() should return nullptr if mask image has not been set";
   }
 
 
@@ -213,9 +210,7 @@ itkImageToListSampleFilterTest(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Exception should have been thrown since \
-      the mask has a different LargestPossibleRegion."
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the mask has a different LargestPossibleRegion." << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
@@ -70,9 +70,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     // calling Size() method prematurely in order to trigger an exception.
     adaptor->Size();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -82,9 +80,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     // calling GetTotalFrequency() method prematurely in order to trigger an exception.
     adaptor->GetTotalFrequency();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -95,9 +91,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     // calling GetMeasurementVector() method prematurely in order to trigger an exception.
     adaptor->GetMeasurementVector(0);
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -108,9 +102,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     // calling GetImage() method prematurely in order to trigger an exception.
     adaptor->GetImage();
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -121,9 +113,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     // calling GetFrequency() method prematurely in order to trigger an exception.
     adaptor->GetFrequency(0);
-    std::cerr << "Exception should have been thrown since the input image \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input image is not set yet" << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -225,9 +215,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   {
     if (!itk::Math::FloatAlmostEqual(v1[m], v2[m], 4, epsilon))
     {
-      std::cerr << "Accessing the measurement vector using the two method produced different \
-                  result "
-                << std::endl;
+      std::cerr << "Accessing the measurement vector using the two method produced different result " << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
@@ -64,9 +64,9 @@ itkListSampleTest(int argc, char * argv[])
   try
   {
     sample->PushBack(mvLargerSize);
-    std::cerr << "Exception was expected since the vector that was\
-                  added to the list has size different from what is set"
-              << std::endl;
+    std::cerr
+      << "Exception was expected since the vector that was added to the list has size different from what is set"
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
@@ -64,8 +64,7 @@ itkMeanSampleFilterTest(int, char *[])
   try
   {
     filter->Update();
-    failureMeassage = "Exception should have been thrown since \
-                    Update() is invoked without setting an input ";
+    failureMeassage = "Exception should have been thrown since Update() is invoked without setting an input ";
     pass = false;
   }
   catch (const itk::ExceptionObject & excp)
@@ -76,8 +75,7 @@ itkMeanSampleFilterTest(int, char *[])
   if (filter->GetInput() != nullptr)
   {
     pass = false;
-    failureMeassage = "GetInput() should return nullptr if the input \
-                     has not been set";
+    failureMeassage = "GetInput() should return nullptr if the input has not been set";
   }
 
   filter->ResetPipeline();

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
@@ -89,9 +89,9 @@ itkMembershipFunctionBaseTest(int, char *[])
   try
   {
     function->SetMeasurementVectorSize(MeasurementVectorSize + 1);
-    std::cerr << "Exception should have been thrown since we are trying to resize\
-                  non-resizeable measurement vector type "
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since we are trying to resize non-resizeable measurement vector type "
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkPointSetToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkPointSetToListSampleAdaptorTest.cxx
@@ -47,9 +47,7 @@ itkPointSetToListSampleAdaptorTest(int, char *[])
   {
     // Purposely calling the Size() method in order to trigger an exception.
     listSample->Size();
-    std::cerr << "Exception should have been thrown since the input point set  \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input point set  is not set yet" << std::endl;
     exceptionsProperlyCaught = false;
   }
   catch (const itk::ExceptionObject & excp)
@@ -60,9 +58,7 @@ itkPointSetToListSampleAdaptorTest(int, char *[])
   {
     // Purposely calling the GetTotalFrequency() method in order to trigger an exception.
     listSample->GetTotalFrequency();
-    std::cerr << "Exception should have been thrown since the input point set  \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input point set  is not set yet" << std::endl;
     exceptionsProperlyCaught = false;
   }
   catch (const itk::ExceptionObject & excp)
@@ -73,9 +69,7 @@ itkPointSetToListSampleAdaptorTest(int, char *[])
   try
   {
     PointSetToListSampleAdaptorType::MeasurementVectorType m = listSample->GetMeasurementVector(0);
-    std::cerr << "Exception should have been thrown since the input point set  \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input point set  is not set yet" << std::endl;
     std::cerr << "The invalid listSample->GetMeasurementVector is: " << m << std::endl;
     exceptionsProperlyCaught = false;
   }
@@ -88,9 +82,7 @@ itkPointSetToListSampleAdaptorTest(int, char *[])
   {
     // Purposely calling the GetPointSet() method in order to trigger an exception.
     listSample->GetPointSet();
-    std::cerr << "Exception should have been thrown since the input point set  \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input point set  is not set yet" << std::endl;
     exceptionsProperlyCaught = false;
   }
   catch (const itk::ExceptionObject & excp)
@@ -102,9 +94,7 @@ itkPointSetToListSampleAdaptorTest(int, char *[])
   {
     // Purposely calling the GetFrequency() method in order to trigger an exception.
     listSample->GetFrequency(0);
-    std::cerr << "Exception should have been thrown since the input point set  \
-                  is not set yet"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since the input point set  is not set yet" << std::endl;
     exceptionsProperlyCaught = false;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest.cxx
@@ -181,9 +181,9 @@ itkSampleTest(int, char *[])
   try
   {
     sample->SetMeasurementVectorSize(MeasurementVectorSize + 1);
-    std::cerr << "Exception should have been thrown since we are trying to resize\
-                  non-resizeable measurement vector type "
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since we are trying to resize non-resizeable measurement vector type "
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -102,9 +102,7 @@ itkScalarImageToCooccurrenceListSampleFilterTest(int, char *[])
 
   if (filter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr since the input is\
-                  not set yet "
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr since the input is not set yet " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -118,17 +118,13 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
 
     if (filter->GetInput() != nullptr)
     {
-      std::cerr << "GetInput() should return nullptr since the input is\
-                    not set yet "
-                << std::endl;
+      std::cerr << "GetInput() should return nullptr since the input is not set yet " << std::endl;
       passed = false;
     }
 
     if (filter->GetMaskImage() != nullptr)
     {
-      std::cerr << "GetMaskImage() should return nullptr since the mask image is\
-                    not set yet "
-                << std::endl;
+      std::cerr << "GetMaskImage() should return nullptr since the mask image is not set yet " << std::endl;
       passed = false;
     }
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -128,17 +128,13 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
 
     if (texFilter->GetInput() != nullptr)
     {
-      std::cerr << "GetInput() should return nullptr since the input is\
-                    not set yet "
-                << std::endl;
+      std::cerr << "GetInput() should return nullptr since the input is not set yet " << std::endl;
       passed = false;
     }
 
     if (texFilter->GetMaskImage() != nullptr)
     {
-      std::cerr << "GetMaskImage() should return nullptr since the mask image is\
-                    not set yet "
-                << std::endl;
+      std::cerr << "GetMaskImage() should return nullptr since the mask image is not set yet " << std::endl;
       passed = false;
     }
 

--- a/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
@@ -98,9 +98,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
   try
   {
     standardDeviationFilter->Update();
-    std::cerr << "Exception should have been thrown since \
-                 Update() is invoked without setting an input "
-              << std::endl;
+    std::cerr << "Exception should have been thrown since Update() is invoked without setting an input " << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -112,9 +110,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
 
   if (standardDeviationFilter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr if the input \
-                     has not been set"
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr if the input has not been set" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -155,8 +151,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
       (itk::Math::abs(standardDeviation[1] - standardDeviation2[1]) > epsilon) ||
       (itk::Math::abs(standardDeviation[2] - standardDeviation2[2]) > epsilon))
   {
-    std::cerr << "Standard Deviation value retrieved using Get() and the decorator\
-                  are not the same:: "
+    std::cerr << "Standard Deviation value retrieved using Get() and the decorator are not the same:: "
               << standardDeviation << "," << standardDeviation2 << std::endl;
     return EXIT_FAILURE;
   }
@@ -182,8 +177,8 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
       (itk::Math::abs(meanCalculatedUsingCovarianceSampleFilter[1] - mean[1]) > epsilon) ||
       (itk::Math::abs(meanCalculatedUsingCovarianceSampleFilter[2] - mean[2]) > epsilon))
   {
-    std::cerr << "Mean calculated using the CovarianceSampleFilter is different from\
-                 the one calculated using the StandardDeviationPerComponentSampleFilter "
+    std::cerr << "Mean calculated using the CovarianceSampleFilter is different from the one calculated using the "
+                 "StandardDeviationPerComponentSampleFilter "
               << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
@@ -112,9 +112,9 @@ itkSubsampleTest(int, char *[])
   try
   {
     subsample->AddInstance(idOutisdeRange);
-    std::cerr << "Exception should have been thrown since \
-      an instance outside the range of the sample container is added"
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since an instance outside the range of the sample container is added"
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -126,8 +126,7 @@ itkSubsampleTest(int, char *[])
   try
   {
     MeasurementVectorType vec = subsample->GetMeasurementVector(idOutisdeRange);
-    std::cerr << "Exception should have been thrown since \
-      the id specified is outside the range of the sample container"
+    std::cerr << "Exception should have been thrown since the id specified is outside the range of the sample container"
               << std::endl;
     std::cerr << "The invalid subsample->GetMeasurementVector() is: " << vec << std::endl;
     return EXIT_FAILURE;
@@ -141,8 +140,7 @@ itkSubsampleTest(int, char *[])
   {
     // Purposely calling GetFrequency() method prematurely in order to trigger an exception.
     subsample->GetFrequency(idOutisdeRange);
-    std::cerr << "Exception should have been thrown since \
-      the id specified is outside the range of the sample container"
+    std::cerr << "Exception should have been thrown since the id specified is outside the range of the sample container"
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -155,9 +153,8 @@ itkSubsampleTest(int, char *[])
   try
   {
     subsample->Swap(2000000, 50);
-    std::cerr << "Exception should have been thrown since \
-      the indices specified to be swapped are outside the range\
-      of the sample container"
+    std::cerr << "Exception should have been thrown since the indices specified to be swapped are outside the range of "
+                 "the sample container"
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -171,9 +168,9 @@ itkSubsampleTest(int, char *[])
   {
     unsigned int          index = listSample->Size() + 2;
     MeasurementVectorType measurementVector = subsample->GetMeasurementVectorByIndex(index);
-    std::cerr << "Exception should have been thrown since \
-      the index specified is outside the range of the sample container"
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since the index specified is outside the range of the sample container"
+      << std::endl;
     std::cerr << "The size of the invalid subsample->GetMeasurementVectorByIndex( index ) is: " << subsample
               << std::endl;
     std::cerr << "The invalid subsample->GetMeasurementVectorByIndex() is: " << measurementVector << std::endl;
@@ -190,10 +187,9 @@ itkSubsampleTest(int, char *[])
     unsigned int                         index = listSample->Size() + 2;
     SubsampleType::AbsoluteFrequencyType frequency = subsample->GetFrequencyByIndex(index);
     std::cout << "Frequency: " << frequency << std::endl;
-    std::cerr << "Exception should have been thrown since \
-      the index specified is outside the range\
-      of the sample container"
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since the index specified is outside the range of the sample container"
+      << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -207,9 +203,9 @@ itkSubsampleTest(int, char *[])
   {
     unsigned int                       index = listSample->Size() + 2;
     ListSampleType::InstanceIdentifier id = subsample->GetInstanceIdentifier(index);
-    std::cerr << "Exception should have been thrown since \
-      the index specified is outside the range of the sample container"
-              << std::endl;
+    std::cerr
+      << "Exception should have been thrown since the index specified is outside the range of the sample container"
+      << std::endl;
     std::cout << "Instance identifier: " << id << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
@@ -108,9 +108,7 @@ itkWeightedCovarianceSampleFilterTest(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Exception should have been thrown since \
-                    Update() is invoked without setting an input"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since Update() is invoked without setting an input" << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -120,9 +118,7 @@ itkWeightedCovarianceSampleFilterTest(int, char *[])
 
   if (filter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr if the input \
-                     has not been set"
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr if the input has not been set" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
@@ -109,9 +109,7 @@ itkWeightedCovarianceSampleFilterTest2(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Exception should have been thrown since \
-                    Update() is invoked without setting an input"
-              << std::endl;
+    std::cerr << "Exception should have been thrown since Update() is invoked without setting an input" << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -121,9 +119,7 @@ itkWeightedCovarianceSampleFilterTest2(int, char *[])
 
   if (filter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr if the input \
-                     has not been set"
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr if the input has not been set" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
@@ -110,9 +110,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
   try
   {
     filter->Update();
-    std::cerr << "Exception should have been thrown since \
-                    Update() is invoked without setting an input "
-              << std::endl;
+    std::cerr << "Exception should have been thrown since Update() is invoked without setting an input " << std::endl;
     return EXIT_FAILURE;
   }
   catch (const itk::ExceptionObject & excp)
@@ -122,9 +120,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
 
   if (filter->GetInput() != nullptr)
   {
-    std::cerr << "GetInput() should return nullptr if the input \
-                     has not been set"
-              << std::endl;
+    std::cerr << "GetInput() should return nullptr if the input has not been set" << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Follow-up to pull request #3713 "Remove backslash (+ indent) from string literals", but now applied to tests (`itk*Test*.cxx` files).

Removes unwanted (unintentional) spaces from test output messages, which were caused by an indentation after a backslash continuation character.