### PR TITLE
BUG:  Need to initialize both seeds.

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1288,7 +1288,8 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   if (m_ReseedIterator || m_RandomSeed != seed)
   {
     m_ReseedIterator = false;
-    m_CurrentRandomSeed = m_RandomSeed = seed;
+    m_RandomSeed = seed;
+    m_CurrentRandomSeed = seed;
     this->Modified();
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1288,7 +1288,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   if (m_ReseedIterator || m_RandomSeed != seed)
   {
     m_ReseedIterator = false;
-    m_RandomSeed = seed;
+    m_CurrentRandomSeed = m_RandomSeed = seed;
     this->Modified();
   }
 }


### PR DESCRIPTION
The second seed (``m_CurrentRandomClass``) was not being initialized which led to non-reproducible behavior.

## PR Checklist
- [ X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ X] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
