### PR TITLE
ENH: Add check if optimizer supports scales

### DIFF
--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -194,6 +194,13 @@ public:
   const std::string
   GetStopConditionDescription() const override;
 
+  /** Returns false unconditionally because LBFGSBOptimizer does not support using scales. */
+  bool
+  CanUseScales() const override
+  {
+    return false;
+  }
+
 protected:
   LBFGSBOptimizer();
   ~LBFGSBOptimizer() override;

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
@@ -101,6 +101,15 @@ public:
   itkGetConstReferenceMacro(CachedDerivative, DerivativeType);
   itkGetConstReferenceMacro(CachedCurrentPosition, ParametersType);
 
+  /** Returns true if derived optimizer supports using scales.
+   * For optimizers that do not support scaling, this
+   * default function is overriden to return false.*/
+  virtual bool
+  CanUseScales() const
+  {
+    return true;
+  }
+
 protected:
   SingleValuedNonLinearVnlOptimizer();
   ~SingleValuedNonLinearVnlOptimizer() override;

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
@@ -170,6 +170,13 @@ public:
    * function. */
   itkGetConstReferenceMacro(InfinityNormOfProjectedGradient, double);
 
+  /** Returns false unconditionally because LBFGSBOptimizerv4 does not support using scales. */
+  bool
+  CanUseScales() const override
+  {
+    return false;
+  }
+
 protected:
   LBFGSBOptimizerv4();
   ~LBFGSBOptimizerv4() override;

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -262,6 +262,15 @@ public:
   virtual const StopConditionReturnStringType
   GetStopConditionDescription() const = 0;
 
+  /** Returns true if derived optimizer supports using scales.
+   * For optimizers that do not support scaling, this
+   * default function is overriden to return false.*/
+  virtual bool
+  CanUseScales() const
+  {
+    return true;
+  }
+
 protected:
   /** Default constructor */
   ObjectToObjectOptimizerBaseTemplate();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -737,7 +737,8 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
 
   this->m_Optimizer->SetMetric(this->m_Metric);
 
-  if ((this->m_Optimizer->GetScales()).Size() != this->m_OutputTransform->GetNumberOfLocalParameters())
+  if (this->m_Optimizer->CanUseScales() &&
+      ((this->m_Optimizer->GetScales()).Size() != this->m_OutputTransform->GetNumberOfLocalParameters()))
   {
     using ScalesType = typename OptimizerType::ScalesType;
     ScalesType scales;


### PR DESCRIPTION
Not all optimizers support scale weights.  The
itkImageRegistrationMethodv4 was unconditionally
setting the scales and causing a confusing warning message to be presented (identified in python, but also present in c++).  Providing an overridable member function that returns the support for weighting scales allow suppression of the warnings.

## PR Checklist
- [X] [API changes] Added new element to allow checking if optimizer supports scales.  Defaults to true.
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
