### PR TITLE
BUG: SetRegions in image_from_dict

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -200,6 +200,12 @@ itk.meshwrite(mesh, sys.argv[5])
 itk.meshwrite(mesh, sys.argv[5], compression=True)
 
 # smoke test wasm / Python / NumPy conversion
+
+image_dict = itk.dict_from_image(image)
+image_back = itk.image_from_dict(image_dict)
+diff = itk.comparison_image_filter(image.astype(itk.F), image_back.astype(itk.F))
+assert np.sum(diff) == 0
+
 mesh_dict = itk.dict_from_mesh(mesh)
 mesh_back = itk.mesh_from_dict(mesh_dict)
 

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -811,6 +811,7 @@ def image_from_dict(image_dict: Dict) -> "itkt.Image":
     image.SetSpacing(image_dict["spacing"])
     image.SetDirection(image_dict["direction"])
     image.SetObjectName(image_dict["name"])
+    image.SetRegions(image_dict["size"])
     return image
 
 


### PR DESCRIPTION
The Regions, BufferedRegion, LargestPossibleRegion, RequestedRegion, should all be the full image, given by the image_dict["size"]. In itk-wasm, it was observed that this could not be initialized.