### PR TITLE
COMP: Fix MSVC warning C26495: `m_PositionIndex` uninitialized

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
@@ -287,15 +287,15 @@ public:
 protected: // made protected so other iterators can access
   typename TImage::ConstWeakPointer m_Image;
 
-  IndexType m_PositionIndex; // Index where we currently are
-  IndexType m_BeginIndex;    // Index to start iterating over
-  IndexType m_EndIndex;      // Index to finish iterating:
-                             // one pixel past the end of each
-                             // row, col, slice, etc....
+  IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
+  IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
+  IndexType m_EndIndex{ { 0 } };      // Index to finish iterating:
+                                      // one pixel past the end of each
+                                      // row, col, slice, etc....
 
   RegionType m_Region; // region to iterate over
 
-  OffsetValueType m_OffsetTable[ImageDimension + 1];
+  OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
   const InternalPixelType * m_Position;
   const InternalPixelType * m_Begin;

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -256,15 +256,15 @@ public:
 protected: // made protected so other iterators can access
   typename TImage::ConstPointer m_Image;
 
-  IndexType m_PositionIndex; // Index where we currently are
-  IndexType m_BeginIndex;    // Index to start iterating over
-  IndexType m_EndIndex;      // Index to finish iterating:
-                             // one pixel past the end of each
-                             // row, col, slice, etc....
+  IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
+  IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
+  IndexType m_EndIndex{ { 0 } };      // Index to finish iterating:
+                                      // one pixel past the end of each
+                                      // row, col, slice, etc....
 
   RegionType m_Region; // region to iterate over
 
-  OffsetValueType m_OffsetTable[ImageDimension + 1];
+  OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
   bool m_Remaining;
 };


### PR DESCRIPTION
Fixed VS2019 Code Analysis warnings, saying:
> warning C26495: Variable 'm_PositionIndex' is uninitialized.
> Always initialize a member variable (type.6)

Also added in-class default member initializers to three other data members that were not yet initialized by the default-constructors of ImageConstIteratorWithIndex and ImageConstIteratorWithOnlyIndex.

Note that `ImageConstIteratorWithIndex<TImage>` and `ImageConstIteratorWithIndex<TImage>` are rather "expensive" classes (having a virtual table) and their default-constructors are already non-trivial, so the extra cost of the added initialization appears relatively low.