### PR TITLE
STYLE: Replace `for` loops SetPointIds(PointIdConstIterator) by copy_n

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -21,6 +21,8 @@
 #include "vnl/vnl_matrix_fixed.h"
 #include "vnl/algo/vnl_determinant.h"
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 
@@ -148,12 +150,7 @@ template <typename TCellInterface>
 void
 HexahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkLineCell.hxx
+++ b/Modules/Core/Common/include/itkLineCell.hxx
@@ -18,6 +18,8 @@
 #ifndef itkLineCell_hxx
 #define itkLineCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -103,12 +105,7 @@ template <typename TCellInterface>
 void
 LineCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkPolyLineCell.hxx
+++ b/Modules/Core/Common/include/itkPolyLineCell.hxx
@@ -18,6 +18,8 @@
 #ifndef itkPolyLineCell_hxx
 #define itkPolyLineCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -113,12 +115,7 @@ template <typename TCellInterface>
 void
 PolyLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < m_PointIds.size(); ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, m_PointIds.size(), m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -28,6 +28,8 @@
 #ifndef itkPolygonCell_hxx
 #define itkPolygonCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -189,12 +191,7 @@ template <typename TCellInterface>
 void
 PolygonCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < m_PointIds.size(); ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, m_PointIds.size(), m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
@@ -18,6 +18,8 @@
 #ifndef itkQuadraticEdgeCell_hxx
 #define itkQuadraticEdgeCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -111,12 +113,7 @@ template <typename TCellInterface>
 void
 QuadraticEdgeCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
@@ -18,6 +18,8 @@
 #ifndef itkQuadraticTriangleCell_hxx
 #define itkQuadraticTriangleCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -123,12 +125,7 @@ template <typename TCellInterface>
 void
 QuadraticTriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -20,6 +20,8 @@
 #include "itkMath.h"
 #include "vnl/algo/vnl_determinant.h"
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 
@@ -126,12 +128,7 @@ template <typename TCellInterface>
 void
 QuadrilateralCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -19,6 +19,8 @@
 #define itkTetrahedronCell_hxx
 #include "vnl/algo/vnl_determinant.h"
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -279,12 +281,7 @@ template <typename TCellInterface>
 void
 TetrahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -19,6 +19,8 @@
 #define itkTriangleCell_hxx
 #include "vnl/algo/vnl_determinant.h"
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /**
@@ -124,12 +126,7 @@ template <typename TCellInterface>
 void
 TriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < NumberOfPoints; ++i, ++ii)
-  {
-    m_PointIds[i] = *ii;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /**

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -18,6 +18,8 @@
 #ifndef itkVertexCell_hxx
 #define itkVertexCell_hxx
 
+#include <algorithm> // For copy_n.
+
 namespace itk
 {
 /** Standard CellInterface: */
@@ -74,12 +76,7 @@ template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
 {
-  PointIdConstIterator ii(first);
-
-  for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
-  {
-    m_PointIds[i] = *ii++;
-  }
+  std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
 /** Standard CellInterface:


### PR DESCRIPTION
Replaced manual `for` loops inside the `SetPointIds(PointIdConstIterator)` member functions of ten "Cel" types by equivalent `std::copy_n` calls. Addresses a few warnings from Clang Tidy (LLVM 15.0.4), saying:

> warning: use range-based for loop instead [modernize-loop-convert]

Note that in these cases, using `std::copy_n` appears even better than using range-based `for` loops!