### PR TITLE
BUG: Use NumPy `dtype`s for type mapping

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
@@ -29,29 +29,29 @@ else:
         loads = dask_deserialize.dispatch(np.ndarray)
         return NDArrayITKBase(loads(header, frames))
 
-def _get_numpy_pixelid(itk_Image_type):
+def _get_numpy_pixelid(itk_Image_type) -> np.dtype:
     """Returns a ITK PixelID given a numpy array."""
 
     # This is a Mapping from numpy array types to itk pixel types.
-    _np_itk = {"UC":np.uint8,
-               "US":np.uint16,
-               "UI":np.uint32,
-               "UL":np.uint64,
-               "ULL":np.uint64,
-               "SC":np.int8,
-               "SS":np.int16,
-               "SI":np.int32,
-               "SL":np.int64,
-               "SLL":np.int64,
-               "F":np.float32,
-               "D":np.float64,
-               "PF2":np.float32,
-               "PF3":np.float32,
+    _np_itk = {"UC":np.dtype(np.uint8),
+               "US":np.dtype(np.uint16),
+               "UI":np.dtype(np.uint32),
+               "UL":np.dtype(np.uint64),
+               "ULL":np.dtype(np.uint64),
+               "SC":np.dtype(np.int8),
+               "SS":np.dtype(np.int16),
+               "SI":np.dtype(np.int32),
+               "SL":np.dtype(np.int64),
+               "SLL":np.dtype(np.int64),
+               "F":np.dtype(np.float32),
+               "D":np.dtype(np.float64),
+               "PF2":np.dtype(np.float32),
+               "PF3":np.dtype(np.float32),
                 }
     import os
     if os.name == 'nt':
-        _np_itk['UL'] = np.uint32
-        _np_itk['SL'] = np.int32
+        _np_itk['UL'] = np.dtype(np.uint32)
+        _np_itk['SL'] = np.dtype(np.int32)
     try:
         return _np_itk[itk_Image_type]
     except KeyError as e:

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -556,8 +556,13 @@ str = str
                 import numpy as np
                 from itk.support import types
 
-                # if both a numpy dtype and a ctype exist, use the latter.
+                # Convert numpy type to dtype object for consistency
+                # i.e. <np.float32> -> np.dtype('float32')
                 if type(pixel_type) is type:
+                    pixel_type = np.dtype(pixel_type)
+
+                # if both a numpy dtype and an ITK ctype exist, use the latter.
+                if issubclass(type(pixel_type), np.dtype):
                     c_pixel_type = types.itkCType.GetCTypeForDType(pixel_type)
                     if c_pixel_type is not None:
                         pixel_type = c_pixel_type

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -312,6 +312,10 @@ assert np.allclose(parameters, np.array(baseline_additional_transform_params))
 
 # BridgeNumPy
 
+arr = np.zeros([3,4,5],dtype=np.dtype('uintc'))
+image = itk.image_from_array(arr)
+assert itk.template(image)[1] == (itk.UI, 3)
+
 # Images
 
 image = itk.imread(filename)

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -270,26 +270,23 @@ def _get_itk_pixelid(numpy_array_type):
 
     # This is a Mapping from numpy array types to itk pixel types.
     _np_itk = {
-        np.uint8: itk.UC,
-        np.uint16: itk.US,
-        np.uint32: itk.UI,
-        np.uint64: _long_type(),
-        np.int8: itk.SC,
-        np.int16: itk.SS,
-        np.int32: itk.SI,
-        np.int64: itk.SL,
-        np.float32: itk.F,
-        np.float64: itk.D,
-        np.complex64: itk.complex[itk.F],
-        np.complex128: itk.complex[itk.D],
+        np.dtype(np.uint8): itk.UC,
+        np.dtype(np.uint16): itk.US,
+        np.dtype(np.uint32): itk.UI,
+        np.dtype(np.uint64): _long_type(),
+        np.dtype(np.int8): itk.SC,
+        np.dtype(np.int16): itk.SS,
+        np.dtype(np.int32): itk.SI,
+        np.dtype(np.int64): itk.SL,
+        np.dtype(np.float32): itk.F,
+        np.dtype(np.float64): itk.D,
+        np.dtype(np.complex64): itk.complex[itk.F],
+        np.dtype(np.complex128): itk.complex[itk.D],
     }
     try:
-        return _np_itk[numpy_array_type.dtype.type]
+        return _np_itk[numpy_array_type.dtype]
     except KeyError as e:
-        for key in _np_itk:
-            if np.issubdtype(numpy_array_type.dtype.type, key):
-                return _np_itk[key]
-            raise e
+        raise e
 
 
 def _GetArrayFromImage(

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -117,28 +117,28 @@ class itkCType:
         """
         import numpy as np
 
-        _F: "itkCType" = itkCType("float", "F", np.float32)
-        _D: "itkCType" = itkCType("double", "D", np.float64)
-        _UC: "itkCType" = itkCType("unsigned char", "UC", np.uint8)
-        _US: "itkCType" = itkCType("unsigned short", "US", np.uint16)
-        _UI: "itkCType" = itkCType("unsigned int", "UI", np.uint32)
+        _F: "itkCType" = itkCType("float", "F", np.dtype(np.float32))
+        _D: "itkCType" = itkCType("double", "D", np.dtype(np.float64))
+        _UC: "itkCType" = itkCType("unsigned char", "UC", np.dtype(np.uint8))
+        _US: "itkCType" = itkCType("unsigned short", "US", np.dtype(np.uint16))
+        _UI: "itkCType" = itkCType("unsigned int", "UI", np.dtype(np.uint32))
         if os.name == "nt":
-            _UL: "itkCType" = itkCType("unsigned long", "UL", np.uint32)
-            _SL: "itkCType" = itkCType("signed long", "SL", np.int32)
+            _UL: "itkCType" = itkCType("unsigned long", "UL", np.dtype(np.uint32))
+            _SL: "itkCType" = itkCType("signed long", "SL", np.dtype(np.int32))
             _LD: "itkCType" = itkCType("long double", "LD")
         else:
-            _UL: "itkCType" = itkCType("unsigned long", "UL", np.uint64)
-            _SL: "itkCType" = itkCType("signed long", "SL", np.int64)
+            _UL: "itkCType" = itkCType("unsigned long", "UL", np.dtype(np.uint64))
+            _SL: "itkCType" = itkCType("signed long", "SL", np.dtype(np.int64))
             if hasattr(np, "float128"):
-                _LD: "itkCType" = itkCType("long double", "LD", np.float128)
+                _LD: "itkCType" = itkCType("long double", "LD", np.dtype(np.float128))
             else:
                 _LD: "itkCType" = itkCType("long double", "LD")
-        _ULL: "itkCType" = itkCType("unsigned long long", "ULL", np.uint64)
-        _SC: "itkCType" = itkCType("signed char", "SC", np.int8)
-        _SS: "itkCType" = itkCType("signed short", "SS", np.int16)
-        _SI: "itkCType" = itkCType("signed int", "SI", np.int32)
-        _SLL: "itkCType" = itkCType("signed long long", "SLL", np.int64)
-        _B: "itkCType" = itkCType("bool", "B", np.bool8)
+        _ULL: "itkCType" = itkCType("unsigned long long", "ULL", np.dtype(np.uint64))
+        _SC: "itkCType" = itkCType("signed char", "SC", np.dtype(np.int8))
+        _SS: "itkCType" = itkCType("signed short", "SS", np.dtype(np.int16))
+        _SI: "itkCType" = itkCType("signed int", "SI", np.dtype(np.int32))
+        _SLL: "itkCType" = itkCType("signed long long", "SLL", np.dtype(np.int64))
+        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool8))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _LD, _ULL, _SC, _SS, _SI, _SLL, _B
 
 


### PR DESCRIPTION
Updates Python wrappings and extras to primarily use `np.dtype` objects for mapping from NumPy to ITK types.

Follows discussion in https://github.com/SimpleITK/SimpleITK/issues/1685 and addresses
https://github.com/InsightSoftwareConsortium/ITK/issues/3544 .

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
