### PR TITLE
Remove `diff` variables from ConvertPixelBuffer, replace `(size_t)` casts

### DIFF
--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -274,7 +274,6 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     // http://www.poynton.com/notes/colour_and_gamma/ColorFAQ.html
     // NOTE: The scale factors are converted to whole numbers for
     // precision
-    ptrdiff_t        diff = inputNumberOfComponents - 4;
     InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
     while (inputData != endInput)
     {
@@ -282,10 +281,9 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
                          0721.0 * static_cast<double>(*(inputData + 2))) /
                         10000.0) *
                        static_cast<double>(*(inputData + 3)) / maxAlpha;
-      inputData += 4;
       auto val = static_cast<OutputComponentType>(tempval);
       OutputConvertTraits::SetNthComponent(0, *outputData++, val);
-      inputData += diff;
+      inputData += inputNumberOfComponents;
     }
   }
 }
@@ -371,15 +369,13 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   // just skip the rest of the data
   else
   {
-    ptrdiff_t        diff = inputNumberOfComponents - 3;
     InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
     while (inputData != endInput)
     {
       OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
       OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
       OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
-      inputData += 3;
-      inputData += diff;
+      inputData += inputNumberOfComponents;
       ++outputData;
     }
   }
@@ -475,7 +471,6 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   }
   else
   {
-    ptrdiff_t        diff = inputNumberOfComponents - 4;
     InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
     while (inputData != endInput)
     {
@@ -483,8 +478,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
       OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
       OutputConvertTraits::SetNthComponent(2, *outputData, static_cast<OutputComponentType>(*(inputData + 2)));
       OutputConvertTraits::SetNthComponent(3, *outputData, static_cast<OutputComponentType>(*(inputData + 3)));
-      inputData += 4;
-      inputData += diff;
+      inputData += inputNumberOfComponents;
       ++outputData;
     }
   }
@@ -603,15 +597,13 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   OutputPixelType * outputData,
   size_t            size)
 {
-  ptrdiff_t        diff = inputNumberOfComponents - 2;
   InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
 
   while (inputData != endInput)
   {
     OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
     OutputConvertTraits::SetNthComponent(1, *outputData, static_cast<OutputComponentType>(*(inputData + 1)));
-    inputData += 2;
-    inputData += diff;
+    inputData += inputNumberOfComponents;
     ++outputData;
   }
 }

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -274,7 +274,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
     // http://www.poynton.com/notes/colour_and_gamma/ColorFAQ.html
     // NOTE: The scale factors are converted to whole numbers for
     // precision
-    InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
+    InputPixelType * endInput = inputData + size * static_cast<size_t>(inputNumberOfComponents);
     while (inputData != endInput)
     {
       double tempval = ((2125.0 * static_cast<double>(*inputData) + 7154.0 * static_cast<double>(*(inputData + 1)) +
@@ -369,7 +369,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   // just skip the rest of the data
   else
   {
-    InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
+    InputPixelType * endInput = inputData + size * static_cast<size_t>(inputNumberOfComponents);
     while (inputData != endInput)
     {
       OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
@@ -471,7 +471,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   }
   else
   {
-    InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
+    InputPixelType * endInput = inputData + size * static_cast<size_t>(inputNumberOfComponents);
     while (inputData != endInput)
     {
       OutputConvertTraits::SetNthComponent(0, *outputData, static_cast<OutputComponentType>(*inputData));
@@ -597,7 +597,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   OutputPixelType * outputData,
   size_t            size)
 {
-  InputPixelType * endInput = inputData + size * (size_t)inputNumberOfComponents;
+  InputPixelType * endInput = inputData + size * static_cast<size_t>(inputNumberOfComponents);
 
   while (inputData != endInput)
   {
@@ -616,7 +616,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   OutputPixelType * outputData,
   size_t            size)
 {
-  size_t length = size * (size_t)inputNumberOfComponents;
+  size_t length = size * static_cast<size_t>(inputNumberOfComponents);
 
   for (size_t i = 0; i < length; ++i)
   {


### PR DESCRIPTION
Removed the four local `diff` variables from ConvertPixelBuffer. These variables appeared unnecessary, after commit f8e3d3b3979529373d6cf1559073c4027c186d34 ("ERR: ++ replaced with +1, +2, etc. to avoid possible compiler problems.", Bill Lorensen (@lorensen), 2002-09-03). Removing them fixed a few Visual Studio 2019 16.11.21 Code Analysis warnings, saying:

> warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2)

Replaced the five `(size_t)inputNumberOfComponents` casts inside ConvertPixelBuffer with `static_cast<size_t>(inputNumberOfComponents)`.