### PR TITLE
STYLE: Add missing braces to the substatements of `for` loops

### DIFF
--- a/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
@@ -96,7 +96,9 @@ AdaptorSupportedModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
     temp_vector = it.Get();
 
     for (i = 0; i < N; ++i)
+    {
       temp_vector[i] += 3.435f;
+    }
 
     it.Set(temp_vector);
     ++it;
@@ -118,7 +120,9 @@ NoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
     temp_vector = it.Get();
 
     for (i = 0; i < N; ++i)
+    {
       temp_vector[i] += 3.435f;
+    }
 
     it.Set(temp_vector);
     ++it;
@@ -140,7 +144,9 @@ BypassAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   while (!it.IsAtEnd())
   {
     for (i = 0; i < N; ++i)
+    {
       (it.Value())[i] += 3.435f;
+    }
 
     ++it;
   }
@@ -159,7 +165,9 @@ BypassNoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   while (!it.IsAtEnd())
   {
     for (i = 0; i < N; ++i)
+    {
       (it.Value())[i] += 3.435f;
+    }
 
     ++it;
   }

--- a/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
@@ -37,7 +37,9 @@ printn(itk::NeighborhoodAllocator<TPixel> & n, const itk::Size<2> & sz)
   for (j = 0; j < sz[1]; ++j)
   {
     for (i = 0; i < sz[0]; ++i, ++k)
+    {
       std::cout << n[k] << " ";
+    }
     std::cout << std::endl;
   }
 }
@@ -137,9 +139,13 @@ itkBoundaryConditionTest(int, char *[])
   //  for (; !it2D.IsAtEnd(); ++it2D) *it2D = 1.0f;
   filln(image2D);
   for (; !it3D.IsAtEnd(); ++it3D)
+  {
     it3D.Set(1.0f);
+  }
   for (; !itND.IsAtEnd(); ++itND)
+  {
     itND.Set(1.0f);
+  }
 
   println("Initializing smart neighborhood iterators");
   itk::Size<2> sz2;

--- a/Modules/Core/Common/test/itkNeighborhoodTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodTest.cxx
@@ -37,17 +37,23 @@ itkNeighborhoodTest(int, char *[])
 
   println("Test data access");
   for (i = 0; i < b.Size(); ++i)
+  {
     b[i] = static_cast<float>(i);
+  }
   b.Print(std::cout);
 
   println("Test non_const iterators");
   for (itk::Neighborhood<float, 2>::Iterator it = b.Begin(); it < b.End(); ++it)
+  {
     *it = 4.0f;
+  }
   b.Print(std::cout);
 
   println("Test const_iterators");
   for (itk::Neighborhood<float, 2>::ConstIterator itc = b.Begin(); itc < b.End(); ++itc)
+  {
     std::cout << *itc << " ";
+  }
 
   println("Copy the buffer into a vnl_vector");
   vnl_vector<float> v = b.GetBufferReference();

--- a/Modules/Core/Common/test/itkNumericsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericsTest.cxx
@@ -27,7 +27,9 @@ print_vnl_matrix(T & mat)
   for (unsigned int r = 0; r < mat.rows(); ++r)
   {
     for (unsigned int c = 0; c < mat.columns(); ++c)
+    {
       std::cout << mat(r, c) << " ";
+    }
     std::cout << std::endl;
   }
 }

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -64,7 +64,9 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
   {
     itr.Set(tensorPixelInput);
     for (unsigned int i = 0; i < 3; ++i)
+    {
       tensorPixelInput[i]++;
+    }
     ++itr;
   }
 

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -307,19 +307,27 @@ PipelineMonitorImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent inde
 
   os << indent << "m_OutputRequestedRegions:" << std::endl;
   for (auto i = m_OutputRequestedRegions.begin(); i != m_OutputRequestedRegions.end(); ++i)
+  {
     i->Print(os, indent.GetNextIndent());
+  }
 
   os << indent << "m_InputRequestedRegions:" << std::endl;
   for (auto i = m_InputRequestedRegions.begin(); i != m_InputRequestedRegions.end(); ++i)
+  {
     i->Print(os, indent.GetNextIndent());
+  }
 
   os << indent << "m_UpdatedBufferedRegions:" << std::endl;
   for (auto i = m_UpdatedBufferedRegions.begin(); i != m_UpdatedBufferedRegions.end(); ++i)
+  {
     i->Print(os, indent.GetNextIndent());
+  }
 
   os << indent << "m_UpdatedRequestedRegions:" << std::endl;
   for (auto i = m_UpdatedRequestedRegions.begin(); i != m_UpdatedRequestedRegions.end(); ++i)
+  {
     i->Print(os, indent.GetNextIndent());
+  }
 
   os << indent << "m_UpdatedOutputOrigin:" << std::endl;
   os << indent.GetNextIndent() << m_UpdatedOutputOrigin << std::endl;

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -142,7 +142,9 @@ NullImageToImageFilterDriver<TInputImage, TOutputImage>::Execute()
   typename TOutputImage::IndexType index;
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
+  {
     index[i] = 0;
+  }
   const typename TOutputImage::RegionType region(index, m_ImageSize);
 
   // Allocate the input

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -94,7 +94,9 @@ itkMaskImageFilterTest(int, char *[])
   // Set to mask first 2 pixels and last 2 pixels and leave the rest as is
   std::cout << "Second operand " << std::endl;
   for (unsigned int i = 0; i < 2; ++i, ++it2)
+  {
     it2.Set(0);
+  }
 
   while (!it2.IsAtEnd())
   {
@@ -103,7 +105,9 @@ itkMaskImageFilterTest(int, char *[])
   }
 
   for (unsigned int i = 0; i < 3; ++i, --it2)
+  {
     it2.Set(0);
+  }
 
   it2.GoToBegin();
   while (!it2.IsAtEnd())

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -96,7 +96,9 @@ itkMaskNegatedImageFilterTest(int, char *[])
   // Set to mask first 2 pixels and last 2 pixels and leave the rest as is
   std::cout << "Second operand " << std::endl;
   for (unsigned int i = 0; i < 2; ++i, ++maskIterator)
+  {
     maskIterator.Set(0);
+  }
 
   while (!maskIterator.IsAtEnd())
   {
@@ -105,7 +107,9 @@ itkMaskNegatedImageFilterTest(int, char *[])
   }
 
   for (unsigned int i = 0; i < 3; ++i, --maskIterator)
+  {
     maskIterator.Set(0);
+  }
 
   maskIterator.GoToBegin();
   while (!maskIterator.IsAtEnd())

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -655,7 +655,9 @@ GDCMImageIO::InternalReadImageInformation()
         m_El.Read(m_Ss);
         assert(m_El.GetLength() == 2);
         for (unsigned long i = 0; i < m_El.GetLength(); ++i)
+        {
           sp.push_back(m_El.GetValue(i));
+        }
         std::swap(sp[0], sp[1]);
         assert(sp.size() == 2);
         spacing[0] = sp[0];

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
@@ -46,7 +46,9 @@ itkImageSeriesReaderDimensionsTest(int argc, char * argv[])
 
   Reader2DType::FileNamesContainer fnames;
   for (int i = 1; i < argc; ++i)
+  {
     fnames.push_back(argv[i]);
+  }
 
 
   std::cout << "testing reading a single 2D image to 2D" << std::endl;

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
@@ -35,7 +35,9 @@ itkImageSeriesReaderVectorTest(int argc, char * argv[])
 
   VectorImageSeriesReader::FileNamesContainer fnames;
   for (int i = 1; i < argc; ++i)
+  {
     fnames.push_back(argv[i]);
+  }
 
 
   std::cout << "testing reading an image series into VecorImage" << std::endl;

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -507,7 +507,9 @@ MINCImageIO::ReadImageInformation()
       miget_dimension_start(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_start);
 
       for (int j = 0; j < 3; ++j)
+      {
         dir_cos[j][i - 1] = _dir[j];
+      }
 
       origin[i - 1] = _start;
       sep[i - 1] = _sep;
@@ -557,7 +559,9 @@ MINCImageIO::ReadImageInformation()
   o_origin = dir_cos * origin;
 
   for (int i = 0; i < spatial_dimension_count; ++i)
+  {
     this->SetOrigin(i, o_origin[i]);
+  }
 
   miclass_t volume_data_class;
 
@@ -1189,7 +1193,9 @@ MINCImageIO::WriteImageInformation()
   if (!dimorder_good) // use default order!
   {
     for (unsigned int i = 0; i < minc_dimensions; ++i)
+    {
       this->m_MINCPImpl->m_MincFileDims[i] = this->m_MINCPImpl->m_MincApparentDims[i];
+    }
   }
 
   mivolumeprops_t hprops;

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -472,12 +472,16 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
               << "acquisition:TestDoubleArray " << std::endl;
     std::cerr << "metaDataDoubleArray=";
     for (size_t i = 0; i < metaDataDoubleArray.size(); ++i)
+    {
       std::cerr << metaDataDoubleArray[i] << " ";
+    }
     std::cerr << std::endl;
 
     std::cerr << "metaDataDoubleArray2=";
     for (size_t i = 0; i < metaDataDoubleArray2.size(); ++i)
+    {
       std::cerr << metaDataDoubleArray2[i] << " ";
+    }
     std::cerr << std::endl;
 
     success = EXIT_FAILURE;
@@ -491,12 +495,16 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
               << "acquisition:TestFloatArray " << std::endl;
     std::cerr << "metaDataFloatArray=";
     for (size_t i = 0; i < metaDataFloatArray.size(); ++i)
+    {
       std::cerr << metaDataFloatArray[i] << " ";
+    }
     std::cerr << std::endl;
 
     std::cerr << "metaDataFloatArray2=";
     for (size_t i = 0; i < metaDataFloatArray2.size(); ++i)
+    {
       std::cerr << metaDataFloatArray2[i] << " ";
+    }
     std::cerr << std::endl;
 
     success = EXIT_FAILURE;

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1760,7 +1760,9 @@ IsAffine(const mat44 & nifti_mat)
 
   for (int i = 0; i < 4; ++i)
     for (int j = 0; j < 4; ++j)
+    {
       mat[i][j] = double{ nifti_mat.m[i][j] };
+    }
 
   // First make sure the bottom row meets the condition that it is (0, 0, 0, 1)
   {

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
@@ -77,7 +77,9 @@ itkNarrowBandTest(int, char *[])
   {
     std::cout << "Region " << i << std::endl;
     for (; regions[i].Begin != regions[i].End; regions[i].Begin++)
+    {
       std::cout << "Index: " << regions[i].Begin->m_Index << " Data: " << regions[i].Begin->m_Data << std::endl;
+    }
     i++;
   }
   std::cout << "Test Passed. " << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -156,7 +156,9 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
   for (it = this->m_ParameterBounds.begin(); it != end; ++it)
+  {
     os << " [" << it->first << ", " << it->second << "]";
+  }
   os << " ]\n";
   os << indent << "Parameters' convergence tolerance: " << this->m_ParametersConvergenceTolerance;
   os << "\n";

--- a/Modules/Registration/Common/test/itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
@@ -112,13 +112,17 @@ itkCorrelationCoefficientHistogramImageToImageMetricTest(int, char *[])
     ParametersType parameters(transform->GetNumberOfParameters());
 
     for (unsigned int k = 0; k < ImageDimension; ++k)
+    {
       parameters[k] = 0.0f;
+    }
 
     // Set scales for derivative calculation.
     ScalesType scales(transform->GetNumberOfParameters());
 
     for (unsigned int k = 0; k < ImageDimension; ++k)
+    {
       scales[k] = 1;
+    }
 
     metric->SetDerivativeStepLengthScales(scales);
 

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -210,7 +210,9 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
   ScalesType scales(transformer->GetNumberOfParameters());
 
   for (unsigned int k = 0; k < transformer->GetNumberOfParameters(); ++k)
+  {
     scales[k] = 1;
+  }
 
   metric->SetDerivativeStepLengthScales(scales);
 

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -164,7 +164,9 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   using PointType = ImageType::PointType;
   PointType p0;
   for (unsigned int i = 0; i < imageDimensionality; ++i)
+  {
     p0[i] = 0;
+  }
 
   itFixed.GoToBegin();
   unsigned int count = 1;

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -202,9 +202,13 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializePrio
 
     WeightsType totalProbMass = 0.0;
     for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
+    {
       totalProbMass += this->m_PriorProbabilities[l];
+    }
     for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
+    {
       this->m_PriorProbabilities[l] /= totalProbMass;
+    }
   }
 }
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -92,13 +92,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 21;
     dblVec[1] = 19;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6
     dblVec[0] = 18;
     dblVec[1] = 14;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   // Row 4-6
@@ -108,13 +112,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 15;
     dblVec[1] = 11;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6
     dblVec[0] = 10;
     dblVec[1] = 16;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -127,13 +135,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 14;
     dblVec[1] = 20;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6 Row k
     dblVec[0] = 18;
     dblVec[1] = 22;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   // Row 4-6
@@ -143,13 +155,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 15;
     dblVec[1] = 15;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6 Row k
     dblVec[0] = 12;
     dblVec[1] = 12;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -162,13 +178,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 19;
     dblVec[1] = 20;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6 Row k
     dblVec[0] = 19;
     dblVec[1] = 21;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   // Row 4-6
@@ -178,13 +198,17 @@ itkMRFImageFilterTest(int, char *[])
     dblVec[0] = 12;
     dblVec[1] = 12;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
 
     // Vector no. 4-6 Row k
     dblVec[0] = 11;
     dblVec[1] = 10;
     for (i = 0; i < halfWidth; ++i, ++outIt)
+    {
       outIt.Set(dblVec);
+    }
   }
 
   //---------------------------------------------------------------
@@ -224,14 +248,18 @@ itkMRFImageFilterTest(int, char *[])
   {
     // Vector no. 1-3 Row k
     for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    {
       classoutIt.Set(2);
+    }
   }
 
   // Row 4-6
   for (k = 0; k < halfHeight; ++k)
   {
     for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    {
       classoutIt.Set(1);
+    }
   }
   //--------------------------------------------------------------------------
   // Slice 2
@@ -241,7 +269,9 @@ itkMRFImageFilterTest(int, char *[])
   {
     // Vector no. 1-3 Row k
     for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    {
       classoutIt.Set(0);
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -251,14 +281,18 @@ itkMRFImageFilterTest(int, char *[])
   {
     // Vector no. 1-3 Row k
     for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    {
       classoutIt.Set(2);
+    }
   }
 
   // Row 4-6
   for (k = 0; k < halfHeight; ++k)
   {
     for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    {
       classoutIt.Set(1);
+    }
   }
 
   //----------------------------------------------------------------------


### PR DESCRIPTION
Ran Notepad++ v8.4.8, Replace in Files, using Regular expression:

    Find what: ^  ([ ]*)(for \(.+\)\r\n)\1    ([^ {].*;)\r\n
    Replace with: $1  $2$1  {\r\n$1    $3\r\n$1  }\r\n

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3875 commit 8d12282fd753fc6404d9c738cc20e8b61a1848cc
"STYLE: Add missing braces to the substatements of `if` statements"