### PR TITLE
BUG: Fix reading of displacement field vectors from NIFTI

### DIFF
--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -188,6 +188,37 @@ public:
   itkSetMacro(LegacyAnalyze75Mode, NiftiImageIOEnums::Analyze75Flavor);
   itkGetConstMacro(LegacyAnalyze75Mode, NiftiImageIOEnums::Analyze75Flavor);
 
+  /** Enable conversion of vector coordinates between RAS coordinate system (in NIFTI file) and
+   * LPS (ITK convention) when reading or writing a generic vector image file (intent code: 1007).
+   *
+   * This flag is disabled by default because vectors may store non-spatial information.
+   *
+   * By default an ITK vector image is written to NIFTI file as a generic vector image, unless
+   * "intent_code" field is set explicitly to set to "1006" (displacement vector).
+   */
+  itkSetMacro(ConvertRASVectors, bool);
+  itkGetConstMacro(ConvertRASVectors, bool);
+  itkBooleanMacro(ConvertRASVectors);
+
+  /** Enable conversion of vector coordinates between RAS coordinate system (in NIFTI file) and
+   * LPS (ITK convention) when reading or writing a "displacement vector" file (intent code: 1006).
+   *
+   * This flag is enabled by default. Disabling it may be useful to avoid unnecessary conversions
+   * in applications that uses RAS coordinate system.
+   *
+   * To write a vector image as displacement vector: set "intent_code" to "1006" in the metadata
+   * dictionary of the input image.
+   *
+   \code
+       itk::MetaDataDictionary& dictionary = image->GetMetaDataDictionary();
+       itk::EncapsulateMetaData<std::string>(dictionary, "intent_code", "1006");
+   \endcode
+   *
+   */
+  itkSetMacro(ConvertRASDisplacementVectors, bool);
+  itkGetConstMacro(ConvertRASDisplacementVectors, bool);
+  itkBooleanMacro(ConvertRASDisplacementVectors);
+
 protected:
   NiftiImageIO();
   ~NiftiImageIO() override;
@@ -237,6 +268,10 @@ private:
 
   double m_RescaleSlope{ 1.0 };
   double m_RescaleIntercept{ 0.0 };
+
+  bool m_ConvertRAS{ false };
+  bool m_ConvertRASVectors{ false };
+  bool m_ConvertRASDisplacementVectors{ true };
 
   IOComponentEnum m_OnDiskComponentType{ IOComponentEnum::UNKNOWNCOMPONENTTYPE };
 


### PR DESCRIPTION
NIFTI image containing displacement field (intent = NIFTI_INTENT_DISPVECT) was read as scalar volume (all 3 vector components were set to the same value). Fixed by reading it the same way as the general-purpose vector image (intent = NIFTI_INTENT_VECTOR).

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

The changes already improve NIFTI compatibility, but we could potentially further improve correctness if we can answer these questions:
1. Should the displacement vectors be converted from RAS (native NIFTI) to LPS coordinate system (ITK convention)? The same way as the reader changes the image origin, spacing, axis directions to be in LPS coordinate system instead RAS.
2. NIFTI distinguishes between "vector" and "displacement vector" intent. Is there a way to keep this distinction in ITK? It would be nice if we read a displacement vector image and then we save it to file again to preserve the exact type.