### PR TITLE
DOC: Clean up method Doxygen documentation

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
@@ -69,7 +69,9 @@ public:
   using ExporterFilterPointer = typename ExporterFilterType::Pointer;
 
   /** Get the output in the form of a vtkImage.
-      This call is delegated to the internal vtkImageImport filter  */
+   *
+   * This call is delegated to the internal vtkImageImport filter.
+   */
   vtkImageData *
   GetOutput() const;
 
@@ -81,22 +83,24 @@ public:
   GetInput();
 
   /** Return the internal VTK image importer filter.
-      This is intended to facilitate users the access
-      to methods in the importer */
+   *
+   * Intended to facilitate users the access to methods in the importer.
+   */
   vtkImageImport *
   GetImporter() const;
 
   /** Return the internal ITK image exporter filter.
-      This is intended to facilitate users the access
-      to methods in the exporter */
+   *
+   * Intended to facilitate users the access to methods in the exporter.
+   */
   ExporterFilterType *
   GetExporter() const;
 
-  /** This call delegates the update to the importer */
+  /** This call delegates the update to the importer. */
   void
   Update() override;
 
-  /** This call delegates the update to the importer */
+  /** This call delegates the update to the importer. */
   void
   UpdateLargestPossibleRegion() override;
 

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -22,9 +22,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TInputImage>
 ImageToVTKImageFilter<TInputImage>::ImageToVTKImageFilter()
 {
@@ -48,9 +45,6 @@ ImageToVTKImageFilter<TInputImage>::ImageToVTKImageFilter()
   m_Importer->SetCallbackUserData(m_Exporter->GetCallbackUserData());
 }
 
-/**
- * Destructor
- */
 template <typename TInputImage>
 ImageToVTKImageFilter<TInputImage>::~ImageToVTKImageFilter()
 {
@@ -61,9 +55,6 @@ ImageToVTKImageFilter<TInputImage>::~ImageToVTKImageFilter()
   }
 }
 
-/**
- * Set an itk::Image as input
- */
 template <typename TInputImage>
 void
 ImageToVTKImageFilter<TInputImage>::SetInput(const InputImageType * inputImage)
@@ -78,9 +69,6 @@ ImageToVTKImageFilter<TInputImage>::GetInput() -> InputImageType *
   return m_Exporter->GetInput();
 }
 
-/**
- * Get a vtkImage as output
- */
 template <typename TInputImage>
 vtkImageData *
 ImageToVTKImageFilter<TInputImage>::GetOutput() const
@@ -88,9 +76,6 @@ ImageToVTKImageFilter<TInputImage>::GetOutput() const
   return m_Importer->GetOutput();
 }
 
-/**
- * Get the importer filter
- */
 template <typename TInputImage>
 vtkImageImport *
 ImageToVTKImageFilter<TInputImage>::GetImporter() const
@@ -98,9 +83,6 @@ ImageToVTKImageFilter<TInputImage>::GetImporter() const
   return m_Importer;
 }
 
-/**
- * Get the exporter filter
- */
 template <typename TInputImage>
 auto
 ImageToVTKImageFilter<TInputImage>::GetExporter() const -> ExporterFilterType *
@@ -108,9 +90,6 @@ ImageToVTKImageFilter<TInputImage>::GetExporter() const -> ExporterFilterType *
   return m_Exporter.GetPointer();
 }
 
-/**
- * Delegate the Update to the importer
- */
 template <typename TInputImage>
 void
 ImageToVTKImageFilter<TInputImage>::Update()
@@ -118,9 +97,6 @@ ImageToVTKImageFilter<TInputImage>::Update()
   m_Importer->Update();
 }
 
-/**
- * Delegate the UpdateLargestPossibleRegion to the importer
- */
 template <typename TInputImage>
 void
 ImageToVTKImageFilter<TInputImage>::UpdateLargestPossibleRegion()

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
@@ -69,21 +69,22 @@ public:
   using OutputImageType = TOutputImage;
   using OutputImagePointer = typename OutputImageType::ConstPointer;
 
-  /** Set the input in the form of a vtkImageData */
+  /** Set the input in the form of a vtkImageData. */
   void
   SetInput(vtkImageData *);
   using Superclass::SetInput;
 
-  /** Return the internal VTK image exporter filter.
-      This is intended to facilitate users the access
-      to methods in the exporter */
+  /** Get the internal VTK image exporter filter.
+   *
+   * Intended to facilitate users the access to methods in the exporter.
+   */
   vtkImageExport *
   GetExporter() const;
 
-  /** Return the internal ITK image importer filter.
-      This is intended to facilitate users the access
-      to methods in the importer.
-      */
+  /** Get the internal ITK image importer filter.
+   *
+   * Intended to facilitate users the access to methods in the importer.
+   */
   const Superclass *
   GetImporter() const;
 

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -25,9 +25,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TOutputImage>
 VTKImageToImageFilter<TOutputImage>::VTKImageToImageFilter()
 {
@@ -51,9 +48,6 @@ VTKImageToImageFilter<TOutputImage>::VTKImageToImageFilter()
   this->SetCallbackUserData(m_Exporter->GetCallbackUserData());
 }
 
-/**
- * Destructor
- */
 template <typename TOutputImage>
 VTKImageToImageFilter<TOutputImage>::~VTKImageToImageFilter()
 {
@@ -64,9 +58,6 @@ VTKImageToImageFilter<TOutputImage>::~VTKImageToImageFilter()
   }
 }
 
-/**
- * Set a vtkImageData as input
- */
 template <typename TOutputImage>
 void
 VTKImageToImageFilter<TOutputImage>::SetInput(vtkImageData * inputImage)
@@ -78,9 +69,6 @@ VTKImageToImageFilter<TOutputImage>::SetInput(vtkImageData * inputImage)
 #endif
 }
 
-/**
- * Get the exporter filter
- */
 template <typename TOutputImage>
 vtkImageExport *
 VTKImageToImageFilter<TOutputImage>::GetExporter() const
@@ -88,9 +76,6 @@ VTKImageToImageFilter<TOutputImage>::GetExporter() const
   return m_Exporter;
 }
 
-/**
- * Get the importer filter
- */
 template <typename TOutputImage>
 auto
 VTKImageToImageFilter<TOutputImage>::GetImporter() const -> const Superclass *

--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.h
@@ -41,15 +41,15 @@ public:
   /** Constructor */
   ChildTreeIterator(const TreeIteratorBase<TTreeType> & iterator);
 
-  /** Get the type of the iterator */
+  /** Get the type of the iterator. */
   NodeType
   GetType() const override;
 
-  /** Go to a specific child node */
+  /** Go to a specific child node. */
   bool
   GoToChild(ChildIdentifier number = 0) override;
 
-  /** Go to a parent node */
+  /** Go to the parent node. */
   bool
   GoToParent() override;
 
@@ -72,11 +72,11 @@ public:
   }
 
 protected:
-  /** Get the next value */
+  /** Get the next node. */
   const ValueType &
   Next() override;
 
-  /** Return true if the next value exists */
+  /** Return true if the next node exists. */
   bool
   HasNext() const override;
 

--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
@@ -22,7 +22,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TTreeType>
 ChildTreeIterator<TTreeType>::ChildTreeIterator(TTreeType * tree, const TreeNodeType * start)
   : TreeIteratorBase<TTreeType>(tree, start)
@@ -42,7 +41,6 @@ ChildTreeIterator<TTreeType>::ChildTreeIterator(const TreeIteratorBase<TTreeType
   this->m_Position = m_ParentNode->GetChild(m_ListPosition);
 }
 
-/** Go to a specific child */
 template <typename TTreeType>
 bool
 ChildTreeIterator<TTreeType>::GoToChild(ChildIdentifier number)
@@ -59,7 +57,6 @@ ChildTreeIterator<TTreeType>::GoToChild(ChildIdentifier number)
   return true;
 }
 
-/** Go to the parent node */
 template <typename TTreeType>
 bool
 ChildTreeIterator<TTreeType>::GoToParent()
@@ -78,7 +75,6 @@ ChildTreeIterator<TTreeType>::GoToParent()
   return true;
 }
 
-/** Return the type of the iterator */
 template <typename TTreeType>
 auto
 ChildTreeIterator<TTreeType>::GetType() const -> NodeType
@@ -86,7 +82,6 @@ ChildTreeIterator<TTreeType>::GetType() const -> NodeType
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::CHILD;
 }
 
-/** Return true if the next node exists */
 template <typename TTreeType>
 bool
 ChildTreeIterator<TTreeType>::HasNext() const
@@ -101,7 +96,6 @@ ChildTreeIterator<TTreeType>::HasNext() const
   }
 }
 
-/** Return the next node */
 template <typename TTreeType>
 auto
 ChildTreeIterator<TTreeType>::Next() -> const ValueType &
@@ -115,7 +109,6 @@ ChildTreeIterator<TTreeType>::Next() -> const ValueType &
   return this->m_Position->Get();
 }
 
-/** Clone function */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType> *
 ChildTreeIterator<TTreeType>::Clone()

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.h
@@ -45,28 +45,28 @@ public:
   /** Constructor with end level specification */
   LevelOrderTreeIterator(TreeType * tree, int endLevel = INT_MAX, const TreeNodeType * start = nullptr);
 
-  /** Constructor with end level specification */
+  /** Constructor with end level specification. */
   LevelOrderTreeIterator(TreeType * tree, int startLevel, int endLevel, const TreeNodeType * start = nullptr);
 
   ~LevelOrderTreeIterator() override = default;
 
-  /** Get the type of the iterator */
+  /** Get the type of the iterator. */
   NodeType
   GetType() const override;
 
-  /** Get the start level */
+  /** Get the start level. */
   int
   GetStartLevel() const;
 
-  /** Get the end level */
+  /** Get the end level. */
   int
   GetEndLevel() const;
 
-  /** Get the current level */
+  /** Get the current level. */
   int
   GetLevel() const;
 
-  /** Clone function */
+  /** Clone function. */
   TreeIteratorBase<TTreeType> *
   Clone() override;
 
@@ -85,21 +85,24 @@ public:
   }
 
 protected:
-  /** Return the next node */
+  /** Get the next node. */
   const ValueType &
   Next() override;
 
-  /** Return true if the next node exists */
+  /** Return true if the next node exists. */
   bool
   HasNext() const override;
 
 private:
+  /** Find the next available node. */
   const TreeNodeType *
   FindNextNode() const;
 
+  /** Helper function to find the next node. */
   const TreeNodeType *
   FindNextNodeHelp() const;
 
+  /** Get the level given a node. */
   int
   GetLevel(const TreeNodeType * node) const;
 

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor with end level specification */
+
 template <typename TTreeType>
 LevelOrderTreeIterator<TTreeType>::LevelOrderTreeIterator(TTreeType * tree, int endLevel, const TreeNodeType * start)
   : TreeIteratorBase<TTreeType>(tree, start)
@@ -44,7 +44,6 @@ LevelOrderTreeIterator<TTreeType>::LevelOrderTreeIterator(TTreeType * tree, int 
   this->m_Begin = this->m_Position;
 }
 
-/** Constructor with end level specification */
 template <typename TTreeType>
 LevelOrderTreeIterator<TTreeType>::LevelOrderTreeIterator(TTreeType *          tree,
                                                           int                  startLevel,
@@ -70,7 +69,6 @@ LevelOrderTreeIterator<TTreeType>::LevelOrderTreeIterator(TTreeType *          t
   this->m_Begin = this->m_Position;
 }
 
-/** Return the type of iterator */
 template <typename TTreeType>
 auto
 LevelOrderTreeIterator<TTreeType>::GetType() const -> NodeType
@@ -78,7 +76,6 @@ LevelOrderTreeIterator<TTreeType>::GetType() const -> NodeType
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::LEVELORDER;
 }
 
-/** Return true if the next value exists */
 template <typename TTreeType>
 bool
 LevelOrderTreeIterator<TTreeType>::HasNext() const
@@ -90,7 +87,6 @@ LevelOrderTreeIterator<TTreeType>::HasNext() const
   return false;
 }
 
-/** Return the next node */
 template <typename TTreeType>
 auto
 LevelOrderTreeIterator<TTreeType>::Next() -> const ValueType &
@@ -103,7 +99,6 @@ LevelOrderTreeIterator<TTreeType>::Next() -> const ValueType &
   return this->m_Position->Get();
 }
 
-/** Get the start Level */
 template <typename TTreeType>
 int
 LevelOrderTreeIterator<TTreeType>::GetStartLevel() const
@@ -111,7 +106,6 @@ LevelOrderTreeIterator<TTreeType>::GetStartLevel() const
   return m_StartLevel;
 }
 
-/** Get the end level */
 template <typename TTreeType>
 int
 LevelOrderTreeIterator<TTreeType>::GetEndLevel() const
@@ -119,7 +113,6 @@ LevelOrderTreeIterator<TTreeType>::GetEndLevel() const
   return m_EndLevel;
 }
 
-/** Find the next available node */
 template <typename TTreeType>
 auto
 LevelOrderTreeIterator<TTreeType>::FindNextNode() const -> const TreeNodeType *
@@ -144,7 +137,6 @@ LevelOrderTreeIterator<TTreeType>::FindNextNode() const -> const TreeNodeType *
   return node;
 }
 
-/** Return the current level */
 template <typename TTreeType>
 int
 LevelOrderTreeIterator<TTreeType>::GetLevel() const
@@ -164,7 +156,6 @@ LevelOrderTreeIterator<TTreeType>::GetLevel() const
   return level;
 }
 
-/** Return the level given a node */
 template <typename TTreeType>
 int
 LevelOrderTreeIterator<TTreeType>::GetLevel(const TreeNodeType * node) const
@@ -183,7 +174,6 @@ LevelOrderTreeIterator<TTreeType>::GetLevel(const TreeNodeType * node) const
   return level;
 }
 
-/** Helper function to find the next node */
 template <typename TTreeType>
 auto
 LevelOrderTreeIterator<TTreeType>::FindNextNodeHelp() const -> const TreeNodeType *
@@ -220,7 +210,6 @@ LevelOrderTreeIterator<TTreeType>::FindNextNodeHelp() const -> const TreeNodeTyp
   return currentNode;
 }
 
-/** Clone function */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType> *
 LevelOrderTreeIterator<TTreeType>::Clone()

--- a/Modules/Compatibility/Deprecated/include/itkTreeContainer.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeContainer.h
@@ -56,64 +56,64 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(TreeContainer, TreeContainerBase);
 
-  /** Constructor */
+  /** Constructor with default children count. */
   TreeContainer(int defaultChildrenCount);
 
-  /** Constructor */
+  /** Constructor by adding a tree. */
   TreeContainer(TreeContainer<TValue> & tree);
 
-  /** Set the root as an element */
+  /** Set the specified element as the root. */
   bool
   SetRoot(const TValue element) override;
 
-  /** The the root as an iterator position */
+  /** Set the specified iterator position as the root. */
   bool
   SetRoot(IteratorType & pos);
 
-  /** Set the root as a tree node */
+  /** Set the specified tree node as the root. */
   bool
   SetRoot(TreeNode<TValue> * node) override;
 
-  /** Return true if the element is in the tree */
+  /** Return true if the element is in the tree. */
   bool
   Contains(const TValue element) override;
 
-  /** Return the number of elements in the tree */
+  /** Return the number of elements in the tree. */
   int
   Count() const override;
 
-  /** Return true if the element is a leaf */
+  /** Return true if the node containing the given element is a leaf of the tree. */
   bool
   IsLeaf(const TValue element) override;
 
-  /** Return true if the element is a root */
+  /** Return true if the node containing the given element is the root. */
   bool
   IsRoot(const TValue element) override;
 
-  /** Clear the tree */
+  /** Clear the tree. */
   bool
   Clear() override;
 
-  /** operator equal */
+  /** operator equal. */
   bool
   operator==(TreeContainer<TValue> & tree);
 
-  /** Swap the iterators */
+  /** Swap the iterators. */
   bool
   Swap(IteratorType & v, IteratorType & w);
 
-  /** Get the root */
+  /** Get the root. */
   const TreeNodeType *
   GetRoot() const override
   {
     return m_Root.GetPointer();
   }
 
-  /** Add a child to a given parent using values */
+  /** Add a child to a given parent. */
   bool
   Add(const TValue child, const TValue parent);
 
-  /** Get node given a value */
+  /** Get the node corresponding to the given a value. */
   const TreeNodeType *
   GetNode(TValue val) const;
 

--- a/Modules/Compatibility/Deprecated/include/itkTreeContainer.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeContainer.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TValue>
 TreeContainer<TValue>::TreeContainer()
 {
@@ -30,7 +30,6 @@ TreeContainer<TValue>::TreeContainer()
   m_DefaultChildrenCount = 2;
 }
 
-/** Constructor with default children count */
 template <typename TValue>
 TreeContainer<TValue>::TreeContainer(int dcc)
 {
@@ -39,7 +38,6 @@ TreeContainer<TValue>::TreeContainer(int dcc)
   m_DefaultChildrenCount = dcc;
 }
 
-/** Constructor by adding a tree */
 template <typename TValue>
 TreeContainer<TValue>::TreeContainer(TreeContainer<TValue> &)
 {
@@ -48,7 +46,6 @@ TreeContainer<TValue>::TreeContainer(TreeContainer<TValue> &)
   m_DefaultChildrenCount = 3;
 }
 
-/** Set the root of the tree */
 template <typename TValue>
 bool
 TreeContainer<TValue>::SetRoot(const TValue element)
@@ -59,7 +56,6 @@ TreeContainer<TValue>::SetRoot(const TValue element)
   return true;
 }
 
-/** Set the root of the tree */
 template <typename TValue>
 bool
 TreeContainer<TValue>::SetRoot(TreeNode<TValue> * node)
@@ -68,7 +64,6 @@ TreeContainer<TValue>::SetRoot(TreeNode<TValue> * node)
   return true;
 }
 
-/** Count the number of nodes in the tree */
 template <typename TValue>
 int
 TreeContainer<TValue>::Count() const
@@ -88,7 +83,6 @@ TreeContainer<TValue>::Count() const
   return size;
 }
 
-/** Swap the iterators */
 template <typename TValue>
 bool
 TreeContainer<TValue>::Swap(IteratorType & v, IteratorType & w)
@@ -129,7 +123,6 @@ TreeContainer<TValue>::Swap(IteratorType & v, IteratorType & w)
   return true;
 }
 
-/** Return true if the tree contains this element */
 template <typename TValue>
 bool
 TreeContainer<TValue>::Contains(const TValue element)
@@ -147,7 +140,6 @@ TreeContainer<TValue>::Contains(const TValue element)
   return false;
 }
 
-/** Equal operator */
 template <typename TValue>
 bool
 TreeContainer<TValue>::operator==(TreeContainer<TValue> & tree)
@@ -170,7 +162,6 @@ TreeContainer<TValue>::operator==(TreeContainer<TValue> & tree)
   return true;
 }
 
-/** Return true if the given element is a leaf of the tree */
 template <typename TValue>
 bool
 TreeContainer<TValue>::IsLeaf(TValue element)
@@ -194,7 +185,6 @@ TreeContainer<TValue>::IsLeaf(TValue element)
   return false;
 }
 
-/** Return true of the node containing the element is the root */
 template <typename TValue>
 bool
 TreeContainer<TValue>::IsRoot(TValue element)
@@ -219,7 +209,6 @@ TreeContainer<TValue>::IsRoot(TValue element)
   return false;
 }
 
-/** Clear the tree */
 template <typename TValue>
 bool
 TreeContainer<TValue>::Clear()
@@ -230,7 +219,6 @@ TreeContainer<TValue>::Clear()
   return success;
 }
 
-/** Get node given a value */
 template <typename TValue>
 const TreeNode<TValue> *
 TreeContainer<TValue>::GetNode(TValue val) const
@@ -248,7 +236,6 @@ TreeContainer<TValue>::GetNode(TValue val) const
   return nullptr;
 }
 
-/** Set the root of the tree from the iterator position */
 template <typename TValue>
 bool
 TreeContainer<TValue>::SetRoot(IteratorType & pos)
@@ -291,7 +278,6 @@ TreeContainer<TValue>::SetRoot(IteratorType & pos)
   return true;
 }
 
-/** Add a child to a given parent */
 template <typename TValue>
 bool
 TreeContainer<TValue>::Add(const TValue child, const TValue parent)
@@ -316,7 +302,6 @@ TreeContainer<TValue>::Add(const TValue child, const TValue parent)
   return false;
 }
 
-/** Print self */
 template <typename TValue>
 void
 TreeContainer<TValue>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
@@ -89,27 +89,30 @@ public:
   static constexpr NodeType LEAF = NodeType::LEAF;
 #endif
 
-  /** Add an element to the tree */
+  /** Add an element to the tree at the current node.
+   *
+   * Creates a new child node.
+   */
   virtual bool
   Add(ValueType element);
 
-  /** Add an element at a given position */
+  /** Add an element to the tree at a given position. */
   virtual bool
   Add(int position, ValueType element);
 
-  /** Add a subtree */
+  /** Add a subtree. */
   virtual bool
   Add(TTreeType & subTree);
 
-  /** Get a value */
+  /** Get the value of the current node. */
   virtual const ValueType &
   Get() const;
 
-  /** Get the subtree */
+  /** Get the subtree. */
   virtual TTreeType *
   GetSubTree() const;
 
-  /** Return true if the current node is a leaf */
+  /** Return true if the current node is a leaf. */
   virtual bool
   IsLeaf() const;
 
@@ -121,85 +124,88 @@ public:
   virtual NodeType
   GetType() const = 0;
 
-  /** Go to the specified child */
+  /** Go to the specified child. */
   virtual bool
   GoToChild(ChildIdentifier number = 0);
 
-  /** Go to the parent */
+  /** Go to the parent of the current node. */
   virtual bool
   GoToParent();
 
-  /** Set the current value of the node */
+  /** Set the specified value to the current node. */
   void
   Set(ValueType element);
 
-  /** Return true if the current node has a child */
+  /** Return true if the current node has a child. */
   virtual bool
   HasChild(int number = 0) const;
 
-  /** Return the current ChildPosition of an element */
+  /** Return the current child position of an element. */
   virtual int
   ChildPosition(ValueType element) const;
 
-  /** Remove a child */
+  /** Remove a child.
+   *
+   * Removes its child nodes as well.
+   * /
   virtual bool
   RemoveChild(int number);
 
-  /** Count the number of children */
+  /** Count the number of children. */
   virtual int
   CountChildren() const;
 
-  /** Return true if the current node has a parent */
+  /** Return true if the current node has a parent. */
   virtual bool
   HasParent() const;
 
-  /** Disconnect the tree */
+  /** Disconnect the tree. */
   virtual bool
   Disconnect();
 
-  /** Return a list of children */
+  /** Return a list of children. */
   virtual TreeIteratorBase<TTreeType> *
   Children();
 
-  /** Return a list of parents */
+  /** Return the list of parents. */
   virtual TreeIteratorBase<TTreeType> *
   Parents();
 
-  /** Return a list of child */
+  /** Get the child corresponding to the given a number at the current node. */
   virtual TreeIteratorBase<TTreeType> *
   GetChild(int number) const;
 
-  /** Count the number of nodes */
+  /** Count the number of nodes. */
   virtual int
   Count();
 
-  /** Remove the current node from the tree */
+  /** Remove the current node from the tree. */
   bool
   Remove();
 
-  /** Get the current node */
+  /** Get the current node. */
   virtual TreeNodeType *
   GetNode();
 
   virtual const TreeNodeType *
   GetNode() const;
 
-  /** Get the root */
+  /** Get the root. */
   TreeNodeType *
   GetRoot();
 
   const TreeNodeType *
   GetRoot() const;
 
-  /** Get the tree */
+  /** Get the tree. */
   TTreeType *
   GetTree() const;
 
-  /** Return the first parent found */
+  /** Return the first parent found. */
   const TreeNodeType *
   GetParent() const;
 
-  /** Move an iterator to the beginning of the tree */
+  /** Move an iterator to the beginning of the tree. */
   void
   GoToBegin()
   {

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
@@ -37,7 +37,7 @@ class ITK_TEMPLATE_EXPORT TreeRemoveEvent;
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TTreeType>
 TreeIteratorBase<TTreeType>::TreeIteratorBase(TTreeType * tree, const TreeNodeType * start)
 {
@@ -55,7 +55,6 @@ TreeIteratorBase<TTreeType>::TreeIteratorBase(TTreeType * tree, const TreeNodeTy
   m_Begin = m_Position;
 }
 
-/** Constructor */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType>::TreeIteratorBase(const TTreeType * tree, const TreeNodeType * start)
 {
@@ -72,7 +71,6 @@ TreeIteratorBase<TTreeType>::TreeIteratorBase(const TTreeType * tree, const Tree
   m_Begin = m_Position;
 }
 
-/** Return the current value of the node */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::Get() const -> const ValueType &
@@ -80,7 +78,6 @@ TreeIteratorBase<TTreeType>::Get() const -> const ValueType &
   return m_Position->Get();
 }
 
-/** Set the current value of the node */
 template <typename TTreeType>
 void
 TreeIteratorBase<TTreeType>::Set(ValueType element)
@@ -91,7 +88,6 @@ TreeIteratorBase<TTreeType>::Set(ValueType element)
   m_Tree->InvokeEvent(TreeNodeChangeEvent<TTreeType>(*this));
 }
 
-/** Add a value to the node. This creates a new child node */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::Add(ValueType element)
@@ -126,7 +122,6 @@ TreeIteratorBase<TTreeType>::Add(ValueType element)
   return true;
 }
 
-/** Add a new element at a given position */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::Add(int itkNotUsed(childPosition), ValueType element)
@@ -150,7 +145,6 @@ TreeIteratorBase<TTreeType>::Add(int itkNotUsed(childPosition), ValueType elemen
   return false;
 }
 
-/** Return true if the current pointed node is a leaf */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::IsLeaf() const
@@ -158,7 +152,6 @@ TreeIteratorBase<TTreeType>::IsLeaf() const
   return !(m_Position->HasChildren());
 }
 
-/** Return true if the current pointed node is a root */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::IsRoot() const
@@ -175,7 +168,6 @@ TreeIteratorBase<TTreeType>::IsRoot() const
   return false;
 }
 
-/** Add a subtree  */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::Add(TTreeType & subTree)
@@ -205,7 +197,6 @@ TreeIteratorBase<TTreeType>::Add(TTreeType & subTree)
   return true;
 }
 
-/** Return the subtree */
 template <typename TTreeType>
 TTreeType *
 TreeIteratorBase<TTreeType>::GetSubTree() const
@@ -216,7 +207,6 @@ TreeIteratorBase<TTreeType>::GetSubTree() const
   return tree;
 }
 
-/** Return true of the current node has a child */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::HasChild(int number) const
@@ -232,7 +222,6 @@ TreeIteratorBase<TTreeType>::HasChild(int number) const
   return false;
 }
 
-/** Return the current position of the child */
 template <typename TTreeType>
 int
 TreeIteratorBase<TTreeType>::ChildPosition(ValueType element) const
@@ -244,7 +233,6 @@ TreeIteratorBase<TTreeType>::ChildPosition(ValueType element) const
   return m_Position->ChildPosition(element);
 }
 
-/** Remove a child */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::RemoveChild(int number)
@@ -272,7 +260,6 @@ TreeIteratorBase<TTreeType>::RemoveChild(int number)
   return false;
 }
 
-/** Count the number of children */
 template <typename TTreeType>
 int
 TreeIteratorBase<TTreeType>::CountChildren() const
@@ -284,7 +271,6 @@ TreeIteratorBase<TTreeType>::CountChildren() const
   return m_Position->CountChildren();
 }
 
-/** Return true of the pointed node has a parent */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::HasParent() const
@@ -292,7 +278,6 @@ TreeIteratorBase<TTreeType>::HasParent() const
   return (m_Position != nullptr && m_Position->GetParent() != nullptr);
 }
 
-/** Disconnect the tree */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::Disconnect()
@@ -329,7 +314,6 @@ TreeIteratorBase<TTreeType>::Disconnect()
   return true;
 }
 
-/** Return the children list */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType> *
 TreeIteratorBase<TTreeType>::Children()
@@ -340,7 +324,6 @@ TreeIteratorBase<TTreeType>::Children()
   return nullptr;
 }
 
-/** Return the first parent found */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::GetParent() const -> const TreeNodeType *
@@ -353,7 +336,6 @@ TreeIteratorBase<TTreeType>::GetParent() const -> const TreeNodeType *
   return m_Position->GetParent();
 }
 
-/** Return the list of parents */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType> *
 TreeIteratorBase<TTreeType>::Parents()
@@ -364,7 +346,6 @@ TreeIteratorBase<TTreeType>::Parents()
   return nullptr;
 }
 
-/** Go to a child */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::GoToChild(ChildIdentifier number)
@@ -384,7 +365,6 @@ TreeIteratorBase<TTreeType>::GoToChild(ChildIdentifier number)
   return true;
 }
 
-/** Go to a parent */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::GoToParent()
@@ -403,7 +383,6 @@ TreeIteratorBase<TTreeType>::GoToParent()
   return true;
 }
 
-/** Get a child given a number */
 template <typename TTreeType>
 TreeIteratorBase<TTreeType> *
 TreeIteratorBase<TTreeType>::GetChild(int number) const
@@ -424,7 +403,6 @@ TreeIteratorBase<TTreeType>::GetChild(int number) const
   return nullptr;
 }
 
-/** Count the number of nodes from the beginning */
 template <typename TTreeType>
 int
 TreeIteratorBase<TTreeType>::Count()
@@ -443,7 +421,6 @@ TreeIteratorBase<TTreeType>::Count()
   return size;
 }
 
-/** Get the node pointed by the iterator */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::GetNode() -> TreeNodeType *
@@ -451,7 +428,6 @@ TreeIteratorBase<TTreeType>::GetNode() -> TreeNodeType *
   return const_cast<TreeNodeType *>(m_Position);
 }
 
-/** Get the node pointed by the iterator */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::GetNode() const -> const TreeNodeType *
@@ -459,7 +435,6 @@ TreeIteratorBase<TTreeType>::GetNode() const -> const TreeNodeType *
   return m_Position;
 }
 
-/** Get the root */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::GetRoot() -> TreeNodeType *
@@ -467,7 +442,6 @@ TreeIteratorBase<TTreeType>::GetRoot() -> TreeNodeType *
   return const_cast<TreeNodeType *>(m_Root);
 }
 
-/** Get the root (const) */
 template <typename TTreeType>
 auto
 TreeIteratorBase<TTreeType>::GetRoot() const -> const TreeNodeType *
@@ -475,7 +449,6 @@ TreeIteratorBase<TTreeType>::GetRoot() const -> const TreeNodeType *
   return m_Root;
 }
 
-/** Remove a specific node (and its child nodes!) */
 template <typename TTreeType>
 bool
 TreeIteratorBase<TTreeType>::Remove()
@@ -519,7 +492,6 @@ TreeIteratorBase<TTreeType>::Remove()
   return true;
 }
 
-/** Return the tree */
 template <typename TTreeType>
 TTreeType *
 TreeIteratorBase<TTreeType>::GetTree() const

--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
@@ -21,18 +21,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::VectorCentralDifferenceImageFunction()
 {
   this->m_UseImageDirection = true;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -41,9 +36,6 @@ VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ost
   os << indent << "UseImageDirection = " << this->m_UseImageDirection << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 auto
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const

--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -55,11 +55,11 @@ public:
 
 public:
   /** Default constructor. It is created with an empty array
-   *  it has to be allocated later by assignment              */
+   *  it has to be allocated later by assignment */
   Array();
 
   /** Copy constructor.  Uses VNL copy constructor with correct
-   *  setting for memory management.                          */
+   *  setting for memory management. */
   Array(const Array &);
 
   /** Construct from a VnlVectorType */

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -22,13 +22,13 @@
 
 namespace itk
 {
-/** Default constructor */
+
 template <typename TValue>
 Array<TValue>::Array()
   : vnl_vector<TValue>()
 {}
 
-/** Copy constructor */
+
 template <typename TValue>
 Array<TValue>::Array(const Self & rhs)
   : vnl_vector<TValue>(rhs)
@@ -43,7 +43,7 @@ Array<TValue>::Array(const VnlVectorType & rhs)
 // no matter the setting of let array manage memory of rhs
 {}
 
-/** Constructor with size */
+
 template <typename TValue>
 Array<TValue>::Array(SizeValueType dimension)
   : vnl_vector<TValue>(dimension)
@@ -51,13 +51,11 @@ Array<TValue>::Array(SizeValueType dimension)
 // no matter the setting of let array manage memory of rhs
 {}
 
-/** Constructor with size and initial value for each element. */
 template <typename TValue>
 Array<TValue>::Array(const SizeValueType dimension, const TValue & value)
   : vnl_vector<TValue>(dimension, value)
 {}
 
-/** Constructor with user specified data */
 template <typename TValue>
 Array<TValue>::Array(ValueType * datain, SizeValueType sz, bool LetArrayManageMemory)
   : m_LetArrayManageMemory(LetArrayManageMemory)
@@ -67,7 +65,6 @@ Array<TValue>::Array(ValueType * datain, SizeValueType sz, bool LetArrayManageMe
 }
 
 #if defined(ITK_LEGACY_REMOVE)
-/** Constructor with user specified const data */
 template <typename TValue>
 Array<TValue>::Array(const ValueType * datain, SizeValueType sz)
   : vnl_vector<TValue>(datain, sz)
@@ -76,7 +73,6 @@ Array<TValue>::Array(const ValueType * datain, SizeValueType sz)
 {}
 
 #else // defined ( ITK_LEGACY_REMOVE )
-/** Constructor with user specified const data */
 template <typename TValue>
 Array<TValue>::Array(const ValueType * datain, SizeValueType sz, bool /* LetArrayManageMemory */)
   : /* NOTE: The 3rd argument "LetArrayManageMemory, was never valid to use, but is
@@ -87,8 +83,6 @@ Array<TValue>::Array(const ValueType * datain, SizeValueType sz, bool /* LetArra
 {}
 #endif
 
-
-/** Destructor */
 template <typename TValue>
 Array<TValue>::~Array()
 {

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -22,25 +22,21 @@
 namespace itk
 {
 
-/** Constructor with number of rows and columns as arguments */
 template <typename TValue>
 Array2D<TValue>::Array2D(unsigned int numberOfRows, unsigned int numberOfCols)
   : vnl_matrix<TValue>(numberOfRows, numberOfCols)
 {}
 
-/** Constructor from a vnl_matrix */
 template <typename TValue>
 Array2D<TValue>::Array2D(const VnlMatrixType & matrix)
   : vnl_matrix<TValue>(matrix)
 {}
 
-/** Copy Constructor  */
 template <typename TValue>
 Array2D<TValue>::Array2D(const Self & array)
   : vnl_matrix<TValue>(array)
 {}
 
-/** Assignment Operator from Array */
 template <typename TValue>
 Array2D<TValue> &
 Array2D<TValue>::operator=(const Self & array)
@@ -49,7 +45,6 @@ Array2D<TValue>::operator=(const Self & array)
   return *this;
 }
 
-/** Assignment Operator from vnl_matrix */
 template <typename TValue>
 Array2D<TValue> &
 Array2D<TValue>::operator=(const VnlMatrixType & matrix)
@@ -58,7 +53,6 @@ Array2D<TValue>::operator=(const VnlMatrixType & matrix)
   return *this;
 }
 
-/** Set the size of the array */
 template <typename TValue>
 void
 Array2D<TValue>::SetSize(unsigned int m, unsigned int n)

--- a/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.hxx
@@ -32,7 +32,6 @@
 namespace itk
 {
 
-/** Set value */
 template <typename T>
 void
 AutoPointerDataObjectDecorator<T>::Set(T * val)
@@ -46,7 +45,6 @@ AutoPointerDataObjectDecorator<T>::Set(T * val)
   }
 }
 
-/** PrintSelf method */
 template <typename T>
 void
 AutoPointerDataObjectDecorator<T>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
+++ b/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor.  Initializes iterators, pointers, and m_IsAtEnd. */
+
 template <typename TStructureType>
 CorrespondenceDataStructureIterator<TStructureType>::CorrespondenceDataStructureIterator(TStructureType * StructurePtr)
 {
@@ -44,8 +44,6 @@ CorrespondenceDataStructureIterator<TStructureType>::IsAtEnd() const
   return m_IsAtEnd;
 }
 
-/** Goes to the next corresponding node clique in the structure,
- *  moving on to the next base node clique if necessary. */
 template <typename TStructureType>
 void
 CorrespondenceDataStructureIterator<TStructureType>::GoToNext()
@@ -58,7 +56,6 @@ CorrespondenceDataStructureIterator<TStructureType>::GoToNext()
   }
 }
 
-/** Goes to the next base node clique. */
 template <typename TStructureType>
 void
 CorrespondenceDataStructureIterator<TStructureType>::GoToNextBaseGroup()
@@ -88,7 +85,6 @@ CorrespondenceDataStructureIterator<TStructureType>::GoToNextBaseGroup()
   }
 }
 
-/** Resets the iterator to the default settings/placement.*/
 template <typename TStructureType>
 void
 CorrespondenceDataStructureIterator<TStructureType>::Reset()

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.h
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.h
@@ -131,7 +131,20 @@ public:
     return *this;
   }
 
-  /** Get Trace value */
+  /** Get the trace value.
+   *
+   * Note that the indices are related to the fact
+   * that we store only the upper-right triangle of
+   * the matrix. Like
+   *
+   *       | 0  1  2  |
+   *       | X  3  4  |
+   *       | X  X  5  |
+   *
+   * The trace is therefore the sum of the components
+   * M[0], M[3] and M[5].
+   *
+   */
   AccumulateValueType
   GetTrace() const;
 
@@ -143,7 +156,7 @@ public:
   RealValueType
   GetRelativeAnisotropy() const;
 
-  /** Get the Inner Scalar Product from the Tensor. */
+  /** Get the inner scalar product from the Tensor. */
   RealValueType
   GetInnerScalarProduct() const;
 };

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
@@ -22,33 +22,22 @@
 
 namespace itk
 {
-/**
- * Constructor with initialization
- */
+
 template <typename T>
 DiffusionTensor3D<T>::DiffusionTensor3D(const Superclass & r)
   : SymmetricSecondRankTensor<T, 3>(r)
 {}
 
-/**
- * Constructor with initialization
- */
 template <typename T>
 DiffusionTensor3D<T>::DiffusionTensor3D(const ComponentType & r)
   : SymmetricSecondRankTensor<T, 3>(r)
 {}
 
-/**
- * Constructor with initialization
- */
 template <typename T>
 DiffusionTensor3D<T>::DiffusionTensor3D(const ComponentArrayType r)
   : SymmetricSecondRankTensor<T, 3>(r)
 {}
 
-/**
- * Assignment Operator
- */
 template <typename T>
 DiffusionTensor3D<T> &
 DiffusionTensor3D<T>::operator=(const ComponentType & r)
@@ -57,9 +46,6 @@ DiffusionTensor3D<T>::operator=(const ComponentType & r)
   return *this;
 }
 
-/**
- * Assignment Operator
- */
 template <typename T>
 DiffusionTensor3D<T> &
 DiffusionTensor3D<T>::operator=(const ComponentArrayType r)
@@ -68,9 +54,6 @@ DiffusionTensor3D<T>::operator=(const ComponentArrayType r)
   return *this;
 }
 
-/**
- * Assignment Operator
- */
 template <typename T>
 DiffusionTensor3D<T> &
 DiffusionTensor3D<T>::operator=(const Superclass & r)
@@ -79,21 +62,6 @@ DiffusionTensor3D<T>::operator=(const Superclass & r)
   return *this;
 }
 
-/**
- * Get the Trace, specialized version for 3D.
- *
- * Note that the indices are related to the fact
- * that we store only the upper-right triangle of
- * the matrix. Like
- *
- *       | 0  1  2  |
- *       | X  3  4  |
- *       | X  X  5  |
- *
- * The trace is therefore the sum of the components
- * M[0], M[3] and M[5].
- *
- */
 template <typename T>
 auto
 DiffusionTensor3D<T>::GetTrace() const -> AccumulateValueType
@@ -105,9 +73,6 @@ DiffusionTensor3D<T>::GetTrace() const -> AccumulateValueType
   return trace;
 }
 
-/**
- *  Compute the value of fractional anisotropy
- */
 template <typename T>
 auto
 DiffusionTensor3D<T>::GetFractionalAnisotropy() const -> RealValueType
@@ -139,9 +104,6 @@ DiffusionTensor3D<T>::GetFractionalAnisotropy() const -> RealValueType
   return 0.0;
 }
 
-/**
- *  Compute the value of relative anisotropy
- */
 template <typename T>
 auto
 DiffusionTensor3D<T>::GetRelativeAnisotropy() const -> RealValueType
@@ -170,9 +132,6 @@ DiffusionTensor3D<T>::GetRelativeAnisotropy() const -> RealValueType
   return relativeAnisotropy;
 }
 
-/**
- *  Compute the inner scalar product
- */
 template <typename T>
 auto
 DiffusionTensor3D<T>::GetInnerScalarProduct() const -> RealValueType

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -194,7 +194,12 @@ public:
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   FixedArray() = default;
 
-  /** Conversion constructors */
+  /** Conversion constructors.
+   *
+   * Constructor assumes input points to array of correct size.
+   * Values are copied individually instead of with a binary copy.  This
+   * allows the ValueType's assignment operator to be executed.
+   */
   FixedArray(const ValueType r[VLength]);
   FixedArray(const ValueType &);
 
@@ -222,7 +227,12 @@ public:
     std::copy_n(r, VLength, m_InternalArray);
   }
 
-  /** Operator= defined for a variety of types. */
+  /** Operator= defined for a variety of types.
+   *
+   * The assignment operator assumes input points to array of correct size.
+   * Values are copied individually instead of with a binary copy.  This
+   * allows the ValueType's assignment operator to be executed.
+   */
   template <typename TFixedArrayValueType>
   FixedArray &
   operator=(const FixedArray<TFixedArrayValueType, VLength> & r)
@@ -302,25 +312,32 @@ public:
     return m_InternalArray;
   }
 
-  /** Get various iterators to the array. */
+  /** Get an Iterator for the beginning of the FixedArray. */
   Iterator
   Begin();
 
+  /** Get a ConstIterator for the beginning of the FixedArray. */
   ConstIterator
   Begin() const;
 
+  /** Get an Iterator for the end of the FixedArray. */
   Iterator
   End();
 
+  /** Get a ConstIterator for the end of the FixedArray. */
   ConstIterator
   End() const;
 
+  /** Get a begin ReverseIterator. */
   itkLegacyMacro(ReverseIterator rBegin());
 
+  /** Get a begin ConstReverseIterator. */
   itkLegacyMacro(ConstReverseIterator rBegin() const);
 
+  /** Get an end ReverseIterator. */
   itkLegacyMacro(ReverseIterator rEnd());
 
+  /** Get an end ConstReverseIterator. */
   itkLegacyMacro(ConstReverseIterator rEnd() const);
 
   constexpr const_iterator
@@ -395,7 +412,7 @@ public:
     return this->crend();
   }
 
-  /** Size of the container */
+  /** Size of the container. */
   SizeType
   Size() const;
 

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -22,31 +22,19 @@
 
 namespace itk
 {
-/**
- * Constructor to initialize entire array to one value.
- */
+
 template <typename TValue, unsigned int VLength>
 FixedArray<TValue, VLength>::FixedArray(const ValueType & r)
 {
   std::fill_n(m_InternalArray, VLength, r);
 }
 
-/**
- * Constructor assumes input points to array of correct size.
- * Values are copied individually instead of with a binary copy.  This
- * allows the ValueType's assignment operator to be executed.
- */
 template <typename TValue, unsigned int VLength>
 FixedArray<TValue, VLength>::FixedArray(const ValueType r[VLength])
 {
   std::copy_n(r, VLength, m_InternalArray);
 }
 
-/**
- * Assignment operator assumes input points to array of correct size.
- * Values are copied individually instead of with a binary copy.  This
- * allows the ValueType's assignment operator to be executed.
- */
 template <typename TValue, unsigned int VLength>
 FixedArray<TValue, VLength> &
 FixedArray<TValue, VLength>::operator=(const ValueType r[VLength])
@@ -58,9 +46,6 @@ FixedArray<TValue, VLength>::operator=(const ValueType r[VLength])
   return *this;
 }
 
-/**
- * Operator != compares different types of arrays.
- */
 template <typename TValue, unsigned int VLength>
 bool
 FixedArray<TValue, VLength>::operator==(const FixedArray & r) const
@@ -68,9 +53,6 @@ FixedArray<TValue, VLength>::operator==(const FixedArray & r) const
   return std::equal(m_InternalArray, m_InternalArray + VLength, r.m_InternalArray);
 }
 
-/**
- * Get an Iterator for the beginning of the FixedArray.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::Begin() -> Iterator
@@ -78,9 +60,6 @@ FixedArray<TValue, VLength>::Begin() -> Iterator
   return Iterator(m_InternalArray);
 }
 
-/**
- * Get a ConstIterator for the beginning of the FixedArray.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::Begin() const -> ConstIterator
@@ -88,9 +67,6 @@ FixedArray<TValue, VLength>::Begin() const -> ConstIterator
   return ConstIterator(m_InternalArray);
 }
 
-/**
- * Get an Iterator for the end of the FixedArray.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::End() -> Iterator
@@ -98,9 +74,6 @@ FixedArray<TValue, VLength>::End() -> Iterator
   return Iterator(m_InternalArray + VLength);
 }
 
-/**
- * Get a ConstIterator for the end of the FixedArray.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::End() const -> ConstIterator
@@ -110,9 +83,6 @@ FixedArray<TValue, VLength>::End() const -> ConstIterator
 
 #if !defined(ITK_LEGACY_REMOVE)
 
-/**
- * Get a begin ReverseIterator.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::rBegin() -> ReverseIterator
@@ -120,9 +90,6 @@ FixedArray<TValue, VLength>::rBegin() -> ReverseIterator
   return ReverseIterator(m_InternalArray + VLength);
 }
 
-/**
- * Get a begin ConstReverseIterator.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::rBegin() const -> ConstReverseIterator
@@ -130,9 +97,6 @@ FixedArray<TValue, VLength>::rBegin() const -> ConstReverseIterator
   return ConstReverseIterator(m_InternalArray + VLength);
 }
 
-/**
- * Get an end ReverseIterator.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::rEnd() -> ReverseIterator
@@ -140,9 +104,6 @@ FixedArray<TValue, VLength>::rEnd() -> ReverseIterator
   return ReverseIterator(m_InternalArray);
 }
 
-/**
- * Get an end ConstReverseIterator.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::rEnd() const -> ConstReverseIterator
@@ -152,9 +113,6 @@ FixedArray<TValue, VLength>::rEnd() const -> ConstReverseIterator
 
 #endif // defined ( ITK_LEGACY_REMOVE )
 
-/**
- * Get the size of the FixedArray.
- */
 template <typename TValue, unsigned int VLength>
 auto
 FixedArray<TValue, VLength>::Size() const -> SizeType
@@ -162,9 +120,6 @@ FixedArray<TValue, VLength>::Size() const -> SizeType
   return VLength;
 }
 
-/**
- * Fill all elements of the array with the given value.
- */
 template <typename TValue, unsigned int VLength>
 void
 FixedArray<TValue, VLength>::Fill(const ValueType & value)

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TInputImage>
 ImageDuplicator<TInputImage>::ImageDuplicator()
 {
@@ -31,7 +31,6 @@ ImageDuplicator<TInputImage>::ImageDuplicator()
   m_InternalImageTime = 0;
 }
 
-/** */
 template <typename TInputImage>
 void
 ImageDuplicator<TInputImage>::Update()

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -204,14 +204,14 @@ public:
     return *this;
   }
 
-  /** Set/Get number of random samples to get from the image region */
+  /** Set/Get number of random samples to extract from the image region. */
   void
   SetNumberOfSamples(SizeValueType number);
 
   SizeValueType
   GetNumberOfSamples() const;
 
-  /** Reinitialize the seed of the random number generator  */
+  /** Reinitialize the seed of the random number generator. */
   void
   ReinitializeSeed();
 
@@ -219,6 +219,7 @@ public:
   ReinitializeSeed(int);
 
 private:
+  /** Execute a random jump. */
   void
   RandomJump();
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Default constructor. Needed since we provide a cast constructor. */
+
 template <typename TImage>
 ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex()
   : ImageConstIteratorWithIndex<TImage>()
@@ -32,8 +32,6 @@ ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex()
   m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
 }
 
-/** Constructor establishes an iterator to walk a particular image and a
- * particular region of that image. */
 template <typename TImage>
 ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex(const ImageType *  ptr,
                                                                              const RegionType & region)
@@ -45,7 +43,6 @@ ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex(con
   m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeValueType number)
@@ -53,7 +50,6 @@ ImageRandomConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeValueType numb
   m_NumberOfSamplesRequested = number;
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 auto
 ImageRandomConstIteratorWithIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
@@ -61,7 +57,6 @@ ImageRandomConstIteratorWithIndex<TImage>::GetNumberOfSamples() const -> SizeVal
   return m_NumberOfSamplesRequested;
 }
 
-/** Reinitialize the seed of the random number generator */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithIndex<TImage>::ReinitializeSeed()
@@ -77,7 +72,6 @@ ImageRandomConstIteratorWithIndex<TImage>::ReinitializeSeed(int seed)
   // vnl_sample_reseed(seed);
 }
 
-/** Execute an acrobatic random jump */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithIndex<TImage>::RandomJump()

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -206,14 +206,14 @@ public:
     return *this;
   }
 
-  /** Set/Get number of random samples to get from the image region */
+  /** Set/Get number of random samples to extract from the image region. */
   void
   SetNumberOfSamples(SizeValueType number);
 
   SizeValueType
   GetNumberOfSamples() const;
 
-  /** Reinitialize the seed of the random number generator  */
+  /** Reinitialize the seed of the random number generator. */
   void
   ReinitializeSeed();
 
@@ -221,6 +221,7 @@ public:
   ReinitializeSeed(int);
 
 private:
+  /** Execute a random jump. */
   void
   RandomJump();
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Default constructor. Needed since we provide a cast constructor. */
+
 template <typename TImage>
 ImageRandomConstIteratorWithOnlyIndex<TImage>::ImageRandomConstIteratorWithOnlyIndex()
   : ImageConstIteratorWithOnlyIndex<TImage>()
@@ -32,8 +32,6 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::ImageRandomConstIteratorWithOnlyI
   m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
 }
 
-/** Constructor establishes an iterator to walk a particular image and a
- * particular region of that image. */
 template <typename TImage>
 ImageRandomConstIteratorWithOnlyIndex<TImage>::ImageRandomConstIteratorWithOnlyIndex(const ImageType *  ptr,
                                                                                      const RegionType & region)
@@ -45,7 +43,6 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::ImageRandomConstIteratorWithOnlyI
   m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithOnlyIndex<TImage>::SetNumberOfSamples(SizeValueType number)
@@ -53,7 +50,6 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::SetNumberOfSamples(SizeValueType 
   m_NumberOfSamplesRequested = number;
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 auto
 ImageRandomConstIteratorWithOnlyIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
@@ -61,7 +57,6 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::GetNumberOfSamples() const -> Siz
   return m_NumberOfSamplesRequested;
 }
 
-/** Reinitialize the seed of the random number generator */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithOnlyIndex<TImage>::ReinitializeSeed()
@@ -76,7 +71,6 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::ReinitializeSeed(int seed)
   m_Generator->SetSeed(seed);
 }
 
-/** Execute an acrobatic random jump */
 template <typename TImage>
 void
 ImageRandomConstIteratorWithOnlyIndex<TImage>::RandomJump()

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -322,14 +322,14 @@ public:
     return *this;
   }
 
-  /** Set/Get number of random samples to get from the image region */
+  /** Set/Get number of random samples to extract from the image region. */
   void
   SetNumberOfSamples(SizeValueType number);
 
   SizeValueType
   GetNumberOfSamples() const;
 
-  /** Reinitialize the seed of the random number generator  */
+  /** Reinitialize the seed of the random number generator. */
   void
   ReinitializeSeed();
 
@@ -339,6 +339,7 @@ public:
   ReinitializeSeed(int);
 
 private:
+  /** Update the position. */
   void
   UpdatePosition();
 

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Default constructor. Needed since we provide a cast constructor. */
+
 template <typename TImage>
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ImageRandomNonRepeatingConstIteratorWithIndex()
   : ImageConstIteratorWithIndex<TImage>()
@@ -32,8 +32,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ImageRandomNonRepeatingCo
   m_Permutation = nullptr;
 }
 
-/** Constructor establishes an iterator to walk a particular image and a
- * particular region of that image. */
 template <typename TImage>
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ImageRandomNonRepeatingConstIteratorWithIndex(
   const ImageType *  ptr,
@@ -46,10 +44,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ImageRandomNonRepeatingCo
   m_Permutation = new RandomPermutation(m_NumberOfPixelsInRegion);
 }
 
-
-//----------------------------------------------------------------------
-//    Assignment Operator
-//----------------------------------------------------------------------
 template <typename TImage>
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage> &
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::operator=(const Self & it)
@@ -72,7 +66,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::operator=(const Self & it
   return *this;
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 void
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeValueType number)
@@ -84,7 +77,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeVa
   }
 }
 
-/**  Set the number of samples to extract from the region */
 template <typename TImage>
 auto
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
@@ -92,7 +84,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::GetNumberOfSamples() cons
   return m_NumberOfSamplesRequested;
 }
 
-/** Reinitialize the seed of the random number generator */
 template <typename TImage>
 void
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ReinitializeSeed()
@@ -109,7 +100,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ReinitializeSeed(int seed
   this->m_Permutation->Shuffle();
 }
 
-/** update the position */
 template <typename TImage>
 void
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetPriorityImage(const PriorityImageType * priorityImage)
@@ -136,7 +126,6 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetPriorityImage(const Pr
   this->m_Permutation->Shuffle();
 }
 
-/** update the position */
 template <typename TImage>
 void
 ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::UpdatePosition()

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -161,7 +161,6 @@ LoggerThreadWrapper<SimpleLoggerType>::Flush()
   this->m_Mutex.unlock();
 }
 
-/** Constructor */
 template <typename SimpleLoggerType>
 LoggerThreadWrapper<SimpleLoggerType>::LoggerThreadWrapper()
 {
@@ -170,7 +169,6 @@ LoggerThreadWrapper<SimpleLoggerType>::LoggerThreadWrapper()
   m_Thread = std::thread(&Self::ThreadFunction, this);
 }
 
-/** Destructor */
 template <typename SimpleLoggerType>
 LoggerThreadWrapper<SimpleLoggerType>::~LoggerThreadWrapper()
 {
@@ -222,7 +220,6 @@ LoggerThreadWrapper<SimpleLoggerType>::ThreadFunction()
   }
 }
 
-/** Print contents of a LoggerThreadWrapper */
 template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -722,7 +722,7 @@ public:
    */
   ~VariableLengthVector();
 
-  /** Reserves memory of a certain length.
+  /** Reserves memory of a certain size of data.
    *
    * If the array already contains data, the existing data is copied over and
    * new space is allocated, if necessary. If the length to reserve is less
@@ -960,11 +960,11 @@ public:
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
-  /** Returns vector's Euclidean Norm  */
+  /** Returns vector's Euclidean norm. */
   RealValueType
   GetNorm() const;
 
-  /** Returns vector's squared Euclidean Norm  */
+  /** Returns vector's squared Euclidean norm. */
   RealValueType
   GetSquaredNorm() const;
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -26,14 +26,13 @@
 
 namespace itk
 {
-/** Default constructor  */
+
 template <typename TValue>
 VariableLengthVector<TValue>::VariableLengthVector()
   : m_Data(nullptr)
 
 {}
 
-/** Constructor with size */
 template <typename TValue>
 VariableLengthVector<TValue>::VariableLengthVector(unsigned int length)
   : m_Data(nullptr)
@@ -43,7 +42,6 @@ VariableLengthVector<TValue>::VariableLengthVector(unsigned int length)
   itkAssertInDebugAndIgnoreInReleaseMacro(m_Data != nullptr);
 }
 
-/** Constructor with user specified data */
 template <typename TValue>
 VariableLengthVector<TValue>::VariableLengthVector(ValueType * datain, unsigned int sz, bool LetArrayManageMemory)
   : m_LetArrayManageMemory(LetArrayManageMemory)
@@ -51,7 +49,6 @@ VariableLengthVector<TValue>::VariableLengthVector(ValueType * datain, unsigned 
   , m_NumElements(sz)
 {}
 
-/** Constructor with user specified data */
 template <typename TValue>
 VariableLengthVector<TValue>::VariableLengthVector(const ValueType * datain, unsigned int sz, bool LetArrayManageMemory)
   : m_LetArrayManageMemory(LetArrayManageMemory)
@@ -60,8 +57,6 @@ VariableLengthVector<TValue>::VariableLengthVector(const ValueType * datain, uns
   m_NumElements = sz;
 }
 
-/** Copy constructor. Overrides the default non-templated copy constructor
- * that the compiler provides */
 template <typename TValue>
 VariableLengthVector<TValue>::VariableLengthVector(const VariableLengthVector<TValue> & v)
 {
@@ -166,7 +161,6 @@ VariableLengthVector<TValue>::operator=(
   return *this;
 }
 
-/** Destructor */
 template <typename TValue>
 VariableLengthVector<TValue>::~VariableLengthVector()
 {
@@ -177,7 +171,6 @@ VariableLengthVector<TValue>::~VariableLengthVector()
   }
 }
 
-/** Reserve memory of certain size for m_Data */
 template <typename TValue>
 void
 VariableLengthVector<TValue>::Reserve(ElementIdentifier size)
@@ -209,7 +202,6 @@ VariableLengthVector<TValue>::Reserve(ElementIdentifier size)
   itkAssertInDebugAndIgnoreInReleaseMacro(m_Data != nullptr);
 }
 
-/** Allocate memory of certain size and return it */
 template <typename TValue>
 TValue *
 VariableLengthVector<TValue>::AllocateElements(ElementIdentifier size) const
@@ -226,12 +218,6 @@ VariableLengthVector<TValue>::AllocateElements(ElementIdentifier size) const
   }
 }
 
-/** Set the pointer from which the data is imported.
- * If "LetArrayManageMemory" is false, then the application retains
- * the responsibility of freeing the memory for this data.  If
- * "LetArrayManageMemory" is true, then this class will free the
- * memory when this object is destroyed. Note that you need to explicitly
- * set the number of elements. */
 template <typename TValue>
 void
 VariableLengthVector<TValue>::SetData(TValue * datain, bool LetArrayManageMemory)
@@ -246,15 +232,6 @@ VariableLengthVector<TValue>::SetData(TValue * datain, bool LetArrayManageMemory
   m_Data = datain;
 }
 
-/** Similar to the previous method. In the above method, the size must be
- * separately set prior to using user-supplied data. This introduces an
- * unnecessary allocation step to be performed. This method avoids it
- * and should be used to import data wherever possible to avoid this.
- * Set the pointer from which the data is imported.
- * If "LetArrayManageMemory" is false, then the application retains
- * the responsibility of freeing the memory for this data.  If
- * "LetArrayManageMemory" is true, then this class will free the
- * memory when this object is destroyed. */
 template <typename TValue>
 void
 VariableLengthVector<TValue>::SetData(TValue * datain, unsigned int sz, bool LetArrayManageMemory)
@@ -314,7 +291,6 @@ VariableLengthVector<TValue>::SetSize(unsigned int sz, TReallocatePolicy realloc
   m_NumElements = sz;
 }
 
-/** Set all the elements of the array to the specified value */
 template <typename TValue>
 void
 VariableLengthVector<TValue>::Fill(TValue const & v)
@@ -325,7 +301,6 @@ VariableLengthVector<TValue>::Fill(TValue const & v)
   std::fill(&this->m_Data[0], &this->m_Data[m_NumElements], v);
 }
 
-/** Copy-Assignment operator */
 template <typename TValue>
 VariableLengthVector<TValue> &
 VariableLengthVector<TValue>::operator=(const Self & v)
@@ -351,7 +326,6 @@ VariableLengthVector<TValue>::operator=(const Self & v)
   return *this;
 }
 
-/** Fast Assignment */
 template <typename TValue>
 inline VariableLengthVector<TValue> &
 VariableLengthVector<TValue>::FastAssign(const Self & v)
@@ -369,7 +343,6 @@ VariableLengthVector<TValue>::FastAssign(const Self & v)
   return *this;
 }
 
-/** Assignment operator */
 template <typename TValue>
 VariableLengthVector<TValue> &
 VariableLengthVector<TValue>::operator=(TValue const & v)
@@ -407,9 +380,6 @@ VariableLengthVector<TValue>::operator==(const Self & v) const
   return true;
 }
 
-/**
- * Returns vector's Euclidean Norm
- */
 template <typename TValue>
 auto
 VariableLengthVector<TValue>::GetNorm() const -> RealValueType
@@ -418,9 +388,6 @@ VariableLengthVector<TValue>::GetNorm() const -> RealValueType
   return static_cast<RealValueType>(sqrt(this->GetSquaredNorm()));
 }
 
-/**
- * Returns vector's Squared Euclidean Norm
- */
 template <typename TValue>
 auto
 VariableLengthVector<TValue>::GetSquaredNorm() const -> RealValueType

--- a/Modules/Core/Common/include/itkVersor.h
+++ b/Modules/Core/Common/include/itkVersor.h
@@ -203,7 +203,7 @@ public:
     return m_W;
   }
 
-  /** Returns the rotation angle in radians.  */
+  /** Returns the rotation angle in radians. */
   ValueType
   GetAngle() const;
 
@@ -219,9 +219,10 @@ public:
   VectorType
   GetRight() const;
 
-  /** Set the versor using a vector and angle
-   * the unit vector parallel to the given vector
-   * will be used. The angle is expected in radians. */
+  /** Set the versor using a vector and angle.
+   *
+   * The unit vector parallel to the given vector will be used. The angle is expected in radians.
+   */
   void
   Set(const VectorType & axis, ValueType angle);
 
@@ -277,7 +278,10 @@ public:
   VectorType
   Transform(const VectorType & v) const;
 
-  /** Transform a covariant vector.  */
+  /** Transform a covariant vector.
+   *
+   * Given that this is an orthogonal transformation CovariantVectors are transformed as vectors.
+   */
   CovariantVectorType
   Transform(const CovariantVectorType & v) const;
 
@@ -297,7 +301,7 @@ public:
   Self
   SquareRoot() const;
 
-  /** Compute the Exponential of the unit quaternion
+  /** Compute the Exponential of the unit quaternion.
    * Exponentiation by a factor is equivalent to
    * multiplication of the rotation angle of the quaternion. */
   Self

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -24,7 +24,6 @@
 
 namespace itk
 {
-/** Constructor to initialize entire vector to one value. */
 template <typename T>
 Versor<T>::Versor()
   : m_X(NumericTraits<T>::ZeroValue())
@@ -33,7 +32,6 @@ Versor<T>::Versor()
   , m_W(NumericTraits<T>::OneValue())
 {}
 
-/** Copy Constructor */
 template <typename T>
 Versor<T>::Versor(const Self & v)
 {
@@ -43,7 +41,6 @@ Versor<T>::Versor(const Self & v)
   m_W = v.m_W;
 }
 
-/** Assignment Operator */
 template <typename T>
 Versor<T> &
 Versor<T>::operator=(const Self & v)
@@ -55,7 +52,6 @@ Versor<T>::operator=(const Self & v)
   return *this;
 }
 
-/** Set to an identity transform */
 template <typename T>
 void
 Versor<T>::SetIdentity()
@@ -66,7 +62,6 @@ Versor<T>::SetIdentity()
   m_W = NumericTraits<T>::OneValue();
 }
 
-/** Return a vnl_quaternion */
 template <typename T>
 vnl_quaternion<T>
 Versor<T>::GetVnlQuaternion() const
@@ -74,7 +69,6 @@ Versor<T>::GetVnlQuaternion() const
   return vnl_quaternion<T>(m_X, m_Y, m_Z, m_W);
 }
 
-/** Assignment and Composition Operator */
 template <typename T>
 const Versor<T> &
 Versor<T>::operator*=(const Self & v)
@@ -92,7 +86,6 @@ Versor<T>::operator*=(const Self & v)
   return *this;
 }
 
-/** Composition Operator */
 template <typename T>
 Versor<T> Versor<T>::operator*(const Self & v) const
 {
@@ -106,7 +99,6 @@ Versor<T> Versor<T>::operator*(const Self & v) const
   return result;
 }
 
-/** Division and Assignment Operator */
 template <typename T>
 const Versor<T> &
 Versor<T>::operator/=(const Self & v)
@@ -124,7 +116,6 @@ Versor<T>::operator/=(const Self & v)
   return *this;
 }
 
-/** Division Operator  */
 template <typename T>
 Versor<T>
 Versor<T>::operator/(const Self & v) const
@@ -139,7 +130,6 @@ Versor<T>::operator/(const Self & v) const
   return result;
 }
 
-/** Comparison operator */
 template <typename T>
 bool
 Versor<T>::operator==(const Self & v) const
@@ -159,7 +149,6 @@ Versor<T>::operator==(const Self & v) const
   return false;
 }
 
-/** Get Conjugate */
 template <typename T>
 Versor<T>
 Versor<T>::GetConjugate() const
@@ -174,7 +163,6 @@ Versor<T>::GetConjugate() const
   return result;
 }
 
-/** Get Reciprocal */
 template <typename T>
 Versor<T>
 Versor<T>::GetReciprocal() const
@@ -189,7 +177,6 @@ Versor<T>::GetReciprocal() const
   return result;
 }
 
-/** Get Tensor part */
 template <typename T>
 auto
 Versor<T>::GetTensor() const -> ValueType
@@ -199,7 +186,6 @@ Versor<T>::GetTensor() const -> ValueType
   return tensor;
 }
 
-/** Normalize */
 template <typename T>
 void
 Versor<T>::Normalize()
@@ -219,7 +205,6 @@ Versor<T>::Normalize()
   m_W /= tensor;
 }
 
-/** Get Axis */
 template <typename T>
 auto
 Versor<T>::GetAxis() const -> VectorType
@@ -248,7 +233,6 @@ Versor<T>::GetAxis() const -> VectorType
   return axis;
 }
 
-/** Get Right part */
 template <typename T>
 auto
 Versor<T>::GetRight() const -> VectorType
@@ -262,7 +246,6 @@ Versor<T>::GetRight() const -> VectorType
   return axis;
 }
 
-/** Get Scalar part */
 template <typename T>
 auto
 Versor<T>::GetScalar() const -> ValueType
@@ -270,7 +253,6 @@ Versor<T>::GetScalar() const -> ValueType
   return m_W;
 }
 
-/** Get Angle (in radians) */
 template <typename T>
 auto
 Versor<T>::GetAngle() const -> ValueType
@@ -286,7 +268,6 @@ Versor<T>::GetAngle() const -> ValueType
   return angle;
 }
 
-/** Get the Square root of the unit quaternion */
 template <typename T>
 Versor<T>
 Versor<T>::SquareRoot() const
@@ -306,7 +287,6 @@ Versor<T>::SquareRoot() const
   return result;
 }
 
-/** Compute the Exponential of the quaternion */
 template <typename T>
 Versor<T>
 Versor<T>::Exponential(ValueType exponent) const
@@ -318,7 +298,6 @@ Versor<T>::Exponential(ValueType exponent) const
   return result;
 }
 
-/** Set Axis and Angle (in radians) */
 template <typename T>
 void
 Versor<T>::Set(const VectorType & axis, ValueType angle)
@@ -344,7 +323,6 @@ Versor<T>::Set(const VectorType & axis, ValueType angle)
   m_W = cosangle2;
 }
 
-/**  Set using an orthogonal matrix. */
 template <typename T>
 void
 Versor<T>::Set(const MatrixType & mat)
@@ -428,7 +406,6 @@ Versor<T>::Set(const MatrixType & mat)
   this->Normalize();
 }
 
-/** Set right Part (in radians) */
 template <typename T>
 void
 Versor<T>::Set(const VectorType & axis)
@@ -452,9 +429,6 @@ Versor<T>::Set(const VectorType & axis)
   m_W = cosangle2;
 }
 
-/** Set the Versor from four components.
- *  After assignment, the quaternion is normalized
- *  in order to get a consistent Versor (unit quaternion). */
 template <typename T>
 void
 Versor<T>::Set(T x, T y, T z, T w)
@@ -483,9 +457,6 @@ Versor<T>::Set(T x, T y, T z, T w)
   this->Normalize();
 }
 
-/** Set from a vnl_quaternion
- *  After assignment, the quaternion is normalized
- *  in order to get a consistent Versor (unit quaternion). */
 template <typename T>
 void
 Versor<T>::Set(const VnlQuaternionType & quaternion)
@@ -497,7 +468,6 @@ Versor<T>::Set(const VnlQuaternionType & quaternion)
   this->Normalize();
 }
 
-/** Set rotation around X axis */
 template <typename T>
 void
 Versor<T>::SetRotationAroundX(ValueType angle)
@@ -511,7 +481,6 @@ Versor<T>::SetRotationAroundX(ValueType angle)
   m_W = cosangle2;
 }
 
-/** Set rotation around Y axis  */
 template <typename T>
 void
 Versor<T>::SetRotationAroundY(ValueType angle)
@@ -525,7 +494,6 @@ Versor<T>::SetRotationAroundY(ValueType angle)
   m_W = cosangle2;
 }
 
-/**  Set rotation around Z axis  */
 template <typename T>
 void
 Versor<T>::SetRotationAroundZ(ValueType angle)
@@ -577,7 +545,6 @@ localTransformVectorMath(const InputVectorType & VectorObject,
 }
 } // namespace
 
-/** Transform a Vector */
 template <typename T>
 auto
 Versor<T>::Transform(const VectorType & v) const -> VectorType
@@ -586,9 +553,6 @@ Versor<T>::Transform(const VectorType & v) const -> VectorType
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
 }
 
-/** Transform a CovariantVector
- *  given that this is an orthogonal transformation
- *  CovariantVectors are transformed as vectors. */
 template <typename T>
 auto
 Versor<T>::Transform(const CovariantVectorType & v) const -> CovariantVectorType
@@ -597,7 +561,6 @@ Versor<T>::Transform(const CovariantVectorType & v) const -> CovariantVectorType
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
 }
 
-/** Transform a Point */
 template <typename T>
 auto
 Versor<T>::Transform(const PointType & v) const -> PointType
@@ -606,7 +569,6 @@ Versor<T>::Transform(const PointType & v) const -> PointType
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
 }
 
-/** Transform a VnlVector */
 template <typename T>
 auto
 Versor<T>::Transform(const VnlVectorType & v) const -> VnlVectorType
@@ -615,7 +577,6 @@ Versor<T>::Transform(const VnlVectorType & v) const -> VnlVectorType
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
 }
 
-/** Get Matrix representation */
 template <typename T>
 Matrix<T, 3, 3>
 Versor<T>::GetMatrix() const

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TElement>
 GPUReduction<TElement>::GPUReduction()
 {
@@ -46,9 +44,6 @@ GPUReduction<TElement>::~GPUReduction()
   this->ReleaseGPUInputBuffer();
 }
 
-/**
- * Standard "PrintSelf" method.
- */
 template <typename TElement>
 void
 GPUReduction<TElement>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImage, typename TAccessor>
 ImageAdaptor<TImage, TAccessor>::ImageAdaptor()
 {
@@ -41,7 +39,7 @@ ImageAdaptor<TImage, TAccessor>::Allocate(bool initialize)
 {
   m_Image->Allocate(initialize);
 }
-//----------------------------------------------------------------------------
+
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::Initialize()
@@ -64,7 +62,6 @@ ImageAdaptor<TImage, TAccessor>::SetPixelContainer(PixelContainer * container)
   }
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::Graft(const Self * imgData)
@@ -79,8 +76,6 @@ ImageAdaptor<TImage, TAccessor>::Graft(const Self * imgData)
   }
 }
 
-
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::Graft(const DataObject * data)
@@ -112,9 +107,6 @@ ImageAdaptor<TImage, TAccessor>::Graft(const DataObject * data)
   }
 }
 
-/**
- *
- */
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::PrintSelf(std::ostream & os, Indent indent) const
@@ -122,7 +114,6 @@ ImageAdaptor<TImage, TAccessor>::PrintSelf(std::ostream & os, Indent indent) con
   Superclass::PrintSelf(os, indent);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetOffsetTable() const -> const OffsetValueType *
@@ -130,7 +121,6 @@ ImageAdaptor<TImage, TAccessor>::GetOffsetTable() const -> const OffsetValueType
   return m_Image->GetOffsetTable();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::ComputeIndex(OffsetValueType offset) const -> IndexType
@@ -138,7 +128,6 @@ ImageAdaptor<TImage, TAccessor>::ComputeIndex(OffsetValueType offset) const -> I
   return m_Image->ComputeIndex(offset);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::Update()
@@ -148,7 +137,6 @@ ImageAdaptor<TImage, TAccessor>::Update()
   m_Image->Update();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::UpdateOutputInformation()
@@ -164,7 +152,6 @@ ImageAdaptor<TImage, TAccessor>::UpdateOutputInformation()
   this->UpdateAccessor(m_Image.GetPointer());
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::UpdateOutputData()
@@ -177,7 +164,6 @@ ImageAdaptor<TImage, TAccessor>::UpdateOutputData()
   SetBufferedRegion(m_Image->GetBufferedRegion());
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::PropagateRequestedRegion()
@@ -189,7 +175,6 @@ ImageAdaptor<TImage, TAccessor>::PropagateRequestedRegion()
   m_Image->PropagateRequestedRegion();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetRequestedRegionToLargestPossibleRegion()
@@ -201,7 +186,6 @@ ImageAdaptor<TImage, TAccessor>::SetRequestedRegionToLargestPossibleRegion()
   m_Image->SetRequestedRegionToLargestPossibleRegion();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::CopyInformation(const DataObject * data)
@@ -217,7 +201,6 @@ ImageAdaptor<TImage, TAccessor>::CopyInformation(const DataObject * data)
   this->UpdateAccessor(m_Image.GetPointer());
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetSpacing() const -> const SpacingType &
@@ -225,7 +208,6 @@ ImageAdaptor<TImage, TAccessor>::GetSpacing() const -> const SpacingType &
   return m_Image->GetSpacing();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetSpacing(const SpacingType & spacing)
@@ -234,7 +216,6 @@ ImageAdaptor<TImage, TAccessor>::SetSpacing(const SpacingType & spacing)
   m_Image->SetSpacing(spacing);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetSpacing(const double * spacing /*[Self::ImageDimension]*/)
@@ -243,7 +224,6 @@ ImageAdaptor<TImage, TAccessor>::SetSpacing(const double * spacing /*[Self::Imag
   m_Image->SetSpacing(spacing);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetSpacing(const float * spacing /*[Self::ImageDimension]*/)
@@ -252,7 +232,6 @@ ImageAdaptor<TImage, TAccessor>::SetSpacing(const float * spacing /*[Self::Image
   m_Image->SetSpacing(spacing);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetOrigin(const PointType origin)
@@ -261,7 +240,6 @@ ImageAdaptor<TImage, TAccessor>::SetOrigin(const PointType origin)
   m_Image->SetOrigin(origin);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetOrigin(const double * origin /*[Self::ImageDimension]*/)
@@ -270,7 +248,6 @@ ImageAdaptor<TImage, TAccessor>::SetOrigin(const double * origin /*[Self::ImageD
   m_Image->SetOrigin(origin);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetOrigin(const float * origin /*[Self::ImageDimension]*/)
@@ -279,7 +256,6 @@ ImageAdaptor<TImage, TAccessor>::SetOrigin(const float * origin /*[Self::ImageDi
   m_Image->SetOrigin(origin);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetOrigin() const -> const PointType &
@@ -287,7 +263,6 @@ ImageAdaptor<TImage, TAccessor>::GetOrigin() const -> const PointType &
   return m_Image->GetOrigin();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetDirection(const DirectionType & direction)
@@ -296,7 +271,6 @@ ImageAdaptor<TImage, TAccessor>::SetDirection(const DirectionType & direction)
   m_Image->SetDirection(direction);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetDirection() const -> const DirectionType &
@@ -304,7 +278,6 @@ ImageAdaptor<TImage, TAccessor>::GetDirection() const -> const DirectionType &
   return m_Image->GetDirection();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetImage(TImage * image)
@@ -317,7 +290,6 @@ ImageAdaptor<TImage, TAccessor>::SetImage(TImage * image)
   this->UpdateAccessor(m_Image.GetPointer());
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetBufferPointer() const -> const InternalPixelType *
@@ -325,7 +297,6 @@ ImageAdaptor<TImage, TAccessor>::GetBufferPointer() const -> const InternalPixel
   return m_Image->GetBufferPointer();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetBufferPointer() -> InternalPixelType *
@@ -333,7 +304,6 @@ ImageAdaptor<TImage, TAccessor>::GetBufferPointer() -> InternalPixelType *
   return m_Image->GetBufferPointer();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::Modified() const
@@ -343,7 +313,6 @@ ImageAdaptor<TImage, TAccessor>::Modified() const
   m_Image->Modified();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 ModifiedTimeType
 ImageAdaptor<TImage, TAccessor>::GetMTime() const
@@ -356,7 +325,6 @@ ImageAdaptor<TImage, TAccessor>::GetMTime() const
   return (mtime1 >= mtime2 ? mtime1 : mtime2);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetBufferedRegion(const RegionType & region)
@@ -368,7 +336,6 @@ ImageAdaptor<TImage, TAccessor>::SetBufferedRegion(const RegionType & region)
   m_Image->SetBufferedRegion(region);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetBufferedRegion() const -> const RegionType &
@@ -377,7 +344,6 @@ ImageAdaptor<TImage, TAccessor>::GetBufferedRegion() const -> const RegionType &
   return m_Image->GetBufferedRegion();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetLargestPossibleRegion(const RegionType & region)
@@ -389,7 +355,6 @@ ImageAdaptor<TImage, TAccessor>::SetLargestPossibleRegion(const RegionType & reg
   m_Image->SetLargestPossibleRegion(region);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetLargestPossibleRegion() const -> const RegionType &
@@ -398,7 +363,6 @@ ImageAdaptor<TImage, TAccessor>::GetLargestPossibleRegion() const -> const Regio
   return m_Image->GetLargestPossibleRegion();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetRequestedRegion(const RegionType & region)
@@ -410,7 +374,6 @@ ImageAdaptor<TImage, TAccessor>::SetRequestedRegion(const RegionType & region)
   m_Image->SetRequestedRegion(region);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 void
 ImageAdaptor<TImage, TAccessor>::SetRequestedRegion(const DataObject * data)
@@ -422,7 +385,6 @@ ImageAdaptor<TImage, TAccessor>::SetRequestedRegion(const DataObject * data)
   m_Image->SetRequestedRegion(data);
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 bool
 ImageAdaptor<TImage, TAccessor>::VerifyRequestedRegion()
@@ -434,7 +396,6 @@ ImageAdaptor<TImage, TAccessor>::VerifyRequestedRegion()
   return m_Image->VerifyRequestedRegion();
 }
 
-//----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
 auto
 ImageAdaptor<TImage, TAccessor>::GetRequestedRegion() const -> const RegionType &

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -38,9 +38,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplineInterpolateImageFunction()
 {
@@ -55,9 +53,6 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplin
   this->m_UseImageDirection = true;
 }
 
-/**
- * Standard "PrintSelf" method
- */
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
@@ -217,37 +217,43 @@ private:
     using Type = T;
   };
 
-  /** Specialized versions of EvaluateAtIndex() method to handle scalar or vector pixel types.*/
+  /** Specialized version of EvaluateAtIndex() method to handle scalar pixel types.*/
   template <typename Type>
   inline void
   EvaluateAtIndexSpecialized(const IndexType & index,
                              OutputType &      orientedDerivative,
                              OutputTypeSpecializationStructType<OutputType>) const;
+
+  /** Specialized version of EvaluateAtIndex() method to handle vector pixel types.*/
   template <typename Type>
   inline void
   EvaluateAtIndexSpecialized(const IndexType & index,
                              OutputType &      derivative,
                              OutputTypeSpecializationStructType<Type>) const;
 
-  /** Specialized versions of EvaluateAtContinuousIndex() method to handle scalar or vector pixel types.*/
+  /** Specialized version of EvaluateAtContinuousIndex() method to handle scalar pixel types.*/
   template <typename Type>
   inline void
   EvaluateAtContinuousIndexSpecialized(const ContinuousIndexType & cindex,
                                        OutputType &                orientedDerivative,
                                        OutputTypeSpecializationStructType<OutputType>) const;
+
+  /** Specialized version of EvaluateAtContinuousIndex() method to handle vector pixel types.*/
   template <typename Type>
   inline void
   EvaluateAtContinuousIndexSpecialized(const ContinuousIndexType & cindex,
                                        OutputType &                derivative,
                                        OutputTypeSpecializationStructType<Type>) const;
 
-  /** Specialized versions of Evaluate() method to handle scalar or vector pixel types.*/
+  /** Specialized version of Evaluate() method to handle scalar pixel types.*/
   // NOTE: for some unknown reason, making these methods inline (as those above are inlined) makes them run *slower*.
   template <typename Type>
   void
   EvaluateSpecialized(const PointType & point,
                       OutputType &      orientedDerivative,
                       OutputTypeSpecializationStructType<OutputType>) const;
+
+  /** Specialized version of Evaluate() method to handle vector pixel types.*/
   template <typename Type>
   void
   EvaluateSpecialized(const PointType & point, OutputType & derivative, OutputTypeSpecializationStructType<Type>) const;

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::CentralDifferenceImageFunction()
 {
@@ -34,9 +32,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::CentralDiff
   this->m_Interpolator = LinearInterpolatorType::New();
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 void
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInputImage(const TInputImage * inputData)
@@ -67,9 +62,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInputIma
   }
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 void
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInterpolator(InterpolatorType * interpolator)
@@ -85,9 +77,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInterpol
   }
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 void
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -96,9 +85,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(s
   os << indent << "UseImageDirection = " << this->m_UseImageDirection << std::endl;
 }
 
-/**
- * EvaluateAtIndex
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 auto
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtIndex(const IndexType & index) const
@@ -115,9 +101,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   return derivative;
 }
 
-/*
- * Specialized for scalar pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void
@@ -171,9 +154,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   }
 }
 
-/*
- * Specialized for vector pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void
@@ -255,9 +235,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   }
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 auto
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::Evaluate(const PointType & point) const
@@ -274,9 +251,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::Evaluate(co
   return derivative;
 }
 
-/*
- * Specialized for scalar pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void
@@ -343,9 +317,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   }
 }
 
-/*
- * Specialized for vector pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void
@@ -457,9 +428,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   }
 }
 
-/**
- * EvaluateAtContinuousIndex
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 typename CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::OutputType
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtContinuousIndex(
@@ -474,9 +442,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
   return derivative;
 }
 
-/*
- * Specialized for scalar pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void
@@ -531,9 +496,6 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
   }
 }
 
-/*
- * Specialized for vector pixels
- */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 template <typename Type>
 void

--- a/Modules/Core/ImageFunction/include/itkImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutput, typename TCoordRep>
 ImageFunction<TInputImage, TOutput, TCoordRep>::ImageFunction()
 {
@@ -34,9 +32,7 @@ ImageFunction<TInputImage, TOutput, TCoordRep>::ImageFunction()
   m_EndContinuousIndex.Fill(0.0f);
 }
 
-/**
- * Standard "PrintSelf" method
- */
+
 template <typename TInputImage, typename TOutput, typename TCoordRep>
 void
 ImageFunction<TInputImage, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -49,9 +45,6 @@ ImageFunction<TInputImage, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Ind
   os << indent << "EndContinuousIndex: " << m_EndContinuousIndex << std::endl;
 }
 
-/**
- * Initialize by setting the input image
- */
 template <typename TInputImage, typename TOutput, typename TCoordRep>
 void
 ImageFunction<TInputImage, TOutput, TCoordRep>::SetInputImage(const InputImageType * ptr)

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 MedianImageFunction<TInputImage, TCoordRep>::MedianImageFunction() = default;
 
@@ -44,10 +42,6 @@ MedianImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigne
   }
 }
 
-
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 MedianImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -56,9 +50,6 @@ MedianImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 auto
 MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> OutputType

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
@@ -23,18 +23,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::NeighborhoodBinaryThresholdImageFunction()
 {
   m_Radius.Fill(1);
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -44,9 +39,6 @@ NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::PrintSelf(std:
   os << indent << "Radius: " << m_Radius << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 bool
 NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
@@ -25,7 +25,7 @@
 
 namespace itk
 {
-/** Print self method */
+
 template <typename TInputImage, typename TOutput>
 void
 NeighborhoodOperatorImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
@@ -34,7 +34,6 @@ NeighborhoodOperatorImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream 
   os << indent << "Applying Operator Function:" << std::endl;
 }
 
-/** Evaluate the function at the specified point */
 template <typename TInputImage, typename TOutput>
 TOutput
 NeighborhoodOperatorImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -22,18 +22,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 ScatterMatrixImageFunction<TInputImage, TCoordRep>::ScatterMatrixImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 ScatterMatrixImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -42,9 +37,6 @@ ScatterMatrixImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os,
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 auto
 ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -23,18 +23,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 VarianceImageFunction<TInputImage, TCoordRep>::VarianceImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 VarianceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -43,9 +38,6 @@ VarianceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Inde
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 auto
 VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -23,17 +23,12 @@
 
 namespace itk
 {
-/**
- * Define the number of neighbors
- */
+
 template <typename TInputImage, typename TCoordRep>
 const unsigned long VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::m_Neighbors =
   1 << TInputImage::ImageDimension;
 
 
-/**
- * Evaluate at image index position
- */
 template <typename TInputImage, typename TCoordRep>
 typename VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
 VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
@@ -30,9 +30,6 @@ template <typename TInputImage, typename TCoordRep>
 const unsigned int VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::m_Neighbors =
   1 << TInputImage::ImageDimension;
 
-/**
- * Evaluate at image index position
- */
 template <typename TInputImage, typename TCoordRep>
 typename VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::OutputType
 VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -22,18 +22,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TCoordRep>
 VectorMeanImageFunction<TInputImage, TCoordRep>::VectorMeanImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 void
 VectorMeanImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
@@ -42,9 +37,6 @@ VectorMeanImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, In
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TCoordRep>
 auto
 VectorMeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -46,7 +46,6 @@ template <unsigned int VRadius, typename TInput, typename TOutput>
 const double BlackmanWindowFunction<VRadius, TInput, TOutput>::m_Factor2 = 2.0 * itk::Math::pi / VRadius;
 } // end namespace Function
 
-
 template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,
@@ -109,7 +108,6 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   }
 }
 
-/** PrintSelf */
 template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,
@@ -123,7 +121,6 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   this->Superclass::PrintSelf(os, indent);
 }
 
-/** Evaluate at image index position */
 template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -87,7 +87,6 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::SetInput(const InputImageType 
   this->ProcessObject::SetNthInput(0, const_cast<InputImageType *>(image));
 }
 
-/** Generate the data */
 template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::GenerateData()
@@ -2689,7 +2688,6 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::SearchThroughLastFrame(int ind
   return result;
 }
 
-/** PrintSelf */
 template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -27,11 +27,7 @@
 
 namespace itk
 {
-/**
- * A protected default constructor allows the New() routine to create an
- * instance of SimplexMesh.   All the containers are initialized to empty
- * containers.
- */
+
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::SimplexMesh()
   : m_LastCellId(0)
@@ -39,11 +35,6 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SimplexMesh()
   m_GeometryData = GeometryMapType::New();
 }
 
-/**
- * Mesh Destructor takes care of releasing the memory of Cells
- * and CellBoundaries objects for which normal pointers are
- * stored.
- */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::~SimplexMesh()
 {
@@ -224,7 +215,6 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::ReplaceFace(CellIdentifier    
   return replaceIndex;
 }
 
-/* PrintSelf. */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 void
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -48,7 +48,6 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::GenerateData()
   this->ComputeCellParameters();
 }
 
-//
 template <typename TInputMesh, typename TOutputMesh>
 void
 SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::Initialize()
@@ -375,7 +374,6 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ModifyNeighborCells(Cel
   outputMesh->BuildCellLinks();
 }
 
-/* PrintSelf. */
 template <typename TInputMesh, typename TOutputMesh>
 void
 SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -113,7 +113,6 @@ SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::FindCellId(CellIdentif
   return *cellIt;
 }
 
-/* PrintSelf. */
 template <typename TInputMesh, typename TOutputMesh>
 void
 SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -193,7 +193,7 @@ private:
   void
   CreateTriangles();
 
-  /** intermediate volume computation */
+  /** Calculate volume of triangle. */
   void
   CalculateTriangleVolume(InputPointType p1, InputPointType p2, InputPointType p3);
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -91,9 +91,6 @@ SimplexMeshVolumeCalculator<TInputMesh>::FindCellId(IdentifierType id1, Identifi
   return *cellIt;
 }
 
-/**
- * Calculate volume of triangle
- */
 template <typename TInputMesh>
 void
 SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType p1,
@@ -253,9 +250,6 @@ SimplexMeshVolumeCalculator<TInputMesh>::Compute()
   this->Finalize();
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputMesh>
 void
 SimplexMeshVolumeCalculator<TInputMesh>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
@@ -185,7 +185,7 @@ public:
   itkSetMacro(Size, SizeType);
   itkGetConstMacro(Size, SizeType);
 
-  /** Set the mesh input of this process object.  */
+  /** Set the input mesh. */
   using Superclass::SetInput;
   void
   SetInput(InputMeshType * input);
@@ -200,7 +200,7 @@ public:
     }
   }
 
-  /** Get the mesh input of this process object.  */
+  /** Get the input mesh. */
   InputMeshType *
   GetInput();
 
@@ -224,6 +224,7 @@ protected:
   virtual void
   RasterizeTriangles();
 
+  /** Convert a single polygon/triangle to raster format. */
   static int
   PolygonToImageRaster(PointVector coords, Point1DArray & zymatrix, int extent[6]);
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -24,7 +24,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TInputMesh, typename TOutputImage>
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::TriangleMeshToBinaryImageFilter()
 {
@@ -47,7 +47,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::TriangleMeshToBinaryI
   m_InfoImage = nullptr;
 }
 
-/** Set the Input Mesh */
 template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetInput(TInputMesh * input)
@@ -55,7 +54,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetInput(TInputMesh *
   this->ProcessObject::SetNthInput(0, input);
 }
 
-/** Get the input Mesh */
 template <typename TInputMesh, typename TOutputImage>
 auto
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput() -> InputMeshType *
@@ -63,7 +61,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput() -> InputMe
   return static_cast<TInputMesh *>(this->ProcessObject::GetInput(0));
 }
 
-/** Get the input Mesh */
 template <typename TInputMesh, typename TOutputImage>
 auto
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput(unsigned int idx) -> InputMeshType *
@@ -71,7 +68,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput(unsigned int
   return itkDynamicCastInDebugMode<TInputMesh *>(this->ProcessObject::GetInput(idx));
 }
 
-//----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetSpacing(const double spacing[3])
@@ -94,7 +90,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetSpacing(const floa
   this->SetSpacing(s);
 }
 
-//----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetOrigin(const double origin[3])
@@ -114,7 +109,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetOrigin(const float
   this->SetOrigin(p);
 }
 
-// used by an STL sort
 template <typename TInputMesh, typename TOutputImage>
 bool
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::ComparePoints2D(Point2DType a, Point2DType b)
@@ -130,7 +124,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::ComparePoints2D(Point
   }
 }
 
-// used by an STL sort
 template <typename TInputMesh, typename TOutputImage>
 bool
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::ComparePoints1D(Point1D a, Point1D b)
@@ -138,9 +131,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::ComparePoints1D(Point
   return (a.m_X < b.m_X);
 }
 
-//----------------------------------------------------------------------------
-
-/** Update */
 template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
@@ -181,10 +171,8 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
   RasterizeTriangles();
 
   itkDebugMacro(<< "TriangleMeshToBinaryImageFilter::Update() finished");
-} // end update function
+}
 
-//----------------------------------------------------------------------------
-/** convert a single polygon/triangle to raster format */
 template <typename TInputMesh, typename TOutputImage>
 int
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(PointVector    coords,
@@ -327,7 +315,6 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(
   return sign;
 }
 
-/** raterize : Courtesy of Dr D Gobbi of Atamai Inc.*/
 template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -265,7 +265,6 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateNewEdge(CellIden
   }
 }
 
-/* PrintSelf. */
 template <typename TInputMesh, typename TOutputMesh>
 void
 TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -32,7 +32,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::QuadEdgeMeshEulerOp
   , m_EdgeStatus(STANDARD_CONFIG)
 {}
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 void
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -81,7 +80,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PrintSelf(std::ostr
   }
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 auto
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
@@ -121,7 +119,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Evaluate(QEType * e
   }
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 TQEType *
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Process(QEType * e)
@@ -232,7 +229,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Process(QEType * e)
   return (result);
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 TQEType *
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedQuadEdge(QEType * e)
@@ -257,7 +253,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedQuad
   return (rebuildEdge);
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 TQEType *
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedFace(
@@ -287,7 +282,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedFace
   }
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QEType *                e,
@@ -316,7 +310,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QETy
   return border;
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 typename QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::EdgeStatusType
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CheckStatus(QEType *                e,
@@ -426,7 +419,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CheckStatus(QEType 
   return STANDARD_CONFIG;
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsTetrahedron(QEType * e)
@@ -499,7 +491,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsTetrahedron(QETyp
   return false;
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsSamosa(QEType * e)
@@ -507,7 +498,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsSamosa(QEType * e
   return ((e->GetOrder() == 2) && (e->GetSym()->GetOrder() == 2));
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEye(QEType * e)
@@ -518,7 +508,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEye(QEType * e)
   return ((OriginOrderIsTwo && !DestinationOrderIsTwo) || (!OriginOrderIsTwo && DestinationOrderIsTwo));
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 auto
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CommonVertexNeighboor(QEType * e) -> PointIdentifier
@@ -558,7 +547,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CommonVertexNeighbo
   return static_cast<PointIdentifier>(intersection_list.size());
 }
 
-//--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
 bool
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEdgeLinkingTwoDifferentBorders(QEType * e)

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -93,14 +93,13 @@ public:
   GetLengthInWorldSpace() const;
 
 protected:
-  /** Compute the Object bounding box */
+  /** Compute the Object bounding box. */
   void
   ComputeMyBoundingBox() override;
 
   ArrowSpatialObject();
   ~ArrowSpatialObject() override = default;
 
-  /** Method to print the object.*/
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 ArrowSpatialObject<TDimension>::ArrowSpatialObject()
 {
@@ -51,7 +51,6 @@ ArrowSpatialObject<TDimension>::Clear()
   this->Modified();
 }
 
-/** Compute the bounding box */
 template <unsigned int TDimension>
 void
 ArrowSpatialObject<TDimension>::ComputeMyBoundingBox()
@@ -64,7 +63,6 @@ ArrowSpatialObject<TDimension>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
 }
 
-/** Check if a given point is on the arrow */
 template <unsigned int TDimension>
 bool
 ArrowSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) const
@@ -140,7 +138,6 @@ ArrowSpatialObject<TDimension>::GetLengthInWorldSpace() const
   return len;
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 ArrowSpatialObject<TDimension>::InternalClone() const

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 BlobSpatialObject<TDimension>::BlobSpatialObject()
 {
@@ -35,7 +35,6 @@ BlobSpatialObject<TDimension>::BlobSpatialObject()
   this->GetProperty().SetAlpha(1);
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 BlobSpatialObject<TDimension>::InternalClone() const
@@ -52,7 +51,6 @@ BlobSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print the blob spatial object */
 template <unsigned int TDimension>
 void
 BlobSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -71,7 +71,7 @@ public:
   /** Get the position of the box spatial object in object space. */
   itkGetConstReferenceMacro(PositionInObjectSpace, PointType);
 
-  /** Test whether a point is inside or outside the object */
+  /** Test whether a point is inside the object. */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 
@@ -88,7 +88,6 @@ protected:
   BoxSpatialObject();
   ~BoxSpatialObject() override = default;
 
-  /** Print the object information in a stream. */
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -96,7 +95,6 @@ protected:
   InternalClone() const override;
 
 private:
-  /** object space */
   SizeType  m_SizeInObjectSpace{};
   PointType m_PositionInObjectSpace{};
 };

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 BoxSpatialObject<TDimension>::BoxSpatialObject()
 {
@@ -45,7 +45,6 @@ BoxSpatialObject<TDimension>::Clear()
   this->Modified();
 }
 
-/** Test whether a point is inside or outside the object */
 template <unsigned int TDimension>
 bool
 BoxSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) const
@@ -55,7 +54,6 @@ BoxSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) con
   return this->GetMyBoundingBoxInObjectSpace()->IsInside(point);
 }
 
-/** Compute the bounds of the box */
 template <unsigned int TDimension>
 void
 BoxSpatialObject<TDimension>::ComputeMyBoundingBox()
@@ -76,7 +74,6 @@ BoxSpatialObject<TDimension>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 BoxSpatialObject<TDimension>::InternalClone() const
@@ -96,7 +93,6 @@ BoxSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print Self function */
 template <unsigned int TDimension>
 void
 BoxSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -126,11 +126,11 @@ public:
     return m_ControlPoints;
   }
 
-  /** Set the list of control points. */
+  /** Set the list of control points defining the contour. */
   void
   SetControlPoints(const ControlPointListType & points);
 
-  /** Set the list of control points. */
+  /** Add a point to the list of control points defining the contour. */
   void
   AddControlPoint(const ControlPointType & point);
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 ContourSpatialObject<TDimension>::ContourSpatialObject()
 {
@@ -104,7 +104,6 @@ ContourSpatialObject<TDimension>::GetOrientationInObjectSpace() const
   return m_OrientationInObjectSpace;
 }
 
-/** Set the control points which are defining the contour */
 template <unsigned int TDimension>
 void
 ContourSpatialObject<TDimension>::SetControlPoints(const ContourPointListType & points)
@@ -122,7 +121,6 @@ ContourSpatialObject<TDimension>::SetControlPoints(const ContourPointListType & 
   this->Modified();
 }
 
-/** Add a control point which is defining the contour */
 template <unsigned int TDimension>
 void
 ContourSpatialObject<TDimension>::AddControlPoint(const ContourPointType & point)
@@ -132,7 +130,6 @@ ContourSpatialObject<TDimension>::AddControlPoint(const ContourPointType & point
   this->Modified();
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 ContourSpatialObject<TDimension>::InternalClone() const
@@ -156,7 +153,6 @@ ContourSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print the contour spatial object */
 template <unsigned int TDimension>
 void
 ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint()
 {
@@ -29,7 +29,6 @@ ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint()
   m_PickedPointInObjectSpace.Fill(0);
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint(const ContourSpatialObjectPoint & other)
   : Superclass(other)

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
@@ -21,14 +21,13 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 DTITubeSpatialObject<TDimension>::DTITubeSpatialObject()
 {
   this->SetTypeName("DTITubeSpatialObject");
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 DTITubeSpatialObject<TDimension>::InternalClone() const

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -117,33 +117,33 @@ public:
     return m_TensorMatrix;
   }
 
-  /** Copy one DTITubeSpatialObjectPoint to another */
+  /** Copy one DTITubeSpatialObjectPoint to another. */
   Self &
   operator=(const DTITubeSpatialObjectPoint & rhs);
 
-  /** Add a field to the point list */
+  /** Add a field to the point list. */
   void
   AddField(const char * name, float value);
 
-  /** Add a field to the point list */
+  /** Add a field to the point list. */
   void
   AddField(DTITubeSpatialObjectPointFieldEnum name, float value);
 
-  /** Set a field value */
+  /** Set a field value. */
   void
   SetField(DTITubeSpatialObjectPointFieldEnum name, float value);
 
   void
   SetField(const char * name, float value);
 
-  /** Return the list of extra fields */
+  /** Get the list of fields. */
   const FieldListType &
   GetFields() const
   {
     return m_Fields;
   }
 
-  /** Return the value of the specific fields */
+  /** Get the value of the specified field. */
   float
   GetField(const char * name) const;
 
@@ -158,7 +158,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Translate the enum to char */
+  /** Translate the enum to a string. */
   std::string
   TranslateEnumToChar(DTITubeSpatialObjectPointFieldEnum name) const;
 };

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint()
 {
@@ -36,7 +36,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint()
   m_TensorMatrix[5] = 1;
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint(const DTITubeSpatialObjectPoint & other)
   : Superclass(other)
@@ -62,7 +61,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
   Superclass::PrintSelf(os, indent);
 }
 
-/** Translate the enumerated types to a string */
 template <unsigned int TPointDimension>
 std::string
 DTITubeSpatialObjectPoint<TPointDimension>::TranslateEnumToChar(DTITubeSpatialObjectPointFieldEnum name) const
@@ -83,7 +81,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::TranslateEnumToChar(DTITubeSpatialOb
   return std::string("");
 }
 
-/** Add a field to the point list */
 template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::AddField(const char * name, float value)
@@ -93,7 +90,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::AddField(const char * name, float va
   m_Fields.push_back(field);
 }
 
-/** Set a field value to the point list */
 template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::SetField(const char * name, float value)
@@ -110,7 +106,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::SetField(const char * name, float va
   }
 }
 
-/** Set a value to a field in the point list */
 template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::SetField(DTITubeSpatialObjectPointFieldEnum name, float value)
@@ -127,7 +122,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::SetField(DTITubeSpatialObjectPointFi
   }
 }
 
-/** Add a field to the point list */
 template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::AddField(DTITubeSpatialObjectPointFieldEnum name, float value)
@@ -145,7 +139,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::AddField(DTITubeSpatialObjectPointFi
   }
 }
 
-/** Return the value of the given field */
 template <unsigned int TPointDimension>
 float
 DTITubeSpatialObjectPoint<TPointDimension>::GetField(const char * name) const
@@ -163,7 +156,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::GetField(const char * name) const
   return -1;
 }
 
-/** Add a field to the point list */
 template <unsigned int TPointDimension>
 float
 DTITubeSpatialObjectPoint<TPointDimension>::GetField(DTITubeSpatialObjectPointFieldEnum name) const

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -67,8 +67,12 @@ public:
   void
   Clear() override;
 
-  /** Set all radii to the same radius value.  Each radius is
-   *  half the length of one axis of the ellipse.  */
+  /** Set all radii to the same radius value
+   *
+   * Each radius is half the length of one axis of the ellipse.
+   *
+   * The ellipse is formed by setting the ObjectToParentTransform.
+   */
   void
   SetRadiusInObjectSpace(double radius);
 
@@ -84,7 +88,11 @@ public:
   /** Get center in object space */
   itkGetConstReferenceMacro(CenterInObjectSpace, PointType);
 
-  /** Test whether a point is inside or outside the object */
+  /** Test whether a point is inside the object.
+   *
+   * For computational speed purposes, it is faster if the method does not  check the name of the class and the
+   * current depth.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 
@@ -110,7 +118,6 @@ protected:
   EllipseSpatialObject();
   ~EllipseSpatialObject() override = default;
 
-  /** Print the object information in a stream. */
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 EllipseSpatialObject<TDimension>::EllipseSpatialObject()
 {
@@ -44,8 +44,6 @@ EllipseSpatialObject<TDimension>::Clear()
   this->Modified();
 }
 
-/** Define the radius of the circle in object space.
- * An ellipse is formed by setting the ObjectToParentTransform */
 template <unsigned int TDimension>
 void
 EllipseSpatialObject<TDimension>::SetRadiusInObjectSpace(double radius)
@@ -65,9 +63,6 @@ EllipseSpatialObject<TDimension>::SetRadiusInObjectSpace(double radius)
   }
 }
 
-/** Test whether a point is inside or outside the object
- *  For computational speed purposes, it is faster if the method does not
- *  check the name of the class and the current depth */
 template <unsigned int TDimension>
 bool
 EllipseSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) const
@@ -97,7 +92,6 @@ EllipseSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point)
   return false;
 }
 
-/** Compute the bounds of the ellipse */
 template <unsigned int TDimension>
 void
 EllipseSpatialObject<TDimension>::ComputeMyBoundingBox()
@@ -118,7 +112,6 @@ EllipseSpatialObject<TDimension>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 EllipseSpatialObject<TDimension>::InternalClone() const
@@ -136,7 +129,6 @@ EllipseSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print Self function */
 template <unsigned int TDimension>
 void
 EllipseSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -85,28 +85,40 @@ public:
   itkSetMacro(Maximum, ScalarType);
   itkGetConstReferenceMacro(Maximum, ScalarType);
 
+  /** Compute the z-score in object space.
+   *
+   * The z-score is the root mean square of the z-scores along each principal axis.
+   */
   ScalarType
   SquaredZScoreInObjectSpace(const PointType & point) const;
 
+  /** Compute the z-score in world space.
+   *
+   * The z-score is the root mean square of the z-scores along each principal axis.
+   */
   ScalarType
   SquaredZScoreInWorldSpace(const PointType & point) const;
 
-  /** Test whether a point is inside or outside the object */
+  /** Test whether a point is inside the object.
+   *
+   * For computational speed purposes, it is faster if the method does not  check the name of the class and the
+   * current depth.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 
   /* Avoid hiding the overload that supports depth and name arguments */
   using Superclass::IsInsideInObjectSpace;
 
-  /** Returns the value of the Gaussian at the given point.  */
+  /** Returns the value of the Gaussian at the given point. */
   bool
   ValueAtInObjectSpace(const PointType &   point,
                        double &            value,
                        unsigned int        depth = 0,
                        const std::string & name = "") const override;
 
-  /** Returns the sigma=m_Radius level set of the Gaussian function, as an
-   * EllipseSpatialObject.  */
+  /** Returns the $sigma = $ \c m_Radius level set of the Gaussian function, as an
+   * EllipseSpatialObject. */
   typename EllipseSpatialObject<TDimension>::Pointer
   GetEllipsoid() const;
 
@@ -124,7 +136,6 @@ protected:
   GaussianSpatialObject();
   ~GaussianSpatialObject() override = default;
 
-  /** Print the object information in a stream. */
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 GaussianSpatialObject<TDimension>::GaussianSpatialObject()
 {
@@ -47,8 +47,6 @@ GaussianSpatialObject<TDimension>::Clear()
   this->Modified();
 }
 
-/** The z-score is the root mean square of the z-scores along
- *  each principal axis. */
 template <unsigned int TDimension>
 auto
 GaussianSpatialObject<TDimension>::SquaredZScoreInObjectSpace(const PointType & point) const -> ScalarType
@@ -61,8 +59,6 @@ GaussianSpatialObject<TDimension>::SquaredZScoreInObjectSpace(const PointType & 
   return r / (m_SigmaInObjectSpace * m_SigmaInObjectSpace);
 }
 
-/** The z-score is the root mean square of the z-scores along
- *  each principal axis. */
 template <unsigned int TDimension>
 auto
 GaussianSpatialObject<TDimension>::SquaredZScoreInWorldSpace(const PointType & point) const -> ScalarType
@@ -72,10 +68,6 @@ GaussianSpatialObject<TDimension>::SquaredZScoreInWorldSpace(const PointType & p
   return this->SquaredZScoreInObjectSpace(transformedPoint);
 }
 
-
-/** Test whether a point is inside or outside the object.
- *  For computational speed purposes, it is faster if the method does not
- *  check the name of the class and the current depth. */
 template <unsigned int TDimension>
 bool
 GaussianSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) const
@@ -102,8 +94,6 @@ GaussianSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point
   return false;
 }
 
-/** Compute the bounds of the Gaussian (as determined by the
- *  specified radius). */
 template <unsigned int TDimension>
 void
 GaussianSpatialObject<TDimension>::ComputeMyBoundingBox()
@@ -124,7 +114,6 @@ GaussianSpatialObject<TDimension>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** Returns the value at one point. */
 template <unsigned int TDimension>
 bool
 GaussianSpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   point,
@@ -155,8 +144,6 @@ GaussianSpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   poin
   return false;
 }
 
-/** Returns the sigma=m_Radius level set of the Gaussian function, as an
- * EllipseSpatialObject. */
 template <unsigned int TDimension>
 typename EllipseSpatialObject<TDimension>::Pointer
 GaussianSpatialObject<TDimension>::GetEllipsoid() const
@@ -176,7 +163,6 @@ GaussianSpatialObject<TDimension>::GetEllipsoid() const
   return ellipse;
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 GaussianSpatialObject<TDimension>::InternalClone() const
@@ -198,7 +184,6 @@ GaussianSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print Self function. */
 template <unsigned int TDimension>
 void
 GaussianSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
@@ -21,14 +21,13 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 GroupSpatialObject<TDimension>::GroupSpatialObject()
 {
   this->SetTypeName("GroupSpatialObject");
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 GroupSpatialObject<TDimension>::InternalClone() const

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -72,8 +72,13 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageMaskSpatialObject, ImageSpatialObject);
 
-  /** Returns true if the point is inside, false otherwise. According to this function,
-   * a point is inside the image mask when the value of its nearest pixel is non-zero. */
+  /** Test whether a point is inside the object.
+   *
+   * A point is inside the image mask when the value of its nearest pixel is non-zero.
+   *
+   * For computational speed purposes, it is faster if the method does not  check the name of the class and the
+   * current depth.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -25,16 +25,13 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension, typename TPixel>
 ImageMaskSpatialObject<TDimension, TPixel>::ImageMaskSpatialObject()
 {
   this->SetTypeName("ImageMaskSpatialObject");
 }
 
-/** Test whether a point is inside or outside the object
- *  For computational speed purposes, it is faster if the method does not
- *  check the name of the class and the current depth */
 template <unsigned int TDimension, typename TPixel>
 bool
 ImageMaskSpatialObject<TDimension, TPixel>::IsInsideInObjectSpace(const PointType & point) const
@@ -114,8 +111,6 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBox()
   }
 }
 
-
-/** InternalClone */
 template <unsigned int TDimension, typename TPixel>
 typename LightObject::Pointer
 ImageMaskSpatialObject<TDimension, TPixel>::InternalClone() const

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -87,7 +87,11 @@ public:
   using Superclass::IsInsideInObjectSpace;
 
   /** Returns the value of the image at the requested point.
-   *  Returns true if that value is valid */
+   *
+   * Returns true if that value is valid.
+   *
+   * The value returned is always of type double; for RGB Images the value returned is the value of the first channel.
+   */
   bool
   ValueAtInObjectSpace(const PointType &   point,
                        double &            value,
@@ -115,7 +119,7 @@ public:
   itkLegacyMacro(const char * GetPixelTypeName()) { return m_PixelType.c_str(); }
 #endif
 
-  /** Set/Get the interpolator */
+  /** Set/Get the interpolator. */
   void
   SetInterpolator(InterpolatorType * interpolator);
   itkGetConstMacro(Interpolator, InterpolatorType *);

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension, typename PixelType>
 ImageSpatialObject<TDimension, PixelType>::ImageSpatialObject()
 {
@@ -34,7 +34,6 @@ ImageSpatialObject<TDimension, PixelType>::ImageSpatialObject()
   this->Update();
 }
 
-/** Destructor */
 template <unsigned int TDimension, typename PixelType>
 ImageSpatialObject<TDimension, PixelType>::~ImageSpatialObject() = default;
 
@@ -56,7 +55,6 @@ ImageSpatialObject<TDimension, PixelType>::Clear()
   this->Modified();
 }
 
-/** Set the interpolator */
 template <unsigned int TDimension, typename PixelType>
 void
 ImageSpatialObject<TDimension, PixelType>::SetInterpolator(InterpolatorType * interpolator)
@@ -72,8 +70,6 @@ ImageSpatialObject<TDimension, PixelType>::SetInterpolator(InterpolatorType * in
   }
 }
 
-
-/** Return true if the given point is inside the image */
 template <unsigned int TDimension, typename PixelType>
 bool
 ImageSpatialObject<TDimension, PixelType>::IsInsideInObjectSpace(const PointType & point) const
@@ -82,10 +78,6 @@ ImageSpatialObject<TDimension, PixelType>::IsInsideInObjectSpace(const PointType
   return m_Image->TransformPhysicalPointToIndex(point, index);
 }
 
-/** Return the value of the image at a specified point
- *  The value returned is always of type double
- *  For RGB Images the value returned is the value of the first channel.
- */
 template <unsigned int TDimension, typename PixelType>
 bool
 ImageSpatialObject<TDimension, PixelType>::ValueAtInObjectSpace(const PointType &   point,
@@ -119,7 +111,6 @@ ImageSpatialObject<TDimension, PixelType>::ValueAtInObjectSpace(const PointType 
   return false;
 }
 
-/** Compute the bounds of the image */
 template <unsigned int TDimension, typename PixelType>
 void
 ImageSpatialObject<TDimension, PixelType>::ComputeMyBoundingBox()
@@ -145,8 +136,6 @@ ImageSpatialObject<TDimension, PixelType>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-
-/** Set the image in the spatial object */
 template <unsigned int TDimension, typename PixelType>
 void
 ImageSpatialObject<TDimension, PixelType>::SetImage(const ImageType * image)
@@ -169,7 +158,6 @@ ImageSpatialObject<TDimension, PixelType>::SetImage(const ImageType * image)
   }
 }
 
-/** Get the image inside the spatial object */
 template <unsigned int TDimension, typename PixelType>
 auto
 ImageSpatialObject<TDimension, PixelType>::GetImage() const -> const ImageType *
@@ -177,7 +165,6 @@ ImageSpatialObject<TDimension, PixelType>::GetImage() const -> const ImageType *
   return m_Image.GetPointer();
 }
 
-/** InternalClone */
 template <unsigned int TDimension, typename PixelType>
 typename LightObject::Pointer
 ImageSpatialObject<TDimension, PixelType>::InternalClone() const
@@ -198,7 +185,6 @@ ImageSpatialObject<TDimension, PixelType>::InternalClone() const
   return loPtr;
 }
 
-/** Print the object */
 template <unsigned int TDimension, typename PixelType>
 void
 ImageSpatialObject<TDimension, PixelType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -214,7 +200,6 @@ ImageSpatialObject<TDimension, PixelType>::PrintSelf(std::ostream & os, Indent i
 #endif
 }
 
-/** Get the modification time */
 template <unsigned int TDimension, typename PixelType>
 ModifiedTimeType
 ImageSpatialObject<TDimension, PixelType>::GetMTime() const
@@ -230,7 +215,6 @@ ImageSpatialObject<TDimension, PixelType>::GetMTime() const
   return latestMTime;
 }
 
-/** Set the slice position */
 template <unsigned int TDimension, typename PixelType>
 void
 ImageSpatialObject<TDimension, PixelType>::SetSliceNumber(unsigned int dimension, int position)

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 LandmarkSpatialObject<TDimension>::LandmarkSpatialObject()
 {
@@ -35,7 +35,6 @@ LandmarkSpatialObject<TDimension>::LandmarkSpatialObject()
   this->GetProperty().SetAlpha(1);
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 LandmarkSpatialObject<TDimension>::InternalClone() const
@@ -53,7 +52,6 @@ LandmarkSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print the blob spatial object */
 template <unsigned int TDimension>
 void
 LandmarkSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension>
 LineSpatialObject<TDimension>::LineSpatialObject()
 {
@@ -32,7 +32,6 @@ LineSpatialObject<TDimension>::LineSpatialObject()
   this->GetProperty().SetAlpha(1);
 }
 
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 LineSpatialObject<TDimension>::InternalClone() const

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -58,11 +58,11 @@ public:
   /** Destructor */
   ~LineSpatialObjectPoint() override = default;
 
-  /** Get Normal */
+  /** Get the normal. */
   const CovariantVectorType &
   GetNormalInObjectSpace(unsigned int index) const;
 
-  /** Set Normal */
+  /** Set the normal. */
   void
   SetNormalInObjectSpace(CovariantVectorType & normal, unsigned int index);
 

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint()
 {
@@ -35,7 +35,6 @@ LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint()
   }
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint(const LineSpatialObjectPoint & other)
   : Superclass(other)
@@ -43,7 +42,6 @@ LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint(const LineSpatia
   this->m_NormalArrayInObjectSpace = other.m_NormalArrayInObjectSpace;
 }
 
-/** Get the specified normal */
 template <unsigned int TPointDimension>
 auto
 LineSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace(unsigned int index) const -> const CovariantVectorType &
@@ -51,7 +49,6 @@ LineSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace(unsigned int ind
   return m_NormalArrayInObjectSpace[index];
 }
 
-/** Print the object */
 template <unsigned int TPointDimension>
 void
 LineSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -77,7 +77,13 @@ public:
   const MeshType *
   GetMesh() const;
 
-  /** Returns true if the point is inside, false otherwise. */
+  /** Test whether a point is inside or outside the object.
+   *
+   * Returns true if the point is inside, false otherwise.
+   *
+   * For computational speed purposes, it is faster if the method does not check the name of the class and the current
+   * depth.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 
@@ -103,7 +109,7 @@ public:
   itkGetConstMacro(IsInsidePrecisionInObjectSpace, double);
 
 protected:
-  /** Compute the boundaries of the image spatial object. */
+  /** Compute the boundaries of the spatial object. */
   void
   ComputeMyBoundingBox() override;
 

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TMesh>
 MeshSpatialObject<TMesh>::MeshSpatialObject()
 {
@@ -48,9 +48,6 @@ MeshSpatialObject<TMesh>::Clear()
   this->Modified();
 }
 
-/** Test whether a point is inside or outside the object
- *  For computational speed purposes, it is faster if the method does not
- *  check the name of the class and the current depth */
 template <typename TMesh>
 bool
 MeshSpatialObject<TMesh>::IsInsideInObjectSpace(const PointType & point) const
@@ -94,7 +91,6 @@ MeshSpatialObject<TMesh>::IsInsideInObjectSpace(const PointType & point) const
   return false;
 }
 
-/** Compute the bounds of the object which is the same as the internal mesh */
 template <typename TMesh>
 void
 MeshSpatialObject<TMesh>::ComputeMyBoundingBox()
@@ -112,7 +108,6 @@ MeshSpatialObject<TMesh>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** Set the Mesh in the spatial object */
 template <typename TMesh>
 void
 MeshSpatialObject<TMesh>::SetMesh(MeshType * mesh)
@@ -124,7 +119,6 @@ MeshSpatialObject<TMesh>::SetMesh(MeshType * mesh)
   }
 }
 
-/** Get the Mesh inside the spatial object */
 template <typename TMesh>
 auto
 MeshSpatialObject<TMesh>::GetMesh() -> MeshType *
@@ -139,7 +133,6 @@ MeshSpatialObject<TMesh>::GetMesh() const -> const MeshType *
   return m_Mesh.GetPointer();
 }
 
-/** InternalClone */
 template <typename TMesh>
 typename LightObject::Pointer
 MeshSpatialObject<TMesh>::InternalClone() const
@@ -159,7 +152,6 @@ MeshSpatialObject<TMesh>::InternalClone() const
   return loPtr;
 }
 
-/** Print the object */
 template <typename TMesh>
 void
 MeshSpatialObject<TMesh>::PrintSelf(std::ostream & os, Indent indent) const
@@ -170,7 +162,6 @@ MeshSpatialObject<TMesh>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << m_Mesh << std::endl;
 }
 
-/** Get the modification time */
 template <typename TMesh>
 ModifiedTimeType
 MeshSpatialObject<TMesh>::GetMTime() const

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -69,11 +69,11 @@ public:
   using MetaConverterPointer = typename MetaConverterBaseType::Pointer;
   using ConverterMapType = std::map<std::string, MetaConverterPointer>;
 
-  /** Read a MetaFile and create a Scene SpatialObject */
+  /** Read a MetaFile and create a Scene SpatialObject. */
   SpatialObjectPointer
   ReadMeta(const std::string & name);
 
-  /** write out a SpatialObject */
+  /** Write out a SpatialObject. */
   bool
   WriteMeta(const SpatialObjectType * soScene,
             const std::string &       fileName,
@@ -108,6 +108,10 @@ public:
                         const std::string &     spatialObjectTypeName,
                         MetaConverterBaseType * converter);
 
+  /** Convert a metaScene into a composite SpatialObject
+   *
+   * Manages tbe composite SpatialObject to keep a hierarchy.
+   */
   MetaScene *
   CreateMetaScene(const SpatialObjectType * soScene,
                   unsigned int              depth = SpatialObjectType::MaximumDepth,

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -39,7 +39,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 MetaSceneConverter<VDimension, PixelType, TMeshTraits>::MetaSceneConverter()
 {
@@ -108,8 +108,6 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::SetTransform(SpatialObje
   so->GetModifiableObjectToParentTransform()->SetOffset(offset);
 }
 
-/** Convert a metaScene into a Composite Spatial Object
- *  Also Managed Composite Spatial Object to keep a hierarchy */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
 MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateSpatialObjectScene(MetaScene * mScene)
@@ -230,7 +228,6 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateSpatialObjectScene
   return soScene;
 }
 
-/** Read a meta file give the type */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
 MetaSceneConverter<VDimension, PixelType, TMeshTraits>::ReadMeta(const std::string & name) -> SpatialObjectPointer
@@ -247,7 +244,6 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::ReadMeta(const std::stri
   return soScene;
 }
 
-/** Write a meta file give the type */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 MetaScene *
 MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const SpatialObjectType * soScene,
@@ -369,7 +365,6 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
   return metaScene;
 }
 
-/** Write a meta file give the type */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 bool
 MetaSceneConverter<VDimension, PixelType, TMeshTraits>::WriteMeta(const SpatialObjectType * soScene,

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -70,16 +70,16 @@ public:
   virtual void
   AddPoint(const SpatialObjectPointType & newPoint);
 
-  /** Removes the indicated point from this object */
+  /** Removes the indicated point from this object. */
   virtual void
   RemovePoint(IdentifierType id);
 
   /** Assign points to this object, and assigned this object to
-   * each point (for computing world coordinates) */
+   * each point (for computing world coordinates). */
   virtual void
   SetPoints(const SpatialObjectPointListType & newPoints);
 
-  /** Get the list of points assigned to this object */
+  /** Get the list of points assigned to this object. */
   virtual SpatialObjectPointListType &
   GetPoints()
   {
@@ -113,14 +113,18 @@ public:
     return static_cast<SizeValueType>(m_Points.size());
   }
 
-  /** Method returns the Point closest to the given point */
+  /** Get the closest point in world space. */
   TSpatialObjectPointType
   ClosestPointInWorldSpace(const PointType & point) const;
 
+  /** Get the closest point in object space. */
   TSpatialObjectPointType
   ClosestPointInObjectSpace(const PointType & point) const;
 
-  /** Returns true if the point is inside the Blob, false otherwise. */
+  /** Test if a world-coordinate point is inside of this object or its children.
+   *
+   * Returns true if the point is inside the blob, false otherwise.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension, class TSpatialObjectPointType>
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::PointBasedSpatialObject()
   : SpatialObject<TDimension>()
@@ -44,7 +44,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::Clear()
   this->Modified();
 }
 
-/** Set Points from a list */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::AddPoint(const SpatialObjectPointType & newPoint)
@@ -55,7 +54,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::AddPoint(const Spa
   this->Modified();
 }
 
-/** Remove a Point from the list */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::RemovePoint(IdentifierType id)
@@ -70,7 +68,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::RemovePoint(Identi
   this->Modified();
 }
 
-/** Set Points from a list */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::SetPoints(const SpatialObjectPointListType & newPoints)
@@ -88,7 +85,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::SetPoints(const Sp
   this->Modified();
 }
 
-/** Determine closest point in object space */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 TSpatialObjectPointType
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInObjectSpace(const PointType & point) const
@@ -118,7 +114,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInObje
   return closestPoint;
 }
 
-/** Determine closest point in world space */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 TSpatialObjectPointType
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInWorldSpace(const PointType & point) const
@@ -148,7 +143,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInWorl
   return closestPoint;
 }
 
-/** Compute bounding box of just this object */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingBox()
@@ -180,8 +174,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingB
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** Test if a world-coordinate point is inside of this object or its
- *    children, if they match the search depth and name */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 bool
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::IsInsideInObjectSpace(const PointType & point) const
@@ -213,8 +205,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::IsInsideInObjectSp
   return false;
 }
 
-
-/** InternalClone */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 typename LightObject::Pointer
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::InternalClone() const
@@ -234,7 +224,6 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::InternalClone() co
   return loPtr;
 }
 
-/** Print the object */
 template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -152,7 +152,12 @@ public:
     return m_TypeName;
   }
 
-  /** Get the class name with the dimension of the spatial object appended */
+  /** Get the class name with the dimension of the spatial object appended.
+   *
+   * Returns the type of the spatial object as a string.
+   *
+   * Used by the SpatialObjectFactory.
+   */
   virtual std::string
   GetClassNameAndDimension() const;
 
@@ -200,23 +205,36 @@ public:
   /* Transforms */
   /**************/
 
-  /** This defines the transformation from the global coordinate frame.
-   *  By setting this transform, the object transform is updated */
+  /** Set the global to local transformation.
+   *
+   * Defines the transformation from the global coordinate frame.
+   *
+   * By setting this transform, the object transform is updated.
+   */
   void
   SetObjectToWorldTransform(const TransformType * transform);
   itkGetModifiableObjectMacro(ObjectToWorldTransform, TransformType);
   const TransformType *
   GetObjectToWorldTransformInverse() const;
 
-  /** Transforms points from the object-specific "physical" space
-   * to the "physical" space of its parent object.  */
+
+  /** Set the local to global transformation.
+   *
+   * Transforms points from the object-specific "physical" space to the "physical" space of its parent object.
+   */
   void
   SetObjectToParentTransform(const TransformType * transform);
   itkGetModifiableObjectMacro(ObjectToParentTransform, TransformType);
   const TransformType *
   GetObjectToParentTransformInverse() const;
 
-  /** Compute the Local transform when the global transform is set */
+
+  /** Set the local to global transformation.
+   *
+   * Compute the local transform when the global transform is set.
+   *
+   * This does not change the IndexToObjectMatrix.
+   */
   void
   ComputeObjectToParentTransform();
 
@@ -232,7 +250,7 @@ public:
    */
   /**********************************************************************/
 
-  /** Returns true if a point is inside the object in object space. */
+  /** Returns true if a point is inside the object or its children in object space. */
   bool
   IsInsideInObjectSpace(const PointType & point, unsigned int depth, const std::string & name = "") const;
 
@@ -247,7 +265,7 @@ public:
   Update() override;
 
 
-  /** Returns the value at a point. Returns true if that value is valid */
+  /** Returns the value at a point. Returns true if that value is valid. */
   virtual bool
   ValueAtInObjectSpace(const PointType &   point,
                        double &            value,
@@ -266,15 +284,19 @@ public:
   /********************************************************/
   /* Helper functions to recurse queries through children */
   /********************************************************/
+
+  /** Return if a point is inside the object or its children. */
   virtual bool
   IsInsideChildrenInObjectSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
 
+  /** Return the value of the object at a point. */
   virtual bool
   ValueAtChildrenInObjectSpace(const PointType &   point,
                                double &            value,
                                unsigned int        depth = 0,
                                const std::string & name = "") const;
 
+  /** Return if the object is evaluable at a point. */
   virtual bool
   IsEvaluableAtChildrenInObjectSpace(const PointType &   point,
                                      unsigned int        depth = 0,
@@ -345,12 +367,17 @@ public:
   virtual bool
   HasParent() const;
 
-
-  /** Return a pointer to the parent object in the hierarchy tree */
+  /** Get the parent of the spatial object.
+   *
+   * Returns a pointer to the parent object in the hierarchy tree.
+   */
   virtual const Self *
   GetParent() const;
 
-  /** Return a pointer to the parent object in the hierarchy tree */
+  /** Get the parent of the spatial object.
+   *
+   * Returns a pointer to the parent object in the hierarchy tree.
+   */
   virtual Self *
   GetParent();
 
@@ -380,14 +407,19 @@ public:
   void
   RemoveAllChildren(unsigned int depth = MaximumDepth);
 
-  /** Returns a list of pointer to the children affiliated to this object.
+  /** Get the children affiliated to this object.
    * A depth of 0 returns the immediate children. A depth of 1 returns the
    * children and those children's children.
-   * \warning User is responsible for freeing the list, but not the elements of
+   * \warning The user is responsible for freeing the list, but not the elements of
    * the list. */
   virtual ChildrenListType *
   GetChildren(unsigned int depth = 0, const std::string & name = "") const;
 
+  /** Get the children affiliated to this object.
+   * A depth of 0 returns the immediate children. A depth of 1 returns the
+   * children and those children's children.
+   * \warning The user is responsible for freeing the list, but not the elements of
+   * the list. */
   virtual ChildrenConstListType *
   GetConstChildren(unsigned int depth = 0, const std::string & name = "") const;
 
@@ -399,11 +431,11 @@ public:
                          unsigned int            depth = 0,
                          const std::string &     name = "") const;
 
-  /** Returns the number of children currently assigned to the object. */
+  /** Get the number of children currently assigned to the object. */
   unsigned int
   GetNumberOfChildren(unsigned int depth = 0, const std::string & name = "") const;
 
-  /** Return a SpatialObject given its ID, if it is a child */
+  /** Return a SpatialObject given its ID, if it is a child. */
   SpatialObject<VDimension> *
   GetObjectById(int id);
 
@@ -413,7 +445,10 @@ public:
   bool
   FixParentChildHierarchyUsingParentIds();
 
-  /** Confirm that every object inherited from this has a unique Id */
+  /** Check if the parent objects have a defined ID.
+   *
+   * Confirms that every object inherited from this has a unique Id.
+   */
   bool
   CheckIdValidity() const;
 
@@ -421,7 +456,10 @@ public:
   void
   FixIdValidity();
 
-  /** Generate a unique Id */
+  /** Generate a unique Id.
+   *
+   * Returns the next available Id. For speed reason the MaxID+1 is returned.
+   */
   int
   GetNextAvailableId() const;
 
@@ -442,7 +480,10 @@ public:
   GetMyBoundingBoxInWorldSpace() const;
 
   /** Compute an axis-aligned bounding box for an object and its selected
-   * children, down to a specified depth, in object space. */
+   * children, down to a specified depth, in object space.
+   *
+   * After computation, the resulting bounding box is stored in m_FamilyBoundingBoxInWorldSpace.
+   */
   virtual bool
   ComputeFamilyBoundingBox(unsigned int depth = 0, const std::string & name = "") const;
 
@@ -460,7 +501,9 @@ public:
   /* Regions used by DataObject */
   /******************************/
 
-  /** Set the region object that defines the size and starting index
+  /** Set the largest possible region.
+   *
+   * Sets the region object that defines the size and starting index
    * for the largest possible region this image could represent.  This
    * is used in determining how much memory would be needed to load an
    * entire dataset.  It is also used to determine boundary
@@ -559,7 +602,7 @@ public:
   void
   UpdateOutputInformation() override;
 
-  /** Copy information from the specified data set.  This method is
+  /** Copy the information from the specified data object.  This method is
    * part of the pipeline execution model. By default, a ProcessObject
    * will copy meta-data from the first input to all of its
    * outputs. See ProcessObject::GenerateOutputInformation().  Each

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -27,7 +27,6 @@
 namespace itk
 {
 
-/** Destructor */
 template <unsigned int TDimension>
 SpatialObject<TDimension>::~SpatialObject()
 {
@@ -81,7 +80,6 @@ SpatialObject<TDimension>::SetId(int id)
   }
 }
 
-/** Return the Derivative at a point given the order of the derivative */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &            point,
@@ -133,7 +131,6 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
   }
 }
 
-/** Return the Derivative at a point given the order of the derivative */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::DerivativeAtInWorldSpace(const PointType &            point,
@@ -148,7 +145,6 @@ SpatialObject<TDimension>::DerivativeAtInWorldSpace(const PointType &           
   this->DerivativeAtInObjectSpace(pnt, order, value, depth, name, offset);
 }
 
-/** Return if a point is inside the object or its children */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsInsideInObjectSpace(const PointType &   point,
@@ -181,7 +177,6 @@ SpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & itkNotUsed(po
   return false;
 }
 
-/** Return if a point is inside the object or its children */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType &   point,
@@ -193,7 +188,6 @@ SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType &   point,
   return IsInsideInObjectSpace(pnt, depth, name);
 }
 
-/** Return if a point is inside the object or its children */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsInsideChildrenInObjectSpace(const PointType &   point,
@@ -216,7 +210,6 @@ SpatialObject<TDimension>::IsInsideChildrenInObjectSpace(const PointType &   poi
   return false;
 }
 
-/** Return if the object is evaluable at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsEvaluableAtInObjectSpace(const PointType &   point,
@@ -240,7 +233,6 @@ SpatialObject<TDimension>::IsEvaluableAtInObjectSpace(const PointType &   point,
   }
 }
 
-/** Return if the object is evaluable at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsEvaluableAtInWorldSpace(const PointType &   point,
@@ -252,7 +244,6 @@ SpatialObject<TDimension>::IsEvaluableAtInWorldSpace(const PointType &   point,
   return this->IsEvaluableAtInObjectSpace(pnt, depth, name);
 }
 
-/** Return if the object is evaluable at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsEvaluableAtChildrenInObjectSpace(const PointType &   point,
@@ -275,7 +266,6 @@ SpatialObject<TDimension>::IsEvaluableAtChildrenInObjectSpace(const PointType & 
   return false;
 }
 
-/** Return the value of the object at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   point,
@@ -311,7 +301,6 @@ SpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   point,
   return false;
 }
 
-/** Return the value of the object at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::ValueAtInWorldSpace(const PointType &   point,
@@ -324,7 +313,6 @@ SpatialObject<TDimension>::ValueAtInWorldSpace(const PointType &   point,
   return this->ValueAtInObjectSpace(pnt, value, depth, name);
 }
 
-/** Return the value of the object at a point */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::ValueAtChildrenInObjectSpace(const PointType &   point,
@@ -350,8 +338,6 @@ SpatialObject<TDimension>::ValueAtChildrenInObjectSpace(const PointType &   poin
   return false;
 }
 
-
-/** InternalClone */
 template <unsigned int TDimension>
 typename LightObject::Pointer
 SpatialObject<TDimension>::InternalClone() const
@@ -375,7 +361,6 @@ SpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-/** Print self */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
@@ -408,7 +393,6 @@ SpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "DefaultOutsideValue:" << m_DefaultOutsideValue << std::endl;
 }
 
-/** Get the bounds of the object */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const -> const BoundingBoxType *
@@ -435,7 +419,6 @@ SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const -> const Bou
   return m_FamilyBoundingBoxInWorldSpace;
 }
 
-/** Add a child to the object */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::AddChild(Self * pointer)
@@ -457,7 +440,6 @@ SpatialObject<TDimension>::AddChild(Self * pointer)
   }
 }
 
-/** Remove a child to the object */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::RemoveChild(Self * pointer)
@@ -483,7 +465,6 @@ SpatialObject<TDimension>::RemoveChild(Self * pointer)
   }
 }
 
-/** Remove a child to the object */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::RemoveAllChildren(unsigned int depth)
@@ -503,7 +484,6 @@ SpatialObject<TDimension>::RemoveAllChildren(unsigned int depth)
   this->Modified();
 }
 
-/** Set the local to global transformation */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::SetObjectToParentTransform(const TransformType * transform)
@@ -519,7 +499,6 @@ SpatialObject<TDimension>::SetObjectToParentTransform(const TransformType * tran
   ProtectedComputeObjectToWorldTransform();
 }
 
-/** Set the local to global transformation */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetObjectToParentTransformInverse() const -> const TransformType *
@@ -531,7 +510,6 @@ SpatialObject<TDimension>::GetObjectToParentTransformInverse() const -> const Tr
   return m_ObjectToParentTransformInverse.GetPointer();
 }
 
-/** Compute the Global Transform */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::ProtectedComputeObjectToWorldTransform()
@@ -559,7 +537,6 @@ SpatialObject<TDimension>::ProtectedComputeObjectToWorldTransform()
   this->Modified();
 }
 
-/** Set the global to local transformation */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::SetObjectToWorldTransform(const TransformType * transform)
@@ -576,7 +553,6 @@ SpatialObject<TDimension>::SetObjectToWorldTransform(const TransformType * trans
   ProtectedComputeObjectToWorldTransform();
 }
 
-/** Set the local to global transformation */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetObjectToWorldTransformInverse() const -> const TransformType *
@@ -588,8 +564,6 @@ SpatialObject<TDimension>::GetObjectToWorldTransformInverse() const -> const Tra
   return m_ObjectToWorldTransformInverse.GetPointer();
 }
 
-/** Compute the Transform when the global transform as been set
- *  This does not change the IndexToObjectMatrix */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::ComputeObjectToParentTransform()
@@ -617,7 +591,6 @@ SpatialObject<TDimension>::ComputeObjectToParentTransform()
   ProtectedComputeObjectToWorldTransform();
 }
 
-/** Get the modification time  */
 template <unsigned int TDimension>
 ModifiedTimeType
 SpatialObject<TDimension>::GetMTime() const
@@ -656,7 +629,6 @@ SpatialObject<TDimension>::ComputeMyBoundingBox()
   }
 }
 
-/** Get the bounds of the object */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const -> const BoundingBoxType *
@@ -683,10 +655,6 @@ SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const -> const Boundin
   return m_MyBoundingBoxInWorldSpace;
 }
 
-/**
- * Compute an axis-aligned bounding box for an object and its selected
- * children, down to a specified depth.  After computation, the
- * resulting bounding box is stored in this->m_FamilyBoundingBoxInWorldSpace.  */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const std::string & name) const
@@ -750,9 +718,6 @@ SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const st
   return bbDefined;
 }
 
-/** Get the children list.
- * User is responsible for freeing the list, but not the elements of
- * the list. */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & name) const -> ChildrenListType *
@@ -782,9 +747,6 @@ SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & n
   return childrenSO;
 }
 
-/** Get the children list as const pointers.
- * User is responsible for freeing the list, but not the elements of
- * the list. */
 template <unsigned int TDimension>
 auto
 SpatialObject<TDimension>::GetConstChildren(unsigned int depth, const std::string & name) const
@@ -869,7 +831,6 @@ SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childr
   }
 }
 
-/** Set children list */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::SetChildren(ChildrenListType & children)
@@ -885,7 +846,6 @@ SpatialObject<TDimension>::SetChildren(ChildrenListType & children)
   }
 }
 
-/** Get the number of children */
 template <unsigned int TDimension>
 unsigned int
 SpatialObject<TDimension>::GetNumberOfChildren(unsigned int depth, const std::string & name) const
@@ -914,8 +874,6 @@ SpatialObject<TDimension>::GetNumberOfChildren(unsigned int depth, const std::st
   return ccount;
 }
 
-/** Return a SpatialObject in the SpatialObject
- *  given a parent ID */
 template <unsigned int TDimension>
 SpatialObject<TDimension> *
 SpatialObject<TDimension>::GetObjectById(int id)
@@ -972,7 +930,6 @@ SpatialObject<TDimension>::FixParentChildHierarchyUsingParentIds()
   return ret;
 }
 
-/** Check if the parent objects have a defined ID */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::CheckIdValidity() const
@@ -1055,7 +1012,6 @@ SpatialObject<TDimension>::FixIdValidity()
   delete children;
 }
 
-/** Return the next available Id. For speed reason the MaxID+1 is returned */
 template <unsigned int TDimension>
 int
 SpatialObject<TDimension>::GetNextAvailableId() const
@@ -1078,7 +1034,6 @@ SpatialObject<TDimension>::GetNextAvailableId() const
   return maxId + 1;
 }
 
-/** Get the parent of the spatial object */
 template <unsigned int TDimension>
 SpatialObject<TDimension> *
 SpatialObject<TDimension>::GetParent()
@@ -1086,7 +1041,6 @@ SpatialObject<TDimension>::GetParent()
   return m_Parent;
 }
 
-/** Get the parent of the spatial object */
 template <unsigned int TDimension>
 const SpatialObject<TDimension> *
 SpatialObject<TDimension>::GetParent() const
@@ -1094,7 +1048,6 @@ SpatialObject<TDimension>::GetParent() const
   return m_Parent;
 }
 
-/** Set the parent of the spatial object */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::SetParent(Self * parent)
@@ -1128,7 +1081,6 @@ SpatialObject<TDimension>::SetParent(Self * parent)
   }
 }
 
-/** Return true if the spatial object has a parent */
 template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::HasParent() const
@@ -1140,7 +1092,6 @@ SpatialObject<TDimension>::HasParent() const
   return true;
 }
 
-/** Set the largest possible region */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::SetLargestPossibleRegion(const RegionType & region)
@@ -1152,7 +1103,6 @@ SpatialObject<TDimension>::SetLargestPossibleRegion(const RegionType & region)
   }
 }
 
-/** Update the Output information */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::UpdateOutputInformation()
@@ -1297,8 +1247,6 @@ SpatialObject<TDimension>::Update()
   this->ProtectedComputeObjectToWorldTransform();
 }
 
-/** Return the type of the spatial object as a string
- *  This is used by the SpatialObjectFactory */
 template <unsigned int TDimension>
 std::string
 SpatialObject<TDimension>::GetClassNameAndDimension() const
@@ -1310,7 +1258,6 @@ SpatialObject<TDimension>::GetClassNameAndDimension() const
   return n.str();
 }
 
-/** Copy the information from another spatial object */
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::CopyInformation(const DataObject * data)

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -148,11 +148,11 @@ public:
     return m_Color;
   }
 
-  /** Set the color */
+  /** Set the color of the point. */
   void
   SetColor(double r, double g, double b, double a = 1);
 
-  /** Set/Get red color of the point */
+  /** Set/Get red color of the point. */
   void
   SetRed(double r)
   {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 SpatialObjectPoint<TPointDimension>::SpatialObjectPoint()
 {
@@ -39,7 +39,6 @@ SpatialObjectPoint<TPointDimension>::SpatialObjectPoint()
   m_SpatialObject = nullptr;
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 SpatialObjectPoint<TPointDimension>::SpatialObjectPoint(const SpatialObjectPoint & other)
 {
@@ -74,7 +73,6 @@ SpatialObjectPoint<TPointDimension>::GetPositionInWorldSpace() const -> PointTyp
   return m_SpatialObject->GetObjectToWorldTransform()->TransformPoint(m_PositionInObjectSpace);
 }
 
-/** Set the color of the point */
 template <unsigned int TPointDimension>
 void
 SpatialObjectPoint<TPointDimension>::SetColor(double r, double g, double b, double a)
@@ -156,7 +154,6 @@ SpatialObjectPoint<TPointDimension>::SetTagScalarDictionary(const std::map<std::
   m_ScalarDictionary = dict;
 }
 
-/** PrintSelfMethod */
 template <unsigned int TPointDimension>
 void
 SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -78,7 +78,7 @@ public:
 
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-  /** Set/Get the image input of this process object.  */
+  /** Set/Get the input spatial object. */
   using Superclass::SetInput;
   virtual void
   SetInput(const InputSpatialObjectType * input);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -24,7 +24,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TInputSpatialObject, typename TOutputImage>
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SpatialObjectToImageFilter()
 {
@@ -45,7 +45,6 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SpatialObjectToIm
   m_UseObjectValue = false;
 }
 
-/** Set the Input SpatialObject */
 template <typename TInputSpatialObject, typename TOutputImage>
 void
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetInput(const InputSpatialObjectType * input)
@@ -54,7 +53,6 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetInput(const In
   this->ProcessObject::SetNthInput(0, const_cast<InputSpatialObjectType *>(input));
 }
 
-/** Connect one of the operands  */
 template <typename TInputSpatialObject, typename TOutputImage>
 void
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetInput(unsigned int                index,
@@ -64,7 +62,6 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetInput(unsigned
   this->ProcessObject::SetNthInput(index, const_cast<TInputSpatialObject *>(object));
 }
 
-/** Get the input Spatial Object */
 template <typename TInputSpatialObject, typename TOutputImage>
 auto
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput() -> const InputSpatialObjectType *
@@ -72,7 +69,6 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput() -> con
   return static_cast<const TInputSpatialObject *>(this->GetPrimaryInput());
 }
 
-/** Get the input Spatial Object */
 template <typename TInputSpatialObject, typename TOutputImage>
 auto
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput(unsigned int idx)

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.h
@@ -125,6 +125,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  /** Compute statistics from the sample vector. */
   bool
   ComputeStatistics();
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -26,7 +26,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TInputImage, typename TInputSpatialObject, unsigned int TSampleDimension>
 SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSampleDimension>::
   SpatialObjectToImageStatisticsCalculator()
@@ -43,7 +43,6 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
   m_Sample = SampleType::New();
 }
 
-/** Compute Statistics from the Sample vector */
 template <typename TInputImage, typename TInputSpatialObject, unsigned int TSampleDimension>
 bool
 SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSampleDimension>::ComputeStatistics()
@@ -78,7 +77,6 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
   return true;
 }
 
-/** */
 template <typename TInputImage, typename TInputSpatialObject, unsigned int TSampleDimension>
 void
 SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSampleDimension>::Update()

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -73,11 +73,11 @@ public:
   Clear() override;
 
 #if !defined(ITK_LEGACY_REMOVE)
-  /** Calculate the normalized tangent - Old spelling of function name */
+  /** Approximate the normals of the surface. */
   itkLegacyMacro(bool Approximate3DNormals());
 #endif
 
-  /** Compute the normals to the surface from neighboring points */
+  /** Compute the normals to the surface from neighboring points. */
   bool
   ComputeNormals();
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension, typename TSurfacePointType>
 SurfaceSpatialObject<TDimension, TSurfacePointType>::SurfaceSpatialObject()
 {
@@ -48,7 +48,6 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::Clear()
   this->Modified();
 }
 
-/** InternalClone */
 template <unsigned int TDimension, typename TSurfacePointType>
 typename LightObject::Pointer
 SurfaceSpatialObject<TDimension, TSurfacePointType>::InternalClone() const
@@ -67,7 +66,6 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::InternalClone() const
 }
 
 #if !defined(ITK_LEGACY_REMOVE)
-/** Approximate the normals of the surface */
 template <unsigned int TDimension, typename TSurfacePointType>
 bool
 SurfaceSpatialObject<TDimension, TSurfacePointType>::Approximate3DNormals()
@@ -76,7 +74,6 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::Approximate3DNormals()
 }
 #endif // LEGACY
 
-/** Approximate the normals of the surface in 2D or 3D */
 template <unsigned int TDimension, typename TSurfacePointType>
 bool
 SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -54,23 +54,23 @@ public:
   /** Destructor */
   ~SurfaceSpatialObjectPoint() override = default;
 
-  /** Get Normal */
+  /** Get the normal in object space. */
   const CovariantVectorType &
   GetNormalInObjectSpace() const;
 
-  /** Get Normal */
+  /** Get the normal in world space. */
   const CovariantVectorType
   GetNormalInWorldSpace() const;
 
-  /** Set Normal */
+  /** Set the normal in object space. */
   void
   SetNormalInObjectSpace(const CovariantVectorType & normal);
 
-  /** Set Normal */
+  /** Set the normal in world space. */
   void
   SetNormalInWorldSpace(const CovariantVectorType & normal);
 
-  /** Copy one SurfaceSpatialObjectPoint to another */
+  /** Copy one SurfaceSpatialObjectPoint to another. */
   Self &
   operator=(const SurfaceSpatialObjectPoint & rhs);
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -21,14 +21,13 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint()
 {
   m_NormalInObjectSpace.Fill(0);
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint(const SurfaceSpatialObjectPoint & other)
   : Superclass(other)
@@ -36,7 +35,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint(const Surf
   this->m_NormalInObjectSpace = other.m_NormalInObjectSpace;
 }
 
-/** Set the normal : N-D case */
 template <unsigned int TPointDimension>
 void
 SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const CovariantVectorType & normal)
@@ -44,7 +42,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const Covaria
   m_NormalInObjectSpace = normal;
 }
 
-/** Set the normal : N-D case */
 template <unsigned int TPointDimension>
 void
 SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInWorldSpace(const CovariantVectorType & normal)
@@ -58,7 +55,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInWorldSpace(const Covarian
     Superclass::m_SpatialObject->GetObjectToWorldTransform()->GetInverseTransform()->TransformCovariantVector(normal);
 }
 
-/** Get the normal at one point */
 template <unsigned int TPointDimension>
 auto
 SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const -> const CovariantVectorType &
@@ -66,7 +62,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const -> co
   return m_NormalInObjectSpace;
 }
 
-/** Get the normal at one point */
 template <unsigned int TPointDimension>
 auto
 SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const -> const CovariantVectorType
@@ -79,7 +74,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const -> con
   return Superclass::m_SpatialObject->GetObjectToWorldTransform()->TransformCovariantVector(m_NormalInObjectSpace);
 }
 
-/** Print the object */
 template <unsigned int TPointDimension>
 void
 SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
@@ -90,7 +84,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
   os << indent << m_NormalInObjectSpace << std::endl;
 }
 
-/** Copy a surface point to another */
 template <unsigned int TPointDimension>
 auto
 SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObjectPoint & rhs) -> Self &

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -79,16 +79,16 @@ public:
   itkGetConstMacro(EndRounded, bool);
   itkBooleanMacro(EndRounded);
 
-  /** Calculate the normalized tangent */
+  /** Compute the tangents and normals of the centerline of the tube. */
   bool
   ComputeTangentsAndNormals();
 
 #if !defined(ITK_LEGACY_REMOVE)
-  /** Calculate the normalized tangent - Old spelling of function name */
+  /** Compute the tangents and normals of the centerline of the tube. */
   itkLegacyMacro(bool ComputeTangentAndNormals()) { return ComputeTangentsAndNormals(); }
 #endif
 
-  /** Remove duplicate points */
+  /** Remove duplicate points. */
   unsigned int
   RemoveDuplicatePointsInObjectSpace(double minSpacingInObjectSpace = 0);
 
@@ -110,13 +110,18 @@ public:
 
   itkBooleanMacro(Root);
 
-  /** Returns true if the point is inside the tube, false otherwise. */
+  /** Test whether a point is inside the object: returns true if the point is inside the tube, false otherwise.
+   *
+   * For computational speed purposes, it is faster if the method does not check the name of the class and the current
+   * depth.
+   */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
 
   /* Avoid hiding the overload that supports depth and name arguments */
   using Superclass::IsInsideInObjectSpace;
 
+  /** Copy the information from another spatial object. */
   void
   CopyInformation(const DataObject * data) override;
 

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TDimension, typename TTubePointType>
 TubeSpatialObject<TDimension, TTubePointType>::TubeSpatialObject()
 {
@@ -52,7 +52,6 @@ TubeSpatialObject<TDimension, TTubePointType>::Clear()
   this->Modified();
 }
 
-/** Copy the information from another spatial object */
 template <unsigned int TDimension, typename TTubePointType>
 void
 TubeSpatialObject<TDimension, TTubePointType>::CopyInformation(const DataObject * data)
@@ -87,7 +86,6 @@ TubeSpatialObject<TDimension, TTubePointType>::CopyInformation(const DataObject 
   // this->SetParentPoint(source->GetParentPoint());
 }
 
-/** InternalClone */
 template <unsigned int TDimension, typename TTubePointType>
 typename LightObject::Pointer
 TubeSpatialObject<TDimension, TTubePointType>::InternalClone() const
@@ -107,7 +105,6 @@ TubeSpatialObject<TDimension, TTubePointType>::InternalClone() const
   return loPtr;
 }
 
-/** Print the object */
 template <unsigned int TDimension, typename TTubePointType>
 void
 TubeSpatialObject<TDimension, TTubePointType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -120,7 +117,6 @@ TubeSpatialObject<TDimension, TTubePointType>::PrintSelf(std::ostream & os, Inde
   Superclass::PrintSelf(os, indent);
 }
 
-/** Compute the bounds of the tube */
 template <unsigned int TDimension, typename TTubePointType>
 void
 TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
@@ -179,9 +175,6 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
   this->GetModifiableMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 }
 
-/** Test whether a point is inside or outside the object
- *  For computational speed purposes, it is faster if the method does not
- *  check the name of the class and the current depth */
 template <unsigned int TDimension, typename TTubePointType>
 bool
 TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const PointType & point) const
@@ -295,7 +288,6 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
   return false;
 }
 
-/** Remove duplicate points */
 template <unsigned int TDimension, typename TTubePointType>
 unsigned int
 TubeSpatialObject<TDimension, TTubePointType>::RemoveDuplicatePointsInObjectSpace(double minSpacingInObjectSpace)
@@ -322,7 +314,6 @@ TubeSpatialObject<TDimension, TTubePointType>::RemoveDuplicatePointsInObjectSpac
   return nPoints;
 }
 
-/** Compute the tangent of the centerline of the tube */
 template <unsigned int TDimension, typename TTubePointType>
 bool
 TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -55,36 +55,36 @@ public:
   /** Default destructor. */
   ~TubeSpatialObjectPoint() override = default;
 
-  /** Get R */
+  /** Get the radius in object space. */
   double
   GetRadiusInObjectSpace() const
   {
     return m_RadiusInObjectSpace;
   }
 
-  /** Get R */
+  /** Get the radius in world space. */
   double
   GetRadiusInWorldSpace() const;
 
-  /** Set R */
+  /** Set the radius in object space. */
   void
   SetRadiusInObjectSpace(double newR)
   {
     m_RadiusInObjectSpace = newR;
   }
 
-  /** Set R */
+  /** Set the radius in world space. */
   void
   SetRadiusInWorldSpace(double newR);
 
-  /** Get the tangent in Object Space */
+  /** Get the tangent in object space. */
   const VectorType &
   GetTangentInObjectSpace() const
   {
     return m_TangentInObjectSpace;
   }
 
-  /** Get the tangent in World Space */
+  /** Get the tangent in world space. */
   const VectorType
   GetTangentInWorldSpace() const;
 

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <unsigned int TPointDimension>
 TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint()
 {
@@ -42,7 +42,6 @@ TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint()
   m_Alpha3 = 0;
 }
 
-/** Copy Constructor */
 template <unsigned int TPointDimension>
 TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint(const TubeSpatialObjectPoint & other)
   : Superclass(other)
@@ -64,7 +63,6 @@ TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint(const TubeSpatia
   this->SetAlpha3(other.GetAlpha3());
 }
 
-/** Get the radius */
 template <unsigned int TPointDimension>
 double
 TubeSpatialObjectPoint<TPointDimension>::GetRadiusInWorldSpace() const
@@ -86,7 +84,6 @@ TubeSpatialObjectPoint<TPointDimension>::GetRadiusInWorldSpace() const
   return worldR;
 }
 
-/** Get the radius */
 template <unsigned int TPointDimension>
 void
 TubeSpatialObjectPoint<TPointDimension>::SetRadiusInWorldSpace(double newR)

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -148,7 +148,7 @@ public:
   using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
-  /** Compose affine transformation with a translation
+  /** Compose affine transformation with a translation.
    *
    * This method modifies self to include a translation of the
    * origin.  The translation is precomposed with self if pre is
@@ -157,7 +157,7 @@ public:
   void
   Translate(const OutputVectorType & trans, bool pre = false);
 
-  /** Compose affine transformation with a scaling
+  /** Compose affine transformation with a scaling.
    *
    * This method modifies self to magnify the source by a given
    * factor along each axis.  If all factors are the same, or only a
@@ -174,7 +174,7 @@ public:
   void
   Scale(const TParametersValueType & factor, bool pre = false);
 
-  /** Compose affine transformation with an elementary rotation
+  /** Compose affine transformation with an elementary rotation.
    *
    * This method composes self with a rotation that affects two
    * specified axes, replacing the current value of self.  The
@@ -192,7 +192,7 @@ public:
   void
   Rotate(int axis1, int axis2, TParametersValueType angle, bool pre = false);
 
-  /** Compose 2D affine transformation with a rotation
+  /** Compose 2D affine transformation with a rotation.
    *
    * This method composes self, which must be a 2D affine
    * transformation, with a clockwise rotation through a given angle
@@ -208,7 +208,7 @@ public:
   void
   Rotate2D(TParametersValueType angle, bool pre = false);
 
-  /** Compose 3D affine transformation with a rotation
+  /** Compose 3D affine transformation with a rotation.
    *
    * This method composes self, which must be a 3D affine
    * transformation, with a clockwise rotation around a specified
@@ -238,15 +238,15 @@ public:
   void
   Shear(int axis1, int axis2, TParametersValueType coef, bool pre = false);
 
-  /** Get an inverse of this transform. */
+  /** Get the inverse of the transform. */
   bool
   GetInverse(Self * inverse) const;
 
-  /** Return an inverse of this transform. */
+  /** Get the inverse of the transform. */
   InverseTransformBasePointer
   GetInverseTransform() const override;
 
-  /** Compute distance between two affine transformations
+  /** Compute distance between two affine transformations.
    *
    * This method computes a "distance" between two affine
    * transformations.  This distance is guaranteed to be a metric,

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -23,26 +23,23 @@
 
 namespace itk
 {
-/** Constructor with default arguments */
+
 template <typename TParametersValueType, unsigned int VDimension>
 AffineTransform<TParametersValueType, VDimension>::AffineTransform()
   : Superclass(ParametersDimension)
 {}
 
-/** Constructor with default arguments */
 template <typename TParametersValueType, unsigned int VDimension>
 AffineTransform<TParametersValueType, VDimension>::AffineTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {}
 
-/** Constructor with explicit arguments */
 template <typename TParametersValueType, unsigned int VDimension>
 AffineTransform<TParametersValueType, VDimension>::AffineTransform(const MatrixType &       matrix,
                                                                    const OutputVectorType & offset)
   : Superclass(matrix, offset)
 {}
 
-/** Compose with a translation */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Translate(const OutputVectorType & trans, bool pre)
@@ -62,7 +59,6 @@ AffineTransform<TParametersValueType, VDimension>::Translate(const OutputVectorT
   this->Modified();
 }
 
-/** Compose with isotropic scaling */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Scale(const TParametersValueType & factor, bool pre)
@@ -88,7 +84,6 @@ AffineTransform<TParametersValueType, VDimension>::Scale(const TParametersValueT
   this->Modified();
 }
 
-/** Compose with anisotropic scaling */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Scale(const OutputVectorType & factor, bool pre)
@@ -118,7 +113,6 @@ AffineTransform<TParametersValueType, VDimension>::Scale(const OutputVectorType 
   this->Modified();
 }
 
-/** Compose with elementary rotation */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Rotate(int axis1, int axis2, TParametersValueType angle, bool pre)
@@ -152,9 +146,6 @@ AffineTransform<TParametersValueType, VDimension>::Rotate(int axis1, int axis2, 
   this->Modified();
 }
 
-/** Compose with 2D rotation
- * \todo Find a way to generate a compile-time error
- * is this is used with VDimension != 2. */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Rotate2D(TParametersValueType angle, bool pre)
@@ -179,9 +170,6 @@ AffineTransform<TParametersValueType, VDimension>::Rotate2D(TParametersValueType
   this->Modified();
 }
 
-/** Compose with 3D rotation
- *  \todo Find a way to generate a compile-time error
- *  is this is used with VDimension != 3. */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Rotate3D(const OutputVectorType & axis,
@@ -230,7 +218,6 @@ AffineTransform<TParametersValueType, VDimension>::Rotate3D(const OutputVectorTy
   this->Modified();
 }
 
-/** Compose with elementary rotation */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Shear(int axis1, int axis2, TParametersValueType coef, bool pre)
@@ -261,7 +248,6 @@ AffineTransform<TParametersValueType, VDimension>::Shear(int axis1, int axis2, T
   this->Modified();
 }
 
-/** Get an inverse of this transform. */
 template <typename TParametersValueType, unsigned int VDimension>
 bool
 AffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
@@ -269,7 +255,6 @@ AffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) co
   return this->Superclass::GetInverse(inverse);
 }
 
-/** Return an inverse of this transform. */
 template <typename TParametersValueType, unsigned int VDimension>
 typename AffineTransform<TParametersValueType, VDimension>::InverseTransformBasePointer
 AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
@@ -279,7 +264,6 @@ AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
   return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
 }
 
-/** Compute a distance between two affine transforms */
 template <typename TParametersValueType, unsigned int VDimension>
 typename AffineTransform<TParametersValueType, VDimension>::ScalarType
 AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const
@@ -299,7 +283,6 @@ AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) co
   return std::sqrt(result);
 }
 
-/** Compute a distance between self and the identity transform */
 template <typename TParametersValueType, unsigned int VDimension>
 typename AffineTransform<TParametersValueType, VDimension>::ScalarType
 AffineTransform<TParametersValueType, VDimension>::Metric() const

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -188,13 +188,11 @@ public:
   void
   SetForwardCartesianToAzimuthElevation();
 
-  /** Perform conversion from Azimuth Elevation coordinates to Cartesian
-   *  Coordinates. */
+  /** Transform a point from azimuth-elevation coordinates to Cartesian coordinates. */
   OutputPointType
   TransformAzElToCartesian(const InputPointType & point) const;
 
-  /** Perform conversion from Cartesian Coordinates to Azimuth Elevation
-   *  coordinates.  */
+  /** Transform a point from Cartesian coordinates to azimuth-elevation coordinates. */
   OutputPointType
   TransformCartesianToAzEl(const OutputPointType & point) const;
 

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-// Constructor with default arguments
+
 template <typename TParametersValueType, unsigned int VDimension>
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::AzimuthElevationToCartesianTransform()
 // add this construction call when deriving from itk::Transform
@@ -36,7 +36,6 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::AzimuthE
   m_ForwardAzimuthElevationToPhysical = true;
 }
 
-// Print self
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
@@ -84,7 +83,6 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::Transfor
   return result;
 }
 
-/** Transform a point, from azimuth-elevation to cartesian */
 template <typename TParametersValueType, unsigned int VDimension>
 typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformAzElToCartesian(
@@ -120,7 +118,6 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::Transfor
   return result;
 }
 
-// Set parameters
 template <typename TParametersValueType, unsigned int VDimension>
 void
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::SetAzimuthElevationToCartesianParameters(

--- a/Modules/Core/Transform/include/itkEuler3DTransform.h
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.h
@@ -131,6 +131,10 @@ public:
   SetComputeZYX(const bool flag);
   itkGetConstMacro(ComputeZYX, bool);
 
+  /** Set the state to the identity.
+   *
+   * Sets the angles to a 0 value.
+   */
   void
   SetIdentity() override;
 
@@ -152,6 +156,7 @@ protected:
   void
   ComputeMatrix() override;
 
+  /** Compute angles from the rotation matrix. */
   void
   ComputeMatrixParameters() override;
 

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-// Constructor with default arguments
+
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform()
   : Superclass(ParametersDimension)
@@ -32,7 +32,6 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform()
   this->m_FixedParameters.Fill(0.0);
 }
 
-// Constructor with default arguments
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform(const MatrixType & matrix, const OutputPointType & offset)
 {
@@ -48,7 +47,6 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform(const MatrixType & matr
   this->m_FixedParameters.Fill(0.0);
 }
 
-// Constructor with arguments
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
@@ -59,7 +57,6 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform(unsigned int parameters
   this->m_FixedParameters.Fill(0.0);
 }
 
-// Set Angles
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetVarRotation(ScalarType angleX, ScalarType angleY, ScalarType angleZ)
@@ -69,7 +66,6 @@ Euler3DTransform<TParametersValueType>::SetVarRotation(ScalarType angleX, Scalar
   this->m_AngleZ = angleZ;
 }
 
-// Set Parameters
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
@@ -103,7 +99,6 @@ Euler3DTransform<TParametersValueType>::SetParameters(const ParametersType & par
   itkDebugMacro(<< "After setting parameters ");
 }
 
-// Get Parameters
 template <typename TParametersValueType>
 auto
 Euler3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
@@ -156,7 +151,6 @@ Euler3DTransform<TParametersValueType>::SetFixedParameters(const FixedParameters
   }
 }
 
-// Set Rotational Part
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetRotation(ScalarType angleX, ScalarType angleY, ScalarType angleZ)
@@ -168,7 +162,6 @@ Euler3DTransform<TParametersValueType>::SetRotation(ScalarType angleX, ScalarTyp
   this->ComputeOffset();
 }
 
-// Compose
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetIdentity()
@@ -179,7 +172,6 @@ Euler3DTransform<TParametersValueType>::SetIdentity()
   m_AngleZ = 0;
 }
 
-// Compute angles from the rotation matrix
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::ComputeMatrixParameters()
@@ -230,7 +222,6 @@ Euler3DTransform<TParametersValueType>::ComputeMatrixParameters()
   this->ComputeMatrix();
 }
 
-// Compute the matrix
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::ComputeMatrix()
@@ -362,7 +353,6 @@ Euler3DTransform<TParametersValueType>::SetComputeZYX(const bool flag)
   }
 }
 
-// Print self
 template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
@@ -24,7 +24,7 @@
 
 namespace itk
 {
-/** Constructor with default arguments */
+
 template <typename TParametersValueType, unsigned int VDimension>
 FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::FixedCenterOfRotationAffineTransform()
   : Superclass(ParametersDimension)

--- a/Modules/Core/Transform/include/itkVersorTransform.h
+++ b/Modules/Core/Transform/include/itkVersorTransform.h
@@ -112,7 +112,7 @@ public:
   const ParametersType &
   GetParameters() const override;
 
-  /** Set the rotational part of the transform */
+  /** Set the rotational part of the transform. */
   void
   SetRotation(const VersorType & versor);
 

--- a/Modules/Core/Transform/include/itkVersorTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorTransform.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Constructor with default arguments */
+
 template <typename TParametersValueType>
 VersorTransform<TParametersValueType>::VersorTransform()
   : Superclass(ParametersDimension)
@@ -30,7 +30,6 @@ VersorTransform<TParametersValueType>::VersorTransform()
   m_Versor.SetIdentity();
 }
 
-/** Constructor with default arguments */
 template <typename TParametersValueType>
 VersorTransform<TParametersValueType>::VersorTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
@@ -38,7 +37,6 @@ VersorTransform<TParametersValueType>::VersorTransform(unsigned int parametersDi
   m_Versor.SetIdentity();
 }
 
-/** Constructor with default arguments */
 template <typename TParametersValueType>
 VersorTransform<TParametersValueType>::VersorTransform(const MatrixType & matrix, const OutputVectorType & offset)
   : Superclass(matrix, offset)
@@ -46,7 +44,6 @@ VersorTransform<TParametersValueType>::VersorTransform(const MatrixType & matrix
   this->ComputeMatrixParameters(); // called in MatrixOffset baseclass
 }
 
-/** Set Parameters */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
@@ -81,7 +78,6 @@ VersorTransform<TParametersValueType>::SetParameters(const ParametersType & para
   itkDebugMacro(<< "After setting parameters ");
 }
 
-/** Set Parameters */
 template <typename TParametersValueType>
 auto
 VersorTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
@@ -93,7 +89,6 @@ VersorTransform<TParametersValueType>::GetParameters() const -> const Parameters
   return this->m_Parameters;
 }
 
-/** Set Rotational Part */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::SetRotation(const VersorType & versor)
@@ -103,7 +98,6 @@ VersorTransform<TParametersValueType>::SetRotation(const VersorType & versor)
   this->ComputeOffset();
 }
 
-/** Set Rotational Part */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::SetRotation(const AxisType & axis, AngleType angle)
@@ -113,7 +107,6 @@ VersorTransform<TParametersValueType>::SetRotation(const AxisType & axis, AngleT
   this->ComputeOffset();
 }
 
-/** Set Identity */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::SetIdentity()
@@ -125,7 +118,6 @@ VersorTransform<TParametersValueType>::SetIdentity()
   this->Modified();
 }
 
-/** Compute the matrix */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::ComputeMatrix()
@@ -133,7 +125,6 @@ VersorTransform<TParametersValueType>::ComputeMatrix()
   this->SetVarMatrix(m_Versor.GetMatrix());
 }
 
-/** Compute the matrix */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::ComputeMatrixParameters()
@@ -189,7 +180,6 @@ VersorTransform<TParametersValueType>::ComputeJacobianWithRespectToParameters(co
   jacobian[2][2] = 2.0 * ((vxw + vyz) * px + (vyw - vxz) * py) / vw;
 }
 
-/** Print self */
 template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::AnisotropicDiffusionImageFilter()
 {
@@ -36,7 +34,6 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::AnisotropicDiffusion
   m_GradientMagnitudeIsFixed = false;
 }
 
-/** Prepare for the iteration process. */
 template <typename TInputImage, typename TOutputImage>
 void
 AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration()

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.h
@@ -79,8 +79,7 @@ public:
     return m_Threshold;
   }
 
-  /** This method computes the solution update for each pixel that does not
-   * lie on a the data set boundary. */
+  /** Compute the solution update for each pixel that does not lie on a the data set boundary. */
   PixelType
   ComputeUpdate(const NeighborhoodType & it,
                 void *                   globalData,

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
@@ -23,19 +23,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImage>
 BinaryMinMaxCurvatureFlowFunction<TImage>::BinaryMinMaxCurvatureFlowFunction()
 {
   m_Threshold = 0.0;
 }
 
-/**
- * Update the solution at pixels which does not lie on the
- * data boundary.
- */
 template <typename TImage>
 typename BinaryMinMaxCurvatureFlowFunction<TImage>::PixelType
 BinaryMinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::BinaryMinMaxCurvatureFlowImageFilter()
 {
@@ -36,20 +34,15 @@ BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::BinaryMinMaxCur
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
   os << indent << "Threshold: " << m_Threshold << std::endl;
 }
 
-/**
- * Initialize the state of filter and equation before each iteration.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::InitializeIteration()

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
@@ -123,8 +123,7 @@ public:
     return m_TimeStep;
   }
 
-  /** This method computes the solution update for each pixel that does not
-   * lie on a the data set boundary. */
+  /** Compute the solution update for each pixel that does not lie on a the data set boundary. */
   PixelType
   ComputeUpdate(const NeighborhoodType & it,
                 void *                   globalData,

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImage>
 CurvatureFlowFunction<TImage>::CurvatureFlowFunction()
 {
@@ -41,9 +39,6 @@ CurvatureFlowFunction<TImage>::CurvatureFlowFunction()
   m_TimeStep = 0.05f;
 }
 
-/**
- * Compute the global time step
- */
 template <typename TImage>
 auto
 CurvatureFlowFunction<TImage>::ComputeGlobalTimeStep(void * itkNotUsed(gd)) const -> TimeStepType
@@ -51,9 +46,6 @@ CurvatureFlowFunction<TImage>::ComputeGlobalTimeStep(void * itkNotUsed(gd)) cons
   return this->GetTimeStep();
 }
 
-/**
- * Update the solution at pixels which lies on the data boundary.
- */
 template <typename TImage>
 typename CurvatureFlowFunction<TImage>::PixelType
 CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::CurvatureFlowImageFilter()
 {
@@ -37,9 +35,6 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::CurvatureFlowImageFilter()
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -49,9 +44,6 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os
   os << std::endl;
 }
 
-/**
- * Initialize the state of filter and equation before each iteration.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::InitializeIteration()
@@ -77,9 +69,6 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::InitializeIteration()
   }
 }
 
-/**
- * GenerateInputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -101,9 +90,6 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegio
   inputPtr->SetRequestedRegion(outputPtr->GetRequestedRegion());
 }
 
-/**
- * EnlargeOutputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * ptr)

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.h
@@ -87,8 +87,7 @@ public:
     return GetRadiusValueType();
   }
 
-  /** This method computes the solution update for each pixel that does not
-   * lie on a the data set boundary. */
+  /** Compute the solution update for each pixel that does not lie on a the data set boundary. */
   PixelType
   ComputeUpdate(const NeighborhoodType & it,
                 void *                   globalData,
@@ -116,8 +115,7 @@ private:
   struct Dispatch : public DispatchBase
   {};
 
-  /** This method computes the threshold by averaging the intensity
-   *  in direction perpendicular to the image gradient. */
+  /** Compute the threshold by averaging the intensity in direction perpendicular to the image gradient. */
   PixelType
   ComputeThreshold(const Dispatch<2> &, const NeighborhoodType & it) const;
 

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImage>
 MinMaxCurvatureFlowFunction<TImage>::MinMaxCurvatureFlowFunction()
 {
@@ -33,9 +31,6 @@ MinMaxCurvatureFlowFunction<TImage>::MinMaxCurvatureFlowFunction()
   this->SetStencilRadius(2);
 }
 
-/**
- * Set the stencil radius.
- */
 template <typename TImage>
 void
 MinMaxCurvatureFlowFunction<TImage>::SetStencilRadius(const RadiusValueType value)
@@ -58,9 +53,6 @@ MinMaxCurvatureFlowFunction<TImage>::SetStencilRadius(const RadiusValueType valu
   this->InitializeStencilOperator();
 }
 
-/**
- * Initialize the stencil operator.
- */
 template <typename TImage>
 void
 MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
@@ -123,10 +115,6 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
   }
 }
 
-/**
- * Compute the threshold by averaging the image intensity in
- * the direction perpendicular to the image gradient.
- */
 template <typename TImage>
 auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, const NeighborhoodType & it) const
@@ -224,10 +212,6 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
   return threshold;
 }
 
-/**
- * Compute the threshold by averaging the image intensity in
- * the direction perpendicular to the image gradient.
- */
 template <typename TImage>
 auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const NeighborhoodType & it) const
@@ -290,10 +274,6 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
   return threshold;
 }
 
-/*
- * Compute the threshold by averaging the image intensity in
- * the direction perpendicular to the image gradient.
- */
 template <typename TImage>
 auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const NeighborhoodType & it) const
@@ -411,9 +391,6 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
   return threshold;
 }
 
-/*
- * Update the solution at pixels which lies on the data boundary.
- */
 template <typename TImage>
 typename MinMaxCurvatureFlowFunction<TImage>::PixelType
 MinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::MinMaxCurvatureFlowImageFilter()
 {
@@ -37,9 +35,6 @@ MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::MinMaxCurvatureFlowIm
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }
 
-/*
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -48,9 +43,6 @@ MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   os << indent << "StencilRadius: " << m_StencilRadius << std::endl;
 }
 
-/*
- * Initialize the state of filter and equation before each iteration.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::InitializeIteration()

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -27,9 +27,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TParametersValueType, unsigned int VDimension>
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSplineExponentialDiffeomorphicTransform()
 
@@ -38,9 +35,6 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSpl
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);
 }
 
-/**
- * set mesh size for update field
- */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::SetMeshSizeForTheUpdateField(
@@ -54,9 +48,6 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::SetM
   this->SetNumberOfControlPointsForTheUpdateField(numberOfControlPoints);
 }
 
-/**
- * set mesh size for update field
- */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::SetMeshSizeForTheConstantVelocityField(
@@ -193,9 +184,6 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSpl
   return smoothField;
 }
 
-/**
- * Standard "PrintSelf" method
- */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -188,8 +188,9 @@ protected:
   typename LightObject::Pointer
   InternalClone() const override;
 
-  /**
-   * Smooth the displacement field using B-splines.
+  /** Smooth the displacement field using B-splines.
+   *
+   * Sets displacement field and projects it onto the space of B-spline transforms.
    */
   DisplacementFieldPointer
   BSplineSmoothDisplacementField(const DisplacementFieldType *, const ArrayType &);

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -27,9 +27,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TParametersValueType, unsigned int VDimension>
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
                                                    VDimension>::BSplineSmoothingOnUpdateDisplacementFieldTransform()
@@ -39,9 +36,6 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
   this->m_NumberOfControlPointsForTheTotalField.Fill(0);
 }
 
-/**
- * set mesh size for update field
- */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::SetMeshSizeForTheUpdateField(
@@ -55,9 +49,6 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
   this->SetNumberOfControlPointsForTheUpdateField(numberOfControlPoints);
 }
 
-/**
- * set mesh size for total field
- */
 template <typename TParametersValueType, unsigned int VDimension>
 void
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::SetMeshSizeForTheTotalField(
@@ -169,9 +160,6 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
   }
 }
 
-/**
- * set displacement field and project it onto the space of b-spline transforms
- */
 template <typename TParametersValueType, unsigned int VDimension>
 typename BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldPointer
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::BSplineSmoothDisplacementField(

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -138,11 +138,11 @@ public:
   void
   UpdateTransformParameters(const DerivativeType & update, ScalarType factor = 1.0) override;
 
-  /** Return an inverse of this transform. */
+  /** Get the inverse of the transform. */
   bool
   GetInverse(Self * inverse) const;
 
-  /** Return an inverse of this transform. */
+  /** Get the inverse of the transform. */
   InverseTransformBasePointer
   GetInverseTransform() const override;
 

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -27,9 +27,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TParametersValueType, unsigned int VDimension>
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::ConstantVelocityFieldTransform()
   : m_ConstantVelocityField(nullptr)
@@ -69,9 +66,6 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransfor
   this->IntegrateVelocityField();
 }
 
-/**
- * return an inverse transformation
- */
 template <typename TParametersValueType, unsigned int VDimension>
 bool
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
@@ -94,7 +88,6 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Sel
   }
 }
 
-// Return an inverse of this transform
 template <typename TParametersValueType, unsigned int VDimension>
 auto
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -29,9 +29,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TParametersValueType, unsigned int VDimension>
 TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::TimeVaryingBSplineVelocityFieldTransform()
 {

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -156,11 +156,11 @@ public:
   void
   UpdateTransformParameters(const DerivativeType & update, ScalarType factor = 1.0) override;
 
-  /** Return an inverse of this transform. */
+  /** Get the inverse of the transform. */
   bool
   GetInverse(Self * inverse) const;
 
-  /** Return an inverse of this transform. */
+  /** Get the inverse of the transform. */
   InverseTransformBasePointer
   GetInverseTransform() const override;
 

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -26,9 +26,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TParametersValueType, unsigned int VDimension>
 VelocityFieldTransform<TParametersValueType, VDimension>::VelocityFieldTransform()
 {
@@ -67,9 +64,6 @@ VelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransformParamet
   this->IntegrateVelocityField();
 }
 
-/**
- * return an inverse transformation
- */
 template <typename TParametersValueType, unsigned int VDimension>
 bool
 VelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
@@ -92,7 +86,6 @@ VelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inve
   }
 }
 
-// Return an inverse of this transform
 template <typename TParametersValueType, unsigned int VDimension>
 auto
 VelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
@@ -172,6 +172,7 @@ protected:
   void
   ThreadedGenerateDataBand(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId);
 
+  /** Split the band if the narrowband mode is used. */
   void
   BeforeThreadedGenerateData() override;
 

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Default constructor.
- */
+
 template <typename TInputImage, typename TOutputImage>
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::IsoContourDistanceImageFilter()
 {
@@ -38,9 +36,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::IsoContourDistanceImag
   m_NarrowBand = nullptr;
 }
 
-/**
- * Set the input narrowband container.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::SetNarrowBand(NarrowBandType * ptr)
@@ -52,23 +47,18 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::SetNarrowBand(NarrowBa
   }
 }
 
-/**
- * PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
   os << indent << "Narrowbanding: " << m_NarrowBanding << std::endl;
   os << indent << "LevelSetValue: " << m_LevelSetValue << std::endl;
   os << indent << "FarValue: " << m_FarValue << std::endl;
   os << std::endl;
 }
 
-/**
- * GenerateInputRequestedRegion method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -77,9 +67,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::GenerateInputRequested
   this->Superclass::GenerateInputRequestedRegion();
 }
 
-/**
- * EnlargeOutputRequestedRegion method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -157,10 +144,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreaderFullCallback(v
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
 
-/**
- * Before ThreadedGenerateData:
- *  Split the band if we use narrowband mode
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
@@ -181,8 +164,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerate
   }
 }
 
-//----------------------------------------------------------------------------
-// The execute method created by the subclass.
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
@@ -223,7 +204,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   }
 }
 
-// The execute method created by the subclass.
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataFull(
@@ -266,8 +246,6 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataFu
   }
 }
 
-
-// The execute method created by the subclass.
 template <typename TInputImage, typename TOutputImage>
 void
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataBand(

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -25,9 +25,7 @@
 
 namespace itk
 {
-/**
- *
- */
+
 template <typename TLevelSet, typename TSpeedImage>
 FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::FastMarchingUpwindGradientImageFilter()
 {
@@ -41,9 +39,6 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::FastMarchingUpwin
   m_NumberOfTargets = 0;
 }
 
-/**
- *
- */
 template <typename TLevelSet, typename TSpeedImage>
 void
 FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -83,9 +78,6 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::VerifyPreconditio
   }
 }
 
-/**
- *
- */
 template <typename TLevelSet, typename TSpeedImage>
 void
 FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * output)
@@ -250,9 +242,6 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::UpdateNeighbors(c
   }
 }
 
-/**
- *
- */
 template <typename TLevelSet, typename TSpeedImage>
 void
 FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::ComputeGradient(

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -23,7 +23,6 @@
 namespace itk
 {
 
-/** Prepare for the iteration process. */
 template <typename TInputImage, typename TOutputImage, typename TParentImageFilter>
 void
 GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter>::InitializeIteration()

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 GPUBinaryThresholdImageFilter<TInputImage, TOutputImage>::GPUBinaryThresholdImageFilter()
 {

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TPixel>
 Hessian3DToVesselnessMeasureImageFilter<TPixel>::Hessian3DToVesselnessMeasureImageFilter()
 {

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
@@ -112,7 +112,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** Set Sigma value. Sigma is measured in the units of image spacing.  */
+  /** Set/Get Sigma value. Sigma is measured in the units of image spacing.  */
   void
   SetSigma(RealType sigma);
   RealType

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::HessianRecursiveGaussianImageFilter()
 {
@@ -79,9 +77,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::HessianRecursive
   this->SetSigma(1.0);
 }
 
-/**
- * Set value of Sigma
- */
 template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealType sigma)
@@ -98,9 +93,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealTyp
   this->Modified();
 }
 
-/**
- * Get value of Sigma
- */
 template <typename TInputImage, typename TOutputImage>
 auto
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> RealType
@@ -108,9 +100,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const
   return m_DerivativeFilterA->GetSigma();
 }
 
-/**
- * Set Normalize Across Scale Space
- */
 template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcrossScale(bool normalize)
@@ -125,9 +114,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcro
   this->Modified();
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -145,9 +131,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputReq
   }
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -160,9 +143,6 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputReq
   }
 }
 
-/**
- * Compute filter for Gaussian kernel
- */
 template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
@@ -99,7 +99,7 @@ public:
   /** Runtime information support. */
   itkTypeMacro(LaplacianRecursiveGaussianImageFilter, ImageToImageFilter);
 
-  /** Set Sigma value. Sigma is measured in the units of image spacing. */
+  /** Set/Get Sigma value. Sigma is measured in the units of image spacing. */
   void
   SetSigma(RealType sigma);
   RealType

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -25,9 +25,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::LaplacianRecursiveGaussianImageFilter()
 {
@@ -63,9 +61,6 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::LaplacianRecur
   this->SetSigma(1.0);
 }
 
-/**
- * Set value of Sigma
- */
 template <typename TInputImage, typename TOutputImage>
 void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealType sigma)
@@ -79,9 +74,6 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealT
   this->Modified();
 }
 
-/**
- * Get value of Sigma
- */
 template <typename TInputImage, typename TOutputImage>
 auto
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> RealType
@@ -89,9 +81,6 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() con
   return m_DerivativeFilter->GetSigma();
 }
 
-/**
- * Set Normalize Across Scale Space
- */
 template <typename TInputImage, typename TOutputImage>
 void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcrossScale(bool normalize)
@@ -107,10 +96,6 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAc
   this->Modified();
 }
 
-
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -123,9 +108,6 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputR
   }
 }
 
-/**
- * Compute filter for Gaussian kernel
- */
 template <typename TInputImage, typename TOutputImage>
 void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
@@ -162,7 +162,8 @@ protected:
    * execution model.  The original documentation of this method is
    * below.
    *
-   * \sa ProcessObject::GenerateOutputInformation()  */
+   * \sa ProcessObject::GenerateOutputInformation()
+   */
   void
   GenerateOutputInformation() override;
 

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 UnaryGeneratorImageFilter<TInputImage, TOutputImage>::UnaryGeneratorImageFilter()
 {
@@ -35,15 +33,6 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::UnaryGeneratorImageFilter(
   this->DynamicMultiThreadingOn();
 }
 
-/**
- * UnaryGeneratorImageFilter can produce an image which is a different resolution
- * than its input image.  As such, UnaryGeneratorImageFilter needs to provide an
- * implementation for GenerateOutputInformation() in order to inform
- * the pipeline execution model.  The original documentation of this
- * method is below.
- *
- * \sa ProcessObject::GenerateOutputInformation()
- */
 template <typename TInputImage, typename TOutputImage>
 void
 UnaryGeneratorImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
@@ -85,21 +85,19 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** Set the label image */
+  /** Set/Get the label image. */
   void
   SetLabelImage(const TLabelImage * input);
-
-  /** Get the label image */
   const LabelImageType *
   GetLabelImage() const;
 
   /** Set/Get the opacity of the colored label image. The value must be
-   * between 0 and 1
+   * between 0 and 1.
    */
   itkSetMacro(Opacity, double);
   itkGetConstReferenceMacro(Opacity, double);
 
-  /** Set/Get the background value */
+  /** Set/Get the background value. */
   itkSetMacro(BackgroundValue, LabelPixelType);
   itkGetConstReferenceMacro(BackgroundValue, LabelPixelType);
 
@@ -111,18 +109,18 @@ public:
   // End concept checking
 #endif
 
-  /** Empty the color LUT container */
+  /** Empty the color LUT container. */
   void
   ResetColors();
 
-  /** Get number of colors in the LUT container */
+  /** Get number of colors in the LUT container. */
   unsigned int
   GetNumberOfColors() const;
 
-  /** type of the color component */
+  /** type of the color component. */
   using ComponentType = typename OutputPixelType::ComponentType;
 
-  /** Add color to the LUT container */
+  /** Add color to the LUT container. */
   void
   AddColor(ComponentType r, ComponentType g, ComponentType b);
 

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor method
- */
+
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::LabelOverlayImageFilter()
 {
@@ -51,10 +49,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GenerateOutputI
   }
 }
 
-
-/**
- * Destructor method
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 void
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::BeforeThreadedGenerateData()
@@ -64,9 +58,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::BeforeThreadedG
   this->SetFunctor(this->GetFunctor());
 }
 
-/**
- * Set Label Image
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 void
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::SetLabelImage(const TLabelImage * input)
@@ -74,9 +65,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::SetLabelImage(c
   this->SetInput2(input);
 }
 
-/**
- * Get Label Image
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 auto
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetLabelImage() const -> const LabelImageType *
@@ -84,9 +72,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetLabelImage()
   return itkDynamicCastInDebugMode<LabelImageType *>(const_cast<DataObject *>(this->ProcessObject::GetInput(1)));
 }
 
-/**
- * Get number of colors in the LUT container
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 unsigned int
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetNumberOfColors() const
@@ -94,9 +79,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetNumberOfColo
   return this->GetFunctor().GetNumberOfColors();
 }
 
-/**
- * Empty the color LUT container
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 void
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::ResetColors()
@@ -104,9 +86,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::ResetColors()
   this->GetFunctor().ResetColors();
 }
 
-/**
- * Add a color to the LUT container
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 void
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::AddColor(ComponentType r,
@@ -116,9 +95,6 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::AddColor(Compon
   this->GetFunctor().AddColor(r, g, b);
 }
 
-/**
- * Standard PrintSelf method
- */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 void
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -28,9 +28,7 @@
 
 namespace itk
 {
-//
-// Constructor
-//
+
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputImageType>::GradientImageFilter()
 {
@@ -42,9 +40,6 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   this->ThreaderUpdateProgressOff();
 }
 
-//
-// Destructor
-//
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputImageType>::~GradientImageFilter()
 {

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
@@ -110,13 +110,14 @@ public:
   /** Runtime information support. */
   itkTypeMacro(GradientMagnitudeRecursiveGaussianImageFilter, InPlaceImageFilter);
 
-  /** Set Sigma value. Sigma is measured in the units of image spacing.  */
+  /** Set/Get Sigma value. Sigma is measured in the units of image spacing.  */
   void
   SetSigma(RealType sigma);
   RealType
   GetSigma();
 
-  /** Define which normalization factor will be used for the Gaussian
+  /** Set/Get the normalization factor that will be used for the Gaussian.
+   *
    *  \sa  RecursiveGaussianImageFilter::SetNormalizeAcrossScale
    */
   void

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage,
                                               TOutputImage>::GradientMagnitudeRecursiveGaussianImageFilter()
@@ -76,9 +74,6 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintS
   os << indent << "Sigma: " << m_DerivativeFilter->GetSigma() << std::endl;
 }
 
-/**
- * Set value of Sigma
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealType sigma)
@@ -117,9 +112,6 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNum
   m_SqrtFilter->SetNumberOfWorkUnits(nb);
 }
 
-/**
- * Set Normalize Across Scale Space
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcrossScale(bool normalize)
@@ -138,9 +130,6 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNor
   }
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -158,9 +147,6 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Genera
   }
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(
@@ -174,9 +160,6 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Enlarg
   }
 }
 
-/**
- * Compute filter for Gaussian kernel
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -129,7 +129,7 @@ public:
   /** Runtime information support. */
   itkTypeMacro(GradientRecursiveGaussianImageFilter, ImageToImageFilter);
 
-  /** Set Sigma value. Sigma is measured in the units of image spacing. */
+  /** Set/Get the Sigma value. Sigma is measured in the units of image spacing. */
   void
   SetSigmaArray(const SigmaArrayType & sigma);
   void
@@ -137,6 +137,8 @@ public:
 
   SigmaArrayType
   GetSigmaArray() const;
+
+  /** Get the value of Sigma along the first dimension. */
   ScalarRealType
   GetSigma() const;
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursiveGaussianImageFilter()
 {
@@ -75,9 +73,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursi
   this->SetSigma(1.0);
 }
 
-/**
- * Set value of Sigma along all dimensions.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(ScalarRealType sigma)
@@ -86,9 +81,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(Scalar
   this->SetSigmaArray(sigmas);
 }
 
-/**
- * Set value of Sigma array.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigmaArray(const SigmaArrayType & sigma)
@@ -108,9 +100,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigmaArray(c
   }
 }
 
-/**
- * Get the Sigma array.
- */
 template <typename TInputImage, typename TOutputImage>
 auto
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray() const -> SigmaArrayType
@@ -118,9 +107,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray()
   return m_Sigma;
 }
 
-/**
- * Get value of Sigma. Returns the sigma along the first dimension.
- */
 template <typename TInputImage, typename TOutputImage>
 auto
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> ScalarRealType
@@ -128,9 +114,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() cons
   return m_Sigma[0];
 }
 
-/**
- * Set Normalize Across Scale Space
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcrossScale(bool normalize)
@@ -148,9 +131,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetNormalizeAcr
   this->Modified();
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -168,9 +148,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRe
   }
 }
 
-//
-//
-//
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -183,9 +160,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputRe
   }
 }
 
-/**
- * Compute filter for Gaussian kernel
- */
 template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
@@ -146,14 +146,22 @@ protected:
   virtual void
   InitializePyramidSplineFilter(int SplineOrder);
 
-  /** The basic operator for reducing a line of data by a factor of 2 */
+  /** Reduce the input data vector by a factor of 2 and writes the results to the location specified by the output
+   * Iterator.
+   *
+   * \p inTraverseSize is the size of the input vector.
+   */
   virtual void
   Reduce1DImage(const std::vector<double> & in,
                 OutputImageIterator &       out,
                 unsigned int                inTraverseSize,
                 ProgressReporter &          progress);
 
-  /** The basic operator for expanding a line of data by a factor of 2 */
+  /** Expand the input data vector by a factor of 2 and writes the results to the location specified by the output
+   * Iterator
+   *
+   * \p inTraverseSize is the size of the in vector.
+   */
   virtual void
   Expand1DImage(const std::vector<double> & in,
                 OutputImageIterator &       out,
@@ -173,12 +181,11 @@ protected:
   std::vector<double> m_H; // upsampling filter coefficients
 
 private:
-  // Resizes m_Scratch Variable based on image sizes
+  /** Allocate scratch space based on image sizes. */
   void
   InitializeScratch(SizeType DataLength);
 
-  // Copies a line of data from the input to the m_Scratch for subsequent
-  // processing
+  /** Copy a line of data from the input to the m_Scratch for subsequent processing. */
   void
   CopyInputLineToScratch(ConstInputImageIterator & Iter);
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -31,9 +31,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::BSplineResampleImageFilterBase()
 {
@@ -43,9 +41,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::BSplineResampleImageF
   this->SetSplineOrder(0);
 }
 
-/**
- * Standard "PrintSelf" method
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -54,9 +49,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   os << indent << "Spline Order: " << m_SplineOrder << std::endl;
 }
 
-/**
- * Initializes the Pyramid Spline Filter parameters for an "l2" filter
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::InitializePyramidSplineFilter(int SplineOrder)
@@ -180,10 +172,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::SetSplineOrder(int sp
   this->Modified();
 }
 
-/** Reduce1DImage - reduces the vector of data (in) by a
- *     factor of 2 and writes the results to the location specified
- *     by the Iterator (out).  inTraverseSize is the size of the in vector.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage(const std::vector<double> & in,
@@ -263,10 +251,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage(const s
   }
 }
 
-/** Expand1DImage - expands the vector of data (in) by a
- *     factor of 2 and writes the results to the location specified
- *     by the Iterator (out).  inTraverseSize is the size of the in vector.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const std::vector<double> & in,
@@ -337,8 +321,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
   }
 }
 
-/**  Reduce an Image by a factor of 2 in each dimension.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputImageIterator & outItr)
@@ -454,8 +436,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
   }
 }
 
-/**  Expand an Image by a factor of 2 in each dimension.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputImageIterator & outItr)
@@ -570,7 +550,6 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
   }
 }
 
-// Allocate scratch space
 template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::InitializeScratch(SizeType DataLength)

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -174,9 +174,6 @@ ChangeInformationImageFilter<TInputImage>::GenerateData()
   output->SetBufferedRegion(region);
 }
 
-/**
- *
- */
 template <typename TInputImage>
 void
 ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
@@ -88,20 +88,25 @@ public:
   itkGetConstReferenceMacro(InverseOrder, PermuteOrderArrayType);
 
 protected:
-  /** PermuteAxesImageFilter produces an image which is a different
-   * resolution and with a different pixel spacing than its input
-   * image.  As such, PermuteAxesImageFilter needs to provide an
-   * implementation for GenerateOutputInformation() in order to inform
-   * the pipeline execution model.  The original documentation of this
-   * method is below.
+  /** PermuteAxesImageFilter produces an image which is a different resolution and with a different pixel spacing than
+   * its input image.
+   *
+   * The output image meta information is obtained by permuting the input image meta information.
+   *
+   * As such, PermuteAxesImageFilter needs to provide an implementation for GenerateOutputInformation() in order to
+   * inform the pipeline execution model.
+   *
    * \sa ProcessObject::GenerateOutputInformaton() */
   void
   GenerateOutputInformation() override;
 
-  /** PermuteAxesImageFilter needs different input requested region than the output
-   * requested region.  As such, PermuteAxesImageFilter needs to provide an
-   * implementation for GenerateInputRequestedRegion() in order to inform the
-   * pipeline execution model.
+  /** PermuteAxesImageFilter needs different input requested region than the output requested region.
+   *
+   * The required input requested region is obtained by permuting the index and size of the output requested region.
+   *
+   * As such, PermuteAxesImageFilter needs to provide an implementation for GenerateInputRequestedRegion() in order to
+   * inform the pipeline execution model.
+   *
    * \sa ProcessObject::GenerateInputRequestedRegion() */
   void
   GenerateInputRequestedRegion() override;

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImage>
 PermuteAxesImageFilter<TImage>::PermuteAxesImageFilter()
 {
@@ -39,9 +37,6 @@ PermuteAxesImageFilter<TImage>::PermuteAxesImageFilter()
   this->ThreaderUpdateProgressOff();
 }
 
-/**
- * PrintSelf
- */
 template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -65,9 +60,6 @@ PermuteAxesImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) cons
   os << m_InverseOrder[j] << "]" << std::endl;
 }
 
-/**
- * Set the permutation order
- */
 template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
@@ -113,10 +105,6 @@ PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
   }
 }
 
-/**
- * The output image meta information is obtained by permuting
- * the input image meta information.
- */
 template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::GenerateOutputInformation()
@@ -170,10 +158,6 @@ PermuteAxesImageFilter<TImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(outputRegion);
 }
 
-/**
- * The required input requested region is obtained by permuting
- * the index and size of the output requested region
- */
 template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::GenerateInputRequestedRegion()
@@ -208,9 +192,6 @@ PermuteAxesImageFilter<TImage>::GenerateInputRequestedRegion()
   inputPtr->SetRequestedRegion(inputRegion);
 }
 
-/**
- *
- */
 template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -27,18 +27,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TPolyline, typename TOutputImage>
 PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::PolylineMask2DImageFilter()
 {
   this->SetNumberOfRequiredInputs(2);
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TPolyline, typename TOutputImage>
 void
 PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::SetInput1(const TInputImage * input)
@@ -48,9 +43,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::SetInput1(const
   this->ProcessObject::SetNthInput(0, const_cast<TInputImage *>(input));
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TPolyline, typename TOutputImage>
 void
 PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::SetInput2(const TPolyline * input)
@@ -59,9 +51,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::SetInput2(const
   this->ProcessObject::SetNthInput(1, const_cast<TPolyline *>(input));
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TPolyline, typename TOutputImage>
 void
 PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 AccumulateImageFilter<TInputImage, TOutputImage>::AccumulateImageFilter()
 {
@@ -135,9 +133,6 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   itkDebugMacro("GenerateInputRequestedRegion End");
 }
 
-/**
- * GenerateData Performs the accumulation
- */
 template <typename TInputImage, typename TOutputImage>
 void
 AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 GetAverageSliceImageFilter<TInputImage, TOutputImage>::GetAverageSliceImageFilter()
 {

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.h
@@ -137,9 +137,11 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  /** Convert a vector of basis images into a matrix flattening each image into 1-D. */
   void
   CalculateBasisMatrix();
 
+  /** Convert an image into a 1-D vector changing the pixel type if necessary. */
   void
   CalculateRecenteredImageAsVector();
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TBasisImage>
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::ImagePCADecompositionCalculator()
 {
@@ -50,9 +48,6 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::SetBasisImages(const 
   this->Modified();
 }
 
-/**
- * Compute the projection
- */
 template <typename TInputImage, typename TBasisImage>
 void
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::Compute()
@@ -65,9 +60,6 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::Compute()
   m_Projection = m_BasisMatrix * m_ImageAsVector;
 }
 
-/*
- * Convert a vector of basis images into a matrix. Each image is flattened into 1-D.
- */
 template <typename TInputImage, typename TBasisImage>
 void
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateBasisMatrix()
@@ -103,9 +95,6 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateBasisMatrix(
   m_ImageAsVector.set_size(m_NumPixels);
 }
 
-/**
- * Convert an image into a 1-D vector, changing the pixel type if necessary.
- */
 template <typename TInputImage, typename TBasisImage>
 void
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateRecenteredImageAsVector()

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -84,14 +84,12 @@ ChainCodePath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
   }
 }
 
-/** Constructor */
 template <unsigned int VDimension>
 ChainCodePath<VDimension>::ChainCodePath()
 {
   m_Start = this->GetZeroIndex();
 }
 
-/** Standard "PrintSelf" method */
 template <unsigned int VDimension>
 void
 ChainCodePath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputChainCodePath, typename TOutputFourierSeriesPath>
 ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath>::ChainCodeToFourierSeriesPathFilter()
 {
@@ -32,9 +30,6 @@ ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath
   m_NumberOfHarmonics = 8;
 }
 
-/**
- * GenerateData Performs the reflection
- */
 template <typename TInputChainCodePath, typename TOutputFourierSeriesPath>
 void
 ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath>::GenerateData()

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
@@ -86,9 +86,6 @@ FourierSeriesPath<VDimension>::AddHarmonic(const VectorType & CosCoefficients, c
   this->Modified();
 }
 
-/**
- * Constructor
- */
 template <unsigned int VDimension>
 FourierSeriesPath<VDimension>::FourierSeriesPath()
 {
@@ -97,9 +94,6 @@ FourierSeriesPath<VDimension>::FourierSeriesPath()
   m_SinCoefficients = CoefficientsType::New();
 }
 
-/**
- * Standard "PrintSelf" method
- */
 template <unsigned int VDimension>
 void
 FourierSeriesPath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -22,7 +22,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TIndexValue, unsigned int VDimension>
 HilbertPath<TIndexValue, VDimension>::HilbertPath()
 
@@ -239,7 +238,6 @@ HilbertPath<TIndexValue, VDimension>::GetEntry(const PathIndexType x) -> PathInd
   }
 }
 
-/** Standard "PrintSelf" method */
 template <typename TIndexValue, unsigned int VDimension>
 void
 HilbertPath<TIndexValue, VDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <unsigned int VDimension>
 ParametricPath<VDimension>::ParametricPath()
 {

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.h
@@ -64,7 +64,7 @@ public:
   /** ImageDimension constants */
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-  /** Set/Get the path input of this process object.  */
+  /** Set/Get the input path. */
   using Superclass::SetInput;
   virtual void
   SetInput(const InputPathType * input);

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -25,7 +25,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TInputPath, typename TOutputImage>
 PathToImageFilter<TInputPath, TOutputImage>::PathToImageFilter()
 {
@@ -129,7 +129,6 @@ PathToImageFilter<TInputPath, TOutputImage>::GetSpacing() const
   return m_Spacing;
 }
 
-//----------------------------------------------------------------------------
 template <typename TInputPath, typename TOutputImage>
 void
 PathToImageFilter<TInputPath, TOutputImage>::SetOrigin(const double * origin)
@@ -180,8 +179,6 @@ PathToImageFilter<TInputPath, TOutputImage>::GetOrigin() const
 {
   return m_Origin;
 }
-
-//----------------------------------------------------------------------------
 
 template <typename TInputPath, typename TOutputImage>
 void
@@ -281,7 +278,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   }
 
   itkDebugMacro(<< "PathToImageFilter::GenerateData() finished");
-} // end update function
+}
 
 template <typename TInputPath, typename TOutputImage>
 void

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1636,7 +1636,6 @@ GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
 #endif
 }
 
-/** Print enum values */
 std::ostream &
 operator<<(std::ostream & out, const GDCMImageIOEnums::Compression value)
 {

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
   ComplexBSplineInterpolateImageFunction()
@@ -37,9 +35,6 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
   this->SetSplineOrder(3);
 }
 
-/**
- * Standard "PrintSelf" method
- */
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
@@ -79,36 +79,49 @@ public:
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Connect the image containing the elements [0,0]
-   * of the input 2D matrix */
+   * of the input 2D matrix. */
   void
   SetInput1(TInputImage * image);
 
   /** Connect the image containing the elements [0,1]
    * of the input 2D matrix. This is the same [1,0]
    * element given that the input matrix is expected
-   * to be symmetric */
+   * to be symmetric. */
   void
   SetInput2(TInputImage * image);
 
   /** Connect the image containing the elements [1,1]
-   * of the input 2D matrix */
+   * of the input 2D matrix. */
   void
   SetInput3(TInputImage * image);
 
-  /** Get the Output image with the greatest eigenvalue */
+  /** Get the output image with the largest eigenvalue.
+   *
+   * The sign is taken into account in the computation.
+   */
   EigenValueImageType *
   GetMaxEigenValue();
 
-  /** Get the Output image with the smallest eigenvalue */
+  /** Get the output image with the smallest eigenvalue.
+   *
+   * The sign is taken into account in the computation.
+   */
   EigenValueImageType *
   GetMinEigenValue();
 
-  /** Get the Output image with the eigen vector associated with
-   * the greatest eigen value */
+  /** Get the output image with the eigenvector associated with
+   * the greatest eigenvalue
+   *
+   * The sign is taken into account in the computation.
+   */
   EigenVectorImageType *
   GetMaxEigenVector();
 
-  /**  Create the Output */
+  /**  Create the output.
+   *
+   * \todo Verify that MakeOutput is creating the right type of objects
+   * this could be the cause of the reinterpret_cast bug in this class.
+   */
   using DataObjectPointerArraySizeType = ProcessObject::DataObjectPointerArraySizeType;
   using Superclass::MakeOutput;
   DataObject::Pointer

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::EigenAnalysis2DImageFilter()
 {
@@ -37,9 +35,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ei
   static_assert(EigenVectorType::Dimension == 2, "Error: PixelType of EigenVector Image must have exactly 2 elements!");
 }
 
-/**
- * Connect one the image containing the [0,0] elements of the input matrix
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 void
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::SetInput1(TInputImage * image)
@@ -47,11 +42,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Se
   this->SetNthInput(0, image);
 }
 
-/**
- * Connect one the image containing the [0,1] elements of the input matrix
- * this element is the same [1,0] because this filter assumes symmetric
- * matrices
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 void
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::SetInput2(TInputImage * image)
@@ -59,9 +49,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Se
   this->SetNthInput(1, image);
 }
 
-/**
- * Connect one the image containing the [1,1] elements of the input matrix
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 void
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::SetInput3(TInputImage * image)
@@ -69,9 +56,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Se
   this->SetNthInput(2, image);
 }
 
-/**
- * Get the largest eigenvalue considering the sign
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMaxEigenValue()
@@ -80,9 +64,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   return dynamic_cast<EigenValueImageType *>(this->ProcessObject::GetOutput(0));
 }
 
-/**
- * Get the smallest eigenvalue considering the sign
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMinEigenValue()
@@ -91,9 +72,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   return dynamic_cast<EigenValueImageType *>(this->ProcessObject::GetOutput(1));
 }
 
-/**
- * Get the eigenvector corresponding to the largest eigenvalue (considering the sign)
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMaxEigenVector()
@@ -117,11 +95,6 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   }
 }
 
-/**
- *   Make Output
- * \todo Verify that MakeOutput is creating the right type of objects
- *  this could be the cause of the reinterpret_cast bug in this class
- */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 DataObject::Pointer
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::MakeOutput(

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -36,9 +36,7 @@ namespace itk
 {
 namespace fem
 {
-/*
- * Default constructor for FEMObject class
- */
+
 template <unsigned int VDimension>
 FEMObject<VDimension>::FEMObject()
 {
@@ -333,9 +331,6 @@ FEMObject<VDimension>::FinalizeMesh()
   this->GenerateMFC();
 }
 
-/**
- * Assign a global freedom number to each DOF in a system.
- */
 template <unsigned int VDimension>
 void
 FEMObject<VDimension>::GenerateMFC()
@@ -369,9 +364,6 @@ FEMObject<VDimension>::GenerateMFC()
   }
 }
 
-/**
- * Assign a global freedom number to each DOF in a system.
- */
 template <unsigned int VDimension>
 void
 FEMObject<VDimension>::GenerateGFN()

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -103,15 +103,15 @@ public:
   /**Get the number of element in each dimension of the generated mesh*/
   itkGetMacro(NumberOfElements, vnl_vector<unsigned int>);
 
-  /**Get/Set the material used for the mesh */
+  /**Get/Set the material used for the mesh. */
   itkGetMacro(Material, MaterialPointerType);
   itkSetMacro(Material, MaterialPointerType);
 
-  /**Get/Set the element type used to generate the mesh */
+  /**Get/Set the element type used to generate the mesh. */
   itkGetMacro(Element, ElementBasePointerType);
   itkSetMacro(Element, ElementBasePointerType);
 
-  /** Set/Get the image input of this process object.  */
+  /** Set/Get the input image. */
   using Superclass::SetInput;
   void
   SetInput(InputImageType * image);
@@ -161,9 +161,11 @@ protected:
   void
   GenerateData() override;
 
+  /** Generate a rectangular mesh of quadrilateral elements. */
   void
   Generate2DRectilinearMesh();
 
+  /** Generate a rectangular mesh of hexahedron elements. */
   void
   Generate3DRectilinearMesh();
 

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -26,9 +26,6 @@ namespace itk
 namespace fem
 {
 
-/*
- * Default constructor for Filter
- */
 template <typename TInputImage>
 ImageToRectilinearFEMObjectFilter<TInputImage>::ImageToRectilinearFEMObjectFilter()
 {
@@ -49,9 +46,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::SetInput(InputImageType * image)
   this->ProcessObject::SetNthInput(0, const_cast<InputImageType *>(image));
 }
 
-/**
- * Connect one of the operands for pixel-wise addition
- */
 template <typename TInputImage>
 void
 ImageToRectilinearFEMObjectFilter<TInputImage>::SetInput(unsigned int index, InputImageType * image)
@@ -60,9 +54,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::SetInput(unsigned int index, Inp
   this->ProcessObject::SetNthInput(index, const_cast<InputImageType *>(image));
 }
 
-/**
- *
- */
 template <typename TInputImage>
 auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput() -> InputImageType *
@@ -75,9 +66,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput() -> InputImageType *
   return itkDynamicCastInDebugMode<InputImageType *>(this->ProcessObject::GetInput(0));
 }
 
-/**
- *
- */
 template <typename TInputImage>
 auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput(unsigned int idx) -> InputImageType *
@@ -85,9 +73,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput(unsigned int idx) -> In
   return itkDynamicCastInDebugMode<InputImageType *>(this->ProcessObject::GetInput(idx));
 }
 
-/**
- *
- */
 template <typename TInputImage>
 auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
@@ -96,9 +81,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::MakeOutput(DataObjectPointerArra
   return FEMObjectType::New().GetPointer();
 }
 
-/**
- *
- */
 template <typename TInputImage>
 auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput() -> FEMObjectType *
@@ -111,9 +93,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput() -> FEMObjectType *
   return itkDynamicCastInDebugMode<FEMObjectType *>(this->ProcessObject::GetOutput(0));
 }
 
-/**
- *
- */
 template <typename TInputImage>
 auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput(unsigned int idx) -> FEMObjectType *
@@ -147,9 +126,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GenerateData()
   }
 }
 
-/**
- * Generate a rectangular mesh of quadrilateral elements
- */
 template <typename TInputImage>
 void
 ImageToRectilinearFEMObjectFilter<TInputImage>::Generate2DRectilinearMesh()
@@ -218,9 +194,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate2DRectilinearMesh()
   }
 }
 
-/**
- * Generate a rectangular mesh of hexahedron elements
- */
 template <typename TInputImage>
 void
 ImageToRectilinearFEMObjectFilter<TInputImage>::Generate3DRectilinearMesh()
@@ -317,9 +290,6 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::Generate3DRectilinearMesh()
   }
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage>
 void
 ImageToRectilinearFEMObjectFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
@@ -68,16 +68,16 @@ public:
   using FEMObjectSpatialObjectConstPointer = typename FEMObjectSpatialObjectType::ConstPointer;
   using FEMObjectMetaObjectType = MetaFEMObject;
 
-  /** Convert the MetaObject to Spatial Object */
+  /** Convert the MetaObject to a SpatialObject. */
   SpatialObjectPointer
   MetaObjectToSpatialObject(const MetaObjectType * mo) override;
 
-  /** Convert the SpatialObject to MetaObject */
+  /** Convert the SpatialObject to a MetaObject. */
   MetaObjectType *
   SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) override;
 
 protected:
-  /** Create the specific MetaObject for this class */
+  /** Create the specific MetaObject for this class. */
   MetaObjectType *
   CreateMetaObject() override;
 

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -29,7 +29,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <unsigned int VDimension>
 MetaFEMObjectConverter<VDimension>::MetaFEMObjectConverter() = default;
 
@@ -40,7 +39,6 @@ MetaFEMObjectConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
   return dynamic_cast<MetaObjectType *>(new FEMObjectMetaObjectType);
 }
 
-/** Convert a metaFEMObject into an FEMObject SpatialObject  */
 template <unsigned int VDimension>
 auto
 MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
@@ -312,7 +310,6 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
   return FEMSO.GetPointer();
 }
 
-/** Convert an FEMObject SpatialObject into a metaFEMObject */
 template <unsigned int VDimension>
 auto
 MetaFEMObjectConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -200,27 +200,18 @@ FRPROptimizer::StartOptimization()
   this->InvokeEvent(EndEvent());
 }
 
-/**
- *
- */
 void
 FRPROptimizer::SetToPolakRibiere()
 {
   m_OptimizationType = OptimizationEnum::PolakRibiere;
 }
 
-/**
- *
- */
 void
 FRPROptimizer::SetToFletchReeves()
 {
   m_OptimizationType = OptimizationEnum::FletchReeves;
 }
 
-/**
- *
- */
 void
 FRPROptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -230,7 +221,6 @@ FRPROptimizer::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Use unit length gradient = " << m_UseUnitLengthGradient << std::endl;
 }
 
-/** Print enum values */
 std::ostream &
 operator<<(std::ostream & out, const FRPROptimizerEnums::Optimization value)
 {

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.h
@@ -125,6 +125,14 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  /** Search the golden section.
+   *
+   * \p a and \p c are the current bounds; the minimum is between them.
+   * \p b is a center point.
+   * \c f(x) is some mathematical function elsewhere defined.
+   * \p a corresponds to \c x1; \p b corresponds to \c x2; \p c corresponds to \c x3.
+   * \c x corresponds to \c x4.
+   */
   TInternalComputationValueType
   GoldenSectionSearch(TInternalComputationValueType a,
                       TInternalComputationValueType b,

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -22,9 +22,6 @@
 namespace itk
 {
 
-/**
- * Default constructor
- */
 template <typename TInternalComputationValueType>
 GradientDescentLineSearchOptimizerv4Template<
   TInternalComputationValueType>::GradientDescentLineSearchOptimizerv4Template()
@@ -50,9 +47,6 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Pri
   Superclass::PrintSelf(os, indent);
 }
 
-/**
- * Advance one Step following the gradient direction
- */
 template <typename TInternalComputationValueType>
 void
 GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::AdvanceOneStep()
@@ -94,11 +88,6 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Adv
 }
 
 
-// a and c are the current bounds; the minimum is between them.
-// b is a center point
-// f(x) is some mathematical function elsewhere defined
-// a corresponds to x1; b corresponds to x2; c corresponds to x3
-// x corresponds to x4
 template <typename TInternalComputationValueType>
 TInternalComputationValueType
 GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::GoldenSectionSearch(

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GradientDescentOptimizerBasev4Template()
 
@@ -53,7 +52,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GradientD
   this->m_DoEstimateLearningRateOnce = true;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -85,8 +83,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
      << std::endl;
 }
 
-
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GetStopConditionDescription() const
@@ -95,7 +91,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GetStopCo
   return this->m_StopConditionDescription.str();
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::StopOptimization()
@@ -105,7 +100,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::StopOptim
   this->InvokeEvent(EndEvent());
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::ModifyGradientByScales()
@@ -174,7 +168,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::StartOpti
   Superclass::StartOptimization(doOnlyInitialization);
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::ModifyGradientByLearningRate()

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -116,15 +116,15 @@ public:
   const StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
-  /** Get the list of optimizers currently held.  */
+  /** Get the list of optimizers currently held. */
   OptimizersListType &
   GetOptimizersList();
 
-  /** Set the list of optimizers to combine */
+  /** Set the list of optimizers to combine. */
   void
   SetOptimizersList(OptimizersListType & p);
 
-  /** Get the list of metric values that we produced after the multi-objective search.  */
+  /** Get the list of metric values that we produced after the multi-objective search. */
   const MetricValuesListType &
   GetMetricValuesList() const;
 

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -22,7 +22,6 @@
 namespace itk
 {
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::MultiGradientOptimizerv4Template()
 
@@ -35,7 +34,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::MultiGradientOp
   this->m_MinimumMetricValue = this->m_MaximumMetricValue;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -45,7 +43,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::
   os << indent << "Stop condition description: " << this->m_StopConditionDescription.str() << std::endl;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetOptimizersList() -> OptimizersListType &
@@ -53,7 +50,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetOptimizersLi
   return this->m_OptimizersList;
 }
 
-/** Set the list of optimizers to use in the multiple gradient descent */
 template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::SetOptimizersList(
@@ -66,7 +62,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::SetOptimizersLi
   }
 }
 
-/** Get the list of metric values that we produced after the multi-gradient optimization.  */
 template <typename TInternalComputationValueType>
 auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetMetricValuesList() const
@@ -75,7 +70,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetMetricValues
   return this->m_MetricValuesList;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
@@ -84,7 +78,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetStopConditio
   return this->m_StopConditionDescription.str();
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::StopOptimization()
@@ -97,9 +90,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::StopOptimizatio
   this->InvokeEvent(EndEvent());
 }
 
-/**
- * Start and run the optimization
- */
 template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::StartOptimization(bool doOnlyInitialization)
@@ -143,9 +133,6 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::StartOptimizati
   }
 }
 
-/**
- * Resume optimization.
- */
 template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::ResumeOptimization()

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -134,15 +134,15 @@ public:
   ParametersListType &
   GetParametersList();
 
-  /** Set the list of parameters over which to search */
+  /** Set the list of parameters over which to search. */
   void
   SetParametersList(ParametersListType & p);
 
-  /** Get the list of metric values that we produced after the multi-start search.  */
+  /** Get the list of metric values that we produced after the multi-start search. */
   const MetricValuesListType &
   GetMetricValuesList() const;
 
-  /** Return the parameters from the best visited position */
+  /** Return the parameters from the best visited position. */
   ParametersType
   GetBestParameters();
 

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -22,7 +22,6 @@
 namespace itk
 {
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 MultiStartOptimizerv4Template<TInternalComputationValueType>::MultiStartOptimizerv4Template()
 
@@ -37,7 +36,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::MultiStartOptimize
   m_LocalOptimizer = nullptr;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -47,7 +45,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ost
   os << indent << "Stop condition description: " << this->m_StopConditionDescription.str() << std::endl;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetParametersList() -> ParametersListType &
@@ -55,7 +52,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::GetParametersList(
   return this->m_ParametersList;
 }
 
-/** Set the list of parameters over which to search */
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::SetParametersList(
@@ -68,7 +64,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::SetParametersList(
   }
 }
 
-/** Get the list of metric values that we produced after the multi-start search.  */
 template <typename TInternalComputationValueType>
 auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetMetricValuesList() const
@@ -77,7 +72,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::GetMetricValuesLis
   return this->m_MetricValuesList;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetBestParameters() -> ParametersType
@@ -85,8 +79,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::GetBestParameters(
   return this->m_ParametersList[m_BestParametersIndex];
 }
 
-
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::InstantiateLocalOptimizer()
@@ -97,7 +89,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::InstantiateLocalOp
   this->m_LocalOptimizer = optimizer;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
@@ -106,7 +97,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDe
   return this->m_StopConditionDescription.str();
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::StopOptimization()
@@ -119,9 +109,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::StopOptimization()
   this->InvokeEvent(EndEvent());
 }
 
-/**
- * Start and run the optimization
- */
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::StartOptimization(bool doOnlyInitialization)
@@ -150,9 +137,6 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::StartOptimization(
   }
 }
 
-/**
- * Resume optimization.
- */
 template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::ResumeOptimization()

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -25,9 +25,6 @@
 namespace itk
 {
 
-/*
- * constructor
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -46,9 +43,6 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   this->m_UserHasSetVirtualDomain = false;
 }
 
-/*
- * Initialize
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -90,9 +84,6 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   }
 }
 
-/*
- * SetTransform
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -104,9 +95,6 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   this->SetMovingTransform(transform);
 }
 
-/*
- * GetTransform
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -118,9 +106,6 @@ const typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualI
   return this->GetMovingTransform();
 }
 
-/*
- * UpdateTransformParameters
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -135,9 +120,6 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   this->m_MovingTransform->UpdateTransformParameters(derivative, factor);
 }
 
-/*
- * GetNumberOfParameters
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -150,9 +132,6 @@ typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, 
   return this->m_MovingTransform->GetNumberOfParameters();
 }
 
-/*
- * GetParameters
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -164,9 +143,6 @@ const typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualI
   return this->m_MovingTransform->GetParameters();
 }
 
-/*
- * SetParameters
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -178,9 +154,6 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   this->m_MovingTransform->SetParametersByValue(params);
 }
 
-/*
- * GetNumberOfLocalParameters
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -193,9 +166,6 @@ typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, 
   return this->m_MovingTransform->GetNumberOfLocalParameters();
 }
 
-/*
- * HasLocalSupport
- */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -197,7 +197,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Check the metric and the transforms. */
+  /** Validate the metric and the transforms and set them. */
   bool
   CheckAndSetInputs();
 
@@ -219,12 +219,19 @@ protected:
    * The templated version of CheckGeneralAffineTransform to check if the
    * transform is a general affine transform that maps a line segment to
    * a line segment.
+   *
+   * Examples are subclasses of MatrixOffsetTransformBaseType, TranslationTransform, Rigid3DPerspectiveTransform,
+   * IdentityTransform, etc.
    */
   template <typename TTransform>
   bool
   CheckGeneralAffineTransformTemplated();
 
-  /** Transform a physical point to a new physical point. */
+  /** Transform a physical point to a new physical point.
+   *
+   * We want to compute shift in physical space so that the scales is not sensitive to spacings and directions of
+   * voxel sampling.
+   */
   template <typename TTargetPointType>
   void
   TransformPoint(const VirtualPointType & point, TTargetPointType & mappedPoint);
@@ -234,7 +241,7 @@ protected:
   void
   TransformPointToContinuousIndex(const VirtualPointType & point, TContinuousIndexType & mappedIndex);
 
-  /** Compute the transform Jacobian at a physical point. */
+  /** Compute the squared norms of the transform Jacobians w.r.t parameters at a physical point. */
   void
   ComputeSquaredJacobianNorms(const VirtualPointType & point, ParametersType & squareNorms);
 
@@ -258,7 +265,7 @@ protected:
   void
   UpdateTransformParameters(const ParametersType & deltaParameters);
 
-  /** Sample the virtual domain and store the physical points in m_SamplePoints. */
+  /** Sample the virtual domain with phyical points and store the results in m_SamplePoints. */
   virtual void
   SampleVirtualDomain();
 
@@ -266,7 +273,10 @@ protected:
   void
   SampleVirtualDomainFully();
 
-  /** Sample the virtual domain with corners. */
+  /** Sample the virtual domain with corners.
+   *
+   * Sample the virtual domain with the points at image corners, and store the results in m_SamplePoints.
+   */
   void
   SampleVirtualDomainWithCorners();
 
@@ -274,7 +284,10 @@ protected:
   void
   SampleVirtualDomainRandomly();
 
-  /** Sample the virtual domain with voxel in the central region. */
+  /** Sample the virtual domain with the voxel in the central region.
+   *
+   * Samples the virtual domain with the voxels around the center.
+   */
   void
   SampleVirtualDomainWithCentralRegion();
 
@@ -286,7 +299,10 @@ protected:
   void
   SampleVirtualDomainWithPointSet();
 
-  /** Get the central index of the virtual domain. */
+  /** Get the central index of the virtual domain.
+   *
+   * Gets the region around the virtual image center.
+   */
   VirtualIndexType
   GetVirtualDomainCentralIndex();
 

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -44,7 +44,6 @@ RegistrationParameterScalesEstimator<TMetric>::RegistrationParameterScalesEstima
   // the metric object must be set before EstimateScales()
 }
 
-/** Estimate the trusted scale for steps. It returns the voxel spacing. */
 template <typename TMetric>
 auto
 RegistrationParameterScalesEstimator<TMetric>::EstimateMaximumStepSize() -> FloatType
@@ -68,7 +67,6 @@ RegistrationParameterScalesEstimator<TMetric>::EstimateMaximumStepSize() -> Floa
   return minSpacing;
 }
 
-/** Validate and set metric and its transforms. */
 template <typename TMetric>
 bool
 RegistrationParameterScalesEstimator<TMetric>::CheckAndSetInputs()
@@ -90,7 +88,6 @@ RegistrationParameterScalesEstimator<TMetric>::CheckAndSetInputs()
   return true;
 }
 
-/** Get the transform being estimated scales for. */
 template <typename TMetric>
 const TransformBaseTemplate<typename TMetric::MeasureType> *
 RegistrationParameterScalesEstimator<TMetric>::GetTransform()
@@ -105,7 +102,6 @@ RegistrationParameterScalesEstimator<TMetric>::GetTransform()
   }
 }
 
-/** Get the dimension of the target transformed to. */
 template <typename TMetric>
 itk::SizeValueType
 RegistrationParameterScalesEstimator<TMetric>::GetDimension()
@@ -119,8 +115,6 @@ RegistrationParameterScalesEstimator<TMetric>::GetDimension()
     return FixedDimension;
   }
 }
-
-/** Check if the transform being optimized has local support. */
 
 template <typename TMetric>
 bool
@@ -226,7 +220,6 @@ RegistrationParameterScalesEstimator<TMetric>::TransformHasLocalSupportForScales
   }
 }
 
-/** Get the number of scales. */
 template <typename TMetric>
 SizeValueType
 RegistrationParameterScalesEstimator<TMetric>::GetNumberOfLocalParameters()
@@ -241,7 +234,6 @@ RegistrationParameterScalesEstimator<TMetric>::GetNumberOfLocalParameters()
   }
 }
 
-/** Update the transform with a change in parameters. */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::UpdateTransformParameters(const ParametersType & deltaParameters)
@@ -263,10 +255,6 @@ RegistrationParameterScalesEstimator<TMetric>::UpdateTransformParameters(const P
   }
 }
 
-/** Transform a physical point to a new physical point.
- *  We want to compute shift in physical space so that the scales is not
- *  sensitive to spacings and directions of voxel sampling.
- */
 template <typename TMetric>
 template <typename TTargetPointType>
 void
@@ -283,7 +271,6 @@ RegistrationParameterScalesEstimator<TMetric>::TransformPoint(const VirtualPoint
   }
 }
 
-/** Get the squared norms of the transform Jacobians w.r.t parameters at a point */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::ComputeSquaredJacobianNorms(const VirtualPointType & point,
@@ -321,9 +308,6 @@ RegistrationParameterScalesEstimator<TMetric>::ComputeSquaredJacobianNorms(const
   }
 }
 
-/** Sample the virtual domain with phyical points
- *  and store the results into this->m_SamplePoints.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomain()
@@ -371,9 +355,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomain()
   this->m_SamplingTime = this->GetTimeStamp();
 }
 
-/**
- * Set the sampling strategy automatically for scales estimation.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SetScalesSamplingStrategy()
@@ -397,9 +378,6 @@ RegistrationParameterScalesEstimator<TMetric>::SetScalesSamplingStrategy()
   }
 }
 
-/**
- * Set the sampling strategy automatically for step scale estimation.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SetStepScaleSamplingStrategy()
@@ -424,10 +402,6 @@ RegistrationParameterScalesEstimator<TMetric>::SetStepScaleSamplingStrategy()
   }
 }
 
-/**
- * Check if the transform is a general affine transform that maps a line
- * segment to a line segment.
- */
 template <typename TMetric>
 bool
 RegistrationParameterScalesEstimator<TMetric>::CheckGeneralAffineTransform()
@@ -442,14 +416,6 @@ RegistrationParameterScalesEstimator<TMetric>::CheckGeneralAffineTransform()
   }
 }
 
-/**
- * The templated version of CheckGeneralAffineTransform to check if the
- * transform is a general affine transform that maps a line segment to
- * a line segment.
- *
- * Examples are subclasses of MatrixOffsetTransformBaseType, TranslationTransform,
- * Rigid3DPerspectiveTransform, IdentityTransform, etc.
- */
 template <typename TMetric>
 template <typename TTransform>
 bool
@@ -472,9 +438,6 @@ RegistrationParameterScalesEstimator<TMetric>::CheckGeneralAffineTransformTempla
   return false;
 }
 
-/**
- *  Get the index of the virtual image center.
- */
 template <typename TMetric>
 auto
 RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex() -> VirtualIndexType
@@ -494,9 +457,6 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex() ->
   return centralIndex;
 }
 
-/**
- *  Get the region around the virtual image center.
- */
 template <typename TMetric>
 auto
 RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion() -> VirtualRegionType
@@ -529,9 +489,6 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion() -
   return centralRegion;
 }
 
-/**
- *  Sample the virtual domain with the voxels around the center.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCentralRegion()
@@ -540,9 +497,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCentralReg
   SampleVirtualDomainWithRegion(centralRegion);
 }
 
-/**
- *  Sample the virtual domain with all voxels inside a region.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithRegion(VirtualRegionType region)
@@ -569,10 +523,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithRegion(Vir
   }
 }
 
-/**
- *  Sample the virtual domain with the points at image corners.
- *  And store the results into this->m_SamplePoints.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCorners()
@@ -602,9 +552,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCorners()
   }
 }
 
-/**
- * Sample the physical points of the virtual domain in a uniform random distribution.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainRandomly()
@@ -649,9 +596,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainRandomly()
   }
 }
 
-/**
- * Sample the virtual domain using a point set.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithPointSet()
@@ -678,9 +622,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithPointSet()
   }
 }
 
-/**
- * Sample the virtual domain fully with all pixels.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainFully()
@@ -689,9 +630,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainFully()
   this->SampleVirtualDomainWithRegion(region);
 }
 
-/**
- * Print the information about this class.
- */
 template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -25,7 +25,6 @@ namespace itk
 ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::ObjectToObjectOptimizerBaseTemplate()
 {
@@ -41,11 +40,9 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::ObjectToObje
   this->m_DoEstimateScales = true;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::~ObjectToObjectOptimizerBaseTemplate() = default;
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -84,7 +81,6 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::PrintSelf(st
   os << indent << "DoEstimateScales: " << this->m_DoEstimateScales << std::endl;
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::SetNumberOfWorkUnits(ThreadIdType number)
@@ -100,7 +96,6 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::SetNumberOfW
   }
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 void
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::StartOptimization(
@@ -191,7 +186,6 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::StartOptimiz
   }
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 const typename ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::ParametersType &
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::GetCurrentPosition() const
@@ -203,7 +197,6 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::GetCurrentPo
   return this->m_Metric->GetParameters();
 }
 
-//-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
 const typename ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::MeasureType &
 ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::GetValue() const

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.h
@@ -86,7 +86,7 @@ public:
   /** Determine the image dimension. */
   static constexpr unsigned int ImageDimension = OutputImageType::ImageDimension;
 
-  /** Set/Get the input of this process object.  */
+  /** Set/Get the input histogram. */
   using Superclass::SetInput;
   virtual void
   SetInput(const HistogramType * input);

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -23,14 +23,13 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename THistogram, typename TImage, typename TFunction>
 HistogramToImageFilter<THistogram, TImage, TFunction>::HistogramToImageFilter()
 {
   this->SetNumberOfRequiredInputs(1);
 }
 
-/** Set the Input Histogram */
 template <typename THistogram, typename TImage, typename TFunction>
 void
 HistogramToImageFilter<THistogram, TImage, TFunction>::SetInput(const HistogramType * input)
@@ -111,9 +110,6 @@ HistogramToImageFilter<THistogram, TImage, TFunction>::GenerateOutputInformation
   outputImage->SetOrigin(origin);   // and origin
 }
 
-//----------------------------------------------------------------------------
-
-/** Update */
 template <typename THistogram, typename TImage, typename TFunction>
 void
 HistogramToImageFilter<THistogram, TImage, TFunction>::GenerateData()

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
@@ -198,9 +198,11 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Static function used as a "callback" by the MultiThreaderBase.  The threading
-   * library will call this routine for each thread, which will delegate the
-   * control to DynamicThreadedGenerateData(). */
+  /** Static function used as a "callback" by the MultiThreaderBase.
+   *
+   * The threading library will call this routine for each thread, which will delegate the control to
+   * DynamicThreadedGenerateData() after setting the correct region for the thread.
+   */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   ThreaderCallback(void * arg);
 

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -228,9 +228,6 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
   m_SimilaritiesValuesArray.reset();
 }
 
-// Callback routine used by the threading library. This routine just calls
-// the ThreadedGenerateData method after setting the correct region for this
-// thread.
 template <typename TFixedImage,
           typename TMovingImage,
           typename TFeatures,

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
@@ -116,22 +116,21 @@ public:
 
   using MovedGradientPixelType = typename MovedGradientImageType::PixelType;
 
-  /** Get the derivatives of the match measure. */
+  /** Get the derivatives of the similarity measure. */
   void
   GetDerivative(const TransformParametersType & parameters, DerivativeType & derivative) const override;
 
-  /**  Get the value for single valued optimizers. */
+  /** Get the value of the similarity measure for single valued optimizers. */
   MeasureType
   GetValue(const TransformParametersType & parameters) const override;
 
-  /**  Get value and derivatives for multiple valued optimizers. */
+  /** Get value and derivatives of the similarity measure for multiple valued optimizers. */
   void
   GetValueAndDerivative(const TransformParametersType & parameters,
                         MeasureType &                   Value,
                         DerivativeType &                Derivative) const override;
 
-  /** Initialize the Metric by making sure that all the components
-   *  are present and plugged together correctly     */
+  /** Initialize the Metric by making sure that all the components are present and plugged together correctly. */
   void
   Initialize() override;
 

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -29,9 +29,7 @@
 #include "itkSimpleFilterWatcher.h"
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDifferenceImageToImageMetric()
 {
@@ -56,9 +54,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDiffere
   this->m_DerivativeDelta = 0.001;
 }
 
-/**
- * Initialize
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
@@ -135,9 +130,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -146,9 +138,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::
   os << indent << "DerivativeDelta: " << this->m_DerivativeDelta << std::endl;
 }
 
-/**
- * Compute the range of the moved image gradients
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGradientRange() const
@@ -186,9 +175,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
   }
 }
 
-/**
- * Compute the gradient variances in each dimension.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance() const
@@ -262,9 +248,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
   }
 }
 
-/**
- * Get the value of the similarity measure
- */
 template <typename TFixedImage, typename TMovingImage>
 typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
@@ -325,9 +308,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   return measure;
 }
 
-/**
- * Get the value of the similarity measure
- */
 template <typename TFixedImage, typename TMovingImage>
 typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
@@ -371,9 +351,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   return currentMeasure;
 }
 
-/**
- * Get the Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
@@ -398,9 +375,6 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   }
 }
 
-/**
- * Get both the match Measure and theDerivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.h
@@ -214,7 +214,7 @@ protected:
   /** Provides derived classes with the ability to set this private var */
   itkSetMacro(LastTransformParameters, ParametersType);
 
-  /* Start the Optimization */
+  /** Start the optimization. */
   void
   StartOptimization();
 

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 ImageRegistrationMethod<TFixedImage, TMovingImage>::ImageRegistrationMethod()
 {
@@ -52,9 +50,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::ImageRegistrationMethod()
   this->SetNumberOfWorkUnits(this->GetMultiThreader()->GetNumberOfWorkUnits());
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage>
 ModifiedTimeType
 ImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() const
@@ -104,9 +99,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() const
   return mtime;
 }
 
-/*
- * Set the initial transform parameters
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::SetInitialTransformParameters(const ParametersType & param)
@@ -115,10 +107,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::SetInitialTransformParameter
   this->Modified();
 }
 
-/**
-
- * Set the region of the fixed image to be considered for registration
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::SetFixedImageRegion(const FixedImageRegionType & region)
@@ -128,9 +116,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::SetFixedImageRegion(const Fi
   this->Modified();
 }
 
-/**
- * Initialize by setting the interconnects between components.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::Initialize()
@@ -205,9 +190,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::Initialize()
   m_Optimizer->SetInitialPosition(m_InitialTransformParameters);
 }
 
-/**
- * Starts the Optimization process
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::StartOptimization()
@@ -232,9 +214,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::StartOptimization()
   m_Transform->SetParameters(m_LastTransformParameters);
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -252,9 +231,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
   os << indent << "Last    Transform Parameters: " << m_LastTransformParameters << std::endl;
 }
 
-/*
- * Generate Data
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
@@ -277,9 +253,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
   this->StartOptimization();
 }
 
-/**
- *  Get Output
- */
 template <typename TFixedImage, typename TMovingImage>
 auto
 ImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const -> const TransformOutputType *

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -219,8 +219,7 @@ public:
     return m_Transform->GetNumberOfParameters();
   }
 
-  /** Initialize the Metric by making sure that all the components
-   *  are present and plugged together correctly     */
+  /** Initialize the Metric by making sure that all the components are present and plugged together correctly. */
   virtual void
   Initialize();
 
@@ -228,8 +227,10 @@ public:
   virtual void
   MultiThreadingInitialize();
 
-  /** Number of spatial samples to used to compute metric
-   *   This sets the number of samples.  */
+  /** Number of spatial samples to compute the metric.
+   *
+   * Sets the number of samples.
+   */
   virtual void
   SetNumberOfFixedImageSamples(SizeValueType numSamples);
   itkGetConstReferenceMacro(NumberOfFixedImageSamples, SizeValueType);
@@ -371,14 +372,21 @@ protected:
   /** FixedImageSamplePoint type alias support */
   using FixedImageSampleContainer = std::vector<FixedImageSamplePoint>;
 
-  /** Uniformly select a sample set from the fixed image domain. */
+  /** Uniformly select a sample set from the fixed image domain.
+   *
+   * Samples the fixed image using a random walk.
+   */
   virtual void
   SampleFixedImageRegion(FixedImageSampleContainer & samples) const;
 
+  /** Use the indexes that have been passed to the metric. */
   virtual void
   SampleFixedImageIndexes(FixedImageSampleContainer & samples) const;
 
-  /** Gather all the pixels from the fixed image domain. */
+  /** Sample the fixed image domain using all pixels in the Fixed image region.
+   *
+   * Gathers all the pixels from the fixed image domain.
+   */
   virtual void
   SampleFullFixedImageRegion(FixedImageSampleContainer & samples) const;
 
@@ -476,11 +484,14 @@ protected:
   mutable std::unique_ptr<BSplineTransformWeightsType[]>    m_ThreaderBSplineTransformWeights;
   mutable std::unique_ptr<BSplineTransformIndexArrayType[]> m_ThreaderBSplineTransformIndices;
 
+  /** Cache pre-transformed points, weights and indices. */
   virtual void
   PreComputeTransformValues();
 
   /** Transform a point from FixedImage domain to MovingImage domain.
-   * This function also checks if mapped point is within support region. */
+   *
+   * This function also checks if mapped point is within support region.
+   */
   virtual void
   TransformPoint(unsigned int           sampleNumber,
                  MovingImagePointType & mappedPoint,
@@ -488,6 +499,10 @@ protected:
                  double &               movingImageValue,
                  ThreadIdType           threadId) const;
 
+  /** Transform a point from FixedImage domain to MovingImage domain.
+   *
+   * This function also checks if mapped point is within support region.
+   */
   virtual void
   TransformPointWithDerivatives(unsigned int           sampleNumber,
                                 MovingImagePointType & mappedPoint,
@@ -504,7 +519,9 @@ protected:
   /** Pointer to central difference calculator. */
   typename DerivativeFunctionType::Pointer m_DerivativeCalculator;
 
-  /** Compute image derivatives at a point. */
+  /** Compute image derivatives at a point using a central difference function if we are not using a
+   * BSplineInterpolator, which includes derivatives.
+   */
   virtual void
   ComputeImageDerivatives(const MovingImagePointType & mappedPoint,
                           ImageDerivativesType &       gradient,
@@ -578,15 +595,19 @@ protected:
   void
   GetValueMultiThreadedPostProcessInitiate() const;
 
+  /** Get the match Measure. */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   GetValueMultiThreaded(void * workunitInfoAsVoid);
 
+  /** Get the match Measure. */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   GetValueMultiThreadedPostProcess(void * workunitInfoAsVoid);
 
+  /** Get the match Measur.e */
   virtual inline void
   GetValueThread(ThreadIdType threadId) const;
 
+  /** Get the match Measure. */
   virtual inline void
   GetValueThreadPreProcess(ThreadIdType itkNotUsed(threadId), bool itkNotUsed(withinSampleThread)) const
   {}
@@ -633,8 +654,10 @@ protected:
   GetValueAndDerivativeThreadPostProcess(ThreadIdType itkNotUsed(threadId), bool itkNotUsed(withinSampleThread)) const
   {}
 
-  /** Synchronizes the threader transforms with the transform
-   *   member variable.
+  /** Synchronizes the threader transforms with the transform member variable.
+   *
+   * This method can be const because we are not altering the m_ThreaderTransform pointer. We are altering the object
+   * that m_ThreaderTransform[idx] points at.* This is allowed under C++ const rules.
    */
   virtual void
   SynchronizeTransforms() const;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 ImageToImageMetric<TFixedImage, TMovingImage>::ImageToImageMetric()
   : m_FixedImageIndexes(0)
@@ -71,11 +69,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ImageToImageMetric()
   */
 }
 
-
-/**
- * Set the number of work units. This will be clamped by the
- * multithreader, so we must check to see if it is accepted.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfWorkUnits(ThreadIdType numberOfWorkUnits)
@@ -84,9 +77,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfWorkUnits(ThreadIdType
   m_NumberOfWorkUnits = m_Threader->GetNumberOfWorkUnits();
 }
 
-/**
- * Set the parameters that define a unique transform
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SetTransformParameters(const ParametersType & parameters) const
@@ -228,9 +218,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SetUseSequentialSampling(bool use
   }
 }
 
-/**
- * Initialize
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
@@ -297,9 +284,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   this->InvokeEvent(InitializeEvent());
 }
 
-/**
- * MultiThreading Initialize
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
@@ -436,9 +420,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
   }
 }
 
-/**
- * Use the indexes that have been passed to the metric
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageIndexes(FixedImageSampleContainer & samples) const
@@ -467,9 +448,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageIndexes(FixedImag
   }
 }
 
-/**
- * Sample the fixed image using a random walk
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImageSampleContainer & samples) const
@@ -586,9 +564,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
   }
 }
 
-/**
- * Sample the fixed image domain using all pixels in the Fixed image region
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedImageSampleContainer & samples) const
@@ -680,9 +655,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
   }
 }
 
-/**
- * Compute the gradient image and assign it to m_GradientImage.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::ComputeGradient()
@@ -709,7 +681,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ComputeGradient()
   m_GradientImage = gradientFilter->GetOutput();
 }
 
-// Method to reinitialize the seed of the random number generator
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::ReinitializeSeed()
@@ -717,7 +688,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ReinitializeSeed()
   m_ReseedIterator = true;
 }
 
-// Method to reinitialize the seed of the random number generator
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::ReinitializeSeed(int seed)
@@ -726,9 +696,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ReinitializeSeed(int seed)
   m_RandomSeed = seed;
 }
 
-/**
- * Cache pre-transformed points, weights and indices.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
@@ -784,10 +751,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
   // m_Transform->SetParameters( *previousParameters );
 }
 
-/**
- * Transform a point from FixedImage domain to MovingImage domain.
- * This function also checks if mapped point is within support region.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int           sampleNumber,
@@ -896,10 +859,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int      
   }
 }
 
-/**
- * Transform a point from FixedImage domain to MovingImage domain.
- * This function also checks if mapped point is within support region.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(unsigned int           sampleNumber,
@@ -1014,11 +973,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(uns
   }
 }
 
-/**
- * Compute image derivatives using a central difference function
- * if we are not using a BSplineInterpolator, which includes
- * derivatives.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::ComputeImageDerivatives(const MovingImagePointType & mappedPoint,
@@ -1071,9 +1025,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueMultiThreadedPostProcessI
   m_Threader->SingleMethodExecute();
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageToImageMetric<TFixedImage, TMovingImage>::GetValueMultiThreaded(void * workunitInfoAsVoid)
@@ -1084,9 +1035,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueMultiThreaded(void * work
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageToImageMetric<TFixedImage, TMovingImage>::GetValueMultiThreadedPostProcess(void * workunitInfoAsVoid)
@@ -1177,9 +1125,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeMultiThreade
   m_Threader->SingleMethodExecute();
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeMultiThreaded(void * workunitInfoAsVoid)
@@ -1190,9 +1135,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeMultiThreade
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeMultiThreadedPostProcess(void * workunitInfoAsVoid)
@@ -1262,9 +1204,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThread(Threa
   }
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -1335,10 +1274,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   os << this->m_UseCachingOfBSplineWeights << std::endl;
 }
 
-/** This method can be const because we are not altering the m_ThreaderTransform
- *  pointer. We are altering the object that m_ThreaderTransform[idx] points at.
- *  This is allowed under C++ const rules.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::SynchronizeTransforms() const

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -144,16 +144,16 @@ public:
                         MeasureType &          Value,
                         DerivativeType &       Derivative) const override = 0;
 
-  /** Return the number of parameters required by the Transform */
+  /** Return the number of parameters required by the Transform. */
   unsigned int
   GetNumberOfParameters() const override;
 
-  /** Initialize the metric */
+  /** Initialize the metric. */
   virtual void
   Initialize();
 
   /** Get the last transformation parameters visited by
-   * the optimizer. This function overload the superclass's one */
+   * the optimizer. This function overload the superclass's one. */
   itkGetConstReferenceMacro(LastTransformParameters, ParametersType);
 
   /** Set/Get the Transform. */

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TFixedImage, typename TMovingSpatialObject>
 ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::ImageToSpatialObjectMetric()
 
@@ -32,7 +32,6 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::ImageToSpatialObj
   m_Interpolator = nullptr;        // has to be provided by the user.
 }
 
-/** Return the number of parameters required by the Transform */
 template <typename TFixedImage, typename TMovingSpatialObject>
 unsigned int
 ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::GetNumberOfParameters() const
@@ -43,10 +42,6 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::GetNumberOfParame
   }
   return m_Transform->GetNumberOfParameters();
 }
-
-/**
- * Initialize
- */
 
 template <typename TFixedImage, typename TMovingSpatialObject>
 void
@@ -82,7 +77,6 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::Initialize()
   this->InvokeEvent(InitializeEvent());
 }
 
-/** PrintSelf */
 template <typename TFixedImage, typename TMovingSpatialObject>
 void
 ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -162,7 +162,10 @@ protected:
 
   /** Static function used as a "callback" by the MultiThreaderBase.  The threading
    * library will call this routine for each thread, which will delegate the
-   * control to ThreadedGetValue(). */
+   * control to ThreadedGetValue.
+   *
+   * Calls the ThreadedGenerateData method after setting the correct region for this thread.
+   */
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   ThreaderCallback(void * arg);
 

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -23,18 +23,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MatchCardinalityImageToImageMetric()
 {
   this->SetComputeGradient(false); // don't use the default gradients
 }
 
-/*
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 typename MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
@@ -43,9 +38,6 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   return const_cast<Self *>(this)->GetNonconstValue(parameters);
 }
 
-/**
- * Get the match Measure (non const version. spawns threads).
- */
 template <typename TFixedImage, typename TMovingImage>
 typename MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
@@ -183,7 +175,6 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
   m_ThreadCounts[threadId] = threadNumberOfPixelsCounted;
 }
 
-//----------------------------------------------------------------------------
 template <typename TFixedImage, typename TMovingImage>
 ThreadIdType
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::SplitFixedRegion(ThreadIdType           i,
@@ -241,9 +232,6 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::SplitFixedRegion(
   return maxThreadIdUsed + 1;
 }
 
-// Callback routine used by the threading library. This routine just calls
-// the ThreadedGenerateData method after setting the correct region for this
-// thread.
 template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreaderCallback(void * arg)
@@ -275,9 +263,6 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreaderCallback(
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -282,7 +282,7 @@ private:
   void
   CommonGetValueProcessing() const;
 
-  /** Precompute fixed image parzen window indices. */
+  /** Compute the Parzen window index locations from the pre-computed samples. */
   void
   ComputeFixedImageParzenWindowIndices(FixedImageSampleContainer & samples);
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -29,9 +29,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MattesMutualInformationImageToImageMetric()
   : m_PRatioArray(0, 0)
@@ -320,10 +318,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
   this->ComputeFixedImageParzenWindowIndices(this->m_FixedImageSamples);
 }
 
-/**
- * From the pre-computed samples, now
- * fill in the parzen window index locations
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeFixedImageParzenWindowIndices(
@@ -697,9 +691,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
   }
 }
 
-/**
- * Get the both Value and Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
@@ -878,9 +869,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::CommonGetV
   }
 }
 
-/**
- * Get the match measure derivative
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const ParametersType & parameters,
@@ -892,9 +880,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivat
   this->GetValueAndDerivative(parameters, value, derivative);
 }
 
-/**
- * Compute PDF derivatives contribution for each parameter
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputePDFDerivatives(

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage,
                                                  TMovingImage>::MeanReciprocalSquareDifferenceImageToImageMetric()
@@ -33,9 +31,6 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage,
   m_Delta = 0.00011;
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
@@ -46,9 +41,6 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Pri
   os << indent << "Delta  value  = " << m_Delta << std::endl;
 }
 
-/*
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 typename MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
@@ -113,9 +105,6 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
   return measure;
 }
 
-/**
- * Get the Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
@@ -140,9 +129,6 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
   }
 }
 
-/**
- * Get both the match Measure and theDerivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/*
- * Constructor
- */
+
 template <typename TFixedPointSet, typename TMovingImage>
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet,
                                                     TMovingImage>::MeanReciprocalSquareDifferencePointSetToImageMetric()
@@ -32,9 +30,6 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet,
   m_Lambda = 1.0;
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 typename MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::MeasureType
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
@@ -92,9 +87,6 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   return measure;
 }
 
-/*
- * Get the Derivative Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
@@ -192,9 +184,6 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   }
 }
 
-/*
- * Get both the match Measure and theDerivative Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDerivative(
@@ -295,9 +284,6 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   value = measure;
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os,

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -150,8 +150,10 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at a non boundary neighbourhood.
+   *
+   * Called by a finite difference solver image filter at each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & neighborhood,
                 void *                   globalData,

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::MeanSquareRegistrationFunction()
 {
@@ -51,9 +49,6 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::M
   m_MovingImageInterpolator = itkDynamicCastInDebugMode<InterpolatorType *>(interp.GetPointer());
 }
 
-/*
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -72,9 +67,6 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::P
   */
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -96,9 +88,6 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::I
   this->SetEnergy(0.0);
 }
 
-/**
- * Compute update at a non boundary neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeanSquaresImageToImageMetric()
 {
@@ -43,9 +41,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeanSquaresImageToImag
   this->SetUseAllPixels(true);
 }
 
-/**
- * Print out internal information about this class
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -53,9 +48,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream
   Superclass::PrintSelf(os, indent);
 }
 
-/**
- * Initialize
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
@@ -177,9 +169,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeT
   return true;
 }
 
-/**
- * Get the both Value and Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersType & parameters,
@@ -241,9 +230,6 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   }
 }
 
-/**
- * Get the match measure derivative
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const ParametersType & parameters,

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.h
@@ -134,7 +134,7 @@ public:
   /** Smart Pointer type to a DataObject. */
   using DataObjectPointer = typename DataObject::Pointer;
 
-  /** Method to stop the registration. */
+  /** Stop the registration. */
   void
   StopRegistration();
 
@@ -174,7 +174,7 @@ public:
   itkSetObjectMacro(MovingImagePyramid, MovingImagePyramidType);
   itkGetModifiableObjectMacro(MovingImagePyramid, MovingImagePyramidType);
 
-  /** Set/Get the schedules . */
+  /** Set/Get the schedules for the fixed and moving image pyramid. */
   void
   SetSchedules(const ScheduleType & fixedImagePyramidSchedule, const ScheduleType & movingImagePyramidSchedule);
 

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::MultiResolutionImageRegistrationMethod()
 {
@@ -64,9 +62,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::MultiResoluti
   this->ProcessObject::SetNthOutput(0, transformDecorator.GetPointer());
 }
 
-/*
- * Initialize by setting the interconnects between components.
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Initialize()
@@ -112,9 +107,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::Initialize()
   transformOutput->Set(m_Transform);
 }
 
-/*
- * Stop the Registration Process
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::StopRegistration()
@@ -122,9 +114,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::StopRegistrat
   m_Stop = true;
 }
 
-/**
- * Set the schedules for the fixed and moving image pyramid
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::SetSchedules(
@@ -153,9 +142,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::SetSchedules(
   this->Modified();
 }
 
-/**
- * Set the number of levels
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::SetNumberOfLevels(SizeValueType numberOfLevels)
@@ -171,9 +157,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::SetNumberOfLe
   this->Modified();
 }
 
-/**
- * Stop the Registration Process
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PreparePyramids()
@@ -277,9 +260,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PreparePyrami
   }
 }
 
-/*
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -321,9 +301,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std
   os << m_MovingImagePyramidSchedule << std::endl;
 }
 
-/*
- * Generate Data
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
@@ -435,9 +412,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() co
   return mtime;
 }
 
-/*
- *  Get Output
- */
 template <typename TFixedImage, typename TMovingImage>
 auto
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const -> const TransformOutputType *

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
@@ -226,7 +226,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Generate the output data. */
+  /** Generate the output data for non-downward divisible schedules. */
   void
   GenerateData() override;
 

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -30,9 +30,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::MultiResolutionPyramidImageFilter()
 {
@@ -42,9 +40,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::MultiResolutionPyr
   m_UseShrinkImageFilter = false;
 }
 
-/**
- * Set the number of computation levels
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(unsigned int num)
@@ -99,9 +94,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(
   }
 }
 
-/*
- * Set the starting shrink factors
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetStartingShrinkFactors(unsigned int factor)
@@ -110,9 +102,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetStartingShrinkF
   this->SetStartingShrinkFactors(fixedArray.GetDataPointer());
 }
 
-/**
- * Set the starting shrink factors
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetStartingShrinkFactors(const unsigned int * factors)
@@ -141,9 +130,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetStartingShrinkF
   this->Modified();
 }
 
-/*
- * Get the starting shrink factors
- */
 template <typename TInputImage, typename TOutputImage>
 const unsigned int *
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GetStartingShrinkFactors() const
@@ -151,9 +137,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GetStartingShrinkF
   return (m_Schedule.data_block());
 }
 
-/*
- * Set the multi-resolution schedule
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetSchedule(const ScheduleType & schedule)
@@ -192,9 +175,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetSchedule(const 
   }
 }
 
-/*
- * Is the schedule downward divisible ?
- */
 template <typename TInputImage, typename TOutputImage>
 bool
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::IsScheduleDownwardDivisible(const ScheduleType & schedule)
@@ -219,9 +199,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::IsScheduleDownward
   return true;
 }
 
-/*
- * GenerateData for non downward divisible schedules
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
@@ -313,9 +290,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
 }
 
-/**
- * PrintSelf method
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -329,9 +303,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
   os << indent << "Use ShrinkImageFilter= " << m_UseShrinkImageFilter << std::endl;
 }
 
-/*
- * GenerateOutputInformation
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
@@ -404,9 +375,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInfo
   }
 }
 
-/*
- * GenerateOutputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequestedRegion(DataObject * refOutput)
@@ -500,9 +468,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
   }
 }
 
-/**
- * GenerateInputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
@@ -137,11 +137,11 @@ public:
   void
   GetDerivative(const ParametersType & parameters, DerivativeType & derivative) const override;
 
-  /**  Get the value. */
+  /** Get the value. */
   MeasureType
   GetValue(const ParametersType & parameters) const override;
 
-  /**  Get the value and derivatives for single valued optimizers. */
+  /** Get the value and derivatives for single valued optimizers. */
   void
   GetValueAndDerivative(const ParametersType & parameters,
                         MeasureType &          value,
@@ -227,15 +227,27 @@ private:
   typename KernelFunctionType::Pointer m_KernelFunction{};
 
   /** Uniformly select samples from the fixed image buffer.
+   *
+   * Each sample consists of:
+   *  - the fixed image value
+   *  - the corresponding moving image value
+   *
    * \warning Note that this method has a different signature than the one in
    * the base OptImageToImageMetric and therefore they are not intended to
    * provide polymorphism. That is, this function is not overriding the one in
-   * the base class. */
+   * the base class.
+   */
   virtual void
   SampleFixedImageDomain(SpatialSampleContainer & samples) const;
 
-  /**
-   * Calculate the intensity derivatives at a point
+  /*
+   * Calculate derivatives of the image intensity at the specified point with respect to the transform parmeters.
+   *
+   * \todo This should really be done by the mapper.
+   *
+   * \todo This is a temporary solution until this feature is implemented
+   * in the mapper. This solution only works for any transform
+   * that support ComputeJacobianWithRespectToParameters()
    */
   void
   CalculateDerivatives(const FixedImagePointType &, DerivativeType &, TransformJacobianType &) const;

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -25,9 +25,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MutualInformationImageToImageMetric()
 {
@@ -64,9 +62,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::o
   os << m_KernelFunction.GetPointer() << std::endl;
 }
 
-/*
- * Set the number of spatial samples
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfSpatialSamples(unsigned int num)
@@ -86,17 +81,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SetNumberOfSpati
   m_SampleB.resize(m_NumberOfSpatialSamples);
 }
 
-/*
- * Uniformly sample the fixed image domain. Each sample consists of:
- *  - the fixed image value
- *  - the corresponding moving image value
- *
- * \warning Note that this method has a different signature than the one in
- * the base OptImageToImageMetric and therefore they are not intended to
- * provide polymorphism. That is, this function is not overriding the one in
- * the base class.
- *
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageDomain(
@@ -193,9 +177,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
   }
 }
 
-/*
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 auto
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
@@ -279,9 +260,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const P
   return measure;
 }
 
-/*
- * Get the both Value and Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(const ParametersType & parameters,
@@ -423,9 +401,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
   derivative /= itk::Math::sqr(m_MovingImageStandardDeviation);
 }
 
-/*
- * Get the match measure derivative
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const ParametersType & parameters,
@@ -437,16 +412,6 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(co
   this->GetValueAndDerivative(parameters, value, derivative);
 }
 
-/*
- * Calculate derivatives of the image intensity with respect
- * to the transform parmeters.
- *
- * This should really be done by the mapper.
- *
- * This is a temporary solution until this feature is implemented
- * in the mapper. This solution only works for any transform
- * that support ComputeJacobianWithRespectToParameters()
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::CalculateDerivatives(

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -22,18 +22,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage>
 NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::NormalizedCorrelationImageToImageMetric()
 {
   m_SubtractMean = false;
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 typename NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
 NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
@@ -126,9 +121,6 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   return measure;
 }
 
-/**
- * Get the Derivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
@@ -311,9 +303,6 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
   }
 }
 
-/*
- * Get both the match Measure and theDerivative Measure
- */
 template <typename TFixedImage, typename TMovingImage>
 void
 NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -22,18 +22,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedPointSet, typename TMovingImage>
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::NormalizedCorrelationPointSetToImageMetric()
 {
   m_SubtractMean = false;
 }
 
-/**
- * Get the match Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 typename NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::MeasureType
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
@@ -112,9 +107,6 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
   return measure;
 }
 
-/**
- * Get the Derivative Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
@@ -257,9 +249,6 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
   }
 }
 
-/*
- * Get both the match Measure and theDerivative Measure
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDerivative(

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.h
@@ -151,15 +151,14 @@ public:
   itkSetMacro(ComputeGradient, bool);
   itkGetConstReferenceMacro(ComputeGradient, bool);
 
-  /** Return the number of parameters required by the Transform */
+  /** Get the number of parameters required by the Transform. */
   unsigned int
   GetNumberOfParameters() const override
   {
     return m_Transform->GetNumberOfParameters();
   }
 
-  /** Initialize the Metric by making sure that all the components
-   *  are present and plugged together correctly     */
+  /** Initialize the Metric by making sure that all the components are present and plugged together correctly. */
   virtual void
   Initialize();
 

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedPointSet, typename TMovingImage>
 PointSetToImageMetric<TFixedPointSet, TMovingImage>::PointSetToImageMetric()
 {
@@ -36,9 +34,6 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::PointSetToImageMetric()
   m_GradientImage = nullptr;   // computed at initialization
 }
 
-/**
- * Set the parameters that define a unique transform
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 PointSetToImageMetric<TFixedPointSet, TMovingImage>::SetTransformParameters(const ParametersType & parameters) const
@@ -50,9 +45,6 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::SetTransformParameters(cons
   m_Transform->SetParameters(parameters);
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 PointSetToImageMetric<TFixedPointSet, TMovingImage>::Initialize()
@@ -109,9 +101,6 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::Initialize()
   }
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedPointSet, typename TMovingImage>
 void
 PointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
@@ -108,7 +108,7 @@ public:
   /** Connect the Transform. */
   itkSetObjectMacro(Transform, TransformType);
 
-  /** Get a pointer to the Transform.  */
+  /** Get a pointer to the Transform. */
   itkGetModifiableObjectMacro(Transform, TransformType);
 
   /** Set the parameters defining the Transform. */
@@ -122,8 +122,7 @@ public:
     return m_Transform->GetNumberOfParameters();
   }
 
-  /** Initialize the Metric by making sure that all the components
-   *  are present and plugged together correctly     */
+  /** Initialize the Metric by making sure that all the components are present and plugged together correctly. */
   virtual void
   Initialize();
 

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
@@ -21,7 +21,7 @@
 
 namespace itk
 {
-/** Constructor */
+
 template <typename TFixedPointSet, typename TMovingPointSet>
 PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::PointSetToPointSetMetric()
 {
@@ -30,7 +30,6 @@ PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::PointSetToPointSetMet
   m_Transform = nullptr;      // has to be provided by the user.
 }
 
-/** Set the parameters that define a unique transform */
 template <typename TFixedPointSet, typename TMovingPointSet>
 void
 PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::SetTransformParameters(
@@ -43,7 +42,6 @@ PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::SetTransformParameter
   m_Transform->SetParameters(parameters);
 }
 
-/** Initialize the metric */
 template <typename TFixedPointSet, typename TMovingPointSet>
 void
 PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initialize()
@@ -70,7 +68,6 @@ PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::Initialize()
   m_FixedPointSet->UpdateSource();
 }
 
-/** PrintSelf */
 template <typename TFixedPointSet, typename TMovingPointSet>
 void
 PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedPointSet, typename TMovingSpatialObject>
 PointSetToSpatialObjectDemonsRegistration<TFixedPointSet,
                                           TMovingSpatialObject>::PointSetToSpatialObjectDemonsRegistration()
@@ -32,9 +30,6 @@ PointSetToSpatialObjectDemonsRegistration<TFixedPointSet,
   m_MovingSpatialObject = nullptr; // has to be provided by the user.
 }
 
-/**
- * PrintSelf
- */
 template <typename TFixedPointSet, typename TMovingSpatialObject>
 void
 PointSetToSpatialObjectDemonsRegistration<TFixedPointSet, TMovingSpatialObject>::PrintSelf(std::ostream & os,

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -30,18 +30,13 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::RecursiveMultiResolutionPyramidImageFilter()
 {
   this->Superclass::m_UseShrinkImageFilter = true;
 }
 
-/**
- * GenerateData
- */
 template <typename TInputImage, typename TOutputImage>
 void
 RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
@@ -216,9 +211,6 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateD
   }
 }
 
-/*
- * GenerateOutputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequestedRegion(DataObject * ptr)
@@ -341,9 +333,6 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   delete oper;
 }
 
-/**
- * GenerateInputRequestedRegion
- */
 template <typename TInputImage, typename TOutputImage>
 void
 RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -20,9 +20,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
   GPUDemonsRegistrationFilter()
@@ -48,9 +46,6 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   os << indent << "Intensity difference threshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::InitializeIteration()
@@ -75,9 +70,6 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   }
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 double
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::GetMetric() const
@@ -92,9 +84,6 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   return drfp->GetMetric();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 double
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -110,9 +99,6 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -128,9 +114,6 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::ApplyUpdate(

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -155,7 +155,10 @@ public:
     return global;
   }
 
-  /** Release memory for global data structure. */
+  /** Release memory for global data structure.
+   *
+   * Updates the metric and releases the per-thread-global data.
+   */
   void
   ReleaseGlobalDataPointer(void * GlobalData) const override;
 
@@ -164,8 +167,7 @@ public:
   void
   GPUAllocateMetricData(unsigned int numPixels) override;
 
-  /** Release GPU buffers for computing metric statistics
-   * */
+  /** Release GPU buffers for computing metric statistics. */
   void
   GPUReleaseMetricData() override;
 
@@ -173,19 +175,24 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at the specified neighbourhood.
+   *
+   * Called by a finite difference solver image filter at each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & neighborhood,
                 void *                   globalData,
                 const FloatOffsetType &  offset = FloatOffsetType(0.0)) override;
 
+  /** Compute update at the specified neighbourhood. */
   void
   GPUComputeUpdate(const DisplacementFieldTypePointer output, DisplacementFieldTypePointer update, void * gd) override;
 
-  /** Get the metric value. The metric value is the mean square difference
-   * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+  /** Get the metric value.
+   *
+   * The metric value is the mean square difference in intensity between the fixed image and transforming moving image
+   * computed over the the overlapping region between the two images.
+   */
   virtual double
   GetMetric() const
   {

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GPUDemonsRegistrationFunction()
 {
@@ -93,9 +91,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
   m_ComputeUpdateGPUKernelHandle = this->m_GPUKernelManager->CreateKernel("ComputeUpdate");
 }
 
-/**
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -127,9 +122,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
   os << m_SumOfSquaredChange << std::endl;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -138,9 +130,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Se
   m_IntensityDifferenceThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold() const
@@ -148,9 +137,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Ge
   return m_IntensityDifferenceThreshold;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -185,9 +171,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::In
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Allocate GPU buffers for computing metric statistics
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GPUAllocateMetricData(
@@ -217,10 +200,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
   m_GPUSquaredChange->ReleaseGPUInputBuffer();
   m_GPUSquaredDifference->ReleaseGPUInputBuffer();
 }
-
-/**
- * Compute update at a specify neighbourhood
- */
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
@@ -298,9 +277,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
   }
 }
 
-/**
- * Compute update at a specify neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
@@ -390,9 +366,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   return update;
 }
 
-/**
- * Update the metric and release the per-thread-global data.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer(void * gd) const

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
@@ -144,10 +144,8 @@ protected:
   GPUPDEDeformableRegistrationFilter();
   ~GPUPDEDeformableRegistrationFilter() override = default;
 
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
-
-  /** A simple method to copy the data from the input to the output.
+  /** Copy the data from the input to the output.
+   *
    * If the input does not exist, a zero field is written to the output. */
   void
   CopyInputToOutput() override;
@@ -158,13 +156,15 @@ protected:
   InitializeIteration() override;
 
   /** Utility to smooth the deformation field (represented in the Output)
-   * using a Gaussian operator. The amount of smoothing can be specified
+   * using a separable Gaussian kernel. The amount of smoothing can be specified
    * by setting the StandardDeviations. */
   void
   SmoothDisplacementField() override;
 
-  /** Smooth a vector field, which may be m_DisplacementField or
-   * m_UpdateBuffer. */
+  /** Smooth a vector field using a separable Gaussian kernel.
+   *
+   * The smoothed field may be m_DisplacementField or m_UpdateBuffer.
+   */
   virtual void
   GPUSmoothVectorField(DisplacementFieldPointer         field,
                        typename GPUDataManager::Pointer GPUSmoothingKernels[],
@@ -173,18 +173,23 @@ protected:
   virtual void
   AllocateSmoothingBuffer();
 
-  /** Utility to smooth the UpdateBuffer using a Gaussian operator.
+  /** Smooth the UpdateBuffer using a separable Gaussian kernel.
    * The amount of smoothing can be specified by setting the
    * UpdateFieldStandardDeviations. */
   void
   SmoothUpdateField() override;
 
-  /** This method is called after the solution has been generated. In this case,
-   * the filter release the memory of the internal buffers. */
+  /** Release the memory of the internal buffers.
+   *
+   * Called after the solution has been generated.
+   */
   void
   PostProcessOutput() override;
 
-  /** This method is called before iterating the solution. */
+  /** Initialize flags.
+   *
+   * Called before iterating the solution.
+   */
   void
   Initialize() override;
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -32,9 +32,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
   GPUPDEDeformableRegistrationFilter()
@@ -87,9 +85,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   GPUSuperclass::PrintSelf(os, indent);
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -117,12 +112,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   this->GPUSuperclass::InitializeIteration();
 }
 
-/*
- * Override the default implementation for the case when the
- * initial deformation is not set.
- * If the initial deformation is not set, the output is
- * fill with zero vectors.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -219,9 +208,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   }
 }
 
-/*
- * Release memory of internal buffers
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -258,9 +244,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   this->GetOutput()->GetBufferPointer();
 }
 
-/*
- * Initialize flags
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::Initialize()
@@ -276,9 +259,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   f->GPUAllocateMetricData(numPixels);
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -406,9 +386,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   }
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -419,9 +396,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   this->m_SmoothFieldTime.Stop();
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
@@ -433,9 +407,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   this->m_SmoothFieldTime.Stop();
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
@@ -75,7 +75,6 @@ EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TIn
   }
 }
 
-/** PrintSelf method */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 void
 EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::PrintSelf(

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::
   ExpectationBasedPointSetToPointSetMetricv4()

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -118,8 +118,7 @@ public:
   using GaussianType = typename DensityFunctionType::GaussianType;
   using DensityFunctionPointer = typename DensityFunctionType::Pointer;
 
-  /** Initialize the Metric by making sure that all the components
-   *  are present and plugged together correctly     */
+  /** Initialize the Metric by making sure that all the components are present and plugged together correctly. */
   void
   Initialize() override;
 
@@ -208,6 +207,7 @@ public:
   MeasureType
   GetLocalNeighborhoodValue(const PointType & point, const PixelType & pixel = 0) const override;
 
+  /** Get the local measure and the derivative values. */
   void
   GetLocalNeighborhoodValueAndDerivative(const PointType &,
                                          MeasureType &,

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -23,7 +23,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TPointSet, class TInternalComputationValueType>
 JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputationValueType>::
   JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4()
@@ -37,7 +36,6 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
   , m_Prefactor1(0.0)
 {}
 
-/** Initialize the metric */
 template <typename TPointSet, class TInternalComputationValueType>
 void
 JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputationValueType>::Initialize()
@@ -76,7 +74,6 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
   return value;
 }
 
-/** Get both the match Measure and the Derivative Measure  */
 template <typename TPointSet, class TInternalComputationValueType>
 void
 JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputationValueType>::

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -26,7 +26,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::
   LabeledPointSetToPointSetMetricv4()
@@ -236,7 +235,6 @@ LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComp
   }
 }
 
-/** PrintSelf method */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 void
 LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::PrintSelf(

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
@@ -138,15 +138,15 @@ public:
   itkSetMacro(MetricWeights, WeightsArrayType);
   itkGetMacro(MetricWeights, WeightsArrayType);
 
-  /** Add a metric to the queue */
+  /** Add a metric to the queue. */
   void
   AddMetric(MetricType * metric);
 
-  /** Clear the metric queue */
+  /** Clear the metric queue. */
   void
   ClearMetricQueue();
 
-  /** Get the number of metrics */
+  /** Get the number of metrics. */
   SizeValueType
   GetNumberOfMetrics() const;
 

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -23,7 +23,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -37,7 +36,6 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
   this->m_MovingTransform = nullptr;
 }
 
-/** Add a metric to the queue. */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -49,7 +47,6 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
   this->m_MetricQueue.push_back(metric);
 }
 
-/** Clear the queue */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
@@ -61,7 +58,6 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
   this->m_MetricQueue.clear();
 }
 
-/** Get the number of metrics */
 template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::
   PointSetToPointSetMetricWithIndexv4()
@@ -57,7 +56,6 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   this->m_CalculateValueAndDerivativeInTangentSpace = false;
 }
 
-/** Initialize the metric */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 void
 PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::Initialize()
@@ -651,8 +649,6 @@ const typename PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointS
   return ranges;
 }
 
-
-/** PrintSelf */
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
 void
 PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::PrintSelf(

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
@@ -28,9 +28,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TImageForceFunction>
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::
   CurvatureRegistrationFilter()
@@ -52,9 +50,6 @@ CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImag
   }
 }
 
-/**
- * Destructor.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TImageForceFunction>
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::
   ~CurvatureRegistrationFilter()
@@ -83,9 +78,6 @@ CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImag
   Superclass::PrintSelf(os, indent);
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TImageForceFunction>
 void
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::Initialize()
@@ -190,9 +182,6 @@ CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImag
   Superclass::Initialize();
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TImageForceFunction>
 double
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::GetMetric() const
@@ -207,9 +196,6 @@ CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImag
   return drfp->GetMetric();
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TImageForceFunction>
 void
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::ApplyUpdate(

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -20,9 +20,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::DemonsRegistrationFilter()
 {
@@ -45,9 +43,6 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PrintSe
   os << indent << "Intensity difference threshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -72,9 +67,6 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::Initial
   }
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetric() const
@@ -89,9 +81,6 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetr
   return drfp->GetMetric();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold() const
@@ -106,9 +95,6 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetInte
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -124,9 +110,6 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetInte
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::ApplyUpdate(const TimeStepType & dt)

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -146,7 +146,10 @@ public:
     return global;
   }
 
-  /** Release memory for global data structure. */
+  /** Release memory for global data structure.
+   *
+   * Updates the metric and release the per-thread-global data.
+   */
   void
   ReleaseGlobalDataPointer(void * gd) const override;
 
@@ -154,8 +157,10 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at the specified neighbourhood.
+   *
+   * Called by a finite difference solver image filter a each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & it, void * gd, const FloatOffsetType & offset = FloatOffsetType(0.0)) override;
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::DemonsRegistrationFunction()
 {
@@ -62,9 +60,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Demon
   m_UseMovingImageGradient = false;
 }
 
-/**
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -96,9 +91,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Print
   os << m_SumOfSquaredChange << std::endl;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -107,9 +99,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetIn
   m_IntensityDifferenceThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold() const
@@ -117,9 +106,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetIn
   return m_IntensityDifferenceThreshold;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -154,9 +140,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Initi
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Compute update at a specify neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
@@ -248,9 +231,6 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Compu
   return update;
 }
 
-/**
- * Update the metric and release the per-thread-global data.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer(void * gd) const

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -179,8 +179,11 @@ protected:
   ApplyUpdate(const TimeStepType & dt) override;
 
 private:
-  /** Downcast the DifferenceFunction using a dynamic_cast to ensure that it is of the correct type.
-   * this method will throw an exception if the function is not of the expected type. */
+  /** Downcast the DifferenceFunction using a dynamic_cast to ensure that it is of the correct type (i.e.
+   * a DemonsRegistrationFunction).
+   *
+   * Throws an exception if the function is not of the expected type.
+   */
   DemonsRegistrationFunctionType *
   DownCastDifferenceFunctionType();
 

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   DiffeomorphicDemonsRegistrationFilter()
@@ -48,10 +46,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   m_Adder->InPlaceOn();
 }
 
-/**
- * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
- * It throws and exception, if it is not.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   DemonsRegistrationFunctionType *
@@ -67,10 +61,6 @@ typename DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDispl
   return drfp;
 }
 
-/**
- * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
- * It throws and exception, if it is not.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 const typename DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   DemonsRegistrationFunctionType *
@@ -87,9 +77,6 @@ const typename DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, 
   return drfp;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -103,9 +90,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   Superclass::InitializeIteration();
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetric() const
@@ -115,9 +99,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   return drfp->GetMetric();
 }
 
-/**
- *  Get Intensity Difference Threshold
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold()
@@ -128,9 +109,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/**
- *  Set Intensity Difference Threshold
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -141,9 +119,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/**
- *  Get Maximum Update Step Length
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMaximumUpdateStepLength() const
@@ -153,9 +128,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   return drfp->GetMaximumUpdateStepLength();
 }
 
-/**
- *  Set Maximum Update Step Length
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetMaximumUpdateStepLength(
@@ -166,9 +138,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   drfp->SetMaximumUpdateStepLength(threshold);
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 const double &
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetRMSChange() const
@@ -178,9 +147,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   return drfp->GetRMSChange();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 auto
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetUseGradientType() const
@@ -191,9 +157,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   return drfp->GetUseGradientType();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetUseGradientType(
@@ -204,9 +167,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   drfp->SetUseGradientType(gtype);
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::AllocateUpdateBuffer()
@@ -224,9 +184,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   upbuf->Allocate();
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::ApplyUpdate(

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
@@ -137,6 +137,7 @@ public:
   virtual double
   GetIntensityDifferenceThreshold() const;
 
+  /** Set/Get the maximum update step length. */
   virtual void
   SetMaximumUpdateStepLength(double);
 
@@ -178,8 +179,11 @@ protected:
   using AdderPointer = typename AdderType::Pointer;
 
 private:
-  /** Downcast the DifferenceFunction using a dynamic_cast to ensure that it is of the correct type.
-   * this method will throw an exception if the function is not of the expected type. */
+  /** Downcast the DifferenceFunction using a dynamic_cast to ensure that it is of the correct type (i.e.
+   * a DemonsRegistrationFunction).
+   *
+   * Throws an exception if the function is not of the expected type.
+   */
   DemonsRegistrationFunctionType *
   DownCastDifferenceFunctionType();
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   FastSymmetricForcesDemonsRegistrationFilter()
@@ -40,9 +38,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   m_Adder->InPlaceOn();
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -56,9 +51,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   Superclass::InitializeIteration();
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetric() const
@@ -68,9 +60,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   return drfp->GetMetric();
 }
 
-/**
- * Return intensity difference threshold
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
@@ -81,9 +70,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/**
- * Sets the intensity difference threshold
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
@@ -94,9 +80,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/**
- * Get the maximum update step length
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMaximumUpdateStepLength()
@@ -107,9 +90,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   return drfp->GetMaximumUpdateStepLength();
 }
 
-/**
- * Set the maximum update step length
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetMaximumUpdateStepLength(
@@ -120,9 +100,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   drfp->SetMaximumUpdateStepLength(threshold);
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 const double &
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetRMSChange() const
@@ -132,9 +109,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   return drfp->GetRMSChange();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 auto
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetUseGradientType() const
@@ -145,9 +119,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   return drfp->GetUseGradientType();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetUseGradientType(
@@ -158,10 +129,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   drfp->SetUseGradientType(gtype);
 }
 
-/**
- * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
- * It throws and exception, if it is not.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   DemonsRegistrationFunctionType *
@@ -178,10 +145,6 @@ typename FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, 
   return drfp;
 }
 
-/**
- * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
- * It throws and exception, if it is not.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 const typename FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   DemonsRegistrationFunctionType *
@@ -215,9 +178,6 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
   upbuf->Allocate();
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::ApplyUpdate(

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -143,7 +143,10 @@ public:
     return global;
   }
 
-  /** Release memory for global data structure. */
+  /** Release memory for global data structure.
+   *
+   * Updates the metric and releases the per-thread-global data.
+   */
   void
   ReleaseGlobalDataPointer(void * GlobalData) const override;
 
@@ -151,8 +154,10 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at a non boundary neighbourhood.
+   *
+   * Called by a finite difference solver image filter at each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & neighborhood,
                 void *                   globalData,

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
   FastSymmetricForcesDemonsRegistrationFunction()
@@ -62,9 +60,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(
@@ -94,9 +89,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   os << m_SumOfSquaredChange << std::endl;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -105,9 +97,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   m_IntensityDifferenceThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -116,9 +105,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   return m_IntensityDifferenceThreshold;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -159,9 +145,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Compute update at a non boundary neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
@@ -273,9 +256,6 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   return update;
 }
 
-/**
- * Update the metric and release the per-thread-global data.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer(

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -126,8 +126,10 @@ public:
     return m_MovingImageInterpolator;
   }
 
-  /** Compute the time step that can taken for this iterations.  In
-   * this context, the timestep is a function of the maximum gradients. */
+  /** Compute the time global step that for this iteration.
+   *
+   * In this context, the timestep is a function of the maximum gradients.
+   */
   TimeStepType
   ComputeGlobalTimeStep(void * GlobalData) const override;
 
@@ -145,7 +147,10 @@ public:
     return global;
   }
 
-  /** Release memory for global data structure. */
+  /** Release memory for global data structure.
+   *
+   * Updates the metric and releases the per-thread-global data.
+   */
   void
   ReleaseGlobalDataPointer(void * gd) const override;
 
@@ -153,8 +158,10 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at the specified neighbourhood.
+   *
+   * Called by a finite difference solver image filter at each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & it, void * gd, const FloatOffsetType & offset = FloatOffsetType(0.0)) override;
 

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::LevelSetMotionRegistrationFunction()
 {
@@ -63,9 +61,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_SmoothMovingImageInterpolator = static_cast<InterpolatorType *>(DefaultInterpolatorType::New().GetPointer());
 }
 
-/*
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -94,9 +89,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   os << m_SumOfSquaredChange << std::endl;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetAlpha(double alpha)
@@ -104,9 +96,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_Alpha = alpha;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetAlpha() const
@@ -114,9 +103,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return m_Alpha;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -125,9 +111,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_IntensityDifferenceThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold()
@@ -136,9 +119,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return m_IntensityDifferenceThreshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetGradientMagnitudeThreshold(
@@ -147,9 +127,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_GradientMagnitudeThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetGradientMagnitudeThreshold() const
@@ -157,9 +134,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return m_GradientMagnitudeThreshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -168,9 +142,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_GradientSmoothingStandardDeviations = sigma;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -179,10 +150,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return m_GradientSmoothingStandardDeviations;
 }
 
-/**
- * Return the flag that defines whether the image spacing should be taken into
- * account in computations.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 bool
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GetUseImageSpacing() const
@@ -190,10 +157,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return this->m_UseImageSpacing;
 }
 
-/**
- * Set the flag that defines whether the image spacing should be taken into
- * account in computations.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::SetUseImageSpacing(
@@ -202,9 +165,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   this->m_UseImageSpacing = useImageSpacing;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -233,9 +193,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Compute update at a specify neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
@@ -391,9 +348,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return update;
 }
 
-/**
- * Compute the global time step for this iteration.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::TimeStepType
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeGlobalTimeStep(
@@ -416,9 +370,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   return dt;
 }
 
-/*
- * Update the metric and release the per-thread-global data.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer(

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -237,8 +237,17 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Generate output data by performing the registration
-   * at each resolution level. */
+  /** Generate output data by performing the registration at each resolution level.
+   *
+   * Performs a the deformable registration using a multiresolution scheme using an internal mini-pipeline
+   *
+   *  ref_pyramid ->  registrator  ->  field_expander --|| tempField
+   * test_pyramid ->           |                              |
+   *                           |                              |
+   *                           --------------------------------
+   *
+   * A tempField image is used to break the cycle between the registrator and field_expander.
+   */
   void
   GenerateData() override;
 

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -25,9 +25,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -70,9 +68,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   m_StopRegistrationFlag = false;
 }
 
-/*
- * Set the moving image image.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -92,9 +87,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   this->ProcessObject::SetNthInput(2, const_cast<MovingImageType *>(ptr));
 }
 
-/*
- * Get the moving image image.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -120,9 +112,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput(2));
 }
 
-/*
- * Set the fixed image.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -142,9 +131,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   this->ProcessObject::SetNthInput(1, const_cast<FixedImageType *>(ptr));
 }
 
-/*
- * Get the fixed image.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -170,9 +156,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput(1));
 }
 
-/*
- *
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -204,9 +187,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   return num;
 }
 
-/**
- * Set the number of multi-resolution levels
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -240,9 +220,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   }
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
@@ -285,19 +262,6 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   os << m_StopRegistrationFlag << std::endl;
 }
 
-/*
- * Perform a the deformable registration using a multiresolution scheme
- * using an internal mini-pipeline
- *
- *  ref_pyramid ->  registrator  ->  field_expander --|| tempField
- * test_pyramid ->           |                              |
- *                           |                              |
- *                           --------------------------------
- *
- * A tempField image is used to break the cycle between the
- * registrator and field_expander.
- *
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
@@ -225,8 +225,9 @@ protected:
     return this->Superclass::Halt();
   }
 
-  /** A simple method to copy the data from the input to the output.
-   * If the input does not exist, a zero field is written to the output. */
+  /** Copy the data from the input to the output.
+   *
+   * When the input is not set, the output is filled with zero values. */
   void
   CopyInputToOutput() override;
 
@@ -236,23 +237,28 @@ protected:
   InitializeIteration() override;
 
   /** Utility to smooth the displacement field (represented in the Output)
-   * using a Gaussian operator. The amount of smoothing can be specified
+   * using a separable Gaussian kernel. The amount of smoothing can be specified
    * by setting the StandardDeviations. */
   virtual void
   SmoothDisplacementField();
 
-  /** Utility to smooth the UpdateBuffer using a Gaussian operator.
+  /** Utility to smooth the UpdateBuffer using a separable Gaussian kernel.
    * The amount of smoothing can be specified by setting the
    * UpdateFieldStandardDeviations. */
   virtual void
   SmoothUpdateField();
 
-  /** This method is called after the solution has been generated. In this case,
-   * the filter release the memory of the internal buffers. */
+  /** Release the memory of the internal buffers.
+   *
+   * Called after the solution has been generated.
+   */
   void
   PostProcessOutput() override;
 
-  /** This method is called before iterating the solution. */
+  /** Initialize flags.
+   *
+   * Called before iterating the solution.
+   */
   void
   Initialize() override;
 

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -30,9 +30,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PDEDeformableRegistrationFilter()
 {
@@ -65,9 +63,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   m_SmoothUpdateField = false;
 }
 
-/*
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 std::vector<SmartPointer<DataObject>>::size_type
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetNumberOfValidRequiredInputs() const
@@ -87,9 +82,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   return num;
 }
 
-/**
- * Set the standard deviations.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetStandardDeviations(double value)
@@ -140,9 +132,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   }
 }
 
-/*
- * Standard PrintSelf method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -173,9 +162,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   os << m_MaximumKernelWidth << std::endl;
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -202,12 +188,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   this->Superclass::InitializeIteration();
 }
 
-/*
- * Override the default implementation for the case when the
- * initial deformation is not set.
- * If the initial deformation is not set, the output is
- * fill with zero vectors.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::CopyInputToOutput()
@@ -296,9 +276,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   }
 }
 
-/*
- * Release memory of internal buffers
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PostProcessOutput()
@@ -307,9 +284,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   m_TempField->Initialize();
 }
 
-/*
- * Initialize flags
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::Initialize()
@@ -318,9 +292,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   m_StopRegistrationFlag = false;
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SmoothDisplacementField()
@@ -382,9 +353,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   delete oper;
 }
 
-/*
- * Smooth deformation using a separable Gaussian kernel
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SmoothUpdateField()

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
@@ -20,9 +20,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   SymmetricForcesDemonsRegistrationFilter()
@@ -33,9 +31,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -60,9 +55,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   }
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetric() const
@@ -77,9 +69,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   return drfp->GetMetric();
 }
 
-/*
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
@@ -95,9 +84,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/*
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -113,9 +99,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 const double &
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetRMSChange() const
@@ -130,9 +113,6 @@ SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacement
   return drfp->GetRMSChange();
 }
 
-/*
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::ApplyUpdate(

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -150,7 +150,10 @@ public:
     return global;
   }
 
-  /** Release memory for global data structure. */
+  /** Release memory for global data structure.
+   *
+   * Updates the metric and releases the per-thread-global data.
+   */
   void
   ReleaseGlobalDataPointer(void * gd) const override;
 
@@ -158,8 +161,10 @@ public:
   void
   InitializeIteration() override;
 
-  /** This method is called by a finite difference solver image filter at
-   * each pixel that does not lie on a data set boundary */
+  /** Compute update at a non boundary neighbourhood.
+   *
+   * Called by a finite difference solver image filter at each pixel that does not lie on a data set boundary.
+   */
   PixelType
   ComputeUpdate(const NeighborhoodType & it, void * gd, const FloatOffsetType & offset = FloatOffsetType(0.0)) override;
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
   SymmetricForcesDemonsRegistrationFunction()
@@ -55,9 +53,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   m_SumOfSquaredChange = 0.0;
 }
 
-/*
- * Standard "PrintSelf" method.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf(std::ostream & os,
@@ -86,9 +81,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   os << m_SumOfSquaredChange << std::endl;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -97,9 +89,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   m_IntensityDifferenceThreshold = threshold;
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
@@ -108,9 +97,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   return m_IntensityDifferenceThreshold;
 }
 
-/**
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -143,9 +129,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   m_SumOfSquaredChange = 0.0;
 }
 
-/**
- * Compute update at a non boundary neighbourhood
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
@@ -295,9 +278,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   return update;
 }
 
-/**
- * Update the metric and release the per-thread-global data.
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer(

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
@@ -313,7 +313,7 @@ public:
    * By initializing the random number generator seed to a value the
    * same deterministic sampling will be used each Update
    * execution. On the other hand, calling the method
-   * ReinitializeSeed() without arguments will use the wall clock in
+   * MetricSamplingReinitializeSeed() without arguments will use the wall clock in
    * order to have psuedo-random initialization of the seeds. This
    * will indeed increase the non-deterministic behavior of the
    * metric.
@@ -438,7 +438,7 @@ public:
   using Superclass::MakeOutput;
   DataObjectPointer MakeOutput(DataObjectPointerArraySizeType) override;
 
-  /** Returns the transform resulting from the registration process  */
+  /** Return the transform resulting from the registration process. */
   virtual DecoratedOutputTransformType *
   GetOutput();
   virtual const DecoratedOutputTransformType *
@@ -527,7 +527,7 @@ protected:
   virtual VirtualImageBaseConstPointer
   GetCurrentLevelVirtualDomainImage();
 
-  /** Get metric samples. */
+  /** Set the metric sample points. */
   virtual void
   SetMetricSamplePoints();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -31,9 +31,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::ImageRegistrationMethodv4()
 {
@@ -244,9 +242,6 @@ const typename ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, 
   return static_cast<const PointSetType *>(this->ProcessObject::GetInput(2 * index + 1));
 }
 
-/*
- * Set optimizer weights and do checking for identity.
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::SetOptimizerWeights(
@@ -282,9 +277,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   }
 }
 
-/*
- * Initialize by setting the interconnects between components.
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::
@@ -816,9 +808,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   this->m_OutputTransform = this->GetModifiableTransform();
 }
 
-/*
- * Start the registration
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::GenerateData()
@@ -838,9 +827,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   }
 }
 
-/**
- * Set the moving transform adaptors per stage
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::
@@ -858,9 +844,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   }
 }
 
-/**
- * Get the moving transform adaptors per stage
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 const typename ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::
   TransformParametersAdaptorsContainerType &
@@ -870,9 +853,6 @@ const typename ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, 
   return this->m_TransformParametersAdaptorsPerLevel;
 }
 
-/**
- * Set the number of levels
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::SetNumberOfLevels(
@@ -909,9 +889,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   }
 }
 
-/**
- * Get the metric samples
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::SetMetricSamplePoints()
@@ -1157,9 +1134,6 @@ typename ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtu
   return currentLevelVirtualDomainImage;
 }
 
-/*
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::PrintSelf(
@@ -1211,9 +1185,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
      << std::endl;
 }
 
-/*
- *  Get output transform
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 typename ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>::
   DecoratedOutputTransformType *

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
@@ -215,7 +215,10 @@ protected:
   void
   GenerateData() override;
 
-  /** Handle optimization internally */
+  /** Start the optimization at each level.
+   *
+   * Performs a basic gradient descent operation.
+   */
   virtual void
   StartOptimization();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -34,9 +34,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   TFixedImage,
@@ -54,9 +52,6 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   this->m_NumberOfIterationsPerLevel[2] = 40;
 }
 
-/*
- * Start the optimization at each level.  We just do a basic gradient descent operation.
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
@@ -837,9 +832,6 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   }
 }
 
-/*
- * Start the registration
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
@@ -869,9 +861,6 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
   this->GetTransformOutput()->Set(this->m_OutputTransform);
 }
 
-/*
- * PrintSelf
- */
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>
 void
 TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
@@ -170,7 +170,10 @@ protected:
   void
   ThreadedGenerateData(const RegionType &, ThreadIdType);
 
-  /** Handle optimization internally */
+  /** Start the optimization at each level.
+   *
+   * Performs a basic gradient descent operation.
+   */
   virtual void
   StartOptimization();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -32,9 +32,6 @@
 namespace itk
 {
 
-/**
- * Constructor
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -55,9 +52,6 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   this->m_NumberOfIterationsPerLevel[2] = 40;
 }
 
-/*
- * Start the optimization at each level.  We just do a basic gradient descent operation.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -408,9 +402,6 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   }
 }
 
-/*
- * Start the registration
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -444,9 +435,6 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   this->GetTransformOutput()->Set(this->m_OutputTransform);
 }
 
-/*
- * PrintSelf
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
@@ -154,7 +154,7 @@ private:
   InputImageConstPointer m_InputImage{};
   ClassifiedImagePointer m_ClassifiedImage{};
 
-  /** Define a virtual Classifier function to classify the whole image. */
+  /** Define a virtual classifier function to classify the whole image. */
   virtual void
   Classify();
 }; // class ImageClassifierBase

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -20,9 +20,7 @@
 
 namespace itk
 {
-/**
- * PrintSelf
- */
+
 template <typename TInputImage, typename TClassifiedImage>
 void
 ImageClassifierBase<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -34,21 +32,15 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os,
   os << m_ClassifiedImage.GetPointer() << std::endl;
   os << indent << "InputImage: ";
   os << m_InputImage.GetPointer() << std::endl;
-} // end PrintSelf
+}
 
-/**
- * Generate data (start the classification process)
- */
 template <typename TInputImage, typename TClassifiedImage>
 void
 ImageClassifierBase<TInputImage, TClassifiedImage>::GenerateData()
 {
   this->Classify();
-} // end Generate data
+}
 
-//------------------------------------------------------------------
-// The core function where classification is carried out
-//------------------------------------------------------------------
 template <typename TInputImage, typename TClassifiedImage>
 void
 ImageClassifierBase<TInputImage, TClassifiedImage>::Classify()
@@ -114,11 +106,8 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Classify()
     outputClassifiedLabel = ClassifiedImagePixelType(classLabel);
     classifiedIt.Set(outputClassifiedLabel);
   }
-} // end Classify
+}
 
-/**
- * Allocate
- */
 template <typename TInputImage, typename TClassifiedImage>
 void
 ImageClassifierBase<TInputImage, TClassifiedImage>::Allocate()

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
@@ -125,7 +125,10 @@ public:
     m_MembershipFunctions.resize(0);
   }
 
-  /** Stores a MembershipCalculator of a class in its internal vector */
+  /** Add a membership function corresponding to the class index.
+   *
+   * Stores a MembershipCalculator of a class in its internal vector.
+   */
   unsigned int
   AddMembershipFunction(MembershipFunctionPointer function);
 

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
@@ -41,9 +41,6 @@ ImageModelEstimatorBase<TInputImage, TMembershipFunction>::GenerateData()
   this->EstimateModels();
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageModelEstimatorBase<TInputImage, TMembershipFunction>::PrintSelf(std::ostream & os, Indent indent) const
@@ -67,11 +64,7 @@ ImageModelEstimatorBase<TInputImage, TMembershipFunction>::PrintSelf(std::ostrea
 
   os << indent << "InputImage: ";
   os << m_InputImage.GetPointer() << std::endl;
-} // end PrintSelf
-
-//------------------------------------------------------------------
-// Add a membership function corresponding to the class index
-//------------------------------------------------------------------
+}
 
 template <typename TInputImage, typename TMembershipFunction>
 unsigned int

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.h
@@ -87,6 +87,7 @@ public:
   using GradientIntensityImageType = Image<PixelType, 3>;
   using GradientIntensityImagePointer = typename GradientIntensityImageType::Pointer;
 
+  /** Set/Get the scalar for balloon force. */
   itkSetMacro(Kappa, double);
   itkGetConstMacro(Kappa, double);
 
@@ -102,17 +103,13 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /**
-   * Compute the external force component
+  /** Compute the external force component.
+   *
+   * Computes the model Displacement according to image gradient forces.
    */
   void
   ComputeExternalForce(SimplexMeshGeometry * data, const GradientImageType * gradientImage) override;
 
-  /** Parameters definitions. */
-
-  /**
-   * scalar for balloon force
-   */
   double m_Kappa{};
 }; // end of class
 } // end namespace itk

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
@@ -34,7 +34,7 @@
 
 namespace itk
 {
-/* Constructor. */
+
 template <typename TInputMesh, typename TOutputMesh>
 DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::DeformableSimplexMesh3DBalloonForceFilter()
 
@@ -42,16 +42,14 @@ DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::DeformableSi
   m_Kappa = 0.1;
 }
 
-/* PrintSelf. */
 template <typename TInputMesh, typename TOutputMesh>
 void
 DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Kappa = " << m_Kappa << std::endl;
-} /* End PrintSelf. */
+}
 
-/** Compute model Displacement according to image gradient forces */
 template <typename TInputMesh, typename TOutputMesh>
 void
 DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::ComputeExternalForce(

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -220,7 +220,6 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::SetGradient(const Gradie
   this->SetNthInput(1, const_cast<GradientImageType *>(gradientImage));
 }
 
-/* Get the gradient image as an input */
 template <typename TInputMesh, typename TOutputMesh>
 auto
 DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GetGradient() const -> const GradientImageType *

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -25,7 +25,7 @@
 
 namespace itk
 {
-/* Constructore  */
+
 template <typename TInputMesh, typename TOutputMesh>
 DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::
   DeformableSimplexMesh3DGradientConstraintForceFilter()

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -29,9 +29,6 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::KLMRegionGrowImageFilter()
   this->SetMaximumNumberOfRegions(2);
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage, typename TOutputImage>
 void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -44,11 +41,8 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os
   os << indent << "Current internal value of lambda parameter: " << m_InternalLambda << std::endl;
   os << indent << "Initial number of regions: " << m_InitialNumberOfRegions << std::endl;
   os << indent << "Current number of regions: " << m_NumberOfRegions << std::endl;
-} // end PrintSelf
+}
 
-/*
- * GenerateInputRequestedRegion method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -62,9 +56,6 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegio
   }
 }
 
-/**
- * EnlargeOutputRequestedRegion method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -91,7 +82,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputPtr->Allocate();
 
   GenerateOutputImage();
-} // end GenerateData
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -164,7 +155,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateOutputImage()
       tmpIndex[idim] = 0;
     }
   }
-} // end GenerateOutputImage()
+}
 
 template <typename TInputImage, typename TOutputImage>
 auto
@@ -183,7 +174,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage() -> Label
   labelImagePtr = GenerateLabelledImage(labelImagePtr);
 
   return labelImagePtr;
-} // end GetLabelledImage()
+}
 
 template <typename TInputImage, typename TOutputImage>
 auto
@@ -244,14 +235,14 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateLabelledImage(Label
 
   // Return the reference to the labelled image
   return labelImagePtr;
-} // end GenerateLabelledImage()
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ApplyRegionGrowImageFilter()
 {
   this->ApplyKLM();
-} // end ApplyRegionGrowImageFilter()
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -272,7 +263,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ApplyKLM()
   }
 
   this->ResolveRegions();
-} // end ApplyKLM()
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -549,7 +540,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
   {
     itkExceptionMacro(<< "KLM initialization is incorrect");
   }
-} // end InitializeKLM()
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -590,7 +581,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeRegionParameters(
     m_InitialRegionArea *= gridSize[idim] * spacing[idim];
   }
   m_InitialRegionMean /= m_InitialRegionArea;
-} // end InitializeRegionParameters
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -691,7 +682,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
     m_BorderCandidate = &(m_BordersDynamicPointer.back());
     m_InternalLambda = m_BorderCandidate->m_Pointer->GetLambda();
   }
-} // end MergeRegions
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -777,7 +768,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
 
     m_RegionsPointer[iregion]->SetRegionParameters(newMeanValue, newAreaValue, newLabelValue);
   }
-} // end ResolveRegions()
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -793,7 +784,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::PrintAlgorithmRegionStats()
       m_RegionsPointer[k]->PrintRegionInfo();
     }
   }
-} // end PrintAlgorithmRegionStats
+}
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -805,7 +796,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::PrintAlgorithmBorderStats()
     std::cout << "Stats for Border No: " << (k + 1) << std::endl;
     m_BordersDynamicPointer[k].m_Pointer->PrintBorderInfo();
   }
-} // end PrintAlgorithmBorderStats
+}
 } // namespace itk
 
 #endif

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
@@ -28,9 +28,6 @@ RegionGrowImageFilter<TInputImage, TOutputImage>::RegionGrowImageFilter()
   m_MaximumNumberOfRegions = 0;
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage, typename TOutputImage>
 void
 RegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -39,7 +36,7 @@ RegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, I
   os << indent << "Region grow image filter object" << std::endl;
   os << indent << "Maximum number of regions: " << m_MaximumNumberOfRegions << std::endl;
   os << indent << "Maximum grid size : " << m_GridSize << std::endl;
-} // end PrintSelf
+}
 } // namespace itk
 
 #endif

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -28,9 +28,6 @@ KLMSegmentationBorder::KLMSegmentationBorder()
 
 KLMSegmentationBorder::~KLMSegmentationBorder() = default;
 
-/**
- * PrintSelf
- */
 void
 KLMSegmentationBorder::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -38,37 +35,37 @@ KLMSegmentationBorder::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Lambda  = " << m_Lambda << std::endl;
   os << indent << "Region1 = " << m_Region1 << std::endl;
   os << indent << "Region2 = " << m_Region2 << std::endl;
-} // end PrintSelf
+}
 
 void
 KLMSegmentationBorder::SetRegion1(KLMSegmentationRegion * Region1)
 {
   m_Region1 = Region1;
-} // end SetRegion1
+}
 
 KLMSegmentationRegion *
 KLMSegmentationBorder::GetRegion1()
 {
   return m_Region1;
-} // end GetRegion2
+}
 
 void
 KLMSegmentationBorder::SetRegion2(KLMSegmentationRegion * Region2)
 {
   m_Region2 = Region2;
-} // end SetRegion2
+}
 
 KLMSegmentationRegion *
 KLMSegmentationBorder::GetRegion2()
 {
   return m_Region2;
-} // end GetRegion2
+}
 
 void
 KLMSegmentationBorder::EvaluateLambda()
 {
   m_Lambda = m_Region1->EnergyFunctional(m_Region2) / this->GetBorderLength();
-} // end EvaluateLambda()
+}
 
 void
 KLMSegmentationBorder::PrintBorderInfo()

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
@@ -110,7 +110,7 @@ public:
     this->SetOutputNarrowBandwidth(value);
   }
 
-  /** Set/Get the input narrowband. */
+  /** Set/Get the input narrowband container. */
   void
   SetInputNarrowBand(NodeContainer * ptr);
 

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Default constructor.
- */
+
 template <typename TLevelSet>
 ReinitializeLevelSetImageFilter<TLevelSet>::ReinitializeLevelSetImageFilter()
 {
@@ -41,9 +39,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::ReinitializeLevelSetImageFilter()
   m_OutputNarrowBand = nullptr;
 }
 
-/*
- * Set the input narrowband container.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::SetInputNarrowBand(NodeContainer * ptr)
@@ -55,9 +50,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::SetInputNarrowBand(NodeContainer * p
   }
 }
 
-/**
- * PrintSelf method.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::PrintSelf(std::ostream & os, Indent indent) const
@@ -75,9 +67,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::PrintSelf(std::ostream & os, Indent 
   os << std::endl;
 }
 
-/*
- * GenerateInputRequestedRegion method.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::GenerateInputRequestedRegion()
@@ -86,9 +75,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateInputRequestedRegion()
   this->Superclass::GenerateInputRequestedRegion();
 }
 
-/*
- * EnlargeOutputRequestedRegion method.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -111,9 +97,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::EnlargeOutputRequestedRegion(DataObj
   }
 }
 
-/*
- * Allocate/initialize memory.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::AllocateOutput()
@@ -131,9 +114,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::AllocateOutput()
   this->m_Marcher->SetOutputDirection(this->GetInput()->GetDirection());
 }
 
-/*
- * Generate the output data.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::GenerateData()
@@ -150,9 +130,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateData()
   }
 }
 
-/*
- * Generate the output data - full set version.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
@@ -225,9 +202,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   }
 }
 
-/*
- * Generate output data - narrowband version.
- */
 template <typename TLevelSet>
 void
 ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFeatureImage, typename TOutputPixel>
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ShapePriorMAPCostFunction()
 {
@@ -35,9 +33,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ShapePriorMAPCostFunctio
   m_Weights.Fill(1.0);
 }
 
-/**
- * PrintSelf
- */
 template <typename TFeatureImage, typename TOutputPixel>
 void
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream & os, Indent indent) const
@@ -49,9 +44,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream &
   os << indent << "Weights: " << m_Weights << std::endl;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogInsideTerm(const ParametersType & parameters) const
@@ -93,9 +85,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogInsideTerm(con
   return output;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogShapePriorTerm(
@@ -112,9 +101,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogShapePriorTerm
   return measure;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogGradientTerm(const ParametersType & parameters) const
@@ -148,9 +134,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogGradientTerm(c
   return sum;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogPosePriorTerm(
@@ -159,9 +142,6 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogPosePriorTerm(
   return 0.0;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 void
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::Initialize()

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFeatureImage, typename TOutputPixel>
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::ShapePriorMAPCostFunctionBase()
 {
@@ -32,9 +30,6 @@ ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::ShapePriorMAPCostFun
   m_FeatureImage = nullptr;
 }
 
-/**
- * PrintSelf
- */
 template <typename TFeatureImage, typename TOutputPixel>
 void
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream & os, Indent indent) const
@@ -45,9 +40,6 @@ ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::PrintSelf(std::ostre
   os << indent << "FeatureImage:  " << m_FeatureImage.GetPointer() << std::endl;
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 auto
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::GetValue(const ParametersType & parameters) const
@@ -57,9 +49,6 @@ ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::GetValue(const Param
           this->ComputeLogShapePriorTerm(parameters) + this->ComputeLogPosePriorTerm(parameters));
 }
 
-/**
- *
- */
 template <typename TFeatureImage, typename TOutputPixel>
 void
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::Initialize()

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TImageType, typename TFeatureImageType>
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ShapePriorSegmentationLevelSetFunction()
 {
@@ -32,9 +30,6 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ShapePrio
   m_ShapePriorWeight = NumericTraits<ScalarValueType>::ZeroValue();
 }
 
-/**
- * PrintSelf
- */
 template <typename TImageType, typename TFeatureImageType>
 void
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PrintSelf(std::ostream & os, Indent indent) const
@@ -44,9 +39,6 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PrintSelf
   os << indent << "ShapePriorWeight: " << m_ShapePriorWeight << std::endl;
 }
 
-/**
- * Compute the equation value.
- */
 template <typename TImageType, typename TFeatureImageType>
 typename ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PixelType
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeUpdate(
@@ -82,9 +74,6 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeUp
   return value;
 }
 
-/**
- * Compute the global time step.
- */
 template <typename TImageType, typename TFeatureImageType>
 auto
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeGlobalTimeStep(void * gd) const

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -267,13 +267,14 @@ public:
   itkSetMacro(SmoothingFactor, double);
   itkGetConstMacro(SmoothingFactor, double);
 
-  /** Set the neighborhood radius */
+  /** Set the neighborhood radius. */
   void
   SetNeighborhoodRadius(const NeighborhoodRadiusType &);
 
-  /** Sets the radius for the neighborhood, calculates size from the
-   * radius, and allocates storage. */
-
+  /** Sets the radius for the neighborhood.
+   *
+   * Calculates size from the radius, and allocates storage.
+   */
   void
   SetNeighborhoodRadius(const SizeValueType);
 
@@ -352,7 +353,7 @@ protected:
   virtual void
   ApplyMRFImageFilter();
 
-  /** Minimization algorithm to be used. */
+  /** Minimize the funcional to be used. */
   virtual void
   MinimizeFunctional();
 
@@ -364,8 +365,8 @@ protected:
 
   /** Labelled status image neighborhood iterator type alias */
   using LabelStatusImageNeighborhoodIterator = NeighborhoodIterator<LabelStatusImageType>;
-  // Function implementing the neighborhood operation
 
+  /** Perform the MRF operation with each neighborhood. */
   virtual void
   DoNeighborhoodOperation(const InputImageNeighborhoodIterator & imageIter,
                           LabelledImageNeighborhoodIterator &    labelledIter,
@@ -428,7 +429,7 @@ private:
   virtual void
   SetDefaultMRFNeighborhoodWeight();
 
-  // Function implementing the ICM algorithm to label the images
+  /** Apply the ICM algorithm to label the images. */
   void
   ApplyICMLabeller();
 }; // class MRFImageFilter

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -71,9 +71,6 @@ MRFImageFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Inde
   os << indent << " Number of iterations: " << m_NumberOfIterations << std::endl;
 } // end PrintSelf
 
-/*
- * GenerateInputRequestedRegion method.
- */
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::GenerateInputRequestedRegion()
@@ -89,9 +86,6 @@ MRFImageFilter<TInputImage, TClassifiedImage>::GenerateInputRequestedRegion()
   }
 }
 
-/**
- * EnlargeOutputRequestedRegion method.
- */
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::EnlargeOutputRequestedRegion(DataObject * output)
@@ -104,9 +98,6 @@ MRFImageFilter<TInputImage, TClassifiedImage>::EnlargeOutputRequestedRegion(Data
   imgData->SetRequestedRegionToLargestPossibleRegion();
 }
 
-/**
- * GenerateOutputInformation method.
- */
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::GenerateOutputInformation()
@@ -159,7 +150,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::GenerateData()
     ++labelledImageIt;
     ++outImageIt;
   }
-} // end GenerateData
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -171,11 +162,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::SetClassifier(typename Classifier
   }
   m_ClassifierPtr = ptrToClassifier;
   m_ClassifierPtr->SetNumberOfClasses(m_NumberOfClasses);
-} // end SetPtrToClassifier
-
-//-------------------------------------------------------
-// Set the neighborhood radius
-//-------------------------------------------------------
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -189,7 +176,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::SetNeighborhoodRadius(const SizeV
     radius[i] = radiusValue;
   }
   this->SetNeighborhoodRadius(radius);
-} // end SetNeighborhoodRadius
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -203,9 +190,8 @@ MRFImageFilter<TInputImage, TClassifiedImage>::SetNeighborhoodRadius(const SizeV
   }
   // Set up the neighborhood
   this->SetNeighborhoodRadius(radius);
-} // end SetNeighborhoodRadius
+}
 
-// Set the neighborhood radius
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::SetNeighborhoodRadius(const NeighborhoodRadiusType & radius)
@@ -217,13 +203,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::SetNeighborhoodRadius(const Neigh
     m_LabelledImageNeighborhoodRadius[i] = radius[i];
     m_LabelStatusImageNeighborhoodRadius[i] = radius[i];
   }
-} // end SetNeighborhoodRadius
-
-//-------------------------------------------------------
-
-//-------------------------------------------------------
-// Set the neighborhood weights
-//-------------------------------------------------------
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -324,12 +304,8 @@ MRFImageFilter<TInputImage, TClassifiedImage>::SetMRFNeighborhoodWeight(std::vec
       m_MRFNeighborhoodWeight[i] = (betaMatrix[i] * m_SmoothingFactor);
     }
   }
-} // end SetDefaultMRFNeighborhoodWeight
+}
 
-//-------------------------------------------------------
-//-------------------------------------------------------
-// Allocate algorithm specific resources
-//-------------------------------------------------------
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
@@ -368,12 +344,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
     rIter.Set(1);
     ++rIter;
   }
-} // Allocate
-
-//-------------------------------------------------------
-//-------------------------------------------------------
-// Apply the MRF image filter
-//-------------------------------------------------------
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -421,12 +392,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::ApplyMRFImageFilter()
   {
     m_StopCondition = MRFStopEnum::ErrorTolerance;
   }
-} // ApplyMRFImageFilter
-
-//-------------------------------------------------------
-//-------------------------------------------------------
-// Minimize the functional
-//-------------------------------------------------------
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -436,10 +402,6 @@ MRFImageFilter<TInputImage, TClassifiedImage>::MinimizeFunctional()
   ApplyICMLabeller();
 }
 
-//-------------------------------------------------------
-//-------------------------------------------------------
-// Core of the ICM algorithm
-//-------------------------------------------------------
 template <typename TInputImage, typename TClassifiedImage>
 void
 MRFImageFilter<TInputImage, TClassifiedImage>::ApplyICMLabeller()
@@ -504,12 +466,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::ApplyICMLabeller()
     ++nLabelledImageNeighborhoodIter;
     ++nLabelStatusImageNeighborhoodIter;
   }
-} // ApplyICMlabeller
-
-//-------------------------------------------------------
-//-------------------------------------------------------
-// Function that performs the MRF operation with each neighborhood
-//-------------------------------------------------------
+}
 
 template <typename TInputImage, typename TClassifiedImage>
 void
@@ -574,13 +531,13 @@ MRFImageFilter<TInputImage, TClassifiedImage>::DoNeighborhoodOperation(
     for (int i = 0; i < m_NeighborhoodSize; ++i)
     {
       labelStatusIter.SetPixel(i, 1);
-    } // End neighborhood processing
-  }   // end if
+    }
+  }
   else
   {
     labelStatusIter.SetCenterPixel(0);
   }
-} // end DoNeighborhoodOperation
+}
 } // namespace itk
 
 #endif

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
@@ -137,7 +137,7 @@ public:
    * executed using the Update() method. */
   itkGetConstReferenceMacro(Variance, InputRealType);
 
-  /** Method to access seed container */
+  /** Method to access seed container. */
   virtual const SeedsContainerType &
   GetSeeds() const;
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -29,9 +29,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::ConfidenceConnectedImageFilter()
 {
@@ -71,7 +69,6 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::AddSeed(const IndexTy
   this->Modified();
 }
 
-/** Method to access seed container */
 template <typename TInputImage, typename TOutputImage>
 auto
 ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const -> const SeedsContainerType &
@@ -80,9 +77,6 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const -> c
   return this->m_Seeds;
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
@@ -114,6 +114,8 @@ public:
    *
    * This seed will be isolated from Seed2 (if possible). All pixels
    * connected to this seed will be replaced with ReplaceValue.
+   *
+   * \deprecated Please use AddSeed1.
    */
   void
   SetSeed1(const IndexType & seed);
@@ -129,6 +131,8 @@ public:
   /**  Set a single seed point 2.
    *
    * This seed will be isolated from Seed1 (if possible).
+   *
+   * \deprecated Please use AddSeed2.
    */
   void
   SetSeed2(const IndexType & seed);

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -28,9 +28,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::IsolatedConnectedImageFilter()
 {
@@ -45,9 +43,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::IsolatedConnectedImageF
   m_ThresholdingFailed = false;
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -91,7 +86,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedR
   output->SetRequestedRegionToLargestPossibleRegion();
 }
 
-/** Add seed point 1. This seed will be isolated from Seed2 (if possible). */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::AddSeed1(const IndexType & seed)
@@ -100,9 +94,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::AddSeed1(const IndexTyp
   this->Modified();
 }
 
-/** \deprecated
- * Set seed point 1. This seed will be isolated from Seed2 (if possible).
- *  This method is deprecated, please use AddSeed1() */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SetSeed1(const IndexType & seed)
@@ -111,7 +102,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SetSeed1(const IndexTyp
   this->AddSeed1(seed);
 }
 
-/** Clear all the seeds1. */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::ClearSeeds1()
@@ -123,7 +113,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::ClearSeeds1()
   }
 }
 
-/** Add seed point 2. This seed will be isolated from Seed1 (if possible). */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::AddSeed2(const IndexType & seed)
@@ -132,9 +121,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::AddSeed2(const IndexTyp
   this->Modified();
 }
 
-
-/** Set seed point 2. This seed will be isolated from Seed1 (if
- *  possible).  This method is deprecated, please use AddSeed2() */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SetSeed2(const IndexType & seed)
@@ -143,7 +129,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SetSeed2(const IndexTyp
   this->AddSeed2(seed);
 }
 
-/** Clear all the seeds2. */
 template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::ClearSeeds2()

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::NeighborhoodConnectedImageFilter()
 {
@@ -63,9 +61,6 @@ NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::AddSeed(const Index
   this->Modified();
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -29,9 +29,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TInputImage, typename TOutputImage>
 VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::VectorConfidenceConnectedImageFilter()
 {
@@ -43,9 +41,6 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::VectorConfidenc
   m_ThresholdFunction = DistanceThresholdFunctionType::New();
 }
 
-/**
- * Standard PrintSelf method.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -25,7 +25,7 @@
 
 namespace itk
 {
-/* Constructor: setting the default parameter values. */
+
 template <typename TInputImage, typename TOutputImage, typename TBinaryPriorImage>
 VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>::VoronoiSegmentationImageFilterBase()
   : m_WorkingVD(VoronoiDiagram::New())

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/* Constructor: setting of the default values for the parameters. */
+
 template <typename TInputImage, typename TOutputImage>
 VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::VoronoiSegmentationRGBImageFilter()
 {
@@ -70,7 +70,6 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetSTDPercentError
   }
 }
 
-/* Initialization for the segmentation. */
 template <typename TInputImage, typename TOutputImage>
 void
 VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(unsigned int           inputNumber,
@@ -79,7 +78,6 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(unsigned 
   this->Superclass::SetInput(inputNumber, input);
 }
 
-/* Initialization for the segmentation. */
 template <typename TInputImage, typename TOutputImage>
 void
 VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const InputImageType * input)

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -23,11 +23,6 @@
 namespace itk
 {
 
-//-CONSTRUCTOR DESTRUCTOR PRINT------------------------------------------------
-
-//
-// Constructor
-//
 template <typename TElement>
 RingBuffer<TElement>::RingBuffer()
   : m_PointerVector()
@@ -36,9 +31,6 @@ RingBuffer<TElement>::RingBuffer()
   this->SetNumberOfBuffers(3);
 }
 
-//
-// PrintSelf
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::PrintSelf(std::ostream & os, Indent indent) const
@@ -48,13 +40,6 @@ RingBuffer<TElement>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "NumberOfBuffers: " << this->m_PointerVector.size() << std::endl;
 }
 
-
-//-PUBLIC METHODS--------------------------------------------------------------
-
-
-//
-// MoveHead
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::MoveHead(OffsetValueType offset)
@@ -66,10 +51,6 @@ RingBuffer<TElement>::MoveHead(OffsetValueType offset)
   this->Modified();
 }
 
-
-//
-// MoveHeadForward
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::MoveHeadForward()
@@ -77,10 +58,6 @@ RingBuffer<TElement>::MoveHeadForward()
   this->MoveHead(1);
 }
 
-
-//
-// MoveHeadBackward
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::MoveHeadBackward()
@@ -88,10 +65,6 @@ RingBuffer<TElement>::MoveHeadBackward()
   this->MoveHead(-1);
 }
 
-
-//
-// BufferIsFull
-//
 template <typename TElement>
 bool
 RingBuffer<TElement>::BufferIsFull(OffsetValueType offset)
@@ -101,9 +74,6 @@ RingBuffer<TElement>::BufferIsFull(OffsetValueType offset)
   return !(this->m_PointerVector[bufferIndex].IsNull());
 }
 
-//
-// GetBufferContents
-//
 template <typename TElement>
 typename TElement::Pointer
 RingBuffer<TElement>::GetBufferContents(OffsetValueType offset)
@@ -115,10 +85,6 @@ RingBuffer<TElement>::GetBufferContents(OffsetValueType offset)
   return this->m_PointerVector[bufferIndex];
 }
 
-
-//
-// SetBufferContents
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::SetBufferContents(OffsetValueType offset, ElementPointer element)
@@ -133,10 +99,6 @@ RingBuffer<TElement>::SetBufferContents(OffsetValueType offset, ElementPointer e
   this->Modified();
 }
 
-
-//
-// GetNumberOfBuffers
-//
 template <typename TElement>
 auto
 RingBuffer<TElement>::GetNumberOfBuffers() -> SizeValueType
@@ -144,10 +106,6 @@ RingBuffer<TElement>::GetNumberOfBuffers() -> SizeValueType
   return static_cast<typename RingBuffer<TElement>::SizeValueType>(this->m_PointerVector.size());
 }
 
-
-//
-// SetNumberOfBuffers
-//
 template <typename TElement>
 void
 RingBuffer<TElement>::SetNumberOfBuffers(SizeValueType n)
@@ -189,12 +147,6 @@ RingBuffer<TElement>::SetNumberOfBuffers(SizeValueType n)
   this->Modified();
 }
 
-
-//-PROTECTED METHODS-----------------------------------------------------------
-
-//
-// GetOffsetBufferIndex
-//
 template <typename TElement>
 auto
 RingBuffer<TElement>::GetOffsetBufferIndex(OffsetValueType offset) -> OffsetValueType

--- a/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
+++ b/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
@@ -22,9 +22,6 @@
 namespace itk
 {
 
-//
-// Constructor
-//
 template <typename TImageToImageFilter>
 ImageFilterToVideoFilterWrapper<TImageToImageFilter>::ImageFilterToVideoFilterWrapper()
 {
@@ -38,9 +35,6 @@ ImageFilterToVideoFilterWrapper<TImageToImageFilter>::ImageFilterToVideoFilterWr
   m_ImageFilter = nullptr;
 }
 
-//
-// PrintSelf
-//
 template <typename TImageToImageFilter>
 void
 ImageFilterToVideoFilterWrapper<TImageToImageFilter>::PrintSelf(std::ostream & os, Indent indent) const
@@ -57,9 +51,6 @@ ImageFilterToVideoFilterWrapper<TImageToImageFilter>::PrintSelf(std::ostream & o
   }
 }
 
-//
-// TemporalStreamingGenerateData
-//
 template <typename TImageToImageFilter>
 void
 ImageFilterToVideoFilterWrapper<TImageToImageFilter>::TemporalStreamingGenerateData()


### PR DESCRIPTION
Clean up method Doxygen documentation:
- Consolidate documentation so that methods are documented in the header
  files. By doing this fix the documentation of methods which had the
  wrong documentation (e.g. copied from another existing, unrelated
  method).
- Remove the documentation of trivial methods: constructors,
  destructors, `PrintSelf` methods, etc.
- Remove non-descriptive documentation of instance variables whose
  documentation should dwell in their public Get/Set macros according to
  the ITK SWG coding style guideline.
- Remove documentation blocks consisting solely of the method name from
  the implementation files.
- Remove unnecessary method ending brace comment blocks.
- Remove empty method documentation blocks from implementation file.
- Fix typos and method names cross-referenced in the documentation.
- Take advantage of the commit to improve the documentation style
  (capitalize first letter in sentence, finish sentences with a period,
  split brief and detailed documentation sentences, etc.)

Note that many of the implementation file method documentation blocks were not in a Doxygen-recognizable format either:
https://doxygen.nl/manual/docblocks.html

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)