### PR TITLE
STYLE: Replace `*x.begin()` with `x.front()`

### DIFF
--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -276,7 +276,7 @@ PolygonCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   if (!m_PointIds.empty())
   {
-    return &*(m_PointIds.begin());
+    return &m_PointIds.front();
   }
   else
   {
@@ -295,7 +295,7 @@ PolygonCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   if (!m_PointIds.empty())
   {
-    return &*(m_PointIds.begin());
+    return &m_PointIds.front();
   }
   else
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -209,7 +209,7 @@ public:
     }
     else
     {
-      return &*(m_PointIds.begin());
+      return &m_PointIds.front();
     }
   }
 
@@ -238,7 +238,7 @@ public:
     }
     else
     {
-      return &*(m_PointIds.begin());
+      return &m_PointIds.front();
     }
   }
 

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -118,7 +118,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   FixedArray<OffsetValueType, 2 * ImageDimension> offset;
 
-  bit = ConstNeighborhoodIterator<InputImageType>(radius, input, *faceList.begin());
+  bit = ConstNeighborhoodIterator<InputImageType>(radius, input, faceList.front());
   // Set the offset of the neighbors to the center pixel.
   for (i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -91,7 +91,7 @@ template <typename TParametersValueType>
 const typename TransformFileWriterTemplate<TParametersValueType>::TransformType *
 TransformFileWriterTemplate<TParametersValueType>::GetInput()
 {
-  ConstTransformPointer res = *(m_TransformList.begin());
+  ConstTransformPointer res = m_TransformList.front();
   return res.GetPointer();
 }
 

--- a/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleTest.cxx
@@ -49,7 +49,7 @@ itkMaximumRatioDecisionRuleTest(int, char *[])
   decisionRule->SetPriorProbabilities(aPrioris);
   for (auto & value : aPrioris)
   {
-    auto index = &value - &*(aPrioris.begin());
+    auto index = &value - &aPrioris.front();
     ITK_TEST_SET_GET_VALUE(value, decisionRule->GetPriorProbabilities()[index]);
   }
 
@@ -64,7 +64,7 @@ itkMaximumRatioDecisionRuleTest(int, char *[])
   decisionRule->SetPriorProbabilities(aPrioris);
   for (auto & value : aPrioris)
   {
-    auto index = &value - &*(aPrioris.begin());
+    auto index = &value - &aPrioris.front();
     ITK_TEST_SET_GET_VALUE(value, decisionRule->GetPriorProbabilities()[index]);
   }
 

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -233,7 +233,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       while (!it.IsAtEnd())
       {
         it.Set(m_ReplaceValue);
-        if (it.GetIndex() == *m_Seeds2.begin())
+        if (it.GetIndex() == m_Seeds2.front())
         {
           break;
         }
@@ -298,7 +298,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       while (!it.IsAtEnd())
       {
         it.Set(m_ReplaceValue);
-        if (it.GetIndex() == *m_Seeds2.begin())
+        if (it.GetIndex() == m_Seeds2.front())
         {
           break;
         }


### PR DESCRIPTION
The expression `x.front()` appears slightly more readable in these cases, because it does not have the `*` at the beginning.