### PR TITLE
BUG: Added missing semicolon in FastMarchingUpwindGradientTest

### DIFF
--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -297,7 +297,7 @@ itkFastMarchingUpwindGradientTest(int, char *[])
 
   // Now stop the algorithm once SOME of the targets have been reached.
   numberOfTargets = targetPoints->Size() + 1;
-  ITK_TRY_EXPECT_NO_EXCEPTION(marcher->SetTargetReachedModeToSomeTargets(numberOfTargets))
+  ITK_TRY_EXPECT_NO_EXCEPTION(marcher->SetTargetReachedModeToSomeTargets(numberOfTargets));
   ITK_TRY_EXPECT_EXCEPTION(marcher->Update());
 
   numberOfTargets = targetPoints->Size() - 1;


### PR DESCRIPTION
Missing semicolon can cause build failure in some configurations if the _ITK_MACROEND_NOOP_STATEMENT_ macro is expanded to `static_assert(true, "")`.

https://open.cdash.org/viewBuildError.php?buildid=8412929