### PR TITLE
DOC: Add link to 5.3 documentation in Doxygen footer

### DIFF
--- a/Documentation/Doxygen/DoxygenFooter.html
+++ b/Documentation/Doxygen/DoxygenFooter.html
@@ -19,6 +19,7 @@
     <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz">xml</a>, and
     <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz">tag file</a>.
   Previous versions of this documentation for version:
+    <a href="https://itk.org/Doxygen53/html/index.html">5.3</a>,
     <a href="https://itk.org/Doxygen52/html/index.html">5.2</a>,
     <a href="https://itk.org/Doxygen51/html/index.html">5.1</a>,
     <a href="https://itk.org/Doxygen50/html/index.html">5.0</a>,


### PR DESCRIPTION
Following 5.3.0 release.
