### PR TITLE
STYLE: Replace double quotes around a space character with single quotes

### DIFF
--- a/Modules/Compatibility/Deprecated/test/itkAtomicIntTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkAtomicIntTest.cxx
@@ -276,8 +276,8 @@ itkAtomicIntTest(int, char *[])
   mt->SetSingleMethod(MyFunction4, nullptr);
   mt->SingleMethodExecute();
 
-  std::cout << Total << " " << TotalAtomic.load() << std::endl;
-  std::cout << Total64 << " " << TotalAtomic64.load() << std::endl;
+  std::cout << Total << ' ' << TotalAtomic.load() << std::endl;
+  std::cout << Total64 << ' ' << TotalAtomic64.load() << std::endl;
 
   std::cout << "MTime: " << AnObject->GetMTime() << std::endl;
 

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -43,7 +43,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Pri
   os << indent << "Bounding Box: ( ";
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
-    os << m_Bounds[2 * i] << "," << m_Bounds[2 * i + 1] << " ";
+    os << m_Bounds[2 * i] << "," << m_Bounds[2 * i + 1] << ' ';
   }
   os << " )" << std::endl;
 }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -573,40 +573,40 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
   os << ", m_Region = { Start = {";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Region.GetIndex()[i] << " ";
+    os << m_Region.GetIndex()[i] << ' ';
   }
   os << "}, Size = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Region.GetSize()[i] << " ";
+    os << m_Region.GetSize()[i] << ' ';
   }
   os << "} }";
   os << ", m_BeginIndex = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_BeginIndex[i] << " ";
+    os << m_BeginIndex[i] << ' ';
   }
   os << "} , m_EndIndex = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_EndIndex[i] << " ";
+    os << m_EndIndex[i] << ' ';
   }
   os << "} , m_Loop = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Loop[i] << " ";
+    os << m_Loop[i] << ' ';
   }
   os << "}, m_Bound = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Bound[i] << " ";
+    os << m_Bound[i] << ' ';
   }
   os << "}, m_IsInBounds = {" << m_IsInBounds;
   os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
   os << "}, m_WrapOffset = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_WrapOffset[i] << " ";
+    os << m_WrapOffset[i] << ' ';
   }
   os << ", m_Begin = " << m_Begin;
   os << ", m_End = " << m_End;
@@ -615,12 +615,12 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
   os << indent << ",  m_InnerBoundsLow = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_InnerBoundsLow[i] << " ";
+    os << m_InnerBoundsLow[i] << ' ';
   }
   os << "}, m_InnerBoundsHigh = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_InnerBoundsHigh[i] << " ";
+    os << m_InnerBoundsHigh[i] << ' ';
   }
   os << "} }" << std::endl;
   Superclass::PrintSelf(os, indent.GetNextIndent());

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -406,33 +406,33 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::PrintSelf(std::ostream & os, Ind
   os << ", m_Region = { Start = {";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Region.GetIndex()[i] << " ";
+    os << m_Region.GetIndex()[i] << ' ';
   }
   os << "}, Size = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Region.GetSize()[i] << " ";
+    os << m_Region.GetSize()[i] << ' ';
   }
   os << "} }";
   os << ", m_BeginIndex = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_BeginIndex[i] << " ";
+    os << m_BeginIndex[i] << ' ';
   }
   os << "} , m_EndIndex = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_EndIndex[i] << " ";
+    os << m_EndIndex[i] << ' ';
   }
   os << "} , m_Loop = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Loop[i] << " ";
+    os << m_Loop[i] << ' ';
   }
   os << "}, m_Bound = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_Bound[i] << " ";
+    os << m_Bound[i] << ' ';
   }
   os << "}, m_IsInBounds = {" << m_IsInBounds;
   os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
@@ -440,12 +440,12 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::PrintSelf(std::ostream & os, Ind
   os << indent << ",  m_InnerBoundsLow = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_InnerBoundsLow[i] << " ";
+    os << m_InnerBoundsLow[i] << ' ';
   }
   os << "}, m_InnerBoundsHigh = { ";
   for (i = 0; i < Dimension; ++i)
   {
-    os << m_InnerBoundsHigh[i] << " ";
+    os << m_InnerBoundsHigh[i] << ' ';
   }
   os << "} }" << std::endl;
   Superclass::PrintSelf(os, indent.GetNextIndent());

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -27,7 +27,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostr
   os << " m_ActiveIndexList = [";
   for (auto it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
   {
-    os << *it << " ";
+    os << *it << ' ';
   }
   os << "] ";
   os << " m_CenterIsActive = " << m_CenterIsActive;

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -87,7 +87,7 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ost
   {
     for (j = 0; j < VDimension; ++j)
     {
-      os << indent << indent << m_Orientations[i][j] << " ";
+      os << indent << indent << m_Orientations[i][j] << ' ';
     }
     os << std::endl;
   }

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -126,13 +126,13 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream & os, 
   os << indent << "Orientation: " << std::endl;
   for (i = 0; i < VDimension; ++i)
   {
-    os << indent << indent << m_Orientation[i] << " ";
+    os << indent << indent << m_Orientation[i] << ' ';
   }
   os << std::endl;
   os << indent << "Normalized Orientation: " << std::endl;
   for (i = 0; i < VDimension; ++i)
   {
-    os << indent << indent << m_NormalizedOrientation[i] << " ";
+    os << indent << indent << m_NormalizedOrientation[i] << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -133,14 +133,14 @@ Neighborhood<TPixel, VDimension, TContainer>::PrintSelf(std::ostream & os, Inden
   os << indent << "StrideTable: [ ";
   for (DimensionValueType i = 0; i < VDimension; ++i)
   {
-    os << m_StrideTable[i] << " ";
+    os << m_StrideTable[i] << ' ';
   }
   os << "]" << std::endl;
 
   os << indent << "OffsetTable: [ ";
   for (DimensionValueType i = 0; i < m_OffsetTable.size(); ++i)
   {
-    os << m_OffsetTable[i] << " ";
+    os << m_OffsetTable[i] << ' ';
   }
   os << "]" << std::endl;
 }

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -45,7 +45,7 @@ printnb(const TIteratorType & nb, bool full)
 
     while (it != nb.End())
     {
-      std::cout << **it << " ";
+      std::cout << **it << ' ';
       if ((count % sz) == 0)
       {
         std::cout << std::endl;

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -246,13 +246,13 @@ ImageIORegion::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Index: ";
   for (const auto i : this->GetIndex())
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
   os << indent << "Size: ";
   for (const auto k : this->GetSize())
   {
-    os << k << " ";
+    os << k << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Core/Common/test/itkAtanRegularizedHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkAtanRegularizedHeavisideStepFunctionTest1.cxx
@@ -58,7 +58,7 @@ itkAtanRegularizedHeavisideStepFunctionTest1(int, char *[])
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);
     OutputType      df = functionBase0->EvaluateDerivative(ix);
-    std::cout << ix << " " << f << " " << df << std::endl;
+    std::cout << ix << ' ' << f << ' ' << df << std::endl;
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
@@ -38,7 +38,7 @@ printn(itk::NeighborhoodAllocator<TPixel> & n, const itk::Size<2> & sz)
   {
     for (i = 0; i < sz[0]; ++i, ++k)
     {
-      std::cout << n[k] << " ";
+      std::cout << n[k] << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -304,7 +304,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
   itk::ConstShapedNeighborhoodIterator<TestImageType>::IndexListType ::const_iterator ali = l.begin();
   while (ali != l.end())
   {
-    std::cout << *ali << " ";
+    std::cout << *ali << ' ';
     ++ali;
   }
   std::cout << std::endl;

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -44,7 +44,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
-      std::cout << p.GetPixel(i) << " ";
+      std::cout << p.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -57,7 +57,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
-      std::cout << v.GetPixel(i)[0] << " ";
+      std::cout << v.GetPixel(i)[0] << ' ';
     }
     std::cout << std::endl;
   }
@@ -79,7 +79,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
       int pixel2 = p.GetPixel(i);
       int pixel3 = v.GetPixel(i)[0];
 
-      std::cout << pixel1 << " ";
+      std::cout << pixel1 << ' ';
 
       // Check agreement of output from three three methods of accessing pixel values.
       if (pixel1 != pixel2 || pixel2 != pixel3)
@@ -147,7 +147,7 @@ itkConstantBoundaryConditionTest(int, char *[])
       VectorImageType::PixelType vectorPixel(1);
       vectorPixel[0] = image->GetPixel(pos);
       vectorImage->SetPixel(pos, vectorPixel);
-      std::cout << image->GetPixel(pos) << " ";
+      std::cout << image->GetPixel(pos) << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkHeavisideStepFunctionTest1.cxx
@@ -41,7 +41,7 @@ itkHeavisideStepFunctionTest1(int, char *[])
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);
     OutputType      df = functionBase0->EvaluateDerivative(ix);
-    std::cout << ix << " " << f << " " << df << std::endl;
+    std::cout << ix << ' ' << f << ' ' << df << std::endl;
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -128,7 +128,7 @@ itkImageRegionIteratorTest(int, char *[])
     std::cout << "Simple iterator backwards loop: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   } while (!backIt.IsAtBegin()); // stop when we reach the beginning

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -176,7 +176,7 @@ itkImageRegionTest(int, char *[])
   {
     std::cout << "Error with IsInside 3C. Expected false." << std::endl
               << "  indexC: " << indexC << std::endl
-              << "  start & size: " << startA << " " << sizeA << std::endl;
+              << "  start & size: " << startA << ' ' << sizeA << std::endl;
     passed = false;
   }
   std::cout << "Testing ContinuousIndexNumericTraits::min()." << std::endl;

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -107,7 +107,7 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << "Simple iterator loop: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   }
@@ -123,7 +123,7 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << "Simple iterator backwards loop: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   } while (!backIt.IsAtBegin()); // stop when we reach the beginning
@@ -138,7 +138,7 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << "Reverse iterator: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   }
@@ -160,7 +160,7 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << "Reverse iterator backwards loop: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   } while (!backReverseIt.IsAtBegin()); // stop when we reach the beginning
@@ -173,7 +173,7 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << "Reverse const iterator: ";
     for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
-      std::cout << index[i] << " ";
+      std::cout << index[i] << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -128,7 +128,7 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
       vectorpixel.Fill(value);
       vectorpixel += vectorvalues;
 
-      std::cout << value << " ";
+      std::cout << value << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkImportImageTest.cxx
+++ b/Modules/Core/Common/test/itkImportImageTest.cxx
@@ -108,7 +108,7 @@ itkImportImageTest(int, char *[])
           (region.GetSize()[0] *
            ((shrink->GetShrinkFactors()[1] / 2) + (shrink->GetShrinkFactors()[0] * iterator2.GetIndex()[1]))))))
     {
-      std::cout << " iterator2.GetIndex() Get() " << iterator2.GetIndex() << " " << iterator2.Get() << " compare value "
+      std::cout << " iterator2.GetIndex() Get() " << iterator2.GetIndex() << ' ' << iterator2.Get() << " compare value "
                 << itk::Math::RoundHalfIntegerUp<short>(static_cast<float>(
                      (shrink->GetShrinkFactors()[0] * iterator2.GetIndex()[0] + shrink->GetShrinkFactors()[0] / 2) +
                      (region.GetSize()[0] * ((shrink->GetShrinkFactors()[1] / 2) +

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -77,14 +77,14 @@ TestIntegersAreSame(const T1 & v1, const T2 & v2)
   {
     std::cout << "Error in "
               << "itk::Math::AlmostEquals(v2, v1) " << std::endl;
-    std::cout << __FILE__ << " " << __LINE__ << " " << v2 << " == " << v1 << std::endl;
+    std::cout << __FILE__ << ' ' << __LINE__ << ' ' << v2 << " == " << v1 << std::endl;
     testPassStatus = EXIT_FAILURE;
   }
   if (itk::Math::AlmostEquals(v1, v2) == true)
   {
     std::cout << "Error in "
               << "itk::Math::AlmostEquals(v1, v2) " << std::endl;
-    std::cout << __FILE__ << " " << __LINE__ << " " << v1 << " == " << v2 << std::endl;
+    std::cout << __FILE__ << ' ' << __LINE__ << ' ' << v1 << " == " << v2 << std::endl;
     testPassStatus = EXIT_FAILURE;
   }
   return testPassStatus;
@@ -602,7 +602,7 @@ main(int, char *[])
     // Test AlmostEquals()
     if (itk::Math::AlmostEquals(f, d) == true || itk::Math::AlmostEquals(d, f) == true)
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     if (itk::Math::AlmostEquals(f, sc) == false || itk::Math::AlmostEquals(sc, f) == false ||
@@ -610,21 +610,21 @@ main(int, char *[])
         itk::Math::AlmostEquals(1, 1.0) == false || itk::Math::AlmostEquals(2.0, 1.0) == true ||
         itk::Math::AlmostEquals(1, 2) == true)
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
 
     // Test ExactlyEquals()  it should detect normal inequalities
     if (itk::Math::ExactlyEquals(f, d) == true || itk::Math::ExactlyEquals(d, f) == true)
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
 
     // Test comparison values of different types
     if (itk::Math::NotExactlyEquals(1.0f, 1.0) || itk::Math::NotExactlyEquals(1.0, 1.0f))
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
 
@@ -639,7 +639,7 @@ main(int, char *[])
     // Very close values should be AlmostEqual
     if (itk::Math::NotAlmostEquals(oneExact.asFloat, oneAlmost.asFloat))
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << oneExact.asFloat << " == " << oneAlmost.asFloat << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << oneExact.asFloat << " == " << oneAlmost.asFloat << std::endl;
       std::cout << "AlmostEquals Test Failure\n" << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
@@ -647,7 +647,7 @@ main(int, char *[])
     // Even very close values are not ExactlyEqual
     if (itk::Math::ExactlyEquals(oneExact.asFloat, oneAlmost.asFloat))
     {
-      std::cout << __FILE__ << " " << __LINE__ << " " << oneExact.asFloat << " == " << oneAlmost.asFloat << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << oneExact.asFloat << " == " << oneAlmost.asFloat << std::endl;
       std::cout << "ExactlyEquals Test Failure\n" << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
@@ -661,7 +661,7 @@ main(int, char *[])
     if (itk::Math::AlmostEquals(z1Double, z1Float) == false)
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -677,7 +677,7 @@ main(int, char *[])
     if (itk::Math::AlmostEquals(z2Double, z2Int) == false)
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -696,7 +696,7 @@ main(int, char *[])
     if (itk::Math::NotAlmostEquals(z1Double, z1DoubleAlmost))
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -713,7 +713,7 @@ main(int, char *[])
     if (itk::Math::NotAlmostEquals(z3Double, r3Double))
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -725,7 +725,7 @@ main(int, char *[])
     if (itk::Math::NotAlmostEquals(z3Double, r3Float))
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -743,7 +743,7 @@ main(int, char *[])
     if (itk::Math::NotAlmostEquals(z4Float, r4FloatAlmost.asFloat))
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else
@@ -755,7 +755,7 @@ main(int, char *[])
     if (itk::Math::NotAlmostEquals(z3Double, r4FloatAlmost.asFloat))
     {
       std::cout << "Test FAILED!!\n" << std::endl;
-      std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
+      std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     else

--- a/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
@@ -44,7 +44,7 @@ public:
     {
       return;
     }
-    std::cout << " " << processObject->GetProgress();
+    std::cout << ' ' << processObject->GetProgress();
   }
 };
 

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -87,7 +87,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -104,7 +104,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -115,7 +115,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -126,7 +126,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -137,7 +137,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -150,7 +150,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -161,7 +161,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -172,7 +172,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -183,7 +183,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   {
     for (x = 0; x < 5; ++x, ++i)
     {
-      std::cout << it3.GetPixel(i) << " ";
+      std::cout << it3.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkNeighborhoodTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodTest.cxx
@@ -52,7 +52,7 @@ itkNeighborhoodTest(int, char *[])
   println("Test const_iterators");
   for (itk::Neighborhood<float, 2>::ConstIterator itc = b.Begin(); itc < b.End(); ++itc)
   {
-    std::cout << *itc << " ";
+    std::cout << *itc << ' ';
   }
 
   println("Copy the buffer into a vnl_vector");

--- a/Modules/Core/Common/test/itkNumericsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericsTest.cxx
@@ -28,7 +28,7 @@ print_vnl_matrix(T & mat)
   {
     for (unsigned int c = 0; c < mat.columns(); ++c)
     {
-      std::cout << mat(r, c) << " ";
+      std::cout << mat(r, c) << ' ';
     }
     std::cout << std::endl;
   }
@@ -77,7 +77,7 @@ itkNumericsTest(int, char *[])
   {
     for (unsigned int c = 0; c < mat.rows(); ++c)
     {
-      std::cout << mat(r, c) << " ";
+      std::cout << mat(r, c) << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -62,7 +62,7 @@ itkOctreeTest(int, char *[])
       }
       else
       {
-        std::cerr << val << " ";
+        std::cerr << val << ' ';
       }
       counter++;
       ri.Set(val);

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -44,7 +44,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
-      std::cout << p.GetPixel(i) << " ";
+      std::cout << p.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -57,7 +57,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
-      std::cout << v.GetPixel(i)[0] << " ";
+      std::cout << v.GetPixel(i)[0] << ' ';
     }
     std::cout << std::endl;
   }
@@ -78,7 +78,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
       int pixel1 = p.GetBoundaryCondition()->GetPixel(index, p.GetImagePointer());
       int pixel2 = p.GetPixel(i);
 
-      std::cout << pixel1 << " ";
+      std::cout << pixel1 << ' ';
 
       // Check agreement of output from three three methods of accessing pixel values.
       if (pixel1 != pixel2)
@@ -146,7 +146,7 @@ itkPeriodicBoundaryConditionTest(int, char *[])
       VectorImageType::PixelType vectorPixel(1);
       vectorPixel[0] = image->GetPixel(pos);
       vectorImage->SetPixel(pos, vectorPixel);
-      std::cout << image->GetPixel(pos) << " ";
+      std::cout << image->GetPixel(pos) << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Common/test/itkPriorityQueueTest.cxx
+++ b/Modules/Core/Common/test/itkPriorityQueueTest.cxx
@@ -67,12 +67,12 @@ itkPriorityQueueTest(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(min_priority_queue->Peek().m_Priority, *it))
     {
-      std::cout << min_priority_queue->Peek().m_Priority << " " << *it << std::endl;
+      std::cout << min_priority_queue->Peek().m_Priority << ' ' << *it << std::endl;
       return EXIT_FAILURE;
     }
     if (min_priority_queue->Size() != i)
     {
-      std::cout << "Size " << min_priority_queue->Size() << " " << i << std::endl;
+      std::cout << "Size " << min_priority_queue->Size() << ' ' << i << std::endl;
       return EXIT_FAILURE;
     }
     min_priority_queue->Pop();
@@ -86,12 +86,12 @@ itkPriorityQueueTest(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(max_priority_queue->Peek().m_Priority, sequence.back()))
     {
-      std::cout << max_priority_queue->Peek().m_Priority << " " << sequence.back() << std::endl;
+      std::cout << max_priority_queue->Peek().m_Priority << ' ' << sequence.back() << std::endl;
       return EXIT_FAILURE;
     }
     if (max_priority_queue->Size() != sequence.size())
     {
-      std::cout << "Size " << max_priority_queue->Size() << " " << sequence.size() << std::endl;
+      std::cout << "Size " << max_priority_queue->Size() << ' ' << sequence.size() << std::endl;
       return EXIT_FAILURE;
     }
     max_priority_queue->Pop();

--- a/Modules/Core/Common/test/itkSinRegularizedHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkSinRegularizedHeavisideStepFunctionTest1.cxx
@@ -58,7 +58,7 @@ itkSinRegularizedHeavisideStepFunctionTest1(int, char *[])
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);
     OutputType      df = functionBase0->EvaluateDerivative(ix);
-    std::cout << ix << " " << f << " " << df << std::endl;
+    std::cout << ix << ' ' << f << ' ' << df << std::endl;
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -98,7 +98,7 @@ PrintRegion(itk::SmartPointer<itk::Image<TPixelType, VDimension>> I)
 
   for (; !iter.IsAtEnd(); ++iter)
   {
-    std::cout << iter.Get() << " ";
+    std::cout << iter.Get() << ' ';
 
     iDim = VDimension - 1;
     bool done = false;
@@ -133,7 +133,7 @@ PrintSlice(TContainer s)
   std::cout << "[";
   for (s = s.Begin(); s < s.End(); ++s)
   {
-    std::cout << *s << " ";
+    std::cout << *s << ' ';
   }
   std::cout << "]" << std::endl;
 }

--- a/Modules/Core/Common/test/itkSmartPointerTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerTest.cxx
@@ -47,14 +47,14 @@ public:
   inline friend std::ostream &
   operator<<(std::ostream & os, itkTestObject const & o)
   {
-    os << "itkTestObject " << (void const *)&o << " " << o.m_ReferenceCount;
+    os << "itkTestObject " << (void const *)&o << ' ' << o.m_ReferenceCount;
     return os;
   }
 
   std::ostream &
   Print(std::ostream & os) const
   {
-    os << "itkTestObject " << (void const *)this << " " << this->m_ReferenceCount;
+    os << "itkTestObject " << (void const *)this << ' ' << this->m_ReferenceCount;
     return os;
   }
 
@@ -141,11 +141,11 @@ itkSmartPointerTest(int, char *[])
     o4 = o1;
     if (o1 < o2)
     {
-      std::cout << "o1 is < o2 " << o1 << " " << o2 << std::endl;
+      std::cout << "o1 is < o2 " << o1 << ' ' << o2 << std::endl;
     }
     else
     {
-      std::cout << "o1 is not < o2 " << &o1 << " " << &o2 << std::endl;
+      std::cout << "o1 is not < o2 " << &o1 << ' ' << &o2 << std::endl;
     }
   }
   std::cout << "end second test" << std::endl << std::endl;

--- a/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
@@ -418,7 +418,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
         if (itk::Math::abs(eigvec2[i] - itk::Math::sgn0(eigenvectors[2][0]) * eigenvectors[2][i]) > tolerance)
         {
-          std::cout << eigenvectors[2][i] << " " << eigvec2[i] << std::endl;
+          std::cout << eigenvectors[2][i] << ' ' << eigvec2[i] << std::endl;
           std::cout << "Eigen vector computation failed" << std::endl;
           return EXIT_FAILURE;
         }

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
@@ -87,7 +87,7 @@ public:
       std::cout << "\nDomain partition per thread:" << std::endl;
       for (itk::ThreadIdType i = 0; i < m_DomainInThreadedExecution.size(); ++i)
       {
-        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << " "
+        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << ' '
                   << m_DomainInThreadedExecution[i][1] << std::endl;
       }
       std::cout << std::endl;

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
@@ -90,7 +90,7 @@ public:
       std::cout << "\nDomain partition per thread:" << std::endl;
       for (itk::ThreadIdType i = 0; i < m_DomainInThreadedExecution.size(); ++i)
       {
-        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << " "
+        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << ' '
                   << m_DomainInThreadedExecution[i][1] << std::endl;
       }
       std::cout << std::endl;

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
@@ -90,7 +90,7 @@ public:
       std::cout << "\nDomain partition per thread:" << std::endl;
       for (itk::ThreadIdType i = 0; i < m_DomainInThreadedExecution.size(); ++i)
       {
-        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << " "
+        std::cout << "ThreadId: " << i << "\t" << m_DomainInThreadedExecution[i][0] << ' '
                   << m_DomainInThreadedExecution[i][1] << std::endl;
       }
       std::cout << std::endl;

--- a/Modules/Core/Common/test/itkVersorTest.cxx
+++ b/Modules/Core/Common/test/itkVersorTest.cxx
@@ -148,10 +148,10 @@ RotationMatrixToVersorTest()
           {
             std::cout << "(alpha,beta,gamma)= (" << alpha << "," << beta << "," << gamma << ")" << std::endl;
 
-            std::cout << newMRtestPoint << " " << newVRtestPoint << " " << newVRFROMMRPoint << " "
+            std::cout << newMRtestPoint << ' ' << newVRtestPoint << ' ' << newVRFROMMRPoint << ' '
                       << newVRFROMMRTransformPoint << std::endl;
-            std::cout << "ERRORS: " << error_newMRtestPoint_newVRtestPoint << " "
-                      << error_newMRtestPoint_newVRFROMMRPoint << " "
+            std::cout << "ERRORS: " << error_newMRtestPoint_newVRtestPoint << ' '
+                      << error_newMRtestPoint_newVRFROMMRPoint << ' '
                       << error_newVRFROMMRPoint_newVRFROMMRTransformPoint << std::endl;
             std::cout << "MR=\n"
                       << MR << "\nVR=\n"

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -43,7 +43,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
-      std::cout << p.GetPixel(i) << " ";
+      std::cout << p.GetPixel(i) << ' ';
     }
     std::cout << std::endl;
   }
@@ -56,7 +56,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   {
     for (x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
-      std::cout << v.GetPixel(i)[0] << " ";
+      std::cout << v.GetPixel(i)[0] << ' ';
     }
     std::cout << std::endl;
   }
@@ -78,7 +78,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
       int pixel2 = p.GetPixel(i);
       int pixel3 = v.GetPixel(i)[0];
 
-      std::cout << pixel1 << " ";
+      std::cout << pixel1 << ' ';
 
       // Check agreement of output from three three methods of accessing pixel values.
       if (pixel1 != pixel2 || pixel2 != pixel3)
@@ -146,7 +146,7 @@ itkZeroFluxBoundaryConditionTest(int, char *[])
       VectorImageType::PixelType vectorPixel(1);
       vectorPixel[0] = image->GetPixel(pos);
       vectorImage->SetPixel(pos, vectorPixel);
-      std::cout << image->GetPixel(pos) << " ";
+      std::cout << image->GetPixel(pos) << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -934,7 +934,7 @@ itkVectorImageTest(int, char * argv[])
         ConstShapedNeighborhoodIteratorType::IndexListType::const_iterator ali = l.begin();
         while (ali != l.end())
         {
-          std::cout << *ali << " ";
+          std::cout << *ali << ' ';
           ++ali;
         }
         std::cout << std::endl;

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -136,7 +136,7 @@ TestGeometricPoint(const TInterpolator * interp, const PointType & point, bool i
   std::cout << " Point: " << point;
 
   bool bvalue = interp->IsInsideBuffer(point);
-  std::cout << " Inside: " << bvalue << " ";
+  std::cout << " Inside: " << bvalue << ' ';
 
   if (bvalue != isInside)
   {

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -81,7 +81,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
         const IndexType index = { { x, y } };
         const PixelType value = valarray[x][y];
         small_image->SetPixel(index, value);
-        std::cout << value << " ";
+        std::cout << value << ' ';
       }
       std::cout << std::endl;
     }

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -137,7 +137,7 @@ RunLinearInterpolateTest()
           VariablePixelType variablevectorpixel = variablevectorimage->GetPixel(index);
           variablevectorpixel.Fill(value);
 
-          std::cout << value << " ";
+          std::cout << value << ' ';
         }
         std::cout << std::endl;
       }

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -120,7 +120,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
       VariablePixelType variablevectorpixel = variablevectorimage->GetPixel(index);
       variablevectorpixel.Fill(value);
 
-      std::cout << value << " ";
+      std::cout << value << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -254,14 +254,14 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
       itkExceptionMacro(<< "Error reading file: " << m_FileName
                         << "point ids must be >= 0.\n"
                            "ids="
-                        << ids[0] << " " << ids[1] << " " << ids[2]);
+                        << ids[0] << ' ' << ids[1] << ' ' << ids[2]);
     }
 
     const auto signedNumberOfPoints = itk::Math::CastWithRangeCheck<OffsetValueType>(numberOfPoints);
     if (ids[0] >= signedNumberOfPoints || ids[1] >= signedNumberOfPoints || ids[2] >= signedNumberOfPoints)
     {
       itkExceptionMacro(<< "Error reading file: " << m_FileName << "Point ids must be < number of points: "
-                        << numberOfPoints << "\nids= " << ids[0] << " " << ids[1] << " " << ids[2]);
+                        << numberOfPoints << "\nids= " << ids[0] << ' ' << ids[1] << ' ' << ids[2]);
     }
 
     CellAutoPointer cell;

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -110,16 +110,15 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
     {
       PointType point = pointIterator.Value();
 
-      outputFile << point[0] << " " << point[1];
+      outputFile << point[0] << ' ' << point[1];
 
       if (TInputMesh::PointDimension > 2)
       {
-        outputFile << " " << point[2];
+        outputFile << ' ' << point[2];
       }
       else
       {
-        outputFile << " "
-                   << "0.0";
+        outputFile << ' ' << "0.0";
       }
 
       outputFile << std::endl;
@@ -171,7 +170,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
     // LINES
     if (numberOfEdges)
     {
-      outputFile << "LINES " << numberOfEdges << " " << 3 * numberOfEdges << std::endl;
+      outputFile << "LINES " << numberOfEdges << ' ' << 3 * numberOfEdges << std::endl;
 
       cellIterator = cells->Begin();
       while (cellIterator != cellEnd)
@@ -187,7 +186,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
             outputFile << cellPointer->GetNumberOfPoints();
             while (pointIdIterator != pointIdEnd)
             {
-              outputFile << " " << IdMap[*pointIdIterator];
+              outputFile << ' ' << IdMap[*pointIdIterator];
               ++pointIdIterator;
             }
             outputFile << std::endl;
@@ -218,7 +217,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
         }
         ++cellIterator;
       }
-      outputFile << "POLYGONS " << numberOfPolygons << " "
+      outputFile << "POLYGONS " << numberOfPolygons << ' '
                  << totalNumberOfPointsInPolygons + numberOfPolygons; // FIXME: Is this right ?
       outputFile << std::endl;
 
@@ -238,7 +237,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
             outputFile << cellPointer->GetNumberOfPoints();
             while (pointIdIterator != pointIdEnd)
             {
-              outputFile << " " << IdMap[*pointIdIterator];
+              outputFile << ' ' << IdMap[*pointIdIterator];
               ++pointIdIterator;
             }
             outputFile << std::endl;

--- a/Modules/Core/Mesh/test/itkAutomaticTopologyMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkAutomaticTopologyMeshSourceTest.cxx
@@ -233,7 +233,7 @@ itkAutomaticTopologyMeshSourceTest(int, char *[])
       PointIdIterator pointsEnd = cell->PointIdsEnd();
       for (; pointIter != pointsEnd; ++pointIter)
       {
-        std::cout << *pointIter << " ";
+        std::cout << *pointIter << ' ';
       }
       std::cout << std::endl;
     }
@@ -257,7 +257,7 @@ itkAutomaticTopologyMeshSourceTest(int, char *[])
         std::cout << "Neighbors across vertex 0: ";
         for (const auto & neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n";
 
@@ -265,7 +265,7 @@ itkAutomaticTopologyMeshSourceTest(int, char *[])
         std::cout << "Neighbors across vertex 1: ";
         for (const auto & neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n";
 
@@ -273,7 +273,7 @@ itkAutomaticTopologyMeshSourceTest(int, char *[])
         std::cout << "Neighbors having edge as boundary: ";
         for (const auto neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n" << std::endl;
       }

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -224,7 +224,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
     if (itk::Math::NotExactlyEquals(testSpacing[i], spacingAsFloatArray[i]))
     {
       std::cerr << "SetSpacing failure " << testSpacing << std::endl
-                << "!= " << spacingAsFloatArray[0] << " " << spacingAsFloatArray[1] << " " << spacingAsFloatArray[2]
+                << "!= " << spacingAsFloatArray[0] << ' ' << spacingAsFloatArray[1] << ' ' << spacingAsFloatArray[2]
                 << std::endl;
       return EXIT_FAILURE;
     }
@@ -242,7 +242,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
     if (itk::Math::NotExactlyEquals(testOrigin[i], originAsFloatArray[i]))
     {
       std::cerr << "SetOrigin failure " << testOrigin << std::endl
-                << "!= " << originAsFloatArray[0] << " " << originAsFloatArray[1] << " " << originAsFloatArray[2]
+                << "!= " << originAsFloatArray[0] << ' ' << originAsFloatArray[1] << ' ' << originAsFloatArray[2]
                 << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -1215,7 +1215,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(const PointIdList & points) -
     {
       if (edge->IsLeftSet())
       {
-        itkDebugMacro("Edge [" << i << " " << ((i + 1) % N) << " has a left face.");
+        itkDebugMacro("Edge [" << i << ' ' << ((i + 1) % N) << " has a left face.");
         return (QEPrimal *)nullptr;
       }
     }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
@@ -56,7 +56,7 @@ QuadEdgeMeshScalarDataVTKPolyDataWriter<TMesh>::WriteCellData()
 
       if (!m_CellDataName.empty())
       {
-        outputFile << m_CellDataName << " " << m_CellDataName << std::endl;
+        outputFile << m_CellDataName << ' ' << m_CellDataName << std::endl;
       }
       else
       {
@@ -107,7 +107,7 @@ QuadEdgeMeshScalarDataVTKPolyDataWriter<TMesh>::WritePointData()
 
     if (!m_PointDataName.empty())
     {
-      outputFile << m_PointDataName << " " << m_PointDataName << std::endl;
+      outputFile << m_PointDataName << ' ' << m_PointDataName << std::endl;
     }
     else
     {
@@ -122,7 +122,7 @@ QuadEdgeMeshScalarDataVTKPolyDataWriter<TMesh>::WritePointData()
 
     while (c_it != pointdata->End())
     {
-      outputFile << c_it.Value() << " ";
+      outputFile << c_it.Value() << ' ';
       if (k % 3 == 0)
       {
         outputFile << std::endl;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
@@ -505,12 +505,12 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
       return EXIT_FAILURE;
     }
 
-    std::cout << "Indices of the quadrangle: [" << quadFace2->GetOrigin() << " " << quadFace2->GetLnext()->GetOrigin()
-              << " " << quadFace2->GetLnext()->GetLnext()->GetOrigin() << " "
-              << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << " "
+    std::cout << "Indices of the quadrangle: [" << quadFace2->GetOrigin() << ' ' << quadFace2->GetLnext()->GetOrigin()
+              << ' ' << quadFace2->GetLnext()->GetLnext()->GetOrigin() << ' '
+              << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << ' '
               << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << "]" << std::endl;
 
-    std::cout << "Correct indices should be: [" << pid[0] << " " << pid[2] << " " << pid[4] << " " << pid[3] << " "
+    std::cout << "Correct indices should be: [" << pid[0] << ' ' << pid[2] << ' ' << pid[4] << ' ' << pid[3] << ' '
               << pid[0] << "]" << std::endl;
 
     std::cout << "Testing value for pid4" << std::endl;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -253,8 +253,7 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
     JoinVertexType::EdgeStatusType status = joinVertex->GetEdgeStatus();
 
     std::cout << "*** " << kk << " ***" << std::endl;
-    std::cout << "org: " << id_org << " "
-              << "dest: " << id_dest << " " << status << std::endl;
+    std::cout << "org: " << id_org << ' ' << "dest: " << id_dest << ' ' << status << std::endl;
 
     if ((status == JoinVertexType::EDGE_JOINING_DIFFERENT_BORDERS) || (status == JoinVertexType::SAMOSA_CONFIG) ||
         (status == JoinVertexType::TETRAHEDRON_CONFIG))
@@ -264,7 +263,7 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
 
     if (!qe_output)
     {
-      std::cout << "Number of Edges: " << mesh->GetNumberOfEdges() << " " << std::endl;
+      std::cout << "Number of Edges: " << mesh->GetNumberOfEdges() << ' ' << std::endl;
       std::cout << "Number of Faces: " << mesh->GetNumberOfFaces() << std::endl;
       std::cout << "FAILED." << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -159,9 +159,9 @@ void
 SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Id: " << m_Id << std::endl;
-  os << indent << "RGBA: " << m_Color.GetRed() << " ";
-  os << m_Color.GetGreen() << " ";
-  os << m_Color.GetBlue() << " ";
+  os << indent << "RGBA: " << m_Color.GetRed() << ' ';
+  os << m_Color.GetGreen() << ' ';
+  os << m_Color.GetBlue() << ' ';
   os << m_Color.GetAlpha() << std::endl;
   os << indent << "Position: ";
   for (unsigned int i = 1; i < TPointDimension; ++i)

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -191,7 +191,7 @@ void
 SpatialObjectProperty::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Name: " << m_Name << std::endl;
-  os << indent << "RGBA: " << m_Color.GetRed() << " " << m_Color.GetGreen() << " " << m_Color.GetBlue() << " "
+  os << indent << "RGBA: " << m_Color.GetRed() << ' ' << m_Color.GetGreen() << ' ' << m_Color.GetBlue() << ' '
      << m_Color.GetAlpha() << std::endl;
   os << indent << "ScalarDictionary size: " << m_ScalarDictionary.size() << std::endl;
   os << indent << "StringDictionary size: " << m_StringDictionary.size() << std::endl;

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -973,7 +973,7 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
   os << indent << "TransformsToOptimizeFlags, begin() to end(): " << std::endl << indent << indent;
   for (auto it = this->m_TransformsToOptimizeFlags.begin(); it != this->m_TransformsToOptimizeFlags.end(); ++it)
   {
-    os << *it << " ";
+    os << *it << ' ';
   }
   os << std::endl;
 

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -65,7 +65,7 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
     os << indent.GetNextIndent();
     for (j = 0; j < VOutputDimension; ++j)
     {
-      os << m_Matrix[i][j] << " ";
+      os << m_Matrix[i][j] << ' ';
     }
     os << std::endl;
   }
@@ -80,7 +80,7 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
     os << indent.GetNextIndent();
     for (j = 0; j < VOutputDimension; ++j)
     {
-      os << this->GetInverseMatrix()[i][j] << " ";
+      os << this->GetInverseMatrix()[i][j] << ' ';
     }
     os << std::endl;
   }

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -83,13 +83,13 @@ ScalableAffineTransform<TParametersValueType, VDimension>::PrintSelf(std::ostrea
   os << indent << "Scale : ";
   for (i = 0; i < VDimension; ++i)
   {
-    os << m_Scale[i] << " ";
+    os << m_Scale[i] << ' ';
   }
   os << std::endl;
   os << indent << "MatrixScale : ";
   for (i = 0; i < VDimension; ++i)
   {
-    os << m_MatrixScale[i] << " ";
+    os << m_MatrixScale[i] << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -907,7 +907,7 @@ itkCompositeTransformTest(int, char *[])
     for (itk::SizeValueType n = 0; n < 12; ++n)
     {
       const TranslationTransformType::ParametersType & params = translationTransformVector[n]->GetParameters();
-      std::cout << " " << params[0];
+      std::cout << ' ' << params[0];
     }
     std::cout << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
@@ -44,7 +44,7 @@ itkScaleLogarithmicTransformTest(int, char *[])
     std::cout << "Scale from instantiating an identity transform:  ";
     for (unsigned int j = 0; j < N; ++j)
     {
-      std::cout << scale[j] << " ";
+      std::cout << scale[j] << ' ';
     }
     std::cout << std::endl;
     for (unsigned int i = 0; i < N; ++i)
@@ -75,7 +75,7 @@ itkScaleLogarithmicTransformTest(int, char *[])
     std::cout << "scale initialization  test:  ";
     for (unsigned int j = 0; j < N; ++j)
     {
-      std::cout << scale[j] << " ";
+      std::cout << scale[j] << ' ';
     }
     std::cout << std::endl;
 

--- a/Modules/Core/Transform/test/itkScaleTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleTransformTest.cxx
@@ -42,7 +42,7 @@ itkScaleTransformTest(int, char *[])
     std::cout << "Scale from instantiating an identity transform:  ";
     for (unsigned int j = 0; j < N; ++j)
     {
-      std::cout << scale[j] << " ";
+      std::cout << scale[j] << ' ';
     }
     std::cout << std::endl;
     for (unsigned int i = 0; i < N; ++i)
@@ -78,7 +78,7 @@ itkScaleTransformTest(int, char *[])
     std::cout << "scale initialization  test:  ";
     for (unsigned int j = 0; j < N; ++j)
     {
-      std::cout << scale[j] << " ";
+      std::cout << scale[j] << ' ';
     }
     std::cout << std::endl;
 

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
@@ -25,7 +25,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << " " << v[1] << " " << v[2] << "]";
+  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
   return o;
 }
 

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -384,7 +384,7 @@ itkPatchBasedDenoisingImageFilterTest(int argc, char * argv[])
       std::cerr << noiseModel << " is not a valid noise model choice. Please choose one of: ";
       for (const auto & modelChoice : modelChoices)
       {
-        std::cerr << modelChoice << " " << std::endl;
+        std::cerr << modelChoice << ' ' << std::endl;
       }
       return EXIT_FAILURE;
     }

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -209,7 +209,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
       std::cout << "\t";
       for (unsigned int j = 0; j < 3; ++j)
       {
-        std::cout << tensorImage->GetPixel(tensorImageIndex)(i, j) << " ";
+        std::cout << tensorImage->GetPixel(tensorImageIndex)(i, j) << ' ';
         if ((itk::Math::abs(tensorImage->GetPixel(tensorImageIndex)(i, j) - expectedResult[i][j])) > precision)
         {
           passed = false;
@@ -228,7 +228,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
         std::cout << "\t";
         for (double j : i)
         {
-          std::cout << j << " ";
+          std::cout << j << ' ';
         }
         std::cout << std::endl;
       }

--- a/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
@@ -130,7 +130,7 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."
@@ -203,7 +203,7 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -147,7 +147,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."
@@ -220,7 +220,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -120,7 +120,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
     }
     std::cout << std::endl;
   }
@@ -184,7 +184,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -112,7 +112,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
     }
     std::cout << std::endl;
   }
@@ -173,7 +173,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     for (int j = -2; j < 3; ++j)
     {
       unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
-      std::cout << params(index) << " ";
+      std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
         std::cout << "Expected to read a smoothed value at this index."

--- a/Modules/Filtering/FFT/test/itkFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkFFTTest.h
@@ -103,7 +103,7 @@ test_fft(unsigned int * SizeOfDimensions)
       }
       else
       {
-        std::cout << val << " ";
+        std::cout << val << ' ';
       }
       counter++;
       originalImageIterator.Set(val);
@@ -158,7 +158,7 @@ test_fft(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizes[0];
       for (unsigned int k = 0; k < sizes[0]; ++k)
       {
-        std::cout << fftbuf[zStride + yStride + k] << " ";
+        std::cout << fftbuf[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -234,7 +234,7 @@ test_fft(unsigned int * SizeOfDimensions)
     }
     else
     {
-      std::cerr << val << " ";
+      std::cerr << val << ' ';
     }
     counter++;
     ++inverseFFTImageIterator;
@@ -258,7 +258,7 @@ test_fft(unsigned int * SizeOfDimensions)
     }
     if (diff > 0.01)
     {
-      std::cerr << "Diff found in test_fft: " << val << " " << val2 << " diff " << diff << std::endl;
+      std::cerr << "Diff found in test_fft: " << val << ' ' << val2 << " diff " << diff << std::endl;
       return -1;
     }
     ++originalImageIterator;
@@ -322,7 +322,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       }
       else
       {
-        std::cout << val << " ";
+        std::cout << val << ' ';
       }
       counter++;
       originalImageIterator.Set(val);
@@ -381,7 +381,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizesA[0];
       for (unsigned int k = 0; k < sizesA[0]; ++k)
       {
-        std::cout << fftbufA[zStride + yStride + k] << " ";
+        std::cout << fftbufA[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -396,7 +396,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizesB[0];
       for (unsigned int k = 0; k < sizesB[0]; ++k)
       {
-        std::cout << fftbufB[zStride + yStride + k] << " ";
+        std::cout << fftbufB[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -425,7 +425,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
         }
         if (diff > 0.01)
         {
-          std::cerr << "Diff found in test_fft_r2c: " << fftbufA[zStrideA + yStrideA + k] << " "
+          std::cerr << "Diff found in test_fft_r2c: " << fftbufA[zStrideA + yStrideA + k] << ' '
                     << fftbufB[zStrideB + yStrideB + k] << " diff " << diff << std::endl;
           return -1;
         }

--- a/Modules/Filtering/FFT/test/itkRealFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkRealFFTTest.h
@@ -89,7 +89,7 @@ test_fft(unsigned int * SizeOfDimensions)
       }
       else
       {
-        std::cout << val << " ";
+        std::cout << val << ' ';
       }
       counter++;
       originalImageIterator.Set(val);
@@ -146,7 +146,7 @@ test_fft(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizes[0];
       for (unsigned int k = 0; k < sizes[0]; ++k)
       {
-        std::cout << fftbuf[zStride + yStride + k] << " ";
+        std::cout << fftbuf[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -185,7 +185,7 @@ test_fft(unsigned int * SizeOfDimensions)
     }
     else
     {
-      std::cerr << val << " ";
+      std::cerr << val << ' ';
     }
     counter++;
     ++inverseFFTImageIterator;
@@ -209,7 +209,7 @@ test_fft(unsigned int * SizeOfDimensions)
     }
     if (diff > 0.01)
     {
-      std::cerr << "Diff found in test_fft: " << val << " " << val2 << " diff " << diff << std::endl;
+      std::cerr << "Diff found in test_fft: " << val << ' ' << val2 << " diff " << diff << std::endl;
       return -1;
     }
     ++originalImageIterator;
@@ -273,7 +273,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       }
       else
       {
-        std::cout << val << " ";
+        std::cout << val << ' ';
       }
       counter++;
       originalImageIterator.Set(val);
@@ -332,7 +332,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizesA[0];
       for (unsigned int k = 0; k < sizesA[0]; ++k)
       {
-        std::cout << fftbufA[zStride + yStride + k] << " ";
+        std::cout << fftbufA[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -347,7 +347,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
       unsigned int yStride = j * sizesB[0];
       for (unsigned int k = 0; k < sizesB[0]; ++k)
       {
-        std::cout << fftbufB[zStride + yStride + k] << " ";
+        std::cout << fftbufB[zStride + yStride + k] << ' ';
       }
       std::cout << std::endl;
     }
@@ -376,7 +376,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
         }
         if (diff > 0.01)
         {
-          std::cerr << "Diff found in test_fft_r2c: " << fftbufA[zStrideA + yStrideA + k] << " "
+          std::cerr << "Diff found in test_fft_r2c: " << fftbufA[zStrideA + yStrideA + k] << ' '
                     << fftbufB[zStrideB + yStrideB + k] << " diff " << diff << std::endl;
           return -1;
         }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -279,9 +279,9 @@ itkFastMarchingExtensionImageFilterTest(int, char *[])
     {
       if (itk::Math::abs(outputValue) / distance > 1.42)
       {
-        std::cout << iterator.GetIndex() << " ";
-        std::cout << itk::Math::abs(outputValue) / distance << " ";
-        std::cout << itk::Math::abs(outputValue) << " " << distance << std::endl;
+        std::cout << iterator.GetIndex() << ' ';
+        std::cout << itk::Math::abs(outputValue) / distance << ' ';
+        std::cout << itk::Math::abs(outputValue) << ' ' << distance << std::endl;
         passed = false;
         break;
       }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -231,9 +231,9 @@ itkFastMarchingTest(int argc, char * argv[])
     }
     if (itk::Math::abs(outputValue) / distance > 1.42)
     {
-      std::cout << iterator.GetIndex() << " ";
-      std::cout << itk::Math::abs(outputValue) / distance << " ";
-      std::cout << itk::Math::abs(outputValue) << " " << distance << std::endl;
+      std::cout << iterator.GetIndex() << ' ';
+      std::cout << itk::Math::abs(outputValue) / distance << ' ';
+      std::cout << itk::Math::abs(outputValue) << ' ' << distance << std::endl;
       passed = false;
     }
   }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -196,9 +196,9 @@ itkFastMarchingTest2(int, char *[])
 
       if (itk::Math::abs(outputValue) / distance > 1.42)
       {
-        std::cout << iterator.GetIndex() << " ";
-        std::cout << itk::Math::abs(outputValue) / distance << " ";
-        std::cout << itk::Math::abs(outputValue) << " " << distance << std::endl;
+        std::cout << iterator.GetIndex() << ' ';
+        std::cout << itk::Math::abs(outputValue) / distance << ' ';
+        std::cout << itk::Math::abs(outputValue) << ' ' << distance << std::endl;
         passed = false;
       }
     }
@@ -206,8 +206,8 @@ itkFastMarchingTest2(int, char *[])
     {
       if (outputValue != 0.)
       {
-        std::cout << iterator.GetIndex() << " ";
-        std::cout << outputValue << " " << 0.;
+        std::cout << iterator.GetIndex() << ' ';
+        std::cout << outputValue << ' ' << 0.;
         std::cout << std::endl;
         passed = false;
       }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -182,8 +182,8 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
 
     if ((outputPixelNorm < 0.9999) || (outputPixelNorm > 1.0001) || (dot < 0.99) || (dot > 1.01))
     {
-      std::cout << iterator.GetIndex() << " ";
-      std::cout << outputPixelNorm << " ";
+      std::cout << iterator.GetIndex() << ' ';
+      std::cout << outputPixelNorm << ' ';
       std::cout << dot << std::endl;
       passed = false;
     }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -221,8 +221,8 @@ itkFastMarchingUpwindGradientTest(int, char *[])
 
     if (outputPixelNorm < 0.9999 || outputPixelNorm > 1.0001 || dot < 0.99 || dot > 1.01)
     {
-      std::cout << iterator.GetIndex() << " ";
-      std::cout << outputPixelNorm << " ";
+      std::cout << iterator.GetIndex() << ' ';
+      std::cout << outputPixelNorm << ' ';
       std::cout << dot << std::endl;
       passed = false;
     }

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
@@ -79,7 +79,7 @@ GPUBinaryThresholdImageFilter<TInputImage, TOutputImage>::GPUBinaryThresholdImag
     {
       if (ii < sz - 1)
       {
-        excpMsg << " " << validTypes[ii] << ",";
+        excpMsg << ' ' << validTypes[ii] << ",";
       }
       else
       {

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -303,7 +303,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
   std::cout << "Specificity: ";
   for (auto value : specificity)
   {
-    std::cout << value << " ";
+    std::cout << value << ' ';
   }
   std::cout << std::endl;
 
@@ -311,7 +311,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
   std::cout << "Sensitivity: ";
   for (auto value : specificity)
   {
-    std::cout << value << " ";
+    std::cout << value << ' ';
   }
   std::cout << std::endl;
 

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -155,7 +155,7 @@ itkHessian3DToVesselnessMeasureImageFilterTest(int argc, char * argv[])
   itg.GoToBegin();
   while (!itg.IsAtEnd())
   {
-    std::cout << itg.Get() << " ";
+    std::cout << itg.Get() << ' ';
     ++itg;
   }
 

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
@@ -29,7 +29,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << " " << v[1] << " " << v[2] << "]";
+  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
   return o;
 }
 

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -24,7 +24,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << " " << v[1] << " " << v[2] << "]";
+  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
   return o;
 }
 

--- a/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorTest.cxx
@@ -34,7 +34,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   for (ul = 0; ul < 100; ++ul)
   {
     pixel = ulf(ul);
-    std::cout << ul << "->" << static_cast<int>(pixel[0]) << " " << static_cast<int>(pixel[1]) << " "
+    std::cout << ul << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
               << static_cast<int>(pixel[2]) << std::endl;
   }
   std::cout << "Testing unsigned long integers in little endian mode" << std::endl;
@@ -43,7 +43,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   for (ul = 0; ul < 100; ++ul)
   {
     pixel = ulf(ul);
-    std::cout << ul << "->" << static_cast<int>(pixel[0]) << " " << static_cast<int>(pixel[1]) << " "
+    std::cout << ul << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
               << static_cast<int>(pixel[2]) << std::endl;
   }
 
@@ -54,7 +54,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   for (char c = 0; c < 100; ++c)
   {
     pixel = ucf(c);
-    std::cout << static_cast<int>(c) << "->" << static_cast<int>(pixel[0]) << " " << static_cast<int>(pixel[1]) << " "
+    std::cout << static_cast<int>(c) << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
               << static_cast<int>(pixel[2]) << std::endl;
   }
 
@@ -67,7 +67,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   {
     pixel = ff(f);
 
-    std::cout << f << "->" << static_cast<int>(pixel[0]) << " " << static_cast<int>(pixel[1]) << " "
+    std::cout << f << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
               << static_cast<int>(pixel[2]) << std::endl;
   }
   std::cout << "Testing float in little endian mode" << std::endl;
@@ -76,7 +76,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   for (f = 0; f < 100; ++f)
   {
     pixel = ff(f);
-    std::cout << f << "->" << static_cast<int>(pixel[0]) << " " << static_cast<int>(pixel[1]) << " "
+    std::cout << f << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
               << static_cast<int>(pixel[2]) << std::endl;
   }
 

--- a/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
@@ -112,7 +112,7 @@ itkDifferenceOfGaussiansGradientTest(int, char *[])
   std::cout << "Seeds for FloodFilledSpatialFunctionConditionalIterator" << std::endl;
   for (const auto & seed : sfi.GetSeeds())
   {
-    std::cout << seed << " ";
+    std::cout << seed << ' ';
   }
   std::cout << std::endl;
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
@@ -27,7 +27,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::CovariantVector<float, 3> & v)
 {
-  o << "[" << v[0] << " " << v[1] << " " << v[2] << "]";
+  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
   return o;
 }
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
@@ -25,7 +25,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << " " << v[1] << " " << v[2] << "]";
+  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
   return o;
 }
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -170,7 +170,7 @@ itkGradientRecursiveGaussianFilterTest3Compare(typename TGradImage1DType::Pointe
         if (itk::Math::abs(truth - test) > tolerance)
         {
           std::cerr << "One or more components of vector gradient image pixel are not as expected: " << std::endl
-                    << "d, c, truth, test: " << d << " " << c << " " << truth << " " << test << std::endl
+                    << "d, c, truth, test: " << d << ' ' << c << ' ' << truth << ' ' << test << std::endl
                     << "scalar pixel gradient: " << scalar << " vector pixel gradient: " << vector << std::endl;
           return EXIT_FAILURE;
         }

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -48,7 +48,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
   os << indent << "Shrink Factor: ";
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
-    os << m_ShrinkFactors[j] << " ";
+    os << m_ShrinkFactors[j] << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -467,13 +467,13 @@ void
 DumpDirections(const std::string & prompt, const typename ImageType::Pointer & image)
 {
   const typename ImageType::DirectionType & dir = image->GetDirection();
-  std::cerr << prompt << " " << SO_OrientationToString(itk::SpatialOrientationAdapter().FromDirectionCosines(dir))
+  std::cerr << prompt << ' ' << SO_OrientationToString(itk::SpatialOrientationAdapter().FromDirectionCosines(dir))
             << std::endl;
   for (unsigned int i = 0; i < 3; ++i)
   {
     for (unsigned int j = 0; j < 3; ++j)
     {
-      std::cerr << dir[i][j] << " ";
+      std::cerr << dir[i][j] << ' ';
     }
     std::cerr << std::endl;
   }
@@ -518,7 +518,7 @@ OrientImageFilter<TInputImage, TOutputImage>::GenerateData()
     permute->SetOrder(m_PermuteOrder);
     permute->ReleaseDataFlagOn();
     DEBUG_EXECUTE(std::cerr << "Permute Axes: "; for (unsigned int i = 0; i < 3; ++i) {
-      std::cerr << m_PermuteOrder[i] << " ";
+      std::cerr << m_PermuteOrder[i] << ' ';
     } std::cerr << std::endl;
                   permute->Update();
                   DumpDirections<TInputImage>("after permute", permute->GetOutput());)
@@ -536,7 +536,7 @@ OrientImageFilter<TInputImage, TOutputImage>::GenerateData()
     flip->FlipAboutOriginOff();
     flip->ReleaseDataFlagOn();
     DEBUG_EXECUTE(std::cerr << "Flip Axes: ";
-                  for (unsigned int i = 0; i < 3; ++i) { std::cerr << m_FlipAxes[i] << " "; } std::cerr << std::endl;
+                  for (unsigned int i = 0; i < 3; ++i) { std::cerr << m_FlipAxes[i] << ' '; } std::cerr << std::endl;
                   flip->Update();
                   DumpDirections<TInputImage>("after flip", flip->GetOutput());)
     castInput = flip->GetOutput();

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -55,7 +55,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
   os << indent << "Shrink Factor: ";
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
-    os << m_ShrinkFactors[j] << " ";
+    os << m_ShrinkFactors[j] << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -99,7 +99,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 1,1 shrink factor
     unsigned int factors[2] = { 1, 1 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->Update();
 
@@ -125,7 +125,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 2,1 shrink factor
     unsigned int factors[2] = { 2, 1 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->UpdateLargestPossibleRegion();
 
@@ -151,7 +151,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 2,2 shrink factor
     unsigned int factors[2] = { 2, 2 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->UpdateLargestPossibleRegion();
 
@@ -177,7 +177,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 5,2 shrink factor
     unsigned int factors[2] = { 5, 2 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->UpdateLargestPossibleRegion();
 
@@ -221,7 +221,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 2,1 shrink factor
     unsigned int factors[2] = { 2, 1 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->UpdateLargestPossibleRegion();
 
@@ -247,7 +247,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 3,1 shrink factor
     unsigned int factors[2] = { 3, 1 };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
     bin->SetShrinkFactors(factors);
     monitor2->UpdateLargestPossibleRegion();
 
@@ -277,7 +277,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   {
     // update with 3,1 shrink factor
     unsigned int factors[2] = { 1, shrink };
-    std::cout << "== Testing with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+    std::cout << "== Testing with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
 
     for (unsigned int x = 1; x < 10; ++x)
       for (unsigned int y = 2 * shrink; y < 20; ++y)
@@ -289,7 +289,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
         sourceImage->SetRegions(region);
         sourceImage->Allocate();
 
-        std::cout << "--Resolution " << x << " " << y << "--" << std::endl;
+        std::cout << "--Resolution " << x << ' ' << y << "--" << std::endl;
 
         itk::ImageRegionIteratorWithIndex<InputImageType> outIt(sourceImage, region);
         for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
@@ -313,7 +313,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
             {
               if (!lfailed)
               {
-                std::cout << "--Resolution " << x << " " << y << "--" << std::endl;
+                std::cout << "--Resolution " << x << ' ' << y << "--" << std::endl;
               }
               std::cout << "Wrong pixel value at " << inIt.GetIndex() << " of " << inIt.Get()
                         << ", expected: " << expectedValue << std::endl;

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
@@ -91,20 +91,20 @@ itkBinShrinkImageFilterTest2(int, char *[])
     {
       factors[1] = yf;
 
-      std::cout << "Testing with shrink factors:" << xf << " " << yf << std::endl;
+      std::cout << "Testing with shrink factors:" << xf << ' ' << yf << std::endl;
 
       using FilterType = itk::BinShrinkImageFilter<ImageType, ImageType>;
       auto shrink = FilterType::New();
 
       shrink->SetInput(source->GetOutput());
 
-      std::cout << "Testing with shrink factors:" << xf << " " << yf << std::endl;
+      std::cout << "Testing with shrink factors:" << xf << ' ' << yf << std::endl;
       shrink->SetShrinkFactors(factors);
       shrink->UpdateLargestPossibleRegion();
       if (!CheckValueIsPhysicalPoint(shrink->GetOutput()))
       {
         pass = false;
-        std::cout << "== Failed with shrink factors " << factors[0] << " " << factors[1] << " == " << std::endl;
+        std::cout << "== Failed with shrink factors " << factors[0] << ' ' << factors[1] << " == " << std::endl;
       }
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -49,12 +49,12 @@ PrintInformation(ImagePointer image1, ImagePointer image2)
     std::cout << "  ";
     for (j = 0; j < ImageDimension; ++j)
     {
-      std::cout << image1->GetDirection()[i][j] << " ";
+      std::cout << image1->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
     for (j = 0; j < ImageDimension; ++j)
     {
-      std::cout << image2->GetDirection()[i][j] << " ";
+      std::cout << image2->GetDirection()[i][j] << ' ';
     }
     std::cout << std::endl;
   }
@@ -91,17 +91,17 @@ PrintInformation3(ImagePointer image1, ImagePointer image2, ImagePointer image3)
     std::cout << "  ";
     for (j = 0; j < ImageDimension; ++j)
     {
-      std::cout << image1->GetDirection()[i][j] << " ";
+      std::cout << image1->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
     for (j = 0; j < ImageDimension; ++j)
     {
-      std::cout << image2->GetDirection()[i][j] << " ";
+      std::cout << image2->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
     for (j = 0; j < ImageDimension; ++j)
     {
-      std::cout << image3->GetDirection()[i][j] << " ";
+      std::cout << image3->GetDirection()[i][j] << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -172,8 +172,8 @@ itkExpandImageFilterTest(int, char *[])
       if (itk::Math::abs(trueValue - value) > 1e-4)
       {
         testPassed = false;
-        std::cout << "Error at Index: " << index << " ";
-        std::cout << "Expected: " << trueValue << " ";
+        std::cout << "Error at Index: " << index << ' ';
+        std::cout << "Expected: " << trueValue << ' ';
         std::cout << "Actual: " << value << std::endl;
       }
     }
@@ -182,8 +182,8 @@ itkExpandImageFilterTest(int, char *[])
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
         testPassed = false;
-        std::cout << "Error at Index: " << index << " ";
-        std::cout << "Expected: " << padValue << " ";
+        std::cout << "Error at Index: " << index << ' ';
+        std::cout << "Expected: " << padValue << ' ';
         std::cout << "Actual: " << value << std::endl;
       }
     }

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
@@ -86,7 +86,7 @@ itkInterpolateImageFilterTest(int, char *[])
   while (!inIter1.IsAtEnd())
   {
 
-    std::cout << " " << inIter1.Get() << " " << inIter2.Get() << " " << outIter.Get() << std::endl;
+    std::cout << ' ' << inIter1.Get() << ' ' << inIter2.Get() << ' ' << outIter.Get() << std::endl;
 
     if (outIter.Get() != temp)
     {

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -53,7 +53,7 @@ PrintImg(ImageType::Pointer img)
     {
       for (Index[0] = 0; Index[0] < 4; Index[0]++)
       {
-        std::cerr << img->GetPixel(Index) << " ";
+        std::cerr << img->GetPixel(Index) << ' ';
       }
       std::cerr << std::endl;
     }

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -37,7 +37,7 @@ PrintImg(ImageType::Pointer img, const OrientImageFilterType::PermuteOrderArrayT
       for (Index[0] = 0; Index[0] < 4; Index[0]++)
       {
         std::cerr << img->GetPixel(Index).c_str()[permute[0]] << img->GetPixel(Index).c_str()[permute[1]]
-                  << img->GetPixel(Index).c_str()[permute[2]] << " ";
+                  << img->GetPixel(Index).c_str()[permute[2]] << ' ';
       }
       std::cerr << " | ";
     }

--- a/Modules/Filtering/ImageGrid/test/itkPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPadImageFilterTest.cxx
@@ -122,7 +122,7 @@ itkPadImageFilterTest(int, char *[])
       index[1] = j;
 
       short pixel = output->GetPixel(index);
-      std::cout << pixel << " ";
+      std::cout << pixel << ' ';
       if (index[0] == 0 && index[1] == 0)
       {
         if (pixel != 1)

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -146,7 +146,7 @@ itkResampleImageTest7(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(itNoSDI.Value(), itSDI.Value()))
     {
-      std::cout << "Pixels differ " << itNoSDI.Value() << " " << itSDI.Value() << std::endl;
+      std::cout << "Pixels differ " << itNoSDI.Value() << ' ' << itSDI.Value() << std::endl;
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error in pixel value at index [" << itNoSDI.GetIndex() << "]" << std::endl;
       std::cerr << "Expected difference " << itNoSDI.Get() - itSDI.Get() << std::endl;

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -118,7 +118,7 @@ TEST(SliceImageFilterTests, PhysicalPoint1)
           img = RunFilter<ImageType>(source->GetOutput(), start, stop, step);
 
           EXPECT_TRUE(CheckValueIsPhysicalPoint(img.GetPointer()))
-            << "== Failed - step:" << step[0] << " " << step[1] << " start: " << start[0] << " " << start[1]
+            << "== Failed - step:" << step[0] << ' ' << step[1] << " start: " << start[0] << ' ' << start[1]
             << std::endl;
         }
 }
@@ -159,8 +159,8 @@ TEST(SliceImageFilterTests, PhysicalPoint2)
           img = RunFilter<ImageType>(source->GetOutput(), start, stop, step);
 
           EXPECT_TRUE(CheckValueIsPhysicalPoint(img.GetPointer()))
-            << "== Failed - step:" << step[0] << " " << step[1] << " start: " << start[0] << " " << start[1]
-            << " stop: " << stop[0] << " " << stop[1] << std::endl;
+            << "== Failed - step:" << step[0] << ' ' << step[1] << " start: " << start[0] << ' ' << start[1]
+            << " stop: " << stop[0] << ' ' << stop[1] << std::endl;
         }
 }
 
@@ -197,8 +197,8 @@ TEST(SliceImageFilterTests, PhysicalPoint3)
           img = RunFilter<ImageType>(source->GetOutput(), start, stop, step);
 
           EXPECT_TRUE(CheckValueIsPhysicalPoint(img.GetPointer()))
-            << "== Failed - step:" << step[0] << " " << step[1] << " start: " << start[0] << " " << start[1]
-            << " stop: " << stop[0] << " " << stop[1] << std::endl;
+            << "== Failed - step:" << step[0] << ' ' << step[1] << " start: " << start[0] << ' ' << start[1]
+            << " stop: " << stop[0] << ' ' << stop[1] << std::endl;
         }
 }
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -310,8 +310,8 @@ itkWarpImageFilterTest(int, char *[])
       if (itk::Math::abs(trueValue - value) > 1e-4)
       {
         testPassed = false;
-        std::cout << "Error at Index: " << index << " ";
-        std::cout << "Expected: " << trueValue << " ";
+        std::cout << "Error at Index: " << index << ' ';
+        std::cout << "Expected: " << trueValue << ' ';
         std::cout << "Actual: " << value << std::endl;
       }
     }
@@ -321,8 +321,8 @@ itkWarpImageFilterTest(int, char *[])
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
         testPassed = false;
-        std::cout << "Error at Index: " << index << " ";
-        std::cout << "Expected: " << padValue << " ";
+        std::cout << "Error at Index: " << index << ' ';
+        std::cout << "Expected: " << padValue << ' ';
         std::cout << "Actual: " << value << std::endl;
       }
     }
@@ -363,8 +363,8 @@ itkWarpImageFilterTest(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(outIter.Get(), streamIter.Get()))
     {
-      std::cout << "Error C at Index: " << outIter.GetIndex() << " ";
-      std::cout << "Expected: " << outIter.Get() << " ";
+      std::cout << "Error C at Index: " << outIter.GetIndex() << ' ';
+      std::cout << "Expected: " << outIter.Get() << ' ';
       std::cout << "Actual: " << streamIter.Get() << std::endl;
       testPassed = false;
     }

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -130,7 +130,7 @@ itkWarpImageFilterTest2(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(it1.Value(), it2.Value()))
     {
-      std::cout << "Pixels differ " << it1.Value() << " " << it2.Value() << std::endl;
+      std::cout << "Pixels differ " << it1.Value() << ' ' << it2.Value() << std::endl;
       return EXIT_FAILURE;
     }
   }
@@ -163,7 +163,7 @@ itkWarpImageFilterTest2(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(streamIt.Value(), it2.Value()))
     {
-      std::cout << "Pixels differ " << streamIt.Value() << " " << it2.Value() << std::endl;
+      std::cout << "Pixels differ " << streamIt.Value() << ' ' << it2.Value() << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -280,8 +280,8 @@ itkWarpVectorImageFilterTest(int, char *[])
         if (itk::Math::abs(trueValue[k] - value[k]) > 1e-4)
         {
           testPassed = false;
-          std::cout << "Error at Index: " << index << " ";
-          std::cout << "Expected: " << trueValue << " ";
+          std::cout << "Error at Index: " << index << ' ';
+          std::cout << "Expected: " << trueValue << ' ';
           std::cout << "Actual: " << value << std::endl;
           break;
         }
@@ -293,8 +293,8 @@ itkWarpVectorImageFilterTest(int, char *[])
       if (value != PixelType(padValue))
       {
         testPassed = false;
-        std::cout << "Error at Index: " << index << " ";
-        std::cout << "Expected: " << padValue << " ";
+        std::cout << "Error at Index: " << index << ' ';
+        std::cout << "Expected: " << padValue << ' ';
         std::cout << "Actual: " << value << std::endl;
       }
     }

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -102,8 +102,8 @@ CompareImages(itk::ImageRegionIterator<ImageType> & refIter, itk::ImageRegionIte
     if (itk::Math::abs(diff) > 1)
     {
       passed = false;
-      std::cout << "Test failed at: " << outIter.GetIndex() << " ";
-      std::cout << "Output value: " << outIter.Get() << " ";
+      std::cout << "Test failed at: " << outIter.GetIndex() << ' ';
+      std::cout << "Output value: " << outIter.Get() << ' ';
       std::cout << "Ref value: " << refIter.Get() << std::endl;
     }
     ++outIter;

--- a/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
@@ -104,7 +104,7 @@ itkChangeLabelImageFilterTest(int, char *[])
 
     const InputPixelType  input = it.Get();
     const OutputPixelType output = ot.Get();
-    std::cout << static_cast<double>(input) << " " << static_cast<double>(output) << std::endl;
+    std::cout << static_cast<double>(input) << ' ' << static_cast<double>(output) << std::endl;
 
     if (output > maxRemainingLabel)
     {
@@ -154,7 +154,7 @@ itkChangeLabelImageFilterTest(int, char *[])
 
     const InputPixelType  input = ita.Get();
     const OutputPixelType output = ota.Get();
-    std::cout << static_cast<double>(input) << " " << static_cast<double>(output) << std::endl;
+    std::cout << static_cast<double>(input) << ' ' << static_cast<double>(output) << std::endl;
 
     if (input != output)
     {

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -348,7 +348,7 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
     InputImageIterator basisImage_it(basis_it, basis_it->GetBufferedRegion());
     for (basisImage_it.GoToBegin(); !basisImage_it.IsAtEnd(); ++basisImage_it)
     {
-      std::cout << basisImage_it.Get() << " ";
+      std::cout << basisImage_it.Get() << ' ';
     }
     std::cout << "]" << std::endl;
   }
@@ -369,7 +369,7 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
     InputImageIterator basisImage_it(basis_it, basis_it->GetBufferedRegion());
     for (basisImage_it.GoToBegin(); !basisImage_it.IsAtEnd(); ++basisImage_it)
     {
-      std::cout << basisImage_it.Get() << " ";
+      std::cout << basisImage_it.Get() << ' ';
     }
     std::cout << "]" << std::endl;
   }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -92,7 +92,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::DoLine(std::vector<InputImagePixelType
     {
       Extreme = buffer[i];
     }
-    //    std::cout << i << " " << static_cast<int>(Extreme) << " " << static_cast<int>(buffer[i]) <<
+    //    std::cout << i << ' ' << static_cast<int>(Extreme) << ' ' << static_cast<int>(buffer[i]) <<
     // std::endl;
     buffer[i] = Extreme;
   }
@@ -104,7 +104,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::DoLine(std::vector<InputImagePixelType
     {
       Extreme = buffer[i];
     }
-    //    std::cout << static_cast<int>(Extreme) << " " << static_cast<int>(buffer[i]) << std::endl;
+    //    std::cout << static_cast<int>(Extreme) << ' ' << static_cast<int>(buffer[i]) << std::endl;
     buffer[i] = Extreme;
   }
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -141,7 +141,7 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
   sPos = static_cast<int>(Tnear * itk::Math::abs(line[perpdir]) + 0.5);
   ePos = static_cast<int>(Tfar * itk::Math::abs(line[perpdir]) + 0.5);
 
-  // std::cout << Tnear << " " << Tfar << std::endl;
+  // std::cout << Tnear << ' ' << Tfar << std::endl;
   if (Tfar < Tnear) // seems to need some margin
   {
     // in theory, no intersection, but search between them
@@ -149,7 +149,7 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
     unsigned int inside = 0; // initialize to avoid warning
     if (Tnear - Tfar < 10)
     {
-      //      std::cout << "Searching " << Tnear << " " << Tfar << std::endl;
+      //      std::cout << "Searching " << Tnear << ' ' << Tfar << std::endl;
       itkAssertInDebugAndIgnoreInReleaseMacro(ePos >= 0);
       itkAssertInDebugAndIgnoreInReleaseMacro(sPos < static_cast<int>(LineOffsets.size()));
       for (int i = ePos; i <= sPos; ++i)

--- a/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
@@ -212,7 +212,7 @@ itkObjectMorphologyImageFilterTest(int, char *[])
         for (x = 0; x < size[0]; ++x)
         {
           i[0] = x;
-          std::cerr << outputImage->GetPixel(i) << outputBinImage->GetPixel(i) << " ";
+          std::cerr << outputImage->GetPixel(i) << outputBinImage->GetPixel(i) << ' ';
         }
         std::cerr << std::endl;
       }
@@ -308,7 +308,7 @@ itkObjectMorphologyImageFilterTest(int, char *[])
         for (x = 0; x < size[0]; ++x)
         {
           i[0] = x;
-          std::cout << output2Image->GetPixel(i) << outputBin2Image->GetPixel(i) << " ";
+          std::cout << output2Image->GetPixel(i) << outputBin2Image->GetPixel(i) << ' ';
         }
         std::cout << std::endl;
       }

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -78,7 +78,7 @@ itkShapedIteratorFromStructuringElementTest(int, char *[])
     PixelType value = imit.Get();
     ++imit;
     ++col;
-    std::cout << value << " ";
+    std::cout << value << ' ';
     if ((col % 10) == 0)
     {
       std::cout << std::endl;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
@@ -235,7 +235,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
       PointIdIterator pointsEnd = cell->PointIdsEnd();
       while (pointIter != pointsEnd)
       {
-        std::cout << *pointIter << " ";
+        std::cout << *pointIter << ' ';
         ++pointIter;
       }
       std::cout << std::endl;
@@ -260,7 +260,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
         std::cout << "Neighbors across vertex 0: ";
         for (const auto & neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n";
 
@@ -268,7 +268,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
         std::cout << "Neighbors across vertex 1: ";
         for (const auto & neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n";
 
@@ -276,7 +276,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
         std::cout << "Neighbors having edge as boundary: ";
         for (const auto & neighborIter : cellSet)
         {
-          std::cout << neighborIter << " ";
+          std::cout << neighborIter << ' ';
         }
         std::cout << "\n" << std::endl;
       }

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -341,7 +341,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::PrintSelf(std::ostream & os, 
   os << indent << "Output: ";
   for (SizeValueType j = 0; j < m_NumberOfThresholds; ++j)
   {
-    os << m_Output[j] << " ";
+    os << m_Output[j] << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
@@ -132,7 +132,7 @@ itkBinaryThresholdSpatialFunctionTest(int, char *[])
   std::cout << "Iterator seeds";
   for (auto seed : iterator.GetSeeds())
   {
-    std::cout << " " << seed;
+    std::cout << ' ' << seed;
   }
   std::cout << std::endl;
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
@@ -49,7 +49,7 @@ itkOtsuMultipleThresholdsCalculatorTest2(int, char *[])
       for (HistogramType::Iterator iter = histogram->Begin(); iter != histogram->End(); ++iter)
       {
         iter.SetFrequency(1);
-        std::cout << " " << iter.GetMeasurementVector()[0];
+        std::cout << ' ' << iter.GetMeasurementVector()[0];
       }
       std::cout << std::endl;
     }
@@ -80,7 +80,7 @@ itkOtsuMultipleThresholdsCalculatorTest2(int, char *[])
     std::cout << thresholdCount << " thresholds:";
     for (unsigned long j = 0; j < thresholdCount; ++j)
     {
-      std::cout << " " << thMid[j] << "(" << thMax[j] << ")";
+      std::cout << ' ' << thMid[j] << "(" << thMax[j] << ")";
       if (thMax[j] <= thMid[j])
       {
         passed = false;

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -108,7 +108,7 @@ itkOtsuMultipleThresholdsImageFilterTest(int argc, char * argv[])
   std::cout << "filter->GetThresholds(): ";
   for (unsigned int i = 0; i < thresholds.size(); ++i)
   {
-    std::cout << itk::NumericTraits<FilterType::InputPixelType>::PrintType(thresholds[i]) << " ";
+    std::cout << itk::NumericTraits<FilterType::InputPixelType>::PrintType(thresholds[i]) << ' ';
   }
   std::cout << std::endl;
 

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -36,7 +36,7 @@ PrintVector(const std::vector<T> & v1)
     typename std::vector<T>::const_iterator it;
     for (it = v1.begin(); it != v1.end(); ++it)
     {
-      std::cout << *it << " ";
+      std::cout << *it << ' ';
     }
     std::cout << std::endl;
   }

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -124,7 +124,7 @@ public:
     std::string val;
     if (this->GetElementOB(group, element, val, throwException) != EXIT_SUCCESS)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     const char * data = val.c_str();
@@ -148,7 +148,7 @@ public:
     std::string val;
     if (this->GetElementOB(group, element, val, throwException) != EXIT_SUCCESS)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     const char * data = val.c_str();
@@ -201,19 +201,19 @@ public:
     auto * dsItem = dynamic_cast<DcmDecimalString *>(resultStack.top());
     if (dsItem == nullptr)
     {
-      DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Element at tag " << std::hex << group << " " << element
+      DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Element at tag " << std::hex << group << ' ' << element
                                   << std::dec);
     }
 
     OFVector<Float64> doubleVals;
     if (dsItem->getFloat64Vector(doubleVals) != EC_Normal)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     if (doubleVals.size() != count)
     {
-      DCMTKExceptionOrErrorReturn(<< "DecimalString " << std::hex << group << " " << std::hex << element << " expected "
+      DCMTKExceptionOrErrorReturn(<< "DecimalString " << std::hex << group << ' ' << std::hex << element << " expected "
                                   << count << "items, but found " << doubleVals.size() << std::dec);
     }
     for (unsigned int i = 0; i < count; ++i)
@@ -283,23 +283,23 @@ public:
     DcmElement * el;
     if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+      DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
     }
     auto * dsItem = dynamic_cast<DcmDecimalString *>(el);
     if (dsItem == nullptr)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     OFVector<Float64> doubleVals;
     if (dsItem->getFloat64Vector(doubleVals) != EC_Normal)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     if (doubleVals.size() != count)
     {
-      DCMTKExceptionOrErrorReturn(<< "DecimalString " << std::hex << group << " " << std::hex << element << " expected "
+      DCMTKExceptionOrErrorReturn(<< "DecimalString " << std::hex << group << ' ' << std::hex << element << " expected "
                                   << count << "items, but found " << doubleVals.size() << std::dec);
     }
     for (unsigned int i = 0; i < count; ++i)
@@ -323,7 +323,7 @@ public:
     std::string val;
     if (this->GetElementOB(group, element, val, throwException) != EXIT_SUCCESS)
     {
-      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex
+      DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex
                                   << element << std::dec);
     }
     const char * data = val.c_str();

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -68,7 +68,7 @@ DCMTKItem::GetElementSQ(const unsigned short group,
   //  this->m_DcmItem->print(std::cerr);
   if (this->m_DcmItem->findAndGetSequence(tagKey, seq) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't find sequence " << std::hex << group << " " << std::hex << entry)
+    DCMTKExceptionOrErrorReturn(<< "Can't find sequence " << std::hex << group << ' ' << std::hex << entry)
   }
   sequence.SetDcmSequenceOfItems(seq);
   return EXIT_SUCCESS;
@@ -84,7 +84,7 @@ DCMTKSequence::GetStack(const unsigned short group,
   DcmTagKey tagkey(group, element);
   if (this->m_DcmSequenceOfItems->search(tagkey, resultStack) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't find tag " << std::hex << group << " " << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Can't find tag " << std::hex << group << ' ' << element << std::dec);
   }
   return EXIT_SUCCESS;
 }
@@ -127,14 +127,14 @@ DCMTKSequence::GetElementCS(const unsigned short group,
   auto * codeStringElement = dynamic_cast<DcmCodeString *>(resultStack.top());
   if (codeStringElement == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find CodeString Element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find CodeString Element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
 
   OFString ofString;
   if (codeStringElement->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get OFString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get OFString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = "";
@@ -158,7 +158,7 @@ DCMTKSequence::GetElementOB(const unsigned short group,
 
   if (obItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   Uint8 * bytes;
@@ -202,7 +202,7 @@ DCMTKSequence::GetElementFD(const unsigned short group,
   auto * fdItem = dynamic_cast<DcmFloatingPointDouble *>(resultStack.top());
   if (fdItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get CodeString Element at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get CodeString Element at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   double *          tmp;
@@ -212,11 +212,11 @@ DCMTKSequence::GetElementFD(const unsigned short group,
   if (fdItem->checkValue(vm).bad())
   {
     DCMTKExceptionOrErrorReturn(<< "Value multiplicity doesn't match " << count << " at  tag " << std::hex << group
-                                << " " << element << std::dec);
+                                << ' ' << element << std::dec);
   }
   if (fdItem->getFloat64Array(tmp) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get floatarray Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get floatarray Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   for (int i = 0; i < count; ++i)
@@ -247,13 +247,13 @@ DCMTKSequence::GetElementDS(const unsigned short group,
   auto * decimalStringElement = dynamic_cast<DcmDecimalString *>(resultStack.top());
   if (decimalStringElement == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Element at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Element at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   OFString ofString;
   if (decimalStringElement->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = "";
@@ -277,7 +277,7 @@ DCMTKSequence::GetElementSQ(const unsigned short group,
   auto * seqElement = dynamic_cast<DcmSequenceOfItems *>(resultStack.top());
   if (seqElement == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << " " << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << ' ' << element << std::dec);
   }
   target.SetDcmSequenceOfItems(seqElement);
   return EXIT_SUCCESS;
@@ -308,7 +308,7 @@ DCMTKSequence::GetElementTM(const unsigned short group,
   auto * dcmTime = dynamic_cast<DcmTime *>(resultStack.top());
   if (dcmTime == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << " " << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << ' ' << element << std::dec);
   }
   char * cs;
   dcmTime->getString(cs);
@@ -417,18 +417,18 @@ DCMTKFileReader::GetElementLO(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * loItem = dynamic_cast<DcmLongString *>(el);
   if (loItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   OFString ofString;
   if (loItem->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant get string from element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant get string from element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   target = "";
@@ -449,12 +449,12 @@ DCMTKFileReader::GetElementLO(const unsigned short       group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * loItem = dynamic_cast<DcmLongString *>(el);
   if (loItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   target.clear();
@@ -483,18 +483,18 @@ DCMTKFileReader::GetElementDS(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * dsItem = dynamic_cast<DcmDecimalString *>(el);
   if (dsItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   OFString ofString;
   if (dsItem->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = "";
@@ -516,12 +516,12 @@ DCMTKFileReader::GetElementFD(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * fdItem = dynamic_cast<DcmFloatingPointDouble *>(el);
   if (fdItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
 
@@ -531,12 +531,12 @@ DCMTKFileReader::GetElementFD(const unsigned short group,
   if (fdItem->checkValue(vm).bad())
   {
     DCMTKExceptionOrErrorReturn(<< "Value multiplicity doesn't match " << count << " at  tag " << std::hex << group
-                                << " " << element << std::dec);
+                                << ' ' << element << std::dec);
   }
   double * doubleArray;
   if (fdItem->getFloat64Array(doubleArray) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                 << element << std::dec);
   }
   for (int i = 0; i < count; ++i)
@@ -565,17 +565,17 @@ DCMTKFileReader::GetElementFL(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * flItem = dynamic_cast<DcmFloatingPointSingle *>(el);
   if (flItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   if (flItem->getFloat32(target) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                 << element << std::dec);
   }
   return EXIT_SUCCESS;
@@ -593,7 +593,7 @@ DCMTKFileReader::GetElementFLorOB(const unsigned short group,
   std::string val;
   if (this->GetElementOB(group, element, val, throwException) != EXIT_SUCCESS)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   const char * data = val.c_str();
@@ -625,17 +625,17 @@ DCMTKFileReader::GetElementUS(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * usItem = dynamic_cast<DcmUnsignedShort *>(el);
   if (usItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   if (usItem->getUint16(target) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                 << element << std::dec);
   }
   return EXIT_SUCCESS;
@@ -650,17 +650,17 @@ DCMTKFileReader::GetElementUS(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * usItem = dynamic_cast<DcmUnsignedShort *>(el);
   if (usItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   if (usItem->getUint16Array(target) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << " " << std::hex
+    DCMTKExceptionOrErrorReturn(<< "Cant extract Array from DecimalString " << std::hex << group << ' ' << std::hex
                                 << element << std::dec);
   }
   return EXIT_SUCCESS;
@@ -677,18 +677,18 @@ DCMTKFileReader::GetElementCS(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * csItem = dynamic_cast<DcmCodeString *>(el);
   if (csItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   OFString ofString;
   if (csItem->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = "";
@@ -726,18 +726,18 @@ DCMTKFileReader::GetElementPN(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * pnItem = dynamic_cast<DcmPersonName *>(el);
   if (pnItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   OFString ofString;
   if (pnItem->getOFStringArray(ofString) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = "";
@@ -760,19 +760,19 @@ DCMTKFileReader::GetElementIS(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * isItem = dynamic_cast<DcmIntegerString *>(el);
   if (isItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   Sint32 _target; // MSVC seems to have type conversion problems with
                   // using int32_t as an argument to getSint32
   if (isItem->getSint32(_target) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = static_cast<itk::int32_t>(_target);
@@ -789,19 +789,19 @@ DCMTKFileReader::GetElementSL(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * isItem = dynamic_cast<DcmSignedLong *>(el);
   if (isItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   Sint32 _target; // MSVC seems to have type conversion problems with
                   // using int32_t as an argument to getSint32
   if (isItem->getSint32(_target) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
+    DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << ' ' << element
                                 << std::dec);
   }
   target = static_cast<itk::int32_t>(_target);
@@ -855,12 +855,12 @@ DCMTKFileReader::GetElementOB(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * obItem = dynamic_cast<DcmOtherByteOtherWord *>(el);
   if (obItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << " " << std::hex << element
+    DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex << group << ' ' << std::hex << element
                                 << std::dec);
   }
   Uint8 * bytes;
@@ -886,7 +886,7 @@ DCMTKFileReader::GetElementSQ(const unsigned short group,
 
   if (this->m_Dataset->findAndGetSequence(tagKey, seq) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't find sequence " << std::hex << group << " " << std::hex << entry)
+    DCMTKExceptionOrErrorReturn(<< "Can't find sequence " << std::hex << group << ' ' << std::hex << entry)
   }
   sequence.SetDcmSequenceOfItems(seq);
   return EXIT_SUCCESS;
@@ -902,7 +902,7 @@ DCMTKFileReader::GetElementUI(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagKey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << entry << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << entry << std::dec);
   }
   auto * uiItem = dynamic_cast<DcmUniqueIdentifier *>(el);
   if (uiItem == nullptr)
@@ -912,7 +912,7 @@ DCMTKFileReader::GetElementUI(const unsigned short group,
   OFString ofString;
   if (uiItem->getOFStringArray(ofString, false) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get UID Value at tag " << std::hex << group << " " << std::hex << entry
+    DCMTKExceptionOrErrorReturn(<< "Can't get UID Value at tag " << std::hex << group << ' ' << std::hex << entry
                                 << std::dec);
   }
   target = "";
@@ -933,12 +933,12 @@ DCMTKFileReader::GetElementDA(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * dcmDate = dynamic_cast<DcmDate *>(el);
   if (dcmDate == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << " " << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << ' ' << element << std::dec);
   }
   char * cs;
   dcmDate->getString(cs);
@@ -957,12 +957,12 @@ DCMTKFileReader::GetElementTM(const unsigned short group,
   DcmElement * el;
   if (this->m_Dataset->findAndGetElement(tagkey, el) != EC_Normal)
   {
-    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << " " << std::hex << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
   }
   auto * dcmTime = dynamic_cast<DcmTime *>(el);
   if (dcmTime == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << " " << element << std::dec);
+    DCMTKExceptionOrErrorReturn(<< "Can't get  at tag " << std::hex << group << ' ' << element << std::dec);
   }
   char * cs;
   dcmTime->getString(cs);

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -167,7 +167,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<bool>(metaDict2, "TestBool", metaDataBool2) || metaDataBool != metaDataBool2)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestBool " << metaDataBool << " " << metaDataBool2 << std::endl;
+              << "TestBool " << metaDataBool << ' ' << metaDataBool2 << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -175,7 +175,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<char>(metaDict2, "TestChar", metaDataChar2) || metaDataChar2 != metaDataChar)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestChar " << metaDataChar2 << " " << metaDataChar << std::endl;
+              << "TestChar " << metaDataChar2 << ' ' << metaDataChar << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -183,7 +183,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<unsigned char>(metaDict2, "TestUChar", metaDataUChar2) || metaDataUChar2 != metaDataUChar)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestUChar " << metaDataUChar2 << " " << metaDataUChar << std::endl;
+              << "TestUChar " << metaDataUChar2 << ' ' << metaDataUChar << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -191,7 +191,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<short>(metaDict2, "TestShort", metaDataShort2) || metaDataShort2 != metaDataShort)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestShort " << metaDataShort2 << " " << metaDataShort << std::endl;
+              << "TestShort " << metaDataShort2 << ' ' << metaDataShort << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -200,7 +200,7 @@ HDF5ReadWriteTest(const char * fileName)
       metaDataUShort2 != metaDataUShort)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestUShort " << metaDataUShort2 << " " << metaDataUShort << std::endl;
+              << "TestUShort " << metaDataUShort2 << ' ' << metaDataUShort << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -208,7 +208,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<int>(metaDict2, "TestInt", metaDataInt2) || metaDataInt2 != metaDataInt)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestInt " << metaDataInt2 << " " << metaDataInt << std::endl;
+              << "TestInt " << metaDataInt2 << ' ' << metaDataInt << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -216,7 +216,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<unsigned int>(metaDict2, "TestUInt", metaDataUInt2) || metaDataUInt2 != metaDataUInt)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestUInt " << metaDataUInt2 << " " << metaDataUInt << std::endl;
+              << "TestUInt " << metaDataUInt2 << ' ' << metaDataUInt << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -224,7 +224,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<long>(metaDict2, "TestLong", metaDataLong2) || metaDataLong2 != metaDataLong)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestLong " << metaDataLong2 << " " << metaDataLong << std::endl;
+              << "TestLong " << metaDataLong2 << ' ' << metaDataLong << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -232,7 +232,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<unsigned long>(metaDict2, "TestULong", metaDataULong2) || metaDataULong2 != metaDataULong)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestULong " << metaDataULong2 << " " << metaDataULong << std::endl;
+              << "TestULong " << metaDataULong2 << ' ' << metaDataULong << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -240,7 +240,7 @@ HDF5ReadWriteTest(const char * fileName)
   if (!itk::ExposeMetaData<long long>(metaDict2, "TestLLong", metaDataLLong2) || metaDataLLong2 != metaDataLLong)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestLLong " << metaDataLLong2 << " " << metaDataLLong << std::endl;
+              << "TestLLong " << metaDataLLong2 << ' ' << metaDataLLong << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -249,7 +249,7 @@ HDF5ReadWriteTest(const char * fileName)
       metaDataULLong2 != metaDataULLong)
   {
     std::cerr << "Failure Reading metaData "
-              << "TestULLong " << metaDataULLong2 << " " << metaDataULLong << std::endl;
+              << "TestULLong " << metaDataULLong2 << ' ' << metaDataULLong << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -258,7 +258,7 @@ HDF5ReadWriteTest(const char * fileName)
       itk::Math::NotAlmostEquals(metaDataFloat2, metaDataFloat))
   {
     std::cerr << "Failure Reading metaData "
-              << "TestFloat " << metaDataFloat2 << " " << metaDataFloat << std::endl;
+              << "TestFloat " << metaDataFloat2 << ' ' << metaDataFloat << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -267,7 +267,7 @@ HDF5ReadWriteTest(const char * fileName)
       itk::Math::NotAlmostEquals(metaDataDouble2, metaDataDouble))
   {
     std::cerr << "Failure reading metaData "
-              << "TestDouble " << metaDataDouble2 << " " << metaDataDouble << std::endl;
+              << "TestDouble " << metaDataDouble2 << ' ' << metaDataDouble << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -277,7 +277,7 @@ HDF5ReadWriteTest(const char * fileName)
       metaDataCharArray2 != metaDataCharArray)
   {
     std::cerr << "Failure reading metaData "
-              << "TestCharArray" << metaDataCharArray2 << " " << metaDataCharArray2 << std::endl;
+              << "TestCharArray" << metaDataCharArray2 << ' ' << metaDataCharArray2 << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -287,7 +287,7 @@ HDF5ReadWriteTest(const char * fileName)
       metaDataDoubleArray2 != metaDataDoubleArray)
   {
     std::cerr << "Failure reading metaData "
-              << "TestDoubleArray " << metaDataDoubleArray2 << " " << metaDataDoubleArray << std::endl;
+              << "TestDoubleArray " << metaDataDoubleArray2 << ' ' << metaDataDoubleArray << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -296,7 +296,7 @@ HDF5ReadWriteTest(const char * fileName)
       metaDataStdString2 != metaDataStdString)
   {
     std::cerr << "Failure reading metaData "
-              << "StdString " << metaDataStdString2 << " " << metaDataStdString << std::endl;
+              << "StdString " << metaDataStdString2 << ' ' << metaDataStdString << std::endl;
     success = EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -51,7 +51,7 @@ public:
       catch (const itk::ExceptionObject & err)
       {
         std::cout << "Caught an exception: " << std::endl;
-        std::cout << err << " " << __FILE__ << " " << __LINE__ << std::endl;
+        std::cout << err << ' ' << __FILE__ << ' ' << __LINE__ << std::endl;
         throw;
       }
       catch (...)

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -714,7 +714,7 @@ WriteBuffer(std::ostream & os, const TComponent * buffer, ImageIOBase::SizeType 
     {
       os << "\n";
     }
-    os << PrintType(*ptr++) << " ";
+    os << PrintType(*ptr++) << ' ';
   }
 }
 } // namespace

--- a/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
+++ b/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
@@ -56,7 +56,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "itk::RGBPixel<float> array converted from float\n";
   for (unsigned int j = 0; j < 3; ++j)
   {
-    std::cerr << pf[j] << " ";
+    std::cerr << pf[j] << ' ';
     for (unsigned int k = 0; k < sizeof(pf) / sizeof(itk::RGBPixel<float>); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(pf[k][j], ipa3com[j + k * 3]);
@@ -69,7 +69,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "itk::RGBAPixel<float> array \n";
   for (unsigned int j = 0; j < 3; ++j)
   {
-    std::cerr << pa[j] << " ";
+    std::cerr << pa[j] << ' ';
     for (unsigned int k = 0; k < sizeof(pa) / sizeof(itk::RGBAPixel<float>); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(pa[k][j], ipa3com[j + k * 3]);
@@ -88,7 +88,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "itk::RGBAPixel<unsigned char> array \n";
   for (unsigned int j = 0; j < 3; ++j)
   {
-    std::cerr << ucpa[j] << " ";
+    std::cerr << ucpa[j] << ' ';
     for (unsigned int k = 0; k < sizeof(ucpa) / sizeof(itk::RGBAPixel<unsigned char>); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(ucpa[k][j], ucipa3com[j + k * 3]);
@@ -107,7 +107,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "\nfloat array  : ";
   for (int i = 0; i < arraySize; ++i)
   {
-    std::cerr << farray[i] << " ";
+    std::cerr << farray[i] << ' ';
     ITK_TEST_EXPECT_EQUAL(darray[i], static_cast<double>(farray[i]));
   }
   // convert a float array to an int array
@@ -115,7 +115,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "\nint array   : ";
   for (int i = 0; i < arraySize; ++i)
   {
-    std::cerr << iarray[i] << " ";
+    std::cerr << iarray[i] << ' ';
     ITK_TEST_EXPECT_EQUAL(iarray[i], static_cast<int>(farray[i]));
   }
   // convert the int array to the float array
@@ -123,7 +123,7 @@ itkConvertBufferTest(int, char *[])
   std::cerr << "\ndouble array : ";
   for (int i = 0; i < arraySize; ++i)
   {
-    std::cerr << darray[i] << " ";
+    std::cerr << darray[i] << ' ';
     ITK_TEST_EXPECT_EQUAL(farray[i], static_cast<float>(iarray[i]));
   }
   std::cerr << "\n";

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -97,8 +97,8 @@ ActualTest(std::string inputFileName,
 {
 
   std::cout << "Writing Combination: ";
-  std::cout << streamWriting << " ";
-  std::cout << pasteWriting << " " << compressWriting << std::endl;
+  std::cout << streamWriting << ' ';
+  std::cout << pasteWriting << ' ' << compressWriting << std::endl;
 
   std::ostringstream outputFileNameStream;
   outputFileNameStream << outputFileNameBase << streamWriting;

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -112,8 +112,8 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   itk::ImageIOBase::Pointer io = reader->GetModifiableImageIO();
 
 
-  std::cout << "ImageIO Pixel Information: " << io->GetPixelTypeAsString(io->GetPixelType()) << " "
-            << io->GetComponentTypeAsString(io->GetComponentType()) << " " << io->GetNumberOfComponents() << std::endl;
+  std::cout << "ImageIO Pixel Information: " << io->GetPixelTypeAsString(io->GetPixelType()) << ' '
+            << io->GetComponentTypeAsString(io->GetComponentType()) << ' ' << io->GetNumberOfComponents() << std::endl;
   if (io->GetNumberOfComponents() != 4 || io->GetComponentType() != itk::IOComponentEnum::DOUBLE ||
       io->GetPixelType() != itk::IOPixelEnum::VECTOR)
   {

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -473,14 +473,14 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     std::cerr << "metaDataDoubleArray=";
     for (size_t i = 0; i < metaDataDoubleArray.size(); ++i)
     {
-      std::cerr << metaDataDoubleArray[i] << " ";
+      std::cerr << metaDataDoubleArray[i] << ' ';
     }
     std::cerr << std::endl;
 
     std::cerr << "metaDataDoubleArray2=";
     for (size_t i = 0; i < metaDataDoubleArray2.size(); ++i)
     {
-      std::cerr << metaDataDoubleArray2[i] << " ";
+      std::cerr << metaDataDoubleArray2[i] << ' ';
     }
     std::cerr << std::endl;
 
@@ -496,14 +496,14 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     std::cerr << "metaDataFloatArray=";
     for (size_t i = 0; i < metaDataFloatArray.size(); ++i)
     {
-      std::cerr << metaDataFloatArray[i] << " ";
+      std::cerr << metaDataFloatArray[i] << ' ';
     }
     std::cerr << std::endl;
 
     std::cerr << "metaDataFloatArray2=";
     for (size_t i = 0; i < metaDataFloatArray2.size(); ++i)
     {
-      std::cerr << metaDataFloatArray2[i] << " ";
+      std::cerr << metaDataFloatArray2[i] << ' ';
     }
     std::cerr << std::endl;
 
@@ -524,7 +524,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
       metaDataStdString2 != metaDataStdString)
   {
     std::cerr << "Failure reading metaData "
-              << "StdString " << metaDataStdString2 << " " << metaDataStdString << std::endl;
+              << "StdString " << metaDataStdString2 << ' ' << metaDataStdString << std::endl;
     success = EXIT_FAILURE;
   }
 
@@ -736,7 +736,7 @@ MINCReadWriteTestVector(const char * fileName,
       metaDataStdString2 != metaDataStdString)
   {
     std::cerr << "Failure reading metaData "
-              << "StdString " << metaDataStdString2 << " " << metaDataStdString << std::endl;
+              << "StdString " << metaDataStdString2 << ' ' << metaDataStdString << std::endl;
     success = EXIT_FAILURE;
   }
 

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -385,18 +385,18 @@ MRCHeaderObject::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "number: " << this->m_Header.nx << " " << this->m_Header.ny << " " << this->m_Header.nz << std::endl;
+  os << indent << "number: " << this->m_Header.nx << ' ' << this->m_Header.ny << ' ' << this->m_Header.nz << std::endl;
   os << indent << "mode: " << this->m_Header.mode << std::endl;
-  os << indent << "start: " << this->m_Header.nxstart << " " << this->m_Header.nystart << " " << this->m_Header.nzstart
+  os << indent << "start: " << this->m_Header.nxstart << ' ' << this->m_Header.nystart << ' ' << this->m_Header.nzstart
      << std::endl;
-  os << indent << "grid: " << this->m_Header.mx << " " << this->m_Header.my << " " << this->m_Header.mz << std::endl;
-  os << indent << "len: " << this->m_Header.xlen << " " << this->m_Header.ylen << " " << this->m_Header.zlen
+  os << indent << "grid: " << this->m_Header.mx << ' ' << this->m_Header.my << ' ' << this->m_Header.mz << std::endl;
+  os << indent << "len: " << this->m_Header.xlen << ' ' << this->m_Header.ylen << ' ' << this->m_Header.zlen
      << std::endl;
-  os << indent << "abg angles: " << this->m_Header.alpha << " " << this->m_Header.beta << " " << this->m_Header.gamma
+  os << indent << "abg angles: " << this->m_Header.alpha << ' ' << this->m_Header.beta << ' ' << this->m_Header.gamma
      << std::endl;
-  os << indent << "map: " << this->m_Header.mapc << " " << this->m_Header.mapr << " " << this->m_Header.maps
+  os << indent << "map: " << this->m_Header.mapc << ' ' << this->m_Header.mapr << ' ' << this->m_Header.maps
      << std::endl;
-  os << indent << "mmm: " << this->m_Header.amin << " " << this->m_Header.amax << " " << this->m_Header.amean
+  os << indent << "mmm: " << this->m_Header.amin << ' ' << this->m_Header.amax << ' ' << this->m_Header.amean
      << std::endl;
   os << indent << "ispg: " << this->m_Header.ispg << std::endl;
   os << indent << "nsymbt: " << this->m_Header.nsymbt << std::endl;
@@ -406,17 +406,17 @@ MRCHeaderObject::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "nreal: " << this->m_Header.nreal << std::endl;
   os << indent << "idtype: " << this->m_Header.idtype << std::endl;
   os << indent << "lens: " << this->m_Header.lens << std::endl;
-  os << indent << "nd: " << this->m_Header.nd1 << " " << this->m_Header.nd2 << std::endl;
-  os << indent << "vd: " << this->m_Header.vd1 << " " << this->m_Header.vd2 << std::endl;
+  os << indent << "nd: " << this->m_Header.nd1 << ' ' << this->m_Header.nd2 << std::endl;
+  os << indent << "vd: " << this->m_Header.vd1 << ' ' << this->m_Header.vd2 << std::endl;
   os << indent << "tiltangles: (" << this->m_Header.tiltangles[0] << ", " << this->m_Header.tiltangles[1] << ", "
      << this->m_Header.tiltangles[2] << ") (" << this->m_Header.tiltangles[3] << ", " << this->m_Header.tiltangles[4]
      << ", " << this->m_Header.tiltangles[5] << ")" << std::endl;
-  os << indent << "org: " << this->m_Header.xorg << " " << this->m_Header.yorg << " " << this->m_Header.zorg
+  os << indent << "org: " << this->m_Header.xorg << ' ' << this->m_Header.yorg << ' ' << this->m_Header.zorg
      << std::endl;
   os << indent << "cmap: \"" << this->m_Header.cmap[0] << this->m_Header.cmap[1] << this->m_Header.cmap[2]
      << this->m_Header.cmap[3] << "\"" << std::endl;
-  os << indent << "stamp: " << static_cast<int>(this->m_Header.stamp[0]) << " "
-     << static_cast<int>(this->m_Header.stamp[1]) << " " << static_cast<int>(this->m_Header.stamp[2]) << " "
+  os << indent << "stamp: " << static_cast<int>(this->m_Header.stamp[0]) << ' '
+     << static_cast<int>(this->m_Header.stamp[1]) << ' ' << static_cast<int>(this->m_Header.stamp[2]) << ' '
      << static_cast<int>(this->m_Header.stamp[3]) << std::endl;
   os << indent << "rms: " << this->m_Header.rms << std::endl;
   os << indent << "nlabl: " << this->m_Header.nlabl << std::endl;

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -426,7 +426,7 @@ MRCImageIO::UpdateHeaderFromImageIO()
 
   if (header.mode == -1)
   {
-    itkExceptionMacro(<< "Unsupported pixel type: " << this->GetPixelTypeAsString(this->GetPixelType()) << " "
+    itkExceptionMacro(<< "Unsupported pixel type: " << this->GetPixelTypeAsString(this->GetPixelType()) << ' '
                       << this->GetComponentTypeAsString(this->GetComponentType()) << std::endl
                       << "Supported pixel types include unsigned byte, unsigned short, short, float, rgb "
                          "unsigned char, float complex");

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
@@ -126,7 +126,7 @@ protected:
       outputFile << indent;
       for (unsigned int jj = 0; jj < this->m_PointDimension; ++jj)
       {
-        outputFile << ConvertNumberToString(buffer[index++]) << " ";
+        outputFile << ConvertNumberToString(buffer[index++]) << ' ';
       }
       outputFile << '\n';
     }

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -435,7 +435,7 @@ protected:
     {
       for (unsigned int jj = 0; jj < this->m_PointDimension - 1; ++jj)
       {
-        outputFile << ConvertNumberToString(buffer[ii * this->m_PointDimension + jj]) << " ";
+        outputFile << ConvertNumberToString(buffer[ii * this->m_PointDimension + jj]) << ' ';
       }
 
       outputFile << ConvertNumberToString(buffer[ii * this->m_PointDimension + this->m_PointDimension - 1]) << '\n';
@@ -476,7 +476,7 @@ protected:
     if (numberOfVertices)
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfVertexIndices", numberOfVertexIndices);
-      outputFile << "VERTICES " << numberOfVertices << " " << numberOfVertexIndices << '\n';
+      outputFile << "VERTICES " << numberOfVertices << ' ' << numberOfVertexIndices << '\n';
       for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
       {
         auto cellType = static_cast<CellGeometryEnum>(static_cast<int>(buffer[index++]));
@@ -486,7 +486,7 @@ protected:
           outputFile << nn;
           for (unsigned int jj = 0; jj < nn; ++jj)
           {
-            outputFile << " " << buffer[index++];
+            outputFile << ' ' << buffer[index++];
           }
           outputFile << '\n';
         }
@@ -534,14 +534,14 @@ protected:
       numberOfLineIndices += numberOfLines;
       EncapsulateMetaData<unsigned int>(metaDic, "numberOfLines", numberOfLines);
       EncapsulateMetaData<unsigned int>(metaDic, "numberOfLineIndices", numberOfLineIndices);
-      outputFile << "LINES " << numberOfLines << " " << numberOfLineIndices << '\n';
+      outputFile << "LINES " << numberOfLines << ' ' << numberOfLineIndices << '\n';
       for (SizeValueType ii = 0; ii < polylines->Size(); ++ii)
       {
         auto nn = static_cast<unsigned int>(polylines->ElementAt(ii).size());
         outputFile << nn;
         for (unsigned int jj = 0; jj < nn; ++jj)
         {
-          outputFile << " " << polylines->ElementAt(ii)[jj];
+          outputFile << ' ' << polylines->ElementAt(ii)[jj];
         }
         outputFile << '\n';
       }
@@ -553,7 +553,7 @@ protected:
     if (numberOfPolygons)
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfPolygonIndices", numberOfPolygonIndices);
-      outputFile << "POLYGONS " << numberOfPolygons << " " << numberOfPolygonIndices << '\n';
+      outputFile << "POLYGONS " << numberOfPolygons << ' ' << numberOfPolygonIndices << '\n';
       for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
       {
         auto cellType = static_cast<CellGeometryEnum>(static_cast<int>(buffer[index++]));
@@ -564,7 +564,7 @@ protected:
           outputFile << nn;
           for (unsigned int jj = 0; jj < nn; ++jj)
           {
-            outputFile << " " << buffer[index++];
+            outputFile << ' ' << buffer[index++];
           }
           outputFile << '\n';
         }
@@ -595,7 +595,7 @@ protected:
     if (numberOfVertices)
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfVertexIndices", numberOfVertexIndices);
-      outputFile << "VERTICES " << numberOfVertices << " " << numberOfVertexIndices << '\n';
+      outputFile << "VERTICES " << numberOfVertices << ' ' << numberOfVertexIndices << '\n';
       const auto data = make_unique_for_overwrite<unsigned int[]>(numberOfVertexIndices);
       ReadCellsBuffer(buffer, data.get());
       itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(
@@ -640,7 +640,7 @@ protected:
       EncapsulateMetaData<unsigned int>(metaDic, "numberOfLines", numberOfLines);
       EncapsulateMetaData<unsigned int>(metaDic, "numberOfLineIndices", numberOfLineIndices);
 
-      outputFile << "LINES " << numberOfLines << " " << numberOfLineIndices << '\n';
+      outputFile << "LINES " << numberOfLines << ' ' << numberOfLineIndices << '\n';
       const auto    data = make_unique_for_overwrite<unsigned int[]>(numberOfLineIndices);
       unsigned long outputIndex = 0;
       for (SizeValueType ii = 0; ii < polylines->Size(); ++ii)
@@ -663,7 +663,7 @@ protected:
     if (numberOfPolygons)
     {
       ExposeMetaData<unsigned int>(metaDic, "numberOfPolygonIndices", numberOfPolygonIndices);
-      outputFile << "POLYGONS " << numberOfPolygons << " " << numberOfPolygonIndices << '\n';
+      outputFile << "POLYGONS " << numberOfPolygons << ' ' << numberOfPolygonIndices << '\n';
       const auto data = make_unique_for_overwrite<unsigned int[]>(numberOfPolygonIndices);
       ReadCellsBuffer(buffer, data.get());
       itk::ByteSwapper<unsigned int>::SwapWriteRangeFromSystemToBigEndian(

--- a/Modules/IO/Meta/include/itkMetaImageIO.h
+++ b/Modules/IO/Meta/include/itkMetaImageIO.h
@@ -218,7 +218,7 @@ MetaImageIO::WriteMatrixInMetaData(std::ostringstream &       strs,
         strs << mval[i][j];
         if (i != VNRows - 1 || j != VNColumns - 1)
         {
-          strs << " ";
+          strs << ' ';
         }
       }
     }

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -630,7 +630,7 @@ MetaImageIO::WriteImageInformation()
       unsigned int i = 0;
       while (i < vval.size() - 1)
       {
-        strs << vval[++i] << " ";
+        strs << vval[++i] << ' ';
       }
       strs << vval[i];
     }

--- a/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
@@ -46,7 +46,7 @@ ReadImage(const std::string & fileName)
   catch (const itk::ExceptionObject & err)
   {
     std::cout << "Caught an exception: " << std::endl;
-    std::cout << err << " " << __FILE__ << " " << __LINE__ << std::endl;
+    std::cout << err << ' ' << __FILE__ << ' ' << __LINE__ << std::endl;
     throw;
   }
   catch (...)

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1036,17 +1036,17 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
   EncapsulateMetaData<std::string>(thisDic, "qoffset_z", qoffset_z.str());
 
   std::ostringstream srow_x;
-  srow_x << nim->sto_xyz.m[0][0] << " " << nim->sto_xyz.m[0][1] << " " << nim->sto_xyz.m[0][2] << " "
+  srow_x << nim->sto_xyz.m[0][0] << ' ' << nim->sto_xyz.m[0][1] << ' ' << nim->sto_xyz.m[0][2] << ' '
          << nim->sto_xyz.m[0][3];
   EncapsulateMetaData<std::string>(thisDic, "srow_x", srow_x.str());
 
   std::ostringstream srow_y;
-  srow_y << nim->sto_xyz.m[1][0] << " " << nim->sto_xyz.m[1][1] << " " << nim->sto_xyz.m[1][2] << " "
+  srow_y << nim->sto_xyz.m[1][0] << ' ' << nim->sto_xyz.m[1][1] << ' ' << nim->sto_xyz.m[1][2] << ' '
          << nim->sto_xyz.m[1][3];
   EncapsulateMetaData<std::string>(thisDic, "srow_y", srow_y.str());
 
   std::ostringstream srow_z;
-  srow_z << nim->sto_xyz.m[2][0] << " " << nim->sto_xyz.m[2][1] << " " << nim->sto_xyz.m[2][2] << " "
+  srow_z << nim->sto_xyz.m[2][0] << ' ' << nim->sto_xyz.m[2][1] << ' ' << nim->sto_xyz.m[2][2] << ' '
          << nim->sto_xyz.m[2][3];
   EncapsulateMetaData<std::string>(thisDic, "srow_z", srow_z.str());
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
@@ -28,7 +28,7 @@ PrintDir(Test4ImageType::DirectionType & dir)
   {
     for (unsigned int j = 0; j < 3; ++j)
     {
-      std::cerr << dir[i][j] << " ";
+      std::cerr << dir[i][j] << ' ';
     }
     std::cerr << std::endl;
   }

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -212,7 +212,7 @@ ReadImage(const std::string &                     fileName,
     catch (const itk::ExceptionObject & err)
     {
       std::cout << "Caught an exception: " << std::endl;
-      std::cout << err << " " << __FILE__ << " " << __LINE__ << std::endl;
+      std::cout << err << ' ' << __FILE__ << ' ' << __LINE__ << std::endl;
       throw;
     }
     catch (...)

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -138,7 +138,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   for (PhilipsRECImageIOType::TriggerTimesContainerType::ElementIdentifier iter = 0; iter < ptrToTimePoints->Size();
        iter++)
   {
-    std::cout << " " << ptrToTimePoints->ElementAt(iter);
+    std::cout << ' ' << ptrToTimePoints->ElementAt(iter);
   }
   std::cout << std::endl;
 
@@ -164,7 +164,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "EchoTimes =";
   for (PhilipsRECImageIOType::EchoTimesContainerType::ElementIdentifier iter = 0; iter < ptrToEchoes->Size(); ++iter)
   {
-    std::cout << " " << ptrToEchoes->ElementAt(iter);
+    std::cout << ' ' << ptrToEchoes->ElementAt(iter);
   }
   std::cout << std::endl;
 
@@ -241,7 +241,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "RepetitionTimes =";
   for (PhilipsRECImageIOType::RepetitionTimesContainerType::ElementIdentifier iter = 0; iter < ptrToTR->Size(); ++iter)
   {
-    std::cout << " " << ptrToTR->ElementAt(iter);
+    std::cout << ' ' << ptrToTR->ElementAt(iter);
   }
   std::cout << std::endl;
 
@@ -401,7 +401,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   for (PhilipsRECImageIOType::GradientBvalueContainerType::ElementIdentifier iter = 0; iter < ptrToBValues->Size();
        iter++)
   {
-    std::cout << " " << ptrToBValues->ElementAt(iter);
+    std::cout << ' ' << ptrToBValues->ElementAt(iter);
   }
   std::cout << std::endl;
 
@@ -429,7 +429,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
        iter < ptrToGradValues->Size();
        iter++)
   {
-    std::cout << " " << ptrToGradValues->ElementAt(iter);
+    std::cout << ' ' << ptrToGradValues->ElementAt(iter);
   }
   std::cout << std::endl;
 
@@ -529,7 +529,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   for (PhilipsRECImageIOType::LabelTypesASLContainerType::ElementIdentifier iter = 0; iter < ptrToASLLabelTypes->Size();
        iter++)
   {
-    std::cout << " " << ptrToASLLabelTypes->ElementAt(iter);
+    std::cout << ' ' << ptrToASLLabelTypes->ElementAt(iter);
   }
   std::cout << std::endl;
 

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -82,7 +82,7 @@ public:
       while (!it.IsAtEndOfLine())
       {
         PixelType readValue = it.Get();
-        std::cout << readValue << " ";
+        std::cout << readValue << ' ';
         if (readValue != value)
         {
           std::cerr << "At index " << it.GetIndex() << std::endl;

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -80,7 +80,7 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
 
   // #define DEBUGHEADER
 #if defined(DEBUGHEADER)
-#  define DB(x) std::cerr << #  x << " " << x << std::endl
+#  define DB(x) std::cerr << #  x << ' ' << x << std::endl
 #else
 #  define DB(x)
 #endif

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -252,7 +252,7 @@ PolygonGroupSpatialObjectXMLFileWriter::WriteFile()
     {
       PolygonSpatialObjectType::PointType curpoint = pointIt->GetPositionInObjectSpace();
       WriteStartElement("POINT", output);
-      output << curpoint[0] << " " << curpoint[1] << " " << curpoint[2];
+      output << curpoint[0] << ' ' << curpoint[1] << ' ' << curpoint[2];
       WriteEndElement("POINT", output);
       output << std::endl;
       ++pointIt;

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -511,25 +511,25 @@ StimulateImageIO::Write(const void * buffer)
   file << "\ndim:";
   for (i = 0; i < m_NumberOfDimensions; ++i)
   {
-    file << " " << m_Dimensions[i];
+    file << ' ' << m_Dimensions[i];
   }
 
   file << "\norigin:";
   for (i = 0; i < m_NumberOfDimensions; ++i)
   {
-    file << " " << m_Origin[i];
+    file << ' ' << m_Origin[i];
   }
 
   file << "\nfov:";
   for (i = 0; i < m_NumberOfDimensions; ++i)
   {
-    file << " " << m_Spacing[i] * m_Dimensions[i]; // fov = interval * dim
+    file << ' ' << m_Spacing[i] * m_Dimensions[i]; // fov = interval * dim
   }
 
   file << "\ninterval:";
   for (i = 0; i < m_NumberOfDimensions; ++i)
   {
-    file << " " << m_Spacing[i];
+    file << ' ' << m_Spacing[i];
   }
 
   // preparation for writing buffer:
@@ -594,6 +594,6 @@ void
 StimulateImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "\nDisplayRange: " << m_DisplayRange[0] << " " << m_DisplayRange[1];
+  os << indent << "\nDisplayRange: " << m_DisplayRange[0] << ' ' << m_DisplayRange[1];
 }
 } // end namespace itk

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1189,8 +1189,8 @@ TIFFImageIO::ReadTIFFTags()
       continue;
     }
 
-    itkDebugMacro(<< "TiffInfo tag " << field_name << "(" << tag << "): " << itkTIFFFieldDataType(field) << " "
-                  << value_count << " " << raw_data);
+    itkDebugMacro(<< "TiffInfo tag " << field_name << "(" << tag << "): " << itkTIFFFieldDataType(field) << ' '
+                  << value_count << ' ' << raw_data);
 
 
 #define itkEncapsulate(T1, T2)                                                         \

--- a/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
@@ -44,21 +44,21 @@ itkTIFFImageIOInfoTest(int argc, char * argv[])
   std::cout << "Dimensions: ( ";
   for (unsigned int d = 0; d < tiffImageIO->GetNumberOfDimensions(); ++d)
   {
-    std::cout << tiffImageIO->GetDimensions(d) << " ";
+    std::cout << tiffImageIO->GetDimensions(d) << ' ';
   }
   std::cout << ")" << std::endl;
 
   std::cout << "Origin: ( ";
   for (unsigned int d = 0; d < tiffImageIO->GetNumberOfDimensions(); ++d)
   {
-    std::cout << tiffImageIO->GetOrigin(d) << " ";
+    std::cout << tiffImageIO->GetOrigin(d) << ' ';
   }
   std::cout << ")" << std::endl;
 
   std::cout << "Spacing: ( ";
   for (unsigned int d = 0; d < tiffImageIO->GetNumberOfDimensions(); ++d)
   {
-    std::cout << tiffImageIO->GetSpacing(d) << " ";
+    std::cout << tiffImageIO->GetSpacing(d) << ' ';
   }
   std::cout << ")" << std::endl;
 

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -666,16 +666,13 @@ VTKImageIO::WriteImageInformation(const void * itkNotUsed(buffer))
 
   // Write characteristics of the data
   file << "DATASET STRUCTURED_POINTS\n"
-       << "DIMENSIONS " << this->GetDimensions(0) << " "
-       << ((this->GetNumberOfDimensions() > 1) ? this->GetDimensions(1) : 1) << " "
-       << ((this->GetNumberOfDimensions() > 2) ? this->GetDimensions(2) : 1) << " "
-       << "\n";
-  file << "SPACING " << this->GetSpacing(0) << " " << ((this->GetNumberOfDimensions() > 1) ? this->GetSpacing(1) : 1.0)
-       << " " << ((this->GetNumberOfDimensions() > 2) ? this->GetSpacing(2) : 1.0) << " "
-       << "\n";
-  file << "ORIGIN " << this->GetOrigin(0) << " " << ((this->GetNumberOfDimensions() > 1) ? this->GetOrigin(1) : 0.0)
-       << " " << ((this->GetNumberOfDimensions() > 2) ? this->GetOrigin(2) : 0.0) << " "
-       << "\n";
+       << "DIMENSIONS " << this->GetDimensions(0) << ' '
+       << ((this->GetNumberOfDimensions() > 1) ? this->GetDimensions(1) : 1) << ' '
+       << ((this->GetNumberOfDimensions() > 2) ? this->GetDimensions(2) : 1) << ' ' << "\n";
+  file << "SPACING " << this->GetSpacing(0) << ' ' << ((this->GetNumberOfDimensions() > 1) ? this->GetSpacing(1) : 1.0)
+       << ' ' << ((this->GetNumberOfDimensions() > 2) ? this->GetSpacing(2) : 1.0) << ' ' << "\n";
+  file << "ORIGIN " << this->GetOrigin(0) << ' ' << ((this->GetNumberOfDimensions() > 1) ? this->GetOrigin(1) : 0.0)
+       << ' ' << ((this->GetNumberOfDimensions() > 2) ? this->GetOrigin(2) : 0.0) << ' ' << "\n";
 
   file << "POINT_DATA " << this->GetImageSizeInPixels() << "\n";
 
@@ -685,8 +682,7 @@ VTKImageIO::WriteImageInformation(const void * itkNotUsed(buffer))
        (this->GetPixelType() == IOPixelEnum::RGBA && this->GetNumberOfComponents() == 4)) &&
       (this->GetComponentType() == IOComponentEnum::UCHAR) && (this->GetFileType() == IOFileEnum::Binary))
   {
-    file << "COLOR_SCALARS color_scalars"
-         << " " << this->GetNumberOfComponents() << "\n";
+    file << "COLOR_SCALARS color_scalars" << ' ' << this->GetNumberOfComponents() << "\n";
   }
   // Prefer the VECTORS representation when possible:
   else if (this->GetPixelType() == IOPixelEnum::VECTOR && this->GetNumberOfComponents() == 3)
@@ -702,7 +698,7 @@ VTKImageIO::WriteImageInformation(const void * itkNotUsed(buffer))
     // According to VTK documentation number of components should in
     // range (1,4):
     // todo this should be asserted or checked earlier!
-    file << "SCALARS scalars " << this->GetComponentTypeAsString(m_ComponentType) << " "
+    file << "SCALARS scalars " << this->GetComponentTypeAsString(m_ComponentType) << ' '
          << this->GetNumberOfComponents() << "\n"
          << "LOOKUP_TABLE default\n";
   }

--- a/Modules/IO/XML/include/itkStringTools.hxx
+++ b/Modules/IO/XML/include/itkStringTools.hxx
@@ -96,7 +96,7 @@ StringTools::FromData(std::string & s, const std::vector<T> & data)
   oss.exceptions(oss.badbit);
   for (size_t i = 0; i < data.size(); ++i)
   {
-    oss << " " << data[i];
+    oss << ' ' << data[i];
   }
 
   s.append(oss.str());
@@ -183,7 +183,7 @@ StringTools::FromData(std::string & s, const Array<T> & data)
   oss.exceptions(oss.badbit);
   for (unsigned int i = 0; i < static_cast<unsigned int>(data.GetSize()); ++i)
   {
-    oss << " " << data[i];
+    oss << ' ' << data[i];
   }
 
   s.append(oss.str());

--- a/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
@@ -64,7 +64,7 @@ DOMNodeXMLWriter::Update(std::ostream & os, std::string indent)
   input->GetAllAttributes(attributes);
   for (auto & attribute : attributes)
   {
-    os << " " << attribute.first << "=\"" << attribute.second << "\"";
+    os << ' ' << attribute.first << "=\"" << attribute.second << "\"";
   }
 
   // write the ending of the start tag, and all children if applicable

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -623,9 +623,8 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     }
   }
 
-  itkDebugMacro("bounds"
-                << " " << bounds[0] << " " << bounds[1] << " " << bounds[2] << " " << bounds[3] << " " << bounds[4]
-                << " " << bounds[5]);
+  itkDebugMacro("bounds" << ' ' << bounds[0] << ' ' << bounds[1] << ' ' << bounds[2] << ' ' << bounds[3] << ' '
+                         << bounds[4] << ' ' << bounds[5]);
 
   // Create duplicate references to the rest of data on the mesh
   this->CopyInputMeshToOutputMeshPointData();

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -610,7 +610,7 @@ VoxBoCUBImageIO::ReadImageInformation()
         {
           if (!oss.str().empty())
           {
-            oss << " ";
+            oss << ' ';
           }
           oss << word;
         }

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -236,7 +236,7 @@ itkImageFunctionTest(int, char *[])
   {
     std::cout << "Error with IsInsideBuffer 3C. Expected  false." << std::endl
               << "  indexC: " << indexC << std::endl
-              << "  start/end continuous indices: " << startIndexC << " " << endIndexC << std::endl;
+              << "  start/end continuous indices: " << startIndexC << ' ' << endIndexC << std::endl;
     result = EXIT_FAILURE;
   }
   indexC[0] = ContinuousIndexNumericTraits::max();

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -75,7 +75,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * 
   std::cout << "Iterator seeds";
   for (auto seed : shapedFloodIt.GetSeeds())
   {
-    std::cout << " " << seed;
+    std::cout << ' ' << seed;
   }
   std::cout << std::endl;
 

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -493,7 +493,7 @@ Element::PrintSelf(std::ostream & os, Indent indent) const
   for (unsigned int i = 0; i < this->m_EdgeIds.size(); ++i)
   {
     os << indent << "Edge Ids (" << i << "): " << this->m_EdgeIds[i][0];
-    os << " " << this->m_EdgeIds[i][1] << std::endl;
+    os << ' ' << this->m_EdgeIds[i][1] << std::endl;
   }
 }
 

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -356,7 +356,7 @@ CheckDisplacements1(Solver2DType * S, int s, double * expectedResults, double to
   for (int i = 0; i < numDOF; ++i)
   {
     double result = S->GetSolution(i);
-    // std::cout  << result << " " << expectedResults[i] << " " << tolerance << std::endl;
+    // std::cout  << result << ' ' << expectedResults[i] << ' ' << tolerance << std::endl;
     if (itk::Math::abs(expectedResults[i] - result) > tolerance)
     {
       std::cout << "ERROR: Solver " << s << " Index " << i << ". Expected " << expectedResults[i] << " Solution "

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -332,7 +332,7 @@ CheckDisplacements1(SolverType * S, int s, double * expectedResults, double tole
   for (int i = 0; i < numDOF; ++i)
   {
     double result = S->GetSolution(i);
-    // std::cout  << result << " " << expectedResults[i] << " " << tolerance << std::endl;
+    // std::cout  << result << ' ' << expectedResults[i] << ' ' << tolerance << std::endl;
     if (itk::Math::abs(expectedResults[i] - result) > tolerance)
     {
       std::cout << "ERROR: Solver " << s << " Index " << i << ". Expected " << expectedResults[i] << " Solution "

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperDenseVNLTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperDenseVNLTest.cxx
@@ -84,7 +84,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -115,7 +115,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 1) << " ";
+      std::cout << it.GetMatrixValue(i, j, 1) << ' ';
     }
     std::cout << std::endl;
   }
@@ -130,7 +130,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -147,7 +147,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -156,7 +156,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   it.MultiplyMatrixVector(1, 0, 0);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -166,12 +166,12 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   it.SwapVectors(0, 1);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Vector 1" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -183,7 +183,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -192,7 +192,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -204,7 +204,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -217,7 +217,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   it.SetSolutionValue(4, 5, 1);
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -227,12 +227,12 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Solution 1" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -242,7 +242,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -254,7 +254,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -266,7 +266,7 @@ itkFEMLinearSystemWrapperDenseVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest.cxx
@@ -84,7 +84,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -115,7 +115,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 1) << " ";
+      std::cout << it.GetMatrixValue(i, j, 1) << ' ';
     }
     std::cout << std::endl;
   }
@@ -130,7 +130,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -147,7 +147,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -156,7 +156,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   it.MultiplyMatrixVector(1, 0, 0);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -166,12 +166,12 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   it.SwapVectors(0, 1);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Vector 1" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -183,7 +183,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -192,7 +192,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -204,7 +204,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -217,7 +217,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   it.SetSolutionValue(4, 5, 1);
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -227,12 +227,12 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Solution 1" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -242,7 +242,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -254,7 +254,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -266,7 +266,7 @@ itkFEMLinearSystemWrapperItpackTest(int argc, char * argv[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest2.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest2.cxx
@@ -74,7 +74,7 @@ itkFEMLinearSystemWrapperItpackTest2(int argc, char * argv[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -89,7 +89,7 @@ itkFEMLinearSystemWrapperItpackTest2(int argc, char * argv[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -129,7 +129,7 @@ itkFEMLinearSystemWrapperItpackTest2(int argc, char * argv[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperVNLTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperVNLTest.cxx
@@ -84,7 +84,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -115,7 +115,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 1) << " ";
+      std::cout << it.GetMatrixValue(i, j, 1) << ' ';
     }
     std::cout << std::endl;
   }
@@ -130,7 +130,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -147,7 +147,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -156,7 +156,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   it.MultiplyMatrixVector(1, 0, 0);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -166,12 +166,12 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   it.SwapVectors(0, 1);
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Vector 1" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 1) << " ";
+    std::cout << it.GetVectorValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -183,7 +183,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 0) << " ";
+      std::cout << it.GetMatrixValue(i, j, 0) << ' ';
     }
     std::cout << std::endl;
   }
@@ -192,7 +192,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -204,7 +204,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -217,7 +217,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   it.SetSolutionValue(4, 5, 1);
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -227,12 +227,12 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   std::cout << "Solution 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 0) << " ";
+    std::cout << it.GetSolutionValue(i, 0) << ' ';
   }
   std::cout << std::endl << "Solution 1" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetSolutionValue(i, 1) << " ";
+    std::cout << it.GetSolutionValue(i, 1) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -242,7 +242,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < N; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 
@@ -254,7 +254,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   {
     for (j = 0; j < N; ++j)
     {
-      std::cout << it.GetMatrixValue(i, j, 2) << " ";
+      std::cout << it.GetMatrixValue(i, j, 2) << ' ';
     }
     std::cout << std::endl;
   }
@@ -266,7 +266,7 @@ itkFEMLinearSystemWrapperVNLTest(int, char *[])
   std::cout << "Vector 0" << std::endl;
   for (i = 0; i < 5; ++i)
   {
-    std::cout << it.GetVectorValue(i, 0) << " ";
+    std::cout << it.GetVectorValue(i, 0) << ' ';
   }
   std::cout << std::endl << std::endl;
 

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -144,7 +144,7 @@ PrintSolution(FEMSolverType * S)
     std::cout << "Solution Node " << i << ":";
     for (unsigned int d = 0, dof; (dof = S->GetInput()->GetNode(i)->GetDegreeOfFreedom(d)) != invalidID; ++d)
     {
-      std::cout << " " << S->GetSolution(dof);
+      std::cout << ' ' << S->GetSolution(dof);
     }
     std::cout << std::endl;
   }

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -336,7 +336,7 @@ CumulativeGaussianOptimizer::PrintArray(MeasureType * array)
 {
   for (int i = 0; i < static_cast<int>(array->GetNumberOfElements()); ++i)
   {
-    std::cerr << i << " " << array->get(i) << std::endl;
+    std::cerr << i << ' ' << array->get(i) << std::endl;
   }
 }
 

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -188,11 +188,11 @@ ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
     const ParticleData & p = *it;
     os << indent;
     PrintParamtersType(p.m_CurrentParameters, os);
-    os << " ";
+    os << ' ';
     PrintParamtersType(p.m_CurrentVelocity, os);
-    os << " " << p.m_CurrentValue << " ";
+    os << ' ' << p.m_CurrentValue << ' ';
     PrintParamtersType(p.m_BestParameters, os);
-    os << " " << p.m_BestValue << "\n";
+    os << ' ' << p.m_BestValue << "\n";
   }
   os << indent << "]\n";
 }
@@ -204,7 +204,7 @@ ParticleSwarmOptimizerBase::PrintParamtersType(const ParametersType & x, std::os
   unsigned int sz = x.size();
   for (unsigned int i = 0; i < sz; ++i)
   {
-    os << x[i] << " ";
+    os << x[i] << ' ';
   }
 }
 

--- a/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
@@ -69,7 +69,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -87,7 +87,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     derivative = DerivativeType(SpaceDimension);

--- a/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
@@ -66,7 +66,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -84,7 +84,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     DerivativeType temp(SpaceDimension);

--- a/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
@@ -68,7 +68,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -86,7 +86,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     DerivativeType temp(SpaceDimension);

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -70,7 +70,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
@@ -72,7 +72,7 @@ public:
     double y = parameters[1];
 
     std::cout << "      GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
@@ -66,7 +66,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -83,7 +83,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     derivative = DerivativeType(SpaceDimension);

--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -66,7 +66,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -83,7 +83,7 @@ public:
     double y = parameters[1];
 
     std::cout << "GetDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     derivative = DerivativeType(SpaceDimension);

--- a/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
@@ -109,7 +109,7 @@ protected:
     auto it = this->m_EnergyValues.begin();
     while (it != this->m_EnergyValues.end())
     {
-      os << "(" << it - this->m_EnergyValues.begin() << "): " << *it << " ";
+      os << "(" << it - this->m_EnergyValues.begin() << "): " << *it << ' ';
       ++it;
     }
     os << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -96,7 +96,7 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Gol
   TInternalComputationValueType c,
   TInternalComputationValueType metricb)
 {
-  itkDebugMacro("GoldenSectionSearch: " << a << " " << b << " " << c << " " << metricb);
+  itkDebugMacro("GoldenSectionSearch: " << a << ' ' << b << ' ' << c << ' ' << metricb);
 
   if (this->m_LineSearchIterations > this->m_MaximumLineSearchIterations)
   {

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -85,7 +85,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = " << std::endl;
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -87,7 +87,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = " << std::endl;
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -86,7 +86,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -87,7 +87,7 @@ public:
     double y = (*m_Parameters)[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = " << std::endl;
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
@@ -202,7 +202,7 @@ public:
     double y = (*m_Parameters)[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = " << std::endl;
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - x + 4 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -83,7 +83,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = " << std::endl;
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -70,7 +70,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -67,7 +67,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "      GetValue( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     MeasureType measure = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -86,7 +86,7 @@ public:
     double y = m_Parameters[1];
 
     std::cout << "GetValueAndDerivative( ";
-    std::cout << x << " ";
+    std::cout << x << ' ';
     std::cout << y << ") = ";
 
     value = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -74,42 +74,42 @@ MultivariateLegendrePolynomial::PrintSelf(std::ostream & os, Indent indent) cons
   os << indent << "DomainSize: ";
   for (const auto i : m_DomainSize)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 
   os << indent << "Cached X coefficients: ";
   for (auto i : m_CachedXCoef)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 
   os << indent << "Cached Y coefficients: ";
   for (auto i : m_CachedYCoef)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 
   os << indent << "Cached Z coefficients: ";
   for (auto i : m_CachedZCoef)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 
   os << indent << "Coefficients: ";
   for (auto i : m_CoefficientArray)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 
   os << indent << "Normalization factors: ";
   for (auto i : m_NormFactor)
   {
-    os << i << " ";
+    os << i << ' ';
   }
   os << std::endl;
 

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -602,7 +602,7 @@ KdTree<TSample>::PlotTree(KdTreeNodeType * node, std::ostream & os) const
       for (unsigned int i = 0; i < node->Size(); ++i)
       {
         os << this->GetMeasurementVector(node->GetInstanceIdentifier(i));
-        os << " ";
+        os << ' ';
       }
       os << "\" ];" << std::endl;
     }
@@ -611,7 +611,7 @@ KdTree<TSample>::PlotTree(KdTreeNodeType * node, std::ostream & os) const
   {
     os << "\"" << node << "\" [label=\"";
     os << this->GetMeasurementVector(node->GetInstanceIdentifier(0));
-    os << " " << partitionDimensionCharSymbol << "=" << partitionValue;
+    os << ' ' << partitionDimensionCharSymbol << "=" << partitionValue;
     os << "\" ];" << std::endl;
   }
 

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -443,7 +443,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::PrintPoint(ParameterType & point)
   std::cout << "[ ";
   for (unsigned int i = 0; i < m_MeasurementVectorSize; ++i)
   {
-    std::cout << point[i] << " ";
+    std::cout << point[i] << ' ';
   }
   std::cout << "]";
 }

--- a/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
@@ -140,7 +140,7 @@ itkKdTreeBasedKmeansEstimatorTest(int argc, char * argv[])
     index = numberOfMeasurements * i;
     for (unsigned int j = 0; j < numberOfMeasurements; ++j)
     {
-      std::cout << trueMeans[index] << " ";
+      std::cout << trueMeans[index] << ' ';
       ++index;
     }
     std::cout << std::endl;
@@ -150,7 +150,7 @@ itkKdTreeBasedKmeansEstimatorTest(int argc, char * argv[])
     index = numberOfMeasurements * i;
     for (unsigned int j = 0; j < numberOfMeasurements; ++j)
     {
-      std::cout << estimatedMeans[index] << " ";
+      std::cout << estimatedMeans[index] << ' ';
       temp = estimatedMeans[index] - trueMeans[index];
       ++index;
       displacement += (temp * temp);

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
@@ -98,7 +98,7 @@ itkMeanSampleFilterTest(int, char *[])
   mean[0] = 2.0;
   mean[1] = 2.0;
 
-  std::cout << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+  std::cout << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
 
   FilterType::MeasurementVectorType::ValueType epsilon = 1e-6;
 

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest2.cxx
@@ -77,7 +77,7 @@ itkMeanSampleFilterTest2(int, char *[])
   expectedMean[0] = 0.5;
   expectedMean[1] = 0.5;
 
-  std::cout << meanOutput[0] << " " << expectedMean[0] << " " << meanOutput[1] << " " << expectedMean[1] << " "
+  std::cout << meanOutput[0] << ' ' << expectedMean[0] << ' ' << meanOutput[1] << ' ' << expectedMean[1] << ' '
             << std::endl;
 
   // FilterType::MeasurementVectorType::ValueType is an int in this case

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
@@ -117,8 +117,8 @@ itkSubsampleTest2(int, char *[])
   IteratorType iter = subSample2->Begin();
   while (iter != subSample2->End())
   {
-    std::cout << iter.GetInstanceIdentifier() << " ";
-    std::cout << iter.GetMeasurementVector() << " ";
+    std::cout << iter.GetInstanceIdentifier() << ' ';
+    std::cout << iter.GetMeasurementVector() << ' ';
     std::cout << iter.GetFrequency() << std::endl;
     ++iter;
   }
@@ -128,8 +128,8 @@ itkSubsampleTest2(int, char *[])
   IteratorType citer = subSample2->Begin();
   while (citer != subSample2->End())
   {
-    std::cout << citer.GetInstanceIdentifier() << " ";
-    std::cout << citer.GetMeasurementVector() << " ";
+    std::cout << citer.GetInstanceIdentifier() << ' ';
+    std::cout << citer.GetMeasurementVector() << ' ';
     std::cout << citer.GetFrequency() << std::endl;
     ++citer;
   }

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest3.cxx
@@ -83,7 +83,7 @@ itkSubsampleTest3(int, char *[])
   mean[0] = 2.0;
   mean[1] = 2.0;
 
-  std::cout << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+  std::cout << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
 
   FilterType::MeasurementVectorType::ValueType epsilon = 1e-6;
 
@@ -120,7 +120,7 @@ itkSubsampleTest3(int, char *[])
   mean[0] = 0.5;
   mean[1] = 0.5;
 
-  std::cout << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+  std::cout << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
 
   if ((itk::Math::abs(meanOutput[0] - mean[0]) > epsilon) || (itk::Math::abs(meanOutput[1] - mean[1]) > epsilon))
   {

--- a/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
@@ -150,7 +150,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
   if ((itk::Math::abs(meanOutput[0] - mean[0]) > epsilon) || (itk::Math::abs(meanOutput[1] - mean[1]) > epsilon))
   {
     std::cerr << "Wrong result " << std::endl;
-    std::cerr << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+    std::cerr << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
     std::cerr << "The result is not what is expected" << std::endl;
     return EXIT_FAILURE;
   }
@@ -179,7 +179,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
   if ((itk::Math::abs(meanOutput[0] - mean[0]) > epsilon) || (itk::Math::abs(meanOutput[1] - mean[1]) > epsilon))
   {
     std::cerr << "Wrong result " << std::endl;
-    std::cerr << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+    std::cerr << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
     std::cerr << "The result is not what is expected" << std::endl;
     return EXIT_FAILURE;
   }
@@ -206,7 +206,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
   if ((itk::Math::abs(meanOutput[0] - mean[0]) > epsilon) || (itk::Math::abs(meanOutput[1] - mean[1]) > epsilon))
   {
     std::cerr << "Wrong result" << std::endl;
-    std::cerr << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+    std::cerr << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
 
     std::cerr << "The result is not what is expected" << std::endl;
     return EXIT_FAILURE;
@@ -234,7 +234,7 @@ itkWeightedMeanSampleFilterTest(int, char *[])
   if ((itk::Math::abs(meanOutput[0] - mean[0]) > epsilon) || (itk::Math::abs(meanOutput[1] - mean[1]) > epsilon))
   {
     std::cerr << "Wrong result" << std::endl;
-    std::cerr << meanOutput[0] << " " << mean[0] << " " << meanOutput[1] << " " << mean[1] << " " << std::endl;
+    std::cerr << meanOutput[0] << ' ' << mean[0] << ' ' << meanOutput[1] << ' ' << mean[1] << ' ' << std::endl;
     std::cerr << "The result is not what is expected" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -226,7 +226,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   metric->SetFixedImageSamplesIntensityThreshold(100);
   if (metric->GetFixedImageSamplesIntensityThreshold() != 100)
   {
-    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(100) failed: " << __FILE__ << " " << __LINE__
+    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(100) failed: " << __FILE__ << ' ' << __LINE__
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -234,20 +234,20 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
                                                      // explicitly.
   if (metric->GetFixedImageSamplesIntensityThreshold() != 0)
   {
-    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(0) failed: " << __FILE__ << " " << __LINE__
+    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(0) failed: " << __FILE__ << ' ' << __LINE__
               << std::endl;
     return EXIT_FAILURE;
   }
   metric->UseAllPixelsOn();
   if (metric->GetUseAllPixels() != true)
   {
-    std::cout << "ERROR: UseAllPixelsOn() failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    std::cout << "ERROR: UseAllPixelsOn() failed: " << __FILE__ << ' ' << __LINE__ << std::endl;
     return EXIT_FAILURE;
   }
   metric->UseAllPixelsOff(); // This should be the default, but exercise this function explicitly.
   if (metric->GetUseAllPixels() != false)
   {
-    std::cout << "ERROR: UseAllPixelsOff() failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    std::cout << "ERROR: UseAllPixelsOff() failed: " << __FILE__ << ' ' << __LINE__ << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -338,7 +338,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
     //  {
     //  break;
     //  }
-    // std::cout << "TEST:  "<< j<< " " << OutputCenterOfMass << " != " << InputCenterOfMass << std::endl;
+    // std::cout << "TEST:  "<< j<< ' ' << OutputCenterOfMass << " != " << InputCenterOfMass << std::endl;
     // if( OutputCenterOfMass != InputCenterOfMass )
     {
       OutputImageType::PointType::VectorType ErrorCenterOfMass = OutputCenterOfMass - InputCenterOfMass;
@@ -347,7 +347,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
         (ErrorCenterOfMass.GetNorm() / pyramid->GetOutput(testLevel)->GetSpacing().GetNorm());
       if (ErrorPercentage > CenterOfMassEpsilonAllowed)
       {
-        std::cout << "ERROR:  " << testLevel << " " << OutputCenterOfMass << " != " << InputCenterOfMass
+        std::cout << "ERROR:  " << testLevel << ' ' << OutputCenterOfMass << " != " << InputCenterOfMass
                   << " at pixel spacing level "
                   << pyramid->GetOutput(testLevel)->GetDirection() * pyramid->GetOutput(testLevel)->GetSpacing()
                   << std::endl;
@@ -356,7 +356,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
       }
       else
       {
-        std::cout << "WITHIN TOLERANCE PASSED:  " << testLevel << " " << OutputCenterOfMass
+        std::cout << "WITHIN TOLERANCE PASSED:  " << testLevel << ' ' << OutputCenterOfMass
                   << " != " << InputCenterOfMass << " at pixel spacing level "
                   << pyramid->GetOutput(testLevel)->GetDirection() * pyramid->GetOutput(testLevel)->GetSpacing()
                   << std::endl;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1012,7 +1012,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ExpandVectorField(
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     pad[i] = 0.0;
-    itkDebugMacro(<< expandFactors[i] << " ");
+    itkDebugMacro(<< expandFactors[i] << ' ');
   }
   itkDebugMacro(<< std::endl);
   auto m_FieldExpander = ExpanderType::New();

--- a/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
+++ b/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
@@ -264,7 +264,7 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
       itkExceptionMacro(<< "Error reading file: " << m_FileName
                         << "point ids must be >= 0.\n"
                            "ids="
-                        << ids[0] << " " << ids[1] << " " << ids[2] << " " << ids[3]);
+                        << ids[0] << ' ' << ids[1] << ' ' << ids[2] << ' ' << ids[3]);
     }
 
     if (static_cast<PointIdentifier>(ids[0]) >= numberOfPoints ||
@@ -273,7 +273,7 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
         static_cast<PointIdentifier>(ids[3]) >= numberOfPoints)
     {
       itkExceptionMacro(<< "Error reading file: " << m_FileName << "Point ids must be < number of points: "
-                        << numberOfPoints << "\nids= " << ids[0] << " " << ids[1] << " " << ids[2] << " " << ids[3]);
+                        << numberOfPoints << "\nids= " << ids[0] << ' ' << ids[1] << ' ' << ids[2] << ' ' << ids[3]);
     }
 
     CellAutoPointer cell;

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -247,7 +247,7 @@ LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComp
   typename LabelSetType::const_iterator itF;
   for (itF = this->m_FixedPointSetLabels.begin(); itF != this->m_FixedPointSetLabels.end(); ++itF)
   {
-    os << *itF << " ";
+    os << *itF << ' ';
   }
   os << std::endl;
 
@@ -255,7 +255,7 @@ LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComp
   typename LabelSetType::const_iterator itM;
   for (itM = this->m_MovingPointSetLabels.begin(); itM != this->m_MovingPointSetLabels.end(); ++itM)
   {
-    os << *itM << " ";
+    os << *itM << ' ';
   }
   os << std::endl;
 }

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -133,8 +133,8 @@ itkEuclideanDistancePointSetMetricTestRun()
 
     for (unsigned int d = 0; d < metric->GetNumberOfParameters(); ++d)
     {
-      moving_str1 << sourcePoint[d] << " ";
-      moving_str2 << targetPoint[d] << " ";
+      moving_str1 << sourcePoint[d] << ' ';
+      moving_str2 << targetPoint[d] << ' ';
     }
     if (Dimension < 3)
     {

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -183,8 +183,8 @@ itkEuclideanDistancePointSetMetricTest2Run()
         passed = false;
       }
     }
-    std::cout << " fixed, moving, txf'ed, moving-txf: " << fixedPoint << " " << movingPoint << " " << transformedPoint
-              << " " << movingPoint - transformedPoint << std::endl;
+    std::cout << " fixed, moving, txf'ed, moving-txf: " << fixedPoint << ' ' << movingPoint << ' ' << transformedPoint
+              << ' ' << movingPoint - transformedPoint << std::endl;
   }
 
   if (!passed)

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -104,7 +104,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
     auto pointId = pointsLocator->FindClosestPoint(tempFixedPoint);
     auto closestPoint = movingPoints->GetPoint(pointId);
     distanceArray.push_back(closestPoint.EuclideanDistanceTo(tempFixedPoint));
-    std::cout << n << " " << tempFixedPoint << " , " << closestPoint << " "
+    std::cout << n << ' ' << tempFixedPoint << " , " << closestPoint << ' '
               << closestPoint.EuclideanDistanceTo(tempFixedPoint) << std::endl;
   }
 

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -145,8 +145,8 @@ itkExpectationBasedPointSetMetricTestRun()
 
     for (unsigned int d = 0; d < metric->GetNumberOfParameters(); ++d)
     {
-      moving_str1 << sourcePoint[d] << " ";
-      moving_str2 << targetPoint[d] << " ";
+      moving_str1 << sourcePoint[d] << ' ';
+      moving_str2 << targetPoint[d] << ' ';
     }
     if (Dimension < 3)
     {

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -202,8 +202,8 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
 
       for (unsigned int d = 0; d < metric->GetNumberOfParameters(); ++d)
       {
-        moving_str1 << sourcePoint[d] << " ";
-        moving_str2 << targetPoint[d] << " ";
+        moving_str1 << sourcePoint[d] << ' ';
+        moving_str2 << targetPoint[d] << ' ';
       }
       if (Dimension < 3)
       {

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -155,8 +155,8 @@ itkLabeledPointSetMetricTestRun()
 
     for (unsigned int d = 0; d < metric->GetNumberOfParameters(); ++d)
     {
-      moving_str1 << sourcePoint[d] << " ";
-      moving_str2 << targetPoint[d] << " ";
+      moving_str1 << sourcePoint[d] << ' ';
+      moving_str2 << targetPoint[d] << ' ';
     }
     if (Dimension < 3)
     {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1170,7 +1170,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent << "Metric sampling percentage: ";
   for (SizeValueType i = 0; i < this->m_NumberOfLevels; ++i)
   {
-    os << this->m_MetricSamplingPercentagePerLevel[i] << " ";
+    os << this->m_MetricSamplingPercentagePerLevel[i] << ' ';
   }
   os << std::endl;
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -100,7 +100,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -89,7 +89,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -102,7 +102,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -105,7 +105,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
@@ -122,7 +122,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -105,7 +105,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
@@ -94,7 +94,7 @@ public:
     {
       for (itk::SizeValueType i = 0; i < gradient.GetSize(); i += (gradient.GetSize() / 16))
       {
-        std::cout << gradient[i] << " ";
+        std::cout << gradient[i] << ' ';
       }
     }
     std::cout << std::endl;

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -193,7 +193,7 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
       std::cout << "\tBounding box = ";
       for (auto jj : bbox)
       {
-        std::cout << jj << " ";
+        std::cout << jj << ' ';
       }
       std::cout << std::endl;
       if (statistics->HasLabel(ii))

--- a/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
@@ -141,7 +141,7 @@ itkCollidingFrontsImageFilterTest(int argc, char * argv[])
       // allow half a pixel diagonal tolerance
       if (distance > radius + 1.414 / 2.0)
       {
-        std::cout << outputPixel << " " << distance << std::endl;
+        std::cout << outputPixel << ' ' << distance << std::endl;
         passed = false;
       }
     }
@@ -149,7 +149,7 @@ itkCollidingFrontsImageFilterTest(int argc, char * argv[])
     {
       if (distance < radius)
       {
-        std::cout << outputPixel << " " << distance << std::endl;
+        std::cout << outputPixel << ' ' << distance << std::endl;
         passed = false;
       }
     }

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -45,7 +45,7 @@ public:
   ShowIteration()
   {
     std::cout << m_Filter->GetElapsedIterations() << ": ";
-    std::cout << m_Filter->GetCurrentParameters() << " ";
+    std::cout << m_Filter->GetCurrentParameters() << ' ';
     std::cout << m_Filter->GetRMSChange() << std::endl;
   }
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
@@ -46,7 +46,7 @@ public:
   ShowIteration()
   {
     std::cout << m_Filter->GetElapsedIterations() << ": ";
-    std::cout << m_Filter->GetCurrentParameters() << " ";
+    std::cout << m_Filter->GetCurrentParameters() << ' ';
     std::cout << m_Filter->GetRMSChange() << std::endl;
   }
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
@@ -69,7 +69,7 @@ itkLevelSetNeighborhoodExtractorTest(int, char *[])
   iterEnd = extractor->GetInsidePoints()->End();
   for (; iter != iterEnd; ++iter)
   {
-    std::cout << iter.Value().GetIndex() << " ";
+    std::cout << iter.Value().GetIndex() << ' ';
     std::cout << iter.Value().GetValue() << std::endl;
   }
 
@@ -78,7 +78,7 @@ itkLevelSetNeighborhoodExtractorTest(int, char *[])
   iterEnd = extractor->GetOutsidePoints()->End();
   for (; iter != iterEnd; ++iter)
   {
-    std::cout << iter.Value().GetIndex() << " ";
+    std::cout << iter.Value().GetIndex() << ' ';
     std::cout << iter.Value().GetValue() << std::endl;
   }
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
@@ -94,8 +94,8 @@ itkLevelSetVelocityNeighborhoodExtractorTest(int, char *[])
   aIterEnd = extractor->GetAuxInsideValues()->End();
   for (; iter != iterEnd; iter++, aIter++)
   {
-    std::cout << iter.Value().GetIndex() << " ";
-    std::cout << iter.Value().GetValue() << " ";
+    std::cout << iter.Value().GetIndex() << ' ';
+    std::cout << iter.Value().GetValue() << ' ';
     std::cout << aIter.Value() << std::endl;
   }
 
@@ -107,8 +107,8 @@ itkLevelSetVelocityNeighborhoodExtractorTest(int, char *[])
 
   for (; iter != iterEnd; iter++, aIter++)
   {
-    std::cout << iter.Value().GetIndex() << " ";
-    std::cout << iter.Value().GetValue() << " ";
+    std::cout << iter.Value().GetIndex() << ' ';
+    std::cout << iter.Value().GetValue() << ' ';
     std::cout << aIter.Value() << std::endl;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -106,7 +106,7 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
         {
           for (const auto & lIt : *lout)
           {
-            std::cout << lIt << " ";
+            std::cout << lIt << ' ';
           }
           std::cout << std::endl;
         }

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
@@ -198,7 +198,7 @@ itkMultiLevelSetChanAndVeseInternalTermTest(int, char *[])
 
       for (const auto & lIt : *lout)
       {
-        std::cout << lIt << " ";
+        std::cout << lIt << ' ';
         levelSet = lscontainer->GetLevelSet(lIt - 1);
         std::cout << levelSet->Evaluate(temp_it.GetIndex()) << std::endl;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -151,7 +151,7 @@ itkMultiLevelSetDenseImageTest(int, char *[])
         {
           for (const auto & lIt : *lout)
           {
-            std::cout << lIt << " " << level_set[lIt]->Evaluate(out_index) << std::endl;
+            std::cout << lIt << ' ' << level_set[lIt]->Evaluate(out_index) << std::endl;
           }
           std::cout << std::endl;
 
@@ -190,7 +190,7 @@ itkMultiLevelSetDenseImageTest(int, char *[])
       // Iterate through all the levelsets at a given pixel location
       for (const auto & lIt : *lout)
       {
-        std::cout << lIt << " " << level_set[lIt]->Evaluate(temp_it.GetIndex()) << std::endl;
+        std::cout << lIt << ' ' << level_set[lIt]->Evaluate(temp_it.GetIndex()) << std::endl;
       }
       std::cout << std::endl;
       ++temp_it;

--- a/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
@@ -64,7 +64,7 @@ itkConfidenceConnectedImageFilterTest(int argc, char * argv[])
   std::cout << "Filter Seeds";
   for (const auto & oneSeed : filter->GetSeeds())
   {
-    std::cout << " " << oneSeed;
+    std::cout << ' ' << oneSeed;
   }
   std::cout << std::endl;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -401,7 +401,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
         }
         else
         {
-          itkDebugMacro(<< "Numerical problem 1" << curr[0] << " " << curr1[1]);
+          itkDebugMacro(<< "Numerical problem 1" << curr[0] << ' ' << curr1[1]);
         }
       }
     }

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -80,7 +80,7 @@ RGBImageTotalAbsDifference(const itk::Image<itk::RGBPixel<TPixelValue>, VDimensi
       ++testIt2;
       IterType validIt2 = validIt;
       ++validIt2;
-      std::cerr << testIt.GetIndex() << " [ " << validPx << " " << validIt2.Get() << "] != [ " << testPx << " "
+      std::cerr << testIt.GetIndex() << " [ " << validPx << ' ' << validIt2.Get() << "] != [ " << testPx << ' '
                 << testIt2.Get() << " ]" << std::endl;
       return localDiff;
     }


### PR DESCRIPTION
Replaced `<< " "` with `<< ' '`, to more explicitly express the intention to just insert a single space character. In general, insertion of a single character might also be faster than insertion of a string, although in this particular case, no noticeable performance effect is expected.
