### PR TITLE
COMP: Do not depend on castxml target when using system version

### DIFF
--- a/Wrapping/macro_files/itk_auto_load_submodules.cmake
+++ b/Wrapping/macro_files/itk_auto_load_submodules.cmake
@@ -124,7 +124,6 @@ function(generate_castxml_commandline_flags)
     # @CASTXML_INCLUDES@, @WRAPPER_MODULE_NAME@, @CASTXML_TYPEDEFS@, @CASTXML_FORCE_INSTANTIATE@
     configure_file("${ITK_WRAP_CASTXML_SOURCE_DIR}/wrap_.cxx.in" "${cxx_file}" @ONLY)
     unset(CASTXML_INCLUDES)
-    unset(_castxml_depends)
 
     # ====== Get list of include files that may trigger needing a re-write of castxml files
     set(_include ${${WRAPPER_LIBRARY_NAME}_SOURCE_DIR}/include)
@@ -152,7 +151,7 @@ function(generate_castxml_commandline_flags)
             @${castxml_inc_file}
             ${cxx_file}
             VERBATIM
-            DEPENDS ${_castxml_depends} ${cxx_file} ${castxml_inc_file} ${_hdrs} castxml
+            DEPENDS ${_castxml_depends} ${cxx_file} ${castxml_inc_file} ${_hdrs}
     )
     unset(cxx_file)
     unset(castxml_inc_file)


### PR DESCRIPTION
_castxml_depends already adds this dependency per:

https://github.com/InsightSoftwareConsortium/ITK/blob/ca9917d1501b56cdf4ab49402cc5cacd7377a5df/Wrapping/macro_files/itk_auto_load_submodules.cmake#L12-L15
