### PR TITLE
DOC: Clarify Python release documentation

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -457,7 +457,11 @@ to the release branch and push to GitHub `upstream`.
 
 Then [build the
 wheels](https://itkpythonpackage.readthedocs.io/en/latest/Build_ITK_Python_packages.html)
-from the `release` branch locally.
+and the build tarballs from the `release` branch locally.
+
+  * Wheel archives are named `dist-<platform>.tar.gz` and contain loadable Python packages;
+  * Build tarballs are named `ITKPythonBuilds-<platform>.tar.zst` and contain ITK dependencies,
+      source and build trees, and scripts for building ITK remote module Python wheels.
 
 Build the sdist and wheels for Linux (amd64):
 
@@ -469,8 +473,10 @@ git checkout release
 git pull origin release
 git clean -fdx
 ./scripts/dockcross-manylinux-build-wheels.sh
+# Create wheel archive
 tar cvzf /tmp/dist-linux.tar.gz ./dist
 rm dist/*
+# Create build tarball
 cd ..
 ./ITKPythonPackage/scripts/dockcross-manylinux-build-tarball.sh
 ```
@@ -496,8 +502,10 @@ git checkout release
 git pull
 git clean -fdx
 ./scripts/macpython-build-wheels.sh
+# Create wheel archive
 tar cvzf /tmp/dist-macos.tar.gz ./dist
 rm dist/*
+# Create build tarball
 cd ..
 ./ITKPythonPackage/scripts/macpython-build-tarball.sh
 ```
@@ -516,8 +524,10 @@ cd C:\P\IPP
 set PATH=C:\P\doxygen;%PATH%
 C:\Python39-x64\python.exe ./scripts/windows_build_wheels.py
 # Back in Git Bash...
+# Create wheel archive
 tar cvzf /c/P/dist-windows.tar.gz ./dist
 rm dist/*
+# Create build tarball
 cd ..
 rm -f ./ITKPythonBuilds-windows.zip
 powershell "IPP/scripts/windows-build-tarball.ps1"


### PR DESCRIPTION
Adds language to clarify the difference between ITK wheel archives which contain loadable Python packages and ITK build archives which cache build artifacts for use in subsequent module builds.

Based on discussion in https://github.com/InsightSoftwareConsortium/ITKPythonPackage/pull/216

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] Updated API documentation (or API not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
