### PR TITLE
DOC: Fix unbalanced grouping commands Doxygen warnings

### DIFF
--- a/Modules/Core/Common/include/itkAutoPointer.h
+++ b/Modules/Core/Common/include/itkAutoPointer.h
@@ -254,6 +254,7 @@ TransferAutoPointer(TAutoPointerBase & pa, TAutoPointerDerived & pb)
     pb.ReleaseOwnership(); // pb Release Ownership and clears
   }
 }
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -186,6 +186,7 @@ private:
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -122,6 +122,7 @@ protected:
   BSplineInterpolationWeightFunction() = default;
   ~BSplineInterpolationWeightFunction() override = default;
 };
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkBSplineKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineKernelFunction.h
@@ -180,6 +180,7 @@ private:
     itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -73,6 +73,7 @@ protected:
     this->FillCenteredDirectional(coeff);
   }
 };
+
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkBufferedImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkBufferedImageNeighborhoodPixelAccessPolicy.h
@@ -126,6 +126,7 @@ public:
   {
     m_NeighborhoodAccessor.Set(imageBufferPointer + m_PixelIndexValue, pixelValue);
   }
+
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -164,6 +164,7 @@ using IOFileModeType = CommonEnums::IOFileMode;
 using IOByteOrderType = CommonEnums::IOByteOrder;
 using CellGeometryType = CommonEnums::CellGeometry;
 #endif
+
 // Define how to print enumeration
 extern ITKCommon_EXPORT std::ostream &
                         operator<<(std::ostream & out, IOPixelEnum value);

--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -83,6 +83,7 @@ namespace itk
  * \ingroup ImageIterators
  * \ingroup ITKCommon
  */
+
 template <unsigned int VImageDimension>
 class ConnectedImageNeighborhoodShape
 {
@@ -247,8 +248,8 @@ private:
   {
     return (includeCenterPixel ? 1 : 0) + CalculateNumberOfConnectedNeighbors(maximumCityblockDistance);
   }
-};
 
+};
 
 /** Generates the offsets for a connected image neighborhood shape. */
 template <unsigned int VImageDimension, size_t VMaximumCityblockDistance, bool VIncludeCenterPixel>

--- a/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
@@ -144,8 +144,8 @@ public:
       m_NeighborhoodAccessor.Set(imageBufferPointer + m_PixelIndexValue, pixelValue);
     }
   }
-};
 
+};
 
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -90,6 +90,7 @@ public:
       (*this)[i] = static_cast<TCoordinate>(index[i]);
     }
   }
+
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -257,6 +257,7 @@ public:
       (*this)[i] = static_cast<T>(pa[i]);
     }
   }
+
 };
 
 /** Premultiply Operator for product of a vector and a scalar.

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -77,6 +77,7 @@ public:
   {
     return pixel.GetScalarValue();
   }
+
 };
 
 #define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)           \

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -155,6 +155,7 @@ public:
   {
     ImageRegionCopier<T1, T2>::operator()(destRegion, srcRegion);
   }
+
 };
 } // end namespace ImageToImageFilterDetail
 } // end namespace itk

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -459,6 +459,7 @@ public:
   {
     return MakeFilled<FixedArray>(value);
   }
+
 };
 
 template <typename TValue, unsigned int VLength>

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -71,6 +71,7 @@ protected:
   {
     this->FillCenteredDirectional(coeff);
   }
+
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkImageIterator.h
+++ b/Modules/Core/Common/include/itkImageIterator.h
@@ -137,6 +137,7 @@ protected:
   ImageIterator(const ImageConstIterator<TImage> & it);
   Self &
   operator=(const ImageConstIterator<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.h
@@ -127,6 +127,7 @@ protected:
   ImageIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
@@ -120,6 +120,7 @@ protected:
   ImageLinearIteratorWithIndex(const ImageLinearConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageLinearConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
@@ -120,6 +120,7 @@ protected:
   ImageRandomIteratorWithIndex(const ImageRandomConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageRandomConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
@@ -132,6 +132,7 @@ protected:
   ImageRandomNonRepeatingIteratorWithIndex(const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
@@ -191,6 +191,7 @@ public:
    * \sa operator++ */
   Self &
   operator--();
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
@@ -187,6 +187,7 @@ public:
    * \sa operator++ */
   Self &
   operator--();
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
@@ -121,6 +121,7 @@ protected:
   ImageRegionExclusionIteratorWithIndex(const ImageRegionExclusionConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageRegionExclusionConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionIterator.h
@@ -133,6 +133,7 @@ protected:
   ImageRegionIterator(const ImageRegionConstIterator<TImage> & it);
   Self &
   operator=(const ImageRegionConstIterator<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
@@ -126,6 +126,7 @@ protected:
   ImageRegionIteratorWithIndex(const ImageRegionConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageRegionConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.h
@@ -122,6 +122,7 @@ protected:
   ImageRegionReverseIterator(const ImageRegionReverseConstIterator<TImage> & it);
   Self &
   operator=(const ImageRegionReverseConstIterator<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseIterator.h
@@ -118,6 +118,7 @@ protected:
   ImageReverseIterator(const ImageRegionReverseConstIterator<TImage> & it);
   Self &
   operator=(const ImageRegionReverseConstIterator<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageScanlineIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.h
@@ -95,6 +95,7 @@ protected:
   ImageScanlineIterator(const ImageScanlineConstIterator<TImage> & it);
   Self &
   operator=(const ImageScanlineConstIterator<TImage> & it);
+
 };
 
 // Deduction guide for class template argument deduction (CTAD).

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -198,6 +198,7 @@ private:
    */
   double m_CoordinateTolerance{ Self::GetGlobalDefaultCoordinateTolerance() };
   double m_DirectionTolerance{ Self::GetGlobalDefaultDirectionTolerance() };
+
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
@@ -122,6 +122,7 @@ protected:
   ImageSliceIteratorWithIndex(const ImageSliceConstIteratorWithIndex<TImage> & it);
   Self &
   operator=(const ImageSliceConstIteratorWithIndex<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkMemoryUsageObserver.h
+++ b/Modules/Core/Common/include/itkMemoryUsageObserver.h
@@ -87,8 +87,10 @@ class ITKCommon_EXPORT LinuxMemoryUsageObserver : public MemoryUsageObserverBase
 public:
   /** destructor */
   ~LinuxMemoryUsageObserver() override;
+
   MemoryLoadType
   GetMemoryUsage() override;
+
 };
 #endif // __linux__
 
@@ -98,8 +100,10 @@ class ITKCommon_EXPORT MacOSXMemoryUsageObserver : public MemoryUsageObserverBas
 public:
   /** destructor */
   ~MacOSXMemoryUsageObserver() override;
+
   MemoryLoadType
   GetMemoryUsage() override;
+
 };
 #endif // Mac OS X
 
@@ -109,8 +113,10 @@ class ITKCommon_EXPORT SunSolarisMemoryUsageObserver : public MemoryUsageObserve
 public:
   /** destructor */
   virtual ~SunSolarisMemoryUsageObserver();
+
   virtual MemoryLoadType
   GetMemoryUsage();
+
 };
 #endif // Sun Solaris
 
@@ -120,8 +126,10 @@ class ITKCommon_EXPORT SysResourceMemoryUsageObserver : public MemoryUsageObserv
 public:
   /** destructor */
   ~SysResourceMemoryUsageObserver() override;
+
   MemoryLoadType
   GetMemoryUsage() override;
+
 };
 
 #  if defined(ITK_HAS_MALLINFO) || defined(ITK_HAS_MALLINFO2)
@@ -134,9 +142,12 @@ class ITKCommon_EXPORT MallinfoMemoryUsageObserver : public MemoryUsageObserverB
 public:
   /** destructor */
   ~MallinfoMemoryUsageObserver() override;
+
   MemoryLoadType
   GetMemoryUsage() override;
+
 };
+
 #  endif // Mallinfo
 #endif   // !defined(WIN32) && !defined(_WIN32)
 

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -263,6 +263,7 @@ INTEL_PRAGMA_WARN_POP
       STD_EXCEPTION,
       UNKNOWN
     } ThreadExitCode;
+
   };
   // clang-format off
 ITK_GCC_PRAGMA_DIAG_POP()

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -328,6 +328,7 @@ public:
   {
     this->SetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis), v);
   }
+
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkOrientationAdapterBase.h
+++ b/Modules/Core/Common/include/itkOrientationAdapterBase.h
@@ -64,6 +64,7 @@ protected:
   /** destructor, to silence "virtual class has non-virtual destructor()"
     warnings */
   virtual ~OrientationAdapterBase() = default;
+
 };
 } // namespace itk
 #else // ITK_LEGACY_REMOVE

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
@@ -105,6 +105,7 @@ public:
    */
   OutputPixelType
   GetPixel(const IndexType & index, const TInputImage * image) const override;
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -123,6 +123,7 @@ public:
   Point(const TPointValueType & v)
     : BaseArray(v)
   {}
+
   Point(const ValueType & v)
     : BaseArray(v)
   {}

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -294,6 +294,7 @@ protected: // made protected so other iterators can access
    * 8 (26 in 3D).
    */
   bool m_FullyConnected{};
+
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -802,6 +802,7 @@ public:
     m_RelativeLocation = location;
     SubtractIndex(m_RelativeLocation, m_BufferedRegionData.m_Index);
   }
+
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -110,6 +110,7 @@ permuteColumnsWithSortIndices(QMatrix & eigenVectors, const std::vector<int> & i
   // Apply it
   eigenVectors = eigenVectors * perm;
 }
+
 } // end namespace detail
 
 /** \class SymmetricEigenAnalysisEnums

--- a/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
@@ -124,6 +124,7 @@ public:
   {
     m_NeighborhoodAccessor.Set(imageBufferPointer + m_PixelIndexValue, pixelValue);
   }
+
 };
 
 } // namespace itk

--- a/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.h
@@ -102,6 +102,7 @@ protected:
    * \sa ProcessObject::ReleaseInputs() */
   void
   ReleaseInputs() override;
+
 };
 
 } // end namespace itk

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -280,6 +280,7 @@ public:
     {
       return ((m_CellId == r.m_CellId) && (m_FeatureId == r.m_FeatureId));
     }
+
   }; // End Class: Mesh::BoundaryAssignmentIdentifier
 
   /** Used for manipulating boundaries and boundary attributes.  A

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -151,6 +151,7 @@ protected:
 public:
   /** Object creation methods. */
   QuadEdgeMeshFrontBaseIterator(MeshType * mesh = nullptr, bool start = true, QEType * seed = nullptr);
+
   virtual ~QuadEdgeMeshFrontBaseIterator();
 
   Self &
@@ -244,12 +245,15 @@ public:
   QuadEdgeMeshFrontIterator(MeshType * mesh = (MeshType *)0, bool start = true, QEType * seed = nullptr)
     : Superclass(mesh, start, seed)
   {}
+
   ~QuadEdgeMeshFrontIterator() override = default;
+
   QEType *
   Value()
   {
     return (this->m_CurrentEdge);
   }
+
 };
 
 /**

--- a/Modules/Core/SpatialObjects/include/itkMetaEvent.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaEvent.h
@@ -44,6 +44,7 @@ public:
   MetaEvent();
   ~MetaEvent() override;
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -683,6 +683,7 @@ public:
   {
     return IsInsideInObjectSpace(point, depth, name);
   }
+
 #endif
 
 protected:

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
@@ -109,6 +109,7 @@ protected:
    * \f$ \alpha = 12 ( 1 - \nu ) - 1\f$
    */
   TParametersValueType m_Alpha{};
+
 };
 } // namespace itk
 

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
@@ -163,6 +163,7 @@ protected:
   {
     Superclass::PrintSelf(os, indent);
   }
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
@@ -99,8 +99,10 @@ protected:
   /** the construction from a const iterator is declared protected
       in order to enforce const correctness. */
   ReflectiveImageRegionIterator(const ReflectiveImageRegionConstIterator<TImage> & it);
+
   Self &
   operator=(const ReflectiveImageRegionConstIterator<TImage> & it);
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -48,6 +48,7 @@ template <typename TPixel1, typename TPixel2>
 class JoinFunctor
 {
 public:
+
   /** Standard type alias */
   using Self = JoinFunctor;
 
@@ -160,6 +161,7 @@ private:
   {
     out[idx] = static_cast<JoinValueType>(B);
   }
+
 }; // class JoinFunction
 
 template <typename TImage1, typename TImage2>

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
@@ -141,6 +141,7 @@ protected:
    */
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+
 };
 } // end of namespace itk
 

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
@@ -101,6 +101,7 @@ protected:
    *     BoxImageFilter::GenerateData() */
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -132,6 +132,7 @@ public:
       this->Modified();
     }
   }
+
   itkGetConstMacro(UseLookupTable, bool);
   itkBooleanMacro(UseLookupTable);
 #endif

--- a/Modules/Filtering/Path/include/itkParametricPath.h
+++ b/Modules/Filtering/Path/include/itkParametricPath.h
@@ -139,6 +139,7 @@ protected:
    * constructor of all instantiable children.  Values set in child constructors
    * overwrite values set in parent constructors. */
   InputType m_DefaultInputStepSize{};
+
 };
 
 } // namespace itk

--- a/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
@@ -105,6 +105,7 @@ protected:
    * \sa ProcessObject::GenerateInputRequestedRegion() */
   void
   GenerateInputRequestedRegion() override;
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkPathToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToPathFilter.h
@@ -87,6 +87,7 @@ protected:
    * \sa ProcessObject::GenerateInputRequestedRegion() */
   void
   GenerateInputRequestedRegion() override;
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
@@ -194,6 +194,7 @@ protected:
    */
   void
   GenerateData() override;
+
 };
 } // namespace itk
 

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
@@ -104,6 +104,7 @@ protected:
    *     ImageToImageFilter::GenerateData() */
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+
 };
 } // end namespace itk
 

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -200,6 +200,7 @@ public:
   static bool
   GetLabelFromTag(const std::string & tag, std::string & labelId);
 
+
   using CompressionEnum = GDCMImageIOEnums::Compression;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -57,6 +57,7 @@ public:
 
   /** Has to have empty throw(). */
   ~ImageFileWriterException() noexcept override;
+
 };
 
 /** \class ImageFileWriter

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -52,6 +52,7 @@ public:
   {
     SetDescription(message);
   }
+
 };
 
 /** \class ImageSeriesWriter

--- a/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
+++ b/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
@@ -48,6 +48,7 @@ public:
     JPT_CFMT = 2,
     MJ2_CFMT = 3
   };
+
   /** \class DFMFormat
    * \ingroup ITKIOJPEG2000
    * */
@@ -58,6 +59,7 @@ public:
     BMP_DFMT = 2,
     YUV_DFMT = 3
   };
+
 };
 // Define how to print enumeration
 extern ITKIOJPEG2000_EXPORT std::ostream &

--- a/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
+++ b/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
@@ -82,6 +82,7 @@ public:
   {
     return pixel.GetScalarValue();
   }
+
 };
 
 #define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)           \

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.h
@@ -79,12 +79,14 @@ public:
   {
     return &m_TransformList;
   }
+
 #else
   const TransformListType *
   GetTransformList()
   {
     return &m_TransformList;
   }
+
 #endif
   TransformListType *
   GetModifiableTransformList()

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -78,6 +78,7 @@ public:
      */
     LINESEARCH_BACKTRACKING_STRONG_WOLFE = 3,
   };
+
 };
 // Define how to print enumeration
 extern ITKOptimizersv4_EXPORT std::ostream &

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -280,6 +280,7 @@ public:
 protected:
   /** Default constructor */
   ObjectToObjectOptimizerBaseTemplate();
+
   ~ObjectToObjectOptimizerBaseTemplate() override;
 
   MetricTypePointer m_Metric{};

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
@@ -96,6 +96,7 @@ protected:
   using Superclass::MakeOutput;
   DataObjectPointer
   MakeOutput(DataObjectPointerArraySizeType idx) override;
+
 }; // end of class
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -185,6 +185,7 @@ private:
   /** Support processing data in multiple threads. Used by subclasses
    * (e.g., ImageSource). */
   MultiThreaderBase::Pointer m_Threader{ MultiThreaderBase::New() };
+
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
@@ -111,6 +111,7 @@ public:
    * computations rather than the image pixel type itself. */
   itkConceptMacro(OnlyDefinedForFloatingPointTypes0, (itk::Concept::IsFloatingPoint<FixedRealType>));
   itkConceptMacro(OnlyDefinedForFloatingPointTypes1, (itk::Concept::IsFloatingPoint<MovingRealType>));
+
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -871,6 +871,7 @@ private:
   using MovingImagePixelValueType = typename PixelTraits<MovingImagePixelType>::ValueType;
   itkConceptMacro(OnlyDefinedForFloatingPointTypes0, (itk::Concept::IsFloatingPoint<FixedImagePixelValueType>));
   itkConceptMacro(OnlyDefinedForFloatingPointTypes1, (itk::Concept::IsFloatingPoint<MovingImagePixelValueType>));
+
 };
 } // namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -120,6 +120,7 @@ protected:
   {
     return this->m_CachedNumberOfLocalParameters;
   }
+
 };
 
 /** \class ImageToImageMetricv4GetValueAndDerivativeThreader
@@ -195,6 +196,7 @@ protected:
   {
     return this->m_CachedNumberOfLocalParameters;
   }
+
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -186,7 +186,9 @@ protected:
      * classes for efficiency. */
     JacobianType MovingTransformJacobian;
     JacobianType MovingTransformJacobianPositional;
+
   };
+
   itkPadStruct(ITK_CACHE_LINE_ALIGNMENT,
                GetValueAndDerivativePerThreadStruct,
                PaddedGetValueAndDerivativePerThreadStruct);

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
@@ -156,6 +156,7 @@ private:
   {
     m_Canny->SetInput(feature);
   }
+
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
@@ -125,6 +125,7 @@ protected:
 
     return false;
   }
+
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
@@ -118,6 +118,7 @@ protected:
 
     return false;
   }
+
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
@@ -267,6 +267,7 @@ private:
   /** Fill layers adjacent to the zero level set (i.e. layer -1 and +1 )*/
   void
   FindPlusOneMinusOneLayer();
+
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
@@ -128,6 +128,7 @@ protected:
    *  \f$ \omega_i( p ) \f$. */
   LevelSetOutputRealType
   Value(const LevelSetInputIndexType & iP, const LevelSetDataType & iData) override;
+
 };
 
 } // namespace itk

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
@@ -137,6 +137,7 @@ protected:
   Value(const LevelSetInputIndexType & iP) override;
   LevelSetOutputRealType
   Value(const LevelSetInputIndexType & iP, const LevelSetDataType & iData) override;
+
 };
 
 } // namespace itk

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -67,6 +67,7 @@ public:
       : label(l)
       , height(s)
     {}
+
     IdentifierType label;
     ScalarType     height;
 
@@ -81,6 +82,7 @@ public:
 
       return false;
     }
+
   };
 
   /** Structure for storing lists of adjacencies (edges) and their


### PR DESCRIPTION
Fix unbalanced grouping commands Doxygen warnings.

Fixes:
```
Modules/Core/Common/include/itkAutoPointer.h:261: warning: unbalanced grouping commands
```

warnings across classes.

The warning is raised when the
Utilities/Doxygen/itkdoxygen.pl

Doxygen Perl script processes the files at issue and starts a `/**@{` block that gets interrupted by an unexpected symbol (e.g. a brace) without being previously closed with the corresponding `/**@}*/` ending token.

Raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8344134

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)