### PR TITLE
ENH: Increase coverage for `itk::ImageRegistrationMethodv4`

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -203,6 +203,17 @@ PerformSimpleImageRegistration(int argc, char * argv[])
     ITK_TEST_SET_GET_VALUE(smoothingSigmasPerLevel, affineSimple->GetSmoothingSigmasPerLevel());
   }
 
+  typename AffineRegistrationType::RealType metricSamplingPercentage = 1.0;
+  affineSimple->SetMetricSamplingPercentage(metricSamplingPercentage);
+
+  typename AffineRegistrationType::MetricSamplingPercentageArrayType metricSamplingPercentagePerLevel;
+  metricSamplingPercentagePerLevel.SetSize(numberOfLevels);
+  metricSamplingPercentagePerLevel.Fill(metricSamplingPercentage);
+  ITK_TEST_SET_GET_VALUE(metricSamplingPercentagePerLevel, affineSimple->GetMetricSamplingPercentagePerLevel());
+
+  affineSimple->SetMetricSamplingPercentagePerLevel(metricSamplingPercentagePerLevel);
+  ITK_TEST_SET_GET_VALUE(metricSamplingPercentagePerLevel, affineSimple->GetMetricSamplingPercentagePerLevel());
+
   using GradientDescentOptimizerv4Type = itk::GradientDescentOptimizerv4;
   typename GradientDescentOptimizerv4Type::Pointer affineOptimizer =
     dynamic_cast<GradientDescentOptimizerv4Type *>(affineSimple->GetModifiableOptimizer());


### PR DESCRIPTION
Increase coverage for `itk::ImageRegistrationMethodv4`:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)