### PR TITLE
DOC: Release process updates for 5.3.0

### DIFF
--- a/Utilities/Maintenance/DownloadLinksCookieCutter/cookiecutter.json
+++ b/Utilities/Maintenance/DownloadLinksCookieCutter/cookiecutter.json
@@ -3,6 +3,5 @@
     "major_version": "5",
     "minor_version": "0",
     "patch_identifier": [".", "a", "b", "rc"],
-    "patch_version": "0",
-    "doxygen_html_download_url": "https://data.kitware.com/api/v1/file/5b22a8378d777f2e622564e2/download"
+    "patch_version": "0"
 }

--- a/Utilities/Maintenance/DownloadLinksCookieCutter/{{cookiecutter.output_directory}}/ReleaseDownloadLinks.html
+++ b/Utilities/Maintenance/DownloadLinksCookieCutter/{{cookiecutter.output_directory}}/ReleaseDownloadLinks.html
@@ -53,20 +53,10 @@
 <td><a href="https://github.com/InsightSoftwareConsortium/ITK/releases/download/v{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}/InsightSphinxExamplesHtml-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.zip">InsightSphinxExamplesHtml-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.zip</a></td>
 </tr>
 
-<tr bgcolor="#f0f0f0">
-<td></td>
-<td><a href="https://github.com/InsightSoftwareConsortium/ITK/releases/download/v{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}/InsightSphinxExamplesEpub-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.epub">InsightSphinxExamplesEpub-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.epub</a></td>
-</tr>
-
-<tr bgcolor="#f0f0f0">
-<td></td>
-<td><a href="https://github.com/InsightSoftwareConsortium/ITK/releases/download/v{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}/InsightSphinxExamplesPdf-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.pdf">InsightSphinxExamplesPdf-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.pdf</a></td>
-</tr>
-
 <tr>
 <td><a href="https://itk.org/Doxygen{{ cookiecutter.major_version}}{{ cookiecutter.minor_version }}/html/">API Documentation</a></td>
-<td><a href="{{ cookiecutter.doxygen_html_download_url }}">InsightDoxygenDocHtml-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{
-cookiecutter.patch_version }}.tar.gz</a></td>
+<td><a
+href="https://github.com/InsightSoftwareConsortium/ITK/releases/download/v{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}/InsightDoxygenDocHtml-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.tar.gz">InsightDoxygenDocHtml-{{ cookiecutter.major_version }}.{{cookiecutter.minor_version }}{{ cookiecutter.patch_identifier }}{{ cookiecutter.patch_version }}.tar.gz</a></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Notes:

- Remove Sphinx Epub, Pdf for simplicity
- Doxygen HTML is now small enough to be hosted on GitHub Releases
- Versioned Doxygen upload process has changed
- Wheel build artifact uploads have changed (more manylinux, macos ARM)
