### PR TITLE
COMP: Fix MSVC error C2516: 'ConstIterator': is not a legal base class

### DIFF
--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -179,7 +179,7 @@ public:
   using typename Superclass::IndexValueType;
 
   /** An  iterator for the ShapedNeighborhood classes. */
-  struct Iterator : public ConstIterator
+  struct Iterator : public Superclass::ConstIterator
   {
     Iterator() = default;
     Iterator(Self * s)

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
@@ -128,8 +128,7 @@ public:
 
   /** A global data type used to store values needed to compute the time step.
    */
-  using typename Superclass::GlobalDataStruct;
-  struct ShapePriorGlobalDataStruct : public GlobalDataStruct
+  struct ShapePriorGlobalDataStruct : public Superclass::GlobalDataStruct
   {
     ScalarValueType m_MaxShapePriorChange;
   };


### PR DESCRIPTION
Originally reported by Astha, March 14, 2022, and further discussed at "ITK build Error in itk::ShapedNeighborhoodIterator", https://discourse.itk.org/t/itk-build-error-in-itk-shapedneighborhooditerator/4861