### PR TITLE
COMP: Fix missing initialization braces warnings

### DIFF
--- a/Modules/Core/Common/test/itkSobelOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorTest.cxx
@@ -49,7 +49,7 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateToRadius(radius);
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesHoriz{
-      { -1.0, 0.0, 1.0, -2.0, 0.0, 2.0, -1.0, 0.0, 1.0 }
+      { { -1.0, 0.0, 1.0, -2.0, 0.0, 2.0, -1.0, 0.0, 1.0 } }
     };
 
     const unsigned int size = sobelOperator.GetBufferReference().size();
@@ -67,7 +67,7 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateDirectional();
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesVert{
-      { -1.0, -2.0, -1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 1.0 }
+      { { -1.0, -2.0, -1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 1.0 } }
     };
     for (itk::SizeValueType i = 0; i < size; ++i)
     {
@@ -91,8 +91,8 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateToRadius(radius);
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesX{
-      { -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -6.0, 0.0,
-        6.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0 }
+      { { -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -6.0, 0.0,
+          6.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0 } }
     };
     const unsigned int size = sobelOperator.GetBufferReference().size();
     for (itk::SizeValueType i = 0; i < size; ++i)
@@ -108,8 +108,8 @@ itkSobelOperatorTest(int, char *[])
 
     ITK_TEST_SET_GET_VALUE(direction, sobelOperator.GetDirection());
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesY{
-      { -1.0, -3.0, -1.0, 0.0, 0.0,  0.0,  1.0,  3.0, 1.0, -3.0, -6.0, -3.0, 0.0, 0.0,
-        0.0,  3.0,  6.0,  3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0,  1.0,  3.0,  1.0 }
+      { { -1.0, -3.0, -1.0, 0.0, 0.0,  0.0,  1.0,  3.0, 1.0, -3.0, -6.0, -3.0, 0.0, 0.0,
+          0.0,  3.0,  6.0,  3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0,  1.0,  3.0,  1.0 } }
     };
     for (itk::SizeValueType i = 0; i < size; ++i)
     {
@@ -124,8 +124,8 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateDirectional();
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesZ{
-      { -1.0, -3.0, -1.0, -3.0, -6.0, -3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0,  0.0,  0.0,  0.0,  1.0,  3.0,  1.0,  3.0,  6.0,  3.0, 1.0, 3.0, 1.0 }
+      { { -1.0, -3.0, -1.0, -3.0, -6.0, -3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0,  0.0,  0.0,  0.0,  1.0,  3.0,  1.0,  3.0,  6.0,  3.0, 1.0, 3.0, 1.0 } }
     };
     for (itk::SizeValueType i = 0; i < size; ++i)
     {

--- a/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
+++ b/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
@@ -73,9 +73,9 @@ itkRandomImageSourceAttributesTest(int, char *[])
   {
     using ImageType2D = itk::Image<PixelType, Dimension2D>;
 
-    const ImageType2D::SizeType      size{ 25, 25 };
-    const ImageType2D::SpacingType   spacing{ { 0.7, 2.1 } };
-    const ImageType2D::PointType     origin{ { -1.7, 5.2 } };
+    const ImageType2D::SizeType      size{ { 25, 25 } };
+    const ImageType2D::SpacingType   spacing{ { { 0.7, 2.1 } } };
+    const ImageType2D::PointType     origin{ { { -1.7, 5.2 } } };
     const double                     d[4] = { 0, 1.0, 1.0, 0 };
     const ImageType2D::DirectionType direction = ImageType2D::DirectionType::InternalMatrixType(d);
     const ImageType2D::ValueType     min{ 0.0 };
@@ -87,9 +87,9 @@ itkRandomImageSourceAttributesTest(int, char *[])
   {
     using ImageType3D = itk::Image<PixelType, Dimension3D>;
 
-    const ImageType3D::SizeType      size{ 14, 17, 36 };
-    const ImageType3D::SpacingType   spacing{ { 0.7, 0.4, 1.2 } };
-    const ImageType3D::PointType     origin{ { -1.7, 5.2, 3.4 } };
+    const ImageType3D::SizeType      size{ { 14, 17, 36 } };
+    const ImageType3D::SpacingType   spacing{ { { 0.7, 0.4, 1.2 } } };
+    const ImageType3D::PointType     origin{ { { -1.7, 5.2, 3.4 } } };
     const double                     d[9] = { 0, 1.0, 0, 1.0, 0, 0, 0, 1.0, 0 };
     const ImageType3D::DirectionType direction = ImageType3D::DirectionType::InternalMatrixType(d);
     const ImageType3D::ValueType     min{ 0.0 };


### PR DESCRIPTION
Fix missing initialization braces warnings.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Core/Common/test/itkSobelOperatorTest.cxx:52:9:
warning: suggest braces around initialization of subobject
[-Wmissing-braces]
      { -1.0, 0.0, 1.0, -2.0, 0.0, 2.0, -1.0, 0.0, 1.0 }
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        {                                             }
```

and warnings of the same kind reported at:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=8264373

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)