### PR TITLE
BUG: transform_to_displacement_field_filter type inference

### DIFF
--- a/Modules/Filtering/DisplacementField/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/wrapping/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 if(ITK_WRAP_PYTHON)
   itk_python_add_test(NAME itkDisplacementFieldTransformPythonTest
                       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkDisplacementFieldTransformTest.py)
+  itk_python_add_test(NAME itkTransformToDisplacementFieldPythonTest
+                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkTransformToDisplacementFieldTest.py)
 endif()

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
@@ -1,0 +1,29 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+import numpy as np
+import itk
+
+itk.auto_progress(2)
+
+img = itk.image_from_array(np.zeros((10, 10, 10)))
+transform = itk.IdentityTransform[itk.D, 3].New()
+field = itk.transform_to_displacement_field_filter(
+    transform,
+    reference_image=img,
+    use_reference_image=True)
+print(field)


### PR DESCRIPTION
Customize implementation since we do not have a image arg that can used to infer the filter type.

Output type is itk.Imgae[itk.Vector[itk.F, output_dim], output_dim] because that is what is wrapped.

Closes #3860