### PR TITLE
VXL 2022-12-23 (8169cc76)

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/vcl/tests/test_include.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/vcl/tests/test_include.cxx
@@ -52,6 +52,6 @@
 #endif
 
 #include <vcl_where_root_dir.h>
-#include <vcl_deprecated.h>
+// #include <vcl_deprecated.h> // This causes compile warnings
 
 int main() { return 0; }

--- a/Modules/ThirdParty/VNL/src/vxl/vcl/vcl_deprecated.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/vcl/vcl_deprecated.cxx
@@ -1,8 +1,6 @@
 // This is vcl/vcl_deprecated.cxx
 #include <iostream>
 #include <cstdlib>
-#include "vcl_deprecated.h"
-
 
 
 #ifdef VXL_WARN_DEPRECATED_ABORT


### PR DESCRIPTION
Code extracted from:

    https://github.com/vxl/vxl.git

at commit 8169cc7697c258fd820ab4b25d13a3e98f93bb99 (master)

Aimed at fixing `CL : warning : vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants. [M:\Dashboard\ITK-build\Modules\ThirdParty\VNL\src\vxl\vcl\itkvcl.vcxproj]`, see [dashboard](https://open.cdash.org/viewBuildError.php?type=1&buildid=8360676).

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
