### PR TITLE
BUG: Use unique names for `itk::SobelOperator` test output files

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -282,7 +282,7 @@ itk_add_test(NAME itkSobelOperatorImageConvolutionHorizTest
   itkSobelOperatorImageConvolutionTest DATA{${ITK_DATA_ROOT}/Input/sf4.png} 0 ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionHorizTest.png)
 itk_add_test(NAME itkSobelOperatorImageFilterHorizTest
   COMMAND ITKCommon1TestDriver
-  --compare DATA{Baseline/itkSobelOperatorImageHorizTest.png} ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionHorizTest.png
+  --compare DATA{Baseline/itkSobelOperatorImageHorizTest.png} ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterHorizTest.png
   itkSobelOperatorImageFilterTest DATA{${ITK_DATA_ROOT}/Input/sf4.png} 0 ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterHorizTest.png)
 itk_add_test(NAME itkSobelOperatorImageConvolutionVertTest
   COMMAND ITKCommon1TestDriver


### PR DESCRIPTION
Use unique names for `itk::SobelOperator` test output files: using the same name for output files across different tests is likely to cause access conflicts (e.g. if tests run in parallel).

Fixes:
```
Test finished.
Exception detected while reading
/tmp/bld/ITK-build/Testing/Temporary/itkSobelOperatorImageConvolutionHorizTest.png :
ITK ERROR: PNGImageIO(0x55ec6cd3c660): Error while reading file:
/tmp/bld/ITK-build/Testing/Temporary/itkSobelOperatorImageConvolutionHorizTest.png
```

reported for example in:
https://open.cdash.org/test/864373640

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)