### PR TITLE
BUG: Fix uninitialized value `ImageRegistrationMethodv4::m_NumberOfLevels`

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
@@ -532,7 +532,7 @@ protected:
   SetMetricSamplePoints();
 
   SizeValueType m_CurrentLevel;
-  SizeValueType m_NumberOfLevels;
+  SizeValueType m_NumberOfLevels{ 0 };
   SizeValueType m_CurrentIteration;
   RealType      m_CurrentMetricValue;
   RealType      m_CurrentConvergenceValue;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -99,7 +99,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   this->ProcessObject::SetNthOutput(0, transformDecorator);
   this->m_OutputTransform = transformDecorator->GetModifiable();
 
-  // By default we set up a 3-level image registration.
+  // Default to a 3-level image registration: force the initialization of the ivars that depend on the number of levels.
   this->SetNumberOfLevels(3);
 
   this->m_ShrinkFactorsPerLevel.resize(this->m_NumberOfLevels);


### PR DESCRIPTION
Fix uninitialized value warning for
`itk::ImageRegistrationMethodv4::m_NumberOfLevels`.

Fixes:
```
UMC ==16463== Conditional jump or move depends on uninitialised value(s)
==16463==    at 0x9BD983: itk::ImageRegistrationMethodv4, itk::Image, itk::DisplacementFieldTransform, itk::Image, itk::PointSet > >::SetNumberOfLevels(unsigned long) (itkImageRegistrationMethodv4.hxx:881)
==16463==    by 0x9C44B6: itk::ImageRegistrationMethodv4, itk::Image, itk::DisplacementFieldTransform, itk::Image, itk::PointSet > >::ImageRegistrationMethodv4() (itkImageRegistrationMethodv4.hxx:103)
==16463==    by 0x9BBFA0: itk::SyNImageRegistrationMethod, itk::Image, itk::DisplacementFieldTransform, itk::Image, itk::PointSet > >::SyNImageRegistrationMethod() (itkSyNImageRegistrationMethod.hxx:41)
==16463==    by 0x9B5974: itk::SyNImageRegistrationMethod, itk::Image, itk::DisplacementFieldTransform, itk::Image, itk::PointSet > >::New() (itkSyNImageRegistrationMethod.h:84)
==16463==    by 0xA15CD4: itkSyNPointSetRegistrationTest(int, char**) (itkSyNPointSetRegistrationTest.cxx:132)
==16463==    by 0x317927: main (ITKRegistrationMethodsv4TestDriver.cxx:222)
```

and similar warnings triggered by registration testing code.

Visible in:
https://open.cdash.org/viewDynamicAnalysis.php?buildid=8374098

Introduced in d1c46d63be7f78d758720e1e0a463b73b30a4055.

Recover the comment highlighting the initialization to a 3-level
registration, and reword to make the need for the call (with a value
different from the current value) even more explicit.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)