### PR TITLE
COMP: Remove in-class {} member initializers of unique_ptr

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -415,9 +415,9 @@ private:
   bool m_UseImageDirection{};
 
   ThreadIdType                          m_NumberOfWorkUnits{};
-  std::unique_ptr<vnl_matrix<long>[]>   m_ThreadedEvaluateIndex {};
-  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeights {};
-  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeightsDerivative {};
+  std::unique_ptr<vnl_matrix<long>[]>   m_ThreadedEvaluateIndex;
+  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeights;
+  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeightsDerivative;
 };
 } // namespace itk
 

--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -203,7 +203,7 @@ private:
   FileNamesContainerType m_OutputFileNames{};
 
   /** Internal structure to order serie from one directory */
-  std::unique_ptr<gdcm::SerieHelper> m_SerieHelper{};
+  std::unique_ptr<gdcm::SerieHelper> m_SerieHelper;
 
   /** Internal structure to keep the list of series UIDs */
   SeriesUIDContainerType m_SeriesUIDs{};

--- a/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
+++ b/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
@@ -161,7 +161,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  std::unique_ptr<JPEG2000ImageIOInternal> m_Internal{};
+  std::unique_ptr<JPEG2000ImageIOInternal> m_Internal;
 
   using SizeValueType = ImageIORegion::SizeValueType;
   using IndexValueType = ImageIORegion::IndexValueType;

--- a/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
+++ b/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
@@ -164,7 +164,7 @@ private:
 
   // Note that it is essential that m_GiftiImageHolder is defined before m_GiftiImage, to ensure that
   // m_GiftiImage can directly get a proxy from m_GiftiImageHolder during GiftiImageIO construction.
-  const std::unique_ptr<GiftiImageProxy> m_GiftiImageHolder{};
+  const std::unique_ptr<GiftiImageProxy> m_GiftiImageHolder;
 
   GiftiImageProxy & m_GiftiImage;
 

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -231,7 +231,7 @@ private:
 
   // Note that it is essential that m_NiftiImageHolder is defined before m_NiftiImage, to ensure that
   // m_NiftiImage can directly get a proxy from m_NiftiImageHolder during NiftiImageIO construction.
-  const std::unique_ptr<NiftiImageProxy> m_NiftiImageHolder{};
+  const std::unique_ptr<NiftiImageProxy> m_NiftiImageHolder;
 
   NiftiImageProxy & m_NiftiImage;
 

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -150,7 +150,7 @@ private:
   void
   WriteOneTransform(const int transformIndex, const TransformType * curTransform);
 
-  std::unique_ptr<H5::H5File> m_H5File{};
+  std::unique_ptr<H5::H5File> m_H5File;
 
   /** Utility function for inferring data storage type
    * from class template.

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -168,7 +168,7 @@ private:
   static constexpr OffsetValueType ACTIVE = -2;
 
   // Just used for area/volume openings at the moment
-  std::unique_ptr<AttributeType[]> m_AuxData{};
+  std::unique_ptr<AttributeType[]> m_AuxData;
 
   using OffsetVecType = std::vector<OffsetType>;
   // offset in the linear array.
@@ -181,11 +181,11 @@ private:
   // it is sorted with a stable sort by grey level as the
   // first step in the algorithm. The sorting step avoids
   // the need to explicitly locate regional extrema.
-  std::unique_ptr<OffsetValueType[]> m_SortPixels{};
-  std::unique_ptr<OffsetValueType[]> m_Parent{};
+  std::unique_ptr<OffsetValueType[]> m_SortPixels;
+  std::unique_ptr<OffsetValueType[]> m_Parent;
 
   // This is a bit ugly, but I can't see an easy way around
-  std::unique_ptr<InputPixelType[]> m_Raw{};
+  std::unique_ptr<InputPixelType[]> m_Raw;
 
   class CompareOffsetType
   {

--- a/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
@@ -176,7 +176,7 @@ private:
   bool                          m_AutomaticInitialSimplex{};
   ParametersType                m_InitialSimplexDelta{};
   bool                          m_OptimizeWithRestarts{};
-  std::unique_ptr<vnl_amoeba>   m_VnlOptimizer{};
+  std::unique_ptr<vnl_amoeba>   m_VnlOptimizer;
 
   std::ostringstream m_StopConditionDescription{};
 };

--- a/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
@@ -88,7 +88,7 @@ protected:
 private:
   /**  The vnl optimization method for conjugate gradient. */
   bool                                   m_OptimizerInitialized{};
-  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer{};
+  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer;
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -224,7 +224,7 @@ private:
   unsigned int m_CurrentIteration{ 0 };
   double       m_InfinityNormOfProjectedGradient{ 0.0 };
 
-  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer{};
+  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer;
   BoundValueType                         m_LowerBound{};
   BoundValueType                         m_UpperBound{};
   BoundSelectionType                     m_BoundSelection{};

--- a/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
@@ -181,7 +181,7 @@ protected:
 
 private:
   bool                                   m_OptimizerInitialized{};
-  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer{};
+  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer;
   mutable std::ostringstream             m_StopConditionDescription{};
 
   bool         m_Trace{};

--- a/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
@@ -97,7 +97,7 @@ protected:
 
 private:
   bool                                   m_OptimizerInitialized{};
-  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer{};
+  std::unique_ptr<InternalOptimizerType> m_VnlOptimizer;
   unsigned int                           m_NumberOfIterations{};
   double                                 m_ValueTolerance{};
   double                                 m_GradientTolerance{};

--- a/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
@@ -159,7 +159,7 @@ private:
   bool                        m_AutomaticInitialSimplex{};
   ParametersType              m_InitialSimplexDelta{};
   bool                        m_OptimizeWithRestarts{};
-  std::unique_ptr<vnl_amoeba> m_VnlOptimizer{};
+  std::unique_ptr<vnl_amoeba> m_VnlOptimizer;
 
   std::ostringstream m_StopConditionDescription{};
 };

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
@@ -218,8 +218,8 @@ private:
 
   // temporary dynamic arrays for storing threads outputs
   SizeValueType                          m_PointsCount{};
-  std::unique_ptr<DisplacementsVector[]> m_DisplacementsVectorsArray{};
-  std::unique_ptr<SimilaritiesValue[]>   m_SimilaritiesValuesArray{};
+  std::unique_ptr<DisplacementsVector[]> m_DisplacementsVectorsArray;
+  std::unique_ptr<SimilaritiesValue[]>   m_SimilaritiesValuesArray;
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -365,7 +365,7 @@ private:
   // See
   //   https://thetweaker.wordpress.com/2010/05/05/stdvector-of-aligned-elements/
   //   https://connect.microsoft.com/VisualStudio/feedback/details/692988
-  std::unique_ptr<AlignedMMIMetricPerThreadStruct[]> m_MMIMetricPerThreadVariables{};
+  std::unique_ptr<AlignedMMIMetricPerThreadStruct[]> m_MMIMetricPerThreadVariables;
 #endif
 
   bool         m_UseExplicitPDFDerivatives{ true };

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
@@ -132,7 +132,7 @@ private:
   };
 
   itkAlignedTypedef(64, PerThreadS, AlignedPerThreadType);
-  std::unique_ptr<AlignedPerThreadType[]> m_PerThread{};
+  std::unique_ptr<AlignedPerThreadType[]> m_PerThread;
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
@@ -134,7 +134,7 @@ private:
                     PaddedCorrelationMetricPerThreadStruct,
                     AlignedCorrelationMetricPerThreadStruct);
   /* per thread variables for correlation and its derivatives */
-  std::unique_ptr<AlignedCorrelationMetricPerThreadStruct[]> m_CorrelationMetricPerThreadVariables{};
+  std::unique_ptr<AlignedCorrelationMetricPerThreadStruct[]> m_CorrelationMetricPerThreadVariables;
 
   /** Internal pointer to the metric object in use by this threader.
    *  This will avoid costly dynamic casting in tight loops. */

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
@@ -124,7 +124,7 @@ protected:
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedJointHistogramMIPerThreadStruct,
                     AlignedJointHistogramMIPerThreadStruct);
-  std::unique_ptr<AlignedJointHistogramMIPerThreadStruct[]> m_JointHistogramMIPerThreadVariables{};
+  std::unique_ptr<AlignedJointHistogramMIPerThreadStruct[]> m_JointHistogramMIPerThreadVariables;
 
 private:
   /** Internal pointer to the metric object in use by this threader.


### PR DESCRIPTION
Errors showed up in (e.g.) https://my.cdash.org/viewBuildError.php?buildid=2273357

Patch 5e2c49f9eb80e78903ce8f9fd2b5952062653cab causes the following errors on GCC 7.4.1:
/usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘itk::NiftiImageIO::NiftiImageProxy’ /usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘itk::LBFGSBOptimizerHelper’ /usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘gdcm::SerieHelper’ /usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘itk::NiftiImageIO::NiftiImageProxy’ /usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘itk::GiftiMeshIO::GiftiImageProxy’ /usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘itk::GiftiMeshIO::GiftiImageProxy’

The issue has already been fixed in the past, see
d7c0128e99f02cfb58e8c447d175008b2b946a9f

All instances have been removed with the script:
for i in $(find Modules -type f)
do
  sed -i "s/\(unique_ptr.*\) *{}/\1/g" $i
done

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
