### PR TITLE
[COMP] Fix unmangled type symbols on HDF5

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/itk_hdf5_mangle.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/itk_hdf5_mangle.h
@@ -934,6 +934,7 @@ e.g. remove mangling for H5Fget_info but leave it for H5Fget_info1 and H5Fget_in
 #define H5E_init itk_H5E_init
 #define H5E_init_g itk_H5E_init_g
 #define H5E_printf_stack itk_H5E_printf_stack
+#define H5E_t itk_H5E_t
 #define H5E_stack_g itk_H5E_stack_g
 #define H5E_term_package itk_H5E_term_package
 #define H5Eauto_is_v2 itk_H5Eauto_is_v2
@@ -1749,6 +1750,7 @@ e.g. remove mangling for H5Fget_info but leave it for H5Fget_info1 and H5Fget_in
 #define H5I_remove itk_H5I_remove
 #define H5I_subst itk_H5I_subst
 #define H5I_term_package itk_H5I_term_package
+#define H5I_type_info_t itk_H5I_type_info_t
 #define H5I_type_info_array_g itk_H5I_type_info_array_g
 #define H5I_type_t itk_H5I_type_t
 #define H5Iclear_type itk_H5Iclear_type
@@ -3804,6 +3806,7 @@ e.g. remove mangling for H5Fget_info but leave it for H5Fget_info1 and H5Fget_in
 #define H5_chunk_elmts_blk_free_list itk_H5_chunk_elmts_blk_free_list
 #define H5_chunk_image_blk_free_list itk_H5_chunk_image_blk_free_list
 #define H5_combine_path itk_H5_combine_path
+#define H5_debug_t itk_H5_debug_t
 #define H5_debug_g itk_H5_debug_g
 #define H5_direct_block_blk_free_list itk_H5_direct_block_blk_free_list
 #define H5_ea_native_elmt_blk_free_list itk_H5_ea_native_elmt_blk_free_list


### PR DESCRIPTION
Hello, I was having trouble with an external python lib calling the itk_hdf5 function as shared below. The ?? sometimes indicates a callback but to be sure I searched all instances of H5VL_group_close and only H5G__close_cb was calling it currently unmangled. I will test this soon and report back.

<details>

```
#0  0x00007febfdaa8b49 in itk_H5CX_get_vol_wrap_ctx () from /home/gabriel/g/bin/../lib/GeoSlicer-5.1/libitkhdf5-shared-5.3.so.1
#1  0x00007febfdd23a44 in itk_H5VL_set_vol_wrapper () from /home/gabriel/g/bin/../lib/GeoSlicer-5.1/libitkhdf5-shared-5.3.so.1
#2  0x00007febfdd1870b in itk_H5VL_group_close () from /home/gabriel/g/bin/../lib/GeoSlicer-5.1/libitkhdf5-shared-5.3.so.1
#3  0x00007febfdb4b11d in ?? () from /home/gabriel/g/bin/../lib/GeoSlicer-5.1/libitkhdf5-shared-5.3.so.1
#4  0x00007fead7b7d480 in H5I_dec_ref () from /home/gabriel/g/lib/Python/lib/python3.9/site-packages/h5py/../h5py.libs/libhdf5-346dbfc8.so.200.1.0
#5  0x00007fead7b7d544 in H5I_dec_app_ref () from /home/gabriel/g/lib/Python/lib/python3.9/site-packages/h5py/../h5py.libs/libhdf5-346dbfc8.so.200.1.0
#6  0x00007fead7b79fd1 in H5Idec_ref () from /home/gabriel/g/lib/Python/lib/python3.9/site-packages/h5py/../h5py.libs/libhdf5-346dbfc8.so.200.1.0
```
</details>

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
