### PR TITLE
DOC: Remove duplicate `FourierTransform` Doxygen grouping command

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
@@ -54,8 +54,6 @@ extern ITKFFT_EXPORT std::ostream &
  * \brief Implements an API to enable the Fourier transform or the inverse
  * Fourier transform of images with complex valued voxels to be computed.
  *
- * \ingroup FourierTransform
- *
  * \author Simon K. Warfield simon.warfield\@childrens.harvard.edu
  *
  * \note Attribution Notice. This research work was made possible by
@@ -69,9 +67,9 @@ extern ITKFFT_EXPORT std::ostream &
  * https://www.insight-journal.org/browse/publication/128
  *
  * \ingroup FourierTransform
+ * \ingroup ITKFFT
  *
  * \sa ForwardFFTImageFilter
- * \ingroup ITKFFT
  */
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ComplexToComplexFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>


### PR DESCRIPTION
Remove duplicate `FourierTransform` Doxygen class grouping command.

Take advantage of the commit to group together the class grouping commands.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)