### PR TITLE
ENH: Increase coverage for `itk::RecursiveGaussianImageFilter`

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -178,6 +178,7 @@ public:
      */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
+  itkBooleanMacro(NormalizeAcrossScale);
 
   /** Set/Get the Order of the Gaussian to convolve with.
       \li ZeroOrder is equivalent to convolving with a Gaussian.  This

--- a/Modules/Filtering/Smoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/Smoothing/test/CMakeLists.txt
@@ -12,9 +12,9 @@ itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
 itkMeanImageFilterTest.cxx
 itkDiscreteGaussianImageFilterTest.cxx
 itkMedianImageFilterTest.cxx
-itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
-itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
-itkRecursiveGaussianImageFiltersTest.cxx
+itkRecursiveGaussianImageFilterOnTensorsTest.cxx
+itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+itkRecursiveGaussianImageFilterTest.cxx
 itkRecursiveGaussianScaleSpaceTest1.cxx
 )
 
@@ -161,12 +161,12 @@ itk_add_test(NAME itkFFTDiscreteGaussianImageFilterFactoryTest
       COMMAND ITKSmoothingTestDriver itkFFTDiscreteGaussianImageFilterFactoryTest)
 itk_add_test(NAME itkMedianImageFilterTest
       COMMAND ITKSmoothingTestDriver itkMedianImageFilterTest)
-itk_add_test(NAME itkRecursiveGaussianImageFiltersOnTensorsTest
-      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFiltersOnTensorsTest)
-itk_add_test(NAME itkRecursiveGaussianImageFiltersOnVectorImageTest
-      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFiltersOnVectorImageTest)
-itk_add_test(NAME itkRecursiveGaussianImageFiltersTest
-      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFiltersTest)
+itk_add_test(NAME itkRecursiveGaussianImageFilterOnTensorsTest
+      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFilterOnTensorsTest)
+itk_add_test(NAME itkRecursiveGaussianImageFilterOnVectorImageTest
+      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFilterOnVectorImageTest)
+itk_add_test(NAME itkRecursiveGaussianImageFilterTest
+      COMMAND ITKSmoothingTestDriver itkRecursiveGaussianImageFilterTest)
 itk_add_test(NAME itkRecursiveGaussianScaleSpaceTest1
       COMMAND ITKSmoothingTestDriver
               itkRecursiveGaussianScaleSpaceTest1)

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -16,37 +16,35 @@
  *
  *=========================================================================*/
 #include "itkRecursiveGaussianImageFilter.h"
-#include "itkSymmetricSecondRankTensor.h"
+#include "itkVectorImage.h"
 #include "itkTestingMacros.h"
 
 int
-itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
+itkRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
 {
-  // In this test, we will create a 9x9 image of tensors with pixels (4,4)
-  // and (1,6) set to 'tensor1'. We will filter it using
+  // In this test, we will create a 9x9 image of vectors with pixels (4,4)
+  // and (1,6) set to 'vector1'. We will filter it using
   // RecursiveGaussianImageFilter and compare a few filtered pixels.
   //
   constexpr unsigned int Dimension = 2;
   constexpr double       sigma = 1;
   constexpr double       tolerance = 0.001;
 
-  // Create ON and OFF tensors.
-  using Double3DTensorType = itk::SymmetricSecondRankTensor<double, 3>;
-  Double3DTensorType tensor0(0.0);
-  Double3DTensorType tensor1;
-  tensor1(0, 0) = 1.0;
-  tensor1(0, 1) = 0.0;
-  tensor1(0, 2) = 0.0;
-  tensor1(1, 0) = 0.0; // overrides (0,1)
-  tensor1(1, 1) = 3.0;
-  tensor1(1, 2) = 0.0;
-  tensor1(2, 0) = 0.0; // overrides (0,2)
-  tensor1(2, 1) = 0.0; // overrides (1,2)
-  tensor1(2, 2) = 1.0;
-
-  using PixelType = Double3DTensorType;
-  using ImageType = itk::Image<PixelType, Dimension>;
+  constexpr unsigned int NumberOfComponents = 4;
+  using PixelComponentType = double;
+  using ImageType = itk::VectorImage<PixelComponentType, Dimension>;
+  using PixelType = ImageType::PixelType;
   using ConstIteratorType = itk::ImageLinearConstIteratorWithIndex<ImageType>;
+
+  // Create ON and OFF vectors.
+  PixelType vector0;
+  PixelType vector1;
+
+  vector0.SetSize(NumberOfComponents);
+  vector1.SetSize(NumberOfComponents);
+
+  vector0.Fill(0.0);
+  vector1.Fill(1.0);
 
   // Create the 9x9 input image
   ImageType::SizeType size;
@@ -58,8 +56,9 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
   region.SetIndex(index);
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region);
+  inputImage->SetNumberOfComponentsPerPixel(NumberOfComponents);
   inputImage->Allocate();
-  inputImage->FillBuffer(tensor0);
+  inputImage->FillBuffer(vector0);
 
   std::cout << "Apply RecursiveGaussianImageFilter with a 9x9 image, pixels (4,4) "
             << "and (1,6) set to ON." << std::endl;
@@ -69,10 +68,10 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
    */
   index[0] = 4;
   index[1] = 4;
-  inputImage->SetPixel(index, tensor1);
+  inputImage->SetPixel(index, vector1);
   index[0] = 1;
   index[1] = 6;
-  inputImage->SetPixel(index, tensor1);
+  inputImage->SetPixel(index, vector1);
 
   // Gaussian filter this image now. Each component of the tensor
   // is filtered independently.
@@ -100,34 +99,21 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
   ConstIteratorType  cit(filteredImage, filteredImage->GetRequestedRegion());
   cit.SetDirection(0);
 
-  /* Print out all Tensor values.
-  for ( cit.GoToBegin(); ! cit.IsAtEnd(); cit.NextLine())
-    {
-    cit.GoToBeginOfLine();
-    while ( ! cit.IsAtEndOfLine() )
-      {
-      std::cout << "Tensor at index: " << cit.GetIndex() << " is " <<
-        cit.Get() << std::endl;
-      ++cit;
-      }
-    }
-  */
-
   index[0] = 4;
   index[1] = 4;
   cit.SetIndex(index);
-  if (itk::Math::abs(cit.Get()(0, 0) - 0.160313) > tolerance)
+  if (itk::Math::abs(cit.Get()[0] - 0.160313) > tolerance)
   {
-    std::cout << "[FAILED] Tensor(0,0) at index (4,4) must be 0.1603 but is " << cit.Get()(0, 0) << std::endl;
+    std::cout << "[FAILED] Tensor(0,0) at index (4,4) must be 0.1603 but is " << cit.Get()[0] << std::endl;
     return EXIT_FAILURE;
   }
 
   index[0] = 6;
   index[1] = 6;
   cit.SetIndex(index);
-  if (itk::Math::abs(cit.Get()(3, 3) - 0.0026944) > tolerance)
+  if (itk::Math::abs(cit.Get()[3] - 0.0026944) > tolerance)
   {
-    std::cout << "[FAILED] Tensor(3,3) at index (6,6) must be 0.0026944 but is " << cit.Get()(3, 3) << std::endl;
+    std::cout << "[FAILED] Tensor(3,3) at index (6,6) must be 0.0026944 but is " << cit.Get()[3] << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -110,11 +110,23 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     // Create a  Filter
     auto filter = myGaussianFilterType::New();
 
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, RecursiveGaussianImageFilter, RecursiveSeparableImageFilter);
+
+
+    unsigned int direction = 2; // apply along Z
+    filter->SetDirection(direction);
+    ITK_TEST_SET_GET_VALUE(direction, filter->GetDirection());
+
+    auto order = itk::GaussianOrderEnum::ZeroOrder;
+    filter->SetOrder(order);
+    ITK_TEST_SET_GET_VALUE(order, filter->GetOrder());
+
+    filter->SetZeroOrder();
+    ITK_TEST_SET_GET_VALUE(order, filter->GetOrder());
 
     // Connect the input images
     filter->SetInput(inputImage);
-    filter->SetDirection(2); // apply along Z
-    filter->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+    ITK_TEST_SET_GET_VALUE(inputImage, filter->GetInput());
 
 
     // Execute the filter
@@ -126,12 +138,17 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     // Create a  Filter
     auto filter1 = myGaussianFilterType::New();
 
+    filter1->SetDirection(direction);
+
+    order = itk::GaussianOrderEnum::FirstOrder;
+    filter1->SetOrder(order);
+    ITK_TEST_SET_GET_VALUE(order, filter1->GetOrder());
+
+    filter1->SetFirstOrder();
+    ITK_TEST_SET_GET_VALUE(order, filter1->GetOrder());
 
     // Connect the input images
     filter1->SetInput(inputImage);
-    filter1->SetDirection(2); // apply along Z
-    filter1->SetOrder(itk::GaussianOrderEnum::FirstOrder);
-
 
     // Execute the filter1
     std::cout << "Executing First Derivative filter...";
@@ -141,10 +158,17 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     // Create a  Filter
     auto filter2 = myGaussianFilterType::New();
 
+    filter2->SetDirection(direction);
+
+    order = itk::GaussianOrderEnum::SecondOrder;
+    filter2->SetOrder(order);
+    ITK_TEST_SET_GET_VALUE(order, filter2->GetOrder());
+
+    filter2->SetSecondOrder();
+    ITK_TEST_SET_GET_VALUE(order, filter2->GetOrder());
+
     // Connect the input images
     filter2->SetInput(inputImage);
-    filter2->SetDirection(2); // apply along Z
-    filter2->SetOrder(itk::GaussianOrderEnum::SecondOrder);
 
     // Execute the filter2
     std::cout << "Executing Second Derivative filter...";
@@ -203,6 +227,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
 
       constexpr double sigmaA = 2.0;
       filter->SetSigma(sigmaA);
+      ITK_TEST_SET_GET_VALUE(sigmaA, filter->GetSigma());
+
       filter->Update();
 
       const PixelType valueA = filter->GetOutput()->GetPixel(index);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -198,7 +198,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     std::cout << "Testing normalization across scales...  ";
     { // begin of test for normalization across scales
 
-      filter->SetNormalizeAcrossScale(true);
+      auto normalizeAcrossScale = true;
+      ITK_TEST_SET_GET_BOOLEAN(filter, NormalizeAcrossScale, normalizeAcrossScale);
 
       constexpr double sigmaA = 2.0;
       filter->SetSigma(sigmaA);
@@ -206,8 +207,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
 
       const PixelType valueA = filter->GetOutput()->GetPixel(index);
 
-
-      filter->SetNormalizeAcrossScale(false);
+      normalizeAcrossScale = false;
+      filter->SetNormalizeAcrossScale(normalizeAcrossScale);
       constexpr double sigmaB = 2.0;
       filter->SetSigma(sigmaB);
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -28,7 +28,7 @@
 
 
 int
-itkRecursiveGaussianImageFiltersTest(int, char *[])
+itkRecursiveGaussianImageFilterTest(int, char *[])
 {
 
   { // 3D test


### PR DESCRIPTION
- STYLE: Use canonical naming in itkRecursiveGaussianImageFilter tests
- ENH: Add boolean macro to across-scale normalization ivar
- ENH: Increase coverage for `itk::RecursiveGaussianImageFilter`

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)