### PR TITLE
STYLE: Move ObjectFactorBase `OverrideInformation` to unnamed namespace

### DIFF
--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -204,18 +204,6 @@ public:
   const char *
   GetLibraryPath();
 
-  /** \class OverrideInformation
-   * \brief Internal implementation class for ObjectFactorBase.
-   * \ingroup ITKCommon
-   */
-  struct OverrideInformation
-  {
-    std::string                       m_Description;
-    std::string                       m_OverrideWithName;
-    bool                              m_EnabledFlag;
-    CreateObjectFunctionBase::Pointer m_CreateObject;
-  };
-
   /** Registers the specified internal factory only once, even when `RegisterInternalFactoryOnce<TFactory>()` is called
    * multiple times (possibly even by multiple threads) for the very same factory. */
   template <typename TFactory>

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -40,6 +40,18 @@
 
 namespace
 {
+/** \class OverrideInformation
+ * \brief Internal implementation class for ObjectFactorBase.
+ * \ingroup ITKCommon
+ */
+struct OverrideInformation
+{
+  std::string                            m_Description;
+  std::string                            m_OverrideWithName;
+  bool                                   m_EnabledFlag;
+  itk::CreateObjectFunctionBase::Pointer m_CreateObject;
+};
+
 
 using FactoryListType = std::list<itk::ObjectFactoryBase *>;
 
@@ -718,7 +730,7 @@ ObjectFactoryBase::RegisterOverride(const char *               classOverride,
                                     bool                       enableFlag,
                                     CreateObjectFunctionBase * createFunction)
 {
-  ObjectFactoryBase::OverrideInformation info;
+  OverrideInformation info;
 
   info.m_Description = description;
   info.m_OverrideWithName = subclass;


### PR DESCRIPTION
`OverrideInformation` is just an internal implementation class type of `ObjectFactorBase`, so it is not meant to be part of the interface of ObjectFactorBase.