### PR TITLE
STYLE: Make `PrintSelf` implementation style consistent

### DIFF
--- a/Examples/Filtering/CompositeFilterExample.cxx
+++ b/Examples/Filtering/CompositeFilterExample.cxx
@@ -237,7 +237,7 @@ CompositeExampleImageFilter<TImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Threshold:" << this->m_Threshold << std::endl;
+  os << indent << "Threshold: " << m_Threshold << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
@@ -33,7 +33,8 @@ void
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageDirection = " << this->m_UseImageDirection << std::endl;
+
+  os << indent << "UseImageDirection: " << m_UseImageDirection << std::endl;
 }
 
 template <typename TInputImage, typename TCoordRep>

--- a/Modules/Core/Common/include/itkBSplineKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineKernelFunction.h
@@ -82,7 +82,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "Spline Order: " << SplineOrder << std::endl;
+
+    os << indent << "SplineOrder: " << SplineOrder << std::endl;
   }
 
 private:

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -19,6 +19,7 @@
 #define itkColorTable_hxx
 
 #include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
 #include "vnl/vnl_sample.h"
 
 #include <sstream>
@@ -365,14 +366,13 @@ template <typename TComponent>
 void
 ColorTable<TComponent>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfColors = " << m_NumberOfColors << std::endl;
-  for (unsigned int i = 0; i < m_NumberOfColors; ++i)
-  {
-    os << indent << "ColorName[" << i << "] = " << m_ColorName[i] << ", "
-       << "Color[" << i << "] = " << m_Color[i] << std::endl;
-  }
+  os << indent << "NumberOfColors: " << m_NumberOfColors << std::endl;
+  os << indent << "ColorName: " << m_ColorName << std::endl;
+  os << indent << "Color: " << m_Color << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -566,6 +566,8 @@ template <typename TImage, typename TBoundaryCondition>
 void
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  Superclass::PrintSelf(os, indent);
+
   DimensionValueType i;
 
   os << indent;
@@ -623,7 +625,6 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
     os << m_InnerBoundsHigh[i] << ' ';
   }
   os << "} }" << std::endl;
-  Superclass::PrintSelf(os, indent.GetNextIndent());
 }
 
 template <typename TImage, typename TBoundaryCondition>

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -399,6 +399,8 @@ template <typename TImage>
 void
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  Superclass::PrintSelf(os, indent);
+
   DimensionValueType i;
 
   os << indent;
@@ -448,7 +450,6 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::PrintSelf(std::ostream & os, Ind
     os << m_InnerBoundsHigh[i] << ' ';
   }
   os << "} }" << std::endl;
-  Superclass::PrintSelf(os, indent.GetNextIndent());
 }
 
 template <typename TImage>

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -23,16 +23,16 @@ template <typename TImage, typename TBoundaryCondition>
 void
 ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "ConstShapedNeighborhoodIterator {this = " << this;
-  os << " m_ActiveIndexList = [";
+  Superclass::PrintSelf(os, indent);
+
+  os << "ActiveIndexList: [";
   for (auto it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
   {
     os << *it << ' ';
   }
   os << "] ";
-  os << " m_CenterIsActive = " << m_CenterIsActive;
-  os << '}' << std::endl;
-  Superclass::PrintSelf(os, indent.GetNextIndent());
+
+  os << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
 }
 
 template <typename TImage, typename TBoundaryCondition>

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -60,9 +60,13 @@ void
 ImageDuplicator<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Input Image: " << m_InputImage << std::endl;
-  os << indent << "Output Image: " << m_DuplicateImage << std::endl;
-  os << indent << "Internal Image Time: " << m_InternalImageTime << std::endl;
+
+  itkPrintSelfObjectMacro(InputImage);
+  itkPrintSelfObjectMacro(DuplicateImage);
+
+  os << indent
+     << "InternalImageTime: " << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -37,17 +37,9 @@ void
 InPlaceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
   os << indent << "InPlace: " << (m_InPlace ? "On" : "Off") << std::endl;
-  if (this->CanRunInPlace())
-  {
-    os << indent << "The input and output to this filter are the same type. The filter can be run in place."
-       << std::endl;
-  }
-  else
-  {
-    os << indent << "The input and output to this filter are different types. The filter cannot be run in place."
-       << std::endl;
-  }
+  os << indent << "RunningInPlace: " << (m_RunningInPlace ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -226,12 +226,15 @@ LoggerThreadWrapper<SimpleLoggerType>::PrintSelf(std::ostream & os, Indent inden
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Thread ID: " << this->m_Thread.get_id() << std::endl;
-  os << indent << "Low-priority Message Delay: " << this->m_Delay << std::endl;
-  os << indent << "Operation Queue Size: " << this->m_OperationQ.size() << std::endl;
-  os << indent << "Message Queue Size: " << this->m_MessageQ.size() << std::endl;
-  os << indent << "Level Queue Size: " << this->m_LevelQ.size() << std::endl;
-  os << indent << "Output Queue Size: " << this->m_OutputQ.size() << std::endl;
+  os << indent << "Thread ID: " << m_Thread.get_id() << std::endl;
+  os << indent << "TerminationRequested: " << m_TerminationRequested << std::endl;
+
+  os << indent << "OperationQ size: " << m_OperationQ.size() << std::endl;
+  os << indent << "MessageQ size: " << m_MessageQ.size() << std::endl;
+  os << indent << "LevelQ size: " << m_LevelQ.size() << std::endl;
+  os << indent << "OutputQ size: " << m_OutputQ.size() << std::endl;
+
+  os << indent << "Delay: " << m_Delay << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -327,10 +327,10 @@ template <typename TPixel, unsigned int VDimension, typename TContainer>
 std::ostream &
 operator<<(std::ostream & os, const Neighborhood<TPixel, VDimension, TContainer> & neighborhood)
 {
-  os << "Neighborhood:" << std::endl;
-  os << "    Radius:" << neighborhood.GetRadius() << std::endl;
-  os << "    Size:" << neighborhood.GetSize() << std::endl;
-  os << "    DataBuffer:" << neighborhood.GetBufferReference() << std::endl;
+  os << "Neighborhood: " << std::endl;
+  os << "    Radius: " << neighborhood.GetRadius() << std::endl;
+  os << "    Size: " << neighborhood.GetSize() << std::endl;
+  os << "    DataBuffer: " << neighborhood.GetBufferReference() << std::endl;
 
   return os;
 }

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -18,6 +18,9 @@
 #ifndef itkObjectStore_hxx
 #define itkObjectStore_hxx
 
+#include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
+
 
 namespace itk
 {
@@ -136,14 +139,16 @@ template <typename TObjectType>
 void
 ObjectStore<TObjectType>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_GrowthStrategy: " << m_GrowthStrategy << std::endl;
-  os << indent << "m_Size: " << m_Size << std::endl;
-  os << indent << "m_LinearGrowthSize: " << static_cast<SizeValueType>(m_LinearGrowthSize) << std::endl;
-  os << indent << "Free list size: " << static_cast<SizeValueType>(m_FreeList.size()) << std::endl;
-  os << indent << "Free list capacity: " << static_cast<SizeValueType>(m_FreeList.capacity()) << std::endl;
-  os << indent << "Number of blocks in store: " << static_cast<SizeValueType>(m_Store.size()) << std::endl;
+  os << indent << "GrowthStrategy: " << m_GrowthStrategy << std::endl;
+  os << indent << "Size: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
+  os << indent
+     << "LinearGrowthSize: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_LinearGrowthSize)
+     << std::endl;
+  os << indent << "FreeList: " << m_FreeList << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.hxx
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.hxx
@@ -39,10 +39,10 @@ PhasedArray3DSpecialCoordinatesImage<TPixel>::PrintSelf(std::ostream & os, Inden
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_RadiusSampleSize = " << m_RadiusSampleSize << std::endl;
-  os << indent << "m_AzimuthAngularSeparation = " << m_AzimuthAngularSeparation << std::endl;
-  os << indent << "m_ElevationAngularSeparation = " << m_ElevationAngularSeparation << std::endl;
-  os << indent << "m_FirstSampleDistance = " << m_FirstSampleDistance << std::endl;
+  os << indent << "RadiusSampleSize: " << m_RadiusSampleSize << std::endl;
+  os << indent << "AzimuthAngularSeparation: " << m_AzimuthAngularSeparation << std::endl;
+  os << indent << "ElevationAngularSeparation: " << m_ElevationAngularSeparation << std::endl;
+  os << indent << "FirstSampleDistance: " << m_FirstSampleDistance << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -42,8 +42,8 @@ SparseFieldLayer<TNodeType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_HeadNode:  " << m_HeadNode << std::endl;
-  os << indent << "Empty? : " << this->Empty() << std::endl;
+  os << indent << "HeadNode: " << m_HeadNode << std::endl;
+  os << indent << "Size: " << m_Size << std::endl;
 }
 
 template <typename TNodeType>

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -208,12 +208,15 @@ ThreadLogger::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Thread ID: " << this->m_Thread.get_id() << std::endl;
-  os << indent << "Low-priority Message Delay: " << this->m_Delay << std::endl;
-  os << indent << "Operation Queue Size: " << this->m_OperationQ.size() << std::endl;
-  os << indent << "Message Queue Size: " << this->m_MessageQ.size() << std::endl;
-  os << indent << "Level Queue Size: " << this->m_LevelQ.size() << std::endl;
-  os << indent << "Output Queue Size: " << this->m_OutputQ.size() << std::endl;
+  os << indent << "Thread ID: " << m_Thread.get_id() << std::endl;
+  os << indent << "TerminationRequested: " << m_TerminationRequested << std::endl;
+
+  os << indent << "OperationQ size: " << m_OperationQ.size() << std::endl;
+  os << indent << "MessageQ size: " << m_MessageQ.size() << std::endl;
+  os << indent << "LevelQ size: " << m_LevelQ.size() << std::endl;
+  os << indent << "OutputQ size: " << m_OutputQ.size() << std::endl;
+
+  os << indent << "Delay: " << m_Delay << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -50,7 +50,17 @@ GPUReduction<TElement>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  // GetTypenameInString( typeid(TElement), os);
+  itkPrintSelfObjectMacro(GPUKernelManager);
+  itkPrintSelfObjectMacro(GPUDataManager);
+
+  os << indent << "ReduceGPUKernelHandle: " << m_ReduceGPUKernelHandle << std::endl;
+  os << indent << "TestGPUKernelHandle: " << m_TestGPUKernelHandle << std::endl;
+
+  os << indent << "Size: " << m_Size << std::endl;
+  os << indent << "SmallBlock: " << (m_SmallBlock ? "On" : "Off") << std::endl;
+
+  os << indent << "GPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_GPUResult) << std::endl;
+  os << indent << "CPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_CPUResult) << std::endl;
 }
 
 template <typename TElement>

--- a/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
@@ -264,12 +264,16 @@ GPUDataManager::Initialize()
 void
 GPUDataManager::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "GPUDataManager (" << this << ')' << std::endl;
-  os << indent << "m_BufferSize: " << m_BufferSize << std::endl;
-  os << indent << "m_IsGPUBufferDirty: " << m_IsGPUBufferDirty << std::endl;
-  os << indent << "m_GPUBuffer: " << m_GPUBuffer << std::endl;
-  os << indent << "m_IsCPUBufferDirty: " << m_IsCPUBufferDirty << std::endl;
-  os << indent << "m_CPUBuffer: " << m_CPUBuffer << std::endl;
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "BufferSize: " << m_BufferSize << std::endl;
+  os << indent << "ContextManager: " << m_ContextManager << std::endl;
+  os << indent << "CommandQueueId: " << m_CommandQueueId << std::endl;
+  os << indent << "MemFlags: " << m_MemFlags << std::endl;
+  os << indent << "GPUBuffer: " << m_GPUBuffer << std::endl;
+  os << indent << "CPUBuffer: " << m_CPUBuffer << std::endl;
+  os << indent << "IsGPUBufferDirty: " << (m_IsGPUBufferDirty ? "On" : "Off") << std::endl;
+  os << indent << "IsCPUBufferDirty: " << m_IsCPUBufferDirty ? "On" : "Off") << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -294,22 +294,20 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::P
                                                                                          Indent         indent) const
 {
   GPUSuperclass::PrintSelf(os, indent);
-  CPUSuperclass::PrintSelf(os, indent);
-  /*
-    os << indent << "UseImageSpacing: " << ( m_UseImageSpacing ? "On" : "Off" ) << std::endl;
-    os << indent << "State: " << m_State << std::endl;
-    os << std::endl;
-    if ( m_DifferenceFunction )
-      {
-      os << indent << "DifferenceFunction: " << std::endl;
-      m_DifferenceFunction->Print( os, indent.GetNextIndent() );
-      }
-    else
-      {
-      os << indent << "DifferenceFunction: " << "(None)" << std::endl;
-      }
-    os << std::endl;
-  */
+
+  os << indent << "InitTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_InitTime) << std::endl;
+  os << indent
+     << "ComputeUpdateTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_ComputeUpdateTime)
+     << std::endl;
+  os << indent << "ApplyUpdateTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_ApplyUpdateTime)
+     << std::endl;
+  os << indent << "SmoothFieldTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_SmoothFieldTime)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(DifferenceFunction);
+
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  os << indent << "State: " << m_State << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -35,6 +35,7 @@
 #include "itkVector.h"
 
 #include "itkMatrix.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -58,10 +59,58 @@ void
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,
                                                                                     Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Spline Order: " << m_SplineOrder << std::endl;
-  os << indent << "UseImageDirection = " << (this->m_UseImageDirection ? "On" : "Off") << std::endl;
-  os << indent << "NumberOfWorkUnits: " << m_NumberOfWorkUnits << std::endl;
+
+  os << indent << "Scratch: " << m_Scratch << std::endl;
+  os << indent
+     << "DataLength: " << static_cast<typename NumericTraits<typename TImageType::SizeType>::PrintType>(m_DataLength)
+     << std::endl;
+  os << indent << "SplineOrder: " << m_SplineOrder << std::endl;
+
+  itkPrintSelfObjectMacro(Coefficients);
+
+  os << indent << "MaxNumberInterpolationPoints: " << m_MaxNumberInterpolationPoints << std::endl;
+  os << indent << "PointsToIndex: " << m_PointsToIndex << std::endl;
+
+  itkPrintSelfObjectMacro(CoefficientFilter);
+
+  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+
+  os << indent
+     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
+     << std::endl;
+
+  os << indent << "ThreadedEvaluateIndex: ";
+  if (m_ThreadedEvaluateIndex != nullptr)
+  {
+    os << m_ThreadedEvaluateIndex.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "ThreadedWeights: ";
+  if (m_ThreadedWeights != nullptr)
+  {
+    os << m_ThreadedWeights.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "ThreadedWeightsDerivative: ";
+  if (m_ThreadedWeightsDerivative != nullptr)
+  {
+    os << m_ThreadedWeightsDerivative.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -82,7 +82,10 @@ void
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageDirection = " << this->m_UseImageDirection << std::endl;
+
+  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(Interpolator);
 }
 
 template <typename TInputImage, typename TCoordRep, typename TOutputType>

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
@@ -30,8 +30,10 @@ template <typename TInputImage, typename TOutput>
 void
 NeighborhoodOperatorImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  this->Superclass::PrintSelf(os, indent);
-  os << indent << "Applying Operator Function:" << std::endl;
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Operator: " << static_cast<typename NumericTraits<NeighborhoodType>::PrintType>(m_Operator)
+     << std::endl;
 }
 
 template <typename TInputImage, typename TOutput>

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -118,7 +118,10 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   std::ostream & os,
   Indent         indent) const
 {
-  this->Superclass::PrintSelf(os, indent);
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "OffsetTable: " << m_OffsetTable << std::endl;
+  os << indent << "WeightOffsetTable: " << m_WeightOffsetTable << std::endl;
 }
 
 template <typename TInputImage,

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -2694,15 +2694,118 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ObjectValue: " << static_cast<NumericTraits<unsigned char>::PrintType>(m_ObjectValue) << std::endl;
-
-  os << indent << "NumberOfNodes: " << m_NumberOfNodes << std::endl;
-
-  os << indent << "NumberOfCells: " << m_NumberOfCells << std::endl;
-
-  os << indent << "RegionOfInterestProvidedByUser: " << m_RegionOfInterestProvidedByUser << std::endl;
-
+  os << indent << "RegionOfInterestProvidedByUser: " << (m_RegionOfInterestProvidedByUser ? "On" : "Off") << std::endl;
   os << indent << "RegionOfInterest: " << m_RegionOfInterest << std::endl;
+
+  os << indent << "LUT: " << m_LUT << std::endl;
+
+  os << indent << "LastVoxel: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(*m_LastVoxel)
+     << std::endl;
+  os << indent << "CurrentVoxel: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(*m_CurrentVoxel)
+     << std::endl;
+
+  os << indent << "LastRow: ";
+  if (m_LastRow != nullptr)
+  {
+    if (*m_LastRow != nullptr)
+    {
+      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_LastRow) << std::endl;
+    }
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "LastFrame: ";
+  if (m_LastFrame != nullptr)
+  {
+    if (*m_LastFrame != nullptr)
+    {
+      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_LastFrame) << std::endl;
+    }
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "CurrentRow: ";
+  if (m_CurrentRow != nullptr)
+  {
+    if (*m_CurrentRow != nullptr)
+    {
+      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_CurrentRow) << std::endl;
+    }
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "CurrentFrame: ";
+  if (m_CurrentFrame != nullptr)
+  {
+    if (*m_CurrentFrame != nullptr)
+    {
+      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_CurrentFrame) << std::endl;
+    }
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "CurrentRowIndex: " << m_CurrentRowIndex << std::endl;
+  os << indent << "CurrentFrameIndex: " << m_CurrentFrameIndex << std::endl;
+  os << indent << "LastRowNum: " << m_LastRowNum << std::endl;
+  os << indent << "LastFrameNum: " << m_LastFrameNum << std::endl;
+  os << indent << "CurrentRowNum: " << m_CurrentRowNum << std::endl;
+  os << indent << "CurrentFrameNum: " << m_CurrentFrameNum << std::endl;
+  os << indent << "AvailableNodes: " << m_AvailableNodes << std::endl;
+
+  os << indent << "LocationOffset: " << m_LocationOffset << std::endl;
+
+  os << indent << "NumberOfNodes: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfNodes)
+     << std::endl;
+  os << indent << "NumberOfCells: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfCells)
+     << std::endl;
+
+  os << indent << "NodeLimit: " << m_NodeLimit << std::endl;
+  os << indent << "CellLimit: " << m_CellLimit << std::endl;
+  os << indent << "ImageWidth: " << m_ImageWidth << std::endl;
+  os << indent << "ImageHeight: " << m_ImageHeight << std::endl;
+  os << indent << "ImageDepth: " << m_ImageDepth << std::endl;
+  os << indent << "ColFlag: " << m_ColFlag << std::endl;
+  os << indent << "RowFlag: " << m_RowFlag << std::endl;
+  os << indent << "FrameFlag: " << m_FrameFlag << std::endl;
+  os << indent << "LastRowIndex: " << m_LastRowIndex << std::endl;
+  os << indent << "LastVoxelIndex: " << m_LastVoxelIndex << std::endl;
+  os << indent << "LastFrameIndex: " << m_LastFrameIndex << std::endl;
+
+  os << indent << "PointFound: " << m_PointFound << std::endl;
+  os << indent << "ObjectValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ObjectValue)
+     << std::endl;
+
+  os << indent << "m_OutputMesh: ";
+  if (m_OutputMesh != nullptr)
+  {
+    os << *m_OutputMesh << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "InputImage: ";
+  if (m_InputImage != nullptr)
+  {
+    os << *m_InputImage << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 } // namespace itk
 

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -221,10 +221,10 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::PrintSelf(std::ostream & os, I
 {
   this->Superclass::PrintSelf(os, indent);
 
-  os << indent << "LastCellId = " << m_LastCellId << std::endl;
+  os << indent << "LastCellId: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_LastCellId)
+     << std::endl;
 
-  GeometryMapPointer geometryMap = this->GetGeometryData();
-  os << indent << "GeometryData: " << geometryMap << std::endl;
+  itkPrintSelfObjectMacro(GeometryData);
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -379,9 +379,17 @@ void
 SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "IdOffset: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_IdOffset)
+     << std::endl;
   os << indent << "Threshold: " << m_Threshold << std::endl;
   os << indent << "SelectionMethod: " << m_SelectionMethod << std::endl;
   os << indent << "ModifiedCount: " << m_ModifiedCount << std::endl;
+
+  itkPrintSelfObjectMacro(Output);
+
+  // ToDo
+  // os << indent << "NewSimplexCellPointer: " << m_NewSimplexCellPointer << std::endl;
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -118,7 +118,8 @@ void
 SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ToDo: implement PrinSelf!!!";
+
+  itkPrintSelfObjectMacro(Centers);
 }
 } // namespace itk
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -255,16 +255,28 @@ void
 SimplexMeshVolumeCalculator<TInputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  //  os << indent << "Mesh   = " << m_SimplexMesh << std::endl;
-  os << indent << "Area = " << m_Area << std::endl;
-  os << indent << "Volume = " << m_Volume << std::endl;
-  os << indent << "VolumeX = " << m_VolumeX << std::endl;
-  os << indent << "VolumeY = " << m_VolumeY << std::endl;
-  os << indent << "VolumeZ = " << m_VolumeZ << std::endl;
-  os << indent << "Kx = " << m_Kx << std::endl;
-  os << indent << "Ky = " << m_Ky << std::endl;
-  os << indent << "Kz = " << m_Kz << std::endl;
-  os << indent << "NumberOfTriangles: " << m_NumberOfTriangles << std::endl;
+
+  itkPrintSelfObjectMacro(Centers);
+  itkPrintSelfObjectMacro(SimplexMesh);
+
+  os << indent << "Volume: " << m_Volume << std::endl;
+  os << indent << "VolumeX: " << m_VolumeX << std::endl;
+  os << indent << "VolumeY: " << m_VolumeY << std::endl;
+  os << indent << "VolumeZ: " << m_VolumeZ << std::endl;
+  os << indent << "Area: " << m_Area << std::endl;
+  os << indent << "Kx: " << m_Kx << std::endl;
+  os << indent << "Ky: " << m_Ky << std::endl;
+  os << indent << "Kz: " << m_Kz << std::endl;
+  os << indent << "Wxyz: " << m_Wxyz << std::endl;
+  os << indent << "Wxy: " << m_Wxy << std::endl;
+  os << indent << "Wxz: " << m_Wxz << std::endl;
+  os << indent << "Wyz: " << m_Wyz << std::endl;
+  os << indent << "Muncx: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncx) << std::endl;
+  os << indent << "Muncy: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncy) << std::endl;
+  os << indent << "Muncz: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncz) << std::endl;
+  os << indent
+     << "NumberOfTriangles: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTriangles)
+     << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -270,7 +270,27 @@ void
 TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ToDo: implement PrinSelf!!!";
+
+  os << indent << "FaceSet: " << m_FaceSet << std::endl;
+
+  itkPrintSelfObjectMacro(Edges);
+  itkPrintSelfObjectMacro(EdgeNeighborList);
+  itkPrintSelfObjectMacro(VertexNeighborList);
+  itkPrintSelfObjectMacro(LineCellIndices);
+
+  os << indent << "IdOffset: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_IdOffset)
+     << std::endl;
+  os << indent << "EdgeCellId: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_EdgeCellId)
+     << std::endl;
+  os << indent
+     << "HandledEdgeIds: " << static_cast<typename NumericTraits<IdVectorPointer>::PrintType>(m_HandledEdgeIds)
+     << std::endl;
+  os << indent << "IdOffset: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_IdOffset)
+     << std::endl;
+
+  // ToDo
+  // os << indent << "NewInputMeshCellPointer: " << m_NewInputMeshCellPointer << std::endl;
+  // os << indent << "NewSimplexCellPointer: " << m_NewSimplexCellPointer << std::endl;
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
@@ -33,32 +33,8 @@ void
 QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_EdgeStatus: ";
-  switch (m_EdgeStatus)
-  {
-    default:
-    case EdgeStatusEnum::STANDARD_CONFIG:
-      os << "STANDARD_CONFIG" << std::endl;
-      break;
-    case EdgeStatusEnum::EDGE_NULL:
-      os << "EDGE_NULL" << std::endl;
-      break;
-    case EdgeStatusEnum::MESH_NULL:
-      os << "MESH_NULL" << std::endl;
-      break;
-    case EdgeStatusEnum::NON_INTERNAL_EDGE:
-      os << "NON_INTERNAL_EDGE" << std::endl;
-      break;
-    case EdgeStatusEnum::NON_TRIANGULAR_RIGHT_FACE:
-      os << "NON_TRIANGULAR_RIGHT_FACE" << std::endl;
-      break;
-    case EdgeStatusEnum::NON_TRIANGULAR_LEFT_FACE:
-      os << "NON_TRIANGULAR_LEFT_FACE" << std::endl;
-      break;
-    case EdgeStatusEnum::EXISTING_OPPOSITE_EDGE:
-      os << "EXISTING_OPPOSITE_EDGE" << std::endl;
-      break;
-  }
+
+  os << indent << "EdgeStatus: " << m_EdgeStatus;
 }
 
 template <typename TMesh, typename TQEType>

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -19,6 +19,7 @@
 #define itkQuadEdgeMeshEulerOperatorJoinVertexFunction_hxx
 
 #include "itkQuadEdgeMeshZipMeshFunction.h"
+#include "itkNumericTraits.h"
 
 #include <list>
 #include <algorithm>
@@ -38,8 +39,9 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_OldPointID: " << m_OldPointID << std::endl;
-  os << indent << "m_EdgeStatus: ";
+  os << indent << "OldPointID: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_OldPointID)
+     << std::endl;
+  os << indent << "EdgeStatus: ";
 
   switch (m_EdgeStatus)
   {

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -162,11 +162,14 @@ template <unsigned int TDimension>
 void
 ArrowSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "ArrowSpatialObject(" << this << ')' << std::endl;
   Superclass::PrintSelf(os, indent);
-  os << indent << "Object Position = " << m_PositionInObjectSpace << std::endl;
-  os << indent << "Object Direction = " << m_DirectionInObjectSpace << std::endl;
-  os << indent << "Object Length = " << m_LengthInObjectSpace << std::endl;
+
+  os << indent << "DirectionInObjectSpace: "
+     << static_cast<typename NumericTraits<VectorType>::PrintType>(m_DirectionInObjectSpace) << std::endl;
+  os << indent
+     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
+     << std::endl;
+  os << indent << "LengthInObjectSpace: " << m_LengthInObjectSpace << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -98,8 +98,12 @@ void
 BoxSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Object Size: " << m_SizeInObjectSpace << std::endl;
-  os << indent << "Object Position: " << m_PositionInObjectSpace << std::endl;
+
+  os << indent << "SizeInObjectSpace: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_SizeInObjectSpace)
+     << std::endl;
+  os << indent
+     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -157,16 +157,18 @@ template <unsigned int TDimension>
 void
 ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "ContourSpatialObject(" << this << ')' << std::endl;
-  os << indent << "#Control Points: " << static_cast<SizeValueType>(m_ControlPoints.size()) << std::endl;
-  os << indent << "Interpolation type: " << m_InterpolationMethod << std::endl;
-  os << indent << "Contour closed: " << m_IsClosed << std::endl;
-  os << indent << "Orientation In Object Space: " << m_OrientationInObjectSpace << std::endl;
-  os << indent << "Orientation time: " << m_OrientationInObjectSpaceMTime << std::endl;
-  os << indent << "Pin to slice : " << m_AttachedToSlice << std::endl;
   Superclass::PrintSelf(os, indent);
-}
 
+  // ToDo
+  // os << indent << "ControlPoints: " << m_ControlPoints << std::endl;
+  os << indent << "InterpolationMethod: " << m_InterpolationMethod << std::endl;
+  os << indent << "InterpolationFactor: " << m_InterpolationFactor << std::endl;
+  os << indent << "IsClosed: " << (m_IsClosed ? "On" : "Off") << std::endl;
+  os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
+  os << indent << "OrientationInObjectSpaceMTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_OrientationInObjectSpaceMTime) << std::endl;
+  os << indent << "AttachedToSlice: " << m_AttachedToSlice << std::endl;
+}
 
 /** Print the contour spatial object */
 template <unsigned int TDimension>

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -84,8 +84,10 @@ ContourSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Picked PointInObjectSpace: " << m_PickedPointInObjectSpace << std::endl;
-  os << indent << "NormalInObjectSpace: " << m_NormalInObjectSpace << std::endl;
+  os << indent << "PickedPointInObjectSpace: " << m_PickedPointInObjectSpace << std::endl;
+  os << indent
+     << "NormalInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_NormalInObjectSpace)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -59,6 +59,10 @@ void
 DTITubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "TensorMatrix: " << m_TensorMatrix << std::endl;
+  // ToDo
+  // os << indent << "Fields: " << m_Fields << std::endl;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -190,14 +190,17 @@ void
 ImageSpatialObject<TDimension, PixelType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Image: " << std::endl;
-  os << indent << m_Image << std::endl;
-  os << indent << "Interpolator: " << std::endl;
-  os << indent << m_Interpolator << std::endl;
-  os << indent << "SliceNumber: " << m_SliceNumber << std::endl;
+
+  itkPrintSelfObjectMacro(Image);
+
+  os << indent << "SliceNumber: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_SliceNumber)
+     << std::endl;
+
 #if !defined(ITK_LEGACY_REMOVE)
   os << indent << "PixelType: " << m_PixelType << std::endl;
 #endif
+
+  itkPrintSelfObjectMacro(Interpolator);
 }
 
 template <unsigned int TDimension, typename PixelType>

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -54,13 +54,8 @@ void
 LineSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "LineSpatialObjectPoint(" << this << ')' << std::endl;
-  unsigned int ii = 0;
-  while (ii < TPointDimension - 1)
-  {
-    os << indent << this->m_NormalArrayInObjectSpace[ii] << std::endl;
-    ++ii;
-  }
+
+  os << indent << "NormalArrayInObjectSpace: " << m_NormalArrayInObjectSpace << std::endl;
 }
 
 /** Set the specified normal */

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -157,9 +157,13 @@ void
 MeshSpatialObject<TMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "Mesh: " << std::endl;
-  os << indent << "m_IsInsidePrecisionInObjectSpace: " << m_IsInsidePrecisionInObjectSpace << std::endl;
-  os << indent << m_Mesh << std::endl;
+
+  itkPrintSelfObjectMacro(Mesh);
+
+#if !defined(ITK_LEGACY_REMOVE)
+  os << indent << "PixelType: " << m_PixelType << std::endl;
+#endif
+  os << indent << "IsInsidePrecisionInObjectSpace: " << m_IsInsidePrecisionInObjectSpace << std::endl;
 }
 
 template <typename TMesh>

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -228,9 +228,10 @@ template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "PointBasedSpatialObject(" << this << ')' << std::endl;
-  os << indent << "Number of points: " << m_Points.size() << std::endl;
   Superclass::PrintSelf(os, indent);
+
+  // ToDo
+  // os << indent << "Points: " << m_Points << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -366,31 +366,36 @@ void
 SpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Id:" << m_Id << std::endl;
-  os << indent << "TypeName:" << m_TypeName << std::endl;
-  os << indent << "ParentId:" << m_ParentId << std::endl;
-  os << indent << "Parent:" << m_Parent << std::endl;
-  os << indent << "LargestPossibleRegion:" << m_LargestPossibleRegion << std::endl;
-  os << indent << "RequestedRegion:" << m_RequestedRegion << std::endl;
-  os << indent << "BufferedRegion:" << m_BufferedRegion << std::endl;
-  os << indent << "My Bounding Box In Object Space:" << std::endl;
-  os << indent << m_MyBoundingBoxInObjectSpace << std::endl;
-  os << indent << "My Bounding Box In World Space:" << std::endl;
-  os << indent << m_MyBoundingBoxInWorldSpace << std::endl;
-  os << indent << "Family Bounding Box In Object Space:" << std::endl;
-  os << indent << m_FamilyBoundingBoxInObjectSpace << std::endl;
-  os << indent << "Family Bounding Box In World Space:" << std::endl;
-  os << indent << m_FamilyBoundingBoxInWorldSpace << std::endl;
-  os << indent << "Object to World Transform: " << m_ObjectToWorldTransform << std::endl;
-  os << indent << "Object to World Transform Inverse: " << m_ObjectToWorldTransformInverse << std::endl;
-  os << indent << "Object to Parent Transform: " << m_ObjectToParentTransform << std::endl;
-  os << indent << "Object to Parent Transform Inverse: " << m_ObjectToParentTransformInverse << std::endl;
-  os << std::endl << std::endl;
-  os << indent << "Object properties: " << std::endl;
-  m_Property.Print(std::cout);
-  os << indent << "ChildrenList:" << m_ChildrenList.size() << std::endl;
-  os << indent << "DefaultInsideValue:" << m_DefaultInsideValue << std::endl;
-  os << indent << "DefaultOutsideValue:" << m_DefaultOutsideValue << std::endl;
+
+  os << indent << "Id: " << m_Id << std::endl;
+  os << indent << "TypeName: " << m_TypeName << std::endl;
+  os << indent << "ParentId: " << m_ParentId << std::endl;
+  os << indent << "Parent: " << m_Parent << std::endl;
+  os << indent << "LargestPossibleRegion: " << m_LargestPossibleRegion << std::endl;
+  os << indent << "RequestedRegion: " << m_RequestedRegion << std::endl;
+  os << indent << "BufferedRegion: " << m_BufferedRegion << std::endl;
+
+  itkPrintSelfObjectMacro(MyBoundingBoxInObjectSpace);
+  itkPrintSelfObjectMacro(MyBoundingBoxInWorldSpace);
+  itkPrintSelfObjectMacro(FamilyBoundingBoxInObjectSpace);
+  itkPrintSelfObjectMacro(FamilyBoundingBoxInWorldSpace);
+
+  itkPrintSelfObjectMacro(ObjectToWorldTransform);
+  itkPrintSelfObjectMacro(ObjectToWorldTransformInverse);
+  itkPrintSelfObjectMacro(ObjectToParentTransform);
+  itkPrintSelfObjectMacro(ObjectToParentTransformInverse);
+
+  os << indent << "Property: ";
+  m_Property.Print(os);
+
+  os << indent << "ChildrenList: " << std::endl;
+  for (const auto & elem : m_ChildrenList)
+  {
+    os << indent.GetNextIndent() << "[" << &elem - &*(m_ChildrenList.begin()) << "]: " << *elem << std::endl;
+  }
+
+  os << indent << "DefaultInsideValue: " << m_DefaultInsideValue << std::endl;
+  os << indent << "DefaultOutsideValue: " << m_DefaultOutsideValue << std::endl;
 }
 
 template <unsigned int TDimension>

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -159,24 +159,18 @@ void
 SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Id: " << m_Id << std::endl;
-  os << indent << "RGBA: " << m_Color.GetRed() << ' ';
-  os << m_Color.GetGreen() << ' ';
-  os << m_Color.GetBlue() << ' ';
-  os << m_Color.GetAlpha() << std::endl;
-  os << indent << "Position: ";
-  for (unsigned int i = 1; i < TPointDimension; ++i)
-  {
-    os << m_PositionInObjectSpace[i - 1] << ',';
-  }
-  os << m_PositionInObjectSpace[TPointDimension - 1] << std::endl;
-  os << indent << "ScalarDictionary: " << std::endl;
+  os << indent
+     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
+     << std::endl;
+  os << indent << "Color: " << static_cast<typename NumericTraits<ColorType>::PrintType>(m_Color) << std::endl;
 
-  auto iter = m_ScalarDictionary.begin();
-  while (iter != m_ScalarDictionary.end())
+  os << indent << "ScalarDictionary: " << std::endl;
+  for (const auto & keyval : m_ScalarDictionary)
   {
-    os << indent << indent << iter->first << " = " << iter->second << std::endl;
-    ++iter;
+    os << indent.GetNextIndent() << keyval.first << ": " << keyval.second << std::endl;
   }
+
+  os << indent << "SpatialObject: " << m_SpatialObject << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -223,16 +223,25 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
   Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Image: " << m_Image << std::endl;
-  os << indent << "SpatialObject: " << m_SpatialObject << std::endl;
+
+  itkPrintSelfObjectMacro(Image);
+  itkPrintSelfObjectMacro(SpatialObject);
+
   os << indent << "Mean: " << m_Mean << std::endl;
-  os << indent << "Covariance Matrix: " << m_CovarianceMatrix << std::endl;
-  os << indent << "Sum: " << m_Sum << std::endl;
-  os << indent << "m_NumberOfPixels: " << m_NumberOfPixels << std::endl;
-  os << indent << "Internal Image Time: " << m_InternalImageTime << std::endl;
-  os << indent << "Internal Spatial Object Time: " << m_InternalSpatialObjectTime << std::endl;
+  os << indent << "Sum: " << static_cast<typename NumericTraits<AccumulateType>::PrintType>(m_Sum) << std::endl;
+  os << indent << "NumberOfPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
+     << std::endl;
+  os << indent << "CovarianceMatrix: " << m_CovarianceMatrix << std::endl;
   os << indent << "SampleDirection: " << m_SampleDirection << std::endl;
-  os << indent << "Sample: " << m_Sample << std::endl;
+  os << indent
+     << "InternalImageTime: " << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
+     << std::endl;
+  os << indent << "InternalSpatialObjectTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalSpatialObjectTime) << std::endl;
+  os << indent << "ModifiedTime: " << static_cast<typename NumericTraits<TimeStamp>::PrintType>(m_ModifiedTime)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(Sample);
 }
 
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -79,9 +79,8 @@ void
 SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "SurfaceSpatialObjectPoint(" << this << ')' << std::endl;
-  os << indent << "Normal definition: ";
-  os << indent << m_NormalInObjectSpace << std::endl;
+
+  os << indent << "NormalInObjectSpace: " << m_NormalInObjectSpace << std::endl;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -109,12 +109,11 @@ template <unsigned int TDimension, typename TTubePointType>
 void
 TubeSpatialObject<TDimension, TTubePointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "TubeSpatialObject(" << this << ')' << std::endl;
-  os << indent << "End Type : " << m_EndRounded << std::endl;
-  os << indent << "Parent Point : " << m_ParentPoint << std::endl;
-  os << indent << "Root : " << m_Root << std::endl;
-
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "ParentPoint : " << m_ParentPoint << std::endl;
+  os << indent << "EndRounded: " << (m_EndRounded ? "On" : "Off") << std::endl;
+  os << indent << "Root: " << (m_Root ? "On" : "Off") << std::endl;
 }
 
 template <unsigned int TDimension, typename TTubePointType>

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -185,12 +185,12 @@ void
 TubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Radius In Object Space: " << m_RadiusInObjectSpace << std::endl;
-  os << indent << "Tangent In Object Space: " << m_TangentInObjectSpace << std::endl;
-  os << indent << "Normal1 In Object Space: " << m_Normal1InObjectSpace << std::endl;
-  os << indent << "Normal2 In Object Space: " << m_Normal2InObjectSpace << std::endl;
-  os << indent << "Medialness: " << m_Medialness << std::endl;
+
+  os << indent << "TangentInObjectSpace: " << m_TangentInObjectSpace << std::endl;
+  os << indent << "Normal1InObjectSpace: " << m_Normal1InObjectSpace << std::endl;
+  os << indent << "Normal2InObjectSpace: " << m_Normal2InObjectSpace << std::endl;
   os << indent << "Branchness: " << m_Branchness << std::endl;
+  os << indent << "Medialness: " << m_Medialness << std::endl;
   os << indent << "Ridgeness: " << m_Ridgeness << std::endl;
   os << indent << "Curvature: " << m_Curvature << std::endl;
   os << indent << "Levelness: " << m_Levelness << std::endl;
@@ -199,6 +199,8 @@ TubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent ind
   os << indent << "Alpha1: " << m_Alpha1 << std::endl;
   os << indent << "Alpha2: " << m_Alpha2 << std::endl;
   os << indent << "Alpha3: " << m_Alpha3 << std::endl;
+
+  os << indent << "RadiusInObjectSpace: " << m_RadiusInObjectSpace << std::endl;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -190,10 +190,19 @@ SpatialObjectProperty::operator=(const SpatialObjectProperty & rhs)
 void
 SpatialObjectProperty::PrintSelf(std::ostream & os, Indent indent) const
 {
+  os << indent << "Color: " << m_Color << std::endl;
   os << indent << "Name: " << m_Name << std::endl;
-  os << indent << "RGBA: " << m_Color.GetRed() << ' ' << m_Color.GetGreen() << ' ' << m_Color.GetBlue() << ' '
-     << m_Color.GetAlpha() << std::endl;
-  os << indent << "ScalarDictionary size: " << m_ScalarDictionary.size() << std::endl;
-  os << indent << "StringDictionary size: " << m_StringDictionary.size() << std::endl;
+
+  os << indent << "ScalarDictionary: " << std::endl;
+  for (const auto & keyval : m_ScalarDictionary)
+  {
+    os << indent.GetNextIndent() << keyval.first << ": " << keyval.second << std::endl;
+  }
+
+  os << indent << "StringDictionary: " << std::endl;
+  for (const auto & keyval : m_StringDictionary)
+  {
+    os << indent.GetNextIndent() << keyval.first << ": " << keyval.second << std::endl;
+  }
 }
 } // end of namespace itk

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -298,45 +298,46 @@ void
 PipelineMonitorImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_NumberOfUpdates: " << m_NumberOfUpdates << std::endl;
 
-  os << indent << "m_NumberOfClearPipeline: " << m_NumberOfClearPipeline << std::endl;
-
-  os << indent << "m_ClearPipelineOnGenerateOutputInformation: " << m_ClearPipelineOnGenerateOutputInformation
+  os << indent
+     << "ClearPipelineOnGenerateOutputInformation: " << (m_ClearPipelineOnGenerateOutputInformation ? "On" : "Off")
      << std::endl;
+  os << indent << "NumberOfUpdates: " << m_NumberOfUpdates << std::endl;
+  os << indent << "NumberOfClearPipeline: " << m_NumberOfClearPipeline << std::endl;
 
-  os << indent << "m_OutputRequestedRegions:" << std::endl;
+  os << indent << "OutputRequestedRegions: " << std::endl;
   for (auto i = m_OutputRequestedRegions.begin(); i != m_OutputRequestedRegions.end(); ++i)
   {
     i->Print(os, indent.GetNextIndent());
   }
 
-  os << indent << "m_InputRequestedRegions:" << std::endl;
+  os << indent << "InputRequestedRegions: " << std::endl;
   for (auto i = m_InputRequestedRegions.begin(); i != m_InputRequestedRegions.end(); ++i)
   {
     i->Print(os, indent.GetNextIndent());
   }
 
-  os << indent << "m_UpdatedBufferedRegions:" << std::endl;
+  os << indent << "UpdatedBufferedRegions: " << std::endl;
   for (auto i = m_UpdatedBufferedRegions.begin(); i != m_UpdatedBufferedRegions.end(); ++i)
   {
     i->Print(os, indent.GetNextIndent());
   }
 
-  os << indent << "m_UpdatedRequestedRegions:" << std::endl;
+  os << indent << "UpdatedRequestedRegions: " << std::endl;
   for (auto i = m_UpdatedRequestedRegions.begin(); i != m_UpdatedRequestedRegions.end(); ++i)
   {
     i->Print(os, indent.GetNextIndent());
   }
 
-  os << indent << "m_UpdatedOutputOrigin:" << std::endl;
-  os << indent.GetNextIndent() << m_UpdatedOutputOrigin << std::endl;
-  os << indent << "m_UpdatedOutputDirection:" << std::endl;
-  os << indent.GetNextIndent() << m_UpdatedOutputDirection << std::endl;
-  os << indent << "m_UpdatedOutputSpacing:" << std::endl;
-  os << indent.GetNextIndent() << m_UpdatedOutputSpacing << std::endl;
-  os << indent << "m_UpdatedOutputLargestPossibleRegion: " << std::endl;
-  m_UpdatedOutputLargestPossibleRegion.Print(os, indent.GetNextIndent());
+  os << indent
+     << "UpdatedOutputOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_UpdatedOutputOrigin)
+     << std::endl;
+  os << indent << "UpdatedOutputDirection: "
+     << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_UpdatedOutputDirection) << std::endl;
+  os << indent
+     << "UpdatedOutputSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_UpdatedOutputSpacing)
+     << std::endl;
+  os << indent << "UpdatedOutputLargestPossibleRegion: " << m_UpdatedOutputLargestPossibleRegion << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -43,26 +43,14 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "x = z*tan(Azimuth)" << std::endl;
-  os << indent << "y = z*tan(Elevation)" << std::endl;
-  os << indent << "z = r * cos(Azimuth) "
-     << " / sqrt((1 + cos(Azimuth) * cos(Azimuth) * tan(Elevation)"
-     << "* tan(Elevation)))" << std::endl;
-  os << indent << "Azimuth = 1 / (tan(x/z))" << std::endl;
-  os << indent << "Elevation = 1 / (tan(y/z))" << std::endl;
-  os << indent << "r = sqrt(x*x + y*y + z*z)" << std::endl;
-  os << indent << "m_MaxAzimuth = " << m_MaxAzimuth << std::endl;
-  os << indent << "m_MaxElevation = " << m_MaxElevation << std::endl;
-  os << indent << "m_RadiusSampleSize = " << m_RadiusSampleSize << std::endl;
-  os << indent << "m_AzimuthAngularSeparation = ";
-  os << indent << m_AzimuthAngularSeparation << std::endl;
-  os << indent << "m_ElevationAngularSeparation = ";
-  os << indent << m_ElevationAngularSeparation << std::endl;
-  os << indent << "m_FirstSampleDistance = ";
-  os << indent << m_FirstSampleDistance << std::endl;
-  os << indent << "m_ForwardAzimuthElevationToPhysical = ";
-  os << indent << (m_ForwardAzimuthElevationToPhysical ? "True" : "False");
-  os << indent << std::endl;
+  os << indent << "MaxAzimuth: " << m_MaxAzimuth << std::endl;
+  os << indent << "MaxElevation: " << m_MaxElevation << std::endl;
+  os << indent << "RadiusSampleSize: " << m_RadiusSampleSize << std::endl;
+  os << indent << "AzimuthAngularSeparation: " << m_AzimuthAngularSeparation << std::endl;
+  os << indent << "ElevationAngularSeparation: " << m_ElevationAngularSeparation << std::endl;
+  os << indent << "FirstSampleDistance: " << m_FirstSampleDistance << std::endl;
+  os << indent << "ForwardAzimuthElevationToPhysical: " << (m_ForwardAzimuthElevationToPhysical ? "On" : "Off")
+     << std::endl;
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -965,28 +965,24 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  if (this->GetNumberOfTransforms() == 0)
-  {
-    return;
-  }
-
-  os << indent << "TransformsToOptimizeFlags, begin() to end(): " << std::endl << indent << indent;
-  for (auto it = this->m_TransformsToOptimizeFlags.begin(); it != this->m_TransformsToOptimizeFlags.end(); ++it)
+  os << indent << "TransformsToOptimizeFlags: " << std::endl << indent << indent;
+  for (auto it = m_TransformsToOptimizeFlags.begin(); it != m_TransformsToOptimizeFlags.end(); ++it)
   {
     os << *it << ' ';
   }
   os << std::endl;
 
-  os << indent << "TransformsToOptimize in queue, from begin to end:" << std::endl;
+  os << indent << "TransformsToOptimizeQueue: " << std::endl;
   typename TransformQueueType::const_iterator cit;
-  for (cit = this->m_TransformsToOptimizeQueue.begin(); cit != this->m_TransformsToOptimizeQueue.end(); ++cit)
+  for (cit = m_TransformsToOptimizeQueue.begin(); cit != m_TransformsToOptimizeQueue.end(); ++cit)
   {
     os << indent << ">>>>>>>>>" << std::endl;
     (*cit)->Print(os, indent);
   }
-  os << indent << "End of TransformsToOptimizeQueue." << std::endl << "<<<<<<<<<<" << std::endl;
 
-  os << indent << "End of CompositeTransform." << std::endl << "<<<<<<<<<<" << std::endl;
+  os << indent << "PreviousTransformsToOptimizeUpdateTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_PreviousTransformsToOptimizeUpdateTime)
+     << std::endl;
 }
 
 

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
@@ -57,7 +57,9 @@ ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, VDimension>::Pr
                                                                                         Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_Alpha: " << m_Alpha << std::endl;
+
+  os << indent << "Alpha: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Alpha)
+     << std::endl;
 }
 } // namespace itk
 #endif

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
@@ -55,7 +55,9 @@ void
 ElasticBodySplineKernelTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_Alpha: " << m_Alpha << std::endl;
+
+  os << indent << "Alpha: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Alpha)
+     << std::endl;
 }
 } // namespace itk
 #endif

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -359,9 +359,10 @@ Euler3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Euler's angles: AngleX=" << m_AngleX << " AngleY=" << m_AngleY << " AngleZ=" << m_AngleZ
-     << std::endl;
-  os << indent << "m_ComputeZYX = " << m_ComputeZYX << std::endl;
+  os << indent << "AngleX: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleX) << std::endl;
+  os << indent << "AngleY: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleY) << std::endl;
+  os << indent << "AngleZ: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleZ) << std::endl;
+  os << indent << "ComputeZYX: " << (m_ComputeZYX ? "On" : "Off") << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -359,21 +359,13 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::PrintSelf(std:
 {
   Superclass::PrintSelf(os, indent);
 
-  if (this->m_TransformQueue.empty())
-  {
-    os << indent << "Transform queue is empty." << std::endl;
-    return;
-  }
-
-  os << indent << "Transforms in queue, from begin to end:" << std::endl;
+  os << indent << "TransformQueue: " << std::endl;
   typename TransformQueueType::const_iterator cit;
   for (cit = this->m_TransformQueue.begin(); cit != this->m_TransformQueue.end(); ++cit)
   {
     os << indent << ">>>>>>>>>" << std::endl;
     (*cit)->Print(os, indent);
   }
-
-  os << indent << "End of MultiTransform." << std::endl << "<<<<<<<<<<" << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -51,7 +51,9 @@ void
 Rigid2DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Angle       = " << m_Angle << std::endl;
+
+  os << indent << "Angle: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Angle)
+     << std::endl;
 }
 
 

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -218,7 +218,8 @@ void
 Similarity2DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Scale =" << m_Scale << std::endl;
+
+  os << indent << "Scale: " << static_cast<typename NumericTraits<ScaleType>::PrintType>(m_Scale) << std::endl;
 }
 
 

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -302,7 +302,8 @@ void
 Similarity3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Scale = " << m_Scale << std::endl;
+
+  os << indent << "Scale: " << static_cast<typename NumericTraits<ScaleType>::PrintType>(m_Scale) << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -101,7 +101,8 @@ template <typename TInputImage, typename TOutputImage>
 void
 AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  Superclass::PrintSelf(os, indent.GetNextIndent());
+  Superclass::PrintSelf(os, indent);
+
   os << indent << "TimeStep: " << m_TimeStep << std::endl;
   os << indent << "ConductanceParameter: " << m_ConductanceParameter << std::endl;
   os << indent << "ConductanceScalingParameter: " << m_ConductanceScalingParameter << std::endl;

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -124,8 +124,12 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_UpperBinaryValue = " << m_UpperBinaryValue << std::endl;
-  os << indent << "m_LowerBinaryValue = " << m_LowerBinaryValue << std::endl;
+  os << indent
+     << "UpperBinaryValue: " << static_cast<typename NumericTraits<BinaryValueType>::PrintType>(m_UpperBinaryValue)
+     << std::endl;
+  os << indent
+     << "LowerBinaryValue: " << static_cast<typename NumericTraits<BinaryValueType>::PrintType>(m_LowerBinaryValue)
+     << std::endl;
 
   itkPrintSelfObjectMacro(InputImage);
 }

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -952,90 +952,41 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(s
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Use interslice intensity correction: ";
-  if (m_UsingInterSliceIntensityCorrection)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
+  itkPrintSelfObjectMacro(EnergyFunction);
+  itkPrintSelfObjectMacro(NormalVariateGenerator);
 
-  os << indent << "Use slab identification: ";
-  if (m_UsingSlabIdentification)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
+  itkPrintSelfObjectMacro(InputMask);
+  itkPrintSelfObjectMacro(OutputMask);
+  itkPrintSelfObjectMacro(InternalInput);
 
-  os << indent << "Use biasfield correction: ";
-  if (m_UsingBiasFieldCorrection)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
+  os << indent << "SlicingDirection: " << m_SlicingDirection << std::endl;
 
-  os << indent << "Generate output image: ";
-  if (m_GeneratingOutput)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
-
-  os << indent << "Is bias field multiplicative: ";
-  if (m_BiasFieldMultiplicative)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
-
-  os << indent << "Biasfield degree = " << m_BiasFieldDegree << std::endl;
-  os << indent << "Optimizer initial radius: " << m_OptimizerInitialRadius << std::endl;
-  os << indent << "Optimizer growth factor: " << m_OptimizerGrowthFactor << std::endl;
-  os << indent << "Optimizer shrink factor: " << m_OptimizerShrinkFactor << std::endl;
-  os << indent << "Volume optimizer max iteration: " << m_VolumeCorrectionMaximumIteration << std::endl;
-  os << indent << "Interslice correction optimizer max iteration: " << m_InterSliceCorrectionMaximumIteration
+  os << indent << "BiasFieldMultiplicative: " << (m_BiasFieldMultiplicative ? "On" : "Off") << std::endl;
+  os << indent << "UsingInterSliceIntensityCorrection: " << (m_UsingInterSliceIntensityCorrection ? "On" : "Off")
      << std::endl;
-  os << indent << "Slicing direction: " << m_SlicingDirection << std::endl;
+  os << indent << "UsingSlabIdentification: " << (m_UsingSlabIdentification ? "On" : "Off") << std::endl;
+  os << indent << "UsingBiasFieldCorrection: " << (m_UsingBiasFieldCorrection ? "On" : "Off") << std::endl;
+  os << indent << "GeneratingOutput: " << (m_GeneratingOutput ? "On" : "Off") << std::endl;
 
-  os << indent << "InputMask: ";
-  if (m_InputMask.IsNotNull())
-  {
-    os << m_InputMask << std::endl;
-  }
-  else
-  {
-    os << "not set." << std::endl;
-  }
+  os << indent << "SlabNumberOfSamples: " << m_SlabNumberOfSamples << std::endl;
+  os << indent << "SlabBackgroundMinimumThreshold: "
+     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_SlabBackgroundMinimumThreshold)
+     << std::endl;
+  os << indent << "SlabTolerance" << m_SlabTolerance << std::endl;
 
-  os << indent << "OutputMask: ";
-  if (m_OutputMask.IsNotNull())
-  {
-    os << m_OutputMask << std::endl;
-  }
-  else
-  {
-    os << "not set." << std::endl;
-  }
+  os << indent << "BiasFieldDegree: " << m_BiasFieldDegree << std::endl;
+  os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
+  os << indent << "Schedule: " << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
 
-  os << indent << "Energy function: " << m_EnergyFunction << std::endl;
-  os << indent << "Normal random variate generator: " << m_NormalVariateGenerator << std::endl;
-  os << indent << "Multires: No. levels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Multires: Schedule: " << std::endl;
-  os << m_Schedule << std::endl;
+  os << indent << "VolumeCorrectionMaximumIteration: " << m_VolumeCorrectionMaximumIteration << std::endl;
+  os << indent << "InterSliceCorrectionMaximumIteration: " << m_InterSliceCorrectionMaximumIteration << std::endl;
+
+  os << indent << "OptimizerInitialRadius: " << m_OptimizerInitialRadius << std::endl;
+  os << indent << "OptimizerGrowthFactor: " << m_OptimizerGrowthFactor << std::endl;
+  os << indent << "OptimizerShrinkFactor: " << m_OptimizerShrinkFactor << std::endl;
+
+  os << indent << "TissueClassMeans: " << m_TissueClassMeans << std::endl;
+  os << indent << "TissueClassSigmas: " << m_TissueClassSigmas << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -214,11 +214,22 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Boundary condition: " << typeid(*m_BoundaryCondition).name() << std::endl;
-  os << indent << "Use boundary condition: " << m_UseBoundaryCondition << std::endl;
+  os << indent << "BoundaryCondition: ";
+  if (m_BoundaryCondition != nullptr)
+  {
+    os << m_BoundaryCondition << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 
-  os << indent << "ObjectValue: " << m_ObjectValue << std::endl;
-  os << indent << "Kernel: " << m_Kernel << std::endl;
+  m_DefaultBoundaryCondition.Print(os, indent);
+
+  os << indent << "UseBoundaryCondition: " << (m_UseBoundaryCondition ? "On" : "Off") << std::endl;
+  os << indent << "Kernel: " << static_cast<typename NumericTraits<KernelType>::PrintType>(m_Kernel) << std::endl;
+  os << indent << "ObjectValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ObjectValue)
+     << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -40,8 +40,8 @@ void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Time step: " << m_TimeStep;
-  os << std::endl;
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -40,7 +40,9 @@ void
 MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "StencilRadius: " << m_StencilRadius << std::endl;
+
+  os << indent << "StencilRadius: " << static_cast<typename NumericTraits<RadiusValueType>::PrintType>(m_StencilRadius)
+     << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -191,11 +191,11 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Prin
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Spline order = " << this->m_SplineOrder << std::endl;
   os << indent
-     << "Number of control points for the velocity field = " << this->m_NumberOfControlPointsForTheConstantVelocityField
+     << "NumberOfControlPointsForTheConstantVelocityField: " << m_NumberOfControlPointsForTheConstantVelocityField
      << std::endl;
-  os << indent << "Number of control points for the update field = " << this->m_NumberOfControlPointsForTheUpdateField
+  os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
+  os << indent << "SplineOrder: " << static_cast<typename NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder)
      << std::endl;
 }
 

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -214,21 +214,11 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Enforce stationary boundary: ";
-  if (this->m_EnforceStationaryBoundary)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
-  os << indent << "B-spline parameters: " << std::endl;
-  os << indent << "  spline order = " << this->m_SplineOrder << std::endl;
-  os << indent << "  number of control points for the update field = " << this->m_NumberOfControlPointsForTheUpdateField
+  os << indent << "SplineOrder: " << static_cast<typename NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder)
      << std::endl;
-  os << indent << "  number of control points for the total field = " << this->m_NumberOfControlPointsForTheTotalField
-     << std::endl;
+  os << indent << "EnforceStationaryBoundary: " << (m_EnforceStationaryBoundary ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
+  os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -389,33 +389,29 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Estimate inverse: ";
-  if (this->m_EstimateInverse)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
-  os << indent << "Enforce stationary boundary: ";
-  if (this->m_EnforceStationaryBoundary)
-  {
-    os << "true" << std::endl;
-  }
-  else
-  {
-    os << "false" << std::endl;
-  }
-  os << indent << "Spline order: " << this->m_SplineOrder << std::endl;
-  os << indent << "Number of fitting levels: " << this->m_NumberOfFittingLevels << std::endl;
-  os << indent << "Number of control points: " << this->m_NumberOfControlPoints << std::endl;
+  os << indent << "EstimateInverse: " << (m_EstimateInverse ? "On" : "Off") << std::endl;
+  os << indent << "EnforceStationaryBoundary: " << (m_EnforceStationaryBoundary ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfControlPoints: " << m_NumberOfControlPoints << std::endl;
+  os << indent << "NumberOfFittingLevels: " << m_NumberOfFittingLevels << std::endl;
 
-  os << indent << "B-spline domain" << std::endl;
-  os << indent << "  Origin: " << this->m_BSplineDomainOrigin << std::endl;
-  os << indent << "  Spacing: " << this->m_BSplineDomainSpacing << std::endl;
-  os << indent << "  Size: " << this->m_BSplineDomainSize << std::endl;
-  os << indent << "  Direction: " << this->m_BSplineDomainDirection << std::endl;
+  itkPrintSelfObjectMacro(PointWeights);
+
+  os << indent << "UsePointWeights: " << (m_UsePointWeights ? "On" : "Off") << std::endl;
+
+  os << indent
+     << "BSplineDomainOrigin: " << static_cast<typename NumericTraits<OriginType>::PrintType>(m_BSplineDomainOrigin)
+     << std::endl;
+  os << indent
+     << "BSplineDomainSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_BSplineDomainSpacing)
+     << std::endl;
+  os << indent << "BSplineDomainSize: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BSplineDomainSize)
+     << std::endl;
+  os << indent << "BSplineDomainDirection: "
+     << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_BSplineDomainDirection) << std::endl;
+
+  os << indent << "BSplineDomainIsDefined: " << (m_BSplineDomainIsDefined ? "On" : "Off") << std::endl;
+  os << indent << "UseInputFieldToDefineTheBSplineDomain: " << (m_UseInputFieldToDefineTheBSplineDomain ? "On" : "Off")
+     << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -613,11 +613,11 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ost
      << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_DisplacementFieldSetTime) << std::endl;
 
   os << indent
-     << "m_IdentityJacobian: " << static_cast<typename NumericTraits<JacobianType>::PrintType>(m_IdentityJacobian)
+     << "IdentityJacobian: " << static_cast<typename NumericTraits<JacobianType>::PrintType>(m_IdentityJacobian)
      << std::endl;
 
-  os << indent << " CoordinateTolerance: " << m_CoordinateTolerance << std::endl;
-  os << indent << " DirectionTolerance: " << m_DirectionTolerance << std::endl;
+  os << indent << "CoordinateTolerance: " << m_CoordinateTolerance << std::endl;
+  os << indent << "DirectionTolerance: " << m_DirectionTolerance << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -233,12 +233,12 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Pri
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Calculate number of integration steps automatically = "
-     << this->m_CalculateNumberOfIntegrationStepsAutomatically << std::endl;
-  os << indent
-     << "Gaussian variance for the velocity field = " << this->m_GaussianSmoothingVarianceForTheConstantVelocityField
+  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheConstantVelocityField)
      << std::endl;
-  os << indent << "Gaussian variance for the update field = " << this->m_GaussianSmoothingVarianceForTheUpdateField
+  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
      << std::endl;
 }
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -246,11 +246,13 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Gaussian smoothing parameters: " << std::endl
-     << indent << "m_GaussianSmoothingVarianceForTheUpdateField: " << this->m_GaussianSmoothingVarianceForTheUpdateField
-     << std::endl
-     << indent << "m_GaussianSmoothingVarianceForTheTotalField: " << this->m_GaussianSmoothingVarianceForTheTotalField
+  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
      << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheTotalField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalField)
+     << std::endl;
+  os << indent << "GaussianSmoothingOperator: " << m_GaussianSmoothingOperator << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -197,9 +197,12 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std:
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "DistanceMap: " << m_DistanceMap << std::endl;
-  os << indent << "MaxDistance: " << m_MaxDistance << std::endl;
-  os << indent << "PixelCount:" << m_PixelCount << std::endl;
+  itkPrintSelfObjectMacro(DistanceMap);
+
+  os << indent << "MaxDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MaxDistance)
+     << std::endl;
+  os << indent << "PixelCount: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(m_PixelCount)
+     << std::endl;
   os << indent << "Sum: " << m_Sum.GetSum();
 
   os << std::endl;
@@ -207,7 +210,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std:
      << static_cast<typename NumericTraits<RealType>::PrintType>(m_DirectedHausdorffDistance) << std::endl;
   os << indent << "AverageHausdorffDistance: "
      << static_cast<typename NumericTraits<RealType>::PrintType>(m_AverageHausdorffDistance) << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -44,14 +44,18 @@ void
 FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Target points: " << m_TargetPoints.GetPointer() << std::endl;
-  os << indent << "Reached points: " << m_ReachedTargetPoints.GetPointer() << std::endl;
-  os << indent << "Gradient image: " << m_GradientImage.GetPointer() << std::endl;
-  os << indent << "Generate gradient image: " << m_GenerateGradientImage << std::endl;
-  os << indent << "Number of targets: " << m_NumberOfTargets << std::endl;
-  os << indent << "Target offset: " << m_TargetOffset << std::endl;
-  os << indent << "Target reach mode: " << m_TargetReachedMode << std::endl;
-  os << indent << "Target value: " << m_TargetValue << std::endl;
+
+  itkPrintSelfObjectMacro(TargetPoints);
+  itkPrintSelfObjectMacro(ReachedTargetPoints);
+  itkPrintSelfObjectMacro(GradientImage);
+
+  os << indent << "GenerateGradientImage: " << (m_GenerateGradientImage ? "On" : "Off") << std::endl;
+  os << indent << "TargetOffset: " << m_TargetOffset << std::endl;
+  os << indent << "TargetReachedMode: " << m_TargetReachedMode << std::endl;
+  os << indent << "TargetValue: " << m_TargetValue << std::endl;
+  os << indent
+     << "NumberOfTargets: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTargets)
+     << std::endl;
 }
 
 template <typename TLevelSet, typename TSpeedImage>

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageScanlineIterator.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -27,11 +28,19 @@ template <typename TInputImage, typename TOutputImage>
 void
 STAPLEImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_MaximumIterations = " << m_MaximumIterations << std::endl;
-  os << indent << "m_ForegroundValue = " << m_ForegroundValue << std::endl;
-  os << indent << "m_ConfidenceWeight = " << m_ConfidenceWeight << std::endl;
-  os << indent << "m_ElapsedIterations = " << m_ElapsedIterations << std::endl;
+
+  os << indent
+     << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
+     << std::endl;
+  os << indent << "ElapsedIterations: " << m_ElapsedIterations << std::endl;
+  os << indent << "MaximumIterations: " << m_MaximumIterations << std::endl;
+  os << indent << "ConfidenceWeight: " << m_ConfidenceWeight << std::endl;
+
+  os << indent << "Sensitivity: " << m_Sensitivity << std::endl;
+  os << indent << "Specificity: " << m_Specificity << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
@@ -29,7 +29,8 @@ void
 LaplacianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing = " << m_UseImageSpacing << std::endl;
+
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -31,7 +31,8 @@ void
 LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing = " << m_UseImageSpacing << std::endl;
+
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkNumericTraits.h"
 #include "itkImageRegionIterator.h"
 #include "itkCompensatedSummation.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -43,26 +44,16 @@ template <typename TImage, typename TMask, typename TFeatures>
 void
 MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "m_NonConnectivity: ";
-  switch (m_NonConnectivity)
-  {
-    case 0:
-      os << "VERTEX_CONNECTIVITY";
-      break;
-    case 1:
-      os << "EDGE_CONNECTIVITY";
-      break;
-    case 2:
-      os << "FACE_CONNECTIVITY";
-      break;
-    default:
-      os << static_cast<unsigned int>(m_NonConnectivity);
-  }
-  os << std::endl
-     << indent << "m_BlockRadius: " << m_BlockRadius << std::endl
-     << indent << "m_ComputeStructureTensors: " << (m_ComputeStructureTensors ? "yes" : "no") << std::endl
-     << indent << "m_SelectFraction: " << m_SelectFraction << std::endl;
+
+  os << indent << "NonConnectivity: " << m_NonConnectivity << std::endl;
+  os << indent << "NonConnectivityOffsets: " << m_NonConnectivityOffsets << std::endl;
+  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BlockRadius)
+     << std::endl;
+  os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
+  os << indent << "ComputeStructureTensors: " << (m_ComputeStructureTensors ? "On" : "Off") << std::endl;
 }
 
 template <typename TImage, typename TMask, typename TFeatures>

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -221,9 +221,18 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (this->m_UseImageSpacing ? "On" : "Off") << std::endl;
-  os << indent << "UseImageDirection = " << (this->m_UseImageDirection ? "On" : "Off") << std::endl;
-  os << indent << "BoundaryCondition = \n" << this->m_BoundaryCondition << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+
+  os << indent << "BoundaryCondition: ";
+  if (m_BoundaryCondition != nullptr)
+  {
+    os << m_BoundaryCondition << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -41,7 +41,8 @@ void
 GradientMagnitudeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing = " << m_UseImageSpacing << std::endl;
+
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -70,8 +70,18 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintS
                                                                                     Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
-  os << indent << "Sigma: " << m_DerivativeFilter->GetSigma() << std::endl;
+
+  os << indent << "SmoothingFilters: ";
+  for (const auto & elem : m_SmoothingFilters)
+  {
+    os << indent.GetNextIndent() << elem << std::endl;
+  }
+
+  itkPrintSelfObjectMacro(DerivativeFilter);
+  itkPrintSelfObjectMacro(SqrSpacingFilter);
+  itkPrintSelfObjectMacro(SqrtFilter);
+
+  os << indent << "NormalizeAcrossScale: " << (m_NormalizeAcrossScale ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -325,9 +326,17 @@ template <typename TInputImage, typename TOutputImage>
 void
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
-  os << indent << "UseImageDirection :   " << (this->m_UseImageDirection ? "On" : "Off") << std::endl;
+
+  os << indent << "SmoothingFilters: " << m_SmoothingFilters << std::endl;
+
+  itkPrintSelfObjectMacro(DerivativeFilter);
+  itkPrintSelfObjectMacro(ImageAdaptor);
+
+  os << indent << "NormalizeAcrossScale: " << (m_NormalizeAcrossScale ? "On" : "Off") << std::endl;
+  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
   os << indent << "Sigma: " << m_Sigma << std::endl;
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -28,6 +28,8 @@
 #ifndef itkBSplineResampleImageFilterBase_hxx
 #define itkBSplineResampleImageFilterBase_hxx
 
+#include "itkPrintHelper.h"
+
 
 namespace itk
 {
@@ -45,8 +47,18 @@ template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Spline Order: " << m_SplineOrder << std::endl;
+
+  os << indent << "SplineOrder: " << m_SplineOrder << std::endl;
+  os << indent << "GSize: " << m_GSize << std::endl;
+  os << indent << "HSize: " << m_HSize << std::endl;
+
+  os << indent << "G: " << m_G << std::endl;
+  os << indent << "H: " << m_H << std::endl;
+
+  os << indent << "Scratch: " << m_Scratch << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -180,47 +180,28 @@ ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
 {
   Superclass::PrintSelf(os, indent);
 
+  itkPrintSelfObjectMacro(ReferenceImage);
+
   os << indent << "CenterImage: " << (m_CenterImage ? "On" : "Off") << std::endl;
   os << indent << "ChangeSpacing: " << (m_ChangeSpacing ? "On" : "Off") << std::endl;
   os << indent << "ChangeOrigin: " << (m_ChangeOrigin ? "On" : "Off") << std::endl;
   os << indent << "ChangeDirection: " << (m_ChangeDirection ? "On" : "Off") << std::endl;
   os << indent << "ChangeRegion: " << (m_ChangeRegion ? "On" : "Off") << std::endl;
   os << indent << "UseReferenceImage: " << (m_UseReferenceImage ? "On" : "Off") << std::endl;
-  if (m_ReferenceImage)
-  {
-    os << indent << "ReferenceImage: " << m_ReferenceImage.GetPointer() << std::endl;
-  }
-  else
-  {
-    os << indent << "ReferenceImage: 0" << std::endl;
-  }
-  os << indent << "OutputSpacing: [";
-  if (ImageDimension >= 1)
-  {
-    os << m_OutputSpacing[0];
-  }
-  for (unsigned int j = 1; j < ImageDimension; ++j)
-  {
-    os << ", " << m_OutputSpacing[j];
-  }
-  os << ']' << std::endl;
 
-  os << indent << "OutputOrigin: [";
-  if (ImageDimension >= 1)
-  {
-    os << m_OutputOrigin[0];
-  }
-  for (unsigned int j = 1; j < ImageDimension; ++j)
-  {
-    os << ", " << m_OutputOrigin[j];
-  }
-  os << ']' << std::endl;
+  os << indent << "OutputSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_OutputSpacing)
+     << std::endl;
+  os << indent << "OutputOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_OutputOrigin)
+     << std::endl;
+  os << indent
+     << "OutputDirection: " << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_OutputDirection)
+     << std::endl;
 
-  os << indent << "OutputDirection:" << std::endl;
-  os << m_OutputDirection << std::endl;
-
-  os << indent << "OutputOffset: [";
-  os << m_OutputOffset << std::endl;
+  os << indent
+     << "OutputOffset: " << static_cast<typename NumericTraits<OutputImageOffsetType>::PrintType>(m_OutputOffset)
+     << std::endl;
+  os << indent << "Shift: " << static_cast<typename NumericTraits<OutputImageOffsetType>::PrintType>(m_Shift)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -224,8 +224,8 @@ void
 CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Spline Order: " << this->m_SplineOrder << std::endl;
-  os << indent << "Piecewise Polynomial Pieces: " << std::endl;
+
+  os << indent << "BSplineShapeFunctions: " << std::endl;
 
   TRealValueType a{ 0.0 };
   TRealValueType b{ 0.0 };
@@ -255,6 +255,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PrintSelf(std::ost
 
     os << ",  X \\in [" << a << ", " << b << ']' << std::endl;
   }
+
+  os << indent << "SplineOrder: " << m_SplineOrder << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -306,12 +306,11 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::PrintSelf(std::ostrea
 {
   Superclass::PrintSelf(os, indent);
 
-
-  os << indent << "DestinationIndex: " << m_DestinationIndex << std::endl;
+  os << indent << "SourceRegion: " << m_SourceRegion << std::endl;
+  os << indent
+     << "DestinationIndex: " << static_cast<typename NumericTraits<InputImageIndexType>::PrintType>(m_DestinationIndex)
+     << std::endl;
   os << indent << "DestinationSkipAxes: " << m_DestinationSkipAxes << std::endl;
-  os << indent << "PresumedDestinationSize: " << this->GetPresumedDestinationSize() << std::endl;
-  os << indent << "SourceRegion:" << std::endl;
-  m_SourceRegion.Print(os, indent.GetNextIndent());
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -19,6 +19,7 @@
 #define itkImagePCADecompositionCalculator_hxx
 
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -141,10 +142,24 @@ template <typename TInputImage, typename TBasisImage>
 void
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
+
   os << indent << "Projection: " << m_Projection << std::endl;
-  os << indent << "Image: " << m_Image.GetPointer() << std::endl;
-  os << indent << "Mean Image: " << m_MeanImage.GetPointer() << std::endl;
+  os << indent << "ImageAsVector: " << m_ImageAsVector << std::endl;
+  os << indent << "BasisImages: " << m_BasisImages << std::endl;
+
+  itkPrintSelfObjectMacro(MeanImage);
+
+  os << indent << "m_Size: " << static_cast<typename NumericTraits<BasisSizeType>::PrintType>(m_Size) << std::endl;
+
+  itkPrintSelfObjectMacro(Image);
+
+  os << indent << "BasisMatrix: " << m_BasisMatrix << std::endl;
+  os << indent << "BasisMatrixCalculated: " << (m_BasisMatrixCalculated ? "On" : "Off") << std::endl;
+  os << indent << "NumPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumPixels)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -743,26 +743,33 @@ protected:
   {
     Superclass::PrintSelf(os, indent);
 
-    os << indent << "NumberOfPixels: " << m_NumberOfPixels << std::endl;
+    os << indent << "BoundingBox: " << m_BoundingBox << std::endl;
+    os << indent
+       << "NumberOfPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
+       << std::endl;
     os << indent << "PhysicalSize: " << m_PhysicalSize << std::endl;
-    os << indent << "Perimeter: " << m_Perimeter << std::endl;
-    os << indent << "NumberOfPixelsOnBorder: " << m_NumberOfPixelsOnBorder << std::endl;
+    os << indent << "Centroid: " << static_cast<typename NumericTraits<CentroidType>::PrintType>(m_Centroid)
+       << std::endl;
+    os << indent << "NumberOfPixelsOnBorder: "
+       << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsOnBorder) << std::endl;
     os << indent << "PerimeterOnBorder: " << m_PerimeterOnBorder << std::endl;
-    os << indent << "PerimeterOnBorderRatio: " << m_PerimeterOnBorderRatio << std::endl;
+    os << indent << "FeretDiameter: " << m_FeretDiameter << std::endl;
+    os << indent << "PrincipalMoments: " << m_PrincipalMoments << std::endl;
+    os << indent << "PrincipalAxes: " << std::endl << m_PrincipalAxes;
     os << indent << "Elongation: " << m_Elongation << std::endl;
-    os << indent << "Flatness: " << m_Flatness << std::endl;
+    os << indent << "Perimeter: " << m_Perimeter << std::endl;
     os << indent << "Roundness: " << m_Roundness << std::endl;
-    os << indent << "Centroid: " << m_Centroid << std::endl;
-    os << indent << "BoundingBox: ";
-    m_BoundingBox.Print(os, indent);
     os << indent << "EquivalentSphericalRadius: " << m_EquivalentSphericalRadius << std::endl;
     os << indent << "EquivalentSphericalPerimeter: " << m_EquivalentSphericalPerimeter << std::endl;
     os << indent << "EquivalentEllipsoidDiameter: " << m_EquivalentEllipsoidDiameter << std::endl;
-    os << indent << "PrincipalMoments: " << m_PrincipalMoments << std::endl;
-    os << indent << "PrincipalAxes: " << std::endl << m_PrincipalAxes;
-    os << indent << "FeretDiameter: " << m_FeretDiameter << std::endl;
-    os << indent << "m_OrientedBoundingBoxSize: " << m_OrientedBoundingBoxSize << std::endl;
-    os << indent << "m_OrientedBoundingBoxOrigin: " << m_OrientedBoundingBoxOrigin << std::endl;
+    os << indent << "Flatness: " << m_Flatness << std::endl;
+    os << indent << "PerimeterOnBorderRatio: " << m_PerimeterOnBorderRatio << std::endl;
+    os << indent << "OrientedBoundingBoxSize: "
+       << static_cast<typename NumericTraits<OrientedBoundingBoxSizeType>::PrintType>(m_OrientedBoundingBoxSize)
+       << std::endl;
+    os << indent << "OrientedBoundingBoxOrigin: "
+       << static_cast<typename NumericTraits<OrientedBoundingBoxPointType>::PrintType>(m_OrientedBoundingBoxOrigin)
+       << std::endl;
   }
 
 private:

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1163,14 +1163,16 @@ void
 FlatStructuringElement<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  if (m_Decomposable)
+
+  os << indent << "Decomposable: " << (m_Decomposable ? "On" : "Off") << std::endl;
+
+  os << "Lines: " << std::endl;
+  for (unsigned int i = 0; i < m_Lines.size(); ++i)
   {
-    os << indent << "SE decomposition:" << std::endl;
-    for (unsigned int i = 0; i < m_Lines.size(); ++i)
-    {
-      os << indent << m_Lines[i] << std::endl;
-    }
+    os << indent << m_Lines[i] << std::endl;
   }
+
+  os << indent << "RadiusIsParametric: " << (m_RadiusIsParametric ? "On" : "Off") << std::endl;
 }
 
 template <unsigned int VDimension>

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -381,9 +381,9 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Run one iteration: " << (m_RunOneIteration ? "on" : "off") << std::endl;
-  os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "RunOneIteration: " << (m_RunOneIteration ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -379,9 +379,9 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Run one iteration: " << (m_RunOneIteration ? "on" : "off") << std::endl;
-  os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "RunOneIteration: " << (m_RunOneIteration ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -19,6 +19,7 @@
 #define itkChainCodePath_hxx
 
 #include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -94,8 +95,12 @@ template <unsigned int VDimension>
 void
 ChainCodePath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Start index:  " << m_Start << std::endl;
+
+  os << indent << "Start: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_Start) << std::endl;
+  os << indent << "Chain: " << m_Chain << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
@@ -99,8 +99,9 @@ void
 FourierSeriesPath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Cos Coefficients:  " << m_CosCoefficients << std::endl;
-  os << indent << "Sin Coefficients:  " << m_SinCoefficients << std::endl;
+
+  itkPrintSelfObjectMacro(CosCoefficients);
+  itkPrintSelfObjectMacro(SinCoefficients);
 }
 } // namespace itk
 

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -18,6 +18,8 @@
 #ifndef itkHilbertPath_hxx
 #define itkHilbertPath_hxx
 
+#include "itkPrintHelper.h"
+
 
 namespace itk
 {
@@ -242,9 +244,13 @@ template <typename TIndexValue, unsigned int VDimension>
 void
 HilbertPath<TIndexValue, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  std::cout << "Hilbert order: " << this->m_HilbertOrder << std::endl;
+  os << "HilbertOrder: " << static_cast<typename NumericTraits<HilbertOrderType>::PrintType>(m_HilbertOrder)
+     << std::endl;
+  os << "HilbertPath: " << m_HilbertPath << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -166,10 +166,40 @@ void
 OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "StepValues:  " << m_StepValues.get() << std::endl;
-  os << indent << "MeritValues:  " << m_MeritValues.get() << std::endl;
-  os << indent << "OptimumStepsValues:  " << m_OptimumStepsValues.get() << std::endl;
-  os << indent << "FinalOffsetValues:  " << m_FinalOffsetValues << std::endl;
+
+  os << indent << "StepValues: ";
+  if (m_StepValues.get() != nullptr)
+  {
+    os << *m_StepValues.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "MeritValues: ";
+  if (m_MeritValues.get() != nullptr)
+  {
+    os << *m_MeritValues.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "OptimumStepsValues: ";
+  if (m_OptimumStepsValues.get() != nullptr)
+  {
+    os << *m_OptimumStepsValues.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  itkPrintSelfObjectMacro(FinalOffsetValues);
+
+  os << indent << "SwathSize: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_SwathSize) << std::endl;
 }
 
 // The next three functions are private helper functions

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -135,7 +135,10 @@ void
 ParametricPath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DefaultInputSize: " << m_DefaultInputStepSize << std::endl;
+
+  os << indent
+     << "DefaultInputStepSize: " << static_cast<typename NumericTraits<InputType>::PrintType>(m_DefaultInputStepSize)
+     << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -285,9 +285,13 @@ void
 PathToImageFilter<TInputPath, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Size : " << m_Size << std::endl;
-  os << indent << "Path Value : " << m_PathValue << std::endl;
-  os << indent << "Background Value : " << m_BackgroundValue << std::endl;
+
+  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  os << indent << "Spacing: " << m_Spacing << std::endl;
+  os << indent << "Origin: " << m_Origin << std::endl;
+  os << indent << "PathValue : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_PathValue) << std::endl;
+  os << indent << "BackgroundValue : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_BackgroundValue)
+     << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1607,34 +1607,45 @@ void
 GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Internal Component Type: " << this->GetComponentTypeAsString(m_InternalComponentType) << std::endl;
+
   os << indent << "RescaleSlope: " << m_RescaleSlope << std::endl;
   os << indent << "RescaleIntercept: " << m_RescaleIntercept << std::endl;
-  os << indent << "KeepOriginalUID:" << (m_KeepOriginalUID ? "On" : "Off") << std::endl;
-  os << indent << "LoadPrivateTags:" << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
   os << indent << "UIDPrefix: " << m_UIDPrefix << std::endl;
   os << indent << "StudyInstanceUID: " << m_StudyInstanceUID << std::endl;
   os << indent << "SeriesInstanceUID: " << m_SeriesInstanceUID << std::endl;
   os << indent << "FrameOfReferenceInstanceUID: " << m_FrameOfReferenceInstanceUID << std::endl;
-  os << indent << "CompressionType:" << m_CompressionType << std::endl;
+  os << indent << "KeepOriginalUID: " << (m_KeepOriginalUID ? "On" : "Off") << std::endl;
+  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
+  os << indent << "ReadYBRtoRGB: " << (m_ReadYBRtoRGB ? "On" : "Off") << std::endl;
+
+  os << indent << "GlobalNumberOfDimensions: " << m_GlobalNumberOfDimensions << std::endl;
+  os << indent << "CompressionType: " << m_CompressionType << std::endl;
+  os << indent << "SingleBit: " << (m_SingleBit ? "On" : "Off") << std::endl;
+  os << indent << "InternalComponentType: " << m_InternalComponentType << std::endl;
+
+  os << indent << "DICOMHeader: ";
+  if (m_DICOMHeader != nullptr)
+  {
+    os << m_DICOMHeader << std::endl;
+  }
 
 #if defined(ITKIO_DEPRECATED_GDCM1_API)
-  os << indent << "Patient Name:" << m_PatientName << std::endl;
-  os << indent << "Patient ID:" << m_PatientID << std::endl;
-  os << indent << "Patient Sex:" << m_PatientSex << std::endl;
-  os << indent << "Patient Age:" << m_PatientAge << std::endl;
-  os << indent << "Study ID:" << m_StudyID << std::endl;
-  os << indent << "Patient DOB:" << m_PatientDOB << std::endl;
-  os << indent << "Study Description:" << m_StudyDescription << std::endl;
-  os << indent << "Body Part:" << m_BodyPart << std::endl;
-  os << indent << "Number Of Series In Study:" << m_NumberOfSeriesInStudy << std::endl;
-  os << indent << "Number Of Study Related Series:" << m_NumberOfStudyRelatedSeries << std::endl;
-  os << indent << "Study Date:" << m_StudyDate << std::endl;
-  os << indent << "Modality:" << m_Modality << std::endl;
-  os << indent << "Manufacturer:" << m_Manufacturer << std::endl;
-  os << indent << "Institution Name:" << m_Institution << std::endl;
-  os << indent << "Model:" << m_Model << std::endl;
-  os << indent << "Scan Options:" << m_ScanOptions << std::endl;
+  os << indent << "PatientName: " << m_PatientName << std::endl;
+  os << indent << "PatientID: " << m_PatientID << std::endl;
+  os << indent << "PatientSex: " << m_PatientSex << std::endl;
+  os << indent << "PatientAge: " << m_PatientAge << std::endl;
+  os << indent << "StudyID: " << m_StudyID << std::endl;
+  os << indent << "PatientDOB: " << m_PatientDOB << std::endl;
+  os << indent << "StudyDescription: " << m_StudyDescription << std::endl;
+  os << indent << "BodyPart: " << m_BodyPart << std::endl;
+  os << indent << "NumberOfSeriesInStudy: " << m_NumberOfSeriesInStudy << std::endl;
+  os << indent << "NumberOfStudyRelatedSeries: " << m_NumberOfStudyRelatedSeries << std::endl;
+  os << indent << "StudyDate: " << m_StudyDate << std::endl;
+  os << indent << "Modality: " << m_Modality << std::endl;
+  os << indent << "Manufacturer: " << m_Manufacturer << std::endl;
+  os << indent << "InstitutionName: " << m_Institution << std::endl;
+  os << indent << "Model: " << m_Model << std::endl;
+  os << indent << "ScanOptions: " << m_ScanOptions << std::endl;
 #endif
 }
 

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -19,6 +19,7 @@
 #include "itkGDCMSeriesFileNames.h"
 #include "itksys/SystemTools.hxx"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 #include "gdcmSerieHelper.h"
 
 namespace itk
@@ -264,31 +265,32 @@ GDCMSeriesFileNames::GetOutputFileNames()
 void
 GDCMSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  unsigned int i;
   os << indent << "InputDirectory: " << m_InputDirectory << std::endl;
-  os << indent << "LoadSequences:" << m_LoadSequences << std::endl;
-  os << indent << "LoadPrivateTags:" << m_LoadPrivateTags << std::endl;
-  if (m_Recursive)
+  os << indent << "OutputDirectory: " << m_OutputDirectory << std::endl;
+
+  os << indent << "InputFileNames: " << m_InputFileNames << std::endl;
+  os << indent << "OutputFileNames: " << m_OutputFileNames << std::endl;
+
+  os << indent << "SerieHelper: ";
+  if (m_SerieHelper.get() != nullptr)
   {
-    os << indent << "Recursive: True" << std::endl;
+    os << m_SerieHelper.get() << std::endl;
   }
   else
   {
-    os << indent << "Recursive: False" << std::endl;
+    os << "(null)" << std::endl;
   }
 
-  for (i = 0; i < m_InputFileNames.size(); ++i)
-  {
-    os << indent << "InputFileNames[" << i << "]: " << m_InputFileNames[i] << std::endl;
-  }
+  os << indent << "SeriesUIDs: " << m_SeriesUIDs << std::endl;
 
-  os << indent << "OutputDirectory: " << m_OutputDirectory << std::endl;
-  for (i = 0; i < m_OutputFileNames.size(); ++i)
-  {
-    os << indent << "OutputFileNames[" << i << "]: " << m_OutputFileNames[i] << std::endl;
-  }
+  os << indent << "UseSeriesDetails: " << (m_UseSeriesDetails ? "On" : "Off") << std::endl;
+  os << indent << "Recursive: " << (m_Recursive ? "On" : "Off") << std::endl;
+  os << indent << "LoadSequences: " << (m_LoadSequences ? "On" : "Off") << std::endl;
+  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
 }
 
 void

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -48,8 +48,11 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::PrintSelf(std::ostream & os, 
 
   itkPrintSelfObjectMacro(ImageIO);
 
-  os << indent << "UserSpecifiedImageIO flag: " << m_UserSpecifiedImageIO << '\n';
-  os << indent << "m_UseStreaming: " << m_UseStreaming << '\n';
+  os << indent << "UserSpecifiedImageIO: " << (m_UserSpecifiedImageIO ? "On" : "Off") << std::endl;
+  os << indent << "UseStreaming: " << (m_UseStreaming ? "On" : "Off") << std::endl;
+
+  os << indent << "ExceptionMessage: " << m_ExceptionMessage << std::endl;
+  os << indent << "ActualIORegion: " << m_ActualIORegion << std::endl;
 }
 
 template <typename TOutputImage, typename ConvertPixelTraits>

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -472,15 +472,15 @@ NiftiImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NiftiImageHolder: " << *(this->m_NiftiImageHolder).get() << std::endl;
-  os << indent << "NiftiImage: " << this->m_NiftiImage << std::endl;
-  os << indent << "RescaleSlope: " << this->m_RescaleSlope << std::endl;
-  os << indent << "RescaleIntercept: " << this->m_RescaleIntercept << std::endl;
-  os << indent << "OnDiskComponentType: " << this->m_OnDiskComponentType << std::endl;
-  os << indent << "LegacyAnalyze75Mode: " << this->m_LegacyAnalyze75Mode << std::endl;
-  os << indent << "ConvertRASVectors: " << m_ConvertRASVectors << std::endl;
-  os << indent << "ConvertRASDisplacementVectors: " << m_ConvertRASDisplacementVectors << std::endl;
-  os << indent << "ConvertRAS: " << m_ConvertRAS << std::endl;
+  os << indent << "NiftiImageHolder: " << *(m_NiftiImageHolder).get() << std::endl;
+  os << indent << "NiftiImage: " << m_NiftiImage << std::endl;
+  os << indent << "RescaleSlope: " << m_RescaleSlope << std::endl;
+  os << indent << "RescaleIntercept: " << m_RescaleIntercept << std::endl;
+  os << indent << "ConvertRAS: " << (m_ConvertRAS ? "On" : "Off") << std::endl;
+  os << indent << "ConvertRASVectors: " << (m_ConvertRASVectors ? "On" : "Off") << std::endl;
+  os << indent << "ConvertRASDisplacementVectors: " << (m_ConvertRASDisplacementVectors ? "On" : "Off") << std::endl;
+  os << indent << "OnDiskComponentType: " << m_OnDiskComponentType << std::endl;
+  os << indent << "LegacyAnalyze75Mode: " << m_LegacyAnalyze75Mode << std::endl;
 }
 
 bool

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
@@ -41,11 +41,13 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
                                                                                            Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Spline Order: " << m_SplineOrder << std::endl;
-  os << indent << "Real Interpolator: " << m_RealInterpolator << std::endl;
-  os << indent << "Imaginary Interpolator: " << m_ImaginaryInterpolator << std::endl;
-  os << indent << "Complex to Real Filter: " << m_RealFilter << std::endl;
-  os << indent << "Complex to Imaginary Filter: " << m_ImaginaryFilter << std::endl;
+
+  os << indent << "SplineOrder: " << m_SplineOrder << std::endl;
+
+  itkPrintSelfObjectMacro(RealInterpolator);
+  itkPrintSelfObjectMacro(ImaginaryInterpolator);
+  itkPrintSelfObjectMacro(RealFilter);
+  itkPrintSelfObjectMacro(ImaginaryFilter);
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -148,7 +148,7 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::PrintSelf(std::ost
      << std::endl;
   os << indent << "ForegroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ForegroundValue)
      << std::endl;
-  os << indent << "m_GridPixSpacing: " << m_GridPixSpacing << std::endl;
+  os << indent << "GridPixSpacing: " << m_GridPixSpacing << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -29,7 +29,7 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_ReinitializeCounter: " << m_ReinitializeCounter << std::endl;
+  os << indent << "ReinitializeCounter: " << m_ReinitializeCounter << std::endl;
 }
 
 template <typename TInputImage, typename TFeatureImage, typename TOutputImage, typename TFunction, typename TIdCell>

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1409,7 +1409,40 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
      << std::endl;
   os << indent << "StatusNull: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusNull)
      << std::endl;
-  os << indent << "SparseData: " << m_SparseData << std::endl;
+
+  os << indent << "SparseData: ";
+  for (IdCellType i = 0; i < m_FunctionCount; ++i)
+  {
+    SparseDataStruct * sparsePtr = this->m_SparseData[i];
+
+    os << indent.GetNextIndent() << "Layers: " << sparsePtr->m_Layers << std::endl;
+
+    os << indent.GetNextIndent() << "StatusImage: ";
+    if (sparsePtr->m_StatusImage != nullptr)
+    {
+      os << sparsePtr->m_StatusImage << std::endl;
+    }
+    else
+    {
+      os << "(null)" << std::endl;
+    }
+
+    os << indent.GetNextIndent() << "LayerNodeStore: ";
+    if (sparsePtr->m_LayerNodeStore != nullptr)
+    {
+      os << sparsePtr->m_LayerNodeStore << std::endl;
+    }
+    else
+    {
+      os << "(null)" << std::endl;
+    }
+
+    os << indent.GetNextIndent() << "UpdateBuffer: " << sparsePtr->m_UpdateBuffer << std::endl;
+
+    os << indent.GetNextIndent() << "Index: " << static_cast <
+      typename NumericTraits<IdCellType>::PrintType(sparsePtr->m_Index) << std::endl;
+  }
+
   os << indent << "NumberOfLayers: " << m_NumberOfLayers << std::endl;
   os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
      << std::endl;
@@ -1420,21 +1453,6 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   os << indent << "RMSSum: " << m_RMSSum << std::endl;
   os << indent << "RMSCounter: " << m_RMSCounter << std::endl;
   os << indent << "BoundsCheckingActive: " << m_BoundsCheckingActive << std::endl;
-
-  for (IdCellType i = 0; i < this->m_FunctionCount; ++i)
-  {
-    SparseDataStruct * sparsePtr = this->m_SparseData[i];
-    os << indent << "m_LayerNodeStore: " << std::endl;
-    sparsePtr->m_LayerNodeStore->Print(os, indent.GetNextIndent());
-    for (i = 0; i < sparsePtr->m_Layers.size(); ++i)
-    {
-      os << indent << "m_Layers[" << i << "]: size=" << sparsePtr->m_Layers[i]->Size() << std::endl;
-      os << indent << sparsePtr->m_Layers[i];
-    }
-
-    os << indent << "m_UpdateBuffer: size=" << static_cast<InputSizeValueType>(sparsePtr->m_UpdateBuffer.size())
-       << " capacity = " << static_cast<InputSizeValueType>(sparsePtr->m_UpdateBuffer.capacity()) << std::endl;
-  }
 }
 } // end namespace itk
 

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -295,10 +295,12 @@ void
 ImageToRectilinearFEMObjectFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Number of Elements: " << m_NumberOfElements << std::endl;
-  os << indent << "Pixels Per Element: " << m_PixelsPerElement << std::endl;
-  os << indent << "Material: " << m_Material << std::endl;
-  os << indent << "Element: " << m_Element << std::endl;
+
+  os << indent << "NumberOfElements: " << m_NumberOfElements << std::endl;
+  os << indent << "PixelsPerElement: " << m_PixelsPerElement << std::endl;
+
+  itkPrintSelfObject(Material);
+  itkPrintSelfObjectMacro(Element);
 }
 
 } // end namespace fem

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -207,6 +207,31 @@ void
 CumulativeGaussianCostFunction::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Range Dimension = " << m_RangeDimension << std::endl;
+
+  os << indent << "OriginalDataArray: ";
+  if (m_OriginalDataArray != nullptr)
+  {
+    os << *m_OriginalDataArray << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "RangeDimension: " << m_RangeDimension << std::endl;
+
+  os << indent << "Measure: " << m_Measure << std::endl;
+
+  os << indent << "MeasurePointer: ";
+  if (m_MeasurePointer != nullptr)
+  {
+    os << *m_MeasurePointer << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "Parameters: " << m_Parameters << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -385,26 +385,30 @@ CumulativeGaussianOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Difference Tolerance = " << m_DifferenceTolerance << std::endl;
-  os << indent << "Computed Mean = " << m_ComputedMean << std::endl;
-  os << indent << "Computed Standard Deviation = " << m_ComputedStandardDeviation << std::endl;
-  os << indent << "Computed Amplitude = " << m_ComputedAmplitude << std::endl;
-  os << indent << "Computed Transition Height = " << m_ComputedTransitionHeight << std::endl;
+  os << indent << "DifferenceTolerance: " << m_DifferenceTolerance << std::endl;
+  os << indent << "ComputedMean: " << m_ComputedMean << std::endl;
+  os << indent << "ComputedStandardDeviation: " << m_ComputedStandardDeviation << std::endl;
+  os << indent << "ComputedAmplitude: " << m_ComputedAmplitude << std::endl;
+  os << indent << "ComputedTransitionHeight: " << m_ComputedTransitionHeight << std::endl;
 
-  os << indent << "Upper Asymptote = " << m_UpperAsymptote << std::endl;
-  os << indent << "Lower Asymptote = " << m_LowerAsymptote << std::endl;
-  os << indent << "Offset For Mean = " << m_OffsetForMean << std::endl;
-  os << indent << "Verbose = " << m_Verbose << std::endl;
-  os << indent << "Fit Error = " << m_FitError << std::endl;
+  os << indent << "UpperAsymptote: " << m_UpperAsymptote << std::endl;
+  os << indent << "LowerAsymptote: " << m_LowerAsymptote << std::endl;
+  os << indent << "OffsetForMean: " << m_OffsetForMean << std::endl;
+  os << indent << "Verbose: " << (m_Verbose ? "On" : "Off") << std::endl;
+  os << indent << "FitError: " << m_FitError << std::endl;
+
+  os << indent << "FinalSampledArray: ";
+  if (m_FinalSampledArray != nullptr)
+  {
+    os << *m_FinalSampledArray << std::endl;
+  }
+
+  os << indent << "CumulativeGaussianArray: ";
+  if (m_CumulativeGaussianArray != nullptr)
+  {
+    os << *m_CumulativeGaussianArray << std::endl;
+  }
 
   os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
-  if (m_FinalSampledArray)
-  {
-    os << indent << "Final Sampled Array = " << m_FinalSampledArray << std::endl;
-  }
-  else
-  {
-    os << indent << "Final Sampled Array = [not defined] " << std::endl;
-  }
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -204,17 +204,28 @@ ExhaustiveOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CurrentValue = " << m_CurrentValue << std::endl;
-  os << indent << "NumberOfSteps = " << m_NumberOfSteps << std::endl;
-  os << indent << "CurrentIteration = " << m_CurrentIteration << std::endl;
-  os << indent << "Stop = " << m_Stop << std::endl;
-  os << indent << "CurrentParameter = " << m_CurrentParameter << std::endl;
-  os << indent << "StepLength = " << m_StepLength << std::endl;
-  os << indent << "CurrentIndex = " << m_CurrentIndex << std::endl;
-  os << indent << "MaximumNumberOfIterations = " << m_MaximumNumberOfIterations << std::endl;
-  os << indent << "MaximumMetricValue = " << m_MaximumMetricValue << std::endl;
-  os << indent << "MinimumMetricValue = " << m_MinimumMetricValue << std::endl;
-  os << indent << "MinimumMetricValuePosition = " << m_MinimumMetricValuePosition << std::endl;
-  os << indent << "MaximumMetricValuePosition = " << m_MaximumMetricValuePosition << std::endl;
+  os << indent << "CurrentValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentValue)
+     << std::endl;
+  os << indent << "NumberOfSteps: " << static_cast<typename NumericTraits<StepsType>::PrintType>(m_NumberOfSteps)
+     << std::endl;
+  os << indent
+     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+     << std::endl;
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "CurrentParameter: " << m_CurrentParameter << std::endl;
+  os << indent << "StepLength: " << m_StepLength << std::endl;
+  os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
+  os << indent << "MaximumNumberOfIterations: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
+  os << indent
+     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
+     << std::endl;
+  os << indent
+     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
+     << std::endl;
+  os << indent << "MinimumMetricValuePosition: " << m_MinimumMetricValuePosition << std::endl;
+  os << indent << "MaximumMetricValuePosition: " << m_MaximumMetricValuePosition << std::endl;
+
+  os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -216,9 +216,9 @@ void
 FRPROptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Optimization Type = " << m_OptimizationType << std::endl;
-  os << indent << "0=FletchReeves, 1=PolakRibiere" << std::endl;
-  os << indent << "Use unit length gradient = " << m_UseUnitLengthGradient << std::endl;
+
+  os << indent << "OptimizationType: " << m_OptimizationType << std::endl;
+  os << indent << "UseUnitLengthGradient: " << (m_UseUnitLengthGradient ? "On" : "Off") << std::endl;
 }
 
 std::ostream &

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -54,33 +54,35 @@ SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "a: " << m_Sa << std::endl;
-  os << indent << "A: " << m_A << std::endl;
-  os << indent << "Alpha: " << m_Alpha << std::endl;
-  os << indent << "c: " << m_Sc << std::endl;
-  os << indent << "Gamma: " << m_Gamma << std::endl;
-  os << indent << "Tolerance: " << m_Tolerance << std::endl;
-  os << indent << "GradientMagnitude: " << m_GradientMagnitude << std::endl;
-  os << indent << "StateOfConvergenceDecayRate: " << m_StateOfConvergenceDecayRate << std::endl;
-  os << indent << "Gradient: " << m_Gradient << std::endl;
-  os << indent << "StateOfConvergence: " << m_StateOfConvergence << std::endl;
-
-  os << indent << "NumberOfPerturbations: " << m_NumberOfPerturbations << std::endl;
-
+  os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Gradient)
+     << std::endl;
   os << indent << "LearningRate: " << m_LearningRate << std::endl;
+  os << indent << "Delta: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Delta) << std::endl;
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "StopCondition: " << m_StopCondition << std::endl;
+  os << indent << "StateOfConvergence: " << m_StateOfConvergence << std::endl;
+  os << indent
+     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+     << std::endl;
 
-  os << indent << "MaximumNumberOfIterations: " << m_MaximumNumberOfIterations << std::endl;
-  os << indent << "MinimumNumberOfIterations: " << m_MinimumNumberOfIterations << std::endl;
+  itkPrintSelfObjectMacro(Generator);
 
-  os << indent << "Maximize: " << m_Maximize << std::endl;
+  os << indent << "MinimumNumberOfIterations: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MinimumNumberOfIterations) << std::endl;
+  os << indent << "MaximumNumberOfIterations: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
+  os << indent << "StateOfConvergenceDecayRate: " << m_StateOfConvergenceDecayRate << std::endl;
+  os << indent << "Tolerance: " << m_Tolerance << std::endl;
+  os << indent << "Maximize: " << (m_Maximize ? "On" : "Off") << std::endl;
+  os << indent << "GradientMagnitude: " << m_GradientMagnitude << std::endl;
+  os << indent << "NumberOfPerturbations: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPerturbations) << std::endl;
 
-  os << indent << "CurrentIteration: " << m_CurrentIteration;
-  if (m_CostFunction)
-  {
-    os << indent << "CostFunction: " << m_CostFunction;
-  }
-  os << indent << "StopCondition: " << m_StopCondition;
-  os << std::endl;
+  os << indent << "Sa: " << m_Sa << std::endl;
+  os << indent << "Sc: " << m_Sc << std::endl;
+  os << indent << "A " << m_A << std::endl;
+  os << indent << "Alpha: " << m_Alpha << std::endl;
+  os << indent << "Gamma: " << m_Gamma << std::endl;
 } // end PrintSelf
 
 /**

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -223,16 +223,24 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "InitialPosition = " << m_InitialPosition << std::endl;
-  os << indent << "CurrentValue = " << m_CurrentValue << std::endl;
-  os << indent << "NumberOfSteps = " << m_NumberOfSteps << std::endl;
-  os << indent << "Stop = " << m_Stop << std::endl;
-  os << indent << "StepLength = " << m_StepLength << std::endl;
-  os << indent << "CurrentIndex = " << m_CurrentIndex << std::endl;
-  os << indent << "MaximumMetricValue = " << m_MaximumMetricValue << std::endl;
-  os << indent << "MinimumMetricValue = " << m_MinimumMetricValue << std::endl;
-  os << indent << "MinimumMetricValuePosition = " << m_MinimumMetricValuePosition << std::endl;
-  os << indent << "MaximumMetricValuePosition = " << m_MaximumMetricValuePosition << std::endl;
+  os << indent << "InitialPosition: " << m_InitialPosition << std::endl;
+  os << indent << "CurrentValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentValue)
+     << std::endl;
+  os << indent << "NumberOfSteps: " << static_cast<typename NumericTraits<StepsType>::PrintType>(m_NumberOfSteps)
+     << std::endl;
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "StepLength: " << m_StepLength << std::endl;
+  os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
+  os << indent
+     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
+     << std::endl;
+  os << indent
+     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
+     << std::endl;
+  os << indent << "MinimumMetricValuePosition: " << m_MinimumMetricValuePosition << std::endl;
+  os << indent << "MaximumMetricValuePosition: " << m_MaximumMetricValuePosition << std::endl;
+
+  os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -45,6 +45,23 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Pri
                                                                                        Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent
+     << "LowerLimit: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_LowerLimit)
+     << std::endl;
+  os << indent
+     << "UpperLimit: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_UpperLimit)
+     << std::endl;
+  os << indent << "Phi: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Phi)
+     << std::endl;
+  os << indent << "Resphi: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Resphi)
+     << std::endl;
+  os << indent
+     << "Epsilon: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Epsilon)
+     << std::endl;
+
+  os << indent << "MaximumLineSearchIterations: " << m_MaximumLineSearchIterations << std::endl;
+  os << indent << "LineSearchIterations: " << m_LineSearchIterations << std::endl;
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -58,28 +58,24 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "DoEstimateLearningRateAtEachIteration: " << (this->m_DoEstimateLearningRateAtEachIteration ? "On" : "Off")
+  os << indent << "DoEstimateLearningRateAtEachIteration: " << (m_DoEstimateLearningRateAtEachIteration ? "On" : "Off")
      << std::endl;
-  os << indent << "DoEstimateLearningRateOnce: " << (this->m_DoEstimateLearningRateOnce ? "On" : "Off") << std::endl;
+  os << indent << "DoEstimateLearningRateOnce: " << (m_DoEstimateLearningRateOnce ? "On" : "Off") << std::endl;
   os << indent << "MaximumStepSizeInPhysicalUnits: "
-     << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(
-          this->m_MaximumStepSizeInPhysicalUnits)
+     << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_MaximumStepSizeInPhysicalUnits)
      << std::endl;
-  os << indent << "UseConvergenceMonitoring: " << (this->m_UseConvergenceMonitoring ? "On" : "Off") << std::endl;
+  os << indent << "UseConvergenceMonitoring: " << (m_UseConvergenceMonitoring ? "On" : "Off") << std::endl;
   os << indent << "ConvergenceWindowSize: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(this->m_ConvergenceWindowSize) << std::endl;
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_ConvergenceWindowSize) << std::endl;
 
   itkPrintSelfObjectMacro(ConvergenceMonitoring);
   itkPrintSelfObjectMacro(ModifyGradientByScalesThreader);
   itkPrintSelfObjectMacro(ModifyGradientByLearningRateThreader);
 
-  os << indent << "Stop: " << (this->m_Stop ? "On" : "Off") << std::endl;
-  os << indent << "StopCondition: "
-     << static_cast<typename NumericTraits<StopConditionObjectToObjectOptimizerEnum>::PrintType>(this->m_StopCondition)
-     << std::endl;
-  os << indent << "StopConditionDescription: " << this->m_StopConditionDescription.str() << std::endl;
-  os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(this->m_Gradient)
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "StopCondition: " << m_StopCondition << std::endl;
+  os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
+  os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Gradient)
      << std::endl;
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -18,6 +18,8 @@
 #ifndef itkMultiGradientOptimizerv4_hxx
 #define itkMultiGradientOptimizerv4_hxx
 
+#include "itkPrintHelper.h"
+
 
 namespace itk
 {
@@ -38,9 +40,21 @@ template <typename TInternalComputationValueType>
 void
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Stop condition:" << this->m_StopCondition << std::endl;
-  os << indent << "Stop condition description: " << this->m_StopConditionDescription.str() << std::endl;
+
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "StopCondition: " << m_StopCondition << std::endl;
+  os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
+  os << indent << "OptimizersList: " << m_OptimizersList << std::endl;
+  os << indent << "MetricValuesList: " << m_MetricValuesList << std::endl;
+  os << indent
+     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
+     << std::endl;
+  os << indent
+     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
+     << std::endl;
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -18,6 +18,8 @@
 #ifndef itkMultiStartOptimizerv4_hxx
 #define itkMultiStartOptimizerv4_hxx
 
+#include "itkPrintHelper.h"
+
 
 namespace itk
 {
@@ -40,9 +42,26 @@ template <typename TInternalComputationValueType>
 void
 MultiStartOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Stop condition:" << this->m_StopCondition << std::endl;
-  os << indent << "Stop condition description: " << this->m_StopConditionDescription.str() << std::endl;
+
+  os << indent << "StopCondition: " << m_StopCondition << std::endl;
+  os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
+
+  os << indent << "ParametersList: " << m_ParametersList << std::endl;
+  os << indent << "MetricValuesList: " << m_MetricValuesList << std::endl;
+
+  os << indent
+     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
+     << std::endl;
+  os << indent
+     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
+     << std::endl;
+  os << indent << "BestParametersIndex: "
+     << static_cast<typename NumericTraits<ParameterListSizeType>::PrintType>(m_BestParametersIndex) << std::endl;
+
+  itkPrintSelfObjectMacro(LocalOptimizer);
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -563,14 +563,14 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ObjectToObjectMetric: " << std::endl;
-
   itkPrintSelfObjectMacro(FixedTransform);
   itkPrintSelfObjectMacro(MovingTransform);
   itkPrintSelfObjectMacro(VirtualImage);
 
-  os << indent << "m_UserHasSetVirtualDomain: " << this->m_UserHasSetVirtualDomain << std::endl
-     << indent << "m_NumberOfValidPoints: " << this->m_NumberOfValidPoints << std::endl;
+  os << indent << "UserHasSetVirtualDomain: " << (m_UserHasSetVirtualDomain ? "On" : "Off") << std::endl;
+  os << indent
+     << "NumberOfValidPoints: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfValidPoints)
+     << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -22,6 +22,7 @@
 #include "itkCompositeTransform.h"
 #include "itkPointSet.h"
 #include "itkObjectToObjectMetric.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -634,18 +635,25 @@ template <typename TMetric>
 void
 RegistrationParameterScalesEstimator<TMetric>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MetricType   = " << std::endl;
-  os << indent << typeid(MetricType).name() << std::endl;
+  itkPrintSelfObjectMacro(Metric);
 
-  os << indent << "m_SamplePoints.size = " << std::endl;
-  os << indent << this->m_SamplePoints.size() << std::endl;
+  os << indent << "SamplePoints: " << m_SamplePoints << std::endl;
+  os << indent << "SamplingTime: " << static_cast<typename NumericTraits<TimeStamp>::PrintType>(m_SamplingTime)
+     << std::endl;
+  os << indent << "NumberOfRandomSamples: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfRandomSamples) << std::endl;
+  os << indent
+     << "CentralRegionRadius: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_CentralRegionRadius)
+     << std::endl;
 
-  os << indent << "m_TransformForward = " << this->m_TransformForward << std::endl;
-  os << indent << "m_SamplingStrategy = " << this->m_SamplingStrategy << std::endl;
+  itkPrintSelfObjectMacro(VirtualDomainPointSet);
 
-  os << indent << "m_VirtualDomainPointSet = " << this->m_VirtualDomainPointSet.GetPointer() << std::endl;
+  os << indent << "TransformForward: " << (m_TransformForward ? "On" : "Off") << std::endl;
+  os << indent << "SamplingStrategy: " << m_SamplingStrategy << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -49,36 +49,29 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::PrintSelf(st
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Number of work units: " << this->m_NumberOfWorkUnits << std::endl;
-  os << indent << "Number of scales:  " << this->m_Scales.Size() << std::endl;
-  if (this->GetScalesInitialized())
-  {
-    os << indent << "m_Scales: " << this->m_Scales << std::endl;
-  }
-  else
-  {
-    os << indent << "m_Scales: uninitialized." << std::endl;
-  }
-  os << indent << "m_ScalesAreIdentity: " << this->GetScalesAreIdentity() << std::endl;
-  if (this->m_Weights.Size() > 0)
-  {
-    os << indent << "m_Weights: " << this->m_Weights << std::endl;
-  }
-  else
-  {
-    os << indent << "m_Weights is unset. Treated as identity." << std::endl;
-  }
-  os << indent << "m_WeightsAreIdentity: " << this->GetWeightsAreIdentity() << std::endl;
   itkPrintSelfObjectMacro(Metric);
+
+  os << indent
+     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
+     << std::endl;
+  os << indent
+     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+     << std::endl;
+  os << indent
+     << "NumberOfIterations: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfIterations)
+     << std::endl;
+  os << indent
+     << "CurrentMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentMetricValue)
+     << std::endl;
+  os << indent << "Scales: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Scales) << std::endl;
+  os << indent << "Weights: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Weights) << std::endl;
+
+  os << indent << "ScalesAreIdentity: " << (m_ScalesAreIdentity ? "On" : "Off") << std::endl;
+
   itkPrintSelfObjectMacro(ScalesEstimator);
-  if (this->m_CurrentIteration > 0)
-  {
-    os << indent << "CurrentIteration: " << this->m_CurrentIteration << std::endl;
-  }
-  os << indent << "Number of iterations: " << this->m_NumberOfIterations << std::endl;
-  os << indent << "CurrentMetricValue: "
-     << static_cast<typename NumericTraits<MeasureType>::PrintType>(this->m_CurrentMetricValue) << std::endl;
-  os << indent << "DoEstimateScales: " << this->m_DoEstimateScales << std::endl;
+
+  os << indent << "WeightsAreIdentity: " << (m_WeightsAreIdentity ? "On" : "Off") << std::endl;
+  os << indent << "DoEstimateScales: " << (m_DoEstimateScales ? "On" : "Off") << std::endl;
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -665,36 +666,45 @@ template <typename TMeasurement, typename TFrequencyContainer>
 void
 Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  // os << indent << "MeasurementVectorSize: " << this->GetMeasurementVectorSize() << std::endl;
-  os << indent << "TotalFrequency: " << this->GetTotalFrequency() << std::endl;
-  os << indent << "Size: ";
-  for (unsigned int i = 0; i < m_Size.Size(); ++i)
+  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  os << indent << "OffsetTable: " << std::endl;
+  for (const auto & elem : m_OffsetTable)
   {
-    os << m_Size[i] << "  ";
+    os << indent.GetNextIndent() << "[" << &elem - &*(m_OffsetTable.begin()) << "]: " << elem << std::endl;
   }
-  os << std::endl;
-  os << indent << "Bin Minima: ";
-  for (unsigned int i = 0; i < m_Min.size(); ++i)
-  {
-    os << m_Min[i][0] << "  ";
-  }
-  os << std::endl;
-  os << indent << "Bin Maxima: ";
-  for (unsigned int i = 0; i < m_Max.size(); ++i)
-  {
-    os << m_Max[i].back() << "  ";
-  }
-  os << std::endl;
-  os << indent << "ClipBinsAtEnds: " << itk::NumericTraits<bool>::PrintType(this->GetClipBinsAtEnds()) << std::endl;
-  os << indent << "OffsetTable: ";
-  for (unsigned int i = 0; i < this->m_OffsetTable.size(); ++i)
-  {
-    os << this->m_OffsetTable[i] << "  ";
-  }
-  os << std::endl;
+
   itkPrintSelfObjectMacro(FrequencyContainer);
+
+  os << indent << "NumberOfInstances: " << m_NumberOfInstances << std::endl;
+
+  os << indent << "Min: " << std::endl;
+  for (const auto & elemVec : m_Min)
+  {
+    for (const auto & elem : elemVec)
+    {
+      os << indent << "[" << &elem - &*(elemVec.begin())
+         << "]: " << static_cast<typename NumericTraits<MeasurementType>::PrintType>(elem) << std::endl;
+    }
+  }
+
+  os << indent << "Max: " << std::endl;
+  for (const auto & elemVec : m_Max)
+  {
+    for (const auto & elem : elemVec)
+    {
+      os << indent << "[" << &elem - &*(elemVec.begin())
+         << "]: " << static_cast<typename NumericTraits<MeasurementType>::PrintType>(elem) << std::endl;
+    }
+  }
+
+  os << indent << "TempMeasurementVector: "
+     << static_cast<typename NumericTraits<MeasurementVectorType>::PrintType>(m_TempMeasurementVector) << std::endl;
+  os << indent << "TempIndex: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
+  os << indent << "ClipBinsAtEnds: " << (m_ClipBinsAtEnds ? "On" : "Off") << std::endl;
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -100,17 +100,20 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Image: ";
-  if (m_Image.IsNotNull())
-  {
-    os << m_Image << std::endl;
-  }
-  else
-  {
-    os << "not set." << std::endl;
-  }
-  os << indent << "UseImageRegion: " << m_UseImageRegion << std::endl;
+  itkPrintSelfObjectMacro(Image);
+
+  os << indent << "MeasurementVectorInternal: "
+     << static_cast<typename NumericTraits<MeasurementVectorType>::PrintType>(m_MeasurementVectorInternal) << std::endl;
+  os << indent << "InstanceIdentifierInternal: "
+     << static_cast<typename NumericTraits<InstanceIdentifier>::PrintType>(m_InstanceIdentifierInternal) << std::endl;
+  os << indent
+     << "NeighborIndexInternal: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_NeighborIndexInternal)
+     << std::endl;
+  os << indent << "Radius: " << static_cast<typename NumericTraits<NeighborhoodRadiusType>::PrintType>(m_Radius)
+     << std::endl;
   os << indent << "Region: " << m_Region << std::endl;
+  os << indent << "OffsetTable: " << m_OffsetTable << std::endl;
+  os << indent << "UseImageRegion: " << (m_UseImageRegion ? "On" : "Off") << std::endl;
   os << indent << "Neighborhood Radius: " << m_Radius << std::endl;
 }
 
@@ -238,10 +241,10 @@ std::ostream &
 operator<<(std::ostream & os, const std::vector<itk::ConstNeighborhoodIterator<TImage, TBoundaryCondition>> & mv)
 {
   itk::ConstNeighborhoodIterator<TImage, TBoundaryCondition> nbhd = mv[0];
-  os << "Neighborhood:" << std::endl;
+  os << "Neighborhood: " << std::endl;
   os << "    Radius: " << nbhd.GetRadius() << std::endl;
   os << "    Size: " << nbhd.GetSize() << std::endl;
-  os << "    Index of Center Pixel: " << nbhd.GetIndex() << std::endl;
+  os << "    Index: " << nbhd.GetIndex() << std::endl;
   return os;
 }
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -103,8 +103,9 @@ void
 ScalarImageToHistogramGenerator<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ImageToListSample adaptor = " << m_ImageToListSampleAdaptor << std::endl;
-  os << indent << "HistogramGenerator = " << m_HistogramGenerator << std::endl;
+
+  itkPrintSelfObjectMacro(ImageToListSampleAdaptor);
+  itkPrintSelfObjectMacro(HistogramGenerator);
 }
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -304,13 +304,20 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Pr
                                                                                         Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Offsets: " << this->GetOffsets() << std::endl;
-  os << indent << "Min: " << this->m_Min << std::endl;
-  os << indent << "Max: " << this->m_Max << std::endl;
-  os << indent << "Min distance: " << this->m_MinDistance << std::endl;
-  os << indent << "Max distance: " << this->m_MaxDistance << std::endl;
-  os << indent << "NumberOfBinsPerAxis: " << this->m_NumberOfBinsPerAxis << std::endl;
-  os << indent << "InsidePixelValue: " << this->m_InsidePixelValue << std::endl;
+
+  os << indent << "NumberOfBinsPerAxis: " << m_NumberOfBinsPerAxis << std::endl;
+  os << indent << "Min: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Min) << std::endl;
+  os << indent << "Max: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Max) << std::endl;
+  os << indent << "MinDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MinDistance)
+     << std::endl;
+  os << indent << "MaxDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MaxDistance)
+     << std::endl;
+  os << indent << "InsidePixelValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_InsidePixelValue)
+     << std::endl;
+  os << indent << "LowerBound: " << m_LowerBound << std::endl;
+  os << indent << "UpperBound: " << m_UpperBound << std::endl;
+
+  itkPrintSelfObjectMacro(Offsets);
 }
 
 template <typename TImageType, typename THistogramFrequencyContainer>

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -127,10 +127,14 @@ BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>:
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "B-spline parameters: " << std::endl;
-  os << indent << "  number of control points for the update field = " << this->m_NumberOfControlPointsForTheUpdateField
+  os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
+  os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;
+  os << indent << "NumberOfControlPointsForTheUpdateFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+          m_NumberOfControlPointsForTheUpdateFieldSetTime)
      << std::endl;
-  os << indent << "  number of control points for the total field = " << this->m_NumberOfControlPointsForTheTotalField
+  os << indent << "NumberOfControlPointsForTheTotalFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheTotalFieldSetTime)
      << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -64,9 +64,33 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
   Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Number of work units: " << this->GetNumberOfWorkUnits() << std::endl
-     << indent << "m_BlockRadius: " << m_BlockRadius << std::endl
-     << indent << "m_SearchRadius: " << m_SearchRadius << std::endl;
+
+  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_BlockRadius)
+     << std::endl;
+  os << indent << "SearchRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_SearchRadius)
+     << std::endl;
+  os << indent << "PointsCount: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_PointsCount)
+     << std::endl;
+
+  os << indent << "DisplacementsVectorsArray: ";
+  if (m_DisplacementsVectorsArray != nullptr)
+  {
+    os << *m_DisplacementsVectorsArray.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "SimilaritiesValuesArray: ";
+  if (m_SimilaritiesValuesArray != nullptr)
+  {
+    os << *m_SimilaritiesValuesArray.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 
 template <typename TFixedImage,

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -128,7 +128,8 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::PrintSelf(s
   itkPrintSelfObjectMacro(FixedImage);
   itkPrintSelfObjectMacro(MovingImage);
 
-  os << indent << "UseMoments  = " << m_UseMoments << std::endl;
+  os << indent << "UseMoments: " << (m_UseMoments ? "On" : "Off") << std::endl;
+
   itkPrintSelfObjectMacro(MovingCalculator);
   itkPrintSelfObjectMacro(FixedCalculator);
 }

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -154,15 +154,10 @@ EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::Pri
                                                                                        Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DistanceMap: " << m_DistanceMap << std::endl;
-  if (m_ComputeSquaredDistance)
-  {
-    os << indent << "m_ComputeSquaredDistance: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "m_ComputeSquaredDistance: False" << std::endl;
-  }
+
+  itkPrintSelfObjectMacro(DistanceMap);
+
+  os << indent << "ComputeSquaredDistance: " << (m_ComputeSquaredDistance ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -84,21 +84,21 @@ GaussianExponentialDiffeomorphicTransformParametersAdaptor<TTransform>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  if (this->m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime > 0)
-  {
-    os << indent << "Gaussian smoothing parameters: " << std::endl;
-    if (this->m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime > 0)
-    {
-      os << indent << "m_GaussianSmoothingVarianceForTheConstantVelocityField: "
-         << this->m_GaussianSmoothingVarianceForTheConstantVelocityField << std::endl;
-    }
-    if (this->m_GaussianSmoothingVarianceForTheUpdateFieldSetTime > 0)
-    {
-      os << indent
-         << "m_GaussianSmoothingVarianceForTheUpdateField: " << this->m_GaussianSmoothingVarianceForTheUpdateField
-         << std::endl;
-    }
-  }
+  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheConstantVelocityField)
+     << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
+     << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime)
+     << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
+     << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -82,23 +82,21 @@ GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>
 {
   Superclass::PrintSelf(os, indent);
 
-  if (this->m_GaussianSmoothingVarianceForTheUpdateFieldSetTime > 0 ||
-      this->m_GaussianSmoothingVarianceForTheTotalFieldSetTime > 0)
-  {
-    os << indent << "Gaussian smoothing parameters: " << std::endl;
-    if (this->m_GaussianSmoothingVarianceForTheUpdateFieldSetTime > 0)
-    {
-      os << indent
-         << "m_GaussianSmoothingVarianceForTheUpdateField: " << this->m_GaussianSmoothingVarianceForTheUpdateField
-         << std::endl;
-    }
-    if (this->m_GaussianSmoothingVarianceForTheTotalFieldSetTime > 0)
-    {
-      os << indent
-         << "m_GaussianSmoothingVarianceForTheTotalField: " << this->m_GaussianSmoothingVarianceForTheTotalField
-         << std::endl;
-    }
-  }
+  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
+     << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheTotalField: "
+     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalField)
+     << std::endl;
+
+  os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
+     << std::endl;
+  os << indent << "GaussianSmoothingVarianceForTheTotalFieldSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+          m_GaussianSmoothingVarianceForTheTotalFieldSetTime)
+     << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -135,7 +135,45 @@ void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DerivativeDelta: " << this->m_DerivativeDelta << std::endl;
+
+  os << indent << "Variance: " << m_Variance << std::endl;
+
+  os << indent << "MinMovedGradient: " << m_MinMovedGradient << std::endl;
+  os << indent << "MaxMovedGradient: " << m_MaxMovedGradient << std::endl;
+  os << indent << "MinFixedGradient: " << m_MinFixedGradient << std::endl;
+  os << indent << "MaxFixedGradient: " << m_MaxFixedGradient << std::endl;
+
+  itkPrintSelfObjectMacro(TransformMovingImageFilter);
+
+  itkPrintSelfObjectMacro(CastFixedImageFilter);
+
+  os << indent << "FixedSobelOperators: ";
+  for (const auto & elem : m_FixedSobelOperators)
+  {
+    os << indent.GetNextIndent() << elem << std::endl;
+  }
+
+  os << indent << "FixedSobelFilters: ";
+  if (m_FixedSobelFilters[0] != nullptr)
+  {
+    for (const auto & elem : m_FixedSobelFilters)
+    {
+      os << indent.GetNextIndent() << *elem << std::endl;
+    }
+  }
+  else
+  {
+    os << "(empty)" << std::endl;
+  }
+
+  m_MovedBoundCond.Print(os, indent);
+  m_FixedBoundCond.Print(os, indent);
+
+  itkPrintSelfObjectMacro(CastMovedImageFilter);
+
+  os << indent << "MovedSobelOperators: " << m_MovedSobelOperators << std::endl;
+
+  os << indent << "DerivativeDelta: " << m_DerivativeDelta << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -219,16 +219,18 @@ void
 ImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Metric: " << m_Metric.GetPointer() << std::endl;
-  os << indent << "Optimizer: " << m_Optimizer.GetPointer() << std::endl;
-  os << indent << "Transform: " << m_Transform.GetPointer() << std::endl;
-  os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
-  os << indent << "Fixed Image: " << m_FixedImage.GetPointer() << std::endl;
-  os << indent << "Moving Image: " << m_MovingImage.GetPointer() << std::endl;
-  os << indent << "Fixed Image Region Defined: " << m_FixedImageRegionDefined << std::endl;
-  os << indent << "Fixed Image Region: " << m_FixedImageRegion << std::endl;
-  os << indent << "Initial Transform Parameters: " << m_InitialTransformParameters << std::endl;
-  os << indent << "Last    Transform Parameters: " << m_LastTransformParameters << std::endl;
+
+  itkPrintSelfObjectMacro(Metric);
+  itkPrintSelfObjectMacro(Optimizer);
+  itkPrintSelfObjectMacro(FixedImage);
+  itkPrintSelfObjectMacro(MovingImage);
+  itkPrintSelfObjectMacro(Transform);
+  itkPrintSelfObjectMacro(Interpolator);
+
+  os << indent << "InitialTransformParameters: " << m_InitialTransformParameters << std::endl;
+  os << indent << "LastTransformParameters: " << m_LastTransformParameters << std::endl;
+  os << indent << "FixedImageRegionDefined: " << (m_FixedImageRegionDefined ? "On" : "Off") << std::endl;
+  os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -357,6 +357,16 @@ protected:
 
     ~FixedImageSamplePoint() = default;
 
+    inline friend std::ostream &
+    operator<<(std::ostream & os, const FixedImageSamplePoint & val)
+    {
+      os << "point: " << static_cast<typename NumericTraits<FixedImagePointType>::PrintType>(val.point) << std::endl;
+      os << "value: " << val.value << std::endl;
+      os << "valueIndex: " << val.valueIndex << std::endl;
+
+      return os;
+    }
+
   public:
     FixedImagePointType point;
     double              value;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRandomConstIteratorWithIndex.h"
 #include "itkMath.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -1208,70 +1209,131 @@ template <typename TFixedImage, typename TMovingImage>
 void
 ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfFixedImageSamples: ";
-  os << m_NumberOfFixedImageSamples << std::endl;
-
+  os << indent << "UseFixedImageIndexes: " << (m_UseFixedImageIndexes ? "On" : "Off") << std::endl;
+  os << indent << "FixedImageIndexes: " << m_FixedImageIndexes << std::endl;
+  os << indent
+     << "UseFixedImageSamplesIntensityThreshold: " << (m_UseFixedImageSamplesIntensityThreshold ? "On" : "Off")
+     << std::endl;
   os << indent << "FixedImageSamplesIntensityThreshold: "
      << static_cast<typename NumericTraits<FixedImagePixelType>::PrintType>(m_FixedImageSamplesIntensityThreshold)
      << std::endl;
-
-  os << indent << "UseFixedImageSamplesIntensityThreshold: ";
-  os << m_UseFixedImageSamplesIntensityThreshold << std::endl;
-
-  if (m_UseFixedImageIndexes)
-  {
-    os << indent << "Use Fixed Image Indexes: True" << std::endl;
-    os << indent << "Number of Fixed Image Indexes = " << m_FixedImageIndexes.size() << std::endl;
-  }
-  else
-  {
-    os << indent << "Use Fixed Image Indexes: False" << std::endl;
-  }
-
-  if (m_UseSequentialSampling)
-  {
-    os << indent << "Use Sequential Sampling: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "Use Sequential Sampling: False" << std::endl;
-  }
-
-  os << indent << "UseAllPixels: ";
-  os << m_UseAllPixels << std::endl;
-
-  os << indent << "ReseedIterator: " << m_ReseedIterator << std::endl;
-  os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
-
-  os << indent << "Threader: " << m_Threader << std::endl;
-  os << indent << "Number of Work units: " << m_NumberOfWorkUnits << std::endl;
-  os << indent << "ThreaderParameter: " << std::endl;
-  os << indent << "ThreaderNumberOfMovingImageSamples: " << std::endl;
-  if (m_ThreaderNumberOfMovingImageSamples)
-  {
-    for (ThreadIdType i = 0; i < m_NumberOfWorkUnits - 1; ++i)
-    {
-      os << "  Thread[" << i << "]= " << static_cast<unsigned int>(m_ThreaderNumberOfMovingImageSamples[i])
-         << std::endl;
-    }
-  }
-
-  os << indent << "ComputeGradient: " << static_cast<typename NumericTraits<bool>::PrintType>(m_ComputeGradient)
+  os << indent << "FixedImageSamples: " << m_FixedImageSamples << std::endl;
+  os << indent
+     << "NumberOfParameters: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfParameters)
      << std::endl;
-  os << indent << "Moving Image: " << m_MovingImage.GetPointer() << std::endl;
-  os << indent << "Fixed  Image: " << m_FixedImage.GetPointer() << std::endl;
-  os << indent << "Gradient Image: " << m_GradientImage.GetPointer() << std::endl;
-  os << indent << "Transform:    " << m_Transform.GetPointer() << std::endl;
-  os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
-  os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
-  os << indent << "Moving Image Mask: " << m_MovingImageMask.GetPointer() << std::endl;
-  os << indent << "Fixed Image Mask: " << m_FixedImageMask.GetPointer() << std::endl;
-  os << indent << "Number of Moving Image Samples: " << m_NumberOfPixelsCounted << std::endl;
+  os << indent << "NumberOfFixedImageSamples: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedImageSamples) << std::endl;
+  os << indent << "NumberOfPixelsCounted: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted) << std::endl;
 
-  os << indent << "UseCachingOfBSplineWeights: ";
-  os << this->m_UseCachingOfBSplineWeights << std::endl;
+  itkPrintSelfObjectMacro(MovingImage);
+  itkPrintSelfObjectMacro(FixedImage);
+  itkPrintSelfObjectMacro(Transform);
+
+  os << indent << "ThreaderTransform: ";
+  if (m_ThreaderTransform.get() != nullptr)
+  {
+    os << *m_ThreaderTransform.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  itkPrintSelfObjectMacro(Interpolator);
+
+  os << indent << "ComputeGradient: " << (m_ComputeGradient ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(GradientImage);
+  itkPrintSelfObjectMacro(MovingImageMask);
+  itkPrintSelfObjectMacro(FixedImageMask);
+
+  os << indent
+     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
+     << std::endl;
+  os << indent << "UseAllPixels: " << (m_UseAllPixels ? "On" : "Off") << std::endl;
+  os << indent << "UseSequentialSampling: " << (m_UseSequentialSampling ? "On" : "Off") << std::endl;
+  os << indent << "ReseedIterator: " << (m_ReseedIterator ? "On" : "Off") << std::endl;
+  os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
+  os << indent << "TransformIsBSpline: " << (m_TransformIsBSpline ? "On" : "Off") << std::endl;
+
+  os << indent
+     << "NumBSplineWeights: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumBSplineWeights)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(BSplineTransform);
+
+  os << indent << "BSplineTransformWeightsArray: " << m_BSplineTransformWeightsArray << std::endl;
+  os << indent << "BSplineTransformIndicesArray: " << m_BSplineTransformIndicesArray << std::endl;
+  os << indent << "BSplinePreTransformPointsArray: " << m_BSplinePreTransformPointsArray << std::endl;
+  os << indent << "WithinBSplineSupportRegionArray: " << m_WithinBSplineSupportRegionArray << std::endl;
+  os << indent << "BSplineParametersOffset: "
+     << static_cast<typename NumericTraits<BSplineParametersOffsetType>::PrintType>(m_BSplineParametersOffset)
+     << std::endl;
+
+  os << indent << "UseCachingOfBSplineWeights: " << (m_UseCachingOfBSplineWeights ? "On" : "Off") << std::endl;
+  os << indent << "BSplineTransformWeights: "
+     << static_cast<typename NumericTraits<BSplineTransformWeightsType>::PrintType>(m_BSplineTransformWeights)
+     << std::endl;
+  os << indent << "BSplineTransformIndices: "
+     << static_cast<typename NumericTraits<BSplineTransformIndexArrayType>::PrintType>(m_BSplineTransformIndices)
+     << std::endl;
+
+  os << indent << "ThreaderBSplineTransformWeights: ";
+  if (m_ThreaderBSplineTransformWeights.get() != nullptr)
+  {
+    os << *m_ThreaderBSplineTransformWeights.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "ThreaderBSplineTransformIndices: ";
+  if (m_ThreaderBSplineTransformIndices.get() != nullptr)
+  {
+    os << *m_ThreaderBSplineTransformIndices.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "InterpolatorIsBSpline: " << (m_InterpolatorIsBSpline ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(BSplineInterpolator);
+  itkPrintSelfObjectMacro(DerivativeCalculator);
+
+  itkPrintSelfObjectMacro(Threader);
+
+  os << indent << "ConstSelfWrapper: ";
+  if (m_ConstSelfWrapper.get() != nullptr)
+  {
+    os << m_ConstSelfWrapper.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "ThreaderNumberOfMovingImageSamples: ";
+  if (m_ThreaderNumberOfMovingImageSamples.get() != nullptr)
+  {
+    os << *m_ThreaderNumberOfMovingImageSamples.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "WithinThreadPreProcess: " << (m_WithinThreadPreProcess ? "On" : "Off") << std::endl;
+  os << indent << "WithinThreadPostProcess: " << (m_WithinThreadPostProcess ? "On" : "Off") << std::endl;
+
+  os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -82,11 +82,19 @@ void
 ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Moving Spatial Object: " << m_MovingSpatialObject.GetPointer() << std::endl;
-  os << indent << "Fixed  Image: " << m_FixedImage.GetPointer() << std::endl;
-  os << indent << "Transform:    " << m_Transform.GetPointer() << std::endl;
-  os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
-  os << indent << "Last Transform parameters = " << m_LastTransformParameters << std::endl;
+
+
+  os << indent << "MatchMeasure: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MatchMeasure)
+     << std::endl;
+  os << indent << "MatchMeasureDerivatives: " << m_MatchMeasureDerivatives << std::endl;
+
+  itkPrintSelfObjectMacro(Transform);
+  itkPrintSelfObjectMacro(Interpolator);
+
+  itkPrintSelfObjectMacro(MovingSpatialObject);
+  itkPrintSelfObjectMacro(FixedImage);
+
+  os << indent << "LastTransformParameters: " << m_LastTransformParameters << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMatrix.h"
 #include "itkSymmetricEigenAnalysis.h"
+#include "itkPrintHelper.h"
 
 #include <cmath>
 #include "vnl/algo/vnl_qr.h"
@@ -819,32 +820,16 @@ void
 LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
                                                                                     Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  itkPrintSelfObjectMacro(Transform);
   itkPrintSelfObjectMacro(ReferenceImage);
+  itkPrintSelfObjectMacro(Transform);
 
-  os << indent << "Fixed Landmarks: " << std::endl;
-  auto fitr = this->m_FixedLandmarks.begin();
-  while (fitr != this->m_FixedLandmarks.end())
-  {
-    os << indent << *fitr << std::endl;
-    ++fitr;
-  }
-  os << indent << "Moving Landmarks: " << std::endl;
-  auto mitr = this->m_MovingLandmarks.begin();
-  while (mitr != this->m_MovingLandmarks.end())
-  {
-    os << indent << *mitr << std::endl;
-    ++mitr;
-  }
-  os << indent << "Landmark Weight: " << std::endl;
-  auto witr = this->m_LandmarkWeight.begin();
-  while (witr != this->m_LandmarkWeight.end())
-  {
-    os << indent << *witr << std::endl;
-    ++witr;
-  }
+  os << indent << "FixedLandmarks: " << m_FixedLandmarks << std::endl;
+  os << indent << "MovingLandmarks: " << m_MovingLandmarks << std::endl;
+  os << indent << "LandmarkWeight: " << m_LandmarkWeight << std::endl;
 
   os << indent << "BSplineNumberOfControlPoints: " << m_BSplineNumberOfControlPoints << std::endl;
 }

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMath.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -267,8 +268,16 @@ template <typename TFixedImage, typename TMovingImage>
 void
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
+
   os << indent << "MeasureMatches: " << (m_MeasureMatches ? "On" : "Off") << std::endl;
+
+  os << indent << "ThreadMatches: " << m_ThreadMatches << std::endl;
+  os << indent << "ThreadCounts: " << m_ThreadCounts << std::endl;
+
+  itkPrintSelfObjectMacro(Threader);
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -37,8 +37,9 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Pri
                                                                                        Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Lambda factor = " << m_Lambda << std::endl;
-  os << indent << "Delta  value  = " << m_Delta << std::endl;
+
+  os << indent << "Lambda: " << m_Lambda << std::endl;
+  os << indent << "Delta: " << m_Delta << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -290,7 +290,8 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
                                                                                              Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Lambda factor = " << m_Lambda << std::endl;
+
+  os << indent << "Lambda: " << m_Lambda << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
@@ -55,16 +55,18 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::P
                                                                                          Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  /*
-    os << indent << "MovingImageIterpolator: ";
-    os << m_MovingImageInterpolator.GetPointer() << std::endl;
-    os << indent << "FixedImageGradientCalculator: ";
-    os << m_FixedImageGradientCalculator.GetPointer() << std::endl;
-    os << indent << "DenominatorThreshold: ";
-    os << m_DenominatorThreshold << std::endl;
-    os << indent << "IntensityDifferenceThreshold: ";
-    os << m_IntensityDifferenceThreshold << std::endl;
-  */
+
+  os << indent
+     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(FixedImageGradientCalculator);
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+
+  os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -46,6 +46,16 @@ void
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "PerThread: ";
+  if (m_PerThread.get() != nullptr)
+  {
+    os << m_PerThread.get() << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -19,6 +19,7 @@
 #define itkMultiResolutionImageRegistrationMethod_hxx
 
 #include "itkRecursiveMultiResolutionPyramidImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -264,41 +265,47 @@ template <typename TFixedImage, typename TMovingImage>
 void
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Metric: " << m_Metric.GetPointer() << std::endl;
-  os << indent << "Optimizer: " << m_Optimizer.GetPointer() << std::endl;
-  os << indent << "Transform: " << m_Transform.GetPointer() << std::endl;
-  os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
-  os << indent << "FixedImage: " << m_FixedImage.GetPointer() << std::endl;
-  os << indent << "MovingImage: " << m_MovingImage.GetPointer() << std::endl;
-  os << indent << "FixedImagePyramid: ";
-  os << m_FixedImagePyramid.GetPointer() << std::endl;
-  os << indent << "MovingImagePyramid: ";
-  os << m_MovingImagePyramid.GetPointer() << std::endl;
 
-  os << indent << "NumberOfLevels: ";
-  os << m_NumberOfLevels << std::endl;
+  itkPrintSelfObjectMacro(Metric);
+  itkPrintSelfObjectMacro(Optimizer);
 
-  os << indent << "CurrentLevel: ";
-  os << m_CurrentLevel << std::endl;
+  itkPrintSelfObjectMacro(MovingImage);
+  itkPrintSelfObjectMacro(FixedImage);
 
-  os << indent << "InitialTransformParameters: ";
-  os << m_InitialTransformParameters << std::endl;
-  os << indent << "InitialTransformParametersOfNextLevel: ";
-  os << m_InitialTransformParametersOfNextLevel << std::endl;
-  os << indent << "LastTransformParameters: ";
-  os << m_LastTransformParameters << std::endl;
-  os << indent << "FixedImageRegion: ";
-  os << m_FixedImageRegion << std::endl;
-  for (unsigned int level = 0; level < m_FixedImageRegionPyramid.size(); ++level)
-  {
-    os << indent << "FixedImageRegion at level " << level << ": ";
-    os << m_FixedImageRegionPyramid[level] << std::endl;
-  }
-  os << indent << "FixedImagePyramidSchedule : " << std::endl;
-  os << m_FixedImagePyramidSchedule << std::endl;
-  os << indent << "MovingImagePyramidSchedule : " << std::endl;
-  os << m_MovingImagePyramidSchedule << std::endl;
+  itkPrintSelfObjectMacro(Transform);
+  itkPrintSelfObjectMacro(Interpolator);
+
+  itkPrintSelfObjectMacro(MovingImagePyramid);
+  itkPrintSelfObjectMacro(FixedImagePyramid);
+
+  os << indent << "InitialTransformParameters: "
+     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_InitialTransformParameters) << std::endl;
+  os << indent << "InitialTransformParametersOfNextLevel: "
+     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_InitialTransformParametersOfNextLevel)
+     << std::endl;
+  os << indent << "LastTransformParameters: "
+     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_LastTransformParameters) << std::endl;
+
+  os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
+  os << indent << "FixedImageRegionPyramid: " << m_FixedImageRegionPyramid << std::endl;
+
+  os << indent << "NumberOfLevels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
+     << std::endl;
+  os << indent << "CurrentLevel: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel)
+     << std::endl;
+
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+
+  os << indent << "FixedImagePyramidSchedule: "
+     << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_FixedImagePyramidSchedule) << std::endl;
+  os << indent << "MovingImagePyramidSchedule: "
+     << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_MovingImagePyramidSchedule) << std::endl;
+
+  os << indent << "ScheduleSpecified: " << (m_ScheduleSpecified ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfLevelsSpecified: " << (m_Stop ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -297,10 +297,9 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
   Superclass::PrintSelf(os, indent);
 
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
-  os << indent << "No. levels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Schedule: " << std::endl;
-  os << m_Schedule << std::endl;
-  os << indent << "Use ShrinkImageFilter= " << m_UseShrinkImageFilter << std::endl;
+  os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
+  os << indent << "Schedule: " << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
+  os << indent << "UseShrinkImageFilter: " << (m_UseShrinkImageFilter ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -106,13 +106,18 @@ void
 PointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Moving Image: " << m_MovingImage.GetPointer() << std::endl;
-  os << indent << "Fixed  Image: " << m_FixedPointSet.GetPointer() << std::endl;
-  os << indent << "Gradient Image: " << m_GradientImage.GetPointer() << std::endl;
-  os << indent << "Transform:    " << m_Transform.GetPointer() << std::endl;
-  os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
-  os << indent << "Number of Pixels Counted: " << m_NumberOfPixelsCounted << std::endl;
-  os << indent << "Compute Gradient: " << m_ComputeGradient << std::endl;
+
+  os << indent << "NumberOfPixelsCounted: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted) << std::endl;
+
+  itkPrintSelfObjectMacro(FixedPointSet);
+  itkPrintSelfObjectMacro(MovingImage);
+  itkPrintSelfObjectMacro(Transform);
+  itkPrintSelfObjectMacro(Interpolator);
+
+  os << indent << "ComputeGradient: " << (m_ComputeGradient ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(GradientImage);
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
@@ -73,9 +73,10 @@ void
 PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Moving PointSet: " << m_MovingPointSet.GetPointer() << std::endl;
-  os << indent << "Fixed  PointSet: " << m_FixedPointSet.GetPointer() << std::endl;
-  os << indent << "Transform:    " << m_Transform.GetPointer() << std::endl;
+
+  itkPrintSelfObjectMacro(MovingPointSet);
+  itkPrintSelfObjectMacro(FixedPointSet);
+  itkPrintSelfObjectMacro(Transform);
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
@@ -36,8 +36,9 @@ PointSetToSpatialObjectDemonsRegistration<TFixedPointSet, TMovingSpatialObject>:
                                                                                            Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Fixed PointSet: " << m_FixedPointSet.GetPointer() << std::endl;
-  os << indent << "Moving SpatialObject: " << m_MovingSpatialObject.GetPointer() << std::endl;
+
+  itkPrintSelfObjectMacro(MovingSpatialObject);
+  itkPrintSelfObjectMacro(FixedPointSet);
 }
 
 } // end namespace itk

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -355,9 +355,9 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Inde
   os << indent << "SolutionIndex2: " << m_SolutionIndex2 << std::endl;
   os << indent << "Gamma: " << m_Gamma << std::endl;
 
-  os << indent << "Solution: " << m_Solution << std::endl;
+  itkPrintSelfObjectMacro(Solution);
 
-  os << indent << "GradSigma: " << itk::NumericTraits<Float>::PrintType(m_GradSigma) << std::endl;
+  os << indent << "GradSigma: " << static_cast<typename NumericTraits<Float>::PrintType>(m_GradSigma) << std::endl;
   os << indent << "Sign: " << m_Sign << std::endl;
   os << indent << "WhichMetric: " << m_WhichMetric << std::endl;
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1457,47 +1457,84 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Min E: " << m_MinE << std::endl;
-  os << indent << "Current Level: " << m_CurrentLevel << std::endl;
-  os << indent << "Max Iterations: " << m_Maxiters << std::endl;
-  os << indent << "Max Level: " << m_MaxLevel << std::endl;
-  os << indent << "Total Iterations: " << m_TotalIterations << std::endl;
+  os << indent << "DoLineSearchOnImageEnergy: " << m_DoLineSearchOnImageEnergy << std::endl;
+  os << indent << "LineSearchMaximumIterations: " << m_LineSearchMaximumIterations << std::endl;
 
-  os << indent << "Descent Direction: " << m_DescentDirection << std::endl;
+  os << indent << "NumberOfIntegrationPoints: " << m_NumberOfIntegrationPoints << std::endl;
+  os << indent << "MetricWidth: " << m_MetricWidth << std::endl;
+  os << indent << "Maxiters: " << m_Maxiters << std::endl;
+  os << indent << "TotalIterations: " << m_TotalIterations << std::endl;
+  os << indent << "MaxLevel: " << m_MaxLevel << std::endl;
+  os << indent << "FileCount: " << m_FileCount << std::endl;
+  os << indent << "CurrentLevel: " << m_CurrentLevel << std::endl;
+  os << indent << "CurrentLevelImageSize: "
+     << static_cast<typename NumericTraits<typename FixedImageType::SizeType>::PrintType>(m_CurrentLevel) << std::endl;
+  os << indent << "WhichMetric: " << m_WhichMetric << std::endl;
+
+  os << indent << "MeshPixelsPerElementAtEachResolution: " << m_MeshPixelsPerElementAtEachResolution << std::endl;
+
+  os << indent << "TimeStep: " << m_TimeStep << std::endl;
   os << indent << "E: " << m_E << std::endl;
-  os << indent << "Gamma: " << m_Gamma << std::endl;
   os << indent << "Rho: " << m_Rho << std::endl;
-  os << indent << "Time Step: " << m_TimeStep << std::endl;
+  os << indent << "Gamma: " << m_Gamma << std::endl;
+  os << indent << "Energy: " << m_Energy << std::endl;
+  os << indent << "MinE: " << m_MinE << std::endl;
+  os << indent << "MinJacobian: " << m_MinJacobian << std::endl;
   os << indent << "Alpha: " << m_Alpha << std::endl;
 
-  os << indent << "Smoothing Standard Deviation: " << m_StandardDeviations << std::endl;
-  os << indent << "Maximum Error: " << m_MaximumError << std::endl;
-  os << indent << "Maximum Kernel Width: " << m_MaximumKernelWidth << std::endl;
+  os << indent << "UseLandmarks: " << (m_UseLandmarks ? "On" : "Off") << std::endl;
+  os << indent << "UseMassMatrix: " << (m_UseNormalizedGradient ? "On" : "Off") << std::endl;
+  os << indent << "UseNormalizedGradient: " << (m_UseNormalizedGradient ? "On" : "Off") << std::endl;
+  os << indent << "CreateMeshFromImage: " << (m_CreateMeshFromImage ? "On" : "Off") << std::endl;
+  os << indent << "EmployRegridding: " << m_EmployRegridding << std::endl;
+  os << indent << "DescentDirection: " << m_DescentDirection << std::endl;
+  os << indent << "EnergyReductionFactor: " << m_EnergyReductionFactor << std::endl;
+  os << indent << "FullImageSize: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_FullImageSize)
+     << std::endl;
+  os << indent << "ImageOrigin: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_ImageOrigin)
+     << std::endl;
 
-  os << indent << "Pixels Per Element: " << m_MeshPixelsPerElementAtEachResolution << std::endl;
-  os << indent << "Number of Integration Points: " << m_NumberOfIntegrationPoints << std::endl;
-  os << indent << "Metric Width: " << m_MetricWidth << std::endl;
-  os << indent << "Line Search Energy = " << m_DoLineSearchOnImageEnergy << std::endl;
-  os << indent << "Line Search Maximum Iterations: " << m_LineSearchMaximumIterations << std::endl;
-  os << indent << "Use Mass Matrix: " << m_UseMassMatrix << std::endl;
-  os << indent << "Employ Regridding: " << m_EmployRegridding << std::endl;
+  os << indent << "ImageScaling: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_ImageScaling)
+     << std::endl;
+  os << indent
+     << "CurrentImageScaling: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_CurrentImageScaling)
+     << std::endl;
 
-  os << indent << "Use Landmarks: " << m_UseLandmarks << std::endl;
-  os << indent << "Use Normalized Gradient: " << m_UseNormalizedGradient << std::endl;
-  os << indent << "Min Jacobian = " << m_MinJacobian << std::endl;
-
-  os << indent << "Image Scaling: " << m_ImageScaling << std::endl;
-  os << indent << "Current Image Scaling: " << m_CurrentImageScaling << std::endl;
-  os << indent << "Full Image Size: " << m_FullImageSize << std::endl;
-  os << indent << "Image Origin: " << m_ImageOrigin << std::endl;
-  os << indent << "Create Mesh: " << m_CreateMeshFromImage << std::endl;
+  os << indent << "FieldRegion: " << m_FieldRegion << std::endl;
+  os << indent
+     << "FieldSize: " << static_cast<typename NumericTraits<typename FieldType::SizeType>::PrintType>(m_FieldSize)
+     << std::endl;
 
   itkPrintSelfObjectMacro(Field);
   itkPrintSelfObjectMacro(TotalField);
   itkPrintSelfObjectMacro(Load);
+  itkPrintSelfObjectMacro(Warper);
   itkPrintSelfObjectMacro(WarpedImage);
+  itkPrintSelfObjectMacro(FloatImage);
+
+  os << indent << "Wregion: " << m_Wregion << std::endl;
+  os << indent
+     << "Windex: " << static_cast<typename NumericTraits<typename FixedImageType::IndexType>::PrintType>(m_Windex)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(MovingImage);
+  itkPrintSelfObjectMacro(OriginalMovingImage);
+  itkPrintSelfObjectMacro(FixedImage);
+
+  itkPrintSelfObjectMacro(Element);
+  itkPrintSelfObjectMacro(Material);
+  itkPrintSelfObjectMacro(Metric);
   itkPrintSelfObjectMacro(FEMObject);
+
+  os << indent << "LandmarkArray: " << m_LandmarkArray << std::endl;
+
   itkPrintSelfObjectMacro(Interpolator);
+
+  os << indent << "MaximumError: " << m_MaximumError << std::endl;
+  os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
+
+  os << indent << "StandardDeviation: "
+     << static_cast<typename NumericTraits<StandardDeviationsType>::PrintType>(m_StandardDeviations) << std::endl;
 }
 
 } // end namespace fem

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
@@ -104,12 +104,14 @@ PhysicsBasedNonRigidRegistrationMethod<TFixedImage, TMovingImage, TMaskImage, TM
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_SelectFraction: " << m_SelectFraction << std::endl;
-  os << indent << "m_NonConnectivity: " << m_NonConnectivity << std::endl;
-  os << indent << "m_BlockRadius: " << m_BlockRadius << std::endl;
-  os << indent << "m_SearchRadius: " << m_SearchRadius << std::endl;
-  os << indent << "m_ApproximationSteps: " << m_ApproximationSteps << std::endl;
-  os << indent << "m_OutlierRejectionSteps: " << m_OutlierRejectionSteps << std::endl;
+  os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
+  os << indent << "NonConnectivity: " << m_NonConnectivity << std::endl;
+  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_BlockRadius)
+     << std::endl;
+  os << indent << "SearchRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_SearchRadius)
+     << std::endl;
+  os << indent << "ApproximationSteps: " << m_ApproximationSteps << std::endl;
+  os << indent << "OutlierRejectionSteps: " << m_OutlierRejectionSteps << std::endl;
 
   itkPrintSelfObjectMacro(FeatureSelectionFilter);
   itkPrintSelfObjectMacro(BlockMatchingFilter);

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -41,9 +41,8 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
   Indent         indent) const
 {
   GPUSuperclass::PrintSelf(os, indent);
-  os << indent << "UseMovingImageGradient: ";
-  os << m_UseMovingImageGradient << std::endl;
-  os << indent << "Intensity difference threshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
+
+  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -98,28 +98,32 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MovingImageIterpolator: ";
-  os << m_MovingImageInterpolator.GetPointer() << std::endl;
-  os << indent << "FixedImageGradientCalculator: ";
-  os << m_FixedImageGradientCalculator.GetPointer() << std::endl;
-  os << indent << "DenominatorThreshold: ";
-  os << m_DenominatorThreshold << std::endl;
-  os << indent << "IntensityDifferenceThreshold: ";
-  os << m_IntensityDifferenceThreshold << std::endl;
+  os << indent << "ZeroUpdateReturn: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
+     << std::endl;
+  os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
-  os << indent << "UseMovingImageGradient: ";
-  os << m_UseMovingImageGradient << std::endl;
+  itkPrintSelfObjectMacro(FixedImageGradientCalculator);
+  itkPrintSelfObjectMacro(MovingImageGradientCalculator);
 
-  os << indent << "Metric: ";
-  os << m_Metric << std::endl;
-  os << indent << "SumOfSquaredDifference: ";
-  os << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: ";
-  os << m_NumberOfPixelsProcessed << std::endl;
-  os << indent << "RMSChange: ";
-  os << m_RMSChange << std::endl;
-  os << indent << "SumOfSquaredChange: ";
-  os << m_SumOfSquaredChange << std::endl;
+  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+
+  os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
+
+  os << indent << "Metric: " << m_Metric << std::endl;
+  os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
+  os << indent << "NumberOfPixelsProcessed: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent << "RMSChange: " << m_RMSChange << std::endl;
+  os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
+
+  itkPrintSelfObjectMacro(GPUPixelCounter);
+  itkPrintSelfObjectMacro(GPUSquaredChange);
+  itkPrintSelfObjectMacro(GPUSquaredDifference);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -83,6 +83,41 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   Indent         indent) const
 {
   GPUSuperclass::PrintSelf(os, indent);
+
+  itkPrintSelfObjectMacro(TempField);
+
+  os << indent << "SmoothingKernelSizes: " << m_SmoothingKernelSizes << std::endl;
+
+  os << indent << "SmoothingKernels: ";
+  if (m_SmoothingKernels != nullptr)
+  {
+    os << static_cast<typename NumericTraits<DeformationScalarType>::PrintType>(*m_SmoothingKernels);
+  }
+  os << std::endl;
+
+  itkPrintSelfObjectMacro(GPUSmoothingKernels);
+
+  os << indent << "UpdateFieldSmoothingKernelSizes: " << m_UpdateFieldSmoothingKernelSizes << std::endl;
+
+  os << indent << "UpdateFieldSmoothingKernels: ";
+  if (m_UpdateFieldSmoothingKernels != nullptr)
+  {
+    os << static_cast<typename NumericTraits<DeformationScalarType>::PrintType>(*m_UpdateFieldSmoothingKernels);
+  }
+  os << std::endl;
+
+  itkPrintSelfObjectMacro(UpdateFieldGPUSmoothingKernels);
+
+  os << indent << "ImageSizes: ";
+  if (m_ImageSizes != nullptr)
+  {
+    os << *m_ImageSizes;
+  }
+  os << std::endl;
+
+  itkPrintSelfObjectMacro(m_GPUImageSizes);
+
+  os << indent << "SmoothDisplacementFieldGPUKernelHandle: " << m_SmoothDisplacementFieldGPUKernelHandle << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -199,19 +199,22 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Alpha: " << this->m_Alpha << std::endl;
-  os << indent << "Point set sigma: " << this->m_PointSetSigma << std::endl;
-  os << indent << "Evaluation k-neighborhood: " << this->m_EvaluationKNeighborhood << std::endl;
+  os << indent << "UseAnisotropicCovariances: " << (m_UseAnisotropicCovariances ? "On" : "Off") << std::endl;
 
-  if (this->m_UseAnisotropicCovariances)
-  {
-    os << indent << "Kernel sigma: " << this->m_KernelSigma << std::endl;
-    os << indent << "Covariance k-neighborhood: " << this->m_CovarianceKNeighborhood << std::endl;
-  }
-  else
-  {
-    os << indent << "Isotropic covariances are used." << std::endl;
-  }
+  os << indent << "PointSetSigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_PointSetSigma)
+     << std::endl;
+  os << indent << "KernelSigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_KernelSigma)
+     << std::endl;
+  os << indent << "CovarianceKNeighborhood: " << m_CovarianceKNeighborhood << std::endl;
+  os << indent << "EvaluationKNeighborhood: " << m_EvaluationKNeighborhood << std::endl;
+
+  os << indent << "Alpha: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Alpha) << std::endl;
+
+  os << indent
+     << "TotalNumberOfPoints: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_TotalNumberOfPoints)
+     << std::endl;
+  os << indent << "Prefactor0: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Prefactor0) << std::endl;
+  os << indent << "Prefactor1: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Prefactor1) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkEuclideanDistancePointSetToPointSetMetricv4.h"
+#include "itkPrintHelper.h"
 
 #include <algorithm>
 
@@ -241,23 +242,17 @@ LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComp
   std::ostream & os,
   Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << "Fixed label set: ";
-  typename LabelSetType::const_iterator itF;
-  for (itF = this->m_FixedPointSetLabels.begin(); itF != this->m_FixedPointSetLabels.end(); ++itF)
-  {
-    os << *itF << ' ';
-  }
-  os << std::endl;
+  itkPrintSelfObjectMacro(PointSetMetric);
 
-  os << "Moving label set: ";
-  typename LabelSetType::const_iterator itM;
-  for (itM = this->m_MovingPointSetLabels.begin(); itM != this->m_MovingPointSetLabels.end(); ++itM)
-  {
-    os << *itM << ' ';
-  }
-  os << std::endl;
+  os << indent << "PointSetMetricClones: " << m_PointSetMetricClones << std::endl;
+
+  os << indent << "FixedPointSetLabels: " << m_FixedPointSetLabels << std::endl;
+  os << indent << "MovingPointSetLabels: " << m_MovingPointSetLabels << std::endl;
+  os << indent << "CommonPointSetLabels: " << m_CommonPointSetLabels << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -656,30 +656,33 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Fixed PointSet: " << this->m_FixedPointSet.GetPointer() << std::endl;
-  os << indent << "Fixed Transform: " << this->m_FixedTransform.GetPointer() << std::endl;
-  os << indent << "Moving PointSet: " << this->m_MovingPointSet.GetPointer() << std::endl;
-  os << indent << "Moving Transform: " << this->m_MovingTransform.GetPointer() << std::endl;
 
-  os << indent << "Store derivative as sparse field = ";
-  if (this->m_StoreDerivativeAsSparseFieldForLocalSupportTransforms)
-  {
-    os << "true." << std::endl;
-  }
-  else
-  {
-    os << "false." << std::endl;
-  }
+  itkPrintSelfObjectMacro(FixedPointSet);
+  itkPrintSelfObjectMacro(FixedTransformedPointSet);
+  itkPrintSelfObjectMacro(FixedTransformedPointsLocator);
+  itkPrintSelfObjectMacro(MovingPointSet);
+  itkPrintSelfObjectMacro(MovingTransformedPointSet);
+  itkPrintSelfObjectMacro(MovingTransformedPointsLocator);
+  itkPrintSelfObjectMacro(VirtualTransformedPointSet);
 
-  os << indent << "Calculate in tangent space = ";
-  if (this->m_CalculateValueAndDerivativeInTangentSpace)
-  {
-    os << "true." << std::endl;
-  }
-  else
-  {
-    os << "false." << std::endl;
-  }
+  os << indent << "UsePointSetData: " << (m_UsePointSetData ? "On" : "Off") << std::endl;
+  os << indent
+     << "CalculateValueAndDerivativeInTangentSpace: " << (m_CalculateValueAndDerivativeInTangentSpace ? "On" : "Off")
+     << std::endl;
+
+  os << indent << "MovingTransformPointLocatorsNeedInitialization: "
+     << (m_MovingTransformPointLocatorsNeedInitialization ? "On" : "Off") << std::endl;
+  os << indent << "FixedTransformPointLocatorsNeedInitialization: "
+     << (m_FixedTransformPointLocatorsNeedInitialization ? "On" : "Off") << std::endl;
+  os << indent << "HaveWarnedAboutNumberOfValidPoints: " << (m_HaveWarnedAboutNumberOfValidPoints ? "On" : "Off")
+     << std::endl;
+  os << indent << "StoreDerivativeAsSparseFieldForLocalSupportTransforms: "
+     << (m_StoreDerivativeAsSparseFieldForLocalSupportTransforms ? "On" : "Off") << std::endl;
+
+  os << indent << "MovingTransformedPointSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_MovingTransformedPointSetTime) << std::endl;
+  os << indent << "FixedTransformedPointSetTime: "
+     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_FixedTransformedPointSetTime) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -38,9 +38,8 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PrintSe
                                                                                    Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "UseMovingImageGradient: ";
-  os << m_UseMovingImageGradient << std::endl;
-  os << indent << "Intensity difference threshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
+
+  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -68,25 +68,24 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MovingImageIterpolator: ";
-  os << m_MovingImageInterpolator.GetPointer() << std::endl;
-  os << indent << "FixedImageGradientCalculator: ";
-  os << m_FixedImageGradientCalculator.GetPointer() << std::endl;
-  os << indent << "DenominatorThreshold: ";
-  os << m_DenominatorThreshold << std::endl;
-  os << indent << "IntensityDifferenceThreshold: ";
-  os << m_IntensityDifferenceThreshold << std::endl;
+  os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
-  os << indent << "Metric: ";
-  os << m_Metric << std::endl;
-  os << indent << "SumOfSquaredDifference: ";
-  os << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: ";
-  os << m_NumberOfPixelsProcessed << std::endl;
-  os << indent << "RMSChange: ";
-  os << m_RMSChange << std::endl;
-  os << indent << "SumOfSquaredChange: ";
-  os << m_SumOfSquaredChange << std::endl;
+  itkPrintSelfObjectMacro(FixedImageGradientCalculator);
+  itkPrintSelfObjectMacro(WarpedMovingImageGradientCalculator);
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+  itkPrintSelfObjectMacro(MovingImageWarper);
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+
+  os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
+
+  os << indent << "Metric: " << m_Metric << std::endl;
+  os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
+  os << indent << "NumberOfPixelsProcessed: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent << "RMSChange: " << m_RMSChange << std::endl;
+  os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -68,25 +68,30 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MovingImageIterpolator: ";
-  os << m_MovingImageInterpolator.GetPointer() << std::endl;
-  os << indent << "IntensityDifferenceThreshold: ";
-  os << m_IntensityDifferenceThreshold << std::endl;
-  os << indent << "GradientMagnitudeThreshold: ";
-  os << m_GradientMagnitudeThreshold << std::endl;
-  os << indent << "Alpha: ";
-  os << m_Alpha << std::endl;
+  os << indent
+     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
+     << std::endl;
+  os << indent << "FixedImageOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_FixedImageOrigin)
+     << std::endl;
 
-  os << indent << "Metric: ";
-  os << m_Metric << std::endl;
-  os << indent << "SumOfSquaredDifference: ";
-  os << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: ";
-  os << m_NumberOfPixelsProcessed << std::endl;
-  os << indent << "RMSChange: ";
-  os << m_RMSChange << std::endl;
-  os << indent << "SumOfSquaredChange: ";
-  os << m_SumOfSquaredChange << std::endl;
+  itkPrintSelfObjectMacro(MovingImageSmoothingFilter);
+
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+  itkPrintSelfObjectMacro(SmoothMovingImageInterpolator);
+
+  os << indent << "Alpha: " << m_Alpha << std::endl;
+  os << indent << "GradientMagnitudeThreshold: " << m_GradientMagnitudeThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
+  os << indent << "GradientSmoothingStandardDeviations: " << m_GradientSmoothingStandardDeviations << std::endl;
+
+  os << indent << "Metric: " << m_Metric << std::endl;
+  os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
+  os << indent << "NumberOfPixelsProcessed: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent << "RMSChange: " << m_RMSChange << std::endl;
+  os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
+
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -237,6 +237,13 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TDefaultRegistrationType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  itkPrintSelfObjectMacro(RegistrationFilter);
+  itkPrintSelfObjectMacro(MovingImagePyramid);
+  itkPrintSelfObjectMacro(FixedImagePyramid);
+  itkPrintSelfObjectMacro(FieldExpander);
+  itkPrintSelfObjectMacro(InitialDisplacementField);
+
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
   os << indent << "CurrentLevel: " << m_CurrentLevel << std::endl;
 
@@ -248,18 +255,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   }
   os << m_NumberOfIterations[ilevel] << ']' << std::endl;
 
-  os << indent << "RegistrationFilter: ";
-  os << m_RegistrationFilter.GetPointer() << std::endl;
-  os << indent << "MovingImagePyramid: ";
-  os << m_MovingImagePyramid.GetPointer() << std::endl;
-  os << indent << "FixedImagePyramid: ";
-  os << m_FixedImagePyramid.GetPointer() << std::endl;
-
-  os << indent << "FieldExpander: ";
-  os << m_FieldExpander.GetPointer() << std::endl;
-
-  os << indent << "StopRegistrationFlag: ";
-  os << m_StopRegistrationFlag << std::endl;
+  os << indent << "StopRegistrationFlag: " << (m_StopRegistrationFlag ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage,

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -138,28 +138,18 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
                                                                                           Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Smooth deformation field: " << (m_SmoothDisplacementField ? "on" : "off") << std::endl;
-  unsigned int j = 0;
-  os << indent << "Standard deviations: [" << m_StandardDeviations[j];
-  for (j = 1; j < ImageDimension; ++j)
-  {
-    os << ", " << m_StandardDeviations[j];
-  }
-  os << ']' << std::endl;
-  os << indent << "Smooth update field: " << (m_SmoothUpdateField ? "on" : "off") << std::endl;
-  j = 0;
-  os << indent << "Update field standard deviations: [" << m_UpdateFieldStandardDeviations[j];
-  for (j = 1; j < ImageDimension; ++j)
-  {
-    os << ", " << m_UpdateFieldStandardDeviations[j];
-  }
-  os << ']' << std::endl;
-  os << indent << "StopRegistrationFlag: ";
-  os << m_StopRegistrationFlag << std::endl;
-  os << indent << "MaximumError: ";
-  os << m_MaximumError << std::endl;
-  os << indent << "MaximumKernelWidth: ";
-  os << m_MaximumKernelWidth << std::endl;
+
+  os << indent << "StandardDeviations: " << m_StandardDeviations << std::endl;
+  os << indent << "UpdateFieldStandardDeviations: " << m_UpdateFieldStandardDeviations << std::endl;
+
+  os << indent << "SmoothDisplacementField: " << (m_SmoothDisplacementField ? "On" : "Off") << std::endl;
+  os << indent << "SmoothUpdateField: " << (m_SmoothUpdateField ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(TempField);
+
+  os << indent << "MaximumError: " << m_MaximumError << std::endl;
+  os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
+  os << indent << "StopRegistrationFlag: " << (m_StopRegistrationFlag ? "On" : "Off") << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -60,25 +60,28 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MovingImageIterpolator: ";
-  os << m_MovingImageInterpolator.GetPointer() << std::endl;
-  os << indent << "FixedImageGradientCalculator: ";
-  os << m_FixedImageGradientCalculator.GetPointer() << std::endl;
-  os << indent << "DenominatorThreshold: ";
-  os << m_DenominatorThreshold << std::endl;
-  os << indent << "IntensityDifferenceThreshold: ";
-  os << m_IntensityDifferenceThreshold << std::endl;
+  os << indent
+     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
+     << std::endl;
+  os << indent << "FixedImageOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_FixedImageOrigin)
+     << std::endl;
 
-  os << indent << "Metric: ";
-  os << m_Metric << std::endl;
-  os << indent << "SumOfSquaredDifference: ";
-  os << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: ";
-  os << m_NumberOfPixelsProcessed << std::endl;
-  os << indent << "RMSChange: ";
-  os << m_RMSChange << std::endl;
-  os << indent << "SumOfSquaredChange: ";
-  os << m_SumOfSquaredChange << std::endl;
+  os << indent << "Normalizer: " << m_Normalizer << std::endl;
+
+  itkPrintSelfObjectMacro(FixedImageGradientCalculator);
+  itkPrintSelfObjectMacro(MovingImageInterpolator);
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+
+  os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
+  os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
+
+  os << indent << "Metric: " << m_Metric << std::endl;
+  os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
+  os << indent << "NumberOfPixelsProcessed: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent << "RMSChange: " << m_RMSChange << std::endl;
+  os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -28,6 +28,7 @@
 #include "itkMattesMutualInformationImageToImageMetricv4.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkRegistrationParameterScalesFromPhysicalShift.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -1140,45 +1141,75 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   std::ostream & os,
   Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  Indent indent2 = indent.GetNextIndent();
 
-  os << indent << "Number of levels = " << this->m_NumberOfLevels << std::endl;
+  os << indent << "CurrentLevel: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel)
+     << std::endl;
+  os << indent << "NumberOfLevels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
+     << std::endl;
+  os << indent
+     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+     << std::endl;
+  os << indent
+     << "CurrentMetricValue: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentMetricValue)
+     << std::endl;
+  os << indent << "CurrentConvergenceValue: "
+     << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentConvergenceValue) << std::endl;
+  os << indent << "IsConverged: " << (m_IsConverged ? "On" : "Off") << std::endl;
 
-  for (SizeValueType level = 0; level < this->m_NumberOfLevels; ++level)
-  {
-    os << indent << "Shrink factors (level " << level << "): " << this->m_ShrinkFactorsPerLevel[level] << std::endl;
-  }
-  os << indent << "Smoothing sigmas: " << this->m_SmoothingSigmasPerLevel << std::endl;
+  os << indent << "FixedSmoothImages: " << m_FixedSmoothImages << std::endl;
+  os << indent << "MovingSmoothImages: " << m_MovingSmoothImages << std::endl;
+  os << indent << "FixedImageMasks: " << m_FixedImageMasks << std::endl;
+  os << indent << "MovingImageMasks: " << m_MovingImageMasks << std::endl;
 
-  if (this->m_SmoothingSigmasAreSpecifiedInPhysicalUnits == true)
-  {
-    os << indent2 << "Smoothing sigmas are specified in physical units." << std::endl;
-  }
-  else
-  {
-    os << indent2 << "Smoothing sigmas are specified in voxel units." << std::endl;
-  }
+  itkPrintSelfObjectMacro(VirtualDomainImage);
 
-  if (this->m_OptimizerWeights.Size() > 0)
-  {
-    os << indent << "Optimizers weights: " << this->m_OptimizerWeights << std::endl;
-  }
+  os << indent << "FixedPointSets: " << m_FixedPointSets << std::endl;
+  os << indent << "MovingPointSets: " << m_MovingPointSets << std::endl;
 
-  os << indent << "Metric sampling strategy: " << this->m_MetricSamplingStrategy << std::endl;
+  os << indent << "NumberOfFixedObjects: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedObjects) << std::endl;
+  os << indent << "NumberOfMovingObjects: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfMovingObjects) << std::endl;
 
-  os << indent << "Metric sampling percentage: ";
-  for (SizeValueType i = 0; i < this->m_NumberOfLevels; ++i)
-  {
-    os << this->m_MetricSamplingPercentagePerLevel[i] << ' ';
-  }
-  os << std::endl;
+  itkPrintSelfObjectMacro(Optimizer);
 
-  os << indent << "ReseedIterator: " << m_ReseedIterator << std::endl;
+  os << indent
+     << "OptimizerWeights: " << static_cast<typename NumericTraits<OptimizerWeightsType>::PrintType>(m_OptimizerWeights)
+     << std::endl;
+  os << indent << "OptimizerWeightsAreIdentity: " << (m_OptimizerWeightsAreIdentity ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(Metric);
+
+  os << indent << "MetricSamplingStrategy: " << m_MetricSamplingStrategy << std::endl;
+  os << indent << "MetricSamplingPercentagePerLevel: " << m_MetricSamplingPercentagePerLevel << std::endl;
+  os << indent
+     << "NumberOfMetrics: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfMetrics)
+     << std::endl;
+  os << indent << "FirstImageMetricIndex: " << m_FirstImageMetricIndex << std::endl;
+  os << indent << "ShrinkFactorsPerLevel: " << m_ShrinkFactorsPerLevel << std::endl;
+  os << indent << "SmoothingSigmasPerLevel: " << m_SmoothingSigmasPerLevel << std::endl;
+  os << indent
+     << "SmoothingSigmasAreSpecifiedInPhysicalUnits: " << (m_SmoothingSigmasAreSpecifiedInPhysicalUnits ? "On" : "Off")
+     << std::endl;
+
+  os << indent << "ReseedIterator: " << (m_ReseedIterator ? "On" : "Off") << std::endl;
   os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
   os << indent << "CurrentRandomSeed: " << m_CurrentRandomSeed << std::endl;
 
-  os << indent << "InPlace: " << (this->m_InPlace ? "On" : "Off") << std::endl;
+  os << indent << "TransformParametersAdaptorsPerLevel: ";
+  for (const auto & val : m_TransformParametersAdaptorsPerLevel)
+  {
+    os << val << " ";
+  }
+  os << std::endl;
+
+  itkPrintSelfObjectMacro(CompositeTransform);
+  itkPrintSelfObjectMacro(OutputTransform);
+
+  os << indent << "InPlace: " << (m_InPlace ? "On" : "Off") << std::endl;
 
   os << indent
      << "InitializeCenterOfLinearOutputTransform: " << (m_InitializeCenterOfLinearOutputTransform ? "On" : "Off")

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -871,10 +871,18 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Number of Iterations: " << this->m_NumberOfIterationsPerLevel << std::endl;
-  os << indent << "Learning rate: " << this->m_LearningRate << std::endl;
-  os << indent << "Convergence threshold: " << this->m_ConvergenceThreshold << std::endl;
-  os << indent << "Convergence window size: " << this->m_ConvergenceWindowSize << std::endl;
+  itkPrintSelfObjectMacro(IdentityDisplacementFieldTransform);
+
+  os << indent << "LearningRate: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LearningRate)
+     << std::endl;
+  os << indent
+     << "ConvergenceThreshold: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_ConvergenceThreshold)
+     << std::endl;
+  os << indent << "ConvergenceWindowSize: " << m_ConvergenceWindowSize << std::endl;
+  os << indent << "NumberOfIterationsPerLevel: " << m_NumberOfIterationsPerLevel << std::endl;
+  os << indent << "NumberOfTimePointSamples: "
+     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTimePointSamples) << std::endl;
+  os << indent << "BoundaryWeight: " << m_BoundaryWeight << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -449,12 +449,13 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Number of levels: " << this->m_NumberOfLevels << std::endl;
-  os << indent << "Smoothing sigmas: " << this->m_SmoothingSigmasPerLevel << std::endl;
-  os << indent << "Number of iterations: " << this->m_NumberOfIterationsPerLevel << std::endl;
-  os << indent << "Convergence threshold: " << this->m_ConvergenceThreshold << std::endl;
-  os << indent << "Convergence window size: " << this->m_ConvergenceWindowSize << std::endl;
-  os << indent << "Learning rate: " << this->m_LearningRate << std::endl;
+  os << indent << "LearningRate: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LearningRate)
+     << std::endl;
+  os << indent
+     << "ConvergenceThreshold: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_ConvergenceThreshold)
+     << std::endl;
+  os << indent << "ConvergenceWindowSize: " << m_ConvergenceWindowSize << std::endl;
+  os << indent << "NumberOfIterationsPerLevel: " << m_NumberOfIterationsPerLevel << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -367,10 +367,12 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "User provided priors =  " << m_UserProvidedPriors << std::endl;
-  os << indent << "User provided smooting filter =  " << m_UserProvidedSmoothingFilter << std::endl;
-  os << indent << "Smoothing filter pointer =  " << m_SmoothingFilter.GetPointer() << std::endl;
-  os << indent << "Number of smoothing iterations =  " << m_NumberOfSmoothingIterations << std::endl;
+  os << indent << "UserProvidedPriors: " << (m_UserProvidedPriors ? "On" : "Off") << std::endl;
+  os << indent << "UserProvidedSmoothingFilter " << (m_UserProvidedSmoothingFilter ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(SmoothingFilter);
+
+  os << indent << "NumberOfSmoothingIterations: " << m_NumberOfSmoothingIterations << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -292,19 +292,12 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
                                                                                                Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "UserSuppliesMembershipFunctions: " << (m_UserSuppliesMembershipFunctions ? "On" : "Off")
+     << std::endl;
   os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
-  if (m_MembershipFunctionContainer)
-  {
-    os << indent << "Membership function container:" << m_MembershipFunctionContainer << std::endl;
-  }
-  if (m_UserSuppliesMembershipFunctions)
-  {
-    os << indent << "Membership functions provided" << std::endl;
-  }
-  else
-  {
-    os << indent << "Membership functions not provided" << std::endl;
-  }
+
+  itkPrintSelfObjectMacro(MembershipFunctionContainer);
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -27,11 +27,8 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "General Image Classifier / Clusterer" << std::endl;
-  os << indent << "ClassifiedImage: ";
-  os << m_ClassifiedImage.GetPointer() << std::endl;
-  os << indent << "InputImage: ";
-  os << m_InputImage.GetPointer() << std::endl;
+  itkPrintSelfObjectMacro(InputImage);
+  itkPrintSelfObjectMacro(ClassifiedImage);
 }
 
 template <typename TInputImage, typename TClassifiedImage>

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
@@ -34,7 +34,16 @@ ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::P
 
   os << indent << "NumberOfSamples: " << m_NumberOfSamples << std::endl;
   os << indent << "Means: " << m_Means << std::endl;
-  os << indent << "Covariance: " << m_Covariance.get() << std::endl;
+
+  os << indent << "Covariance: ";
+  if (m_Covariance != nullptr)
+  {
+    os << *m_Covariance.get() << std::endl;
+  }
+  else
+  {
+    os << "(null): " << std::endl;
+  }
 
   itkPrintSelfObjectMacro(TrainingImage);
 }

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
@@ -19,6 +19,7 @@
 #define itkImageModelEstimatorBase_hxx
 
 #include "itkCommand.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -45,25 +46,14 @@ template <typename TInputImage, typename TMembershipFunction>
 void
 ImageModelEstimatorBase<TInputImage, TMembershipFunction>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Number of models: " << m_NumberOfModels << std::endl;
-  os << indent << "                   " << std::endl;
 
-  os << indent << "Results of the model estimator." << std::endl;
-  os << indent << "====================================" << std::endl;
+  os << indent << "NumberOfModels: " << m_NumberOfModels << std::endl;
+  os << indent << "MembershipFunctions: " << m_MembershipFunctions << std::endl;
 
-  for (unsigned int classIndex = 0; classIndex < m_NumberOfModels; ++classIndex)
-  {
-    os << indent << "Statistics for " << classIndex << std::endl;
-    (m_MembershipFunctions[classIndex])->Print(os);
-
-    os << indent << "====================================" << std::endl;
-  }
-
-  os << indent << "                   " << std::endl;
-
-  os << indent << "InputImage: ";
-  os << m_InputImage.GetPointer() << std::endl;
+  itkPrintSelfObjectMacro(InputImage);
 }
 
 template <typename TInputImage, typename TMembershipFunction>

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
@@ -47,7 +47,8 @@ void
 DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Kappa = " << m_Kappa << std::endl;
+
+  os << indent << "Kappa: " << m_Kappa << std::endl;
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -68,37 +68,19 @@ void
 DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Alpha = " << this->GetAlpha() << std::endl;
-  os << indent << "Beta = " << this->GetBeta() << std::endl;
-  os << indent << "Gamma = " << this->GetGamma() << std::endl;
-  os << indent << "Rigidity = " << this->GetRigidity() << std::endl;
-  os << indent << "Iterations = " << this->GetIterations() << std::endl;
-  os << indent << "Step = " << this->GetStep() << std::endl;
-  os << indent << "ImageDepth = " << this->GetImageDepth() << std::endl;
 
-  const GradientImageType * gradientImage = this->GetGradient();
+  os << indent << "Alpha: " << m_Alpha << std::endl;
+  os << indent << "Beta: " << m_Beta << std::endl;
+  os << indent << "Gamma: " << m_Gamma << std::endl;
+  os << indent << "Damping: " << m_Damping << std::endl;
+  os << indent << "Rigidity: " << m_Rigidity << std::endl;
+  os << indent << "Step: " << m_Step << std::endl;
+  os << indent << "ImageWidth: " << m_ImageWidth << std::endl;
+  os << indent << "ImageHeight: " << m_ImageHeight << std::endl;
+  os << indent << "ImageDepth: " << m_ImageDepth << std::endl;
+  os << indent << "Iterations: " << m_Iterations << std::endl;
 
-  if (gradientImage)
-  {
-    os << indent << "Gradient = " << gradientImage << std::endl;
-  }
-  else
-  {
-    os << indent << "Gradient = "
-       << "(None)" << std::endl;
-  }
-  os << indent << "ImageHeight = " << this->GetImageHeight() << std::endl;
-  os << indent << "ImageWidth = " << this->GetImageWidth() << std::endl;
-  os << indent << "Damping = " << this->GetDamping() << std::endl;
-  if (this->m_Data.IsNotNull())
-  {
-    os << indent << "Data = " << this->GetData() << std::endl;
-  }
-  else
-  {
-    os << indent << "Data = "
-       << "(None)" << std::endl;
-  }
+  itkPrintSelfObjectMacro(Data);
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
@@ -95,6 +95,18 @@ public:
   {
     m_Value = val;
   }
+
+  inline friend std::ostream &
+  operator<<(std::ostream & os, const ImageVoxel & val)
+  {
+    os << "Vpos: " << val.m_Vpos << std::endl;
+    os << "Spos: " << val.m_Spos << std::endl;
+    os << "Value: " << val.m_Value << std::endl;
+    os << "Distance: " << val.m_Distance << std::endl;
+    os << "Index: " << val.m_Index << std::endl;
+
+    return os;
+  }
 };
 /** \class DeformableSimplexMesh3DGradientConstraintForceFilterEnums
  * \brief Contains all enum classes used by the DeformableSimplexMesh3DGradientConstraintForceFilter class.

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 #include <set>
 
@@ -46,9 +47,26 @@ void
 DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os,
                                                                                          Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Range = " << m_Range << std::endl;
-  os << indent << "Image = " << m_Image << std::endl;
+
+  os << indent << "Range: " << m_Range << std::endl;
+
+  os << indent << "StartVoxel: ";
+  if (m_StartVoxel != nullptr)
+  {
+    os << *m_StartVoxel << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "Positive: " << m_Positive << std::endl;
+  os << indent << "Negative: " << m_Negative << std::endl;
+
+  itkPrintSelfObjectMacro(Image);
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
@@ -33,9 +33,9 @@ void
 RegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Region grow image filter object" << std::endl;
-  os << indent << "Maximum number of regions: " << m_MaximumNumberOfRegions << std::endl;
-  os << indent << "Maximum grid size : " << m_GridSize << std::endl;
+
+  os << indent << "MaximumNumberOfRegions: " << m_MaximumNumberOfRegions << std::endl;
+  os << indent << "GridSize: " << static_cast<typename NumericTraits<GridSizeType>::PrintType>(m_GridSize) << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -32,9 +32,28 @@ void
 KLMSegmentationBorder::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Lambda  = " << m_Lambda << std::endl;
-  os << indent << "Region1 = " << m_Region1 << std::endl;
-  os << indent << "Region2 = " << m_Region2 << std::endl;
+
+  os << indent << "Lambda: " << m_Lambda << std::endl;
+
+  os << indent << "Region1: ";
+  if (m_Region1 != nullptr)
+  {
+    os << m_Region1 << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "Region2: ";
+  if (m_Region2 != nullptr)
+  {
+    os << m_Region2 << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 
 void

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -151,8 +151,10 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_HasLabelForUndecidedPixels = " << this->m_HasLabelForUndecidedPixels << std::endl;
-  os << indent << "m_LabelForUndecidedPixels = " << this->m_LabelForUndecidedPixels << std::endl;
+  os << indent << "LabelForUndecidedPixels: "
+     << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_HasLabelForUndecidedPixels) << std::endl;
+  os << indent << "HasLabelForUndecidedPixels: " << (m_HasLabelForUndecidedPixels ? "On" : "Off") << std::endl;
+  os << indent << "TotalLabelCount: " << m_TotalLabelCount << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -150,11 +150,14 @@ void
 CollidingFrontsImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ApplyConnectivity = " << m_ApplyConnectivity << std::endl;
-  os << indent << "SeedPoints1: " << m_SeedPoints1.GetPointer() << std::endl;
-  os << indent << "SeedPoints2: " << m_SeedPoints2.GetPointer() << std::endl;
+
+  itkPrintSelfObjectMacro(SeedPoints1);
+  itkPrintSelfObjectMacro(SeedPoints2);
+
+  os << indent << "StopOnTargets: " << (m_StopOnTargets ? "On" : "Off") << std::endl;
+  os << indent << "ApplyConnectivity: " << (m_ApplyConnectivity ? "On" : "Off") << std::endl;
+
   os << indent << "NegativeEpsilon: " << m_NegativeEpsilon << std::endl;
-  os << indent << "StopOnTargets: " << m_StopOnTargets << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -121,7 +121,7 @@ public:
   }
 
   void
-  Print(std::ostream & os) const;
+  Print(std::ostream & os, Indent indent) const;
 
 private:
   char                      m_Pad1[128];

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -27,6 +27,7 @@
 #include <fstream>
 #include "itkMath.h"
 #include "itkPlatformMultiThreader.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -76,14 +77,20 @@ ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::ParallelSparseField
 
 template <typename TNeighborhoodType>
 void
-ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os) const
+ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   os << "ParallelSparseFieldCityBlockNeighborList: " << std::endl;
-  for (unsigned int i = 0; i < this->GetSize(); ++i)
-  {
-    os << "m_ArrayIndex[" << i << "]: " << m_ArrayIndex[i] << std::endl
-       << "m_NeighborhoodOffset[" << i << "]: " << m_NeighborhoodOffset[i] << std::endl;
-  }
+
+  os << indent << "m_Pad1: " << m_Pad1 << std::endl;
+  os << indent << "Size: " << m_Size << std::endl;
+  os << indent << "Radius: " << m_Radius << std::endl;
+  os << indent << "ArrayIndex: " << m_ArrayIndex << std::endl;
+  os << indent << "NeighborhoodOffset: " << m_NeighborhoodOffset << std::endl;
+
+  os << indent << "StrideTable: " << m_StrideTable << std::endl;
+  os << indent << "Pad2: " << m_Pad2 << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -2502,25 +2509,102 @@ template <typename TInputImage, typename TOutputImage>
 void
 ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  unsigned int i;
-  os << indent << "m_NumberOfLayers: " << NumericTraits<StatusType>::PrintType(this->GetNumberOfLayers()) << std::endl;
-  os << indent << "m_IsoSurfaceValue: " << this->GetIsoSurfaceValue() << std::endl;
-  os << indent << "m_LayerNodeStore: " << m_LayerNodeStore;
-  ThreadIdType ThreadId;
-  for (ThreadId = 0; ThreadId < m_NumOfWorkUnits; ++ThreadId)
+  m_NeighborList.Print(os, indent);
+
+  os << indent << "ConstantGradientValue: " << m_ConstantGradientValue << std::endl;
+
+  itkPrintSelfObjectMacro(ShiftedImage);
+
+  os << indent << "Layers: " << m_Layers << std::endl;
+
+  os << indent << "NumberOfLayers: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_NumberOfLayers)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(StatusImage);
+  itkPrintSelfObjectMacro(OutputImage);
+
+  itkPrintSelfObjectMacro(StatusImageTemp);
+  itkPrintSelfObjectMacro(OutputImageTemp);
+
+  itkPrintSelfObjectMacro(LayerNodeStore);
+
+  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
+     << std::endl;
+
+  os << indent << "TimeStepList: " << m_TimeStepList << std::endl;
+  os << indent << "ValidTimeStepList: " << m_ValidTimeStepList << std::endl;
+
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+
+  os << indent << "NumOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumOfWorkUnits)
+     << std::endl;
+
+  os << indent << "SplitAxis: " << m_SplitAxis << std::endl;
+  os << indent << "ZSize: " << m_ZSize << std::endl;
+  os << indent << "BoundaryChanged: " << (m_BoundaryChanged ? "On" : "Off") << std::endl;
+
+  os << indent << "Boundary: ";
+  if (m_Boundary != nullptr)
+  {
+    os << *m_Boundary << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "GlobalZHistogram: ";
+  if (m_GlobalZHistogram != nullptr)
+  {
+    os << *m_GlobalZHistogram << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "MapZToThreadNumber: ";
+  if (m_MapZToThreadNumber != nullptr)
+  {
+    os << *m_MapZToThreadNumber << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "ZCumulativeFrequency: ";
+  if (m_ZCumulativeFrequency != nullptr)
+  {
+    os << *m_ZCumulativeFrequency << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
+
+  os << indent << "Data: ";
+  for (ThreadIdType ThreadId = 0; ThreadId < m_NumOfWorkUnits; ++ThreadId)
   {
     os << indent << "ThreadId: " << ThreadId << std::endl;
     if (m_Data != nullptr)
     {
-      for (i = 0; i < m_Data[ThreadId].m_Layers.size(); ++i)
+      for (unsigned int i = 0; i < m_Data[ThreadId].m_Layers.size(); ++i)
       {
-        os << indent << "m_Layers[" << i << "]: size=" << m_Data[ThreadId].m_Layers[i]->Size() << std::endl;
+        os << indent << "m_Layers[" << i << "] size: " << m_Data[ThreadId].m_Layers[i]->Size() << std::endl;
         os << indent << m_Data[ThreadId].m_Layers[i];
       }
     }
   }
+  os << std::endl;
+
+  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  os << indent << "InterpolateSurfaceLocation: " << (m_InterpolateSurfaceLocation ? "On" : "Off") << std::endl;
+  os << indent << "BoundsCheckingActive: " << (m_BoundsCheckingActive ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -55,16 +55,18 @@ void
 ReinitializeLevelSetImageFilter<TLevelSet>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Level set value: " << m_LevelSetValue << std::endl;
-  os << indent << "Narrowbanding: " << m_NarrowBanding << std::endl;
-  os << indent << "Input narrow bandwidth: " << m_InputNarrowBandwidth;
-  os << std::endl;
-  os << indent << "Output narrow bandwidth: " << m_OutputNarrowBandwidth;
-  os << std::endl;
-  os << indent << "Input narrow band: " << m_InputNarrowBand.GetPointer();
-  os << std::endl;
-  os << indent << "Output narrow band: " << m_OutputNarrowBand.GetPointer();
-  os << std::endl;
+
+  os << indent << "LevelSetValue: " << m_LevelSetValue << std::endl;
+
+  itkPrintSelfObjectMacro(Locator);
+  itkPrintSelfObjectMacro(Marcher);
+
+  os << indent << "Narrowbanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+  os << indent << "InputNarrowBandwidth: " << m_InputNarrowBandwidth << std::endl;
+  os << indent << "OutputNarrowBandwidth: " << m_OutputNarrowBandwidth << std::endl;
+
+  itkPrintSelfObjectMacro(InputNarrowBand);
+  itkPrintSelfObjectMacro(OutputNarrowBand);
 }
 
 template <typename TLevelSet>

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
@@ -109,9 +109,18 @@ SegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType>::P
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "m_ReverseExpansionDirection = " << m_ReverseExpansionDirection << std::endl;
-  os << indent << "m_AutoGenerateSpeedAdvection = " << m_AutoGenerateSpeedAdvection << std::endl;
-  os << indent << "m_SegmentationFunction = " << m_SegmentationFunction << std::endl;
+  os << indent << "ReverseExpansionDirection: " << (m_ReverseExpansionDirection ? "On" : "Off") << std::endl;
+  os << indent << "AutoGenerateSpeedAdvection: " << (m_AutoGenerateSpeedAdvection ? "On" : "Off") << std::endl;
+
+  os << indent << "SegmentationFunction: ";
+  if (m_SegmentationFunction != nullptr)
+  {
+    os << m_SegmentationFunction << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 }
 
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
@@ -38,10 +38,12 @@ void
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
   os << indent << "ShapeParameterMeans: " << m_ShapeParameterMeans << std::endl;
-  os << indent << "ShapeParameterStandardDeviations:  ";
-  os << m_ShapeParameterStandardDeviations << std::endl;
+  os << indent << "ShapeParameterStandardDeviations: " << m_ShapeParameterStandardDeviations << std::endl;
   os << indent << "Weights: " << m_Weights << std::endl;
+
+  itkPrintSelfObjectMacro(GaussianFunction);
 }
 
 template <typename TFeatureImage, typename TOutputPixel>

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
@@ -35,9 +35,10 @@ void
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ShapeFunction: " << m_ShapeFunction.GetPointer() << std::endl;
-  os << indent << "ActiveRegion:  " << m_ActiveRegion.GetPointer() << std::endl;
-  os << indent << "FeatureImage:  " << m_FeatureImage.GetPointer() << std::endl;
+
+  itkPrintSelfObjectMacro(ShapeFunction);
+  itkPrintSelfObjectMacro(ActiveRegion);
+  itkPrintSelfObjectMacro(FeatureImage);
 }
 
 template <typename TFeatureImage, typename TOutputPixel>

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -35,8 +35,12 @@ void
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "ShapeFunction: " << m_ShapeFunction.GetPointer() << std::endl;
-  os << indent << "ShapePriorWeight: " << m_ShapePriorWeight << std::endl;
+
+  itkPrintSelfObjectMacro(ShapeFunction);
+
+  os << indent
+     << "ShapePriorWeight: " << static_cast<typename NumericTraits<ScalarValueType>::PrintType>(m_ShapePriorWeight)
+     << std::endl;
 }
 
 template <typename TImageType, typename TFeatureImageType>

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -112,7 +112,7 @@ public:
   ~SparseFieldCityBlockNeighborList() = default;
 
   void
-  Print(std::ostream & os) const;
+  Print(std::ostream & os, Indent indent) const;
 
 private:
   unsigned int              m_Size;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkShiftScaleImageFilter.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -72,14 +73,17 @@ SparseFieldCityBlockNeighborList<TNeighborhoodType>::SparseFieldCityBlockNeighbo
 
 template <typename TNeighborhoodType>
 void
-SparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os) const
+SparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   os << "SparseFieldCityBlockNeighborList: " << std::endl;
-  for (unsigned int i = 0; i < this->GetSize(); ++i)
-  {
-    os << "m_ArrayIndex[" << i << "]: " << m_ArrayIndex[i] << std::endl;
-    os << "m_NeighborhoodOffset[" << i << "]: " << m_NeighborhoodOffset[i] << std::endl;
-  }
+
+  os << indent << "Size: " << m_Size << std::endl;
+  os << indent << "Radius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_Radius) << std::endl;
+  os << indent << "ArrayIndex: " << m_ArrayIndex << std::endl;
+  os << indent << "NeighborhoodOffset: " << m_NeighborhoodOffset << std::endl;
+  os << indent << "StrideTable: " << m_StrideTable << std::endl;
 }
 
 // template<typename TInputImage, typename TOutputImage>
@@ -1131,19 +1135,32 @@ template <typename TInputImage, typename TOutputImage>
 void
 SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  unsigned int i;
-  os << indent << "m_IsoSurfaceValue: " << m_IsoSurfaceValue << std::endl;
+  m_NeighborList.Print(os, indent);
+
+  os << indent << "ConstantGradientValue: " << m_ConstantGradientValue << std::endl;
+
+  itkPrintSelfObjectMacro(ShiftedImage);
+
+  os << indent << "Layers: " << m_Layers << std::endl;
+  os << indent << "NumberOfLayers: " << m_NumberOfLayers << std::endl;
+
+  itkPrintSelfObjectMacro(StatusImage);
   itkPrintSelfObjectMacro(LayerNodeStore);
-  os << indent << "m_BoundsCheckingActive: " << m_BoundsCheckingActive;
-  for (i = 0; i < m_Layers.size(); ++i)
-  {
-    os << indent << "m_Layers[" << i << "]: size=" << m_Layers[i]->Size() << std::endl;
-    os << indent << m_Layers[i];
-  }
-  os << indent << "m_UpdateBuffer: size=" << static_cast<SizeValueType>(m_UpdateBuffer.size())
-     << " capacity=" << static_cast<SizeValueType>(m_UpdateBuffer.capacity()) << std::endl;
+
+  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
+     << std::endl;
+  os << indent << "UpdateBuffer: " << static_cast<typename NumericTraits<UpdateBufferType>::PrintType>(m_UpdateBuffer)
+     << std::endl;
+  os << indent << "InterpolateSurfaceLocation: " << (m_InterpolateSurfaceLocation ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(InputImage);
+  itkPrintSelfObjectMacro(OutputImage);
+
+  os << indent << "BoundsCheckingActive: " << (m_BoundsCheckingActive ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -46,30 +46,43 @@ MRFImageFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Inde
 {
   using namespace print_helper;
 
-  Superclass::PrintSelf(os, indent);
-
-  os << indent << " MRF Image filter object " << std::endl;
-
-  os << indent << " Number of classes: " << m_NumberOfClasses << std::endl;
-
-  os << indent << " Maximum number of iterations: " << m_MaximumNumberOfIterations << std::endl;
-
-  os << indent << " Error tolerance for convergence: " << m_ErrorTolerance << std::endl;
-
-  os << indent << " Size of the MRF neighborhood radius:" << m_InputImageNeighborhoodRadius << std::endl;
-
-  os << indent
-     << " Number of elements in MRF neighborhood :" << static_cast<SizeValueType>(m_MRFNeighborhoodWeight.size())
+  os << indent << "InputImageNeighborhoodRadius: "
+     << static_cast<typename NumericTraits<InputImageNeighborhoodRadiusType>::PrintType>(m_InputImageNeighborhoodRadius)
+     << std::endl;
+  os << indent << "LabelledImageNeighborhoodRadius: "
+     << static_cast<typename NumericTraits<LabelledImageNeighborhoodRadiusType>::PrintType>(
+          m_LabelledImageNeighborhoodRadius)
+     << std::endl;
+  os << indent << "LabelStatusImageNeighborhoodRadius: "
+     << static_cast<typename NumericTraits<LabelStatusImageNeighborhoodRadiusType>::PrintType>(
+          m_LabelStatusImageNeighborhoodRadius)
      << std::endl;
 
-  os << indent << " Neighborhood weight : " << m_MRFNeighborhoodWeight << std::endl;
+  os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
+  os << indent << "MaximumNumberOfIterations: " << m_MaximumNumberOfIterations << std::endl;
+  os << indent << "KernelSize: " << m_KernelSize << std::endl;
 
-  os << indent << " Smoothing factor for the MRF neighborhood:" << m_SmoothingFactor << std::endl;
+  os << indent << "ErrorCounter: " << m_ErrorCounter << std::endl;
+  os << indent << "NeighborhoodSize: " << m_NeighborhoodSize << std::endl;
+  os << indent << "TotalNumberOfValidPixelsInOutputImage: " << m_TotalNumberOfValidPixelsInOutputImage << std::endl;
+  os << indent << "TotalNumberOfPixelsInInputImage: " << m_TotalNumberOfPixelsInInputImage << std::endl;
+  os << indent << "ErrorTolerance: " << m_ErrorTolerance << std::endl;
 
+  os << indent << "SmoothingFactor: " << m_SmoothingFactor << std::endl;
+  os << indent << "ClassProbability: " << m_ClassProbability << std::endl;
+  os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
 
-  os << indent << " Number of iterations: " << m_NumberOfIterations << std::endl;
+  itkPrintSelfObjectMacro(LabelStatusImage);
+
+  os << indent << "MRFNeighborhoodWeight: " << m_MRFNeighborhoodWeight << std::endl;
+  os << indent << "NeighborInfluence: " << m_NeighborInfluence << std::endl;
+  os << indent << "MahalanobisDistance: " << m_MahalanobisDistance << std::endl;
+  os << indent << "DummyVector: " << m_DummyVector << std::endl;
+
+  itkPrintSelfObjectMacro(ClassifierPtr);
 } // end PrintSelf
+
 
 template <typename TInputImage, typename TClassifiedImage>
 void

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkBinaryThresholdImageFunction.h"
 #include "itkFloodFilledImageFunctionConditionalIterator.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -81,15 +82,20 @@ template <typename TInputImage, typename TOutputImage>
 void
 ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  this->Superclass::PrintSelf(os, indent);
-  os << indent << "Number of iterations: " << m_NumberOfIterations << std::endl;
-  os << indent << "Multiplier for confidence interval: " << m_Multiplier << std::endl;
+  using namespace print_helper;
+
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Seeds: " << m_Seeds << std::endl;
+  os << indent << "Multiplier: " << m_Multiplier << std::endl;
+  os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent
      << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
      << std::endl;
   os << indent << "InitialNeighborhoodRadius: " << m_InitialNeighborhoodRadius << std::endl;
-  os << indent << "Mean of the connected region: " << m_Mean << std::endl;
-  os << indent << "Variance of the connected region: " << m_Variance << std::endl;
+  os << indent << "Mean: " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Mean) << std::endl;
+  os << indent << "Variance: " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Variance)
+     << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkMath.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -47,23 +48,30 @@ template <typename TInputImage, typename TOutputImage>
 void
 IsolatedConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   this->Superclass::PrintSelf(os, indent);
+
+  os << indent << "Seeds1: " << std::endl;
+  os << indent << "Seeds2: " << std::endl;
+
   os << indent << "Lower: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Lower)
      << std::endl;
   os << indent << "Upper: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Upper)
      << std::endl;
+
   os << indent
      << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
      << std::endl;
+
   os << indent
      << "IsolatedValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_IsolatedValue)
      << std::endl;
   os << indent << "IsolatedValueTolerance: "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_IsolatedValueTolerance) << std::endl;
-  os << indent << "FindUpperThreshold: " << static_cast<typename NumericTraits<bool>::PrintType>(m_FindUpperThreshold)
-     << std::endl;
-  os << indent << "Thresholding Failed: " << static_cast<typename NumericTraits<bool>::PrintType>(m_ThresholdingFailed)
-     << std::endl;
+
+  os << indent << "FindUpperThreshold: " << (m_FindUpperThreshold ? "On" : "Off") << std::endl;
+  os << indent << "ThresholdingFailed: " << (m_ThresholdingFailed ? "On" : "Off") << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNeighborhoodBinaryThresholdImageFunction.h"
 #include "itkFloodFilledImageFunctionConditionalIterator.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -65,7 +66,11 @@ template <typename TInputImage, typename TOutputImage>
 void
 NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  this->Superclass::PrintSelf(os, indent);
+  using namespace print_helper;
+
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Seeds: " << m_Seeds << std::endl;
   os << indent << "Upper: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Upper)
      << std::endl;
   os << indent << "Lower: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Lower)

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkFloodFilledImageFunctionConditionalIterator.h"
 #include "itkNumericTraitsRGBPixel.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -45,13 +46,19 @@ template <typename TInputImage, typename TOutputImage>
 void
 VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  this->Superclass::PrintSelf(os, indent);
-  os << indent << "Number of iterations: " << m_NumberOfIterations << std::endl;
-  os << indent << "Multiplier for confidence interval: " << m_Multiplier << std::endl;
+  using namespace print_helper;
+
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Seeds: " << m_Seeds << std::endl;
+  os << indent << "Multiplier: " << m_Multiplier << std::endl;
+  os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent
      << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
      << std::endl;
   os << indent << "InitialNeighborhoodRadius: " << m_InitialNeighborhoodRadius << std::endl;
+
+  itkPrintSelfObjectMacro(ThresholdFunction);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -203,12 +203,12 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Mean = " << m_Mean << std::endl;
-  os << indent << "MeanTolerance = " << m_MeanTolerance << std::endl;
-  os << indent << "MeanPercentError = " << m_MeanPercentError << std::endl;
-  os << indent << "STD = " << m_STD << std::endl;
-  os << indent << "STDTolerance = " << m_STDTolerance << std::endl;
-  os << indent << "STDPercentError = " << m_STDPercentError << std::endl;
+  os << indent << "Mean: " << m_Mean << std::endl;
+  os << indent << "STD: " << m_STD << std::endl;
+  os << indent << "MeanTolerance: " << m_MeanTolerance << std::endl;
+  os << indent << "STDTolerance: " << m_STDTolerance << std::endl;
+  os << indent << "MeanPercentError: " << m_MeanPercentError << std::endl;
+  os << indent << "STDPercentError: " << m_STDPercentError << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -21,6 +21,7 @@
 
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkVoronoiDiagram2DGenerator.h"
+#include "itkPrintHelper.h"
 #include <cmath>
 
 namespace itk
@@ -39,20 +40,32 @@ void
 VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>::PrintSelf(std::ostream & os,
                                                                                             Indent         indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "Number Of Seeds: " << m_NumberOfSeeds << std::endl;
 
-  os << indent << "Minimum Region for Split: " << m_MinRegion << std::endl;
+  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  os << indent << "NumberOfSeeds: " << m_NumberOfSeeds << std::endl;
+  os << indent << "MinRegion: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MinRegion)
+     << std::endl;
+  os << indent << "Steps: " << m_Steps << std::endl;
+  os << indent << "LastStepSeeds: " << m_LastStepSeeds << std::endl;
+  os << indent << "NumberOfSeedsToAdded: " << m_NumberOfSeedsToAdded << std::endl;
+  os << indent << "NumberOfBoundary: " << m_NumberOfBoundary << std::endl;
 
-  os << indent << "Number Of Steps to Run: (0 means runs until no region to split) " << m_Steps << std::endl;
+  os << indent << "NumberOfPixels: " << m_NumberOfPixels << std::endl;
+  os << indent << "Label: " << m_Label << std::endl;
 
-  os << indent << "UseBackgroundInAPrior = " << m_UseBackgroundInAPrior << std::endl;
-  os << indent << "OutputBoundary = " << m_OutputBoundary << std::endl;
-  os << indent << "MeanDeviation = " << m_MeanDeviation << std::endl;
-  os << indent << "LastStepSeeds = " << m_LastStepSeeds << std::endl;
-  os << indent << "InteractiveSegmentation = " << m_InteractiveSegmentation << std::endl;
-  os << indent << "NumberOfSeedsToAdded = " << m_NumberOfSeedsToAdded << std::endl;
-  os << indent << "Size = " << m_Size << std::endl;
+  os << indent << "MeanDeviation: " << m_MeanDeviation << std::endl;
+  os << indent << "UseBackgroundInAPrior: " << (m_UseBackgroundInAPrior ? "On" : "Off") << std::endl;
+  os << indent << "OutputBoundary: " << (m_OutputBoundary ? "On" : "Off") << std::endl;
+
+  os << indent << "InteractiveSegmentation: " << (m_InteractiveSegmentation ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(WorkingVD);
+  itkPrintSelfObjectMacro(VDGenerator);
+
+  os << indent << "SeedsToAdded: " << m_SeedsToAdded << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TBinaryPriorImage>

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
@@ -107,7 +107,7 @@ BoundaryResolver<TPixelType, TDimension>::PrintSelf(std::ostream & os, Indent in
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Face = " << m_Face << std::endl;
+  os << indent << "Face: " << m_Face << std::endl;
 }
 } // end namespace watershed
 } // end namespace itk

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -19,6 +19,7 @@
 #define itkRingBuffer_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -35,9 +36,11 @@ template <typename TElement>
 void
 RingBuffer<TElement>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  os << indent << "RingBuffer:" << std::endl;
-  os << indent << "NumberOfBuffers: " << this->m_PointerVector.size() << std::endl;
+
+  os << indent << "PointerVector: " << m_PointerVector << std::endl;
 }
 
 template <typename TElement>

--- a/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
+++ b/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
@@ -40,15 +40,8 @@ void
 ImageFilterToVideoFilterWrapper<TImageToImageFilter>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  if (m_ImageFilter)
-  {
-    os << indent << "ImageFilter:" << std::endl;
-    m_ImageFilter->Print(os, indent.GetNextIndent());
-  }
-  else
-  {
-    os << indent << "ImageFilterType: " << typeid(ImageFilterType).name() << std::endl;
-  }
+
+  itkPrintSelfObjectMacro(ImageFilter);
 }
 
 template <typename TImageToImageFilter>

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -297,14 +297,25 @@ template <typename TInputVideoStream>
 void
 VideoFileWriter<TInputVideoStream>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FileName: " << this->m_FileName << std::endl;
-  if (!m_VideoIO.IsNull())
-  {
-    os << indent << "VideoIO:" << std::endl;
-    this->m_VideoIO->Print(os, indent.GetNextIndent());
-  }
+  os << indent << "FileName: " << m_FileName << std::endl;
+
+  itkPrintSelfObjectMacro(VideoIO);
+
+  os << indent << "OutputTemporalRegion: " << m_OutputTemporalRegion << std::endl;
+
+  os << indent
+     << "FramesPerSecond: " << static_cast<typename NumericTraits<TemporalRatioType>::PrintType>(m_FramesPerSecond)
+     << std::endl;
+  os << indent << "FourCC: " << m_FourCC << std::endl;
+  os << indent << "Dimensions: " << m_Dimensions << std::endl;
+  os << indent
+     << "NumberOfComponents: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfComponents)
+     << std::endl;
+  os << indent << "ComponentType: " << m_ComponentType << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -18,6 +18,7 @@
 #include "itkFileListVideoIO.h"
 
 #include "itkImageIOFactory.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -488,21 +489,13 @@ FileListVideoIO::VerifyExtensions(const std::vector<std::string> & fileList) con
 void
 FileListVideoIO::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  if (!m_ImageIO.IsNull())
-  {
-    os << indent << "Internal ImageIO:" << std::endl;
-    m_ImageIO->Print(os, indent.GetNextIndent());
-  }
+  itkPrintSelfObjectMacro(ImageIO);
 
-  os << indent << "Image filenames:" << std::endl;
-  auto it = m_FileNames.begin();
-  while (it != m_FileNames.end())
-  {
-    os << indent << *it << std::endl;
-    ++it;
-  }
+  os << indent << "FileNames: " << m_FileNames << std::endl;
 }
 
 } // end namespace itk


### PR DESCRIPTION
Make `PrintSelf`implementation style consistent following the ITK SWG
coding style guideline and the available ITK macros:
- Always print the superclass first.
- Print only the class instance variables.
- Use the `os << indent << "{ivarName}: " << m_ivarName << std::endl`
  recipe: do not print the leading `m_` of the ivar; use a colon after
  printing its name; leave a whitespace between the colon and the
  printed value of the ivar.
- For boolean ivars print `On`/`Off` according to their values using the
  ternary operator.
- Use `itkPrintSelfObjectMacro` to print objects inheriting from
  `itk::LightObject` that can be null.
- For pointers that do not inherit from `itk::LightObject` check whether
  they are non-null before attempting to print them and print the
  `(empty)` string otherwise.
- Rely on the self printing ability of the ITK classes to avoid
  boilerplate code when printing the corresponding ivars in other
  classes' `PrintSelf` methods.
- Take advantage of the output stream `<<` insertion operator overload
  for `std::vector` types in the `itk::print_helper` namespace defined
  in `itkPrintHelper.h` to print such types consistently.
- Cast custom types to their numerical values using
  `itk::NumericTraits::PrinType` so that they are printed as expected.
- Remove statements printing the hard-coded class name and its own
  pointer, e.g.
  ```
  os << indent << "ArrowSpatialObject(" << this << ")" << std::endl;
  ```
  `PrintSelf` does this without requiring the removed line.
- Save typing `this->` to point to the instance of the current class.

Apply the same principles to the `<<` operator overloads.

Overload the ostream operator for the `FixedImageSamplePoint` class used
by the `itk::ImageToImageMetric` class.

Overload the ostream operator for the `ImageVoxel` class used by the
`itk::DeformableSimplexMesh3DGradientConstraintForceFilter` class.

Overload the ostream operator for the `ImageVoxel` class used by the
`itk::DeformableSimplexMesh3DGradientConstraintForceFilter` class.
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)