### PR TITLE
STYLE: In-class default-member-initialization in Command derived classes and VTKImageImport 

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -185,21 +185,21 @@ protected:
   GenerateOutputInformation() override;
 
 private:
-  void *                            m_CallbackUserData;
-  UpdateInformationCallbackType     m_UpdateInformationCallback;
-  PipelineModifiedCallbackType      m_PipelineModifiedCallback;
-  WholeExtentCallbackType           m_WholeExtentCallback;
-  SpacingCallbackType               m_SpacingCallback;
-  FloatSpacingCallbackType          m_FloatSpacingCallback;
-  OriginCallbackType                m_OriginCallback;
-  FloatOriginCallbackType           m_FloatOriginCallback;
-  DirectionCallbackType             m_DirectionCallback;
-  ScalarTypeCallbackType            m_ScalarTypeCallback;
-  NumberOfComponentsCallbackType    m_NumberOfComponentsCallback;
-  PropagateUpdateExtentCallbackType m_PropagateUpdateExtentCallback;
-  UpdateDataCallbackType            m_UpdateDataCallback;
-  DataExtentCallbackType            m_DataExtentCallback;
-  BufferPointerCallbackType         m_BufferPointerCallback;
+  void *                            m_CallbackUserData{ nullptr };
+  UpdateInformationCallbackType     m_UpdateInformationCallback{ nullptr };
+  PipelineModifiedCallbackType      m_PipelineModifiedCallback{ nullptr };
+  WholeExtentCallbackType           m_WholeExtentCallback{ nullptr };
+  SpacingCallbackType               m_SpacingCallback{ nullptr };
+  FloatSpacingCallbackType          m_FloatSpacingCallback{ nullptr };
+  OriginCallbackType                m_OriginCallback{ nullptr };
+  FloatOriginCallbackType           m_FloatOriginCallback{ nullptr };
+  DirectionCallbackType             m_DirectionCallback{ nullptr };
+  ScalarTypeCallbackType            m_ScalarTypeCallback{ nullptr };
+  NumberOfComponentsCallbackType    m_NumberOfComponentsCallback{ nullptr };
+  PropagateUpdateExtentCallbackType m_PropagateUpdateExtentCallback{ nullptr };
+  UpdateDataCallbackType            m_UpdateDataCallback{ nullptr };
+  DataExtentCallbackType            m_DataExtentCallback{ nullptr };
+  BufferPointerCallbackType         m_BufferPointerCallback{ nullptr };
 
   std::string m_ScalarTypeName;
 };

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -94,22 +94,6 @@ VTKImageImport<TOutputImage>::VTKImageImport()
   {
     itkExceptionMacro(<< "Type currently not supported");
   }
-  m_DataExtentCallback = nullptr;
-  m_WholeExtentCallback = nullptr;
-  m_BufferPointerCallback = nullptr;
-  m_UpdateDataCallback = nullptr;
-  m_PipelineModifiedCallback = nullptr;
-  m_NumberOfComponentsCallback = nullptr;
-  m_SpacingCallback = nullptr;
-  m_FloatSpacingCallback = nullptr;
-  m_OriginCallback = nullptr;
-  m_FloatOriginCallback = nullptr;
-  m_DirectionCallback = nullptr;
-  m_UpdateInformationCallback = nullptr;
-  m_ScalarTypeCallback = nullptr;
-  m_DataExtentCallback = nullptr;
-  m_PropagateUpdateExtentCallback = nullptr;
-  m_CallbackUserData = nullptr;
 }
 
 /**

--- a/Modules/Core/Common/include/itkCommand.h
+++ b/Modules/Core/Common/include/itkCommand.h
@@ -139,15 +139,11 @@ public:
   }
 
 protected:
-  T *                         m_This;
-  TMemberFunctionPointer      m_MemberFunction;
-  TConstMemberFunctionPointer m_ConstMemberFunction;
+  T *                         m_This{ nullptr };
+  TMemberFunctionPointer      m_MemberFunction{ nullptr };
+  TConstMemberFunctionPointer m_ConstMemberFunction{ nullptr };
 
-  MemberCommand()
-    : m_This(nullptr)
-    , m_MemberFunction(nullptr)
-    , m_ConstMemberFunction(nullptr)
-  {}
+  MemberCommand() = default;
 
   ~MemberCommand() override = default;
 };
@@ -210,13 +206,10 @@ public:
   }
 
 protected:
-  T *                    m_This;
-  TMemberFunctionPointer m_MemberFunction;
+  T *                    m_This{ nullptr };
+  TMemberFunctionPointer m_MemberFunction{ nullptr };
 
-  ReceptorMemberCommand()
-    : m_This(nullptr)
-    , m_MemberFunction(nullptr)
-  {}
+  ReceptorMemberCommand() = default;
 
   ~ReceptorMemberCommand() override = default;
 };
@@ -277,13 +270,10 @@ public:
   }
 
 protected:
-  T *                    m_This;
-  TMemberFunctionPointer m_MemberFunction;
+  T *                    m_This{ nullptr };
+  TMemberFunctionPointer m_MemberFunction{ nullptr };
 
-  SimpleMemberCommand()
-    : m_This(nullptr)
-    , m_MemberFunction(nullptr)
-  {}
+  SimpleMemberCommand() = default;
 
   ~SimpleMemberCommand() override = default;
 };
@@ -344,13 +334,10 @@ public:
   }
 
 protected:
-  const T *              m_This;
-  TMemberFunctionPointer m_MemberFunction;
+  const T *              m_This{ nullptr };
+  TMemberFunctionPointer m_MemberFunction{ nullptr };
 
-  SimpleConstMemberCommand()
-    : m_This(nullptr)
-    , m_MemberFunction(nullptr)
-  {}
+  SimpleConstMemberCommand() = default;
 
   ~SimpleConstMemberCommand() override = default;
 };


### PR DESCRIPTION
Using `nullptr` as default-member-initializer of all their internal pointers.

Following C++ Core Guidelines, September 23, 2022, "Prefer in-class initializers to member initializers in constructors for constant initializers", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer