### PR TITLE
STYLE: Add missing braces to the substatements of `if` statements

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -410,9 +410,13 @@ struct AlmostEqualsSignedVsUnsigned
   AlmostEqualsFunction(TSignedInt signedVariable, TUnsignedInt unsignedVariable)
   {
     if (signedVariable < 0)
+    {
       return false;
+    }
     if (unsignedVariable > static_cast<size_t>(itk::NumericTraits<TSignedInt>::max()))
+    {
       return false;
+    }
     return signedVariable == static_cast<TSignedInt>(unsignedVariable);
   }
 };

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -47,7 +47,9 @@ printnb(const TIteratorType & nb, bool full)
     {
       std::cout << **it << " ";
       if ((count % sz) == 0)
+      {
         std::cout << std::endl;
+      }
       ++it;
       ++count;
     }
@@ -82,7 +84,9 @@ FillImage(itk::Image<itk::Index<VDimension>, VDimension> * img)
         loop[i] = 0;
       }
       else
+      {
         break;
+      }
     }
     ++it;
   }

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix_feenableexcept_using_fegetenv.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix_feenableexcept_using_fegetenv.cxx
@@ -58,7 +58,9 @@ itk_feenableexcept(const fexcept_t excepts)
 
   static fenv_t fenv;
   if (fegetenv(&fenv))
+  {
     return static_cast<fexcept_t>(-1);
+  }
 
   // all previous masks
   const fexcept_t old_excepts = (fenv & FM_ALL_EXCEPT) << FE_EXCEPT_SHIFT;
@@ -74,7 +76,9 @@ itk_fedisableexcept(const fexcept_t excepts)
 
   static fenv_t fenv;
   if (fegetenv(&fenv))
+  {
     return static_cast<fexcept_t>(-1);
+  }
 
   // previous masks
   const fexcept_t old_excepts = (fenv & FM_ALL_EXCEPT) << FE_EXCEPT_SHIFT;
@@ -109,7 +113,9 @@ itk_feenableexcept(const fexcept_t excepts)
 
   static fenv_t fenv;
   if (fegetenv(&fenv))
+  {
     return static_cast<fexcept_t>(-1);
+  }
 
   // previous masks
   const fexcept_t old_excepts = fenv._itk_control_word & FE_ALL_EXCEPT;
@@ -128,7 +134,9 @@ itk_fedisableexcept(const fexcept_t excepts)
 
   static fenv_t fenv;
   if (fegetenv(&fenv))
+  {
     return static_cast<fexcept_t>(-1);
+  }
 
   // all previous masks
   fexcept_t old_excepts = fenv._itk_control_word & FE_ALL_EXCEPT;

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -83,7 +83,9 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
         testPosition[2] = z;
         functionValue = spatialFunc->Evaluate(testPosition);
         if (functionValue == 1)
+        {
           interiorPixelCounter++;
+        }
       }
     }
   }

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
@@ -88,7 +88,9 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
         testPosition[2] = z;
         functionValue = spatialFunc->Evaluate(testPosition);
         if (functionValue == 1)
+        {
           interiorPixelCounter++;
+        }
       }
     }
   }

--- a/Modules/Core/Common/test/itkFixedArrayTest2.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest2.cxx
@@ -112,9 +112,13 @@ itkFixedArrayTest2(int, char *[])
 
   const bool sameptr = (vec == vec2);
   if (sameptr)
+  {
     std::cout << "Same pointers: true" << std::endl;
+  }
   else
+  {
     std::cout << "Same pointers: false" << std::endl;
+  }
 
   std::cout << "Performance ratio = " << ratio << "%" << std::endl;
 

--- a/Modules/Core/Common/test/itkHashTableTest.cxx
+++ b/Modules/Core/Common/test/itkHashTableTest.cxx
@@ -82,7 +82,9 @@ itkHashTableTest(int, char *[])
   // CppCheck gives us a warning if the return value isn't used.
   // This is to prevent the user from calling empty() when they mean clear().
   if (Set.empty())
+  {
     std::cout << "Set is empty." << std::endl;
+  }
   Set.rehash(50);
   Set.insert("the horror");
   auto                        hsh_it = Set.begin();
@@ -116,7 +118,9 @@ itkHashTableTest(int, char *[])
   // CppCheck gives us a warning if the return value isn't used.
   // This is to prevent the user from calling empty() when they mean clear().
   if (months.empty())
+  {
     std::cout << "Set is empty." << std::endl;
+  }
   months.rehash(50);
   HashMapType::value_type p("psychotic break", 2);
   months.insert(p);

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -41,7 +41,9 @@ CheckBuffer(const TImageType * image, typename TImageType::PixelType p)
   while (!iter.IsAtEnd())
   {
     if (itk::Math::NotExactlyEquals(iter.Get(), p))
+    {
       return false;
+    }
     ++iter;
   }
   return true;

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -252,15 +252,23 @@ itkImageRegionTest(int, char *[])
 
     indexC.Fill(13);
     if (regionA.IsInside(indexC))
+    {
       std::cout << "13,13,13 IsInside" << std::endl;
+    }
     else
+    {
       std::cout << "13,13,13 is not inside !" << std::endl;
+    }
 
     indexC[0] = ContinuousIndexNumericTraits::quiet_NaN();
     if (regionA.IsInside(indexC))
+    {
       std::cout << "** NaN,13,13 *is* inside. **" << std::endl;
+    }
     else
+    {
       std::cout << "NaN,13,13 is not inside" << std::endl;
+    }
 
     std::cout << "NaN < -1 = " << (indexC[0] < -1.0) << std::endl;
     std::cout << "NaN > -1 = " << (indexC[0] > -1.0) << std::endl;

--- a/Modules/Core/Common/test/itkIntTypesTest.cxx
+++ b/Modules/Core/Common/test/itkIntTypesTest.cxx
@@ -53,10 +53,14 @@ CheckTraits(bool issigned, T * = nullptr)
 
   // make sure the numeric_limits is specialized
   if (!itk::NumericTraits<T>::is_specialized)
+  {
     return false;
+  }
 
   if (itk::NumericTraits<T>::is_signed != issigned)
+  {
     return false;
+  }
 
   return true;
 }
@@ -69,14 +73,20 @@ CheckType(size_t size, bool exactSize, bool issigned, const char * name, T * = n
   bool ret = true;
 
   if (exactSize)
+  {
     ret &= CheckSize<T>(size);
+  }
   else
+  {
     ret &= CheckAtleastSize<T>(size);
+  }
 
   ret &= CheckTraits<T>(issigned);
 
   if (ret)
+  {
     return ret;
+  }
 
   std::cout << "error with type \"" << name << "\" sizeof: " << sizeof(T)
             << " specialized: " << itk::NumericTraits<T>::is_specialized << " digits: " << itk::NumericTraits<T>::digits
@@ -140,7 +150,9 @@ itkIntTypesTest(int, char *[])
 
 
   if (pass)
+  {
     return EXIT_SUCCESS;
+  }
 
   return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
+++ b/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
@@ -158,7 +158,11 @@ itkMathCastWithRangeCheckTest(int, char *[])
 #endif
 
   if (pass)
+  {
     return EXIT_SUCCESS;
+  }
   else
+  {
     return EXIT_FAILURE;
+  }
 }

--- a/Modules/Core/Common/test/itkMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixTest.cxx
@@ -398,7 +398,9 @@ itkMatrixTest(int, char *[])
       for (unsigned int j = 0; j < 3; ++j)
       {
         if (itk::Math::isnan(invertedMatrix[i][j]))
+        {
           ++num_nans;
+        }
       }
     }
 

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -44,7 +44,9 @@ ImageBoundaryFaceCalculatorTest(TImage *                          image,
   }
 
   if (faceList.empty())
+  {
     return true;
+  }
 
   image->FillBuffer(0);
   for (auto fit = faceList.begin(); fit != faceList.end(); ++fit)
@@ -112,7 +114,9 @@ NeighborhoodAlgorithmTest()
 
   // test 1: requestToProcessRegion match the bufferedRegion
   if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+  {
     return false;
+  }
 
   ind.Fill(1);
   size.Fill(4);
@@ -121,7 +125,9 @@ NeighborhoodAlgorithmTest()
 
   // test 2: requestToProcessRegion is part of bufferedRegion
   if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+  {
     return false;
+  }
 
   ind.Fill(0);
   region.SetIndex(ind);
@@ -138,7 +144,9 @@ NeighborhoodAlgorithmTest()
 
   // test 3: requestToProcessRegion match the bufferedRegion, but all the bufferedRegion is inside the boundary
   if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+  {
     return false;
+  }
 
   size.Fill(5);
   region.SetSize(size);
@@ -153,7 +161,9 @@ NeighborhoodAlgorithmTest()
 
   // test 4: bufferedRegion is part of the requestToProcessRegion
   if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+  {
     return false;
+  }
 
   ind.Fill(0);
   size.Fill(10);
@@ -170,7 +180,9 @@ NeighborhoodAlgorithmTest()
   region.SetSize(size);
   // test 5: requestToProcessRegion is part of boundary of bufferedRegion
   if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+  {
     return false;
+  }
 
   if (VDimension == 2)
   {
@@ -191,7 +203,9 @@ NeighborhoodAlgorithmTest()
     radius.Fill(4);
     // test 6: test condition encountered by BoxMeanImageFilterTest with 24 threads
     if (!ImageBoundaryFaceCalculatorTest(image.GetPointer(), region, radius))
+    {
       return false;
+    }
   }
 
 
@@ -202,16 +216,24 @@ int
 itkNeighborhoodAlgorithmTest(int, char *[])
 {
   if (!NeighborhoodAlgorithmTest<int, 1>())
+  {
     return EXIT_FAILURE;
+  }
 
   if (!NeighborhoodAlgorithmTest<int, 2>())
+  {
     return EXIT_FAILURE;
+  }
 
   if (!NeighborhoodAlgorithmTest<int, 3>())
+  {
     return EXIT_FAILURE;
+  }
 
   if (!NeighborhoodAlgorithmTest<int, 4>())
+  {
     return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkNumericsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericsTest.cxx
@@ -41,7 +41,9 @@ solve_with_warning(vnl_matrix<V> const & M, vnl_matrix<V> const & B)
   vnl_svd<V> svd(M, 1e-8);
   // Check for rank-deficiency
   if (svd.singularities() > 1)
+  {
     std::cout << "Warning: Singular matrix, condition = " << svd.well_condition() << std::endl;
+  }
   return svd.solve(B);
 }
 

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -57,9 +57,13 @@ itkOctreeTest(int, char *[])
     {
       unsigned int val = rand() % 16384;
       if (counter && counter % 8 == 0)
+      {
         std::cerr << val << std::endl;
+      }
       else
+      {
         std::cerr << val << " ";
+      }
       counter++;
       ri.Set(val);
       ++ri;

--- a/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
+++ b/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
@@ -68,7 +68,9 @@ itkSparseFieldLayerTest(int, char *[])
     while (cit != layer->End())
     {
       if (cit->value != i || cit->value != i)
+      {
         return EXIT_FAILURE;
+      }
       ++cit;
       --i;
     }
@@ -78,10 +80,14 @@ itkSparseFieldLayerTest(int, char *[])
     while (it != layer->End())
     {
       if (it->value != i || it->value != i)
+      {
         return EXIT_FAILURE;
+      }
       it->value = 32567;
       if (it->value != 32567 || it->value != 32567)
+      {
         return EXIT_FAILURE;
+      }
       ++it;
       --i;
     }

--- a/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
@@ -58,7 +58,11 @@ itkSpatialFunctionTest(int, char *[])
   // The function should have returned a value of 1, since the center is inside
   // the sphere
   if (funcVal == 1)
+  {
     return EXIT_SUCCESS;
+  }
   else
+  {
     return EXIT_FAILURE;
+  }
 }

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -79,7 +79,9 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
         testPosition[2] = z;
         functionValue = spatialFunc->Evaluate(testPosition);
         if (functionValue == 1)
+        {
           interiorPixelCounter++;
+        }
       }
     }
   }

--- a/Modules/Core/Common/test/itkTimeProbesTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbesTest.cxx
@@ -43,7 +43,9 @@ TestTransformIndexToPhysicalPoint(T * image)
       }
     }
     if (k == 5)
+    {
       std::cout << point3D << std::endl;
+    }
   }
 }
 template <typename T>
@@ -66,7 +68,9 @@ TestTransformPhysicalPointToIndex(T * image)
       }
     }
     if (k == 5)
+    {
       std::cout << point3D << std::endl;
+    }
   }
 }
 //-------------------------

--- a/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
@@ -120,7 +120,9 @@ public:
   SetKernelArgWithImageAndBufferedRegion(int kernelIdx, cl_uint & argIdx, TGPUImageDataManager * manager)
   {
     if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+    {
       return false;
+    }
 
     cl_int errid;
 

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -250,7 +250,9 @@ GPUReduction<TElement>::GPUGenerateData()
   this->GetNumBlocksAndThreads(whichKernel, size, maxBlocks, maxThreads, numBlocks, numThreads);
 
   if (numBlocks == 1)
+  {
     cpuFinalThreshold = 1;
+  }
 
   // allocate output data for the result
   auto * h_odata = (TElement *)malloc(numBlocks * sizeof(TElement));

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -85,7 +85,9 @@ GPUKernelManager::LoadProgramFromFile(const char * filename, const char * cPream
   // allocate a buffer for the source code string and read it in
   char * cSourceString = (char *)malloc(szSourceLength + szPreambleLength + 1000);
   if (szPreambleLength > 0)
+  {
     memcpy(cSourceString, cPreamble, szPreambleLength);
+  }
   if (fread((cSourceString) + szPreambleLength, szSourceLength, 1, pFileStream) != 1)
   {
     fclose(pFileStream);
@@ -170,7 +172,9 @@ GPUKernelManager::LoadProgramFromString(const char * cSource, const char * cPrea
   // allocate a buffer for the source code string and read it in
   char * cSourceString = (char *)malloc(szFinalLength + 1);
   if (szPreambleLength > 0)
+  {
     memcpy(cSourceString, cPreamble, szPreambleLength);
+  }
 
   memcpy(cSourceString + szPreambleLength, cSource, szSourceLength);
 
@@ -311,7 +315,9 @@ bool
 GPUKernelManager::SetKernelArg(int kernelIdx, cl_uint argIdx, size_t argSize, const void * argVal)
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   cl_int errid;
 
@@ -405,7 +411,9 @@ bool
 GPUKernelManager::SetKernelArgWithImage(int kernelIdx, cl_uint argIdx, GPUDataManager * manager)
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   cl_int errid;
 
@@ -427,7 +435,9 @@ GPUKernelManager::CheckArgumentReady(int kernelIdx)
   for (int i = 0; i < nArg; ++i)
   {
     if (!(m_KernelArgumentReady[kernelIdx][i].m_IsReady))
+    {
       return false;
+    }
 
     // automatic synchronization before kernel launch
     if (m_KernelArgumentReady[kernelIdx][i].m_GPUDataManager != (GPUDataManager::Pointer) nullptr)
@@ -454,7 +464,9 @@ bool
 GPUKernelManager::LaunchKernel1D(int kernelIdx, size_t globalWorkSize, size_t itkNotUsed(localWorkSize))
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   if (!CheckArgumentReady(kernelIdx))
   {
@@ -495,7 +507,9 @@ GPUKernelManager::LaunchKernel2D(int    kernelIdx,
                                  size_t itkNotUsed(localWorkSizeY))
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   if (!CheckArgumentReady(kernelIdx))
   {
@@ -546,7 +560,9 @@ GPUKernelManager::LaunchKernel3D(int    kernelIdx,
                                  size_t itkNotUsed(localWorkSizeZ))
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   if (!CheckArgumentReady(kernelIdx))
   {
@@ -593,7 +609,9 @@ bool
 GPUKernelManager::LaunchKernel(int kernelIdx, int dim, size_t * globalWorkSize, size_t * localWorkSize)
 {
   if (kernelIdx < 0 || kernelIdx >= static_cast<int>(m_KernelContainer.size()))
+  {
     return false;
+  }
 
   if (!CheckArgumentReady(kernelIdx))
   {

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -360,7 +360,9 @@ IsGPUAvailable()
   cl_platform_id platformId = OpenCLSelectPlatform("NVIDIA");
 
   if (platformId == nullptr)
+  {
     return false;
+  }
 
   cl_device_type devType = CL_DEVICE_TYPE_GPU;
 
@@ -370,7 +372,9 @@ IsGPUAvailable()
   free(device_id);
 
   if (numDevices < 1)
+  {
     return false;
+  }
 
   return true;
 }

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -303,13 +303,17 @@ test1DCubicSpline()
     passed = TestContinuousIndex<InterpolatorType1D, ContinuousIndexType1D>(interp, cindex, b_Inside[ii], truth[ii]);
 
     if (!passed)
+    {
       flag += 1;
+    }
 
     image->TransformContinuousIndexToPhysicalPoint(cindex, point);
     passed = TestGeometricPoint<InterpolatorType1D, PointType1D>(interp, point, b_Inside[ii], truth[ii]);
 
     if (!passed)
+    {
       flag += 1;
+    }
   }
 
   return (flag);
@@ -377,13 +381,17 @@ test2DSpline()
         interp, cindex, b_Inside[ii], truth[ii][splineOrder]);
 
       if (!passed)
+      {
         flag += 1;
+      }
 
       image->TransformContinuousIndexToPhysicalPoint(cindex, point);
       passed = TestGeometricPoint<InterpolatorType2D, PointType2D>(interp, point, b_Inside[ii], truth[ii][splineOrder]);
 
       if (!passed)
+      {
         flag += 1;
+      }
     }
   } // end of splineOrder
 
@@ -447,14 +455,18 @@ test3DSpline()
         interp, cindex, b_Inside[ii], truth[ii][splineOrder - 2]);
 
       if (!passed)
+      {
         flag += 1;
+      }
 
       image->TransformContinuousIndexToPhysicalPoint(cindex, point);
       passed =
         TestGeometricPoint<InterpolatorType3D, PointType3D>(interp, point, b_Inside[ii], truth[ii][splineOrder - 2]);
 
       if (!passed)
+      {
         flag += 1;
+      }
     }
   } // end of splineOrder
 
@@ -521,7 +533,9 @@ test3DSplineDerivative()
       passed = TestContinuousIndexDerivative<InterpolatorType3D, ContinuousIndexType3D>(
         interp, cindex, b_Inside[ii], &truth[splineOrder - 1][ii][0]);
       if (!passed)
+      {
         flag += 1;
+      }
     }
   } // end of splineOrder
 
@@ -585,14 +599,18 @@ testInteger3DSpline()
         interp, cindex, b_Inside[ii], truth[ii][splineOrder - 2]);
 
       if (!passed)
+      {
         flag += 1;
+      }
 
       image->TransformContinuousIndexToPhysicalPoint(cindex, point);
       passed = TestGeometricPoint<InterpolatorIntegerType3D, PointIntegerType3D>(
         interp, point, b_Inside[ii], truth[ii][splineOrder - 2]);
 
       if (!passed)
+      {
         flag += 1;
+      }
     }
   } // end of splineOrder
 

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -73,30 +73,42 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
 
   int failed = 0;
   if (!threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   threshold->ThresholdAbove(100.0);
   if (!threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   threshold->ThresholdAbove(101.0);
   if (threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   threshold->ThresholdBetween(100.0, 100.0);
   if (!threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   threshold->ThresholdBetween(-100.0, 0.0);
   if (threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   index[0] = 8;
   index[1] = 8;
   index[2] = 8;
   threshold->ThresholdBetween(100.0, 200.0);
   if (threshold->EvaluateAtIndex(index))
+  {
     failed++;
+  }
 
   std::cout << threshold;
 

--- a/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
@@ -238,13 +238,17 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = RGBInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position at the image border
   {
@@ -256,13 +260,17 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = RGBInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position near image border
   {
@@ -275,13 +283,17 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = RGBInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position outside the image
   {
@@ -293,13 +305,17 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = RGBInterpolate::TestGeometricPoint(interp, point, false, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // at non-integer position
   {
@@ -311,13 +327,17 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = RGBInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
 
   /* Return results of test */

--- a/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
@@ -225,13 +225,17 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   index[0] = 10;
   index[1] = 20;
@@ -255,13 +259,17 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position near image border
   {
@@ -274,13 +282,17 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position outside the image
   {
@@ -292,13 +304,17 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, false, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // at non-integer position
   {
@@ -310,13 +326,17 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
 
   // Return results of test

--- a/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -240,13 +240,17 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   index[0] = 10;
   index[1] = 20;
@@ -270,13 +274,17 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position near image border
   {
@@ -289,13 +297,17 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position outside the image
   {
@@ -307,13 +319,17 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, false, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // at non-integer position
   {
@@ -325,13 +341,17 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
 
   /* Return results of test */

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -211,13 +211,17 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = SincInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position at the image border
   {
@@ -228,13 +232,17 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = SincInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position near image border
   {
@@ -246,13 +254,17 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = SincInterpolate::TestGeometricPoint(interp, point, true, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // position outside the image
   {
@@ -263,13 +275,17 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   }
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = SincInterpolate::TestGeometricPoint(interp, point, false, output);
 
   if (!passed)
+  {
     flag = 1;
+  }
 
   // at non-integer position
   {

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshNoPointConstTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshNoPointConstTest.cxx
@@ -35,18 +35,30 @@ itkQuadEdgeMeshNoPointConstTest(int, char *[])
   std::cout << "QE mesh limit: " << QEM_LIMIT << std::endl;
 
   if (NUM_LIMIT != GQE_LIMIT)
+  {
     return EXIT_FAILURE;
+  }
   if (NUM_LIMIT != QEM_LIMIT)
+  {
     return EXIT_FAILURE;
+  }
   if (QEM_LIMIT != GQE_LIMIT)
+  {
     return EXIT_FAILURE;
+  }
 
   if (NUM_LIMIT == 0)
+  {
     return EXIT_FAILURE;
+  }
   if (GQE_LIMIT == 0)
+  {
     return EXIT_FAILURE;
+  }
   if (QEM_LIMIT == 0)
+  {
     return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -112,9 +112,13 @@ itkTransformsSetParametersTest(int, char *[])
   affine->SetParameters(affineParams);
   endMTime = affine->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
 
   std::cout << "CenteredAffineTransform->SetParameters() - " << std::flush;
@@ -126,9 +130,13 @@ itkTransformsSetParametersTest(int, char *[])
   centeredAffine->SetParameters(centeredAffineParams);
   endMTime = centeredAffine->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "CenteredEuler3DTransform->SetParameters() - " << std::flush;
   using CenteredEuler3D = itk::CenteredEuler3DTransform<double>;
@@ -139,9 +147,13 @@ itkTransformsSetParametersTest(int, char *[])
   centeredEuler3D->SetParameters(centeredEuler3DParams);
   endMTime = centeredEuler3D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "CenteredRigid2DTransform->SetParameters() - " << std::flush;
   using CenteredRigid2D = itk::CenteredRigid2DTransform<double>;
@@ -152,9 +164,13 @@ itkTransformsSetParametersTest(int, char *[])
   centeredRigid2D->SetParameters(centeredRigid2DParams);
   endMTime = centeredRigid2D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "CenteredSimilarity2DTransform->SetParameters() - " << std::flush;
   using CenteredSimilarity2D = itk::CenteredSimilarity2DTransform<double>;
@@ -165,9 +181,13 @@ itkTransformsSetParametersTest(int, char *[])
   centeredSimilarity2D->SetParameters(centeredSimilarity2DParams);
   endMTime = centeredSimilarity2D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "Euler2DTransform->SetParameters() - " << std::flush;
   using Euler2D = itk::Euler2DTransform<double>;
@@ -178,9 +198,13 @@ itkTransformsSetParametersTest(int, char *[])
   euler2D->SetParameters(euler2DParams);
   endMTime = euler2D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "Euler3DTransform->SetParameters() - " << std::flush;
   using Euler3D = itk::Euler3DTransform<double>;
@@ -191,9 +215,13 @@ itkTransformsSetParametersTest(int, char *[])
   euler3D->SetParameters(euler3DParams);
   endMTime = euler3D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "FixedCenteredAffineTransform->SetParameters() - " << std::flush;
   using FixedCenteredAffine = itk::FixedCenterOfRotationAffineTransform<double, 3>;
@@ -204,9 +232,13 @@ itkTransformsSetParametersTest(int, char *[])
   fixedCenteredAffine->SetParameters(fixedCenteredAffineParams);
   endMTime = fixedCenteredAffine->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
 
   std::cout << "QuaternionRigidTransform->SetParameters() - " << std::flush;
@@ -218,9 +250,13 @@ itkTransformsSetParametersTest(int, char *[])
   quaternionRigid->SetParameters(quaternionRigidParams);
   endMTime = quaternionRigid->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "Rigid2DTransform->SetParameters() - " << std::flush;
   using Rigid2D = itk::Rigid2DTransform<double>;
@@ -231,9 +267,13 @@ itkTransformsSetParametersTest(int, char *[])
   rigid2D->SetParameters(rigid2DParams);
   endMTime = rigid2D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
 
   std::cout << "Rigid3DPerspectiveTransform->SetParameters() - " << std::flush;
@@ -245,9 +285,13 @@ itkTransformsSetParametersTest(int, char *[])
   rigid3DPerspective->SetParameters(rigid3DPerspectiveParams);
   endMTime = rigid3DPerspective->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "ScalableAffineTransform->SetParameters() - " << std::flush;
   using ScalableAffine = itk::ScalableAffineTransform<double, 3>;
@@ -258,9 +302,13 @@ itkTransformsSetParametersTest(int, char *[])
   scalableAffine->SetParameters(scalableAffineParams);
   endMTime = scalableAffine->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "ScaleLogarithmicTransform->SetParameters() - " << std::flush;
   using ScaleLogarithmic = itk::ScaleLogarithmicTransform<double, 3>;
@@ -271,9 +319,13 @@ itkTransformsSetParametersTest(int, char *[])
   scaleLogarithmic->SetParameters(scaleLogarithmicParams);
   endMTime = scaleLogarithmic->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "ScaleSkewVersor3DTransform->SetParameters() - " << std::flush;
   using ScaleSkewVersor3D = itk::ScaleSkewVersor3DTransform<double>;
@@ -284,9 +336,13 @@ itkTransformsSetParametersTest(int, char *[])
   scaleSkewVersor3D->SetParameters(scaleSkewVersor3DParams);
   endMTime = scaleSkewVersor3D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "ScaleTransform->SetParameters() - " << std::flush;
   using Scale = itk::ScaleTransform<double, 3>;
@@ -297,9 +353,13 @@ itkTransformsSetParametersTest(int, char *[])
   scale->SetParameters(scaleParams);
   endMTime = scale->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "Similarity2DTransform->SetParameters() - " << std::flush;
   using Similarity2D = itk::Similarity2DTransform<double>;
@@ -310,9 +370,13 @@ itkTransformsSetParametersTest(int, char *[])
   similarity2D->SetParameters(similarity2DParams);
   endMTime = similarity2D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "Similarity3DTransform->SetParameters() - " << std::flush;
   using Similarity3D = itk::Similarity3DTransform<double>;
@@ -323,9 +387,13 @@ itkTransformsSetParametersTest(int, char *[])
   similarity3D->SetParameters(similarity3DParams);
   endMTime = similarity3D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "TranslationTransform->SetParameters() - " << std::flush;
   using Translation = itk::TranslationTransform<double, 3>;
@@ -336,9 +404,13 @@ itkTransformsSetParametersTest(int, char *[])
   translation->SetParameters(translationParams);
   endMTime = translation->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "VersorTransform->SetParameters() - " << std::flush;
   using Versor = itk::VersorTransform<double>;
@@ -349,9 +421,13 @@ itkTransformsSetParametersTest(int, char *[])
   versor->SetParameters(versorParams);
   endMTime = versor->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "AzimuthElevationToCartesianTransform->SetParameters() - " << std::flush;
   using AzimuthElevationToCartesian = itk::AzimuthElevationToCartesianTransform<double, 3>;
@@ -362,9 +438,13 @@ itkTransformsSetParametersTest(int, char *[])
   azimuthElevation->SetParameters(azimuthElevationParams);
   endMTime = azimuthElevation->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
   std::cout << "VersorRigid3DTransform->SetParameters() - " << std::flush;
   using VersorRigid3D = itk::VersorRigid3DTransform<double>;
@@ -375,9 +455,13 @@ itkTransformsSetParametersTest(int, char *[])
   versorRigid3D->SetParameters(versorRigid3DParams);
   endMTime = versorRigid3D->GetMTime();
   if (endMTime > beginMTime)
+  {
     std::cout << "PASS" << std::endl;
+  }
   else
+  {
     std::cout << "FAIL" << std::endl;
+  }
 
 
   std::cout << "BSplineTransform->SetParameters() - Not Tested (manual check indicates PASS)" << std::endl;

--- a/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
@@ -128,7 +128,9 @@ IterativeDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInte
   {
     this->InvokeEvent(IterationEvent());
     if (m_StopIteration)
+    {
       break;
+    }
 
     this->Iteration(progress, iterationWeight);
   }

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -85,11 +85,17 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   {
     bool ok = true;
     if (i < linelength && itk::Math::NotAlmostEquals(params[i], paramsZero))
+    {
       ok = false;
+    }
     if (i % linelength == 0 && itk::Math::NotAlmostEquals(params[i], paramsZero))
+    {
       ok = false;
+    }
     if (i % linelength == (linelength - 1) && itk::Math::NotAlmostEquals(params[i], paramsZero))
+    {
       ok = false;
+    }
     if (!ok)
     {
       std::cout << "0-valued boundaries not found when expected "
@@ -128,11 +134,17 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     {
       bool ok = true;
       if (i < linelength && itk::Math::NotAlmostEquals(params[i], paramsZero))
+      {
         ok = false;
+      }
       if (i % linelength == 0 && itk::Math::NotAlmostEquals(params[i], paramsZero))
+      {
         ok = false;
+      }
       if (i % linelength == (linelength - 1) && itk::Math::NotAlmostEquals(params[i], paramsZero))
+      {
         ok = false;
+      }
       if (!ok)
       {
         std::cout << "0-valued boundaries not found when expected "

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -126,7 +126,9 @@ itkGradientImageFilterTest2(int argc, char * argv[])
   const unsigned int dimension = iobase->GetNumberOfDimensions();
 
   if (dimension == 2)
+  {
     return DoIt<itk::Image<float, 2>>(infname, outfname);
+  }
   else if (dimension == 3)
     return DoIt<itk::Image<float, 3>>(infname, outfname);
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
@@ -645,7 +645,9 @@ itkBSplineResampleImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
     passed = true;
   }
   if (!passed)
+  {
     std::cout << "*** " << flag << " expected exception was not caught." << std::endl;
+  }
   passed = false;
 
   try
@@ -660,7 +662,9 @@ itkBSplineResampleImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
     passed = true;
   }
   if (!passed)
+  {
     std::cout << "*** " << flag << " expected exception was not caught." << std::endl;
+  }
   passed = false;
 
   try
@@ -675,7 +679,9 @@ itkBSplineResampleImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
     passed = true;
   }
   if (!passed)
+  {
     std::cout << "*** " << flag << " expected exception was not caught." << std::endl;
+  }
   passed = false;
 
   try
@@ -690,7 +696,9 @@ itkBSplineResampleImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
     passed = true;
   }
   if (!passed)
+  {
     std::cout << "*** " << flag << " expected exception was not caught." << std::endl;
+  }
 
   std::cout << "dummyflag: " << dummyflag << std::endl;
   // Return results of test

--- a/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
@@ -90,7 +90,9 @@ itkCyclicShiftImageFilterTest(int argc, char * argv[])
     {
       outputIndex[i] = (outputIndex[i] + shift[i]) % imageSize[i];
       if (outputIndex[i] < 0)
+      {
         outputIndex[i] += imageSize[i];
+      }
       outputIndex[i] += newOrigin[i];
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -115,7 +115,9 @@ itkOrientImageFilterTest(int argc, char * argv[])
         ImageType::PixelType orig = randImage->GetPixel(originalIndex);
         ImageType::PixelType xfrm = IRP->GetPixel(transformedIndex);
         if (orig != xfrm)
+        {
           return EXIT_FAILURE;
+        }
       }
     }
   }
@@ -148,7 +150,9 @@ itkOrientImageFilterTest(int argc, char * argv[])
         ImageType::PixelType orig = randImage->GetPixel(originalIndex);
         ImageType::PixelType xfrm = LIP->GetPixel(transformedIndex);
         if (orig != xfrm)
+        {
           return EXIT_FAILURE;
+        }
       }
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -135,9 +135,13 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
     }
   }
   if (!passed)
+  {
     std::cout << "Forward Sampling Failed!!!\n\n" << std::endl;
+  }
   else
+  {
     std::cout << "Forward Sampling Passed\n" << std::endl;
+  }
 
   // Create and configure an image to be a restored "copy" of the input
   InputImagePointerType image2;
@@ -184,9 +188,13 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
     }
   }
   if (!passed)
+  {
     std::cout << "Resampling back to Phased Array coordinates Failed!!!\n\n" << std::endl;
+  }
   else
+  {
     std::cout << "Resampling back to Phased Array coordinates Passed\n" << std::endl;
+  }
 
   if (!passed)
   {

--- a/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
@@ -30,21 +30,37 @@ int
 VerifyPixel(int row, int col, short val, float & expected)
 {
   if (row < 0)
+  {
     row += 8;
+  }
   if (row < 0)
+  {
     row += 8;
+  }
   if (row > 7)
+  {
     row -= 8;
+  }
   if (row > 7)
+  {
     row -= 8;
+  }
   if (col < 0)
+  {
     col += 12;
+  }
   if (col < 0)
+  {
     col += 12;
+  }
   if (col > 11)
+  {
     col -= 12;
+  }
   if (col > 11)
+  {
     col -= 12;
+  }
   expected = 8 * col + row;
   return (itk::Math::AlmostEquals(val, expected));
 }

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
@@ -84,7 +84,9 @@ itkTernaryOperatorImageFilterTest(int, char *[])
   for (maskIt.GoToBegin(); !maskIt.IsAtEnd(); ++maskIt)
   {
     if (maskIt.GetIndex()[0] + maskIt.GetIndex()[1] % 2 == 0)
+    {
       maskIt.Set(true);
+    }
   }
 
   constexpr short val1 = 25;

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -122,7 +122,9 @@ HDF5ReadWriteTest2(const char * fileName)
 
   // Check streaming regions.
   if (!writerMonitor->VerifyInputFilterExecutedStreaming(5))
+  {
     return EXIT_FAILURE;
+  }
   typename ImageType::RegionType expectedRegion;
   expectedRegion.SetIndex(0, 0);
   expectedRegion.SetIndex(1, 0);
@@ -202,7 +204,9 @@ HDF5ReadWriteTest2(const char * fileName)
 
   // Check number of streaming regions.
   if (!readerMonitor->VerifyInputFilterExecutedStreaming(5))
+  {
     return EXIT_FAILURE;
+  }
 
   // Check streaming regions.
   typename MonitorFilterType::RegionVectorType readerRegionVector = readerMonitor->GetUpdatedBufferedRegions();

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
@@ -196,7 +196,9 @@ FileFreeImageIO ::SplitString(const std::string &        text,
   {
     std::string::size_type stop = text.find_first_of(separators, start);
     if (stop > n)
+    {
       stop = n;
+    }
     words.push_back(text.substr(start, stop - start));
     start = text.find_first_not_of(separators, stop + 1);
   }

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
@@ -61,7 +61,9 @@ SameRegionImage(ImageConstPointer test, ImageConstPointer baseline)
   std::cout << "NumberOfPixelsWithDifferences: " << status << std::endl;
 
   if (status > numberOfPixelTolerance)
+  {
     return false;
+  }
   return true;
 }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -256,10 +256,14 @@ itkImageFileWriterStreamingPastingCompressingTest1(int argc, char * argv[])
     {
       expectException[i] = 0;
       if (std::stoi(argv[i + expectedExceptionOffset]) == 1)
+      {
         expectException[i] = 1;
+      }
     }
     else
+    {
       expectException[i] = -1;
+    }
   }
 
   i = 0;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
@@ -52,7 +52,9 @@ itkImageFileWriterStreamingTest1(int argc, char * argv[])
   if (argc > 4)
   {
     if (std::stoi(argv[4]) == 1)
+    {
       forceNoStreamingInput = true;
+    }
   }
 
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
@@ -54,7 +54,9 @@ SameImage(std::string output, std::string baseline)
   unsigned long status = diff->GetNumberOfPixelsWithDifferences();
 
   if (status > numberOfPixelTolerance)
+  {
     return false;
+  }
   return true;
 }
 
@@ -93,10 +95,14 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   writer->SetNumberOfStreamDivisions(numberOfDataPieces);
 
   if (std::string(argv[2]) != writer->GetFileName())
+  {
     return EXIT_FAILURE;
+  }
 
   if (numberOfDataPieces != writer->GetNumberOfStreamDivisions())
+  {
     return EXIT_FAILURE;
+  }
 
   // Write the whole image
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
@@ -143,7 +149,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   }
 
   if (!SameImage(argv[1], argv[2]))
+  {
     return EXIT_FAILURE;
+  }
 
   reader->Modified();
   ////////////////////////////////////////////////
@@ -168,7 +176,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   }
 
   if (!SameImage(argv[1], argv[2]))
+  {
     return EXIT_FAILURE;
+  }
 
 
   reader->Modified();
@@ -194,7 +204,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   }
 
   if (!SameImage(argv[1], argv[2]))
+  {
     return EXIT_FAILURE;
+  }
 
 
   reader->Modified();
@@ -319,7 +331,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
 
   if (!SameImage(argv[1], argv[2]))
+  {
     return EXIT_FAILURE;
+  }
 
 
   return EXIT_SUCCESS;

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1076,7 +1076,9 @@ MINCImageIO::WriteImageInformation()
       ExposeMetaData<std::string>(thisDic, "storage_data_type", storage_data_type))
   {
     if (storage_data_type == typeid(char).name())
+    {
       this->m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
+    }
     else if (storage_data_type == typeid(unsigned char).name())
       this->m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
     else if (storage_data_type == typeid(short).name())
@@ -1350,9 +1352,13 @@ get_buffer_min_max(const void * _buffer, size_t len, double & buf_min, double & 
   for (size_t i = 0; i < len; ++i)
   {
     if (buf[i] < static_cast<double>(buf_min))
+    {
       buf_min = static_cast<double>(buf[i]);
+    }
     if (buf[i] > static_cast<double>(buf_max))
+    {
       buf_max = static_cast<double>(buf[i]);
+    }
   }
 }
 

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -261,7 +261,9 @@ equal(const itk::VariableLengthVector<TPixel> & pix1, const itk::VariableLengthV
   for (size_t i = 0; i < pix1.GetSize(); ++i)
   {
     if (pix1[i] != pix2[i])
+    {
       return false;
+    }
   }
   return true;
 }
@@ -276,7 +278,9 @@ abs_vector_diff(const itk::VariableLengthVector<TPixel> & pix1, const itk::Varia
   {
     double d = itk::Math::abs(static_cast<double>(pix1[i] - pix2[i]));
     if (d > diff)
+    {
       diff = d;
+    }
   }
   return diff;
 }
@@ -383,9 +387,13 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
   {
     TPixel pix;
     if (tolerance > 0.0)
+    {
       RandomPix(randgen, pix, 100);
+    }
     else
+    {
       RandomPix(randgen, pix);
+    }
     it.Set(pix);
   }
 
@@ -629,9 +637,13 @@ MINCReadWriteTestVector(const char * fileName,
   {
     InternalPixelType pix(vector_length);
     if (tolerance > 0.0)
+    {
       RandomVectorPix<TPixel>(randgen, pix, 100.0);
+    }
     else
+    {
       RandomVectorPix<TPixel>(randgen, pix);
+    }
     it.Set(pix);
   }
 

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -1793,7 +1793,9 @@ GiftiMeshIO::GetNumberOfPixelComponentsFromGifti(int datatype)
   nifti_datatype_sizes(datatype, &BytePerVoxel, &SwapSize);
 
   if (SwapSize == 0 && BytePerVoxel > 0)
+  {
     numComponents = BytePerVoxel;
+  }
   else if (SwapSize > 0 && BytePerVoxel > 0)
     numComponents = BytePerVoxel / SwapSize;
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1020,7 +1020,9 @@ NiftiImageIO::ReadImageInformation()
     else
     {
       if (this->GetLegacyAnalyze75Mode() == NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning)
+      {
         itkWarningMacro(<< this->GetFileName() << " is Analyze file and it's deprecated ");
+      }
       // to disable this message, specify preferred Analyze flavor using SetLegacyAnalyze75Mode
     }
   }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
@@ -30,7 +30,9 @@ itkNiftiImageIOTest2(int argc, char * argv[])
     itksys::SystemTools::ChangeDirectory(testdir);
   }
   if (argc != 4)
+  {
     return EXIT_FAILURE;
+  }
   char * arg1 = argv[1];
   char * arg2 = argv[2];
   char * prefix = argv[3];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
@@ -43,23 +43,31 @@ WriteNiftiTestFiles(const std::string & prefix)
   // Force to be Nifti-compliant
   std::ofstream little_hdr((prefix + "NiftiLittleEndian.hdr").c_str(), std::ios::binary | std::ios::out);
   if (!little_hdr.is_open())
+  {
     return EXIT_FAILURE;
+  }
   std::cout << "NiftiLittleEndian written" << std::endl;
   little_hdr.write(reinterpret_cast<const char *>(&NiftiLittleEndian), sizeof(NiftiLittleEndian));
   little_hdr.close();
   std::ofstream little_img((prefix + "NiftiLittleEndian.img").c_str(), std::ios::binary | std::ios::out);
   if (!little_img.is_open())
+  {
     return EXIT_FAILURE;
+  }
   little_img.write(reinterpret_cast<const char *>(LittleEndian_img), sizeof(LittleEndian_img));
   little_img.close();
   std::ofstream big_hdr((prefix + "NiftiBigEndian.hdr").c_str(), std::ios::binary | std::ios::out);
   if (!big_hdr.is_open())
+  {
     return EXIT_FAILURE;
+  }
   big_hdr.write(reinterpret_cast<const char *>(&NiftiBigEndian), sizeof(NiftiBigEndian));
   big_hdr.close();
   std::ofstream big_img((prefix + "NiftiBigEndian.img").c_str(), std::ios::binary | std::ios::out);
   if (!big_img.is_open())
+  {
     return EXIT_FAILURE;
+  }
   big_img.write(reinterpret_cast<const char *>(BigEndian_img), sizeof(BigEndian_img));
   big_img.close();
   return EXIT_SUCCESS;
@@ -100,12 +108,16 @@ TestNiftiByteSwap(const std::string & prefix)
     while (!littleIter.IsAtEnd())
     {
       if (itk::Math::NotExactlyEquals(littleIter.Get(), bigIter.Get()))
+      {
         break;
+      }
       ++littleIter;
       ++bigIter;
     }
     if (!littleIter.IsAtEnd() || !bigIter.IsAtEnd())
+    {
       rval = -1;
+    }
   }
   catch (const itk::ExceptionObject & ex)
   {

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -277,7 +277,9 @@ itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                
   catch (...)
   {
     if (analyze_mode == itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject)
+    {
       std::cerr << "Failure is expected" << std::endl << std::endl;
+    }
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -390,7 +390,9 @@ PNGImageIO::ReadImageInformation()
       png_get_PLTE(png_ptr, info_ptr, &palette, &num_entry);
 
       if (num_entry < 0)
+      {
         num_entry = 0;
+      }
       auto num_entryI(static_cast<size_t>(num_entry));
 
       m_ColorPalette.resize(num_entryI);

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -267,7 +267,9 @@ public:
   {
     cleanup();
     if (input_transform_file(xfm, &m_Xfm) != VIO_OK)
+    {
       itkExceptionMacro(<< "Error reading XFM:" << xfm);
+    }
     m_Initialized = true;
   }
 
@@ -275,7 +277,9 @@ public:
   Invert()
   {
     if (!m_Initialized)
+    {
       itkExceptionMacro(<< "XFM not initialized");
+    }
     if (!m_Initialized_invert)
     {
       create_inverse_general_transform(&m_Xfm, &m_Xfm_inv);
@@ -288,7 +292,9 @@ protected:
   MINCTransformAdapter()
   {
     if (VInputDimension != 3 || VOutputDimension != 3)
+    {
       itkExceptionMacro(<< "Sorry, only 3D to 3d minc xfm transform is currently implemented");
+    }
   }
 
   ~MINCTransformAdapter() override { cleanup(); }

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -53,7 +53,9 @@ void
 MINCTransformIOTemplate<TParametersValueType>::_cleanup()
 {
   if (m_XFM_initialized)
+  {
     delete_general_transform(&m_XFM);
+  }
   m_XFM_initialized = false;
 }
 

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -87,9 +87,13 @@ bool
 ImagesEqual(const TImage * img1, const TImage * img2, const typename TImage::RegionType & region)
 {
   if (!img1->GetBufferedRegion().IsInside(region))
+  {
     return false;
+  }
   if (!img2->GetBufferedRegion().IsInside(region))
+  {
     return false;
+  }
 
   itk::ImageRegionConstIterator<TImage> it1(img1, region);
   itk::ImageRegionConstIterator<TImage> it2(img2, region);

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -253,9 +253,13 @@ ParticleSwarmOptimizerBase::StartOptimization()
     if (this->m_IterationIndex >= m_NumberOfGenerationsWithMinimalImprovement)
     {
       if (index == this->m_NumberOfGenerationsWithMinimalImprovement)
+      {
         prevIndex = 0;
+      }
       else
+      {
         prevIndex = index + 1;
+      }
       // function value hasn't improved for a while, check the
       // parameter space to see if the "best" swarm has collapsed
       // around the swarm's best parameters, indicating convergence
@@ -281,9 +285,13 @@ ParticleSwarmOptimizerBase::StartOptimization()
 
   this->m_StopConditionDescription << GetNameOfClass() << ": ";
   if (converged)
+  {
     this->m_StopConditionDescription << "successfully converged after " << m_IterationIndex << " iterations";
+  }
   else
+  {
     this->m_StopConditionDescription << "terminated after " << m_IterationIndex << " iterations";
+  }
   InvokeEvent(EndEvent());
 }
 

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -369,7 +369,9 @@ AmoebaTest1()
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > xTolerance)
+    {
       pass = false;
+    }
   }
 
   if (!pass)
@@ -442,7 +444,9 @@ AmoebaTest1()
     for (unsigned int j = 0; j < 2; ++j)
     {
       if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > xTolerance)
+      {
         pass = false;
+      }
     }
 
     if (!pass)

--- a/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
@@ -246,7 +246,9 @@ itkConjugateGradientOptimizerTest(int, char *[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   if (!pass)

--- a/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
@@ -176,7 +176,9 @@ itkFRPROptimizerTest(int, char *[])
     for (unsigned int j = 0; j < 2; ++j)
     {
       if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+      {
         pass = false;
+      }
     }
 
     // Exercise various member functions.
@@ -229,7 +231,9 @@ itkFRPROptimizerTest(int, char *[])
     for (unsigned int j = 0; j < 2; ++j)
     {
       if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+      {
         pass = false;
+      }
     }
 
     // Exercise various member functions.

--- a/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
@@ -184,7 +184,9 @@ itkGradientDescentOptimizerTest(int, char *[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   std::cout << "Stop description   = " << itkOptimizer->GetStopConditionDescription() << std::endl;

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -224,7 +224,9 @@ itkLBFGSOptimizerTest(int, char *[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   if (!pass)

--- a/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
@@ -377,7 +377,9 @@ itkRunLevenbergMarquardOptimization(bool   useGradient,
   for (unsigned int j = 0; j < LMCostFunction::SpaceDimension; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   if (!pass)

--- a/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
@@ -188,7 +188,9 @@ itkPowellOptimizerTest(int argc, char * argv[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   // Exercise various member functions.

--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -230,7 +230,9 @@ itkSPSAOptimizerTest(int, char *[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
   if (itkOptimizer->GetStopCondition() == itk::SPSAOptimizer::StopConditionSPSAOptimizerEnum::Unknown)
   {

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -432,7 +432,9 @@ AmoebaTest1()
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > xTolerance)
+    {
       pass = false;
+    }
   }
 
   if (!pass)

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -77,7 +77,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = m_Parameters[0];
     double y = m_Parameters[1];

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -79,7 +79,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = m_Parameters[0];
     double y = m_Parameters[1];

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -78,7 +78,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = m_Parameters[0];
     double y = m_Parameters[1];

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
@@ -73,7 +73,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != this->GetNumberOfParameters())
+    {
       derivative.SetSize(this->GetNumberOfParameters());
+    }
 
     value = 0.0;
 

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -79,7 +79,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = (*m_Parameters)[0];
     double y = (*m_Parameters)[1];
@@ -192,7 +194,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = (*m_Parameters)[0];
     double y = (*m_Parameters)[1];

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -75,7 +75,9 @@ public:
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     if (derivative.Size() != 2)
+    {
       derivative.SetSize(2);
+    }
 
     double x = m_Parameters[0];
     double y = m_Parameters[1];

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -226,7 +226,9 @@ itkPowellOptimizerv4Test(int argc, char * argv[])
   for (unsigned int j = 0; j < 2; ++j)
   {
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
+    {
       pass = false;
+    }
   }
 
   // Exercise various member functions.

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -35,7 +35,9 @@ public:
   {
 
     if (!ptr)
+    {
       return;
+    }
     m_Registrator = ptr;
     typename itk::SimpleMemberCommand<SimpleMultiResolutionImageRegistrationUI>::Pointer iterationCommand =
       itk::SimpleMemberCommand<SimpleMultiResolutionImageRegistrationUI>::New();
@@ -101,14 +103,18 @@ public:
     this->Superclass::StartNewLevel();
 
     if (!this->m_Registrator)
+    {
       return;
+    }
 
     // Try to cast the optimizer to a gradient descent type,
     // return if casting didn't work.
     itk::GradientDescentOptimizer::Pointer optimizer =
       dynamic_cast<itk::GradientDescentOptimizer *>(this->m_Registrator->GetModifiableOptimizer());
     if (!optimizer)
+    {
       return;
+    }
 
     unsigned int level = this->m_Registrator->GetCurrentLevel();
     if (m_NumberOfIterations.Size() >= level + 1)

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -373,7 +373,9 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
       }
       unsigned int sz = inputSize[j] / schedule[testLevel][j];
       if (sz == 0)
+      {
         sz = 1;
+      }
       if (outputSize[j] != sz)
       {
         break;

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -277,7 +277,9 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
     }
     unsigned int sz = inputSize[j] / schedule[testLevel][j];
     if (sz == 0)
+    {
       sz = 1;
+    }
     if (outputSize[j] != sz)
     {
       break;

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -78,9 +78,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
     ++it;
   }
 }

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -175,7 +175,9 @@ ImageToImageMetricv4TestTestArray(const TVector & v1, const TVector & v2)
   {
     const double epsilon = 1e-10;
     if (itk::Math::abs(v1[i] - v2[i]) > epsilon)
+    {
       pass = false;
+    }
   }
   return pass;
 }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -217,9 +217,13 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   try
   {
     if (numberOfDisplacementIterations > 0)
+    {
       optimizer->StartOptimization();
+    }
     else
+    {
       std::cout << "** SKIPPING DISPLACEMENT FIELD OPT\n";
+    }
   }
   catch (const itk::ExceptionObject & e)
   {

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -67,7 +67,9 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   bool rotateinput = false;
   if (argc > 5)
     if (std::stoi(argv[5]) == 1)
+    {
       rotateinput = true;
+    }
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned short; // I assume png is unsigned short
   using InternalPixelType = double;
@@ -170,7 +172,9 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   metric->SetFixedImage(fixedImage);
   metric->SetMovingImage(movingImage);
   if (rotateinput)
+  {
     metric->SetMovingImage(resample->GetOutput());
+  }
   metric->SetFixedTransform(identityTransform);
   metric->SetMovingTransform(affineTransform);
   bool gaussian = false;
@@ -228,7 +232,9 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   resampleout->SetTransform(affineTransform);
   resampleout->SetInput(movingImage);
   if (rotateinput)
+  {
     resampleout->SetInput(resample->GetOutput());
+  }
   resampleout->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
   resampleout->SetOutputOrigin(fixedImage->GetOrigin());
   resampleout->SetOutputSpacing(fixedImage->GetSpacing());
@@ -243,7 +249,11 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   writer->Update();
   std::cout << "After optimization affine params are: " << affineTransform->GetParameters() << std::endl;
   if (MOptimizer->GetBestParametersIndex() == 18)
+  {
     return EXIT_SUCCESS;
+  }
   else
+  {
     return EXIT_FAILURE;
+  }
 }

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -74,9 +74,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
     ++it;
   }
 }

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -77,9 +77,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
     ++it;
   }
 }

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -70,9 +70,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
   }
 }
 

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -76,9 +76,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
   }
 }
 

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -115,9 +115,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
     ++it;
   }
 }

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -67,9 +67,13 @@ FillWithCircle(TImage *                   image,
       distance += itk::Math::sqr(static_cast<double>(index[j]) - center[j]);
     }
     if (distance <= r2)
+    {
       it.Set(foregnd);
+    }
     else
+    {
       it.Set(backgnd);
+    }
     ++it;
   }
 }

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -271,9 +271,13 @@ itkKmeansModelEstimatorTest(int, char *[])
   meanCDBKvalue /= NCODEWORDS * NUMBANDS;
 
   if (error < 0.1 * meanCDBKvalue)
+  {
     std::cout << "Kmeans algorithm passed (without initial input)" << std::endl;
+  }
   else
+  {
     std::cout << "Kmeans algorithm failed (without initial input)" << std::endl;
+  }
 
   // Validation with no codebook/initial Kmeans estimate
   vnl_matrix<double> kmeansResult = applyKmeansEstimator->GetKmeansResults();

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -61,9 +61,13 @@ square(unsigned int x, unsigned int y)
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS)))
+  {
     dis = RADIUS - std::max(X, Y);
+  }
   else
+  {
     dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
+  }
   return dis;
 }
 
@@ -198,9 +202,13 @@ private:
   Halt() override
   {
     if (this->GetElapsedIterations() == m_Iterations)
+    {
       return true;
+    }
     else
+    {
       return false;
+    }
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -142,9 +142,13 @@ itkNarrowBandThresholdSegmentationLevelSetImageFilterTest(int, char *[])
         for (i = 0; i < 3; ++i)
         {
           if (idx[i] < 32)
+          {
             val += idx[i];
+          }
           else
+          {
             val += 64 - idx[i];
+          }
         }
         inputImage->SetPixel(idx, val);
       }

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -208,9 +208,13 @@ private:
   Halt() override
   {
     if (this->GetElapsedIterations() == m_Iterations)
+    {
       return true;
+    }
     else
+    {
       return false;
+    }
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -99,9 +99,13 @@ private:
   Halt() override
   {
     if (this->GetElapsedIterations() == m_NumberOfIterations)
+    {
       return true;
+    }
     else
+    {
       return false;
+    }
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -55,9 +55,13 @@ square(unsigned int x, unsigned int y)
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS)))
+  {
     dis = RADIUS - std::max(X, Y);
+  }
   else
+  {
     dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
+  }
   return (dis);
 }
 

--- a/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -177,9 +177,13 @@ itkThresholdSegmentationLevelSetImageFilterTest(int, char *[])
         for (i = 0; i < 3; ++i)
         {
           if (idx[i] < 32)
+          {
             val += idx[i];
+          }
           else
+          {
             val += 64 - idx[i];
+          }
         }
         inputImage->SetPixel(idx, val);
       }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkGibbsTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkGibbsTest.cxx
@@ -343,7 +343,9 @@ itkGibbsTest(int, char *[])
     labeloutIt.GoToBegin();
     while ( !labeloutIt.IsAtEnd() ) {
     if ((i%ImageWidth<10) && (i/ImageWidth<10) && (labeloutIt.Get()==1))
+    {
       j++;
+    }
     i++;
     ++labeloutIt;
     }


### PR DESCRIPTION
Ran Notepad++ v8.4.8, Replace in Files (Filter: itk*.h;itk*.hxx;itk*.cxx), using Regular expression:

    Find what: ^  ([ ]*)(if \(.+\)\r\n)\1    ([^ {].*;)\r\n
    Find what: ^  ([ ]*)(else\r\n)\1    ([^ {].*;)\r\n
    Replace with: $1  $2$1  {\r\n$1    $3\r\n$1  }\r\n

Suggested by Jon Haitz Legarreta Gorroño (@jhlegarreta).

Aims to supersede pull request #3868 "STYLE: Use braces for single line conditional loop body statements"