### PR TITLE
DOC: Improve doxygen footer formatting

### DIFF
--- a/Documentation/Doxygen/DoxygenFooter.html
+++ b/Documentation/Doxygen/DoxygenFooter.html
@@ -13,19 +13,18 @@
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/>
 <div class="footer" align="left">
-  <p><small>Tarballs of the nightly generated Doxygen documentation are available
+  <small>Tarballs of the nightly generated Doxygen documentation are available
     for the
     <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocHtml.tar.gz">html</a>,
     <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz">xml</a>, and
     <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz">tag file</a>.
-  </small></p>
-  <p><small>Previous versions of this documentation for version:
+  Previous versions of this documentation for version:
     <a href="https://itk.org/Doxygen52/html/index.html">5.2</a>,
     <a href="https://itk.org/Doxygen51/html/index.html">5.1</a>,
     <a href="https://itk.org/Doxygen50/html/index.html">5.0</a>,
     <a href="https://itk.org/Doxygen413/html/index.html">4.13</a>,
     <a href="https://itk.org/Doxygen320/html/index.html">3.20</a>.
-  </small></p>
+  </small>
 </div>
 <address class="footer"><small>
 Generated on <span id="datetime">unknown</span> for $projectname by &#160;


### PR DESCRIPTION
Put all link content on a single line and reduce vertical space usage.
