### PR TITLE
Fix MSVC warning C26495: `ZwQuerySystemInformation`, `m_MetaDataObjectValue` uninitialized

### DIFF
--- a/Modules/Core/Common/include/itkMemoryUsageObserver.h
+++ b/Modules/Core/Common/include/itkMemoryUsageObserver.h
@@ -74,9 +74,9 @@ protected:
   using PZwQuerySystemInformation = NTSTATUS(WINAPI *)(UINT, PVOID, ULONG, PULONG);
 
   // handle ntdll.dll library
-  HMODULE m_hNTLib;
+  HMODULE m_hNTLib{ nullptr };
   // Windows native API function to query system information
-  PZwQuerySystemInformation ZwQuerySystemInformation;
+  PZwQuerySystemInformation ZwQuerySystemInformation{ nullptr };
 #  endif // defined(SUPPORT_TOOLHELP32)
 };
 #endif // defined(WIN32) || defined(_WIN32)

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -207,7 +207,7 @@ private:
    * A variable to store this derived type.
    * \author Hans J. Johnson
    */
-  MetaDataObjectType m_MetaDataObjectValue;
+  MetaDataObjectType m_MetaDataObjectValue{};
 };
 
 /**


### PR DESCRIPTION
Fixed Visual Studio 2019 Code Analysis warnings from both `MetaDataObject` and `WindowsMemoryUsageObserver`, saying:
> warning C26495: Variable is uninitialized. Always initialize a member variable (type.6)
