### PR TITLE
COMP: zlib crc32_braid.c cast to smaller integer type

### DIFF
--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/crc32_braid.c
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/crc32_braid.c
@@ -125,7 +125,7 @@ Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len) 
         int k;
 
         /* Compute the CRC up to a z_word_t boundary. */
-        while (len && ((z_size_t)buf & (W - 1)) != 0) {
+        while (len && ((uintptr_t)buf & (W - 1)) != 0) {
             len--;
             DO1;
         }


### PR DESCRIPTION
Port of: https://github.com/zlib-ng/zlib-ng/pull/1371

To address:

```
 D:\a\bld\ITK\Modules\ThirdParty\ZLIB\src\itkzlib-ng\crc32_braid.c(128): warning C4311: 'type cast': pointer truncation from 'const uint8_t *' to 'unsigned long'
```

in https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/pull/402