### PR TITLE
STYLE: Default default-constructor ImageConstIteratorWithIndex/OnlyIndex

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
@@ -138,7 +138,7 @@ public:
 
   /** Default Constructor. Need to provide a default constructor since we
    * provide a copy constructor. */
-  ImageConstIteratorWithIndex();
+  ImageConstIteratorWithIndex() = default;
 
   /** Copy Constructor. The copy constructor is provided to make sure the
    * handle to the image is properly reference counted. */
@@ -285,7 +285,7 @@ public:
   }
 
 protected: // made protected so other iterators can access
-  typename TImage::ConstWeakPointer m_Image;
+  typename TImage::ConstWeakPointer m_Image{};
 
   IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
   IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
@@ -293,18 +293,18 @@ protected: // made protected so other iterators can access
                                       // one pixel past the end of each
                                       // row, col, slice, etc....
 
-  RegionType m_Region; // region to iterate over
+  RegionType m_Region{}; // region to iterate over
 
   OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
-  const InternalPixelType * m_Position;
-  const InternalPixelType * m_Begin;
-  const InternalPixelType * m_End;
+  const InternalPixelType * m_Position{ nullptr };
+  const InternalPixelType * m_Begin{ nullptr };
+  const InternalPixelType * m_End{ nullptr };
 
-  bool m_Remaining;
+  bool m_Remaining{ false };
 
-  AccessorType        m_PixelAccessor;
-  AccessorFunctorType m_PixelAccessorFunctor;
+  AccessorType        m_PixelAccessor{};
+  AccessorFunctorType m_PixelAccessorFunctor{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -25,18 +25,6 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex()
-{
-  m_Position = nullptr;
-  m_Begin = nullptr;
-  m_End = nullptr;
-  m_Remaining = false;
-}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
 ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const Self & it)
 {
   m_Image = it.m_Image; // copy the smart pointer

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -124,7 +124,7 @@ public:
 
   /** Default Constructor. Need to provide a default constructor since we
    * provide a copy constructor. */
-  ImageConstIteratorWithOnlyIndex();
+  ImageConstIteratorWithOnlyIndex() = default;
 
   /** Copy Constructor. The copy constructor is provided to make sure the
    * handle to the image is properly reference counted. */
@@ -254,7 +254,7 @@ public:
   }
 
 protected: // made protected so other iterators can access
-  typename TImage::ConstPointer m_Image;
+  typename TImage::ConstPointer m_Image{};
 
   IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
   IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
@@ -262,11 +262,11 @@ protected: // made protected so other iterators can access
                                       // one pixel past the end of each
                                       // row, col, slice, etc....
 
-  RegionType m_Region; // region to iterate over
+  RegionType m_Region{}; // region to iterate over
 
   OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
-  bool m_Remaining;
+  bool m_Remaining{ false };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -25,15 +25,6 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex()
-{
-  m_Remaining = false;
-}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
 ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const Self & it)
 {
   m_Image = it.m_Image; // copy the smart pointer


### PR DESCRIPTION
Defaulted the default-constructors of ImageConstIteratorWithIndex and ImageConstIteratorWithOnlyIndex. Added in-class default member initializers to their data members.