### PR TITLE
STYLE: Remove obsolete `__GNUC__` macro checks for GCC version 4

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -252,7 +252,7 @@ public:
    */
 // false positive warnings with GCC
 #if defined(__GNUC__)
-#  if (__GNUC__ == 4) && (__GNUC_MINOR__ == 9) || (__GNUC__ >= 7)
+#  if (__GNUC__ >= 7)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Warray-bounds"
 #  endif
@@ -260,7 +260,7 @@ public:
   constexpr reference       operator[](unsigned int index) { return m_InternalArray[index]; }
   constexpr const_reference operator[](unsigned int index) const { return m_InternalArray[index]; }
 #if defined(__GNUC__)
-#  if (__GNUC__ == 4) && (__GNUC_MINOR__ == 9) || (__GNUC__ >= 7)
+#  if (__GNUC__ >= 7)
 #    pragma GCC diagnostic pop
 #  endif
 #endif

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -204,7 +204,7 @@ namespace itk
 #  define ITK_ABI_EXPORT __declspec(dllexport)
 #  define ITK_ABI_HIDDEN
 #else
-#  if __GNUC__ >= 4
+#  ifdef __GNUC__
 #    define ITK_ABI_IMPORT __attribute__((visibility("default")))
 #    define ITK_ABI_EXPORT __attribute__((visibility("default")))
 #    define ITK_ABI_HIDDEN __attribute__((visibility("hidden")))

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -111,15 +111,9 @@ static_assert(vnl_matrix_fixed_is_convertible_to_itk_Matrix<itk::Matrix<float>>(
               "itk::Matrix should allow implicit conversion from vnl_matrix_fixed");
 
 
-// GCC version 4 does not yet support C++11 `std::is_trivially_copyable`, as
-// GCC 4.8.5 produced an error message on an attempt to build ITK 5 from the
-// master branch (CentOS Coverage, 2021-03-30), saying:
-// > error: 'is_trivially_copyable' is not a member of 'std'
-#if (!defined(__GNUC__)) || (__GNUC__ > 4)
 static_assert(std::is_trivially_copyable<itk::Matrix<float>>() && std::is_trivially_copyable<itk::Matrix<double>>() &&
                 std::is_trivially_copyable<itk::Matrix<double, 2, 2>>(),
               "Matrix classes of built-in element types should be trivially copyable!");
-#endif
 
 
 TEST(Matrix, DefaultConstructorZeroInitializesAllElements)


### PR DESCRIPTION
GCC 4 support was dropped with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2563 commit 4e812d60743a3ed7c09647e7f3f0e8498583c2da
"COMP: Require compiler versions that support C++14", June 3, 2021
