### PR TITLE
COMP: Set `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE` for Windows wrapping

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -60,6 +60,9 @@ else()
     if(ITK_BINARY_DIR)
       itk_download_attempt_check(CastXML)
     endif()
+    # Set the CMP0135 policy to NEW: set the timestamps of the
+    # extracted files to their extraction timestamps. Used for
+    # CMake-based projects such as CastXML.
     cmake_policy(PUSH)
     if(POLICY CMP0135)
       cmake_policy(SET CMP0135 NEW)

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -59,6 +59,9 @@ else()
 
     include(ExternalProject)
 
+    # Set the timestamps of the extracted files to their archived
+    # timestamps. Necessary to build configure/autoconf-based
+    # projects such as SWIG and PCRE robustly.
     if(${CMAKE_VERSION} VERSION_LESS 3.24)
       set(download_extract_timestamp_flag)
     else()

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -58,6 +58,13 @@ else()
     set(SWIG_VERSION ${ITK_SWIG_VERSION})
 
     include(ExternalProject)
+
+    if(${CMAKE_VERSION} VERSION_LESS 3.24)
+      set(download_extract_timestamp_flag)
+    else()
+      set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+    endif()
+
     if(WIN32)
       # If we are building ITK
       if(ITK_BINARY_DIR)
@@ -70,6 +77,7 @@ else()
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
+        ${download_extract_timestamp_flag}
         )
       set(SWIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_VERSION})
     else()
@@ -137,11 +145,6 @@ else()
             make
               install
         )
-      endif()
-      if(${CMAKE_VERSION} VERSION_LESS 3.24)
-        set(download_extract_timestamp_flag)
-      else()
-        set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
       endif()
       set(pcre_hash "abac4c4f9df9e61d7d7761a9c50843882611752e1df0842a54318f358c28f5953025eba2d78997d21ee690756b56cc9f1c04a5ed591dd60654cc78ba16d9ecfb")
       ExternalProject_Add(PCRE
@@ -246,11 +249,6 @@ message(STATUS \"Swig configure successfully completed.\")
         )
       endif()
 
-      if(${CMAKE_VERSION} VERSION_LESS 3.24)
-        set(download_extract_timestamp_flag)
-      else()
-        set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
-      endif()
       ExternalProject_Add(swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
         URL_HASH SHA512=${swig_hash}


### PR DESCRIPTION
- COMP: Set `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE` for Windows wrapping
- DOC: Document the wrapping modules' extraction/archived timestamp flags

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)