### PR TITLE
COMP: Fix missing initialization braces warning in Convolution test

### DIFF
--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -34,7 +34,7 @@ GenerateKernelForStreamingTest()
   using SourceType = itk::GaussianImageSource<KernelImageType>;
   using KernelSizeType = typename SourceType::SizeType;
   auto           source = SourceType::New();
-  KernelSizeType kernelSize{ 3, 5 };
+  KernelSizeType kernelSize{ { 3, 5 } };
   source->SetSize(kernelSize);
   source->SetMean(2);
   source->SetSigma(3.0);


### PR DESCRIPTION
Fix missing initialization braces warning in Convolution test.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx:37:30:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  KernelSizeType kernelSize{ 3, 5 };
                             ^~~~
                             {   }
```

reported in:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=8376254

Left behind in 5834520.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)