### PR TITLE
Declare `m_PointIds` of Cell types `std::array`

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -20,6 +20,9 @@
 
 #include "itkQuadrilateralCell.h"
 #include "itkHexahedronCellTopology.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -155,7 +158,8 @@ public:
 
 protected:
   /** Store the number of points needed for a hexahedron. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 
   void
   InterpolationDerivs(CoordRepType pcoords[Self::CellDimension],
@@ -170,13 +174,7 @@ protected:
                    InterpolationWeightType * weights);
 
 public:
-  HexahedronCell()
-  {
-    for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  HexahedronCell() = default;
 
   ~HexahedronCell() override = default;
 };

--- a/Modules/Core/Common/include/itkLineCell.h
+++ b/Modules/Core/Common/include/itkLineCell.h
@@ -19,6 +19,9 @@
 #define itkLineCell_h
 
 #include "itkVertexCell.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -110,19 +113,14 @@ public:
   /** Visitor interface */
   itkCellVisitMacro(CellGeometryEnum::LINE_CELL);
 
-  LineCell()
-  {
-    for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  LineCell() = default;
 
   ~LineCell() override = default;
 
 protected:
   /** Store number of points needed for a line segment. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.h
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.h
@@ -19,6 +19,9 @@
 #define itkQuadraticEdgeCell_h
 
 #include "itkVertexCell.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -105,13 +108,7 @@ public:
   /** Visitor interface */
   itkCellVisitMacro(CellGeometryEnum::QUADRATIC_EDGE_CELL);
 
-  QuadraticEdgeCell()
-  {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  QuadraticEdgeCell() = default;
 
   ~QuadraticEdgeCell() override = default;
 
@@ -123,7 +120,8 @@ public:
 
 protected:
   /** Store number of points needed for a line segment. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.h
@@ -20,6 +20,9 @@
 
 #include "itkQuadraticEdgeCell.h"
 #include "itkQuadraticTriangleCellTopology.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -126,19 +129,14 @@ public:
                          ShapeFunctionsArrayType &        weights) const override;
 
 public:
-  QuadraticTriangleCell()
-  {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  QuadraticTriangleCell() = default;
 
   ~QuadraticTriangleCell() override = default;
 
 protected:
   /** Store the number of points needed for a triangle. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -20,6 +20,9 @@
 
 #include "itkLineCell.h"
 #include "itkQuadrilateralCellTopology.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -130,13 +133,7 @@ public:
   itkCellVisitMacro(CellGeometryEnum::QUADRILATERAL_CELL);
 
   /** Constructor and destructor */
-  QuadrilateralCell()
-  {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  QuadrilateralCell() = default;
 
 #if defined(__GNUC__)
   // A bug in some versions of the GCC and Clang compilers
@@ -151,7 +148,8 @@ public:
 
 protected:
   /** Store the number of points needed for a quadrilateral. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 
   void
   InterpolationDerivs(const CoordRepType pointCoords[CellDimension], CoordRepType derivs[NumberOfDerivatives]);

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -20,6 +20,9 @@
 
 #include "itkTriangleCell.h"
 #include "itkTetrahedronCellTopology.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -136,19 +139,14 @@ public:
                    InterpolationWeightType *) override;
 
 public:
-  TetrahedronCell()
-  {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  TetrahedronCell() = default;
 
   ~TetrahedronCell() override = default;
 
 protected:
   /** Store the number of points needed for a tetrahedron. */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -20,8 +20,9 @@
 
 #include "itkLineCell.h"
 #include "itkTriangleCellTopology.h"
+#include "itkMakeFilled.h"
 
-#include <vector>
+#include <array>
 
 namespace itk
 {
@@ -147,9 +148,7 @@ public:
   ComputeCircumCenter(PointsContainer *);
 
 public:
-  TriangleCell()
-    : m_PointIds(NumberOfPoints, NumericTraits<PointIdentifier>::max())
-  {}
+  TriangleCell() = default;
 #if defined(__GNUC__)
   // A bug in some versions of the GCC and Clang compilers
   // result in an ICE or linker error when "= default" is requested.
@@ -163,7 +162,8 @@ public:
 
 protected:
   /** Store the number of points needed for a triangle. */
-  std::vector<PointIdentifier> m_PointIds;
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 
 private:
   /** Computes the SQUARED distance between a point and a line segment defined

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -20,6 +20,9 @@
 
 #include "itkCellInterface.h"
 #include "itkNumericTraits.h"
+#include "itkMakeFilled.h"
+
+#include <array>
 
 namespace itk
 {
@@ -110,13 +113,7 @@ public:
                    InterpolationWeightType *) override;
 
 public:
-  VertexCell()
-  {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
-    {
-      m_PointIds[i] = NumericTraits<PointIdentifier>::max();
-    }
-  }
+  VertexCell() = default;
 
   ~VertexCell() override = default;
 
@@ -124,7 +121,8 @@ protected:
   /**
    * Store the number of points needed for a vertex.
    */
-  PointIdentifier m_PointIds[NumberOfPoints];
+  std::array<PointIdentifier, NumberOfPoints> m_PointIds{ MakeFilled<std::array<PointIdentifier, NumberOfPoints>>(
+    NumericTraits<PointIdentifier>::max()) };
 };
 } // end namespace itk
 


### PR DESCRIPTION
@arnaudgelas Do you still remember why you changed TriangleCell::m_PointIds from fixed-size array of 3 elements to resizable std::vector, with commit 8bbb15afa41e14b1cffe2a881a00d41d8e66999c ?