### PR TITLE
Update nifti clib 2022-11-22 (b2826a4831dcc0a4021e8e627b8e9eeebbce7fcb)

### DIFF
--- a/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.c
+++ b/Modules/ThirdParty/NIFTI/src/nifti/niftilib/nifti1_io.c
@@ -7044,6 +7044,13 @@ int nifti_read_subregion_image( nifti_image * nim,
 
   /* get the file open */
   fp = nifti_image_load_prep( nim );
+  if(znz_isnull(fp))
+    {
+    if(g_opts.debug > 0)
+      fprintf(stderr,"** nifti_read_subregion_image, failed load_prep\n");
+    return -1;
+    }
+
   /* the current offset is just past the nifti header, save
    * location so that SEEK_SET can be used below
    */
@@ -7070,6 +7077,7 @@ int nifti_read_subregion_image( nifti_image * nim,
       {
       fprintf(stderr,"allocation of %d bytes failed\n",total_alloc_size);
       }
+    znzclose(fp);
     return -1;
     }
 
@@ -7117,11 +7125,12 @@ int nifti_read_subregion_image( nifti_image * nim,
               nread = (int)nifti_read_buffer(fp, readptr, read_amount, nim);
               if(nread != read_amount)
                 {
-                if(g_opts.debug > 1)
+                if(g_opts.debug > 0)
                   {
                   fprintf(stderr,"read of %d bytes failed\n",read_amount);
-                  return -1;
                   }
+                znzclose(fp);
+                return -1;
                 }
               bytes += nread;
               readptr += read_amount;
@@ -7132,6 +7141,7 @@ int nifti_read_subregion_image( nifti_image * nim,
       }
     }
   }
+  znzclose(fp);
   return bytes;
 }
 


### PR DESCRIPTION
[BUG: memory leak in nifti_read_subregion_image](https://github.com/NIFTI-Imaging/nifti_clib/commit/b2826a4831dcc0a4021e8e627b8e9eeebbce7fcb)
[BUG: in nifti_read_subregion_image g_opts.debug changed behavior](https://github.com/NIFTI-Imaging/nifti_clib/commit/1c21e747d1cbb252c951a610fffb2b824a5bafb6)

Closes #3747