### PR TITLE
COMP: Remove unused local variables in image iterator tests

### DIFF
--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -93,9 +93,6 @@ itkImageRegionIteratorTest(int, char *[])
   (*o3)[regionEndIndex3D] = (*o3)[regionStartIndex3D];
   TestConstPixelAccess(*o3, *o3);
 
-
-  itk::ImageIterator<itk::Image<itk::Vector<unsigned short, 5>, 3>> standardIt(o3, region);
-
   // Iterate over a region using a simple for loop
   itk::ImageRegionIterator<itk::Image<itk::Vector<unsigned short, 5>, 3>> it(o3, region);
 

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -98,9 +98,6 @@ itkImageReverseIteratorTest(int, char *[])
   (*o3)[regionEndIndex3D] = (*o3)[regionStartIndex3D];
   TestConstPixelAccess(*o3, *o3);
 
-
-  itk::ImageIterator<ImageType> standardIt(o3, region);
-
   // Iterate over a region using a simple for loop
   itk::ImageRegionIterator<ImageType> it(o3, region);
 


### PR DESCRIPTION
Remove unused local variables in image iterator tests.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)