### PR TITLE
DOC: Remove outdated comment about sparse sampling

### DIFF
--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
@@ -84,11 +84,6 @@ namespace itk
  * derived classes, operate on meshes, images, etc.  This class computes a
  * value that measures the similarity between the two objects.
  *
- * \note Sparse sampling is not supported by this metric. An exception will be
- * thrown if m_UseSampledPointSet is set. Support for sparse sampling
- * will require a parallel implementation of the neighborhood scanning, which
- * currently caches information as the neighborhood window moves.
- *
  * \ingroup ITKMetricsv4
  */
 template <typename TFixedImage,


### PR DESCRIPTION
The comment said that sparse sampling was not allowed in itkANTSNeighborhoodCorrelationImageToImageMetricv4:

>  Sparse sampling is not supported by this metric. An exception will be
>  thrown if m_UseSampledPointSet is set. Support for sparse sampling
>  will require a parallel implementation of the neighborhood scanning, which
>  currently caches information as the neighborhood window moves.

This was true when the class was written, but a [sparse sampling implementation](https://github.com/InsightSoftwareConsortium/ITK/commit/651dcd0aecfb76e2c2ddcdd5e8bf38214408ad8f) was later added.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.