### PR TITLE
ENH: Increase coverage for `itk::OnePlusOneEvolutionaryOptimizer`

### DIFF
--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -73,6 +73,8 @@ OnePlusOneEvolutionaryOptimizer::Initialize(double initialRadius, double grow, d
   {
     m_ShrinkFactor = shrink;
   }
+
+  m_Initialized = true;
 }
 
 void

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -225,18 +225,8 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
 
   itkOptimizer->SetInitialPosition(initialPosition);
 
-  try
-  {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cout << "Exception thrown ! " << std::endl;
-    std::cout << "An error occurred during Optimization" << std::endl;
-    std::cout << "Location    = " << e.GetLocation() << std::endl;
-    std::cout << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
+
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -153,6 +153,9 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
   // Declaration of an itkOptimizer
   auto itkOptimizer = OptimizerType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(itkOptimizer, OnePlusOneEvolutionaryOptimizer, SingleValuedNonLinearOptimizer);
+
+
   ITK_TEST_EXPECT_TRUE(!itkOptimizer->GetInitialized());
 
   itk::OnePlusOneCommandIterationUpdate::Pointer observer = itk::OnePlusOneCommandIterationUpdate::New();
@@ -175,11 +178,44 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
   initialPosition[0] = 100;
   initialPosition[1] = -100;
 
+  auto maximize = false;
   itkOptimizer->MinimizeOn();
-  itkOptimizer->Initialize(10);
-  itkOptimizer->SetEpsilon(0.1);
-  itkOptimizer->SetMaximumIteration(8000);
+  ITK_TEST_SET_GET_VALUE(!maximize, itkOptimizer->GetMinimize());
+  ITK_TEST_SET_GET_BOOLEAN(itkOptimizer, Maximize, maximize);
 
+  unsigned int maximumIteration = 8000;
+  itkOptimizer->SetMaximumIteration(8000);
+  ITK_TEST_SET_GET_VALUE(maximumIteration, itkOptimizer->GetMaximumIteration());
+
+  auto growthFactor = 1.05;
+  itkOptimizer->SetGrowthFactor(growthFactor);
+  ITK_TEST_SET_GET_VALUE(growthFactor, itkOptimizer->GetGrowthFactor());
+
+  auto shrinkFactor = std::pow(growthFactor, -0.25);
+  itkOptimizer->SetShrinkFactor(shrinkFactor);
+  ITK_TEST_SET_GET_VALUE(shrinkFactor, itkOptimizer->GetShrinkFactor());
+
+  auto initialRadius = 1.01;
+  itkOptimizer->SetInitialRadius(initialRadius);
+  ITK_TEST_SET_GET_VALUE(initialRadius, itkOptimizer->GetInitialRadius());
+
+  auto epsilon = 0.1;
+  itkOptimizer->SetEpsilon(epsilon);
+  ITK_TEST_SET_GET_VALUE(epsilon, itkOptimizer->GetEpsilon());
+
+  auto catchGetValueException = false;
+  itkOptimizer->SetCatchGetValueException(catchGetValueException);
+  ITK_TEST_SET_GET_VALUE(catchGetValueException, itkOptimizer->GetCatchGetValueException());
+
+  auto metricWorstPossibleValue = 0;
+  itkOptimizer->SetMetricWorstPossibleValue(metricWorstPossibleValue);
+  ITK_TEST_SET_GET_VALUE(metricWorstPossibleValue, itkOptimizer->GetMetricWorstPossibleValue());
+
+  initialRadius = 10;
+  itkOptimizer->Initialize(initialRadius);
+  ITK_TEST_SET_GET_VALUE(initialRadius, itkOptimizer->GetInitialRadius());
+  ITK_TEST_SET_GET_VALUE(growthFactor, itkOptimizer->GetGrowthFactor());
+  ITK_TEST_SET_GET_VALUE(shrinkFactor, itkOptimizer->GetShrinkFactor());
 
   ITK_TEST_EXPECT_TRUE(itkOptimizer->GetInitialized());
 

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -20,6 +20,7 @@
 #include "itkNormalVariateGenerator.h"
 #include "itkCommand.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 namespace itk
 {
@@ -152,6 +153,8 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
   // Declaration of an itkOptimizer
   auto itkOptimizer = OptimizerType::New();
 
+  ITK_TEST_EXPECT_TRUE(!itkOptimizer->GetInitialized());
+
   itk::OnePlusOneCommandIterationUpdate::Pointer observer = itk::OnePlusOneCommandIterationUpdate::New();
   itkOptimizer->AddObserver(itk::IterationEvent(), observer);
 
@@ -177,6 +180,8 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
   itkOptimizer->SetEpsilon(0.1);
   itkOptimizer->SetMaximumIteration(8000);
 
+
+  ITK_TEST_EXPECT_TRUE(itkOptimizer->GetInitialized());
 
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
   auto generator = GeneratorType::New();

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -145,9 +145,6 @@ private:
 int
 itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
 {
-  std::cout << "Gradient Descent Optimizer Test ";
-  std::cout << std::endl << std::endl;
-
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
 
   // Declaration of an itkOptimizer

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -193,9 +193,6 @@ private:
 int
 itkOnePlusOneEvolutionaryOptimizerv4Test(int, char *[])
 {
-  std::cout << "OnePlusOne Evolutionary Optimizer Test ";
-  std::cout << std::endl << std::endl;
-
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizerv4<double>;
 
   // Declaration of an itkOptimizer

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -260,18 +260,8 @@ itkOnePlusOneEvolutionaryOptimizerv4Test(int, char *[])
   std::cout << "Set metric parameters." << std::endl;
   metric->SetParameters(initialPosition);
 
-  try
-  {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cout << "Exception thrown ! " << std::endl;
-    std::cout << "An error occurred during Optimization" << std::endl;
-    std::cout << "Location    = " << e.GetLocation() << std::endl;
-    std::cout << "Description = " << e.GetDescription() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
+
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";


### PR DESCRIPTION
- BUG: Set ivar to appropriate value when condition is met
- ENH: Increase coverage for `itk::OnePlusOneEvolutionaryOptimizer`
- STYLE: Prefer using exception macros in tests
- STYLE: Remove unnecessary test starting message

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)