### PR TITLE
STYLE: Make data of PixelReferenceWrapper (in ImageBufferRange) private

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -251,8 +251,6 @@ private:
     class PixelReferenceWrapper final
     {
     public:
-      QualifiedPixelType & m_Pixel;
-
       // Wraps the pixel reference that is specified by the first argument.
       // Note: the second parameter is unused, but it is there just to support
       // the use case of iterator::operator*(), which uses either
@@ -266,6 +264,9 @@ private:
 
       // Converts implicitly to a reference to the pixel.
       operator QualifiedPixelType &() const noexcept { return m_Pixel; }
+
+    private:
+      QualifiedPixelType & m_Pixel;
     };
 
 


### PR DESCRIPTION
PixelReferenceWrapper is itself already private, nested inside QualifiedIterator, which is private as well, nested inside ImageBufferRange.

Fixed a LLVM 15.04 clang-tidy warning:
> member variable 'm_Pixel' has public visibility [misc-non-private-member-variables-in-classes]