### PR TITLE
STYLE: Initialize `faceList` directly by ImageBoundaryFacesCalculator

### DIFF
--- a/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
@@ -40,7 +40,6 @@ ScalarAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   PixelRealType                             val;
   SizeValueType                             counter;
   BFC_type                                  bfc;
-  typename BFC_type::FaceListType           faceList;
   typename RNI_type::RadiusType             radius;
   typename BFC_type::FaceListType::iterator fit;
 
@@ -61,7 +60,7 @@ ScalarAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   }
 
   // Get the various region "faces" that are on the data set boundary.
-  faceList = bfc(ip, ip->GetRequestedRegion(), radius);
+  typename BFC_type::FaceListType faceList = bfc(ip, ip->GetRequestedRegion(), radius);
   fit = faceList.begin();
 
   // Now do the actual processing

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -39,7 +39,6 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   PixelType                                 val;
   SizeValueType                             counter;
   BFC_type                                  bfc;
-  typename BFC_type::FaceListType           faceList;
   typename RNI_type::RadiusType             radius;
   typename BFC_type::FaceListType::iterator fit;
 
@@ -60,7 +59,7 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   }
 
   // Get the various region "faces" that are on the data set boundary.
-  faceList = bfc(ip, ip->GetRequestedRegion(), radius);
+  typename BFC_type::FaceListType faceList = bfc(ip, ip->GetRequestedRegion(), radius);
   fit = faceList.begin();
 
   // Now do the actual processing

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -126,9 +126,9 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
   }
 
   // Find the boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        fC;
-  faceList = fC(this->GetInput(), outputRegionForThread, m_Kernel.GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    fC(this->GetInput(), outputRegionForThread, m_Kernel.GetRadius());
 
 
   // Setup the kernel that spans the immediate neighbors of the current

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -142,9 +142,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
 
   using FaceListType = typename BFC::FaceListType;
   BFC          faceCalculator;
-  FaceListType faceList;
-
-  faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
+  FaceListType faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -177,11 +177,11 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   ImageRegionIterator<TOutputImage>                     it;
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>                        bC;
-  faceList = bC(dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()),
-                outputRegionForThread,
-                m_NeighborhoodRadius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType faceList =
+    bC(dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()),
+       outputRegionForThread,
+       m_NeighborhoodRadius);
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -243,9 +243,9 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   ZeroFluxNeumannBoundaryCondition<TInputImage> BC;
 
   // Find the boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        fC;
-  faceList = fC(this->GetInput(), outputRegionForThread, m_GaussianKernel.GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    fC(this->GetInput(), outputRegionForThread, m_GaussianKernel.GetRadius());
 
   OutputPixelRealType centerPixel;
   OutputPixelRealType val, tableArg, normFactor, rangeGaussian, rangeDistance, pixel, gaussianProduct;

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -111,9 +111,9 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   radius.Fill(1);
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
-  faceList = bC(input, outputRegionForThread, radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList =
+    bC(input, outputRegionForThread, radius);
 
   // Process the non-boundady region and then each of the boundary faces.
   // These are N-d regions which border the edge of the buffer.
@@ -404,9 +404,9 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   radius.Fill(1);
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
-  faceList = bC(input, outputRegionForThread, radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList =
+    bC(input, outputRegionForThread, radius);
 
   InputImagePixelType zero = NumericTraits<InputImagePixelType>::ZeroValue();
 

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -55,9 +55,9 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  faceList = bC(input, outputRegionForThread, this->GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    bC(input, outputRegionForThread, this->GetRadius());
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -107,9 +107,9 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   radius.Fill(1);
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
-  faceList = bC(input, outputRegionForThread, radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList =
+    bC(input, outputRegionForThread, radius);
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -114,9 +114,7 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
 
   using FaceListType = typename BFC::FaceListType;
   BFC          faceCalculator;
-  FaceListType faceList;
-
-  faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
+  FaceListType faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -84,7 +84,6 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
 
   NeighborhoodInnerProduct<InputImageType, OperatorValueType, ComputingPixelType> smartInnerProduct;
   BFC                                                                             faceCalculator;
-  FaceListType                                                                    faceList;
 
   OutputImageType *      output = this->GetOutput();
   const InputImageType * input = this->GetInput();
@@ -94,7 +93,7 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
   // we pass in the input image and the OUTPUT requested region. We are
   // only concerned with centering the neighborhood operator at the
   // pixels that correspond to output pixels.
-  faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
+  FaceListType faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
 
   ImageRegionIterator<OutputImageType> it;
 

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -51,9 +51,9 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  faceList = bC(input, outputRegionForThread, this->GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    bC(input, outputRegionForThread, this->GetRadius());
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -83,7 +83,6 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::DynamicThreade
 
   VectorNeighborhoodInnerProduct<InputImageType> smartInnerProduct;
   BFC                                            faceCalculator;
-  FaceListType                                   faceList;
 
   // Allocate output
   OutputImageType *      output = this->GetOutput();
@@ -94,7 +93,7 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::DynamicThreade
   // we pass in the input image and the OUTPUT requested region. We are
   // only concerned with centering the neighborhood operator at the
   // pixels that correspond to output pixels.
-  faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
+  FaceListType faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -136,9 +136,9 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   const auto radius = Size<ImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
-  faceList = bC(input, outputRegionForThread, radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList =
+    bC(input, outputRegionForThread, radius);
 
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -195,11 +195,11 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
   ImageRegionIterator<TOutputImage>                     it;
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType faceList;
-  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>                        bC;
-  RadiusType                                                                                      r1;
+  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType> bC;
+  RadiusType                                                               r1;
   r1.Fill(1);
-  faceList = bC(m_RealValuedInputImage.GetPointer(), outputRegionForThread, r1);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType faceList =
+    bC(m_RealValuedInputImage.GetPointer(), outputRegionForThread, r1);
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -287,11 +287,11 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
 
   // Find the boundary "faces". Structuring element is elementary
   // (face connected neighbors within a radius of 1).
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList;
-  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>                        fC;
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::RadiusType   kernelRadius;
+  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>                      fC;
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::RadiusType kernelRadius;
   kernelRadius.Fill(1);
-  faceList = fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList =
+    fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
 
   typename NeighborhoodIteratorType::OffsetValueType i;
   typename NeighborhoodIteratorType::OffsetType      offset;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -283,11 +283,11 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
 
   // Find the boundary "faces". Structuring element is elementary
   // (face connected neighbors within a radius of 1).
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList;
-  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>                        fC;
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::RadiusType   kernelRadius;
+  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>                      fC;
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::RadiusType kernelRadius;
   kernelRadius.Fill(1);
-  faceList = fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList =
+    fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
 
   typename NeighborhoodIteratorType::OffsetValueType i;
   typename NeighborhoodIteratorType::OffsetType      offset;

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
@@ -44,9 +44,9 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreadedGenera
   NeighborhoodIteratorType b_iter;
 
   // Find the boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        fC;
-  faceList = fC(this->GetInput(), outputRegionForThread, this->GetKernel().GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    fC(this->GetInput(), outputRegionForThread, this->GetKernel().GetRadius());
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -147,10 +147,9 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
   {
     FaceCalculatorType faceCalculator;
 
-    FaceListType   faceList;
     FaceListTypeIt fit;
 
-    faceList = faceCalculator(maskImageP, maskImageP->GetLargestPossibleRegion(), kernelRadius);
+    FaceListType faceList = faceCalculator(maskImageP, maskImageP->GetLargestPossibleRegion(), kernelRadius);
     // we will only be processing the body region
     fit = faceList.begin();
     // must be a better way of doing this

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -228,7 +228,6 @@ BoxMeanCalculatorFunction(const TInputImage *               accImage,
   using FaceListType = typename FaceCalculatorType::FaceListType;
   FaceCalculatorType faceCalculator;
 
-  FaceListType                                  faceList;
   ZeroFluxNeumannBoundaryCondition<TInputImage> nbc;
 
   // this process is actually slightly asymmetric because we need to
@@ -271,7 +270,7 @@ BoxMeanCalculatorFunction(const TInputImage *               accImage,
     realCorners.push_back(thisCorner);
   }
 
-  faceList = faceCalculator(accImage, outputRegion, internalRadius);
+  FaceListType faceList = faceCalculator(accImage, outputRegion, internalRadius);
   // start with the body region
   for (const auto & face : faceList)
   {
@@ -418,7 +417,6 @@ BoxSigmaCalculatorFunction(const TInputImage *               accImage,
   using FaceListType = typename FaceCalculatorType::FaceListType;
   FaceCalculatorType faceCalculator;
 
-  FaceListType                                  faceList;
   ZeroFluxNeumannBoundaryCondition<TInputImage> nbc;
 
   // this process is actually slightly asymmetric because we need to
@@ -460,7 +458,7 @@ BoxSigmaCalculatorFunction(const TInputImage *               accImage,
     realCorners.push_back(thisCorner);
   }
 
-  faceList = faceCalculator(accImage, outputRegion, internalRadius);
+  FaceListType faceList = faceCalculator(accImage, outputRegion, internalRadius);
   // start with the body region
   for (const auto & face : faceList)
   {

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -91,8 +91,8 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
   kernelRadius.Fill(1);
   using FaceCalculatorType = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>;
   FaceCalculatorType                        faceCalculator;
-  typename FaceCalculatorType::FaceListType faceList;
-  faceList = faceCalculator(input, output->GetRequestedRegion(), kernelRadius);
+  typename FaceCalculatorType::FaceListType faceList =
+    faceCalculator(input, output->GetRequestedRegion(), kernelRadius);
   typename FaceCalculatorType::FaceListType::iterator fit;
   ProgressReporter                                    progress(this, 0, buffsize * 4); // pretend we have 4 steps
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1024,15 +1024,15 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     // Initialize the boundary pixels in the status image to
     // m_StatusBoundaryPixel values.  Uses the face calculator to find all of
     // the region faces.
-    BFCType                        faceCalculator;
-    typename BFCType::FaceListType faceList;
+    BFCType faceCalculator;
 
     // Set the difference function radius here
     typename BFCType::SizeType               sz = this->m_DifferenceFunctions[fId]->GetRadius();
     typename BFCType::FaceListType::iterator fit;
 
     // Compute the boundary pixel regions set in a container
-    faceList = faceCalculator(sparsePtr->m_StatusImage, sparsePtr->m_StatusImage->GetRequestedRegion(), sz);
+    typename BFCType::FaceListType faceList =
+      faceCalculator(sparsePtr->m_StatusImage, sparsePtr->m_StatusImage->GetRequestedRegion(), sz);
 
     // Iterate over the boundary region sets
     fit = faceList.begin();

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
@@ -91,9 +91,9 @@ WarpHarmonicEnergyCalculator<TInputImage>::Compute()
   ConstNeighborhoodIteratorType               bIt;
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>                        bC;
-  faceList = bC(m_Image, m_Region, m_NeighborhoodRadius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>::FaceListType faceList =
+    bC(m_Image, m_Region, m_NeighborhoodRadius);
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>::FaceListType::iterator fIt;
   fIt = faceList.begin();

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -79,8 +79,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
   using FaceCalculatorType = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>;
 
-  FaceCalculatorType                        faceCalculator;
-  typename FaceCalculatorType::FaceListType faceList;
+  FaceCalculatorType faceCalculator;
 
   using ShapeNeighborhoodIterator = typename ShapedNeighborhoodIteratorType::ConstIterator;
 
@@ -97,7 +96,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
   output->SetMeasurementVectorSize(measurementVectorSize);
 
-  faceList = faceCalculator(input, input->GetRequestedRegion(), radius);
+  typename FaceCalculatorType::FaceListType faceList = faceCalculator(input, input->GetRequestedRegion(), radius);
 
   OffsetType center_offset;
   center_offset.Fill(0);

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -102,9 +102,9 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  faceList = bC(input, outputRegionForThread, m_Radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    bC(input, outputRegionForThread, m_Radius);
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
@@ -86,9 +86,9 @@ VotingBinaryHoleFillingImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  faceList = bC(input, outputRegionForThread, this->GetRadius());
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    bC(input, outputRegionForThread, this->GetRadius());
 
   ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -101,9 +101,9 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  faceList = bC(input, outputRegionForThread, m_Radius);
+  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
+    bC(input, outputRegionForThread, m_Radius);
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
   // Process each of the boundary faces.  These are N-d regions which border

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -224,12 +224,11 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   using BFCType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<StatusImageType>;
 
   BFCType                                  faceCalculator;
-  typename BFCType::FaceListType           faceList;
   typename BFCType::SizeType               sz;
   typename BFCType::FaceListType::iterator fit;
 
   sz.Fill(1);
-  faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);
+  typename BFCType::FaceListType faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);
   fit = faceList.begin();
 
   for (++fit; fit != faceList.end(); ++fit) // skip the first (nonboundary) region

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -535,12 +535,11 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   using BFCType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<StatusImageType>;
 
   BFCType                                  faceCalculator;
-  typename BFCType::FaceListType           faceList;
   typename BFCType::SizeType               sz;
   typename BFCType::FaceListType::iterator fit;
 
   sz.Fill(1);
-  faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);
+  typename BFCType::FaceListType faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);
   fit = faceList.begin();
 
   for (++fit; fit != faceList.end(); ++fit) // skip the first (nonboundary)


### PR DESCRIPTION
Instead of default-initializing those `faceList` variables and assigning the `ImageBoundaryFacesCalculator` result afterwards.

Following C++ Core Guidelines, September 23, 2022, "Don’t introduce a variable (or constant) before you need to use it" and "Don’t declare a variable until you have a value to initialize it with", http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines