### PR TITLE
COMP: Ensure client project can find externally build ITK module

### DIFF
--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -50,6 +50,12 @@ if(NOT ITK_BINARY_DIR)
   set(ITK_BINARY_DIR ${ITK_DIR})
 endif()
 
+# Set default value for project that are not using the
+# "GNUInstallDirs" CMake module.
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 # The default path when not wrapping.  Restore standard build location
 # if python wrapping is turned on, and then turned off.
 if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)


### PR DESCRIPTION
This commit fixes a regression introduced in 5b09d5466 (`COMP: Allow install lib directory name changes`).

Client project not explicitly setting `CMAKE_INSTALL_LIBDIR` (or including the "GNUInstallDirs" CMake module) would fail to find externally build ITK module.

This commit addresses this by setting `CMAKE_INSTALL_LIBDIR` default value to "lib". This approach is consistent with how the `CMAKE_INSTALL_LIBDIR `default value is set in the top-level `CMakeLists.txt`.

Before this change, there was discrepancy between the value of "/path/to/<module>.cmake" used when configuring the file and the one used when looking up the file following a call to `find_package(ITK COMPONENTS <module>)`.

For example:

```
  Location of the configured file:
  /path/to/ITK-build//cmake/ITK-5.3/Modules/Ultrasound.cmake
```

vs

```
  Location expected by "itk_module_load()"
  /path/to/ITK-build/lib/cmake/ITK-5.3/Modules/Ultrasound.cmake
```

## Context

This issue was discovered while working on fixing the build of the following Slicer extensions like [SlicerITKUltrasound](https://github.com/KitwareMedical/SlicerITKUltrasound), [SlicerOpenCV](https://github.com/Slicer/SlicerOpenCV), [BoneTextureExtension](https://github.com/Kitware/BoneTextureExtension) and [PBNRR](https://github.com/aangelos28/PBNRR) that are all building ITK module as part of their `SuperBuild`. See issue [Slicer#6587](https://github.com/Slicer/Slicer/issues/6587)

The extensions started to fail building following https://github.com/Slicer/Slicer/commit/4d1c98ef8f9623cc4ef175b9dc734e9540bd9f02 integrated through https://github.com/Slicer/Slicer/pull/6454 on `2022.09.16` where ITK was updated from `~v5.3rc03` (be81e62) to `post-v5.3rc04` (05adf2d).

This is confirmed by querying CDash:

| ![image](https://user-images.githubusercontent.com/219043/199891585-f2e7ad1b-f925-409d-b691-4e93ccc4bfda.png) |
|--|
| [CDash query](https://slicer.cdash.org/index.php?project=SlicerPreview&begin=2022-09-14&end=2022-09-20&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=SlicerITKUltrasound&field2=site&compare2=63&value2=metroplex) for `SlicerITKUltrasound`|


| ![image](https://user-images.githubusercontent.com/219043/199891869-23be38f3-9398-4627-aae7-9bfb176331e5.png) |
|--|
| [CDash query](https://slicer.cdash.org/index.php?project=SlicerPreview&begin=2022-09-14&end=2022-09-20&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=PBNRR&field2=site&compare2=63&value2=metroplex) for `PBNRR`|


| ![image](https://user-images.githubusercontent.com/219043/199892031-3f72c6ce-451b-4bda-9e1e-94fefdaae10a.png)|
|--|
| [CDash query](https://slicer.cdash.org/index.php?project=SlicerPreview&begin=2022-09-14&end=2022-09-20&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=BoneTextureExtension&field2=site&compare2=63&value2=metroplex) for `BoneTextureExtension`|

| ![image](https://user-images.githubusercontent.com/219043/199892350-f729afdf-4517-4f20-8e03-d602c53cd390.png) |
|--|
| [CDash query](https://slicer.cdash.org/index.php?project=SlicerPreview&begin=2022-09-14&end=2022-09-20&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=SlicerOpenCV&field2=site&compare2=63&value2=metroplex) for `SlicerOpenCV`|

Notes:
* `SlicerOpenCV` failures are unrelated [^1].

[^1]: `ImportError: No module named numpy.distutils`. See https://slicer.cdash.org/viewBuildError.php?buildid=2799558

## Proposal for additional improvement

Since the location where the `<module>.cmake` files are expected to be located is specific to an ITK build tree, the corresponding value should likely be hard-coded into the `ITKConfig.cmake`. 

Doing so would ensure module build against ITK would configured their `<module>.cmake` files in a location known by ITK. Alternatively, we could also expect each `<module>` to generate their own `<module>Config.cmake` and the expect client project to be configured with the relevant `<module>_DIR` corresponding to their direct dependencies.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

## Related issues or pull requests
* https://github.com/InsightSoftwareConsortium/ITK/pull/3522
* https://github.com/Slicer/Slicer/issues/6587
* https://github.com/Slicer/Slicer/pull/6454
* https://github.com/InsightSoftwareConsortium/ITK/issues/3556 (Note that I realized the problem was already reported (:pray: @SimonRit) only after working on this issue & creating this PR.


@hjmjohnson @tbirdso @thewtex 
