### PR TITLE
COMP: Do #include "itkConfigure.h" before using `ITK_USE_WIN32_THREADS`

### DIFF
--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -20,6 +20,8 @@
 
 #include <cstdlib>
 
+#include "itkConfigure.h" // For ITK_USE_WIN32_THREADS, ITK_USE_PTHREADS, etc.
+
 // This implementation uses a routine called SignalObjectAndWait()
 // which is only defined on WinNT 4.0 or greater systems.  We need to
 // define this symbol in order to get the prototype for the
@@ -36,7 +38,6 @@
 #  include "itkWindows.h"
 #  include <winbase.h>
 #endif
-#include "itkConfigure.h"
 
 
 namespace itk


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/821 commit 5715d174cd040c8c6e1fdb5060112269f730aee3
"BUG: itkConfigure.h defines ITK_DEFAULT_MAX_THREADS", Hans Johnson (@hjmjohnson) , May 6, 2019.