### PR TITLE
ENH: Use `itkPrintSelfObjectMacro` to print objects that can be null

### DIFF
--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
@@ -39,7 +39,8 @@ void
 PointSetFunction<TInputPointSet, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "InputPointSet: " << m_PointSet.GetPointer() << std::endl;
+
+  itkPrintSelfObjectMacro(PointSet);
 }
 
 /**


### PR DESCRIPTION
Use `itkPrintSelfObjectMacro` to print objects that can be null.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)