### PR TITLE
ENH: Fix `clang-format` workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
       with:
         error-message: 'Code is inconsistent with ITK Coding Style. Add the *action:ApplyClangFormat* PR label to correct.'


### PR DESCRIPTION
Fix `clang-format` linter workflow action warnings linked to `Node.js`: bump `actions/checkout` to `v3`.

Fixes:
```
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16: actions/checkout@v2.
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITK/actions/runs/3907066020

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)