### PR TITLE
ENH: Apply the `type:Infrastructure` label to CI config files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -104,4 +104,5 @@ type:Infrastructure:
   files:
     - ".github/*"
     - "CMake/*"
+    - "Testing/ContinuousIntegration/*"
     - "Utilities/*"


### PR DESCRIPTION
Apply the `type:Infrastructure` labeler class when changing the CI config files located in `Testing/ContinuousIntegration`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)