### PR TITLE
COMP: Fix missing initialization braces warnings

### DIFF
--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
@@ -208,7 +208,7 @@ protected:
 
 private:
   SizeValueType      m_SizeGreatestPrimeFactor;
-  InternalSizeType   m_FFTPadSize{ 0 };
+  InternalSizeType   m_FFTPadSize{ { 0 } };
   InternalRegionType m_PaddedInputRegion;
 };
 } // namespace itk

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
@@ -32,7 +32,7 @@ GenerateGaussianKernelForSubregionTest()
   using SourceType = itk::GaussianImageSource<KernelImageType>;
   using KernelSizeType = typename SourceType::SizeType;
   auto           source = SourceType::New();
-  KernelSizeType kernelSize{ 3, 5 };
+  KernelSizeType kernelSize{ { 3, 5 } };
   source->SetSize(kernelSize);
   source->SetMean(2);
   source->SetSigma(3.0);

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -238,7 +238,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   using MetricTypePointer = MetricType::Pointer;
   MetricTypePointer metric = MetricType::New();
 
-  const itk::Size<ImageDimension> neighborhoodRadius0{ 1 };
+  const itk::Size<ImageDimension> neighborhoodRadius0{ { 1 } };
 
   metric->SetRadius(neighborhoodRadius0);
   ITK_TEST_SET_GET_VALUE(neighborhoodRadius0, metric->GetRadius());


### PR DESCRIPTION
Fix missing initialization braces warnings.

Fixes:
```
[CTest: warning matched]
Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h:211:36:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  InternalSizeType   m_FFTPadSize{ 0 };
                                   ^
                                   {}
```

and warnings of the same kind reported at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8365102

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)