### PR TITLE
STYLE: Add missing `<< indent` insertions to `PrintSelf` implementations

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -345,63 +345,63 @@ VTKImageImport<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
   if (m_DataExtentCallback)
   {
-    os << "DataExtentCallback: " << m_DataExtentCallback << std::endl;
+    os << indent << "DataExtentCallback: " << m_DataExtentCallback << std::endl;
   }
   if (m_WholeExtentCallback)
   {
-    os << "WholeExtentCallback: " << m_WholeExtentCallback << std::endl;
+    os << indent << "WholeExtentCallback: " << m_WholeExtentCallback << std::endl;
   }
   if (m_BufferPointerCallback)
   {
-    os << "BufferPointerCallback: " << m_BufferPointerCallback << std::endl;
+    os << indent << "BufferPointerCallback: " << m_BufferPointerCallback << std::endl;
   }
   if (m_UpdateDataCallback)
   {
-    os << "UpdateDataCallback: " << m_UpdateDataCallback << std::endl;
+    os << indent << "UpdateDataCallback: " << m_UpdateDataCallback << std::endl;
   }
   if (m_PipelineModifiedCallback)
   {
-    os << "PipelineModifiedCallback: " << m_PipelineModifiedCallback << std::endl;
+    os << indent << "PipelineModifiedCallback: " << m_PipelineModifiedCallback << std::endl;
   }
   if (m_NumberOfComponentsCallback)
   {
-    os << "NumberOfComponentsCallback: " << m_NumberOfComponentsCallback << std::endl;
+    os << indent << "NumberOfComponentsCallback: " << m_NumberOfComponentsCallback << std::endl;
   }
   if (m_SpacingCallback)
   {
-    os << "SpacingCallback: " << m_SpacingCallback << std::endl;
+    os << indent << "SpacingCallback: " << m_SpacingCallback << std::endl;
   }
   if (m_FloatSpacingCallback)
   {
-    os << "FloatSpacingCallback: " << m_FloatSpacingCallback << std::endl;
+    os << indent << "FloatSpacingCallback: " << m_FloatSpacingCallback << std::endl;
   }
   if (m_OriginCallback)
   {
-    os << "OriginCallback: " << m_OriginCallback << std::endl;
+    os << indent << "OriginCallback: " << m_OriginCallback << std::endl;
   }
   if (m_FloatOriginCallback)
   {
-    os << "FloatOriginCallback: " << m_FloatOriginCallback << std::endl;
+    os << indent << "FloatOriginCallback: " << m_FloatOriginCallback << std::endl;
   }
   if (m_DirectionCallback)
   {
-    os << "DirectionCallback: " << m_DirectionCallback << std::endl;
+    os << indent << "DirectionCallback: " << m_DirectionCallback << std::endl;
   }
   if (m_UpdateInformationCallback)
   {
-    os << "UpdateInformationCallback: " << m_UpdateInformationCallback << std::endl;
+    os << indent << "UpdateInformationCallback: " << m_UpdateInformationCallback << std::endl;
   }
   if (m_ScalarTypeCallback)
   {
-    os << "ScalarTypeCallback: " << m_ScalarTypeCallback << std::endl;
+    os << indent << "ScalarTypeCallback: " << m_ScalarTypeCallback << std::endl;
   }
   if (m_PropagateUpdateExtentCallback)
   {
-    os << "PropagateUpdateExtentCallback: " << m_PropagateUpdateExtentCallback << std::endl;
+    os << indent << "PropagateUpdateExtentCallback: " << m_PropagateUpdateExtentCallback << std::endl;
   }
   if (m_CallbackUserData)
   {
-    os << "CallbackUserData: " << m_CallbackUserData << std::endl;
+    os << indent << "CallbackUserData: " << m_CallbackUserData << std::endl;
   }
 }
 } // namespace itk

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -102,8 +102,8 @@ void
 BoxSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Object Size: " << m_SizeInObjectSpace << std::endl;
-  os << "Object Position: " << m_PositionInObjectSpace << std::endl;
+  os << indent << "Object Size: " << m_SizeInObjectSpace << std::endl;
+  os << indent << "Object Position: " << m_PositionInObjectSpace << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -143,8 +143,8 @@ EllipseSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
 {
   os << indent << "EllipseSpatialObject(" << this << ")" << std::endl;
   Superclass::PrintSelf(os, indent);
-  os << "Object Radii: " << m_RadiusInObjectSpace << std::endl;
-  os << "Object Center: " << m_CenterInObjectSpace << std::endl;
+  os << indent << "Object Radii: " << m_RadiusInObjectSpace << std::endl;
+  os << indent << "Object Center: " << m_CenterInObjectSpace << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -204,10 +204,10 @@ void
 GaussianSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Maximum: " << m_Maximum << std::endl;
-  os << "Radius: " << m_RadiusInObjectSpace << std::endl;
-  os << "Sigma: " << m_SigmaInObjectSpace << std::endl;
-  os << "Center: " << m_CenterInObjectSpace << std::endl;
+  os << indent << "Maximum: " << m_Maximum << std::endl;
+  os << indent << "Radius: " << m_RadiusInObjectSpace << std::endl;
+  os << indent << "Sigma: " << m_SigmaInObjectSpace << std::endl;
+  os << indent << "Center: " << m_CenterInObjectSpace << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -166,7 +166,7 @@ MeshSpatialObject<TMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << "Mesh: " << std::endl;
-  os << "m_IsInsidePrecisionInObjectSpace: " << m_IsInsidePrecisionInObjectSpace << std::endl;
+  os << indent << "m_IsInsidePrecisionInObjectSpace: " << m_IsInsidePrecisionInObjectSpace << std::endl;
   os << indent << m_Mesh << std::endl;
 }
 

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -252,9 +252,9 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
 
   itkPrintSelfObjectMacro(Interpolator);
 
-  os << "Maximum number of iterations: " << this->m_MaximumNumberOfIterations << std::endl;
-  os << "Max error tolerance threshold: " << this->m_MaxErrorToleranceThreshold << std::endl;
-  os << "Mean error tolerance threshold: " << this->m_MeanErrorToleranceThreshold << std::endl;
+  os << indent << "Maximum number of iterations: " << this->m_MaximumNumberOfIterations << std::endl;
+  os << indent << "Max error tolerance threshold: " << this->m_MaxErrorToleranceThreshold << std::endl;
+  os << indent << "Mean error tolerance threshold: " << this->m_MeanErrorToleranceThreshold << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -471,16 +471,16 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Variance: " << m_Variance << std::endl;
-  os << "MaximumError: " << m_MaximumError << std::endl;
+  os << indent << "Variance: " << m_Variance << std::endl;
+  os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent
      << "UpperThreshold: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_UpperThreshold)
      << std::endl;
   os << indent
      << "LowerThreshold: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_LowerThreshold)
      << std::endl;
-  os << "Center: " << m_Center << std::endl;
-  os << "Stride: " << m_Stride << std::endl;
+  os << indent << "Center: " << m_Center << std::endl;
+  os << indent << "Stride: " << m_Stride << std::endl;
   itkPrintSelfObjectMacro(GaussianFilter);
   itkPrintSelfObjectMacro(MultiplyImageFilter);
   itkPrintSelfObjectMacro(UpdateBuffer1);

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -354,7 +354,7 @@ void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
+  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -264,7 +264,7 @@ void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
+  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -72,8 +72,8 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintS
                                                                                     Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
-  os << "Sigma: " << m_DerivativeFilter->GetSigma() << std::endl;
+  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
+  os << indent << "Sigma: " << m_DerivativeFilter->GetSigma() << std::endl;
 }
 
 /**

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -354,7 +354,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
   Superclass::PrintSelf(os, indent);
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "UseImageDirection :   " << (this->m_UseImageDirection ? "On" : "Off") << std::endl;
-  os << "Sigma: " << m_Sigma << std::endl;
+  os << indent << "Sigma: " << m_Sigma << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -405,9 +405,10 @@ TileImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "DefaultPixelValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_DefaultPixelValue)
+  os << indent
+     << "DefaultPixelValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_DefaultPixelValue)
      << std::endl;
-  os << "Layout: " << m_Layout << std::endl;
+  os << indent << "Layout: " << m_Layout << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
@@ -58,13 +58,15 @@ AdaptiveHistogramEqualizationImageFilter<TImageType, TKernel>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Alpha: " << m_Alpha << std::endl;
-  os << "Beta: " << m_Beta << std::endl;
+  os << indent << "Alpha: " << m_Alpha << std::endl;
+  os << indent << "Beta: " << m_Beta << std::endl;
 
-  os << "InputMinimum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMinimum) << std::endl;
-  os << "InputMaximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMaximum) << std::endl;
+  os << indent << "InputMinimum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMinimum)
+     << std::endl;
+  os << indent << "InputMaximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMaximum)
+     << std::endl;
 
-  os << "UseLookupTable: " << (m_UseLookupTable ? "On" : "Off") << std::endl;
+  os << indent << "UseLookupTable: " << (m_UseLookupTable ? "On" : "Off") << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -339,9 +339,9 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Sigma: " << m_Sigma << std::endl;
-  os << "Order: " << m_Order << std::endl;
-  os << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
+  os << indent << "Sigma: " << m_Sigma << std::endl;
+  os << indent << "Order: " << m_Order << std::endl;
+  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -91,7 +91,7 @@ OtsuMultipleThresholdsImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
   os << indent << "Thresholds: " << std::endl;
   for (SizeValueType j = 0; j < m_Thresholds.size(); ++j)
   {
-    os << "\tThreshold #" << j << ": "
+    os << indent << "\tThreshold #" << j << ": "
        << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Thresholds[j]) << std::endl;
   }
 }

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -194,12 +194,12 @@ void
 CSVArray2DDataObject<TData>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Number of rows in matrix: " << this->m_Matrix.rows() << std::endl;
-  os << "Number of columns in matrix: " << this->m_Matrix.cols() << std::endl << std::endl;
-  os << "Column Headers existence: " << this->m_HasColumnHeaders << std::endl;
-  os << "Row Headers existence: " << this->m_HasRowHeaders << std::endl;
-  os << "Number of Column Headers: " << this->m_ColumnHeaders.size() << std::endl;
-  os << "Number of Row Headers: " << this->m_RowHeaders.size() << std::endl;
+  os << indent << "Number of rows in matrix: " << this->m_Matrix.rows() << std::endl;
+  os << indent << "Number of columns in matrix: " << this->m_Matrix.cols() << std::endl << std::endl;
+  os << indent << "Column Headers existence: " << this->m_HasColumnHeaders << std::endl;
+  os << indent << "Row Headers existence: " << this->m_HasRowHeaders << std::endl;
+  os << indent << "Number of Column Headers: " << this->m_ColumnHeaders.size() << std::endl;
+  os << indent << "Number of Row Headers: " << this->m_RowHeaders.size() << std::endl;
 
   os << "Below is the data: " << std::endl << std::endl;
 

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -133,7 +133,7 @@ MultipleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent)
   os << indent << "Cached Value: " << m_CachedValue << std::endl;
   os << indent << "Cached Derivative: " << m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << m_CachedCurrentPosition << std::endl;
-  os << "Command observer " << m_Command.GetPointer() << std::endl;
-  os << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
+  os << indent << "Command observer " << m_Command.GetPointer() << std::endl;
+  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -102,7 +102,7 @@ SingleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent) c
   os << indent << "Cached Value: " << m_CachedValue << std::endl;
   os << indent << "Cached Derivative: " << m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << m_CachedCurrentPosition << std::endl;
-  os << "Command observer " << m_Command.GetPointer() << std::endl;
-  os << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
+  os << indent << "Command observer " << m_Command.GetPointer() << std::endl;
+  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -135,7 +135,7 @@ WindowConvergenceMonitoringFunction<TScalar>::PrintSelf(std::ostream & os, Inden
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Window size: " << this->m_WindowSize << std::endl;
+  os << indent << "Window size: " << this->m_WindowSize << std::endl;
 }
 
 } // end namespace Function

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -117,7 +117,7 @@ SingleValuedNonLinearVnlOptimizerv4::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
   os << indent << "Cached Derivative: " << this->m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << this->m_CachedCurrentPosition << std::endl;
-  os << "Command observer " << this->m_Command.GetPointer() << std::endl;
-  os << "Cost Function adaptor" << this->m_CostFunctionAdaptor << std::endl;
+  os << indent << "Command observer " << this->m_Command.GetPointer() << std::endl;
+  os << indent << "Cost Function adaptor" << this->m_CostFunctionAdaptor << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -103,8 +103,8 @@ void
 ScalarImageToHistogramGenerator<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "ImageToListSample adaptor = " << m_ImageToListSampleAdaptor << std::endl;
-  os << "HistogramGenerator = " << m_HistogramGenerator << std::endl;
+  os << indent << "ImageToListSample adaptor = " << m_ImageToListSampleAdaptor << std::endl;
+  os << indent << "HistogramGenerator = " << m_HistogramGenerator << std::endl;
 }
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
@@ -277,11 +277,11 @@ BSplineTransformParametersAdaptor<TTransform>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Required transform domain origin: " << this->m_RequiredTransformDomainOrigin << std::endl;
-  os << "Required transform domain direction: " << this->m_RequiredTransformDomainDirection << std::endl;
-  os << "Required transform domain physical dimensions: " << this->m_RequiredTransformDomainPhysicalDimensions
+  os << indent << "Required transform domain origin: " << this->m_RequiredTransformDomainOrigin << std::endl;
+  os << indent << "Required transform domain direction: " << this->m_RequiredTransformDomainDirection << std::endl;
+  os << indent << "Required transform domain physical dimensions: " << this->m_RequiredTransformDomainPhysicalDimensions
      << std::endl;
-  os << "Required transform domain mesh size: " << this->m_RequiredTransformDomainMeshSize << std::endl;
+  os << indent << "Required transform domain mesh size: " << this->m_RequiredTransformDomainMeshSize << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -42,8 +42,8 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Pri
                                                                                        Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Lambda factor = " << m_Lambda << std::endl;
-  os << "Delta  value  = " << m_Delta << std::endl;
+  os << indent << "Lambda factor = " << m_Lambda << std::endl;
+  os << indent << "Delta  value  = " << m_Delta << std::endl;
 }
 
 /*

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -304,7 +304,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
                                                                                              Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Lambda factor = " << m_Lambda << std::endl;
+  os << indent << "Lambda factor = " << m_Lambda << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -326,7 +326,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
   os << indent << "No. levels: " << m_NumberOfLevels << std::endl;
   os << indent << "Schedule: " << std::endl;
   os << m_Schedule << std::endl;
-  os << "Use ShrinkImageFilter= " << m_UseShrinkImageFilter << std::endl;
+  os << indent << "Use ShrinkImageFilter= " << m_UseShrinkImageFilter << std::endl;
 }
 
 /*

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -343,11 +343,11 @@ TimeVaryingBSplineVelocityFieldTransformParametersAdaptor<TTransform>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "Required transform domain origin: " << this->m_RequiredTransformDomainOrigin << std::endl;
-  os << "Required transform domain mesh size: " << this->m_RequiredTransformDomainMeshSize << std::endl;
-  os << "Required transform domain sampled size: " << this->m_RequiredTransformDomainSize << std::endl;
-  os << "Required transform domain sampled spacing: " << this->m_RequiredTransformDomainSpacing << std::endl;
-  os << "Required transform domain direction: " << this->m_RequiredTransformDomainDirection << std::endl;
+  os << indent << "Required transform domain origin: " << this->m_RequiredTransformDomainOrigin << std::endl;
+  os << indent << "Required transform domain mesh size: " << this->m_RequiredTransformDomainMeshSize << std::endl;
+  os << indent << "Required transform domain sampled size: " << this->m_RequiredTransformDomainSize << std::endl;
+  os << indent << "Required transform domain sampled spacing: " << this->m_RequiredTransformDomainSpacing << std::endl;
+  os << indent << "Required transform domain direction: " << this->m_RequiredTransformDomainDirection << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.hxx
@@ -60,7 +60,7 @@ GeodesicActiveContourLevelSetImageFilter<TInputImage, TFeatureImage, TOutputType
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "GeodesicActiveContourFunction: " << m_GeodesicActiveContourFunction.GetPointer() << std::endl;
+  os << indent << "GeodesicActiveContourFunction: " << m_GeodesicActiveContourFunction.GetPointer() << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.hxx
@@ -60,7 +60,7 @@ GeodesicActiveContourShapePriorLevelSetImageFilter<TInputImage, TFeatureImage, T
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "GeodesicActiveContourFunction: " << m_GeodesicActiveContourFunction.GetPointer() << std::endl;
+  os << indent << "GeodesicActiveContourFunction: " << m_GeodesicActiveContourFunction.GetPointer() << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.hxx
@@ -39,7 +39,7 @@ NarrowBandThresholdSegmentationLevelSetImageFilter<TInputImage, TFeatureImage, T
   Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "ThresholdFunction: " << m_ThresholdFunction;
+  os << indent << "ThresholdFunction: " << m_ThresholdFunction;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.hxx
@@ -38,7 +38,7 @@ ThresholdSegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputType
                                                                                              Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "ThresholdFunction: " << m_ThresholdFunction;
+  os << indent << "ThresholdFunction: " << m_ThresholdFunction;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.hxx
@@ -37,7 +37,7 @@ VectorThresholdSegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutp
                                                                                                    Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "ThresholdFunction: " << m_ThresholdFunction;
+  os << indent << "ThresholdFunction: " << m_ThresholdFunction;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -755,15 +755,15 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os,
   os << indent << "StartPoint: " << m_StartPoint << std::endl;
   if (m_TrainingImage)
   {
-    os << "TraingImage: " << m_TrainingImage;
+    os << indent << "TraingImage: " << m_TrainingImage;
   }
   if (m_LabelledImage)
   {
-    os << "TrainingImage: " << m_TrainingImage;
+    os << indent << "TrainingImage: " << m_TrainingImage;
   }
   if (m_ClassifierPtr)
   {
-    os << "ClassifierPtr: " << m_ClassifierPtr;
+    os << indent << "ClassifierPtr: " << m_ClassifierPtr;
   }
 }
 } /* end namespace itk. */


### PR DESCRIPTION
`PrintSelf` should usually produce an indentation for each data member.