### PR TITLE
STYLE: Break line before calling `PrintSelf` in test

### DIFF
--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -50,7 +50,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     constexpr unsigned int SplineOrder = 2;
 
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
-    std::cout << " and SplineOrder= " << SplineOrder << "  ";
+    std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
     using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;
@@ -150,7 +150,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     constexpr unsigned int SplineOrder = 3;
 
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
-    std::cout << " and SplineOrder= " << SplineOrder << "  ";
+    std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
     using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;
@@ -238,7 +238,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     constexpr unsigned int SpaceDimension = 3;
     constexpr unsigned int SplineOrder = 3;
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
-    std::cout << " and SplineOrder= " << SplineOrder << "  ";
+    std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
     using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;


### PR DESCRIPTION
Break line before calling `PrintSelf` in test in order to be able to clearly idenify the information printed by the `PrintSelf` method being called by the basic method exercising macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)