### PR TITLE
BUG: ITK_COMPILER_SUPPORTS_SSE2_64 incorrectly set for 32-bit x86

### DIFF
--- a/Modules/Core/Common/src/itkConfigure.h.in
+++ b/Modules/Core/Common/src/itkConfigure.h.in
@@ -182,13 +182,13 @@
 // For 32 bit Intel with MSVC, check _M_IX86_FP.
 // 64 bit Intel x86 always supports both 32 and 64 bit SSE2.
 
-#if defined(__SSE2__) || defined(__x86_64__) || defined(_M_X64) || defined(__amd64)
-#  define ITK_COMPILER_SUPPORTS_SSE2_64
-#endif
-
-#if defined(ITK_COMPILER_SUPPORTS_SSE2_64) || \
-    (defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
+#if defined(__x86_64__) || defined(__amd64__) || (defined(_M_AMD64) && !defined(_M_ARM64EC))
 #  define ITK_COMPILER_SUPPORTS_SSE2_32
+#  define ITK_COMPILER_SUPPORTS_SSE2_64
+#else
+#  if defined(__SSE2__) || (defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
+#    define ITK_COMPILER_SUPPORTS_SSE2_32
+#  endif
 #endif
 
 #endif //itkConfigure_h


### PR DESCRIPTION
If the argument `-msse2` is used for 32-bits x86 build, then __SSE2__ is defined. This causes ITK_COMPILER_SUPPORTS_SSE2_64 to be set for 32-bits x86.
```
/usr/local/include/ITK-5.3/itkMathDetail.h:317:10: error: use of undeclared identifier '_mm_cvtsd_si64'
  return _mm_cvtsd_si64(_mm_set_sd(x));
         ^
/usr/local/include/ITK-5.3/itkMathDetail.h:326:10: error: use of undeclared identifier '_mm_cvtss_si64'; did you mean '_mm_cvtss_si32'?
  return _mm_cvtss_si64(_mm_set_ss(x));
         ^
/usr/lib/clang/14.0.5/include/xmmintrin.h:1306:1: note: '_mm_cvtss_si32' declared here _mm_cvtss_si32(__m128 __a)
^
2 errors generated.
```

Minimal example:

_CMakeLists.txt:_

```
cmake_minimum_required(VERSION 3.11)
project(TEST)
set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} " -msse2")
set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -msse2")
find_package(ITK REQUIRED)
include(${ITK_USE_FILE})
add_executable(test test.cpp)
target_link_libraries(test ${ITK_LIBRARIES})
```

_test.cpp:_

```cpp
#include "itkImage.h"
int main(int, char**)
{
	return 0;
}
```

S. [itkConfigure.in.h](https://github.com/InsightSoftwareConsortium/ITK/blob/935533fbcbb451f32038c4643843a0bc606123ca/Modules/Core/Common/src/itkConfigure.h.in#L185):

```
#if defined(__SSE2__) || defined(__x86_64__) || defined(_M_X64) || defined(__amd64)
#  define ITK_COMPILER_SUPPORTS_SSE2_64
#endif
```

Closes #3771