### PR TITLE
BUG: Fix Superclass name in RTTI macro

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
@@ -101,7 +101,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MovingHistogramImageFilter, MovingHistogramImageFilter);
+  itkTypeMacro(MovingHistogramImageFilter, MovingHistogramImageFilterBase);
 
   /** Image related type alias. */
   using InputImageType = TInputImage;

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -122,7 +122,7 @@ public:
   using ParametersType = Superclass::ParametersType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageToSpatialObjectMetric, Object);
+  itkTypeMacro(ImageToSpatialObjectMetric, SingleValuedCostFunction);
 
   /** Get/Set the FixedImage. */
   itkSetConstObjectMacro(FixedImage, FixedImageType);


### PR DESCRIPTION
Fix Superclass name in RTTI macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)