### PR TITLE
Fix new warning STL4037 raised by VS2022

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -463,6 +463,9 @@ scalar value) is discouraged. With ITK 5.3, when having `ITK_LEGACY_REMOVE=ON`, 
 declared `explicit`. ITK 5.3 has included a preferable alternative to these constructors:
 `itk::MakeFilled<ContainerType>(value)`.
 
+`itk::NumericTraits` can no longer be instantiated with `std::complex<T>`, if T is not a floating point type.
+The old behavior can be restored by turning off `ITK_LEGACY_REMOVE`.
+
 Consolidated Vector Filter
 --------------------------
 

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -31,6 +31,7 @@
 
 #include <limits> // for std::numeric_limits
 #include <complex>
+#include <type_traits> // for std::is_floating_point
 
 namespace itk
 {
@@ -1979,6 +1980,12 @@ public:
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
+
+#if defined(ITK_LEGACY_REMOVE)
+  static_assert(std::is_floating_point<TComponent>::value,
+                "As per https://en.cppreference.com/w/cpp/numeric/complex the behavior is unspecified and may fail to "
+                "compile if TComponent is not float, double, or long double and undefined if T is not NumericType.");
+#endif // defined(ITK_LEGACY_REMOVE)
 };
 /// \endcond
 } // end namespace itk

--- a/Modules/Core/Common/src/itkNumericTraits.cxx
+++ b/Modules/Core/Common/src/itkNumericTraits.cxx
@@ -71,6 +71,7 @@ constexpr double NumericTraits<double>::One;
 constexpr long double NumericTraits<long double>::Zero;
 constexpr long double NumericTraits<long double>::One;
 
+#if !defined(ITK_LEGACY_REMOVE)
 template <>
 const std::complex<char> NumericTraits<std::complex<char>>::Zero = std::complex<char>(0, 0);
 template <>
@@ -114,6 +115,7 @@ const std::complex<unsigned long> NumericTraits<std::complex<unsigned long>>::Ze
 template <>
 const std::complex<unsigned long> NumericTraits<std::complex<unsigned long>>::One = std::complex<unsigned long>(1UL,
                                                                                                                 0UL);
+#endif // !defined(ITK_LEGACY_REMOVE)
 
 template <>
 const std::complex<float> NumericTraits<std::complex<float>>::Zero = std::complex<float>(0.0f, 0.0f);

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -655,8 +655,6 @@ main(int, char *[])
     // Test AlmostEquals complex comparisons
     const std::complex<double> z1Double(1.1, 2.1);
     const std::complex<float>  z1Float(1.1f, 2.1f);
-    const std::complex<double> z2Double(1.0, 3.0);
-    const std::complex<int>    z2Int(1, 3);
 
     // Test AlmostEquals with complex numbers of the same value and different types
     std::cout << "Testing COMPLEX vs COMPLEX, DOUBLE vs FLOAT, SAME values " << std::endl;
@@ -671,6 +669,10 @@ main(int, char *[])
       std::cout << "Test passed\n" << std::endl;
     }
 
+#if !defined(ITK_LEGACY_REMOVE)
+    const std::complex<double> z2Double(1.0, 3.0);
+    const std::complex<int>    z2Int(1, 3);
+
     std::cout << "Testing COMPLEX vs COMPLEX, DOUBLE vs INT, SAME values " << std::endl;
     if (itk::Math::AlmostEquals(z2Double, z2Int) == false)
     {
@@ -682,6 +684,7 @@ main(int, char *[])
     {
       std::cout << "Test passed\n" << std::endl;
     }
+#endif // !defined(ITK_LEGACY_REMOVE)
 
     // Test Comparisons with complex values that are very close
     FloatRepresentationD z1AlmostRealPart;

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -316,6 +316,7 @@ CheckAllSignedAndIntegerTraits()
   std::cout << "\tThis first one should fail" << std::endl << std::endl;
   didAllTestsPass &= !CheckSignedAndIntegerTraitsForComplexTypes<std::complex<ForcedFailureTestCase>>(
     "std::complex< ForcedFailureTestCase >");
+#if !defined(ITK_LEGACY_REMOVE)
   didAllTestsPass &= CheckSignedAndIntegerTraitsForComplexTypes<std::complex<UnknownTypeTestCase>>(
     "std::complex< UnknownTypeTestCase >");
   didAllTestsPass &= CheckSignedAndIntegerTraitsForComplexTypes<std::complex<char>>(" std::complex< char > ");
@@ -331,6 +332,7 @@ CheckAllSignedAndIntegerTraits()
   didAllTestsPass &=
     CheckSignedAndIntegerTraitsForComplexTypes<std::complex<unsigned long>>(" std::complex< unsigned long > ");
   didAllTestsPass &= CheckSignedAndIntegerTraitsForComplexTypes<std::complex<float>>(" std::complex< float > ");
+#endif // !defined(ITK_LEGACY_REMOVE)
   didAllTestsPass &= CheckSignedAndIntegerTraitsForComplexTypes<std::complex<double>>(" std::complex< double > ");
   didAllTestsPass &=
     CheckSignedAndIntegerTraitsForComplexTypes<std::complex<long double>>(" std::complex< long double > ");
@@ -364,12 +366,17 @@ CheckIsComplexTraits()
                 "std::complex<float> does not have the correct IsComplex trait");
   static_assert(itk::NumericTraits<std::complex<double>>::IsComplex,
                 "std::complex<double> does not have the correct IsComplex trait");
+  static_assert(itk::NumericTraits<std::complex<long double>>::IsComplex,
+                "std::complex<long double> does not have the correct IsComplex trait");
+
+#if !defined(ITK_LEGACY_REMOVE)
   static_assert(itk::NumericTraits<std::complex<char>>::IsComplex,
                 "std::complex<char> does not have the correct IsComplex trait");
   static_assert(itk::NumericTraits<std::complex<int>>::IsComplex,
                 "std::complex<int> does not have the correct IsComplex trait");
   static_assert(itk::NumericTraits<std::complex<unsigned long>>::IsComplex,
                 "std::complex<unsigned long> does not have the correct IsComplex trait");
+#endif // !defined(ITK_LEGACY_REMOVE)
 } // End CheckIsComplexTraits()
 
 } // end anonymous namespace
@@ -1265,6 +1272,7 @@ itkNumericTraitsTest(int, char *[])
 
 
   // std::complex
+#  if !defined(ITK_LEGACY_REMOVE)
   CheckFixedArrayTraits(std::complex<char>());
   CheckFixedArrayTraits(std::complex<unsigned char>());
   CheckFixedArrayTraits(std::complex<short>());
@@ -1273,6 +1281,7 @@ itkNumericTraitsTest(int, char *[])
   CheckFixedArrayTraits(std::complex<unsigned int>());
   CheckFixedArrayTraits(std::complex<long>());
   CheckFixedArrayTraits(std::complex<unsigned long>());
+#  endif // !defined(ITK_LEGACY_REMOVE)
   CheckFixedArrayTraits(std::complex<float>());
   CheckFixedArrayTraits(std::complex<double>());
   CheckFixedArrayTraits(std::complex<long double>());

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -263,7 +263,7 @@ itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest(int, char *[])
   constexpr unsigned int Dimension = 3;
 
   using CharPixelType = char;
-  using FloatPixelType = char;
+  using FloatPixelType = float;
 
   // Even input image size test
   {


### PR DESCRIPTION
Example error message:

`M:\Dashboard\ITK\Modules\Core\Common\src\itkNumericTraits.cxx(77,85): warning C4996: 'std::complex<char>::complex': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning. [M:\Dashboard\ITK-build\Modules\Core\Common\src\ITKCommon.vcxproj]`

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)

