### PR TITLE
BUG: Fix symbol exportation macro module name in `itk::DCMTKImageIO`

### DIFF
--- a/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
@@ -189,8 +189,8 @@ private:
 };
 
 // Define how to print enumeration
-extern ITKCommon_EXPORT std::ostream &
-                        operator<<(std::ostream & out, DCMTKImageIO::LogLevelEnum value);
+extern ITKIODCMTK_EXPORT std::ostream &
+                         operator<<(std::ostream & out, DCMTKImageIO::LogLevelEnum value);
 
 } // end namespace itk
 


### PR DESCRIPTION
Fix the symbol exportation macro module name in the `itk::DCMTKImageIO` strongly typed enum class serialization method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)