### PR TITLE
BUG: use DICOM for reading directories only if imageio is not specified

### DIFF
--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1240,7 +1240,7 @@ def imread(
     if type(filename) not in [list, tuple]:
         import os
 
-        if os.path.isdir(filename):
+        if os.path.isdir(filename) and imageio is None:
             # read DICOM series of 1 image in a folder, refer to: https://github.com/RSIP-Vision/medio
             names_generator = itk.GDCMSeriesFileNames.New()
             names_generator.SetUseSeriesDetails(True)


### PR DESCRIPTION
Without this, a file-system-backed zarr container
is attempted to be read as a DICOM directory:

```py
image2 = itk.imread("C:/Dev/ITKIOOME-py/Testing/Temporary/cthead1py.zarr", imageio=imageio)
```
```log
WARNING: In C:\Dev\ITK-git\Modules\IO\GDCM\src\itkGDCMSeriesFileNames.cxx, line 100 GDCMSeriesFileNames (0000027927F2B7E0): No Series were found

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\extras.py", line 1194, in imread
    raise FileNotFoundError(f"no DICOMs in: {filename}.")
FileNotFoundError: no DICOMs in: C:/Dev/ITKIOOME-py/Testing/Temporary/cthead1py.zarr.
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
