### PR TITLE
NumberToStringGTest: add #include, avoid narrowing conversion pow, mention floating point type on an expect failure 

### DIFF
--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -19,6 +19,7 @@
 // First include the header file to be tested:
 #include "itkNumberToString.h"
 #include <gtest/gtest.h>
+#include <cmath> // For std::pow.
 
 namespace
 {
@@ -81,7 +82,7 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
 
   for (int8_t exponent{ 20 }; exponent > 0; --exponent)
   {
-    const auto power_of_ten = std::pow(TValue{ 10 }, static_cast<TValue>(exponent));
+    const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
 
     // Test +/- 10 ^ exponent
     EXPECT_EQ(numberToString(power_of_ten), '1' + std::string(exponent, '0'));
@@ -90,7 +91,7 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
 
   for (int8_t exponent{ -6 }; exponent < 0; ++exponent)
   {
-    const auto power_of_ten = std::pow(TValue{ 10 }, static_cast<TValue>(exponent));
+    const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
 
     // Test +/- 10 ^ exponent
     EXPECT_EQ(numberToString(power_of_ten), "0." + std::string(-1 - exponent, '0') + '1');

--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -24,6 +24,14 @@
 namespace
 {
 
+template <typename>
+constexpr const char * floatingPointTypeName = "unspecified type";
+template <>
+constexpr const char * floatingPointTypeName<float> = "float";
+template <>
+constexpr const char * floatingPointTypeName<double> = "double";
+
+
 template <typename TValue>
 void
 Test_all_digits()
@@ -43,10 +51,11 @@ Test_non_finite_special_floating_point_values()
 {
   using NumericLimitsType = std::numeric_limits<TValue>;
   const itk::NumberToString<TValue> numberToString{};
+  const auto                        message = std::string("Floating point type: ") + floatingPointTypeName<TValue>;
 
-  EXPECT_EQ(numberToString(NumericLimitsType::quiet_NaN()), "NaN");
-  EXPECT_EQ(numberToString(NumericLimitsType::infinity()), "Infinity");
-  EXPECT_EQ(numberToString(-NumericLimitsType::infinity()), "-Infinity");
+  EXPECT_EQ(numberToString(NumericLimitsType::quiet_NaN()), "NaN") << message;
+  EXPECT_EQ(numberToString(NumericLimitsType::infinity()), "Infinity") << message;
+  EXPECT_EQ(numberToString(-NumericLimitsType::infinity()), "-Infinity") << message;
 }
 
 
@@ -56,6 +65,7 @@ Test_round_trip_of_finite_numeric_limits()
 {
   using NumericLimitsType = std::numeric_limits<TValue>;
   const itk::NumberToString<TValue> numberToString{};
+  const auto                        message = std::string("Floating point type: ") + floatingPointTypeName<TValue>;
 
   for (const TValue expectedValue : { NumericLimitsType::lowest(),
                                       NumericLimitsType::epsilon(),
@@ -65,11 +75,11 @@ Test_round_trip_of_finite_numeric_limits()
                                       NumericLimitsType::max() })
   {
     std::istringstream inputStream{ numberToString(expectedValue) };
-    EXPECT_FALSE(inputStream.eof());
+    EXPECT_FALSE(inputStream.eof()) << message;
     TValue actualValue;
     inputStream >> actualValue;
-    EXPECT_TRUE(inputStream.eof());
-    EXPECT_EQ(actualValue, expectedValue);
+    EXPECT_TRUE(inputStream.eof()) << message;
+    EXPECT_EQ(actualValue, expectedValue) << message;
   }
 }
 
@@ -79,14 +89,15 @@ void
 Test_decimal_notation_supports_up_to_twentyone_digits()
 {
   const itk::NumberToString<TValue> numberToString{};
+  const auto                        message = std::string("Floating point type: ") + floatingPointTypeName<TValue>;
 
   for (int8_t exponent{ 20 }; exponent > 0; --exponent)
   {
     const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
 
     // Test +/- 10 ^ exponent
-    EXPECT_EQ(numberToString(power_of_ten), '1' + std::string(exponent, '0'));
-    EXPECT_EQ(numberToString(-power_of_ten), "-1" + std::string(exponent, '0'));
+    EXPECT_EQ(numberToString(power_of_ten), '1' + std::string(exponent, '0')) << message;
+    EXPECT_EQ(numberToString(-power_of_ten), "-1" + std::string(exponent, '0')) << message;
   }
 
   for (int8_t exponent{ -6 }; exponent < 0; ++exponent)
@@ -94,8 +105,8 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
     const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
 
     // Test +/- 10 ^ exponent
-    EXPECT_EQ(numberToString(power_of_ten), "0." + std::string(-1 - exponent, '0') + '1');
-    EXPECT_EQ(numberToString(-power_of_ten), "-0." + std::string(-1 - exponent, '0') + '1');
+    EXPECT_EQ(numberToString(power_of_ten), "0." + std::string(-1 - exponent, '0') + '1') << message;
+    EXPECT_EQ(numberToString(-power_of_ten), "-0." + std::string(-1 - exponent, '0') + '1') << message;
   }
 }
 


### PR DESCRIPTION
A few small improvements of NumberToStringGTest, triggered by the `NumberToString.DecimalNotationUpTo21Digits` failures reported by @yurivict at issue https://github.com/InsightSoftwareConsortium/ITK/issues/3739 saying:

    /disk-samsung/freebsd-ports/science/InsightToolkit/work/ITK-5.2.1/Modules/Core/Common/test/itkNumberToStringGTest.cxx:87: Failure
    Expected equality of these values:
      numberToString(power_of_ten)
        Which is: "100000010000"
      '1' + std::string(exponent, '0')
        Which is: "100000000000"