### PR TITLE
STYLE:  Prefer using exception macros in tests

### DIFF
--- a/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
@@ -88,16 +88,8 @@ InternalTest(int argc, char * argv[])
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   // Store the input image for convenience
   typename ImageType::Pointer image = reader->GetOutput();
@@ -158,15 +150,8 @@ InternalTest(int argc, char * argv[])
   // Set the input mesh for the parametric filter
   parametricFilter->SetInput(mesh);
 
-  try
-  {
-    parametricFilter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Error: " << e.what() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(parametricFilter->Update());
+
 
   if (parametricFilter->GetOutput()->GetNumberOfPoints() != mesh->GetNumberOfPoints())
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
@@ -107,16 +107,8 @@ itkGrayscaleGeodesicErodeDilateImageFilterTest(int argc, char * argv[])
   itk::SimpleFilterWatcher watchDilate(dilate);
   itk::SimpleFilterWatcher watchErode(erode);
 
-  // Execute the filter
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception caught:" << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -315,18 +315,8 @@ itkLBFGSBOptimizerv4Test(int, char *[])
   itkOptimizer->AddObserver(itk::IterationEvent(), eventChecker);
   itkOptimizer->AddObserver(itk::EndEvent(), eventChecker);
 
-  try
-  {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during Optimization" << std::endl;
-    std::cerr << "Location    = " << e.GetLocation() << std::endl;
-    std::cerr << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
+
 
   const OptimizerType::ParametersType & finalPosition = itkOptimizer->GetCurrentPosition();
 
@@ -400,18 +390,8 @@ itkLBFGSBOptimizerv4Test(int, char *[])
   metric->SetParameters(initialValue);
   itkOptimizer->SetNumberOfIterations(1);
 
-  try
-  {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during Optimization" << std::endl;
-    std::cerr << "Location    = " << e.GetLocation() << std::endl;
-    std::cerr << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
+
 
   std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
@@ -458,18 +438,8 @@ itkLBFGSBOptimizerv4Test(int, char *[])
   itkOptimizer2->AddObserver(itk::IterationEvent(), eventChecker);
   itkOptimizer2->AddObserver(itk::EndEvent(), eventChecker);
 
-  try
-  {
-    itkOptimizer2->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during Optimization" << std::endl;
-    std::cerr << "Location    = " << e.GetLocation() << std::endl;
-    std::cerr << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer2->StartOptimization());
+
 
   std::cout << "Boundaries after optimization: " << std::endl;
   std::cout << "Upper bound size: " << itkOptimizer2->GetUpperBound().size() << std::endl;

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -211,18 +211,8 @@ itkPowellOptimizerv4Test(int argc, char * argv[])
   itkOptimizer->SetMetricWorstPossibleValue(metricWorstPossibleValue);
   ITK_TEST_SET_GET_VALUE(metricWorstPossibleValue, itkOptimizer->GetMetricWorstPossibleValue());
 
-  try
-  {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cout << "Exception thrown ! " << std::endl;
-    std::cout << "An error occurred during Optimization" << std::endl;
-    std::cout << "Location    = " << e.GetLocation() << std::endl;
-    std::cout << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
+
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -294,79 +294,26 @@ itkImageToSpatialObjectRegistrationTest(int, char *[])
   std::cout << "Number of Parameters  : " << metric->GetNumberOfParameters() << std::endl;
   ITK_TEST_EXPECT_EQUAL(metric->GetNumberOfParameters(), 3);
 
-  bool catching;
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   registration->SetFixedImage(image);
   ITK_TEST_SET_GET_VALUE(image, registration->GetFixedImage());
 
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   registration->SetMovingSpatialObject(group);
   ITK_TEST_SET_GET_VALUE(group, registration->GetMovingSpatialObject());
 
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   registration->SetMetric(metric);
   ITK_TEST_SET_GET_VALUE(metric, registration->GetMetric());
 
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   /** Setup the optimizer */
   TransformType::ParametersType m_ParametersScale;
@@ -410,42 +357,14 @@ itkImageToSpatialObjectRegistrationTest(int, char *[])
   registration->SetOptimizer(optimizer);
   ITK_TEST_SET_GET_VALUE(optimizer, registration->GetOptimizer());
 
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
-
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   registration->SetTransform(transform);
   ITK_TEST_SET_GET_VALUE(transform, registration->GetTransform());
 
-
-  try
-  {
-    catching = false;
-    registration->Update();
-  }
-  catch (...)
-  {
-    catching = true;
-  }
-
-  if (!catching)
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test exception
+  ITK_TRY_EXPECT_EXCEPTION(registration->Update());
 
   registration->SetInterpolator(interpolator);
   ITK_TEST_SET_GET_VALUE(interpolator, registration->GetInterpolator());

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -255,60 +255,23 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   std::cout << "movingImage:" << std::endl;
   ANTSNeighborhoodCorrelationImageToImageMetricv4Test_PrintImage(movingImage);
 
-  /* Initialize. */
-  try
-  {
-    std::cout << "Calling Initialize..." << std::endl;
-    metric->Initialize();
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during Initialize: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Initialize
+  ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
+
 
   // Evaluate
   MetricType::MeasureType    valueReturn1;
   MetricType::DerivativeType derivativeReturn;
-  try
-  {
-    std::cout << "Calling GetValueAndDerivative..." << std::endl;
-    metric->GetValueAndDerivative(valueReturn1, derivativeReturn);
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during GetValueAndDerivative: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn1, derivativeReturn));
 
-  /* Re-initialize. */
-  try
-  {
-    std::cout << "Calling Initialize..." << std::endl;
-    metric->Initialize();
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during re-initialize: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Re-initialize
+  ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
+
 
   // Evaluate with GetValue
   MetricType::MeasureType valueReturn2;
-  try
-  {
-    std::cout << "Calling GetValue..." << std::endl;
-    valueReturn2 = metric->GetValue();
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during GetValue: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn2 = metric->GetValue());
+
 
   // Test same value returned by different methods
   std::cout << "Check Value return values..." << std::endl;
@@ -362,31 +325,13 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   metricSparse->SetFixedSampledPointSet(pset);
   metricSparse->SetUseSampledPointSet(true);
 
-  try
-  {
-    metricSparse->Initialize();
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during Initialize() for sparse threader: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(metricSparse->Initialize());
+
 
   MetricType::MeasureType    valueReturnSparse;
   MetricType::DerivativeType derivativeReturnSparse;
+  ITK_TRY_EXPECT_NO_EXCEPTION(metricSparse->GetValueAndDerivative(valueReturnSparse, derivativeReturnSparse));
 
-  try
-  {
-    std::cout << "Calling GetValueAndDerivative..." << std::endl;
-    metricSparse->GetValueAndDerivative(valueReturnSparse, derivativeReturnSparse);
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << "Caught unexpected exception during GetValueAndDrivative() for sparse threader: " << exc;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
 
   std::cout << "Check Value return values between dense and sparse threader..." << std::endl;
   std::cout << "dense: " << valueReturn1 << ", sparse: " << valueReturnSparse << std::endl;

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -299,14 +299,8 @@ itkParallelSparseFieldLevelSetImageFilterTest(int argc, char * argv[])
   mf->SetNumberOfWorkUnits(numberOfWorkUnits);
   mf->SetNumberOfLayers(3);
 
-  try
-  {
-    mf->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << e << std::endl;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(mf->Update());
+
 
   mf->GetOutput()->Print(std::cout);
 


### PR DESCRIPTION
Use the `ITK_TRY_EXPECT_EXCEPTION` and `ITK_TRY_EXPECT_NO_EXCEPTION`
macros in tests in lieu of `try/catch` blocks for the sake of
readability and compactness, and to save typing/avoid boilerplate code.

Remove unnecessary print messages that inform about the method being
called.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)