### PR TITLE
STYLE: Replace double quotes around single characters with single quotes

### DIFF
--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
@@ -88,7 +88,7 @@ ParticleSwarmOptimizerSAXWriter::WriteFile()
     ofs << " ConvergedPercentageToStop=\""
         << this->m_InputObject->GetPercentageParticlesConverged() << "\"";
 
-    ofs << ">";
+    ofs << '>';
     ofs << "\n";
 
     // write the lower bound
@@ -97,7 +97,7 @@ ParticleSwarmOptimizerSAXWriter::WriteFile()
     ofs << " value=\"";
     for (const auto & bound : this->m_InputObject->GetParameterBounds())
     {
-      ofs << " " << bound.first;
+      ofs << ' ' << bound.first;
     }
     ofs << "\"";
 
@@ -111,7 +111,7 @@ ParticleSwarmOptimizerSAXWriter::WriteFile()
     ofs << " value=\"";
     for (const auto & bound : this->m_InputObject->GetParameterBounds())
     {
-      ofs << " " << bound.second;
+      ofs << ' ' << bound.second;
     }
     ofs << "\"";
 
@@ -129,7 +129,7 @@ ParticleSwarmOptimizerSAXWriter::WriteFile()
     //       elements.
     for (unsigned int i = 0; i < ptols.GetSize(); ++i)
     {
-      ofs << " " << ptols[i];
+      ofs << ' ' << ptols[i];
     }
 
     ofs << "</ParametersConvergenceTolerance>";

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -237,7 +237,7 @@ VTKImageImport<TOutputImage>::GenerateOutputInformation()
           std::string ijk = "IJK";
           std::string xyz = "XYZ";
           itkExceptionMacro(<< "Cannot convert a VTK image to an ITK image of dimension " << OutputImageDimension
-                            << " since the VTK image direction matrix element at (" << i << "," << j
+                            << " since the VTK image direction matrix element at (" << i << ',' << j
                             << ") is not equal to 0.0:\n"
                             << "   I  J  K\n"
                             << "X  " << inDirection[0] << ", " << inDirection[1] << ", " << inDirection[2] << "\n"
@@ -246,7 +246,7 @@ VTKImageImport<TOutputImage>::GenerateOutputInformation()
                             << "This means that the " << ijk[j] << " data axis has a " << xyz[i]
                             << " component in physical space, but the ITK image can only represent values"
                             << " along " << ijk.substr(0, OutputImageDimension) << " projected on "
-                            << xyz.substr(0, OutputImageDimension) << "." << std::endl);
+                            << xyz.substr(0, OutputImageDimension) << '.' << std::endl);
         }
       }
     }

--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -91,7 +91,7 @@ itkImageToVTKImageFilterTest(int, char *[])
     {
       if (input->GetDirection()[i][j] != output->GetDirectionMatrix()->GetData()[i * 3 + j])
       {
-        std::cerr << "Error: directions do not match for component (" << i << "," << j << ")." << std::endl;
+        std::cerr << "Error: directions do not match for component (" << i << ',' << j << ")." << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
@@ -74,7 +74,7 @@ itkVTKImageToImageFilterTest(int, char *[])
     {
       if (output->GetDirection()[i][j] != input->GetDirectionMatrix()->GetData()[i * 3 + j])
       {
-        std::cerr << "Error: directions do not match for component (" << i << "," << j << ")." << std::endl;
+        std::cerr << "Error: directions do not match for component (" << i << ',' << j << ")." << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Compatibility/Deprecated/include/itkImageTransformer.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkImageTransformer.hxx
@@ -296,7 +296,7 @@ ImageTransformer<TInputImage>::ThreadedGenerateData(const InputImageRegionType &
   // 'noreturn' function does return
   std::ostringstream message;
 
-  message << "itk::ERROR: " << this->GetNameOfClass() << "(" << this << "): "
+  message << "itk::ERROR: " << this->GetNameOfClass() << '(' << this << "): "
           << "Subclass should override this method!!!";
   ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
   throw e_;

--- a/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx
@@ -56,7 +56,7 @@ itkTreeContainerTest(int, char *[])
   levelIt.GoToBegin();
   while (!levelIt.IsAtEnd())
   {
-    std::cout << levelIt.Get() << " (" << levelIt.GetLevel() << ")" << std::endl;
+    std::cout << levelIt.Get() << " (" << levelIt.GetLevel() << ')' << std::endl;
     ++levelIt;
   }
 

--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -212,7 +212,7 @@ template <typename TValue>
 std::ostream &
 operator<<(std::ostream & os, const Array<TValue> & arr)
 {
-  os << "[";
+  os << '[';
   const unsigned int length = arr.size();
   if (length >= 1)
   {
@@ -223,7 +223,7 @@ operator<<(std::ostream & os, const Array<TValue> & arr)
     }
     os << arr[last];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -99,7 +99,7 @@ operator<<(std::ostream & os, const Array2D<TValue> & arr)
 
   for (unsigned int r = 0; r < numberOfRows; ++r)
   {
-    os << "[";
+    os << '[';
     if (numberOfColumns >= 1)
     {
       const unsigned int lastColumn = numberOfColumns - 1;
@@ -109,7 +109,7 @@ operator<<(std::ostream & os, const Array2D<TValue> & arr)
       }
       os << arr(r, lastColumn);
     }
-    os << "]" << std::endl;
+    os << ']' << std::endl;
   }
 
   return os;

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -43,7 +43,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Pri
   os << indent << "Bounding Box: ( ";
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
-    os << m_Bounds[2 * i] << "," << m_Bounds[2 * i + 1] << ' ';
+    os << m_Bounds[2 * i] << ',' << m_Bounds[2 * i + 1] << ' ';
   }
   os << " )" << std::endl;
 }

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -249,8 +249,8 @@ ColorTable<TComponent>::UseRandomColors(unsigned int n)
     b = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][2] = b;
     std::ostringstream name;
-    name << "Random(" << std::fixed << std::setprecision(2) << static_cast<float>(r) << "," << static_cast<float>(g)
-         << "," << static_cast<float>(b) << ")";
+    name << "Random(" << std::fixed << std::setprecision(2) << static_cast<float>(r) << ',' << static_cast<float>(g)
+         << ',' << static_cast<float>(b) << ')';
     m_ColorName[i] = name.str();
   }
 }

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -90,14 +90,14 @@ ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::os
   {
     os << m_Origin[i] << ", ";
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "Gradient at origin: [";
   for (i = 0; i < VDimension - 1; ++i)
   {
     os << m_OriginGradient[i] << ", ";
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "DistanceMin: " << m_DistanceMin << std::endl;
   os << indent << "DistanceMax: " << m_DistanceMax << std::endl;

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -610,7 +610,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
   }
   os << ", m_Begin = " << m_Begin;
   os << ", m_End = " << m_End;
-  os << "}" << std::endl;
+  os << '}' << std::endl;
 
   os << indent << ",  m_InnerBoundsLow = { ";
   for (i = 0; i < Dimension; ++i)

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -31,7 +31,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostr
   }
   os << "] ";
   os << " m_CenterIsActive = " << m_CenterIsActive;
-  os << "}" << std::endl;
+  os << '}' << std::endl;
   Superclass::PrintSelf(os, indent.GetNextIndent());
 }
 
@@ -120,7 +120,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::CreateActiveListFro
   if (this->GetRadius() != neighborhood.GetRadius())
   {
     itkGenericExceptionMacro(<< "Radius of shaped iterator(" << this->GetRadius()
-                             << ") does not equal radius of neighborhood(" << neighborhood.GetRadius() << ")");
+                             << ") does not equal radius of neighborhood(" << neighborhood.GetRadius() << ')');
   }
   typename NeighborhoodType::ConstIterator nit;
   NeighborIndexType                        idx = 0;

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -131,7 +131,7 @@ template <typename TValue, unsigned int VLength>
 std::ostream &
 operator<<(std::ostream & os, const FixedArray<TValue, VLength> & arr)
 {
-  os << "[";
+  os << '[';
   if (VLength == 1)
   {
     os << arr[0];
@@ -144,7 +144,7 @@ operator<<(std::ostream & os, const FixedArray<TValue, VLength> & arr)
     }
     os << arr[VLength - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 } // namespace itk

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -129,7 +129,7 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoef
       // if the coeff is less then this value then the value of cap
       // will not change, and it will not contribute to the operator
       itkWarningMacro("Kernel failed to accumulate to approximately one with current remainder "
-                      << cap - sum.GetSum() << " and current coefficient " << coeff[i] << ".");
+                      << cap - sum.GetSum() << " and current coefficient " << coeff[i] << '.');
 
       break;
     }

--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -85,7 +85,7 @@ public:
   virtual void
   Print(std::ostream & os, Indent i = 0) const
   {
-    os << i << this->GetNameOfClass() << " (" << this << ")" << std::endl;
+    os << i << this->GetNameOfClass() << " (" << this << ')' << std::endl;
   }
 
   /** Returns a value for a given out-of-bounds pixel.  The arguments are the

--- a/Modules/Core/Common/include/itkImportImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImportImageFilter.hxx
@@ -59,14 +59,14 @@ ImportImageFilter<TPixel, VImageDimension>::PrintSelf(std::ostream & os, Indent 
   {
     os << m_Spacing[i] << ", ";
   }
-  os << m_Spacing[i] << "]" << std::endl;
+  os << m_Spacing[i] << ']' << std::endl;
 
   os << indent << "Origin: [";
   for (i = 0; i < static_cast<int>(VImageDimension) - 1; ++i)
   {
     os << m_Origin[i] << ", ";
   }
-  os << m_Origin[i] << "]" << std::endl;
+  os << m_Origin[i] << ']' << std::endl;
   os << indent << "Direction: " << std::endl << this->GetDirection() << std::endl;
 }
 

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -517,7 +517,7 @@ template <unsigned int VDimension>
 std::ostream &
 operator<<(std::ostream & os, const Index<VDimension> & obj)
 {
-  os << "[";
+  os << '[';
   for (unsigned int i = 0; i + 1 < VDimension; ++i)
   {
     os << obj[i] << ", ";
@@ -526,7 +526,7 @@ operator<<(std::ostream & os, const Index<VDimension> & obj)
   {
     os << obj[VDimension - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -562,7 +562,7 @@ OutputWindowDisplayDebugText(const char *);
  * a condition that results in program failure). Example usage looks like:
  * itkExceptionMacro(<< "this is error info" << this->SomeVariable); */
 #define itkExceptionMacro(x) \
-  itkSpecializedMessageExceptionMacro(ExceptionObject, << this->GetNameOfClass() << "(" << this << "): " x)
+  itkSpecializedMessageExceptionMacro(ExceptionObject, << this->GetNameOfClass() << '(' << this << "): " x)
 
 #define itkGenericExceptionMacro(x) itkSpecializedMessageExceptionMacro(ExceptionObject, x)
 

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -135,14 +135,14 @@ Neighborhood<TPixel, VDimension, TContainer>::PrintSelf(std::ostream & os, Inden
   {
     os << m_StrideTable[i] << ' ';
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "OffsetTable: [ ";
   for (DimensionValueType i = 0; i < m_OffsetTable.size(); ++i)
   {
     os << m_OffsetTable[i] << ' ';
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -460,7 +460,7 @@ template <unsigned int VDimension>
 std::ostream &
 operator<<(std::ostream & os, const Offset<VDimension> & ind)
 {
-  os << "[";
+  os << '[';
   unsigned int dimlim = VDimension - 1;
   for (unsigned int i = 0; i < dimlim; ++i)
   {
@@ -470,7 +470,7 @@ operator<<(std::ostream & os, const Offset<VDimension> & ind)
   {
     os << ind[VDimension - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -266,7 +266,7 @@ template <typename T, unsigned int TPointDimension>
 std::ostream &
 operator<<(std::ostream & os, const Point<T, TPointDimension> & vct)
 {
-  os << "[";
+  os << '[';
   if (TPointDimension == 1)
   {
     os << vct[0];
@@ -279,7 +279,7 @@ operator<<(std::ostream & os, const Point<T, TPointDimension> & vct)
     }
     os << vct[TPointDimension - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -39,9 +39,9 @@ operator<<(std::ostream & os, const std::vector<T> & v)
     return os << "()";
   }
 
-  os << "(";
+  os << '(';
   std::copy(v.begin(), v.end() - 1, std::ostream_iterator<T>(os, ", "));
-  return os << v.back() << ")";
+  return os << v.back() << ')';
 }
 
 } // end namespace print_helper

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -257,7 +257,7 @@ ResourceProbe<ValueType, MeanType>::PrintSystemInformation(std::ostream & os)
 
   os << "    Operating System is " << (systeminfo.Is64Bits() ? "64 bit" : "32 bit") << std::endl;
 
-  os << "ITK Version: " << ITK_VERSION_STRING << "." << ITK_VERSION_PATCH << std::endl;
+  os << "ITK Version: " << ITK_VERSION_STRING << '.' << ITK_VERSION_PATCH << std::endl;
 }
 
 
@@ -551,7 +551,7 @@ ResourceProbe<ValueType, MeanType>::PrintJSONSystemInformation(std::ostream & os
   os << "    },\n";
 
   std::ostringstream itkVersionStringStream;
-  itkVersionStringStream << ITK_VERSION_STRING << "." << ITK_VERSION_PATCH;
+  itkVersionStringStream << ITK_VERSION_STRING << '.' << ITK_VERSION_PATCH;
 
   PrintJSONvar(os, "ITKVersion", itkVersionStringStream.str(), 4, false);
   os << "  }";

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -418,7 +418,7 @@ template <unsigned int VDimension>
 std::ostream &
 operator<<(std::ostream & os, const Size<VDimension> & obj)
 {
-  os << "[";
+  os << '[';
   for (unsigned int i = 0; i + 1 < VDimension; ++i)
   {
     os << obj[i] << ", ";
@@ -427,7 +427,7 @@ operator<<(std::ostream & os, const Size<VDimension> & obj)
   {
     os << obj[VDimension - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
@@ -64,7 +64,7 @@ SphereSpatialFunction<VImageDimension, TInput>::PrintSelf(std::ostream & os, Ind
   {
     os << m_Center[i] << ", ";
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "Radius: " << m_Radius << std::endl;
 }

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -54,7 +54,7 @@ TorusInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream
   {
     os << m_Origin[i] << ", ";
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "Major radius: " << m_MajorRadius << std::endl;
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -1322,7 +1322,7 @@ template <typename TExpr1, typename TExpr2, typename TBinaryOp>
 std::ostream &
 operator<<(std::ostream & os, VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp> const & v)
 {
-  os << "[";
+  os << '[';
   if (v.Size() != 0)
   {
     os << v[0];
@@ -1331,7 +1331,7 @@ operator<<(std::ostream & os, VariableLengthVectorExpression<TExpr1, TExpr2, TBi
       os << ", " << v[i];
     }
   }
-  return os << "]";
+  return os << ']';
 }
 
 /** Returns vector's Euclidean Norm.
@@ -1377,7 +1377,7 @@ operator<<(std::ostream & os, const VariableLengthVector<TValue> & arr)
   const unsigned int length = arr.Size();
   const int          last = static_cast<unsigned int>(length) - 1;
 
-  os << "[";
+  os << '[';
   for (int i = 0; i < last; ++i)
   {
     os << arr[i] << ", ";
@@ -1386,7 +1386,7 @@ operator<<(std::ostream & os, const VariableLengthVector<TValue> & arr)
   {
     os << arr[last];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 //@}

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -63,9 +63,9 @@ VariableSizeMatrix<T> VariableSizeMatrix<T>::operator*(const Self & matrix) cons
 {
   if (this->Cols() != matrix.Rows())
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << this->Rows() << "," << this->Cols()
-                             << ") cannot be multiplied by matrix with size (" << matrix.Rows() << "," << matrix.Cols()
-                             << ")");
+    itkGenericExceptionMacro(<< "Matrix with size (" << this->Rows() << ',' << this->Cols()
+                             << ") cannot be multiplied by matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                             << ')');
   }
   Self result;
   result = m_Matrix * matrix.m_Matrix;
@@ -81,9 +81,9 @@ VariableSizeMatrix<T>::operator+(const Self & matrix) const
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << "," << matrix.Cols()
-                             << ") cannot be added to a matrix with size (" << this->Rows() << "," << this->Cols()
-                             << ")");
+    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                             << ") cannot be added to a matrix with size (" << this->Rows() << ',' << this->Cols()
+                             << ')');
   }
 
   Self result(this->Rows(), this->Cols());
@@ -106,9 +106,9 @@ VariableSizeMatrix<T>::operator+=(const Self & matrix)
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << "," << matrix.Cols()
-                             << ") cannot be added to a matrix with size (" << this->Rows() << "," << this->Cols()
-                             << ")");
+    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                             << ") cannot be added to a matrix with size (" << this->Rows() << ',' << this->Cols()
+                             << ')');
   }
 
   for (unsigned int r = 0; r < this->Rows(); ++r)
@@ -130,9 +130,9 @@ VariableSizeMatrix<T>::operator-(const Self & matrix) const
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << "," << matrix.Cols()
-                             << ") cannot be subtracted from matrix with size (" << this->Rows() << "," << this->Cols()
-                             << ")");
+    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                             << ") cannot be subtracted from matrix with size (" << this->Rows() << ',' << this->Cols()
+                             << ')');
   }
 
   Self result(this->Rows(), this->Cols());
@@ -155,9 +155,9 @@ VariableSizeMatrix<T>::operator-=(const Self & matrix)
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << "," << matrix.Cols()
-                             << ") cannot be subtracted from matrix with size (" << this->Rows() << "," << this->Cols()
-                             << ")");
+    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                             << ") cannot be subtracted from matrix with size (" << this->Rows() << ',' << this->Cols()
+                             << ')');
   }
 
   for (unsigned int r = 0; r < this->Rows(); ++r)

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -169,7 +169,7 @@ template <typename T, unsigned int TVectorDimension>
 std::ostream &
 operator<<(std::ostream & os, const Vector<T, TVectorDimension> & vct)
 {
-  os << "[";
+  os << '[';
   if (TVectorDimension == 1)
   {
     os << vct[0];
@@ -182,7 +182,7 @@ operator<<(std::ostream & os, const Vector<T, TVectorDimension> & vct)
     }
     os << vct[TVectorDimension - 1];
   }
-  os << "]";
+  os << ']';
   return os;
 }
 

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -356,7 +356,7 @@ Versor<T>::Set(const MatrixType & mat)
       itk::Math::abs(I[2][2] - itk::NumericTraits<T>::OneValue()) > epsilonDiff || vnl_det(I) < 0)
   {
     itkGenericExceptionMacro(<< "The following matrix does not represent rotation to within an epsion of " << epsilon
-                             << "." << std::endl
+                             << '.' << std::endl
                              << m << std::endl
                              << "det(m * m transpose) is: " << vnl_det(I) << std::endl
                              << "m * m transpose is:" << std::endl

--- a/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
+++ b/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
@@ -24,7 +24,7 @@ namespace itk
 template <>
 std::ostream & operator<<<double>(std::ostream & os, const Array<double> & arr)
 {
-  os << "[";
+  os << '[';
   const size_t length = arr.size();
   if (length >= 1)
   {
@@ -35,14 +35,14 @@ std::ostream & operator<<<double>(std::ostream & os, const Array<double> & arr)
     }
     os << ConvertNumberToString(arr[last]);
   }
-  os << "]";
+  os << ']';
   return os;
 }
 
 template <>
 std::ostream & operator<<<float>(std::ostream & os, const Array<float> & arr)
 {
-  os << "[";
+  os << '[';
   const size_t length = arr.size();
   if (length >= 1)
   {
@@ -53,7 +53,7 @@ std::ostream & operator<<<float>(std::ostream & os, const Array<float> & arr)
     }
     os << ConvertNumberToString(arr[last]);
   }
-  os << "]";
+  os << ']';
   return os;
 }
 
@@ -65,7 +65,7 @@ std::ostream & operator<<<double>(std::ostream & os, const Array2D<double> & arr
 
   for (unsigned int r = 0; r < numberOfRows; ++r)
   {
-    os << "[";
+    os << '[';
     if (numberOfColumns >= 1)
     {
       const unsigned int lastColumn = numberOfColumns - 1;
@@ -75,7 +75,7 @@ std::ostream & operator<<<double>(std::ostream & os, const Array2D<double> & arr
       }
       os << ConvertNumberToString(arr(r, lastColumn));
     }
-    os << "]" << std::endl;
+    os << ']' << std::endl;
   }
 
   return os;
@@ -89,7 +89,7 @@ std::ostream & operator<<<float>(std::ostream & os, const Array2D<float> & arr)
 
   for (unsigned int r = 0; r < numberOfRows; ++r)
   {
-    os << "[";
+    os << '[';
     if (numberOfColumns >= 1)
     {
       const unsigned int lastColumn = numberOfColumns - 1;
@@ -99,7 +99,7 @@ std::ostream & operator<<<float>(std::ostream & os, const Array2D<float> & arr)
       }
       os << ConvertNumberToString(arr(r, lastColumn));
     }
-    os << "]" << std::endl;
+    os << ']' << std::endl;
   }
 
   return os;

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -43,7 +43,7 @@ public:
   {
     std::ostringstream loc;
 
-    loc << ":" << m_Line << ":\n";
+    loc << ':' << m_Line << ":\n";
     m_What = m_File;
     m_What += loc.str();
     m_What += m_Description;

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -252,7 +252,7 @@ Object::SubjectImplementation::PrintObservers(std::ostream & os, Indent indent) 
   {
     const EventObject * e = observer.m_Event.get();
     const Command *     c = observer.m_Command;
-    os << indent << e->GetEventName() << "(" << c->GetNameOfClass();
+    os << indent << e->GetEventName() << '(' << c->GetNameOfClass();
     if (!c->GetObjectName().empty())
     {
       os << " \"" << c->GetObjectName() << "\"";

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -85,7 +85,7 @@ ProcessObject::MakeOutput(const DataObjectIdentifierType & name)
    * virtual.
    */
 
-  itkDebugMacro("MakeOutput(" << name << ")");
+  itkDebugMacro("MakeOutput(" << name << ')');
   if (this->IsIndexedOutputName(name))
   {
     return this->MakeOutput(this->MakeIndexFromOutputName(name));
@@ -1214,7 +1214,7 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
       {
         req = " *";
       }
-      os << indent2 << input.first << ": (" << input.second.GetPointer() << ")" << req << std::endl;
+      os << indent2 << input.first << ": (" << input.second.GetPointer() << ')' << req << std::endl;
     }
   }
   else
@@ -1226,7 +1226,7 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
   unsigned int idx = 0;
   for (auto it = m_IndexedInputs.begin(); it != m_IndexedInputs.end(); ++it, ++idx)
   {
-    os << indent2 << idx << ": " << (*it)->first << " (" << (*it)->second.GetPointer() << ")" << std::endl;
+    os << indent2 << idx << ": " << (*it)->first << " (" << (*it)->second.GetPointer() << ')' << std::endl;
   }
 
   if (!m_RequiredInputNames.empty())
@@ -1253,7 +1253,7 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "Outputs: " << std::endl;
     for (const auto & output : m_Outputs)
     {
-      os << indent2 << output.first << ": (" << output.second.GetPointer() << ")" << std::endl;
+      os << indent2 << output.first << ": (" << output.second.GetPointer() << ')' << std::endl;
     }
   }
   else
@@ -1264,7 +1264,7 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
   idx = 0;
   for (auto it = m_IndexedOutputs.begin(); it != m_IndexedOutputs.end(); ++it, ++idx)
   {
-    os << indent2 << idx << ": " << (*it)->first << " (" << (*it)->second.GetPointer() << ")" << std::endl;
+    os << indent2 << idx << ": " << (*it)->first << " (" << (*it)->second.GetPointer() << ')' << std::endl;
   }
 
   os << indent << "NumberOfRequiredOutputs: " << m_NumberOfRequiredOutputs << std::endl;

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -126,7 +126,7 @@ XMLFileOutputWindow::DisplayXML(const char * tag, const char * text)
   {
     this->Initialize();
   }
-  *m_Stream << "<" << tag << ">" << xmlText.get() << "</" << tag << ">" << std::endl;
+  *m_Stream << '<' << tag << '>' << xmlText.get() << "</" << tag << '>' << std::endl;
 
   if (m_Flush)
   {

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -297,7 +297,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
       }
       if (itk::Math::abs(weights[counter] - value) > 1e-7)
       {
-        std::cout << "Error at weights[" << counter << "]" << std::endl;
+        std::cout << "Error at weights[" << counter << ']' << std::endl;
         std::cout << "Computed value: " << weights[counter] << std::endl;
         std::cout << "Expected value: " << value << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
+++ b/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
@@ -61,7 +61,7 @@ itkCMakeInformationPrintFile(const char * name, std::ostream & os)
     const char * div = "=======================================================================";
     os << ":\n[" << div << "[\n";
     os << fin.rdbuf();
-    os << "]" << div << "]\n";
+    os << ']' << div << "]\n";
     os.flush();
   }
   else

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -200,7 +200,7 @@ itkCompensatedSummationTest2(int, char *[])
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << "." << std::endl;
+                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
       return EXIT_FAILURE;
     }
     std::cout << "# of digits precision in double: " << std::numeric_limits<double>::digits10 << std::endl;

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -148,7 +148,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   std::cout << it.GetNext(1) << std::endl;
 
   println("Testing GetNext(0) = GetNext(0,1)");
-  std::cout << it.GetNext(0) << "=" << it.GetNext(0, 1) << std::endl;
+  std::cout << it.GetNext(0) << '=' << it.GetNext(0, 1) << std::endl;
 
   println("Testing GetNext(0, 1)");
   std::cout << it.GetNext(0, 1) << std::endl;
@@ -166,7 +166,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   std::cout << it.GetPrevious(1) << std::endl;
 
   println("Testing GetPrevious(0) = GetPrevious(0,1)");
-  std::cout << it.GetPrevious(0) << "=" << it.GetPrevious(0, 1) << std::endl;
+  std::cout << it.GetPrevious(0) << '=' << it.GetPrevious(0, 1) << std::endl;
 
   println("Testing GetPrevious(0, 1)");
   std::cout << it.GetPrevious(0, 1) << std::endl;

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -28,7 +28,7 @@ PrintShapedNeighborhood(const itk::ConstShapedNeighborhoodIterator<TestImageType
   {
     std::cout << it.Get();
   }
-  std::cout << "]" << std::endl;
+  std::cout << ']' << std::endl;
 }
 
 int

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -166,7 +166,7 @@ itkConstantBoundaryConditionTest(int, char *[])
 
   if (bc.GetConstant() != constant)
   {
-    std::cerr << "Got unexpected constant " << bc.GetConstant() << ", expected " << constant << "." << std::endl;
+    std::cerr << "Got unexpected constant " << bc.GetConstant() << ", expected " << constant << '.' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -176,7 +176,7 @@ itkConstantBoundaryConditionTest(int, char *[])
 
   if (vbc.GetConstant()[0] != constant)
   {
-    std::cerr << "Got unexpected constant " << vbc.GetConstant() << ", expected " << vectorConstant << "." << std::endl;
+    std::cerr << "Got unexpected constant " << vbc.GetConstant() << ", expected " << vectorConstant << '.' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -117,10 +117,10 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
     // function value = 1
     std::cout << "calculated ellipsoid volume = " << volume << std::endl
               << "measured ellipsoid volume = " << interiorPixelCounter << std::endl
-              << "volume error = " << volumeError << "%" << std::endl
+              << "volume error = " << volumeError << '%' << std::endl
               << "function value = " << functionValue << std::endl
               << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-              << spatialFunc->GetCenter()[2] << ")" << std::endl
+              << spatialFunc->GetCenter()[2] << ')' << std::endl
               << "major axis length = " << spatialFunc->GetAxes()[0]
               << " minor axis 1 length = " << spatialFunc->GetAxes()[1]
               << " minor axis 2 length = " << spatialFunc->GetAxes()[2] << std::endl
@@ -130,10 +130,10 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   // Default behavior is to fail
   std::cerr << "calculated ellipsoid volume = " << volume << std::endl
             << "measured ellipsoid volume = " << interiorPixelCounter << std::endl
-            << "volume error = " << volumeError << "%" << std::endl
+            << "volume error = " << volumeError << '%' << std::endl
             << "function value = " << functionValue << std::endl
             << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-            << spatialFunc->GetCenter()[2] << ")" << std::endl
+            << spatialFunc->GetCenter()[2] << ')' << std::endl
             << "major axis length = " << spatialFunc->GetAxes()[0]
             << " minor axis 1 length = " << spatialFunc->GetAxes()[1]
             << " minor axis 2 length = " << spatialFunc->GetAxes()[2] << std::endl

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -60,7 +60,7 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
     ASSERT_NE(actualDescription, nullptr);
 
     std::ostringstream expectedDescription;
-    expectedDescription << "ITK ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << message;
+    expectedDescription << "ITK ERROR: " << testObject.GetNameOfClass() << '(' << &testObject << "): " << message;
 
     EXPECT_EQ(actualDescription, expectedDescription.str());
   }

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
@@ -122,10 +122,10 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
     // function value = 1
     std::cout << "calculated cylinder volume = " << volume << std::endl
               << "measured cylinder volume = " << interiorPixelCounter << std::endl
-              << "volume error = " << volumeError << "%" << std::endl
+              << "volume error = " << volumeError << '%' << std::endl
               << "function value = " << functionValue << std::endl
               << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-              << spatialFunc->GetCenter()[2] << ")" << std::endl
+              << spatialFunc->GetCenter()[2] << ')' << std::endl
               << "axis length = " << axis << std::endl
               << "itkFiniteCylinderSpatialFunction test ended successfully!" << std::endl;
     return EXIT_SUCCESS;
@@ -133,10 +133,10 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
   // Default is to produce error code
   std::cerr << "calculated ellipsoid volume = " << volume << std::endl
             << "measured ellipsoid volume = " << interiorPixelCounter << std::endl
-            << "volume error = " << volumeError << "%" << std::endl
+            << "volume error = " << volumeError << '%' << std::endl
             << "function value = " << functionValue << std::endl
             << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-            << spatialFunc->GetCenter()[2] << ")" << std::endl
+            << spatialFunc->GetCenter()[2] << ')' << std::endl
             << "axis length = " << axis << std::endl
             << "itkFiniteCylinderSpatialFunction test failed :(" << std::endl;
   return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkFixedArrayTest2.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest2.cxx
@@ -120,7 +120,7 @@ itkFixedArrayTest2(int, char *[])
     std::cout << "Same pointers: false" << std::endl;
   }
 
-  std::cout << "Performance ratio = " << ratio << "%" << std::endl;
+  std::cout << "Performance ratio = " << ratio << '%' << std::endl;
 
   if (!sameptr && ratio > 20.0) // tolerates only 20%
   {

--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -114,17 +114,17 @@ itkImageAdaptorPipeLineTest(int, char *[])
   while (!it.IsAtEnd())
   {
     myIndexType index = it.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(4);
-    std::cout << it.Get().GetRed() << ",";
+    std::cout << it.Get().GetRed() << ',';
     std::cout.width(4);
-    std::cout << it.Get().GetGreen() << ",";
+    std::cout << it.Get().GetGreen() << ',';
     std::cout.width(4);
     std::cout << it.Get().GetBlue() << std::endl;
     ++it;
@@ -158,11 +158,11 @@ itkImageAdaptorPipeLineTest(int, char *[])
   while (!itf.IsAtEnd())
   {
     myIndexType index = itf.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);
@@ -224,11 +224,11 @@ itkImageAdaptorPipeLineTest(int, char *[])
   while (!ito.IsAtEnd())
   {
     myIndexType index = ito.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);

--- a/Modules/Core/Common/test/itkMathRoundTest2.cxx
+++ b/Modules/Core/Common/test/itkMathRoundTest2.cxx
@@ -22,7 +22,7 @@
 #define RoundTestHelperMacro(rndname, input, output)                                                         \
   if (rndname((input)) != (output))                                                                          \
   {                                                                                                          \
-    std::cout << "Failure! " << #rndname << "(" << static_cast<int>(input) << ") expected "                  \
+    std::cout << "Failure! " << #rndname << '(' << static_cast<int>(input) << ") expected "                  \
               << static_cast<int>(output) << " but got " << static_cast<int>(rndname((input))) << std::endl; \
     ok = false;                                                                                              \
   }                                                                                                          \

--- a/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
@@ -160,7 +160,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   std::cout << "Testing 2D LaplacianOperator" << std::endl;
   itk::LaplacianOperator<PixelType, Dimension2D, vnl_vector<PixelType>> a2;
@@ -180,7 +180,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   std::cout << "Testing 3D LaplacianOperator" << std::endl;
   itk::LaplacianOperator<PixelType, Dimension3D, vnl_vector<PixelType>> a3;
@@ -200,7 +200,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   std::cout << "Testing SobelOperator2D" << std::endl;
   itk::SobelOperator<PixelType, Dimension2D, vnl_vector<PixelType>> c;
@@ -222,7 +222,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   direction = 1;
   c.SetDirection(direction);
@@ -239,7 +239,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   std::cout << "Testing SobelOperator3D" << std::endl;
   itk::SobelOperator<PixelType, Dimension3D, vnl_vector<PixelType>> c2;
@@ -259,7 +259,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   direction = 1;
   c2.SetDirection(direction);
@@ -276,7 +276,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
   direction = 2;
   c2.SetDirection(direction);
@@ -293,7 +293,7 @@ itkNeighborhoodOperatorTest(int, char *[])
       std::cout << ", ";
     }
   }
-  std::cout << "]" << std::endl << std::endl;
+  std::cout << ']' << std::endl << std::endl;
 
 
   std::cout << "Test finished." << std::endl;

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -93,7 +93,7 @@ CheckVariableLengthArrayTraits(const T & t)
 #endif
 
   // check std::numeric_limits members
-  std::cout << "itk::NumericTraits<" << name << ">" << std::endl;
+  std::cout << "itk::NumericTraits<" << name << '>' << std::endl;
   std::cout << "\tmin(" << name
             << "): " << static_cast<typename itk::NumericTraits<T>::PrintType>(itk::NumericTraits<T>::min(t))
             << std::endl;
@@ -139,7 +139,7 @@ CheckFixedArrayTraits(const T & t)
 #endif
 
   // check std::numeric_limits members
-  std::cout << "itk::NumericTraits<" << name << ">" << std::endl;
+  std::cout << "itk::NumericTraits<" << name << '>' << std::endl;
   std::cout << "\tZero: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::Zero))
             << std::endl;
   std::cout << "\tOne: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::One))
@@ -169,7 +169,7 @@ void
 CheckTraits(const char * name, T t)
 {
   // check std::numeric_limits members
-  std::cout << "itk::NumericTraits<" << name << ">" << std::endl;
+  std::cout << "itk::NumericTraits<" << name << '>' << std::endl;
   std::cout << "\tis_specialized: " << itk::NumericTraits<T>::digits << std::endl;
   std::cout << "\tdigits: " << itk::NumericTraits<T>::digits << std::endl;
   std::cout << "\tdigits10: " << itk::NumericTraits<T>::digits10 << std::endl;

--- a/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
@@ -40,7 +40,7 @@ runTestByType()
   if (paramsSize.GetSize() != dim)
   {
     std::cerr << "Constructor with dimension failed. Expected size of " << dim << ", but got " << paramsSize.GetSize()
-              << "." << std::endl;
+              << '.' << std::endl;
     passed = false;
   }
 

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -130,12 +130,12 @@ template <typename TContainer>
 void
 PrintSlice(TContainer s)
 {
-  std::cout << "[";
+  std::cout << '[';
   for (s = s.Begin(); s < s.End(); ++s)
   {
     std::cout << *s << ' ';
   }
-  std::cout << "]" << std::endl;
+  std::cout << ']' << std::endl;
 }
 
 

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -110,20 +110,20 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
     // function value = 1
     std::cout << "calculated ellipsoid volume = " << volume << std::endl
               << "measured ellipsoid volume = " << interiorPixelCounter << std::endl
-              << "volume error = " << volumeError << "%" << std::endl
+              << "volume error = " << volumeError << '%' << std::endl
               << "function value = " << functionValue << std::endl
               << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-              << spatialFunc->GetCenter()[2] << ")" << std::endl
+              << spatialFunc->GetCenter()[2] << ')' << std::endl
               << "itkSymmetricEllipsoidSpatialFunction ended successfully!" << std::endl;
     return EXIT_SUCCESS;
   }
   // Default behavior is to fail
   std::cerr << "calculated ellipsoid volume = " << volume << std::endl
             << "measured ellipsoid volume = " << interiorPixelCounter << std::endl
-            << "volume error = " << volumeError << "%" << std::endl
+            << "volume error = " << volumeError << '%' << std::endl
             << "function value = " << functionValue << std::endl
             << "center location = (" << spatialFunc->GetCenter()[0] << ", " << spatialFunc->GetCenter()[0] << ", "
-            << spatialFunc->GetCenter()[2] << ")" << std::endl
+            << spatialFunc->GetCenter()[2] << ')' << std::endl
             << "itkSymmetricEllipsoidSpatialFunction failed :(" << std::endl;
   return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
@@ -163,13 +163,13 @@ ThreadedIndexedContainerPartitionerRunTest(DomainThreaderAssociate & enclosingCl
     /* Check that we got the begin of the range */
     if (i == 0 && subRange[0] != fullRange[0])
     {
-      std::cerr << "Error: subRange[0][0] should be " << fullRange[0] << ", but it's " << subRange[0] << ".";
+      std::cerr << "Error: subRange[0][0] should be " << fullRange[0] << ", but it's " << subRange[0] << '.';
       return EXIT_FAILURE;
     }
     /* Check that we got the end of the range */
     if (i == numberOfThreads - 1 && subRange[1] != fullRange[1])
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << fullRange[1] << ", but it's " << subRange[1] << ".";
+      std::cerr << "Error: subRange[N-1][1] should be " << fullRange[1] << ", but it's " << subRange[1] << '.';
       return EXIT_FAILURE;
     }
     /* Check that the sub-range endings and beginnings are continuous */
@@ -249,7 +249,7 @@ itkThreadedIndexedContainerPartitionerTest(int, char *[])
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads - 1)
     {
       std::cerr << "Error: Expected to use only " << maxNumberOfThreads - 1 << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << "." << std::endl;
+                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
     }
   }
   else

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
@@ -176,7 +176,7 @@ ThreadedIteratorRangePartitionerRunTest(
     /* Check that we got the begin of the range */
     if (i == 0 && subRange[0] != *(fullDomain.Begin()))
     {
-      std::cerr << "Error: subRange[0][0] should be " << *(fullDomain.Begin()) << ", but it's " << subRange[0] << ".";
+      std::cerr << "Error: subRange[0][0] should be " << *(fullDomain.Begin()) << ", but it's " << subRange[0] << '.';
       return EXIT_FAILURE;
     }
     /* Check that we got the end of the range */
@@ -184,7 +184,7 @@ ThreadedIteratorRangePartitionerRunTest(
     --fullIt;
     if (i == numberOfThreads - 1 && subRange[1] != *fullIt)
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << *fullIt << ", but it's " << subRange[1] << ".";
+      std::cerr << "Error: subRange[N-1][1] should be " << *fullIt << ", but it's " << subRange[1] << '.';
       return EXIT_FAILURE;
     }
     /* Check that the sub-range endings and beginnings are continuous */
@@ -296,7 +296,7 @@ itkThreadedIteratorRangePartitionerTest(int, char *[])
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << "." << std::endl;
+                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
     }
   }
   else

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
@@ -181,7 +181,7 @@ ThreadedIteratorRangePartitionerRunTest(
     if (i == 0 && subRange[0] != (fullDomain.Begin()).Value())
     {
       std::cerr << "Error: subRange[0][0] should be " << (fullDomain.Begin()).Value() << ", but it's " << subRange[0]
-                << ".";
+                << '.';
       return EXIT_FAILURE;
     }
 
@@ -191,7 +191,7 @@ ThreadedIteratorRangePartitionerRunTest(
     --fullIt;
     if (i == numberOfThreads - 1 && subRange[1] != fullIt.Value())
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Value() << ", but it's " << subRange[1] << ".";
+      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Value() << ", but it's " << subRange[1] << '.';
       return EXIT_FAILURE;
     }
     /* Check that the sub-range endings and beginnings are continuous */
@@ -314,7 +314,7 @@ itkThreadedIteratorRangePartitionerTest2(int, char *[])
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << "." << std::endl;
+                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
     }
   }
   else

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
@@ -181,7 +181,7 @@ ThreadedIteratorRangePartitionerRunTest(
     if (i == 0 && subRange[0] != (fullDomain.Begin()).Index())
     {
       std::cerr << "Error: subRange[0][0] should be " << (fullDomain.Begin()).Index() << ", but it's " << subRange[0]
-                << ".";
+                << '.';
       return EXIT_FAILURE;
     }
 
@@ -191,7 +191,7 @@ ThreadedIteratorRangePartitionerRunTest(
     --fullIt;
     if (i == numberOfThreads - 1 && subRange[1] != fullIt.Index())
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Index() << ", but it's " << subRange[1] << ".";
+      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Index() << ", but it's " << subRange[1] << '.';
       return EXIT_FAILURE;
     }
     /* Check that the sub-range endings and beginnings are continuous */
@@ -313,7 +313,7 @@ itkThreadedIteratorRangePartitionerTest3(int, char *[])
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << "." << std::endl;
+                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
     }
   }
   else

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -20,14 +20,13 @@
 #include "itkVariableLengthVector.h"
 #include "itkMath.h"
 
-#define ASSERT(cond, text)                                                   \
-  CLANG_PRAGMA_PUSH                                                          \
-  CLANG_SUPPRESS_Wfloat_equal if (!(cond)) CLANG_PRAGMA_POP                  \
-  {                                                                          \
-    std::cerr << __FILE__ << ":" << __LINE__ << ":"                          \
-              << "Assertion failed: " << #cond << ": " << text << std::endl; \
-    result = EXIT_FAILURE;                                                   \
-  }                                                                          \
+#define ASSERT(cond, text)                                                                                         \
+  CLANG_PRAGMA_PUSH                                                                                                \
+  CLANG_SUPPRESS_Wfloat_equal if (!(cond)) CLANG_PRAGMA_POP                                                        \
+  {                                                                                                                \
+    std::cerr << __FILE__ << ':' << __LINE__ << ':' << "Assertion failed: " << #cond << ": " << text << std::endl; \
+    result = EXIT_FAILURE;                                                                                         \
+  }                                                                                                                \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -216,7 +216,7 @@ itkVectorTest(int, char *[])
   b[1] = 1.0;
   b[2] = 0.0;
   c = itk::CrossProduct(a, b);
-  std::cout << "(" << a << ") cross (" << b << ") : (" << c << ")" << std::endl;
+  std::cout << '(' << a << ") cross (" << b << ") : (" << c << ')' << std::endl;
 
   using DoubleVector3 = itk::Vector<double, 3>;
   DoubleVector3 aa, bb, cc;
@@ -227,7 +227,7 @@ itkVectorTest(int, char *[])
   bb[1] = 1.0;
   bb[2] = 0.0;
   cc = itk::CrossProduct(aa, bb);
-  std::cout << "(" << aa << ") cross (" << bb << ") : (" << cc << ")" << std::endl;
+  std::cout << '(' << aa << ") cross (" << bb << ") : (" << cc << ')' << std::endl;
   DoubleVector3 ia, ib, ic;
   ia[0] = 1;
   ia[1] = 0;
@@ -236,7 +236,7 @@ itkVectorTest(int, char *[])
   ib[1] = 1;
   ib[2] = 0;
   ic = itk::CrossProduct(ia, ib);
-  std::cout << "(" << ia << ") cross (" << ib << ") : (" << ic << ")" << std::endl;
+  std::cout << '(' << ia << ") cross (" << ib << ") : (" << ic << ')' << std::endl;
   if (passed)
   {
     std::cout << "Vector test passed." << std::endl;

--- a/Modules/Core/Common/test/itkVersorTest.cxx
+++ b/Modules/Core/Common/test/itkVersorTest.cxx
@@ -146,7 +146,7 @@ RotationMatrixToVersorTest()
           if ((error_newMRtestPoint_newVRtestPoint + error_newMRtestPoint_newVRFROMMRPoint +
                error_newVRFROMMRPoint_newVRFROMMRTransformPoint) > maxAllowedPointError)
           {
-            std::cout << "(alpha,beta,gamma)= (" << alpha << "," << beta << "," << gamma << ")" << std::endl;
+            std::cout << "(alpha,beta,gamma)= (" << alpha << ',' << beta << ',' << gamma << ')' << std::endl;
 
             std::cout << newMRtestPoint << ' ' << newVRtestPoint << ' ' << newVRFROMMRPoint << ' '
                       << newVRFROMMRTransformPoint << std::endl;

--- a/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
@@ -264,7 +264,7 @@ GPUDataManager::Initialize()
 void
 GPUDataManager::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "GPUDataManager (" << this << ")" << std::endl;
+  os << indent << "GPUDataManager (" << this << ')' << std::endl;
   os << indent << "m_BufferSize: " << m_BufferSize << std::endl;
   os << indent << "m_IsGPUBufferDirty: " << m_IsGPUBufferDirty << std::endl;
   os << indent << "m_GPUBuffer: " << m_GPUBuffer << std::endl;

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -131,7 +131,7 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
     {
       std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance1))));
       std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetSplinePoles() at index: [" << i << "]" << std::endl;
+      std::cout << "Error in GetSplinePoles() at index: [" << i << ']' << std::endl;
       std::cout << "Expected: " << expectedSplinePole << std::endl;
       std::cout << " , but got: " << resultSplinePole << std::endl;
       std::cout << " Values differ by more than: " << tolerance1 << std::endl;

--- a/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
@@ -78,7 +78,7 @@ itkMeanImageFunctionTest(int, char *[])
   if (!itk::Math::FloatAlmostEqual(static_cast<FunctionType::RealType>(initialValue), mean, 10, epsilon))
   {
     std::cout.precision(static_cast<unsigned int>(itk::Math::abs(std::log10(epsilon))));
-    std::cout << "Mean value (" << mean << ") does not equal initialValue (" << initialValue << ")" << std::endl;
+    std::cout << "Mean value (" << mean << ") does not equal initialValue (" << initialValue << ')' << std::endl;
     testStatus = EXIT_FAILURE;
   }
 
@@ -93,7 +93,7 @@ itkMeanImageFunctionTest(int, char *[])
   if (!itk::Math::FloatAlmostEqual(static_cast<FunctionType::RealType>(initialValue), mean2, 10, epsilon))
   {
     std::cout.precision(static_cast<unsigned int>(itk::Math::abs(std::log10(epsilon))));
-    std::cout << "Mean value (" << mean2 << ") does not equal initialValue (" << initialValue << ")" << std::endl;
+    std::cout << "Mean value (" << mean2 << ") does not equal initialValue (" << initialValue << ')' << std::endl;
     testStatus = EXIT_FAILURE;
   }
 
@@ -108,7 +108,7 @@ itkMeanImageFunctionTest(int, char *[])
   if (!itk::Math::FloatAlmostEqual(static_cast<FunctionType::RealType>(initialValue), mean3, 10, epsilon))
   {
     std::cout.precision(static_cast<unsigned int>(itk::Math::abs(std::log10(epsilon))));
-    std::cout << "Mean value (" << mean3 << ") does not equal initialValue (" << initialValue << ")" << std::endl;
+    std::cout << "Mean value (" << mean3 << ") does not equal initialValue (" << initialValue << ')' << std::endl;
     testStatus = EXIT_FAILURE;
   }
 

--- a/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
+++ b/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
@@ -48,7 +48,7 @@ TestCellInterface(std::string name, TCell * aCell)
 {
   CellAutoPointer cell(aCell, true);
 
-  std::cout << "-------- " << name << " (" << aCell->GetNameOfClass() << ")" << std::endl;
+  std::cout << "-------- " << name << " (" << aCell->GetNameOfClass() << ')' << std::endl;
   std::cout << "    Type: " << static_cast<int>(cell->GetType()) << std::endl;
   std::cout << "    Dimension: " << cell->GetDimension() << std::endl;
   std::cout << "    NumberOfPoints: " << cell->GetNumberOfPoints() << std::endl;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
@@ -508,10 +508,10 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
     std::cout << "Indices of the quadrangle: [" << quadFace2->GetOrigin() << ' ' << quadFace2->GetLnext()->GetOrigin()
               << ' ' << quadFace2->GetLnext()->GetLnext()->GetOrigin() << ' '
               << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << ' '
-              << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << "]" << std::endl;
+              << quadFace2->GetLnext()->GetLnext()->GetLnext()->GetLnext()->GetOrigin() << ']' << std::endl;
 
     std::cout << "Correct indices should be: [" << pid[0] << ' ' << pid[2] << ' ' << pid[4] << ' ' << pid[3] << ' '
-              << pid[0] << "]" << std::endl;
+              << pid[0] << ']' << std::endl;
 
     std::cout << "Testing value for pid4" << std::endl;
     if (quadFace2->GetLnext()->GetLnext()->GetLnext()->GetOrigin() == pid[3])

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -78,7 +78,7 @@ TestCellInterface(std::string name, TCell * aCell)
   CellAutoPointer cell(aCell, true);
   const TCell *   cell2 = aCell;
 
-  std::cout << "-------- " << name << "(" << aCell->GetNameOfClass() << ")" << std::endl;
+  std::cout << "-------- " << name << '(' << aCell->GetNameOfClass() << ')' << std::endl;
   std::cout << "    Type: " << static_cast<int>(cell->GetType()) << std::endl;
   std::cout << "    Dimension: " << cell->GetDimension() << std::endl;
   std::cout << "    NumberOfPoints: " << cell->GetNumberOfPoints() << std::endl;
@@ -182,7 +182,7 @@ template <typename TCell>
 int
 TestQECellInterface(std::string name, TCell * aCell)
 {
-  std::cout << "-------- " << name << "(" << aCell->GetNameOfClass() << ")" << std::endl;
+  std::cout << "-------- " << name << '(' << aCell->GetNameOfClass() << ')' << std::endl;
 
   TCell *       cell = aCell;
   const TCell * cell2 = aCell;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
@@ -114,7 +114,7 @@ itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest(int, char *[])
   if (mesh->GetPoint(createCenterVertex->GetNewPointID()).GetValence() != 3)
   {
     std::cout << "FAILED, wrong valence of " << mesh->GetPoint(createCenterVertex->GetNewPointID()).GetValence()
-              << " for vertex " << createCenterVertex->GetNewPointID() << "." << std::endl;
+              << " for vertex " << createCenterVertex->GetNewPointID() << '.' << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << ".OK" << std::endl;
@@ -171,7 +171,7 @@ itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest(int, char *[])
   if (mesh->GetPoint(createCenterVertex->GetNewPointID()).GetValence() != 8)
   {
     std::cout << "FAILED, wrong valence of " << mesh->GetPoint(createCenterVertex->GetNewPointID()).GetValence()
-              << " for vertex " << createCenterVertex->GetNewPointID() << "." << std::endl;
+              << " for vertex " << createCenterVertex->GetNewPointID() << '.' << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << ".OK" << std::endl;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
@@ -83,7 +83,7 @@ itkQuadEdgeMeshEulerOperatorSplitVertexTest(int, char *[])
   if (mesh->GetPoint(splitVertex->GetNewPointID()).GetValence() != 4)
   {
     std::cout << "FAILED, wrong valence of " << mesh->GetPoint(splitVertex->GetNewPointID()).GetValence()
-              << " for vertex " << splitVertex->GetNewPointID() << "." << std::endl;
+              << " for vertex " << splitVertex->GetNewPointID() << '.' << std::endl;
     return EXIT_FAILURE;
   }
   if (mesh->GetPoint(11).GetValence() != 4)

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -162,7 +162,7 @@ template <unsigned int TDimension>
 void
 ArrowSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "ArrowSpatialObject(" << this << ")" << std::endl;
+  os << indent << "ArrowSpatialObject(" << this << ')' << std::endl;
   Superclass::PrintSelf(os, indent);
   os << indent << "Object Position = " << m_PositionInObjectSpace << std::endl;
   os << indent << "Object Direction = " << m_DirectionInObjectSpace << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
@@ -55,7 +55,7 @@ template <unsigned int TDimension>
 void
 BlobSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "BlobSpatialObject(" << this << ")" << std::endl;
+  os << indent << "BlobSpatialObject(" << this << ')' << std::endl;
   Superclass::PrintSelf(os, indent);
 }
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -157,7 +157,7 @@ template <unsigned int TDimension>
 void
 ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "ContourSpatialObject(" << this << ")" << std::endl;
+  os << indent << "ContourSpatialObject(" << this << ')' << std::endl;
   os << indent << "#Control Points: " << static_cast<SizeValueType>(m_ControlPoints.size()) << std::endl;
   os << indent << "Interpolation type: " << m_InterpolationMethod << std::endl;
   os << indent << "Contour closed: " << m_IsClosed << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -133,7 +133,7 @@ template <unsigned int TDimension>
 void
 EllipseSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "EllipseSpatialObject(" << this << ")" << std::endl;
+  os << indent << "EllipseSpatialObject(" << this << ')' << std::endl;
   Superclass::PrintSelf(os, indent);
   os << indent << "Object Radii: " << m_RadiusInObjectSpace << std::endl;
   os << indent << "Object Center: " << m_CenterInObjectSpace << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
@@ -56,7 +56,7 @@ template <unsigned int TDimension>
 void
 LandmarkSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "LandmarkSpatialObject(" << this << ")" << std::endl;
+  os << indent << "LandmarkSpatialObject(" << this << ')' << std::endl;
   os << indent << "ID: " << this->GetId() << std::endl;
   os << indent << "nb of points: " << static_cast<SizeValueType>(this->m_Points.size()) << std::endl;
   Superclass::PrintSelf(os, indent);

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -54,7 +54,7 @@ void
 LineSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "LineSpatialObjectPoint(" << this << ")" << std::endl;
+  os << indent << "LineSpatialObjectPoint(" << this << ')' << std::endl;
   unsigned int ii = 0;
   while (ii < TPointDimension - 1)
   {

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -228,7 +228,7 @@ template <unsigned int TDimension, class TSpatialObjectPointType>
 void
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "PointBasedSpatialObject(" << this << ")" << std::endl;
+  os << indent << "PointBasedSpatialObject(" << this << ')' << std::endl;
   os << indent << "Number of points: " << m_Points.size() << std::endl;
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -1253,7 +1253,7 @@ SpatialObject<TDimension>::GetClassNameAndDimension() const
 {
   std::ostringstream n;
 
-  n << GetNameOfClass() << "_" << TDimension;
+  n << GetNameOfClass() << '_' << TDimension;
 
   return n.str();
 }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -166,7 +166,7 @@ SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent)
   os << indent << "Position: ";
   for (unsigned int i = 1; i < TPointDimension; ++i)
   {
-    os << m_PositionInObjectSpace[i - 1] << ",";
+    os << m_PositionInObjectSpace[i - 1] << ',';
   }
   os << m_PositionInObjectSpace[TPointDimension - 1] << std::endl;
   os << indent << "ScalarDictionary: " << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -79,7 +79,7 @@ void
 SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "SurfaceSpatialObjectPoint(" << this << ")" << std::endl;
+  os << indent << "SurfaceSpatialObjectPoint(" << this << ')' << std::endl;
   os << indent << "Normal definition: ";
   os << indent << m_NormalInObjectSpace << std::endl;
 }

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -109,7 +109,7 @@ template <unsigned int TDimension, typename TTubePointType>
 void
 TubeSpatialObject<TDimension, TTubePointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "TubeSpatialObject(" << this << ")" << std::endl;
+  os << indent << "TubeSpatialObject(" << this << ')' << std::endl;
   os << indent << "End Type : " << m_EndRounded << std::endl;
   os << indent << "Parent Point : " << m_ParentPoint << std::endl;
   os << indent << "Root : " << m_Root << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -124,7 +124,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
       {
         std::cerr << "ERROR: ValueAtInWorldSpace is wrong. " << outsideIfZeroValue
                   << " << computed, but should not be very close to 0.0." << std::endl;
-        std::cerr << "     : Index=" << constIndex << "\n     : PhysicalPoint=" << point << "." << std::endl;
+        std::cerr << "     : Index=" << constIndex << "\n     : PhysicalPoint=" << point << '.' << std::endl;
         retval = EXIT_FAILURE;
         break;
       }

--- a/Modules/Core/TestKernel/include/itkGTestPredicate.h
+++ b/Modules/Core/TestKernel/include/itkGTestPredicate.h
@@ -68,7 +68,7 @@ VectorDoubleRMSPredFormat(const char * expr1,
   {
     return ::testing::AssertionFailure() << "The size of " << expr1 << " and " << expr2 << " different, where\n"
                                          << expr1 << " evaluates to " << val1 << ",\n"
-                                         << expr2 << " evaluates to " << val2 << ".";
+                                         << expr2 << " evaluates to " << val2 << '.';
   }
   double total = 0.0;
   for (unsigned int i = 0; i < val1Size; ++i)
@@ -86,7 +86,7 @@ VectorDoubleRMSPredFormat(const char * expr1,
                                        << ",\n  which exceeds " << rmsErrorExpr << ", where\n"
                                        << expr1 << " evaluates to " << val1 << ",\n"
                                        << expr2 << " evaluates to " << val2 << ", and\n"
-                                       << rmsErrorExpr << " evaluates to " << rmsError << ".";
+                                       << rmsErrorExpr << " evaluates to " << rmsError << '.';
 }
 
 } // end namespace Predicate

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -171,7 +171,7 @@ RandomImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) con
     os << m_Origin[ii] << ", ";
     ++ii;
   }
-  os << m_Origin[ii] << "]" << std::endl;
+  os << m_Origin[ii] << ']' << std::endl;
 
   os << indent << "Spacing: [";
   ii = 0;
@@ -180,7 +180,7 @@ RandomImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) con
     os << m_Spacing[ii] << ", ";
     ++ii;
   }
-  os << m_Spacing[ii] << "]" << std::endl;
+  os << m_Spacing[ii] << ']' << std::endl;
 
   os << indent << "Size: [";
   ii = 0;
@@ -189,7 +189,7 @@ RandomImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) con
     os << m_Size[ii] << ", ";
     ++ii;
   }
-  os << m_Size[ii] << "]" << std::endl;
+  os << m_Size[ii] << ']' << std::endl;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -980,7 +980,7 @@ RegressionTestBaselines(char * baselineFilename)
   while (++x)
   {
     std::ostringstream filename;
-    filename << originalBaseline << "." << x << suffix;
+    filename << originalBaseline << '.' << x << suffix;
     std::ifstream filestream(filename.str().c_str());
     if (!filestream)
     {

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -72,7 +72,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformTy
   if (VSplineOrder != 3)
   {
     std::ostringstream n;
-    n << Superclass::GetTransformTypeAsString() << "_" << VSplineOrder;
+    n << Superclass::GetTransformTypeAsString() << '_' << VSplineOrder;
     return n.str();
   }
   return Superclass::GetTransformTypeAsString();

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -659,7 +659,7 @@ CompositeTransform<TParametersValueType, VDimension>::SetParameters(const Parame
   if (inputParameters.Size() != this->GetNumberOfParameters())
   {
     itkExceptionMacro(<< "Input parameter list size is not expected size. " << inputParameters.Size() << " instead of "
-                      << this->GetNumberOfParameters() << ".");
+                      << this->GetNumberOfParameters() << '.');
   }
 
   if (transforms.size() == 1)
@@ -742,7 +742,7 @@ CompositeTransform<TParametersValueType, VDimension>::SetFixedParameters(const F
   if (inputParameters.Size() != this->GetNumberOfFixedParameters())
   {
     itkExceptionMacro(<< "Input parameter list size is not expected size. " << inputParameters.Size() << " instead of "
-                      << this->GetNumberOfFixedParameters() << ".");
+                      << this->GetNumberOfFixedParameters() << '.');
   }
   this->m_FixedParameters = inputParameters;
 

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -132,7 +132,7 @@ Euler3DTransform<TParametersValueType>::SetFixedParameters(const FixedParameters
   if (parameters.size() < InputSpaceDimension)
   {
     itkExceptionMacro(<< "Error setting fixed parameters: parameters array size (" << parameters.size()
-                      << ") is less than expected  (InputSpaceDimension = " << InputSpaceDimension << ")");
+                      << ") is less than expected  (InputSpaceDimension = " << InputSpaceDimension << ')');
   }
 
   InputPointType c;

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -459,7 +459,7 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
   if (fp.size() < VInputDimension)
   {
     itkExceptionMacro(<< "Error setting fixed parameters: parameters array size (" << fp.size()
-                      << ") is less than expected  (VInputDimension = " << VInputDimension << ")");
+                      << ") is less than expected  (VInputDimension = " << VInputDimension << ')');
   }
   this->m_FixedParameters = fp;
   InputPointType c;
@@ -520,7 +520,7 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
                       << ") is less than expected "
                       << " (VInputDimension * VOutputDimension + VOutputDimension) "
                       << " (" << VInputDimension << " * " << VOutputDimension << " + " << VOutputDimension << " = "
-                      << VInputDimension * VOutputDimension + VOutputDimension << ")");
+                      << VInputDimension * VOutputDimension + VOutputDimension << ')');
   }
 
   unsigned int par = 0;

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -116,7 +116,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetParameters(
   if (inputParameters.Size() != this->GetNumberOfParameters())
   {
     itkExceptionMacro(<< "Input parameter list size is not expected size. " << inputParameters.Size() << " instead of "
-                      << this->GetNumberOfParameters() << ".");
+                      << this->GetNumberOfParameters() << '.');
   }
 
   TransformQueueType     transforms = this->GetTransformQueue();
@@ -183,7 +183,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetFixedParame
   if (inputParameters.Size() != this->GetNumberOfFixedParameters())
   {
     itkExceptionMacro(<< "Input parameter list size is not expected size. " << inputParameters.Size() << " instead of "
-                      << this->GetNumberOfFixedParameters() << ".");
+                      << this->GetNumberOfFixedParameters() << '.');
   }
 
   /* Assumes input params are concatenation of the parameters of the

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -38,8 +38,8 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::GetTransform
 {
   std::ostringstream n;
 
-  n << GetNameOfClass() << "_" << this->GetTransformTypeAsString(static_cast<TParametersValueType *>(nullptr)) << "_"
-    << this->GetInputSpaceDimension() << "_" << this->GetOutputSpaceDimension();
+  n << GetNameOfClass() << '_' << this->GetTransformTypeAsString(static_cast<TParametersValueType *>(nullptr)) << '_'
+    << this->GetInputSpaceDimension() << '_' << this->GetOutputSpaceDimension();
   return n.str();
 }
 

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -47,7 +47,7 @@ TranslationTransform<TParametersValueType, VDimension>::SetParameters(const Para
   if (parameters.Size() < SpaceDimension)
   {
     itkExceptionMacro(<< "Error setting parameters: parameters array size (" << parameters.Size()
-                      << ") is less than expected (SpaceDimension = " << SpaceDimension << ")");
+                      << ") is less than expected (SpaceDimension = " << SpaceDimension << ')');
   }
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.

--- a/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
@@ -276,7 +276,7 @@ itkCenteredEuler3DTransformTest(int, char *[])
           approxJacobian[j][k] = approxDerivative;
           if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-5)
           {
-            std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+            std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
             std::cerr << "Result should be: " << approxDerivative << std::endl;
             std::cerr << "Reported result is: " << computedDerivative << std::endl;
             std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
@@ -352,7 +352,7 @@ itkCenteredRigid2DTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-4)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -326,7 +326,7 @@ itkEuler2DTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-4)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
@@ -316,7 +316,7 @@ itkEuler3DTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-5)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
@@ -456,7 +456,7 @@ itkQuaternionRigidTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-5)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -408,7 +408,7 @@ itkSimilarity2DTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-4)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;
@@ -567,7 +567,7 @@ itkSimilarity2DTransformTest(int, char *[])
         approxJacobian[j][k] = approxDerivative;
         if (itk::Math::abs(approxDerivative - computedDerivative) > 1e-4)
         {
-          std::cerr << "Error computing Jacobian [" << j << "][" << k << "]" << std::endl;
+          std::cerr << "Error computing Jacobian [" << j << "][" << k << ']' << std::endl;
           std::cerr << "Result should be: " << approxDerivative << std::endl;
           std::cerr << "Reported result is: " << computedDerivative << std::endl;
           std::cerr << " [ FAILED ] " << std::endl;

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -195,7 +195,7 @@ public:
   bool
   RunTests()
   {
-    std::cout << "Testing itkTransform<" << VInputDimension << "," << VOutputDimension << ">" << std::endl;
+    std::cout << "Testing itkTransform<" << VInputDimension << ',' << VOutputDimension << '>' << std::endl;
     auto transform = TransformType::New();
 
     InputPointType pnt;

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
@@ -25,7 +25,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
+  o << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
   return o;
 }
 

--- a/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
@@ -43,7 +43,7 @@ itkMRIBiasFieldCorrectionFilterTest(int, char *[])
   imageSize[0] = 30;
   imageSize[1] = 30;
   imageSize[2] = 15;
-  std::cout << "Random Test image size: " << imageSize[0] << "x" << imageSize[1] << "x" << imageSize[2] << std::endl;
+  std::cout << "Random Test image size: " << imageSize[0] << 'x' << imageSize[1] << 'x' << imageSize[2] << std::endl;
 
   imageIndex.Fill(0);
   float spacing[ImageDimension] = { 1.0, 1.0, 1.0 };

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -58,7 +58,7 @@ public:
     std::cout << "  Iteration " << filter->GetElapsedIterations() << " (of "
               << filter->GetMaximumNumberOfIterations()[filter->GetCurrentLevel()] << ").  ";
     std::cout << " Current convergence value = " << filter->GetCurrentConvergenceMeasurement()
-              << " (threshold = " << filter->GetConvergenceThreshold() << ")" << std::endl;
+              << " (threshold = " << filter->GetConvergenceThreshold() << ')' << std::endl;
   }
 };
 

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -216,7 +216,7 @@ itkParametricBlindLeastSquaresDeconvolutionImageFilterTest(int argc, char * argv
   if (itk::Math::abs(kernelSource->GetParameters()[0] - expectedSigmaX) > 1e-5)
   {
     std::cerr << "Kernel parameter[0] should have been " << expectedSigmaX << ", was "
-              << kernelSource->GetParameters()[0] << "." << std::endl;
+              << kernelSource->GetParameters()[0] << '.' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -224,7 +224,7 @@ itkParametricBlindLeastSquaresDeconvolutionImageFilterTest(int argc, char * argv
   if (itk::Math::abs(kernelSource->GetParameters()[1] - expectedSigmaY) > 1e-5)
   {
     std::cerr << "Kernel parameter[1] should have been " << expectedSigmaY << ", was "
-              << kernelSource->GetParameters()[0] << "." << std::endl;
+              << kernelSource->GetParameters()[0] << '.' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -342,7 +342,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
     }
   }
 
-  itkDebugMacro(<< "Image Intensity range: [" << m_ImageMin << "," << m_ImageMax << "], "
+  itkDebugMacro(<< "Image Intensity range: [" << m_ImageMin << ',' << m_ImageMax << "], "
                 << "IntensityRescaleInvFactor: " << m_IntensityRescaleInvFactor << " , "
                 << "KernelBandwidthMultiplicationFactor: " << m_KernelBandwidthMultiplicationFactor << " , "
                 << "KernelBandwidthSigma initialized to: " << m_KernelBandwidthSigma);

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -267,7 +267,7 @@ doDenoising(const std::string & inputFileName,
       {
         std::cout.precision(static_cast<unsigned int>(itk::Math::abs(std::log10(tolerance))));
         std::cout << "Error in GetKernelBandwidthSigma() "
-                  << "at index: [" << i << "]" << std::endl;
+                  << "at index: [" << i << ']' << std::endl;
         std::cout << "Expected value: " << expectedValue << ", but got: " << resultValue << std::endl;
         std::cout << "Test failed!" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -131,8 +131,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
         {
           std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
           std::cerr << "Test failed!" << std::endl;
-          std::cerr << "Error in gradientDirection [" << i << "]"
-                    << "[" << j << "]" << std::endl;
+          std::cerr << "Error in gradientDirection [" << i << ']' << '[' << j << ']' << std::endl;
           std::cerr << "Expected value " << gradientDirectionComponent << std::endl;
           std::cerr << " differs from " << outputComponent;
           std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -109,7 +109,7 @@ TestDisplacementJacobianDeterminantValue()
   if (itk::Math::abs(jacobianDeterminant - expectedJacobianDeterminant) > epsilon)
   {
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in pixel value at index [" << index << "]" << std::endl;
+    std::cerr << "Error in pixel value at index [" << index << ']' << std::endl;
     std::cerr << "Expected value " << jacobianDeterminant << std::endl;
     std::cerr << " differs from " << expectedJacobianDeterminant;
     std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -37,7 +37,7 @@ samePoint(const TPoint & p1, const TPoint & p2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(p1[i], p2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << "]" << std::endl;
+      std::cout << "Error at index [" << i << ']' << std::endl;
       std::cout << "Expected: "
                 << static_cast<typename itk::NumericTraits<typename TPoint::ValueType>::PrintType>(p1[i])
                 << ", but got: "
@@ -58,7 +58,7 @@ sameVector(const TVector & v1, const TVector & v2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(v1[i], v2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << "]" << std::endl;
+      std::cout << "Error at index [" << i << ']' << std::endl;
       std::cout << "Expected: "
                 << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i])
                 << ", but got: "
@@ -86,7 +86,7 @@ sameVariableVector(const TVector & v1, const TVector & v2, double epsilon = 1e-8
   {
     if (!itk::Math::FloatAlmostEqual(v1[i], v2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << "]" << std::endl;
+      std::cout << "Error at index [" << i << ']' << std::endl;
       std::cout << "Expected: "
                 << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i])
                 << ", but got: "
@@ -107,7 +107,7 @@ sameTensor(const TTensor & t1, const TTensor & t2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(t1[i], t2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << "]" << std::endl;
+      std::cout << "Error at index [" << i << ']' << std::endl;
       std::cout << "Expected: "
                 << static_cast<typename itk::NumericTraits<typename TTensor::ValueType>::PrintType>(t1[i])
                 << ", but got: "
@@ -134,7 +134,7 @@ sameArray2D(const TArray2D & a1, const TArray2D_ARG1 & a2, double epsilon = 1e-8
     {
       if (!itk::Math::FloatAlmostEqual(a1(j, i), a2(j, i), 10, epsilon))
       {
-        std::cout << "Error at index (" << j << ", " << i << ")" << std::endl;
+        std::cout << "Error at index (" << j << ", " << i << ')' << std::endl;
         std::cout << "Expected: "
                   << static_cast<typename itk::NumericTraits<typename TArray2D::element_type>::PrintType>(a1(j, i))
                   << ", but got: "
@@ -580,7 +580,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
     if (itk::Math::NotExactlyEquals(params[i], updateTruth[i]))
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in UpdateTransformParameters(...) at index [" << i << "]" << std::endl;
+      std::cout << "Error in UpdateTransformParameters(...) at index [" << i << ']' << std::endl;
       std::cout << "Expected: "
                 << static_cast<itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
                      updateTruth[i])

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
@@ -101,16 +101,16 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
     {
       while (!it2D4.IsAtEndOfLine())
       {
-        std::cout << "[";
+        std::cout << '[';
         for (unsigned int i = 0; i < 2; ++i)
         {
           std::cout << it2D4.Get()[i];
           if (i == 0)
           {
-            std::cout << ",";
+            std::cout << ',';
           }
         }
-        std::cout << "]";
+        std::cout << ']';
         std::cout << "\t";
         ++it2D4;
       }

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -141,16 +141,16 @@ test(int testIdx)
     {
       while (!it2D4.IsAtEndOfLine())
       {
-        std::cout << "[";
+        std::cout << '[';
         for (unsigned int i = 0; i < 2; ++i)
         {
           std::cout << it2D4.Get()[i];
           if (i == 0)
           {
-            std::cout << ",";
+            std::cout << ',';
           }
         }
-        std::cout << "]";
+        std::cout << ']';
         std::cout << "\t";
         ++it2D4;
       }

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
@@ -142,7 +142,7 @@ FFTWComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
   Superclass::PrintSelf(os, indent);
 
 #ifndef ITK_USE_CUFFTW
-  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ")"
+  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ')'
      << std::endl;
 #endif
 }

--- a/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.hxx
@@ -145,7 +145,7 @@ FFTWForwardFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
   Superclass::PrintSelf(os, indent);
 
 #ifndef ITK_USE_CUFFTW
-  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ")"
+  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ')'
      << std::endl;
 #endif
 }

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -157,7 +157,7 @@ FFTWHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::PrintSe
   Superclass::PrintSelf(os, indent);
 
 #ifndef ITK_USE_CUFFTW
-  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ")"
+  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ')'
      << std::endl;
 #endif
 }

--- a/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
@@ -121,7 +121,7 @@ FFTWInverseFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
   Superclass::PrintSelf(os, indent);
 
 #ifndef ITK_USE_CUFFTW
-  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ")"
+  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ')'
      << std::endl;
 #endif
 }

--- a/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -115,7 +115,7 @@ FFTWRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::PrintSe
   Superclass::PrintSelf(os, indent);
 
 #ifndef ITK_USE_CUFFTW
-  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ")"
+  os << indent << "PlanRigor: " << FFTWGlobalConfiguration::GetPlanRigorName(m_PlanRigor) << " (" << m_PlanRigor << ')'
      << std::endl;
 #endif
 }

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -184,19 +184,19 @@ HardwareWisdomFilenameGenerator::GenerateWisdomFilename(const std::string & base
 
   if (this->m_UseOSName)
   {
-    OSD << hardwareInfo.GetOSName() << "_";
+    OSD << hardwareInfo.GetOSName() << '_';
   }
   if (this->m_UseOSRelease)
   {
-    OSD << hardwareInfo.GetOSRelease() << "_";
+    OSD << hardwareInfo.GetOSRelease() << '_';
   }
   if (this->m_UseOSVersion)
   {
-    OSD << hardwareInfo.GetOSVersion() << "_";
+    OSD << hardwareInfo.GetOSVersion() << '_';
   }
   if (this->m_UseOSPlatform)
   {
-    OSD << hardwareInfo.GetOSPlatform() << "_";
+    OSD << hardwareInfo.GetOSPlatform() << '_';
   }
   if (this->m_UseOSBitSize)
   {
@@ -205,27 +205,27 @@ HardwareWisdomFilenameGenerator::GenerateWisdomFilename(const std::string & base
   }
   if (this->m_UseNumberOfProcessors)
   {
-    OSD << hardwareInfo.GetNumberOfLogicalCPU() << "x" << hardwareInfo.GetNumberOfPhysicalCPU() << "_";
+    OSD << hardwareInfo.GetNumberOfLogicalCPU() << 'x' << hardwareInfo.GetNumberOfPhysicalCPU() << '_';
   }
   if (this->m_UseVendorString)
   {
-    OSD << hardwareInfo.GetVendorString() << "_";
+    OSD << hardwareInfo.GetVendorString() << '_';
   }
   if (this->m_UseVendorID)
   {
-    OSD << hardwareInfo.GetVendorID() << "_";
+    OSD << hardwareInfo.GetVendorID() << '_';
   }
   if (this->m_UseTypeID)
   {
-    OSD << hardwareInfo.GetTypeID() << "_";
+    OSD << hardwareInfo.GetTypeID() << '_';
   }
   if (this->m_UseFamilyID)
   {
-    OSD << hardwareInfo.GetFamilyID() << "_";
+    OSD << hardwareInfo.GetFamilyID() << '_';
   }
   if (this->m_UseModelID)
   {
-    OSD << hardwareInfo.GetModelID() << "_";
+    OSD << hardwareInfo.GetModelID() << '_';
   }
   if (this->m_UseSteppingCode)
   {

--- a/Modules/Filtering/FFT/test/itkForwardInverseFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkForwardInverseFFTTest.h
@@ -50,9 +50,9 @@ ForwardInverseFullFFTTest(const char * inputFileName)
   {
     if (it.Get() > tolerance)
     {
-      std::cerr << "Error found at pixel " << it.GetIndex() << "." << std::endl;
+      std::cerr << "Error found at pixel " << it.GetIndex() << '.' << std::endl;
       std::cerr << "Absolute difference is " << it.Get() << ", which is greater than the acceptable tolerance of"
-                << tolerance << "." << std::endl;
+                << tolerance << '.' << std::endl;
       success = false;
       break;
     }
@@ -94,9 +94,9 @@ ForwardInverseHalfFFTTest(const char * inputFileName)
   {
     if (it.Get() > tolerance)
     {
-      std::cerr << "ForwardInverseHalfFFTTest: Error found at pixel " << it.GetIndex() << "." << std::endl;
+      std::cerr << "ForwardInverseHalfFFTTest: Error found at pixel " << it.GetIndex() << '.' << std::endl;
       std::cerr << "Absolute difference is " << it.Get() << ", which is greater than the acceptable tolerance of"
-                << tolerance << "." << std::endl;
+                << tolerance << '.' << std::endl;
       success = false;
       break;
     }

--- a/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
@@ -115,7 +115,7 @@ itkHalfToFullHermitianImageFilterTest(int argc, char * argv[])
       std::cerr << std::endl
                 << "Mismatch found in conjugate index " << conjugateIndex << " (original index " << index
                 << "). Expected " << std::conj(halfToFullFilter->GetOutput()->GetPixel(index)) << ", got " << it.Get()
-                << "." << std::endl;
+                << '.' << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -193,7 +193,7 @@ itkFastMarchingImageFilterRealTest1(int itkNotUsed(argc), char * itkNotUsed(argv
     {
       if (itk::Math::abs(outputValue) / distance > outputValueThreshold)
       {
-        std::cout << "Error at index [" << iterator.GetIndex() << "]" << std::endl;
+        std::cout << "Error at index [" << iterator.GetIndex() << ']' << std::endl;
         std::cout << "Expected scaled output value be less than: " << outputValueThreshold
                   << ", but got: " << itk::Math::abs(outputValue) / distance
                   << ", where output: " << itk::Math::abs(outputValue) << "; scale factor: " << distance << std::endl;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -221,7 +221,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
       {
         if (itk::Math::abs(outputValue) / distance > threshold)
         {
-          std::cout << "Error at index [" << iterator.GetIndex() << "]" << std::endl;
+          std::cout << "Error at index [" << iterator.GetIndex() << ']' << std::endl;
           std::cout << "Expected scaled output value be less than: " << threshold
                     << ", but got: " << itk::Math::abs(outputValue) / distance
                     << ", where output: " << itk::Math::abs(outputValue) << "; scale factor: " << distance << std::endl;
@@ -233,7 +233,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
     {
       if (outputValue != 0.)
       {
-        std::cout << "Error at index [" << iterator.GetIndex() << "]" << std::endl;
+        std::cout << "Error at index [" << iterator.GetIndex() << ']' << std::endl;
         std::cout << "Expected output value: " << 0. << ", but got: " << outputValue << std::endl;
         passed = false;
       }

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -161,7 +161,7 @@ runGPUGradientAnisotropicDiffusionImageFilterTest(const std::string & inFile, co
         }
         if (RMSError > RMSThreshold)
         {
-          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ")" << std::endl;
+          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ')' << std::endl;
           return EXIT_FAILURE;
         }
       }

--- a/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
@@ -150,7 +150,7 @@ runGPUNeighborhoodOperatorImageFilterTest(const std::string & inFile, const std:
         }
         if (RMSError > RMSThreshold)
         {
-          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ")" << std::endl;
+          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ')' << std::endl;
           return EXIT_FAILURE;
         }
       }

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
@@ -144,7 +144,7 @@ runGPUDiscreteGaussianImageFilterTest(const std::string & inFile, const std::str
         }
         if (RMSError > RMSThreshold)
         {
-          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ")" << std::endl;
+          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ')' << std::endl;
           return EXIT_FAILURE;
         }
       }

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
@@ -79,7 +79,7 @@ GPUBinaryThresholdImageFilter<TInputImage, TOutputImage>::GPUBinaryThresholdImag
     {
       if (ii < sz - 1)
       {
-        excpMsg << ' ' << validTypes[ii] << ",";
+        excpMsg << ' ' << validTypes[ii] << ',';
       }
       else
       {

--- a/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
@@ -145,7 +145,7 @@ runGPUBinaryThresholdImageFilterTest(const std::string & inFile, const std::stri
         }
         if (RMSError > RMSThreshold)
         {
-          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ")" << std::endl;
+          std::cout << "RMS Error exceeds threshold (" << RMSThreshold << ')' << std::endl;
           return EXIT_FAILURE;
         }
       }

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -67,7 +67,7 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5
     if (numComponents != image->GetNumberOfComponentsPerPixel())
     {
       itkExceptionMacro(<< "Primary input has " << numComponents << " numberOfComponents "
-                        << "but input " << idx << " has " << image->GetNumberOfComponentsPerPixel() << "!");
+                        << "but input " << idx << " has " << image->GetNumberOfComponentsPerPixel() << '!');
     }
   }
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -305,7 +305,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   auto         it = m_CirclesList.begin();
   while (it != m_CirclesList.end())
   {
-    os << indent << "[" << i << "]: " << *it << std::endl;
+    os << indent << '[' << i << "]: " << *it << std::endl;
     ++it;
     ++i;
   }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -376,7 +376,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::PrintSelf(s
   auto         it = m_LinesList.begin();
   while (it != m_LinesList.end())
   {
-    os << indent << "[" << i << "]: " << *it << std::endl;
+    os << indent << '[' << i << "]: " << *it << std::endl;
     ++it;
     ++i;
   }

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -98,7 +98,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::ComputeConnectivityOf
   else
   {
     itkExceptionMacro("Cannot use non-connectivity of value "
-                      << m_NonConnectivity << ", expected a value in the range 0.." << ImageDimension - 1 << ".");
+                      << m_NonConnectivity << ", expected a value in the range 0.." << ImageDimension - 1 << '.');
   }
 }
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -547,7 +547,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
     {
       std::cout << "Failure for circle #" << i << std::endl;
       std::cout << "Expected center: [" << center[i][0] << ", " << center[i][1] << "], found [" << centerResult[i][0]
-                << ", " << centerResult[i][1] << "]" << std::endl;
+                << ", " << centerResult[i][1] << ']' << std::endl;
       std::cout << "Expected radius: " << radius[i] << ", found " << radiusResult[i] << std::endl;
       success = false;
     }

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
@@ -29,7 +29,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
+  o << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
   return o;
 }
 

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -24,7 +24,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
+  o << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
   return o;
 }
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -195,7 +195,7 @@ public:
       if (it.GetLargestPositiveFrequencyIndex()[dim] != truthHalfIndex[dim])
       {
         std::cerr << "Test failed! " << std::endl;
-        std::cerr << "Error in GetLargestPositiveFrequencyIndex()[" << dim << "]" << std::endl;
+        std::cerr << "Error in GetLargestPositiveFrequencyIndex()[" << dim << ']' << std::endl;
         std::cerr << "Expected: " << truthHalfIndex << ", but got " << it.GetLargestPositiveFrequencyIndex()
                   << std::endl;
         return false;

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
@@ -27,7 +27,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::CovariantVector<float, 3> & v)
 {
-  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
+  o << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
   return o;
 }
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
@@ -25,7 +25,7 @@
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 {
-  o << "[" << v[0] << ' ' << v[1] << ' ' << v[2] << "]";
+  o << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
   return o;
 }
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -115,7 +115,7 @@ itkVectorGradientMagnitudeImageFilterTest1(int argc, char * argv[])
 
 
   std::cout << "The gradient image range was (low, high) = (" << rescale->GetInputMinimum() << ", "
-            << rescale->GetInputMaximum() << ")" << std::endl;
+            << rescale->GetInputMaximum() << ')' << std::endl;
   std::cout << "Output was scaled, shifted = " << rescale->GetScale() << ", " << rescale->GetShift() << std::endl;
 
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -119,7 +119,7 @@ itkVectorGradientMagnitudeImageFilterTest2(int argc, char * argv[])
   }
 
   std::cout << "The gradient image range was (low, high) = (" << rescale->GetInputMinimum() << ", "
-            << rescale->GetInputMaximum() << ")" << std::endl;
+            << rescale->GetInputMaximum() << ')' << std::endl;
   std::cout << "Output was scaled, shifted = " << rescale->GetScale() << ", " << rescale->GetShift() << std::endl;
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -1142,7 +1142,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::PrintSe
   os << indent << "Refined lattice coefficients: " << std::endl;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    os << indent << "[" << i << "]: " << this->m_RefinedLatticeCoefficients[i] << std::endl;
+    os << indent << '[' << i << "]: " << this->m_RefinedLatticeCoefficients[i] << std::endl;
   }
 
   itkPrintSelfObjectMacro(ResidualPointSetValues);

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -203,7 +203,7 @@ ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
   {
     os << ", " << m_OutputSpacing[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "OutputOrigin: [";
   if (ImageDimension >= 1)
@@ -214,7 +214,7 @@ ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
   {
     os << ", " << m_OutputOrigin[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "OutputDirection:" << std::endl;
   os << m_OutputDirection << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -253,7 +253,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PrintSelf(std::ost
       b += TRealValueType{ 1.0 };
     }
 
-    os << ",  X \\in [" << a << ", " << b << "]" << std::endl;
+    os << ",  X \\in [" << a << ", " << b << ']' << std::endl;
   }
 }
 } // namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -53,7 +53,7 @@ ExpandImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
   {
     os << m_ExpandFactors[j] << ", ";
   }
-  os << m_ExpandFactors[j] << "]" << std::endl;
+  os << m_ExpandFactors[j] << ']' << std::endl;
 
   os << indent << "Interpolator: ";
   os << m_Interpolator.GetPointer() << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -610,10 +610,10 @@ OrientImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   axes = m_CodeToString.find(m_DesiredCoordinateOrientation);
   os << indent << "Desired Coordinate Orientation: " << static_cast<long>(this->GetDesiredCoordinateOrientation())
-     << " (" << axes->second << ")" << std::endl;
+     << " (" << axes->second << ')' << std::endl;
   axes = m_CodeToString.find(m_GivenCoordinateOrientation);
   os << indent << "Given Coordinate Orientation: " << static_cast<long>(this->GetGivenCoordinateOrientation()) << " ("
-     << axes->second << ")" << std::endl;
+     << axes->second << ')' << std::endl;
   os << indent << "Use Image Direction: " << m_UseImageDirection << std::endl;
   os << indent << "Permute Axes: " << m_PermuteOrder << std::endl;
   os << indent << "Flip Axes: " << m_FlipAxes << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
@@ -59,7 +59,7 @@ PadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent i
   {
     os << ", " << m_PadLowerBound[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 
   os << indent << "Output Pad Upper Bounds: [";
   if (ImageDimension >= 1)
@@ -70,7 +70,7 @@ PadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent i
   {
     os << ", " << m_PadUpperBound[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 }
 
 /**

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -50,14 +50,14 @@ PermuteAxesImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) cons
   {
     os << m_Order[j] << ", ";
   }
-  os << m_Order[j] << "]" << std::endl;
+  os << m_Order[j] << ']' << std::endl;
 
   os << indent << "InverseOrder: [";
   for (j = 0; j < ImageDimension - 1; ++j)
   {
     os << m_InverseOrder[j] << ", ";
   }
-  os << m_InverseOrder[j] << "]" << std::endl;
+  os << m_InverseOrder[j] << ']' << std::endl;
 }
 
 template <typename TImage>

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -312,7 +312,7 @@ SliceImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONS
   {
     if (m_Step[i] == 0)
     {
-      itkExceptionMacro("Step size is zero " << m_Step << "!");
+      itkExceptionMacro("Step size is zero " << m_Step << '!');
     }
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -394,7 +394,7 @@ TileImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
     if (numComponents != image->GetNumberOfComponentsPerPixel())
     {
       itkExceptionMacro(<< "Primary input has " << numComponents << " numberOfComponents "
-                        << "but input " << idx << " has " << image->GetNumberOfComponentsPerPixel() << "!");
+                        << "but input " << idx << " has " << image->GetNumberOfComponentsPerPixel() << '!');
     }
   }
 }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -148,7 +148,7 @@ itkResampleImageTest7(int, char *[])
     {
       std::cout << "Pixels differ " << itNoSDI.Value() << ' ' << itSDI.Value() << std::endl;
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in pixel value at index [" << itNoSDI.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << itNoSDI.GetIndex() << ']' << std::endl;
       std::cerr << "Expected difference " << itNoSDI.Get() - itSDI.Get() << std::endl;
       std::cerr << " differs from 0 ";
       return EXIT_FAILURE;
@@ -158,7 +158,7 @@ itkResampleImageTest7(int, char *[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Iterators don't agree on end of image" << std::endl;
-    std::cerr << "at index [" << itNoSDI.GetIndex() << "]" << std::endl;
+    std::cerr << "at index [" << itNoSDI.GetIndex() << ']' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -128,7 +128,7 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
         if (itk::Math::NotAlmostEquals(value, (index[2] - 1) * 2))
         {
           std::cout << " (Error in resampled image: Pixel " << index << " = " << value << ", expecting "
-                    << (index[2] - 1) * 2 << ")" << std::endl;
+                    << (index[2] - 1) * 2 << ')' << std::endl;
           passed = false;
         }
       }
@@ -181,7 +181,7 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
         if (itk::Math::NotAlmostEquals(value, index[2]))
         {
           std::cout << " (Error in resampled image: Pixel " << index << " = " << value << ", expecting " << index[2]
-                    << ")" << std::endl;
+                    << ')' << std::endl;
           passed = false;
         }
       }

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
@@ -53,7 +53,7 @@ Clamp<TInput, TOutput>::SetBounds(const OutputType lowerBound, const OutputType 
 {
   if (lowerBound > upperBound)
   {
-    itkGenericExceptionMacro("invalid bounds: [" << lowerBound << "; " << upperBound << "]");
+    itkGenericExceptionMacro("invalid bounds: [" << lowerBound << "; " << upperBound << ']');
   }
 
   m_LowerBound = lowerBound;

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -386,7 +386,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
       pflag = true;
     }
 
-    itkDebugMacro(<< "Polyline:" << startImageIndex << "," << endImageIndex);
+    itkDebugMacro(<< "Polyline:" << startImageIndex << ',' << endImageIndex);
     LineIteratorType it(projectionImagePtr, startImageIndex, endImageIndex);
     it.GoToBegin();
 

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -57,7 +57,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
   {
     os << m_ExpandFactors[j] << ", ";
   }
-  os << m_ExpandFactors[j] << "]" << std::endl;
+  os << m_ExpandFactors[j] << ']' << std::endl;
 
   os << indent << "Interpolator: ";
   os << m_Interpolator.GetPointer() << std::endl;

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
@@ -119,7 +119,7 @@ itkAddImageFilterTest(int, char *[])
     if (!itk::Math::ExactlyEquals(oIt.Get(), expectedValue))
     {
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ']' << std::endl;
       std::cerr << "Expected: " << expectedValue << ", but got: " << oIt.Get() << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
@@ -119,7 +119,7 @@ itkDivideImageFilterTest(int, char *[])
     {
       std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ']' << std::endl;
       std::cerr << "Expected value " << expectedValue << std::endl;
       std::cerr << " differs from " << oIt.Get();
       std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
@@ -125,7 +125,7 @@ itkDivideImageFilterTest2(int, char *[])
       {
         std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
         std::cerr << "Test failed!" << std::endl;
-        std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ":" << i << "]" << std::endl;
+        std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ':' << i << ']' << std::endl;
         std::cerr << "Expected value " << expectedValue << std::endl;
         std::cerr << " differs from " << oIt.Get()[i];
         std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -369,7 +369,7 @@ itkHistogramMatchingImageFilterTest()
       passed = false; // We should never get here, and exception should have been thrown
       std::cout
         << "ERROR: Reached code that should have aborted due to thrown exception of missing ReferenceHistogram\n"
-        << __FILE__ << ":" << __LINE__ << std::endl;
+        << __FILE__ << ':' << __LINE__ << std::endl;
     }
     catch (const itk::ExceptionObject &)
     {
@@ -389,7 +389,7 @@ itkHistogramMatchingImageFilterTest()
       mismatchReferenceChoice->Update();
       passed = false; // We should never get here, and exception should have been thrown
       std::cout << "ERROR: Reached code that should have aborted due to thrown exception of missing ReferenceImage\n"
-                << __FILE__ << ":" << __LINE__ << std::endl;
+                << __FILE__ << ':' << __LINE__ << std::endl;
     }
     catch (const itk::ExceptionObject &)
     {

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -118,17 +118,17 @@ itkImageAdaptorNthElementTest(int, char *[])
   while (!it.IsAtEnd())
   {
     myIndexType index = it.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(4);
-    std::cout << it.Get()[0] << ",";
+    std::cout << it.Get()[0] << ',';
     std::cout.width(4);
-    std::cout << it.Get()[1] << ",";
+    std::cout << it.Get()[1] << ',';
     std::cout.width(4);
     std::cout << it.Get()[2] << std::endl;
     ++it;
@@ -162,11 +162,11 @@ itkImageAdaptorNthElementTest(int, char *[])
   while (!itf.IsAtEnd())
   {
     myIndexType index = itf.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);
@@ -231,11 +231,11 @@ itkImageAdaptorNthElementTest(int, char *[])
   while (!ito.IsAtEnd())
   {
     myIndexType index = ito.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);
@@ -258,11 +258,11 @@ itkImageAdaptorNthElementTest(int, char *[])
   while (!ito.IsAtEnd())
   {
     myIndexType index = ito.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);
@@ -285,11 +285,11 @@ itkImageAdaptorNthElementTest(int, char *[])
   while (!ito.IsAtEnd())
   {
     myIndexType index = ito.GetIndex();
-    std::cout << "[";
+    std::cout << '[';
     std::cout.width(3);
-    std::cout << index[0] << ",";
+    std::cout << index[0] << ',';
     std::cout.width(3);
-    std::cout << index[1] << ",";
+    std::cout << index[1] << ',';
     std::cout.width(3);
     std::cout << index[2] << "] =  ";
     std::cout.width(8);

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
@@ -84,8 +84,8 @@ itkIntensityWindowingImageFilterTest(int, char *[])
   filter->SetWindowMaximum(windowMaximum);
   ITK_TEST_SET_GET_VALUE(windowMaximum, filter->GetWindowMaximum());
 
-  std::cout << "Window minimum:maximum = " << windowMinimum << ":" << windowMaximum << ", equivalent window:level = "
-            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindow()) << ":"
+  std::cout << "Window minimum:maximum = " << windowMinimum << ':' << windowMaximum << ", equivalent window:level = "
+            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindow()) << ':'
             << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetLevel()) << std::endl;
 
   std::cout << "Gray level linear transformation scale = "
@@ -133,10 +133,10 @@ itkIntensityWindowingImageFilterTest(int, char *[])
   filter->SetWindowLevel(window, level);
 
   std::cout << "Window:level = "
-            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindow()) << ":"
+            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindow()) << ':'
             << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetLevel())
             << ", equivalent window minimum:maximum = "
-            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindowMinimum()) << ":"
+            << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindowMinimum()) << ':'
             << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(filter->GetWindowMaximum())
             << std::endl;
 

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -127,9 +127,9 @@ itkMatrixIndexSelectionImageFilterTest(int argc, char * argv[])
   if (indexA != testIndexA || indexB != testIndexB)
   {
     std::cerr << "Error " << std::endl;
-    std::cerr << " Expected indices: (" << indexA << ", " << indexB << ")" << std::endl;
+    std::cerr << " Expected indices: (" << indexA << ", " << indexB << ')' << std::endl;
     std::cerr << " differ from ";
-    std::cerr << " obtained indices: (" << testIndexA << ", " << testIndexB << ")" << std::endl;
+    std::cerr << " obtained indices: (" << testIndexA << ", " << testIndexB << ')' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
@@ -119,7 +119,7 @@ itkMultiplyImageFilterTest(int, char *[])
     {
       std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ']' << std::endl;
       std::cerr << "Expected value " << expectedValue << std::endl;
       std::cerr << " differs from " << oIt.Get();
       std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/ImageIntensity/test/itkNormalizeToConstantImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNormalizeToConstantImageFilterTest.cxx
@@ -74,7 +74,7 @@ itkNormalizeToConstantImageFilterTest(int, char *[])
   if (!itk::Math::FloatAlmostEqual(constant, sum, 10, epsilon))
   {
     std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
-    std::cout << "First sum (" << sum << ") does not equal constant (" << constant << ")" << std::endl;
+    std::cout << "First sum (" << sum << ") does not equal constant (" << constant << ')' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -94,7 +94,7 @@ itkNormalizeToConstantImageFilterTest(int, char *[])
   if (!itk::Math::FloatAlmostEqual(constant, sum, 10, epsilon))
   {
     std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
-    std::cout << "Second sum (" << sum << ") does not equal constant (" << constant << ")" << std::endl;
+    std::cout << "Second sum (" << sum << ") does not equal constant (" << constant << ')' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
@@ -118,7 +118,7 @@ itkSubtractImageFilterTest(int, char *[])
     if (!itk::Math::ExactlyEquals(oIt.Get(), expectedValue))
     {
       std::cerr << "Test failed!" << std::endl;
-      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << oIt.GetIndex() << ']' << std::endl;
       std::cerr << "Expected: " << expectedValue << ", but got: " << oIt.Get() << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
@@ -113,7 +113,7 @@ itkGaussianImageSourceTest(int argc, char * argv[])
   GaussianSourceType::ParametersType params = gaussianImage->GetParameters();
   if (params.GetSize() != 7)
   {
-    std::cerr << "Incorrect number of parameters. Expected 7, got " << params.GetSize() << "." << std::endl;
+    std::cerr << "Incorrect number of parameters. Expected 7, got " << params.GetSize() << '.' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -152,7 +152,7 @@ itkGaussianImageSourceTest(int argc, char * argv[])
   {
     std::cerr << "Sigma disagrees with parameters array." << std::endl;
     std::cerr << "Sigma: " << gaussianImage->GetSigma() << ", parameters: [" << params[0] << ", " << params[1] << ", "
-              << params[2] << "]" << std::endl;
+              << params[2] << ']' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -162,7 +162,7 @@ itkGaussianImageSourceTest(int argc, char * argv[])
   {
     std::cerr << "Mean disagrees with parameters array." << std::endl;
     std::cerr << "Mean: " << gaussianImage->GetMean() << ", parameters: [" << params[3] << ", " << params[4] << ", "
-              << params[5] << "]" << std::endl;
+              << params[5] << ']' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -344,20 +344,20 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   std::cout << "The basis of projection is: " << std::endl;
   for (const auto & basis_it : basis_check)
   {
-    std::cout << "[";
+    std::cout << '[';
     InputImageIterator basisImage_it(basis_it, basis_it->GetBufferedRegion());
     for (basisImage_it.GoToBegin(); !basisImage_it.IsAtEnd(); ++basisImage_it)
     {
       std::cout << basisImage_it.Get() << ' ';
     }
-    std::cout << "]" << std::endl;
+    std::cout << ']' << std::endl;
   }
 
   // Print the projections
-  std::cout << "The projection of [0 2 2 0] is [" << proj3 << "]" << std::endl;
+  std::cout << "The projection of [0 2 2 0] is [" << proj3 << ']' << std::endl;
   std::cout << "this should be approx [-1.5412 -2.3716]" << std::endl;
 
-  std::cout << "The projection of [0 3 3 0] is [" << proj4 << "]" << std::endl;
+  std::cout << "The projection of [0 3 3 0] is [" << proj4 << ']' << std::endl;
   std::cout << "this should be approx [3.5574 -2.3119]" << std::endl;
 
   // Print the basis and projections: now the new basis
@@ -365,26 +365,26 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   std::cout << "Now the basis of projection is: " << std::endl;
   for (const auto & basis_it : basis_check_2)
   {
-    std::cout << "[";
+    std::cout << '[';
     InputImageIterator basisImage_it(basis_it, basis_it->GetBufferedRegion());
     for (basisImage_it.GoToBegin(); !basisImage_it.IsAtEnd(); ++basisImage_it)
     {
       std::cout << basisImage_it.Get() << ' ';
     }
-    std::cout << "]" << std::endl;
+    std::cout << ']' << std::endl;
   }
 
   // Print the projections
-  std::cout << "The projection of [0 2 2 0] is [" << proj3_2 << "]" << std::endl;
+  std::cout << "The projection of [0 2 2 0] is [" << proj3_2 << ']' << std::endl;
   std::cout << "this should be approx [1.4142 -1.4142 0]" << std::endl;
 
-  std::cout << "The projection of [0 3 3 0] is [" << proj4_2 << "]" << std::endl;
+  std::cout << "The projection of [0 3 3 0] is [" << proj4_2 << ']' << std::endl;
   std::cout << "this should be approx [2.1213 2.1213 3.000]" << std::endl;
 
-  std::cout << "The projection of [0 2 2 0] is (mean of zero set) [" << proj3_3 << "]" << std::endl;
+  std::cout << "The projection of [0 2 2 0] is (mean of zero set) [" << proj3_3 << ']' << std::endl;
   std::cout << "this should be approx [1.4142 -1.4142 0]" << std::endl;
 
-  std::cout << "The projection of [0 3 3 0] is (mean of zero set) [" << proj4_3 << "]" << std::endl;
+  std::cout << "The projection of [0 3 3 0] is (mean of zero set) [" << proj4_3 << ']' << std::endl;
   std::cout << "this should be approx [2.1213 2.1213 3.000]" << std::endl;
 
   // Test for the eigen values for the test case precomputed using Matlab

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
@@ -182,7 +182,7 @@ itkImagePCAShapeModelEstimatorTest(int, char *[])
   std::cout << "The mean image is:" << std::endl;
   while (!outImageIt.IsAtEnd())
   {
-    std::cout << static_cast<double>(outImageIt.Get()) << ";" << std::endl;
+    std::cout << static_cast<double>(outImageIt.Get()) << ';' << std::endl;
     ++outImageIt;
   }
   std::cout << "  " << std::endl;
@@ -198,7 +198,7 @@ itkImagePCAShapeModelEstimatorTest(int, char *[])
     std::cout << "The eigen vector number: " << j << " is:" << std::endl;
     while (!outImage2It.IsAtEnd())
     {
-      std::cout << static_cast<double>(outImage2It.Get()) << ";" << std::endl;
+      std::cout << static_cast<double>(outImage2It.Get()) << ';' << std::endl;
       ++outImage2It;
     }
     std::cout << "  " << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -120,7 +120,7 @@ BinaryShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, In
      << std::endl;
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
@@ -124,7 +124,7 @@ BinaryShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent 
      << std::endl;
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -124,7 +124,7 @@ BinaryStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(s
      << std::endl;
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
@@ -127,7 +127,7 @@ BinaryStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::o
      << std::endl;
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -127,7 +127,7 @@ LabelMap<TLabelObject>::GetLabelObject(const LabelType & label) -> LabelObjectTy
   if (it == m_LabelObjectContainer.end())
   {
     itkExceptionMacro(<< "No label object with label "
-                      << static_cast<typename NumericTraits<LabelType>::PrintType>(label) << ".");
+                      << static_cast<typename NumericTraits<LabelType>::PrintType>(label) << '.');
   }
 
   return it->second;
@@ -147,7 +147,7 @@ LabelMap<TLabelObject>::GetLabelObject(const LabelType & label) const -> const L
   if (it == m_LabelObjectContainer.end())
   {
     itkExceptionMacro(<< "No label object with label "
-                      << static_cast<typename NumericTraits<LabelType>::PrintType>(label) << ".");
+                      << static_cast<typename NumericTraits<LabelType>::PrintType>(label) << '.');
   }
 
   return it->second;
@@ -379,7 +379,7 @@ LabelMap<TLabelObject>::GetLabelObject(const IndexType & idx) const -> LabelObje
       return it->second.GetPointer();
     }
   }
-  itkExceptionMacro(<< "No label object at index " << idx << ".");
+  itkExceptionMacro(<< "No label object at index " << idx << '.');
   //   return nullptr;
 }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
@@ -114,7 +114,7 @@ LabelShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, Ind
      << std::endl;
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
@@ -114,7 +114,7 @@ LabelShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
      << std::endl;
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
@@ -117,7 +117,7 @@ LabelStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(st
      << std::endl;
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
@@ -117,7 +117,7 @@ LabelStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::os
      << std::endl;
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.hxx
@@ -54,7 +54,7 @@ ShapeKeepNObjectsLabelMapFilter<TImage>::PrintSelf(std::ostream & os, Indent ind
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
@@ -53,7 +53,7 @@ ShapeOpeningLabelMapFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) 
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Lambda: " << m_Lambda << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.hxx
@@ -56,7 +56,7 @@ ShapePositionLabelMapFilter<TImage>::PrintSelf(std::ostream & os, Indent indent)
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
@@ -111,7 +111,7 @@ ShapeRelabelImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.hxx
@@ -47,7 +47,7 @@ ShapeRelabelLabelMapFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) 
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.hxx
@@ -47,7 +47,7 @@ ShapeUniqueLabelMapFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) c
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
@@ -114,7 +114,7 @@ StatisticsRelabelImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::ostream
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ")"
+  os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -114,7 +114,7 @@ itkLabelImageToLabelMapFilterTest(int, char *[])
       index[1] = ctrJ;
       unsigned long val;
       val = map->GetPixel(index);
-      std::cout << "Pixel[" << ctrI << "," << ctrJ << "]: " << val << std::endl;
+      std::cout << "Pixel[" << ctrI << ',' << ctrJ << "]: " << val << std::endl;
       if (((ctrI == 5) || (ctrJ == 5)) && (ctrI != 7) && (ctrJ != 7))
       {
         itkAssertOrThrowMacro((val == 1), "Error in Label Image (foreground).");

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
@@ -121,8 +121,8 @@ itkLabelObjectTest(int argc, char * argv[])
 
   while (!it1.IsAtEnd())
   {
-    std::cout << it1.GetLine().GetIndex() << "-" << it1.GetLine().GetLength() << "    ";
-    std::cout << it2.GetLine().GetIndex() << "-" << it2.GetLine().GetLength();
+    std::cout << it1.GetLine().GetIndex() << '-' << it1.GetLine().GetLength() << "    ";
+    std::cout << it2.GetLine().GetIndex() << '-' << it2.GetLine().GetLength();
     std::cout << std::endl;
     if (it1.GetLine().GetIndex() != it2.GetLine().GetIndex() || it1.GetLine().GetLength() != it2.GetLine().GetLength())
     {
@@ -189,7 +189,7 @@ itkLabelObjectTest(int argc, char * argv[])
     }
     if (!lo->HasIndex(idxs[i]))
     {
-      std::cerr << "label object should have the index " << idxs[i] << "!" << std::endl;
+      std::cerr << "label object should have the index " << idxs[i] << '!' << std::endl;
       return EXIT_FAILURE;
     }
   }
@@ -200,7 +200,7 @@ itkLabelObjectTest(int argc, char * argv[])
   idx[2] = 10;
   if (lo->HasIndex(idx))
   {
-    std::cerr << "label object shouldn't have the index " << idx << "!" << std::endl;
+    std::cerr << "label object shouldn't have the index " << idx << '!' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
@@ -88,7 +88,7 @@ itkShiftLabelObjectTest(int argc, char * argv[])
       index[1] = ctrJ;
       unsigned long val;
       val = map->GetPixel(index);
-      std::cout << "Pixel[" << ctrI << "," << ctrJ << "]: " << val << std::endl;
+      std::cout << "Pixel[" << ctrI << ',' << ctrJ << "]: " << val << std::endl;
       if ((ctrI == 5) || (ctrJ == 5))
       {
         itkAssertOrThrowMacro((val == 1), "Error in Label Image (foreground).");

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -252,7 +252,7 @@ ComputeAreaError(const SEType & k, unsigned int thickness)
   std::cout << "Expected foreground area: " << expectedForegroundArea << std::endl;
   std::cout << "Computed foreground area: " << computedForegroundArea << std::endl;
   std::cout << "Foreground area error: "
-            << 100 * itk::Math::abs(expectedForegroundArea - computedForegroundArea) / expectedForegroundArea << "%"
+            << 100 * itk::Math::abs(expectedForegroundArea - computedForegroundArea) / expectedForegroundArea << '%'
             << "\n\n";
 
   return EXIT_FAILURE;

--- a/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
@@ -53,16 +53,16 @@ itkChainCodePath2DTest(int, char *[])
   offset[1] = -1;
   path->InsertStep(5, offset); // insert new step 5 = 5
   offset = path->Evaluate(5);
-  std::cout << "Inserted new step[5] of 5 = (" << offset[0] << "," << offset[1] << ")" << std::endl;
+  std::cout << "Inserted new step[5] of 5 = (" << offset[0] << ',' << offset[1] << ')' << std::endl;
 
   path->ChangeStep(8, 3); // rotate the second 4 (now step 8) up to a 3
   offset = path->Evaluate(8);
-  std::cout << "Changed step[8] to 3 = (" << offset[0] << "," << offset[1] << ")" << std::endl;
+  std::cout << "Changed step[8] to 3 = (" << offset[0] << ',' << offset[1] << ')' << std::endl;
 
 
   path->ChangeStep(6, offset); // rotate the second 4 (now step 8) up to a 3
   offset = path->Evaluate(6);
-  std::cout << "Changed step[6] to = (" << offset[0] << "," << offset[1] << ")" << std::endl;
+  std::cout << "Changed step[6] to = (" << offset[0] << ',' << offset[1] << ')' << std::endl;
 
 
   std::cout << "Path is " << path->NumberOfSteps() << " steps: \"" << path->GetChainCodeAsString() << "\"."
@@ -74,7 +74,7 @@ itkChainCodePath2DTest(int, char *[])
 
 
   index = path->GetStart();
-  std::cout << "Starting at index (" << index[0] << "," << index[1] << ")" << std::endl;
+  std::cout << "Starting at index (" << index[0] << ',' << index[1] << ')' << std::endl;
   for (unsigned int input = 0;;)
   {
     offset = path->IncrementInput(input);
@@ -82,8 +82,8 @@ itkChainCodePath2DTest(int, char *[])
     {
       index = path->EvaluateToIndex(input);
 
-      std::cout << "Step[" << input - 1 << "] is (" << offset[0] << "," << offset[1] << ")";
-      std::cout << "\t to index (" << index[0] << "," << index[1] << ")" << std::endl;
+      std::cout << "Step[" << input - 1 << "] is (" << offset[0] << ',' << offset[1] << ')';
+      std::cout << "\t to index (" << index[0] << ',' << index[1] << ')' << std::endl;
     }
     else
     {

--- a/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
@@ -52,7 +52,7 @@ HilbertPathTestHelper(unsigned int maxHilbertPathOder)
       if (d != path->EvaluateInverse(index))
       {
         std::cerr << "Test failed!" << std::endl;
-        std::cerr << "Incorrect match-up for path index (" << d << ") and multi-dimensional index (" << index << ")"
+        std::cerr << "Incorrect match-up for path index (" << d << ") and multi-dimensional index (" << index << ')'
                   << std::endl;
         testStatus = EXIT_FAILURE;
       }
@@ -67,7 +67,7 @@ HilbertPathTestHelper(unsigned int maxHilbertPathOder)
       if (d != path->EvaluateInverse(index))
       {
         std::cerr << "Test failed!" << std::endl;
-        std::cerr << "Incorrect match-up for path index (" << d << ") and multi-dimensional index (" << index << ")"
+        std::cerr << "Incorrect match-up for path index (" << d << ") and multi-dimensional index (" << index << ')'
                   << std::endl;
         testStatus = EXIT_FAILURE;
       }

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -87,7 +87,7 @@ itkPathFunctionsTest(int, char *[])
   pixelIndex[0] = 32;
   pixelIndex[1] = 32;
   storedValue = image->GetPixel(pixelIndex);
-  std::cout << "The pixel at index (" << pixelIndex[0] << "," << pixelIndex[1] << ") has the value " << storedValue
+  std::cout << "The pixel at index (" << pixelIndex[0] << ',' << pixelIndex[1] << ") has the value " << storedValue
             << ".\n"
             << std::endl;
 

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -82,7 +82,7 @@ itkPathIteratorTest(int, char *[])
   pixelIndex[0] = 32;
   pixelIndex[1] = 32;
   storedValue = image->GetPixel(pixelIndex);
-  std::cout << "The pixel at index (" << pixelIndex[0] << "," << pixelIndex[1] << ") has the value " << storedValue
+  std::cout << "The pixel at index (" << pixelIndex[0] << ',' << pixelIndex[1] << ") has the value " << storedValue
             << ".\n"
             << std::endl;
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -81,7 +81,7 @@ InPlaceTest(char * inputFilename, bool normalizeAcrossScale, typename TFilter::S
       std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error in pixel value at index [" << std::endl;
-      std::cerr << "Error in pixel value at index [" << it1.GetIndex() << "]" << std::endl;
+      std::cerr << "Error in pixel value at index [" << it1.GetIndex() << ']' << std::endl;
       std::cerr << "Expected value " << it1.Get() << std::endl;
       std::cerr << " differs from " << it2.Get();
       std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
@@ -150,7 +150,7 @@ itkBinaryThresholdSpatialFunctionTest(int, char *[])
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error at index: " << index << std::endl;
       std::cout << "Point value: " << value << " is not within thresholds [" << lowerThreshold << ", " << upperThreshold
-                << "]" << std::endl;
+                << ']' << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
@@ -80,11 +80,11 @@ itkOtsuMultipleThresholdsCalculatorTest2(int, char *[])
     std::cout << thresholdCount << " thresholds:";
     for (unsigned long j = 0; j < thresholdCount; ++j)
     {
-      std::cout << ' ' << thMid[j] << "(" << thMax[j] << ")";
+      std::cout << ' ' << thMid[j] << '(' << thMax[j] << ')';
       if (thMax[j] <= thMid[j])
       {
         passed = false;
-        std::cout << "*";
+        std::cout << '*';
       }
     }
     std::cout << std::endl;

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -942,7 +942,7 @@ BMPImageIO::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "ColorPalette:" << std::endl;
     for (unsigned int i = 0; i < m_ColorPalette.size(); ++i)
     {
-      os << indent << "[" << i << "]" << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
+      os << indent << '[' << i << ']' << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
          << std::endl;
     }
   }

--- a/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
@@ -139,7 +139,7 @@ itkBMPImageIOTestPalette(int argc, char * argv[])
       std::cout << "Palette: " << std::endl;
       for (unsigned int i = 0; i < palette.size(); ++i)
       {
-        std::cout << "[" << i << "]:" << palette[i] << std::endl;
+        std::cout << '[' << i << "]:" << palette[i] << std::endl;
       }
     }
     else

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -907,7 +907,7 @@ DCMTKFileReader::GetElementUI(const unsigned short group,
   auto * uiItem = dynamic_cast<DcmUniqueIdentifier *>(el);
   if (uiItem == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't convert data item " << group << "," << entry);
+    DCMTKExceptionOrErrorReturn(<< "Can't convert data item " << group << ',' << entry);
   }
   OFString ofString;
   if (uiItem->getOFStringArray(ofString, false) != EC_Normal)

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -276,7 +276,7 @@ DCMTKImageIO::Read(void * buffer)
   this->OpenDicomImage();
   if (m_DImage->getStatus() != EIS_Normal)
   {
-    itkExceptionMacro(<< "Error: cannot load DICOM image (" << DicomImage::getString(m_DImage->getStatus()) << ")");
+    itkExceptionMacro(<< "Error: cannot load DICOM image (" << DicomImage::getString(m_DImage->getStatus()) << ')');
   }
 
   m_Dimensions[0] = static_cast<unsigned int>(m_DImage->getWidth());

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
@@ -58,7 +58,7 @@ itkDCMTKImageIONoPreambleTest(int argc, char * argv[])
 
   InputImageType::SizeType extentSize;
   extentSize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
-  std::cout << "Read image dimensions: (" << extentSize[0] << ", " << extentSize[1] << ", " << extentSize[2] << ")"
+  std::cout << "Read image dimensions: (" << extentSize[0] << ", " << extentSize[1] << ", " << extentSize[2] << ')'
             << std::endl;
   if (extentSize[0] == 0 || extentSize[1] == 0 || extentSize[2] == 0)
   {

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
@@ -66,7 +66,7 @@ itkGDCMImageIONoPreambleTest(int argc, char * argv[])
 
   InputImageType::SizeType extentSize;
   extentSize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
-  std::cout << "Read image dimensions: (" << extentSize[0] << ", " << extentSize[1] << ", " << extentSize[2] << ")"
+  std::cout << "Read image dimensions: (" << extentSize[0] << ", " << extentSize[1] << ", " << extentSize[2] << ')'
             << std::endl;
   if (extentSize[0] == 0 || extentSize[1] == 0 || extentSize[2] == 0)
   {

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -197,7 +197,7 @@ HDF5ReadWriteTest2(const char * fileName)
     const TPixel origValue(idx[2] * 100 + idx[1] * 10 + idx[0]);
     if (itk::Math::NotAlmostEquals(it.Get(), origValue))
     {
-      std::cout << "Original Pixel (" << origValue << ") doesn't match read-in Pixel (" << it.Get() << ")" << std::endl;
+      std::cout << "Original Pixel (" << origValue << ") doesn't match read-in Pixel (" << it.Get() << ')' << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -281,7 +281,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
         if (slice > m_MetaDataDictionaryArray->size() - 1)
         {
           itkExceptionMacro("The slice number: " << slice + 1 << " exceeds the size of the MetaDataDictionaryArray "
-                                                 << m_MetaDataDictionaryArray->size() << ".");
+                                                 << m_MetaDataDictionaryArray->size() << '.');
         }
         DictionaryRawPointer dictionary = (*m_MetaDataDictionaryArray)[slice];
         m_ImageIO->SetMetaDataDictionary((*dictionary));

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -323,7 +323,7 @@ ImageIOBase::GetPixelSize() const
 {
   if (m_ComponentType == IOComponentEnum::UNKNOWNCOMPONENTTYPE || m_PixelType == IOPixelEnum::UNKNOWNPIXELTYPE)
   {
-    itkExceptionMacro("Unknown pixel or component type: (" << m_PixelType << ", " << m_ComponentType << ")");
+    itkExceptionMacro("Unknown pixel or component type: (" << m_PixelType << ", " << m_ComponentType << ')');
   }
 
   return this->GetComponentSize() * this->GetNumberOfComponents();

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -62,7 +62,7 @@ NumericSeriesFileNames::GetFileNames()
     {
       std::stringstream message_cache;
       message_cache << "The filename is too long for temp buffer."
-                    << " Truncated form: " << temp.get() << "." << std::endl
+                    << " Truncated form: " << temp.get() << '.' << std::endl
                     << "nchars: " << nchars << " bufflen: " << bufflen << " result: " << result;
       itkExceptionMacro(<< message_cache.str());
     }

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -103,7 +103,7 @@ ActualTest(std::string inputFileName,
   std::ostringstream outputFileNameStream;
   outputFileNameStream << outputFileNameBase << streamWriting;
   outputFileNameStream << pasteWriting << compressWriting;
-  outputFileNameStream << "." << outputFileNameExtension;
+  outputFileNameStream << '.' << outputFileNameExtension;
   std::string outputFileName = outputFileNameStream.str();
 
   std::cout << "Writing to File: " << outputFileName << std::endl;

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -179,7 +179,7 @@ itkImageIOBaseTest(int, char *[])
         if (componentTypeString.compare(listComponentTypeString[i]) != 0)
         {
           std::cerr << "GetComponentTypeAsString(" << listComponentType[i] << ") should return '"
-                    << listComponentTypeString[i] << "'" << std::endl;
+                    << listComponentTypeString[i] << '\'' << std::endl;
           return EXIT_FAILURE;
         }
       }
@@ -189,7 +189,7 @@ itkImageIOBaseTest(int, char *[])
         if (pixelTypeString.compare(listIOPixelTypeString[i]) != 0)
         {
           std::cerr << "GetPixelTypeAsString(" << listIOPixelType[i] << ") should return '" << listIOPixelTypeString[i]
-                    << "'" << std::endl;
+                    << '\'' << std::endl;
           return EXIT_FAILURE;
         }
       }
@@ -227,7 +227,7 @@ itkImageIOBaseTest(int, char *[])
         if (componentTypeString.compare(listComponentTypeString[i]) != 0)
         {
           std::cerr << "GetComponentTypeAsString(" << listComponentType[i] << ") should return '"
-                    << listComponentTypeString[i] << "'" << std::endl;
+                    << listComponentTypeString[i] << '\'' << std::endl;
           return EXIT_FAILURE;
         }
       }

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -93,8 +93,8 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     {
       std::cout << "voxelunitstr.size()=" << voxelunitstr.size() << std::endl;
       std::cout << "metadatastr.size()=" << metadatastr.size() << std::endl;
-      std::cout << "voxelunitstr=|" << voxelunitstr << "|" << std::endl;
-      std::cout << "metadatastr=|" << metadatastr << "|" << std::endl;
+      std::cout << "voxelunitstr=|" << voxelunitstr << '|' << std::endl;
+      std::cout << "metadatastr=|" << metadatastr << '|' << std::endl;
       ++numWrongMetaData;
     }
   }
@@ -110,8 +110,8 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     {
       std::cout << "datestr.size()=" << datestr.size() << std::endl;
       std::cout << "metadatastr.size()=" << metadatastr.size() << std::endl;
-      std::cout << "datestr=|" << datestr << "|" << std::endl;
-      std::cout << "metadatastr=|" << metadatastr << "|" << std::endl;
+      std::cout << "datestr=|" << datestr << '|' << std::endl;
+      std::cout << "metadatastr=|" << metadatastr << '|' << std::endl;
       ++numWrongMetaData;
     }
   }
@@ -127,8 +127,8 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     {
       std::cout << "timestr.size()=" << timestr.size() << std::endl;
       std::cout << "metadatastr.size()=" << metadatastr.size() << std::endl;
-      std::cout << "timestr=|" << timestr << "|" << std::endl;
-      std::cout << "metadatastr=|" << metadatastr << "|" << std::endl;
+      std::cout << "timestr=|" << timestr << '|' << std::endl;
+      std::cout << "metadatastr=|" << metadatastr << '|' << std::endl;
       ++numWrongMetaData;
     }
   }
@@ -144,8 +144,8 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     {
       std::cout << "patientstr.size()=" << patientstr.size() << std::endl;
       std::cout << "metadatastr.size()=" << metadatastr.size() << std::endl;
-      std::cout << "patientstr=|" << patientstr << "|" << std::endl;
-      std::cout << "metadatastr=|" << metadatastr << "|" << std::endl;
+      std::cout << "patientstr=|" << patientstr << '|' << std::endl;
+      std::cout << "metadatastr=|" << metadatastr << '|' << std::endl;
       ++numWrongMetaData;
     }
   }

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -410,7 +410,7 @@ MRCHeaderObject::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "vd: " << this->m_Header.vd1 << ' ' << this->m_Header.vd2 << std::endl;
   os << indent << "tiltangles: (" << this->m_Header.tiltangles[0] << ", " << this->m_Header.tiltangles[1] << ", "
      << this->m_Header.tiltangles[2] << ") (" << this->m_Header.tiltangles[3] << ", " << this->m_Header.tiltangles[4]
-     << ", " << this->m_Header.tiltangles[5] << ")" << std::endl;
+     << ", " << this->m_Header.tiltangles[5] << ')' << std::endl;
   os << indent << "org: " << this->m_Header.xorg << ' ' << this->m_Header.yorg << ' ' << this->m_Header.zorg
      << std::endl;
   os << indent << "cmap: \"" << this->m_Header.cmap[0] << this->m_Header.cmap[1] << this->m_Header.cmap[2]
@@ -436,13 +436,13 @@ MRCHeaderObject::PrintSelf(std::ostream & os, Indent indent) const
        << std::endl;
     for (int32_t z = 0; z < this->m_Header.nz && z < 1024; ++z)
     {
-      os << indent << "(" << this->m_ExtendedFeiHeader[z].atilt << ", " << this->m_ExtendedFeiHeader[z].btilt << ", "
+      os << indent << '(' << this->m_ExtendedFeiHeader[z].atilt << ", " << this->m_ExtendedFeiHeader[z].btilt << ", "
          << this->m_ExtendedFeiHeader[z].xstage << ", " << this->m_ExtendedFeiHeader[z].ystage << ", "
          << this->m_ExtendedFeiHeader[z].zstage << ", " << this->m_ExtendedFeiHeader[z].xshift << ", "
          << this->m_ExtendedFeiHeader[z].yshift << ", " << this->m_ExtendedFeiHeader[z].defocus << ", "
          << this->m_ExtendedFeiHeader[z].exptime << ", " << this->m_ExtendedFeiHeader[z].meanint << ", "
          << this->m_ExtendedFeiHeader[z].tiltaxis << ", " << this->m_ExtendedFeiHeader[z].pixelsize << ", "
-         << this->m_ExtendedFeiHeader[z].magnification << ")" << std::endl;
+         << this->m_ExtendedFeiHeader[z].magnification << ')' << std::endl;
     }
   }
 }

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -91,7 +91,7 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
     writer->SetImageIO(mrcIO);
 
     std::ostringstream m_NameWithIndex;
-    m_NameWithIndex << filePrefix << "_" << m_CallNumber << ".mrc";
+    m_NameWithIndex << filePrefix << '_' << m_CallNumber << ".mrc";
 
     std::ostringstream m_OutputFileName;
 
@@ -116,7 +116,7 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
     // otherwise, add / and the name
     else
     {
-      m_OutputFileName << outputPath << "/" << m_NameWithIndex.str();
+      m_OutputFileName << outputPath << '/' << m_NameWithIndex.str();
     }
 #endif
 
@@ -158,7 +158,7 @@ MRCImageIOTester<TImageType>::Read(const std::string & filePrefix, std::string &
 
     // construct the image filename
     std::ostringstream m_NameWithIndex;
-    m_NameWithIndex << filePrefix << "_" << index << ".mrc";
+    m_NameWithIndex << filePrefix << '_' << index << ".mrc";
 
     std::ostringstream m_OutputFileName;
 
@@ -183,7 +183,7 @@ MRCImageIOTester<TImageType>::Read(const std::string & filePrefix, std::string &
     // otherwise, add / and the name
     else
     {
-      m_OutputFileName << outputPath << "/" << m_NameWithIndex.str();
+      m_OutputFileName << outputPath << '/' << m_NameWithIndex.str();
     }
 #endif
     reader->SetFileName(m_OutputFileName.str());

--- a/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
@@ -78,7 +78,7 @@ Test(const std::string & inFileName, const std::string & outFileName, const std:
 
         std::string tagvalue = entryvalue->GetMetaDataObjectValue();
 
-        std::cout << "(" << key << ") ";
+        std::cout << '(' << key << ") ";
         std::cout << " = " << tagvalue << std::endl;
       }
     }

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -834,7 +834,7 @@ NiftiImageIO::Read(void * buffer)
     if (this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT)
     {
       itkExceptionMacro(<< "RAS conversion requires pixel to be 3-component vector or point. Current pixel type is "
-                        << numComponents << "-component " << this->GetPixelType() << ".");
+                        << numComponents << "-component " << this->GetPixelType() << '.');
     }
     switch (this->m_ComponentType)
     {
@@ -912,7 +912,7 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
     std::ostringstream dim;
     dim << nim->dim[idx];
     std::ostringstream dimKey;
-    dimKey << "dim[" << idx << "]";
+    dimKey << "dim[" << idx << ']';
     EncapsulateMetaData<std::string>(thisDic, dimKey.str(), dim.str());
   }
 
@@ -949,7 +949,7 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
     std::ostringstream pixdim;
     pixdim << nim->pixdim[idx];
     std::ostringstream pixdimKey;
-    pixdimKey << "pixdim[" << idx << "]";
+    pixdimKey << "pixdim[" << idx << ']';
     EncapsulateMetaData<std::string>(thisDic, pixdimKey.str(), pixdim.str());
   }
 
@@ -2419,7 +2419,7 @@ NiftiImageIO::Write(const void * buffer)
       if (this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT)
       {
         itkExceptionMacro(<< "RAS conversion requires pixel to be 3-component vector or point. Current pixel type is "
-                          << numComponents << "-component " << this->GetPixelType() << ".");
+                          << numComponents << "-component " << this->GetPixelType() << '.');
       }
       switch (this->m_ComponentType)
       {

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -196,7 +196,7 @@ MakeNiftiImage()
         qform_temp != "NIFTI_XFORM_SCANNER_ANAT")
     {
       std::cerr << "ERROR: qform code not recovered from file properly: 'NIFTI_XFORM_SCANNER_ANAT' != ." << qform_temp
-                << "'" << std::endl;
+                << '\'' << std::endl;
       return EXIT_FAILURE;
     }
     std::string sform_temp = "";
@@ -204,13 +204,13 @@ MakeNiftiImage()
         sform_temp != "NIFTI_XFORM_SCANNER_ANAT")
     {
       std::cerr << "ERROR: sform code not recovered from file properly:  'NIFTI_XFORM_SCANNER_ANAT' != '" << sform_temp
-                << "'" << std::endl;
+                << '\'' << std::endl;
       return EXIT_FAILURE;
     }
     std::string auxfile_temp = "";
     if (!itk::ExposeMetaData<std::string>(thisDic, "aux_file", auxfile_temp) || auxfile_temp != "aux_info.txt")
     {
-      std::cerr << "ERROR: aux_file not recovered from file properly:  'aux_info.txt' != '" << auxfile_temp << "'"
+      std::cerr << "ERROR: aux_file not recovered from file properly:  'aux_info.txt' != '" << auxfile_temp << '\''
                 << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -286,7 +286,7 @@ NrrdImageIO::ReadImageInformation()
 
       // don't use macro so that we can free err
       std::ostringstream message;
-      message << "itk::ERROR: " << this->GetNameOfClass() << "(" << this << "): "
+      message << "itk::ERROR: " << this->GetNameOfClass() << '(' << this << "): "
               << "ReadImageInformation: Error reading " << this->GetFileName() << ":\n"
               << err;
       ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -298,7 +298,7 @@ PNGImageIO::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "ColorPalette:" << std::endl;
     for (unsigned int i = 0; i < m_ColorPalette.size(); ++i)
     {
-      os << indent << "[" << i << "]" << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
+      os << indent << '[' << i << ']' << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
          << std::endl;
     }
   }

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -124,7 +124,7 @@ itkPNGImageIOTest(int argc, char * argv[])
     std::cout << "Palette: " << std::endl;
     for (unsigned int i = 0; i < palette.size(); ++i)
     {
-      std::cout << "[" << i << "]:" << palette[i] << std::endl;
+      std::cout << '[' << i << "]:" << palette[i] << std::endl;
     }
   }
   else

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -169,7 +169,7 @@ itkPNGImageIOTest2(int argc, char * argv[])
     std::cout << "PaletteType: " << std::endl;
     for (unsigned int i = 0; i < palette.size(); ++i)
     {
-      std::cout << "[" << i << "]:" << palette[i] << std::endl;
+      std::cout << '[' << i << "]:" << palette[i] << std::endl;
     }
   }
   else

--- a/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
@@ -211,7 +211,7 @@ itkPNGImageIOTestPalette(int argc, char * argv[])
     {
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Read and written palette don't have the same size ( " << palette_read.size() << " vs "
-                << palette_written.size() << ")" << std::endl;
+                << palette_written.size() << ')' << std::endl;
       return EXIT_FAILURE;
     }
     bool   palette_equal = true;

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -186,7 +186,7 @@ TIFFImageIO::Read(void * buffer)
   {
     if (!this->CanReadFile(m_FileName.c_str()))
     {
-      itkExceptionMacro(<< "Cannot open file " << this->m_FileName << "!");
+      itkExceptionMacro(<< "Cannot open file " << this->m_FileName << '!');
     }
   }
 
@@ -255,7 +255,7 @@ TIFFImageIO::PrintSelf(std::ostream & os, Indent indent) const
        << "\n";
     for (size_t i = 0; i < m_ColorPalette.size(); ++i)
     {
-      os << indent << "[" << i << "]" << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
+      os << indent << '[' << i << ']' << itk::NumericTraits<PaletteType::value_type>::PrintType(m_ColorPalette[i])
          << std::endl;
     }
   }
@@ -340,7 +340,7 @@ TIFFImageIO::ReadImageInformation()
   {
     if (!this->CanReadFile(m_FileName.c_str()))
     {
-      itkExceptionMacro(<< "Cannot open file " << this->m_FileName << "!");
+      itkExceptionMacro(<< "Cannot open file " << this->m_FileName << '!');
     }
   }
 
@@ -1189,7 +1189,7 @@ TIFFImageIO::ReadTIFFTags()
       continue;
     }
 
-    itkDebugMacro(<< "TiffInfo tag " << field_name << "(" << tag << "): " << itkTIFFFieldDataType(field) << ' '
+    itkDebugMacro(<< "TiffInfo tag " << field_name << '(' << tag << "): " << itkTIFFFieldDataType(field) << ' '
                   << value_count << ' ' << raw_data);
 
 

--- a/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
@@ -46,21 +46,21 @@ itkTIFFImageIOInfoTest(int argc, char * argv[])
   {
     std::cout << tiffImageIO->GetDimensions(d) << ' ';
   }
-  std::cout << ")" << std::endl;
+  std::cout << ')' << std::endl;
 
   std::cout << "Origin: ( ";
   for (unsigned int d = 0; d < tiffImageIO->GetNumberOfDimensions(); ++d)
   {
     std::cout << tiffImageIO->GetOrigin(d) << ' ';
   }
-  std::cout << ")" << std::endl;
+  std::cout << ')' << std::endl;
 
   std::cout << "Spacing: ( ";
   for (unsigned int d = 0; d < tiffImageIO->GetNumberOfDimensions(); ++d)
   {
     std::cout << tiffImageIO->GetSpacing(d) << ' ';
   }
-  std::cout << ")" << std::endl;
+  std::cout << ')' << std::endl;
 
   using DictionaryType = itk::MetaDataDictionary;
   using MetaDataStringType = itk::MetaDataObject<std::string>;

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
@@ -29,7 +29,7 @@ printPalette(std::vector<T> palette)
 {
   for (unsigned int i = 0; i < palette.size(); ++i)
   {
-    std::cout << "[" << i << "]:" << palette[i] << std::endl;
+    std::cout << '[' << i << "]:" << palette[i] << std::endl;
   }
 }
 
@@ -211,7 +211,7 @@ itkTIFFImageIOTestPalette(int argc, char * argv[])
     {
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Read and written palette don't have the same size ( " << palette_read.size() << " vs "
-                << palette_written.size() << ")" << std::endl;
+                << palette_written.size() << ')' << std::endl;
       return EXIT_FAILURE;
     }
     bool   palette_equal = true;

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -494,7 +494,7 @@ const std::string
 GetTransformName(int i)
 {
   std::stringstream s;
-  s << HDF5CommonPathNames::transformGroupName << "/" << i;
+  s << HDF5CommonPathNames::transformGroupName << '/' << i;
   return s.str();
 }
 

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -589,7 +589,7 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
   os << "MNI Transform File" << std::endl;
   os << std::endl;
   os << "Transform_Type = Grid_Transform;" << std::endl;
-  os << "Displacement_Volume = " << transform_grid_file << ";" << std::endl;
+  os << "Displacement_Volume = " << transform_grid_file << ';' << std::endl;
   os << "Transform_Type = Linear;" << std::endl;
 
   os << "Linear_Transform =" << std::endl;

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -40,7 +40,7 @@ public:
   SetupFileName(const std::string & filePrefix, const std::string & fileExtension, std::string & outputPath)
   {
     std::ostringstream m_NameWithIndex;
-    m_NameWithIndex << filePrefix << "_" << m_CallNumber << "." << fileExtension;
+    m_NameWithIndex << filePrefix << '_' << m_CallNumber << '.' << fileExtension;
 
     std::ostringstream m_OutputFileName;
 
@@ -64,7 +64,7 @@ public:
     // otherwise, add / and the name
     else
     {
-      m_OutputFileName << outputPath << "/" << m_NameWithIndex.str();
+      m_OutputFileName << outputPath << '/' << m_NameWithIndex.str();
     }
 #endif
 

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -178,12 +178,12 @@ TestStreamWrite(char * file1, unsigned int numberOfStreams = 0)
   if (!imagesEqual)
   {
     std::cout << "[FAILED] writing (" << componentType << ", dim = " << TDimension
-              << ", numberOfStreams = " << numberOfStreams << ")" << std::endl;
+              << ", numberOfStreams = " << numberOfStreams << ')' << std::endl;
     return EXIT_FAILURE;
   }
 
   std::cout << "[PASSED] writing (" << componentType << ", dim = " << TDimension
-            << ", numberOfStreams = " << numberOfStreams << ")" << std::endl;
+            << ", numberOfStreams = " << numberOfStreams << ')' << std::endl;
   return EXIT_SUCCESS;
 }
 
@@ -273,12 +273,12 @@ TestStreamRead(char * file1, unsigned int numberOfStreams = 0)
   if (!imagesEqual)
   {
     std::cout << "[FAILED] reading (" << componentType << ", dim = " << TDimension
-              << ", numberOfStreams = " << numberOfStreams << ")" << std::endl;
+              << ", numberOfStreams = " << numberOfStreams << ')' << std::endl;
     return EXIT_FAILURE;
   }
 
   std::cout << "[PASSED] reading (" << componentType << ", dim = " << TDimension
-            << ", numberOfStreams = " << numberOfStreams << ")" << std::endl;
+            << ", numberOfStreams = " << numberOfStreams << ')' << std::endl;
   return EXIT_SUCCESS;
 }
 

--- a/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
@@ -49,7 +49,7 @@ DOMNodeXMLWriter::Update(std::ostream & os, std::string indent)
   }
 
   // write the start tag name
-  os << indent << "<" << input->GetName();
+  os << indent << '<' << input->GetName();
 
   // write the "id" attribute if it is present
   std::string id = input->GetID();
@@ -74,7 +74,7 @@ DOMNodeXMLWriter::Update(std::ostream & os, std::string indent)
   if (!children.empty())
   {
     // write the closing bracket for the start tag
-    os << ">" << std::endl;
+    os << '>' << std::endl;
     // write the children
     for (auto & i : children)
     {
@@ -83,7 +83,7 @@ DOMNodeXMLWriter::Update(std::ostream & os, std::string indent)
       this->SetInput(input);
     }
     // write the end tag
-    os << indent << "</" << input->GetName() << ">" << std::endl;
+    os << indent << "</" << input->GetName() << '>' << std::endl;
   }
   else
   {

--- a/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
@@ -72,7 +72,7 @@ protected:
       return;
     }
 
-    std::cout << static_cast<int>(100 * reconstructor->GetProgress()) << "%" << std::endl;
+    std::cout << static_cast<int>(100 * reconstructor->GetProgress()) << '%' << std::endl;
   }
 };
 

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -195,7 +195,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     if (varReturned[i] != varChanged[i])
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetVariance() at index [" << i << "]" << std::endl;
+      std::cout << "Error in GetVariance() at index [" << i << ']' << std::endl;
       std::cout << "Expected: " << varChanged[i] << ", but got: " << varReturned[i] << std::endl;
       return EXIT_FAILURE;
     }
@@ -214,7 +214,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     if (itk::Math::NotAlmostEquals(varReturned[i], itk::Math::pi))
     {
       std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetVariance() at index [" << i << "]" << std::endl;
+      std::cout << "Error in GetVariance() at index [" << i << ']' << std::endl;
       std::cout << "Expected: " << itk::Math::pi << ", but got: " << varReturned[i] << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -96,14 +96,14 @@ public:
     itk::TimeProbe timer;
 
     timer.Start();
-    std::cout << "/" << std::flush;
+    std::cout << '/' << std::flush;
 
     ITK_TRY_EXPECT_NO_EXCEPTION(fractalFilter->Update());
 
-    std::cout << "/" << std::flush;
+    std::cout << '/' << std::flush;
     timer.Stop();
 
-    std::cout << "   (elapsed time: " << timer.GetMean() << ")" << std::endl;
+    std::cout << "   (elapsed time: " << timer.GetMean() << ')' << std::endl;
 
     using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -450,7 +450,7 @@ FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(const char * file
 {
   std::ostringstream buf;
 
-  buf << "Index of " << moreDescription << " out of bounds (" << index1 << ")";
+  buf << "Index of " << moreDescription << " out of bounds (" << index1 << ')';
   SetDescription(buf.str().c_str());
 }
 
@@ -464,7 +464,7 @@ FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(const char * file
 {
   std::ostringstream buf;
 
-  buf << "Index out of bounds (" << index1 << "," << index2 << ")";
+  buf << "Index out of bounds (" << index1 << ',' << index2 << ')';
   SetDescription(buf.str().c_str());
 }
 

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -283,7 +283,7 @@ PrintK1(Solver2DType * S, int s)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl << "k" << s << "=[";
+  std::cout << std::endl << 'k' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     std::cout << " [";
@@ -301,7 +301,7 @@ PrintK1(Solver2DType * S, int s)
     }
     else
     {
-      std::cout << "]";
+      std::cout << ']';
     }
   }
   std::cout << "];" << std::endl;
@@ -313,7 +313,7 @@ PrintF1(Solver2DType * S, int s)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl << "f" << s << "=[";
+  std::cout << std::endl << 'f' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     if (j > 0)
@@ -338,7 +338,7 @@ PrintNodalCoordinates1(Solver2DType * S, int w)
   {
     std::cout << " [";
     std::cout << S->GetInput()->GetNode(i)->GetCoordinates();
-    std::cout << "]";
+    std::cout << ']';
   }
   std::cout << "];" << std::endl;
 }

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -259,7 +259,7 @@ PrintK1(SolverType * S, int s)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl << "k" << s << "=[";
+  std::cout << std::endl << 'k' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     std::cout << " [";
@@ -277,7 +277,7 @@ PrintK1(SolverType * S, int s)
     }
     else
     {
-      std::cout << "]";
+      std::cout << ']';
     }
   }
   std::cout << "];" << std::endl;
@@ -289,7 +289,7 @@ PrintF1(SolverType * S, int s)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl << "f" << s << "=[";
+  std::cout << std::endl << 'f' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     if (j > 0)
@@ -314,7 +314,7 @@ PrintNodalCoordinates1(SolverType * S, int w)
   {
     std::cout << " [";
     std::cout << S->GetInput()->GetNode(i)->GetCoordinates();
-    std::cout << "]";
+    std::cout << ']';
   }
   std::cout << "];" << std::endl;
 }

--- a/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
@@ -391,7 +391,7 @@ PrintK(itk::fem::Solver & S, int s, char)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S.GetLinearSystemWrapper();
 
-  std::cout << std::endl << "k" << s << "=[";
+  std::cout << std::endl << 'k' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     if (IDL_OUTPUT)
@@ -414,7 +414,7 @@ PrintK(itk::fem::Solver & S, int s, char)
       }
       else
       {
-        std::cout << "]";
+        std::cout << ']';
       }
     }
     else if (MATLAB_OUTPUT)
@@ -443,7 +443,7 @@ PrintF(itk::fem::Solver & S, int s, char)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S.GetLinearSystemWrapper();
 
-  std::cout << std::endl << "f" << s << "=[";
+  std::cout << std::endl << 'f' << s << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     if (j > 0)
@@ -485,7 +485,7 @@ PrintNodalCoordinates(itk::fem::Solver & S, int w, char comment)
       // changes made - kiran
       else
       {
-        std::cout << "]";
+        std::cout << ']';
       }
     }
     else if (MATLAB_OUTPUT)
@@ -501,7 +501,7 @@ PrintU(itk::fem::Solver & S, int s, char comment)
 // Prints the components of the problem for debugging/reporting purposes
 {
   std::cout << std::endl << comment << "Displacements: " << std::endl;
-  std::cout << "u" << s << "=[";
+  std::cout << 'u' << s << "=[";
   // changes made - kiran
   // for( itk::fem::Solver::NodeArray::iterator n = S.node.begin();
   // n!=S.node.end(); n++) {
@@ -533,7 +533,7 @@ PrintU(itk::fem::Solver & S, int s, char comment)
       // changes made - kiran
       else
       {
-        std::cout << "]";
+        std::cout << ']';
       }
     }
     else if (MATLAB_OUTPUT)
@@ -562,7 +562,7 @@ CheckDisplacements(itk::fem::Solver & S, int s, char comment, double * expectedR
       if (itk::Math::abs(result - expectedResults[index]) > tolerance)
       {
         std::cout << "Error: Result (" << result << ") expected (" << expectedResults[index] << ") with tolerance ("
-                  << tolerance << ")" << std::endl;
+                  << tolerance << ')' << std::endl;
         foundError = true;
       }
       index++;

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -31,9 +31,7 @@ PrintK(FEMSolverType * S)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl
-            << "k"
-            << "=[";
+  std::cout << std::endl << 'k' << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     std::cout << " [";
@@ -51,7 +49,7 @@ PrintK(FEMSolverType * S)
     }
     else
     {
-      std::cout << "]";
+      std::cout << ']';
     }
   }
   std::cout << "];" << std::endl;
@@ -63,9 +61,7 @@ PrintF(FEMSolverType * S)
 {
   itk::fem::LinearSystemWrapper::Pointer lsw = S->GetLinearSystemWrapper();
 
-  std::cout << std::endl
-            << "f"
-            << "=[";
+  std::cout << std::endl << 'f' << "=[";
   for (unsigned int j = 0; j < lsw->GetSystemOrder(); ++j)
   {
     if (j > 0)
@@ -91,7 +87,7 @@ PrintNodalCoordinates(FEMSolverType * S)
   {
     std::cout << " [";
     std::cout << S->GetInput()->GetNode(i)->GetCoordinates();
-    std::cout << "]";
+    std::cout << ']';
   }
   std::cout << "];" << std::endl;
 }
@@ -141,7 +137,7 @@ PrintSolution(FEMSolverType * S)
 
   for (int i = 0; i < numberOfNodes; ++i)
   {
-    std::cout << "Solution Node " << i << ":";
+    std::cout << "Solution Node " << i << ':';
     for (unsigned int d = 0, dof; (dof = S->GetInput()->GetNode(i)->GetDegreeOfFreedom(d)) != invalidID; ++d)
     {
       std::cout << ' ' << S->GetSolution(dof);

--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
@@ -96,7 +96,7 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
   vnl_vector<unsigned int> testNumberOfElements = meshFilter->GetNumberOfElements();
   for (unsigned int i = 0; i < 2; ++i)
   {
-    std::cout << "Pixels per Element Test " << i << ":";
+    std::cout << "Pixels per Element Test " << i << ':';
     if (testPixelsPerElement[i] != pixelsPerElement[i])
     {
       std::cout << " [FAILED]" << std::endl;
@@ -109,7 +109,7 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
       std::cout << " [PASSED]" << std::endl;
     }
 
-    std::cout << "Number Of Elements Test " << i << ":";
+    std::cout << "Number Of Elements Test " << i << ':';
     if (testNumberOfElements[i] != numberOfElements[i])
     {
       std::cout << " [FAILED]" << std::endl;
@@ -203,9 +203,9 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
         (itk::Math::abs(femObject->GetNode(nodeNumber)->GetCoordinates()[1] - loc[1]) > tolerance))
     {
       std::cout << "[FAILED]" << std::endl;
-      std::cout << "\tExpected (" << loc[0] << "," << loc[1] << "), Got (";
-      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[0] << ",";
-      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[1] << ")" << std::endl;
+      std::cout << "\tExpected (" << loc[0] << ',' << loc[1] << "), Got (";
+      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[0] << ',';
+      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[1] << ')' << std::endl;
       foundError = true;
     }
     else
@@ -232,12 +232,12 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
         (femObject->GetElement(elementNumber)->GetNode(3)->GetGlobalNumber() != nodes[3]))
     {
       std::cout << "[FAILED]" << std::endl;
-      std::cout << "\tExpected (" << nodes[0] << "," << nodes[0] << "," << nodes[1];
-      std::cout << "," << nodes[2] << "," << nodes[3] << "), Got (";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(0)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(1)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(2)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(3)->GetGlobalNumber() << ")" << std::endl;
+      std::cout << "\tExpected (" << nodes[0] << ',' << nodes[0] << ',' << nodes[1];
+      std::cout << ',' << nodes[2] << ',' << nodes[3] << "), Got (";
+      std::cout << femObject->GetElement(elementNumber)->GetNode(0)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(1)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(2)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(3)->GetGlobalNumber() << ')' << std::endl;
       foundError = true;
     }
     else

--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
@@ -99,7 +99,7 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
   vnl_vector<unsigned int> testNumberOfElements = meshFilter->GetNumberOfElements();
   for (unsigned int i = 0; i < 3; ++i)
   {
-    std::cout << "Pixels per Element Test " << i << ":";
+    std::cout << "Pixels per Element Test " << i << ':';
     if (testPixelsPerElement[i] != pixelsPerElement[i])
     {
       std::cout << " [FAILED]" << std::endl;
@@ -112,7 +112,7 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
       std::cout << " [PASSED]" << std::endl;
     }
 
-    std::cout << "Number Of Elements Test " << i << ":";
+    std::cout << "Number Of Elements Test " << i << ':';
     if (testNumberOfElements[i] != numberOfElements[i])
     {
       std::cout << " [FAILED]" << std::endl;
@@ -210,10 +210,10 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
         (itk::Math::abs(femObject->GetNode(nodeNumber)->GetCoordinates()[2] - loc[2]) > tolerance))
     {
       std::cout << "[FAILED]" << std::endl;
-      std::cout << "\tExpected (" << loc[0] << "," << loc[1] << "," << loc[2] << "), Got (";
-      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[0] << ",";
-      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[1] << ",";
-      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[2] << ")" << std::endl;
+      std::cout << "\tExpected (" << loc[0] << ',' << loc[1] << ',' << loc[2] << "), Got (";
+      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[0] << ',';
+      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[1] << ',';
+      std::cout << femObject->GetNode(nodeNumber)->GetCoordinates()[2] << ')' << std::endl;
       foundError = true;
     }
     else
@@ -248,17 +248,17 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
         (femObject->GetElement(elementNumber)->GetNode(7)->GetGlobalNumber() != nodes[7]))
     {
       std::cout << "[FAILED]" << std::endl;
-      std::cout << "\tExpected (" << nodes[0] << "," << nodes[0] << "," << nodes[1];
-      std::cout << "," << nodes[2] << "," << nodes[3] << "," << nodes[4] << ",";
-      std::cout << nodes[5] << "," << nodes[6] << "," << nodes[7] << "), Got (";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(0)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(1)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(2)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(3)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(4)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(5)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(6)->GetGlobalNumber() << ",";
-      std::cout << femObject->GetElement(elementNumber)->GetNode(7)->GetGlobalNumber() << ")" << std::endl;
+      std::cout << "\tExpected (" << nodes[0] << ',' << nodes[0] << ',' << nodes[1];
+      std::cout << ',' << nodes[2] << ',' << nodes[3] << ',' << nodes[4] << ',';
+      std::cout << nodes[5] << ',' << nodes[6] << ',' << nodes[7] << "), Got (";
+      std::cout << femObject->GetElement(elementNumber)->GetNode(0)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(1)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(2)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(3)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(4)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(5)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(6)->GetGlobalNumber() << ',';
+      std::cout << femObject->GetElement(elementNumber)->GetNode(7)->GetGlobalNumber() << ')' << std::endl;
       foundError = true;
     }
     else

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -68,7 +68,7 @@ ExhaustiveOptimizer::StartWalking()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size() << ", but the NumberOfParameters is "
-                      << spaceDimension << ".");
+                      << spaceDimension << '.');
   }
 
   // Setup first grid position.

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -160,7 +160,7 @@ GradientDescentOptimizer::AdvanceOneStep()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << '.');
   }
 
   DerivativeType transformedGradient(spaceDimension);

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -36,7 +36,7 @@ InitializationBiasedParticleSwarmOptimizer::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
   os << "Acceleration coefficients [inertia, personal, global, initialization]: ";
-  os << "[" << this->m_InertiaCoefficient << ", " << this->m_PersonalCoefficient << ", ";
+  os << '[' << this->m_InertiaCoefficient << ", " << this->m_PersonalCoefficient << ", ";
   os << this->m_GlobalCoefficient << ", " << this->m_InitializationCoefficient << "]\n";
 }
 

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -130,7 +130,7 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << '.');
   }
 
   A.set_identity();

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -39,7 +39,7 @@ ParticleSwarmOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << "Acceleration coefficients [inertia, personal, global]: ";
-  os << "[" << this->m_InertiaCoefficient << ", " << this->m_PersonalCoefficient << ", ";
+  os << '[' << this->m_InertiaCoefficient << ", " << this->m_PersonalCoefficient << ", ";
   os << this->m_GlobalCoefficient << "]\n";
 }
 

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -146,7 +146,7 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 
   Superclass::PrintSelf(os, indent);
   os << indent << "Create swarm using [normal, uniform] distribution: ";
-  os << "[" << this->m_InitializeNormalDistribution << ", ";
+  os << '[' << this->m_InitializeNormalDistribution << ", ";
   os << !this->m_InitializeNormalDistribution << "]\n";
   os << indent << "Number of particles in swarm: " << this->m_NumberOfParticles << "\n";
   os << indent << "Maximal number of iterations: " << this->m_MaximalNumberOfIterations << "\n";
@@ -157,7 +157,7 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Parameter bounds: [";
   for (it = this->m_ParameterBounds.begin(); it != end; ++it)
   {
-    os << " [" << it->first << ", " << it->second << "]";
+    os << " [" << it->first << ", " << it->second << ']';
   }
   os << " ]\n";
   os << indent << "Parameters' convergence tolerance: " << this->m_ParametersConvergenceTolerance;

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -479,7 +479,7 @@ PowellOptimizer::StartOptimization()
     {
       m_StopConditionDescription << "Cost function values at the current parameter (" << fx
                                  << ") and at the local extrema (" << fp << ") are within Value Tolerance ("
-                                 << m_ValueTolerance << ")";
+                                 << m_ValueTolerance << ')';
       this->InvokeEvent(EndEvent());
       return;
     }

--- a/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
@@ -36,7 +36,7 @@ QuaternionRigidTransformGradientDescentOptimizer::AdvanceOneStep()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size() << ", but the NumberOfParameters is "
-                      << spaceDimension << ".");
+                      << spaceDimension << '.');
   }
 
   DerivativeType transformedGradient(spaceDimension);

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -164,7 +164,7 @@ RegularStepGradientDescentBaseOptimizer::AdvanceOneStep()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << '.');
   }
 
   for (unsigned int i = 0; i < spaceDimension; ++i)

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -300,7 +300,7 @@ SPSAOptimizer::GenerateDelta(const unsigned int spaceDimension)
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << '.');
   }
 
   const ScalesType & invScales = this->GetInverseScales();

--- a/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
@@ -96,9 +96,9 @@ public:
     derivative = DerivativeType(SpaceDimension);
     derivative[0] = 3 * x + 2 * y - 2;
     derivative[1] = 2 * x + 6 * y + 8;
-    std::cout << "(";
+    std::cout << '(';
     std::cout << derivative[0] << " , ";
-    std::cout << derivative[1] << ")" << std::endl;
+    std::cout << derivative[1] << ')' << std::endl;
   }
 
   unsigned int
@@ -238,8 +238,8 @@ itkConjugateGradientOptimizerTest(int, char *[])
   finalPosition = itkOptimizer->GetCurrentPosition();
 
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   bool   pass = true;
   double trueParameters[2] = { 2, -2 };

--- a/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
@@ -228,8 +228,8 @@ itkExhaustiveOptimizerTest(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetMinimumMetricValuePosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   bool                       visitedIndicesPass = true;
   std::vector<unsigned long> visitedIndices = idxObserver->m_VisitedIndices;

--- a/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
@@ -165,8 +165,8 @@ itkFRPROptimizerTest(int, char *[])
 
     ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
     std::cout << "Solution        = (";
-    std::cout << finalPosition[0] << ",";
-    std::cout << finalPosition[1] << ")" << std::endl;
+    std::cout << finalPosition[0] << ',';
+    std::cout << finalPosition[1] << ')' << std::endl;
 
     //
     // check results to see if it is within range
@@ -220,8 +220,8 @@ itkFRPROptimizerTest(int, char *[])
 
     ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
     std::cout << "Solution        = (";
-    std::cout << finalPosition[0] << ",";
-    std::cout << finalPosition[1] << ")" << std::endl;
+    std::cout << finalPosition[0] << ',';
+    std::cout << finalPosition[1] << ')' << std::endl;
 
     //
     // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
@@ -173,8 +173,8 @@ itkGradientDescentOptimizerTest(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
@@ -98,9 +98,9 @@ public:
     derivative = DerivativeType(SpaceDimension);
     derivative[0] = 3 * x + 2 * y - 2;
     derivative[1] = 2 * x + 6 * y + 8;
-    std::cout << "(";
+    std::cout << '(';
     std::cout << derivative[0] << " , ";
-    std::cout << derivative[1] << ")" << std::endl;
+    std::cout << derivative[1] << ')' << std::endl;
   }
 
 
@@ -270,7 +270,7 @@ itkLBFGSBOptimizerTest(int, char *[])
 
   const OptimizerType::ParametersType & finalPosition = itkOptimizer->GetCurrentPosition();
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "Final Function Value = " << itkOptimizer->GetValue() << std::endl;
 
   std::cout << "Infinity Norm of Projected Gradient = " << itkOptimizer->GetInfinityNormOfProjectedGradient()

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -94,9 +94,9 @@ public:
     derivative = DerivativeType(SpaceDimension);
     derivative[0] = 3 * x + 2 * y - 2;
     derivative[1] = 2 * x + 6 * y + 8;
-    std::cout << "(";
+    std::cout << '(';
     std::cout << derivative[0] << " , ";
-    std::cout << derivative[1] << ")" << std::endl;
+    std::cout << derivative[1] << ')' << std::endl;
   }
 
 
@@ -212,7 +212,7 @@ itkLBFGSOptimizerTest(int, char *[])
   OptimizerType::ParametersType finalPosition;
   finalPosition = itkOptimizer->GetCurrentPosition();
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
 
   std::cout << "End condition   = " << itkOptimizer->GetStopConditionDescription() << std::endl;
 

--- a/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
@@ -364,9 +364,9 @@ itkRunLevenbergMarquardOptimization(bool   useGradient,
   finalPosition = optimizer->GetCurrentPosition();
 
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ",";
-  std::cout << finalPosition[2] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ',';
+  std::cout << finalPosition[2] << ')' << std::endl;
 
 
   //

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -227,8 +227,8 @@ itkOnePlusOneEvolutionaryOptimizerTest(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
@@ -177,8 +177,8 @@ itkPowellOptimizerTest(int argc, char * argv[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
@@ -162,8 +162,8 @@ itkRegularStepGradientDescentOptimizerTest(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range
@@ -206,8 +206,8 @@ itkRegularStepGradientDescentOptimizerTest(int, char *[])
 
     finalPosition = itkOptimizer->GetCurrentPosition();
     std::cout << "Solution        = (";
-    std::cout << finalPosition[0] << ",";
-    std::cout << finalPosition[1] << ")" << std::endl;
+    std::cout << finalPosition[0] << ',';
+    std::cout << finalPosition[1] << ')' << std::endl;
 
     //
     // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -210,8 +210,8 @@ itkSPSAOptimizerTest(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   std::cout << "StateOfConvergence in last iteration: " << itkOptimizer->GetStateOfConvergence() << std::endl;
   std::cout << "NumberOfIterations: " << itkOptimizer->GetCurrentIteration() << std::endl;

--- a/Modules/Numerics/Optimizers/test/itkVersorRigid3DTransformOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkVersorRigid3DTransformOptimizerTest.cxx
@@ -312,14 +312,14 @@ itkVersorRigid3DTransformOptimizerTest(int, char *[])
   }
   finalRotation.Set(finalRightPart);
   std::cout << std::endl;
-  std::cout << "Solution versor  = (" << finalRotation << ")" << std::endl;
+  std::cout << "Solution versor  = (" << finalRotation << ')' << std::endl;
 
   VersorType::VectorType finalTranslation;
   for (unsigned int j = 0; j < spaceDimensions; ++j)
   {
     finalTranslation[j] = finalPosition[j + spaceDimensions];
   }
-  std::cout << "Solution vector  = (" << finalTranslation << ")" << std::endl;
+  std::cout << "Solution vector  = (" << finalTranslation << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizers/test/itkVersorTransformOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkVersorTransformOptimizerTest.cxx
@@ -256,7 +256,7 @@ itkVersorTransformOptimizerTest(int, char *[])
     finalRightPart[i] = finalPosition[i];
   }
   finalRotation.Set(finalRightPart);
-  std::cout << "Solution        = (" << finalRotation << ")" << std::endl;
+  std::cout << "Solution        = (" << finalRotation << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
@@ -109,7 +109,7 @@ protected:
     auto it = this->m_EnergyValues.begin();
     while (it != this->m_EnergyValues.end())
     {
-      os << "(" << it - this->m_EnergyValues.begin() << "): " << *it << ' ';
+      os << '(' << it - this->m_EnergyValues.begin() << "): " << *it << ' ';
       ++it;
     }
     os << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -76,7 +76,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::StartWalking()
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size() << ", but the NumberOfParameters is "
-                      << spaceDimension << ".");
+                      << spaceDimension << '.');
   }
 
   // Setup first grid position.

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -127,7 +127,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
         {
           this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::CONVERGENCE_CHECKER_PASSED;
           this->m_StopConditionDescription << "Convergence checker passed at iteration " << this->m_CurrentIteration
-                                           << ".";
+                                           << '.';
           this->StopOptimization();
           break;
         }

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -137,7 +137,7 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
   if (scales.size() != spaceDimension)
   {
     itkExceptionMacro(<< "The size of Scales is " << scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << spaceDimension << '.');
   }
 
   A.set_identity();

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -473,7 +473,7 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
     {
       m_StopConditionDescription << "Cost function values at the current parameter (" << fx
                                  << ") and at the local extrema (" << fp << ") are within Value Tolerance ("
-                                 << m_ValueTolerance << ")";
+                                 << m_ValueTolerance << ')';
       this->InvokeEvent(EndEvent());
       return;
     }

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -130,7 +130,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::AdvanceOneStep()
                                      << " iterations since"
                                      << " there is no progress in the last " << m_MaximumIterationsWithoutProgress
                                      << " steps." << std::endl
-                                     << " The best value is from Iteration " << m_BestIteration << ".";
+                                     << " The best value is from Iteration " << m_BestIteration << '.';
     this->StopOptimization();
     return;
   }

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
@@ -84,7 +84,7 @@ RegularStepGradientDescentOptimizerv4<TInternalComputationValueType>::AdvanceOne
   if (this->m_Scales.size() != this->m_Gradient.Size())
   {
     itkExceptionMacro(<< "The size of Scales is " << this->m_Scales.size()
-                      << ", but the NumberOfParameters for the CostFunction is " << this->m_Gradient.Size() << ".");
+                      << ", but the NumberOfParameters for the CostFunction is " << this->m_Gradient.Size() << '.');
   }
 
   if (this->m_RelaxationFactor < 0.0)

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -178,8 +178,8 @@ ConjugateGradientLineSearchOptimizerv4RunTest(itk::ConjugateGradientLineSearchOp
   using ParametersType = ConjugateGradientLineSearchOptimizerv4TestMetric::ParametersType;
   ParametersType finalPosition = itkOptimizer->GetMetric()->GetParameters();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
@@ -88,7 +88,7 @@ public:
     derivative[0] = -(3 * x + 2 * y - 2);
     derivative[1] = -(2 * x + 6 * y + 8);
 
-    std::cout << "(" << derivative[0] << " , " << derivative[1] << ")" << std::endl;
+    std::cout << '(' << derivative[0] << " , " << derivative[1] << ')' << std::endl;
   }
 
   void
@@ -278,8 +278,8 @@ itkExhaustiveOptimizerv4Test(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetMinimumMetricValuePosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   std::cout << "CurrentValue: " << itkOptimizer->GetCurrentValue() << std::endl;
 

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -180,8 +180,8 @@ GradientDescentLineSearchOptimizerv4RunTest(itk::GradientDescentLineSearchOptimi
   using ParametersType = GradientDescentLineSearchOptimizerv4TestMetric::ParametersType;
   ParametersType finalPosition = itkOptimizer->GetMetric()->GetParameters();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -174,8 +174,8 @@ GradientDescentOptimizerv4RunTest(itk::GradientDescentOptimizerv4::Pointer &    
   using ParametersType = GradientDescentOptimizerv4TestMetric::ParametersType;
   ParametersType finalPosition = itkOptimizer->GetMetric()->GetParameters();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   std::cout << "ConvergenceValue: " << itkOptimizer->GetConvergenceValue() << std::endl;
 

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
@@ -90,7 +90,7 @@ public:
     derivative[0] = -(3 * x + 2 * y - 2);
     derivative[1] = -(2 * x + 6 * y + 8);
 
-    std::cout << "(" << derivative[0] << " , " << derivative[1] << ")" << std::endl;
+    std::cout << '(' << derivative[0] << " , " << derivative[1] << ')' << std::endl;
   }
 
   void
@@ -279,7 +279,7 @@ itkLBFGS2Optimizerv4Test(int, char *[])
   OptimizerType::ParametersType finalPosition;
   finalPosition = itkOptimizer->GetCurrentPosition();
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
 
   std::cout << "End condition   = " << itkOptimizer->GetStopConditionDescription() << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
@@ -340,7 +340,7 @@ itkLBFGS2Optimizerv4Test(int, char *[])
     return EXIT_FAILURE;
   }
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
 
   if (itkOptimizer->GetCurrentIteration() != 2)

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -140,8 +140,8 @@ public:
     derivative[0] = -(3 * x + 2 * y - 2);
     derivative[1] = -(2 * x + 6 * y + 8);
 
-    std::cout << "GetDerivative ( " << x << " , " << y << ") = "
-              << "(" << -derivative[0] << " , " << -derivative[1] << ")" << std::endl;
+    std::cout << "GetDerivative ( " << x << " , " << y << ") = " << '(' << -derivative[0] << " , " << -derivative[1]
+              << ')' << std::endl;
   }
 
   void
@@ -322,7 +322,7 @@ itkLBFGSBOptimizerv4Test(int, char *[])
 
   const OptimizerType::ParametersType & finalPosition = itkOptimizer->GetCurrentPosition();
 
-  std::cout << "Solution = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "Final Function Value = " << itkOptimizer->GetValue() << std::endl;
 
   std::cout << "Infinity Norm of Projected Gradient = " << itkOptimizer->GetInfinityNormOfProjectedGradient()
@@ -395,7 +395,7 @@ itkLBFGSBOptimizerv4Test(int, char *[])
   ITK_TRY_EXPECT_NO_EXCEPTION(itkOptimizer->StartOptimization());
 
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
 
   if (itkOptimizer->GetCurrentIteration() != 1)
@@ -448,7 +448,7 @@ itkLBFGSBOptimizerv4Test(int, char *[])
   std::cout << "Lower bound size: " << itkOptimizer2->GetLowerBound().size() << std::endl;
 
   const OptimizerType::ParametersType & finalPosition2 = itkOptimizer2->GetCurrentPosition();
-  std::cout << "Solution = (" << finalPosition2[0] << "," << finalPosition2[1] << ")" << std::endl;
+  std::cout << "Solution = (" << finalPosition2[0] << ',' << finalPosition2[1] << ')' << std::endl;
   std::cout << "Final Function Value = " << itkOptimizer2->GetValue() << std::endl;
 
   // check results

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
@@ -91,7 +91,7 @@ public:
     derivative[0] = -(3 * x + 2 * y - 2);
     derivative[1] = -(2 * x + 6 * y + 8);
 
-    std::cout << "(" << derivative[0] << " , " << derivative[1] << ")" << std::endl;
+    std::cout << '(' << derivative[0] << " , " << derivative[1] << ')' << std::endl;
   }
 
   void
@@ -253,7 +253,7 @@ itkLBFGSOptimizerv4Test(int, char *[])
   OptimizerType::ParametersType finalPosition;
   finalPosition = itkOptimizer->GetCurrentPosition();
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
 
   std::cout << "End condition   = " << itkOptimizer->GetStopConditionDescription() << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
@@ -308,7 +308,7 @@ itkLBFGSOptimizerv4Test(int, char *[])
     return EXIT_FAILURE;
   }
 
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "NumberOfIterations  = " << itkOptimizer->GetCurrentIteration() << std::endl;
 
   if (itkOptimizer->GetCurrentIteration() != 5)
@@ -345,7 +345,7 @@ itkLBFGSOptimizerv4Test(int, char *[])
 
   std::cout << "Scales after optimization: " << itkOptimizer->GetScales() << std::endl;
   finalPosition = itkOptimizer->GetCurrentPosition();
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
 
   // check results to see if it is within range
   pass = true;

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -301,8 +301,8 @@ MultiGradientOptimizerv4RunTest(itk::MultiGradientOptimizerv4::Pointer & itkOpti
   ParametersType finalPosition = itkOptimizer->GetMetric()->GetParameters();
 
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -176,11 +176,11 @@ MultiStartOptimizerv4RunTest(itk::MultiStartOptimizerv4::Pointer & itkOptimizer)
   ParametersType bestPosition = itkOptimizer->GetBestParameters();
 
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
   std::cout << "Best Solution   = (";
-  std::cout << bestPosition[0] << ",";
-  std::cout << bestPosition[1] << ")" << std::endl;
+  std::cout << bestPosition[0] << ',';
+  std::cout << bestPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -262,8 +262,8 @@ itkOnePlusOneEvolutionaryOptimizerv4Test(int, char *[])
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // check results to see if it is within range

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -215,7 +215,7 @@ itkPowellOptimizerv4Test(int argc, char * argv[])
 
 
   ParametersType finalPosition = itkOptimizer->GetCurrentPosition();
-  std::cout << "Solution        = (" << finalPosition[0] << "," << finalPosition[1] << ")" << std::endl;
+  std::cout << "Solution        = (" << finalPosition[0] << ',' << finalPosition[1] << ')' << std::endl;
   std::cout << "StopConditionDescription: " << itkOptimizer->GetStopConditionDescription() << std::endl;
 
   //

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -235,8 +235,8 @@ RegularStepGradientDescentOptimizerv4TestHelper(
 
   ParametersType finalPosition = optimizer->GetMetric()->GetParameters();
   std::cout << "Solution        = (";
-  std::cout << finalPosition[0] << ",";
-  std::cout << finalPosition[1] << ")" << std::endl;
+  std::cout << finalPosition[0] << ',';
+  std::cout << finalPosition[1] << ')' << std::endl;
 
   //
   // Check results to see if it is within range

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
@@ -60,7 +60,7 @@ EuclideanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
   {
     itkExceptionMacro(<< "The two measurement vectors have unequal size ("
                       << NumericTraits<MeasurementVectorType>::GetLength(x1) << " and "
-                      << NumericTraits<MeasurementVectorType>::GetLength(x2) << ")");
+                      << NumericTraits<MeasurementVectorType>::GetLength(x2) << ')');
   }
 
   double sumOfSquares = 0.0;

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -53,7 +53,7 @@ GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::GetIntegerVariate(Ran
 {
   if (upperBound < lowerBound)
   {
-    itkExceptionMacro(<< "upperBound (" << upperBound << ") not >= to lowerBound(" << lowerBound << ")");
+    itkExceptionMacro(<< "upperBound (" << upperBound << ") not >= to lowerBound(" << lowerBound << ')');
   }
 
   RandomIntType randInt = 0;

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -534,7 +534,7 @@ KdTree<TSample>::PrintTree(KdTreeNodeType * node,
     os << "          ";
     for (unsigned int i = 0; i < node->Size(); ++i)
     {
-      os << "[" << node->GetInstanceIdentifier(i) << "] "
+      os << '[' << node->GetInstanceIdentifier(i) << "] "
          << this->m_Sample->GetMeasurementVector(node->GetInstanceIdentifier(i)) << ", ";
     }
     os << std::endl;
@@ -576,7 +576,7 @@ KdTree<TSample>::PlotTree(std::ostream & os) const
   //
   // Graph footer
   //
-  os << "}" << std::endl;
+  os << '}' << std::endl;
 }
 
 template <typename TSample>
@@ -611,7 +611,7 @@ KdTree<TSample>::PlotTree(KdTreeNodeType * node, std::ostream & os) const
   {
     os << "\"" << node << "\" [label=\"";
     os << this->GetMeasurementVector(node->GetInstanceIdentifier(0));
-    os << ' ' << partitionDimensionCharSymbol << "=" << partitionValue;
+    os << ' ' << partitionDimensionCharSymbol << '=' << partitionValue;
     os << "\" ];" << std::endl;
   }
 

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -445,7 +445,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::PrintPoint(ParameterType & point)
   {
     std::cout << point[i] << ' ';
   }
-  std::cout << "]";
+  std::cout << ']';
 }
 } // end of namespace Statistics
 } // end namespace itk

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -257,14 +257,14 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
 
         itkDebugStatement(typename HistogramType::IndexType tempMeasurementIndex);
         itkDebugStatement(output->GetIndex(run, tempMeasurementIndex));
-        itkDebugMacro("centerIndex<->index: " << static_cast<int>(centerPixelIntensity) << "@" << centerIndex << "<->"
-                                              << static_cast<int>(pixelIntensity) << "@" << index << ", Bin# "
+        itkDebugMacro("centerIndex<->index: " << static_cast<int>(centerPixelIntensity) << '@' << centerIndex << "<->"
+                                              << static_cast<int>(pixelIntensity) << '@' << index << ", Bin# "
                                               << tempMeasurementIndex << ", Measurement: (" << run[0] << ", " << run[1]
-                                              << ")"
-                                              << ", Center bin [" << this->GetOutput()->GetBinMinFromValue(0, run[0])
-                                              << "," << this->GetOutput()->GetBinMaxFromValue(0, run[0]) << "]"
-                                              << "~[" << this->GetOutput()->GetBinMinFromValue(1, run[1]) << ","
-                                              << this->GetOutput()->GetBinMaxFromValue(1, run[1]) << "]" << std::endl);
+                                              << ')' << ", Center bin ["
+                                              << this->GetOutput()->GetBinMinFromValue(0, run[0]) << ','
+                                              << this->GetOutput()->GetBinMaxFromValue(0, run[0]) << ']' << "~["
+                                              << this->GetOutput()->GetBinMinFromValue(1, run[1]) << ','
+                                              << this->GetOutput()->GetBinMaxFromValue(1, run[1]) << ']' << std::endl);
       }
     }
   }

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -35,7 +35,7 @@ MaximumRatioDecisionRule::PrintSelf(std::ostream & os, Indent indent) const
   {
     N = m_PriorProbabilities.size();
   }
-  os << "[" << std::endl;
+  os << '[' << std::endl;
   for (PriorProbabilityVectorType::size_type i = 0; i < N; ++i)
   {
     os << m_PriorProbabilities[i];
@@ -48,7 +48,7 @@ MaximumRatioDecisionRule::PrintSelf(std::ostream & os, Indent indent) const
   {
     os << ", ...";
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
 }
 
 void

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
@@ -134,7 +134,7 @@ itkCovarianceSampleFilterTest(int, char *[])
   if ((itk::Math::abs(mean[0] - mean2[0]) > epsilon) || (itk::Math::abs(mean[1] - mean2[1]) > epsilon) ||
       (itk::Math::abs(mean[2] - mean2[2]) > epsilon))
   {
-    std::cerr << "Mean parameter value retrieved using GetMean() and the decorator are not the same:: " << mean << ","
+    std::cerr << "Mean parameter value retrieved using GetMean() and the decorator are not the same:: " << mean << ','
               << mean2 << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
@@ -198,8 +198,8 @@ itkCovarianceSampleFilterTest3(int, char *[])
     {
       if (itk::Math::abs(covariance[i][j] - covarianceOutput[i][j]) > epsilon)
       {
-        std::cerr << "Computed covariance matrix value is incorrrect:" << i << "," << j << "=" << covariance[i][j]
-                  << "," << covarianceOutput[i][j] << std::endl;
+        std::cerr << "Computed covariance matrix value is incorrrect:" << i << ',' << j << '=' << covariance[i][j]
+                  << ',' << covarianceOutput[i][j] << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
@@ -157,7 +157,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
   const unsigned int measurementVectorSize = sample->GetMeasurementVectorSize();
   for (i = 0; i < numberOfClasses; ++i)
   {
-    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "Cluster[" << i << ']' << std::endl;
     std::cout << "    Parameters:" << std::endl;
     std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
     std::cout << "    Proportion: ";

--- a/Modules/Numerics/Statistics/test/itkHistogramTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramTest.cxx
@@ -248,7 +248,7 @@ itkHistogramTest(int, char *[])
 
   if (!pass)
   {
-    std::cerr << "Test failed in " << whereFail << "." << std::endl;
+    std::cerr << "Test failed in " << whereFail << '.' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -846,7 +846,7 @@ itkHistogramTest(int, char *[])
 
   if (!pass)
   {
-    std::cout << "Test failed in " << whereFail << "." << std::endl;
+    std::cout << "Test failed in " << whereFail << '.' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
@@ -101,12 +101,12 @@ itkKdTreeGeneratorTest(int, char *[])
     tree->Search(queryPoint, numberOfNeighbors, neighbors);
 
     std::cout << "kd-tree knn search result:" << std::endl
-              << "query point = [" << queryPoint << "]" << std::endl
+              << "query point = [" << queryPoint << ']' << std::endl
               << "k = " << numberOfNeighbors << std::endl;
     std::cout << "measurement vector : distance" << std::endl;
     for (unsigned int i = 0; i < numberOfNeighbors; ++i)
     {
-      std::cout << "[" << tree->GetMeasurementVector(neighbors[i])
+      std::cout << '[' << tree->GetMeasurementVector(neighbors[i])
                 << "] : " << distanceMetric->Evaluate(tree->GetMeasurementVector(neighbors[i])) << std::endl;
     }
 
@@ -115,12 +115,12 @@ itkKdTreeGeneratorTest(int, char *[])
     tree->Search(queryPoint, radius, neighbors);
 
     std::cout << "kd-tree radius search result:" << std::endl
-              << "query point = [" << queryPoint << "]" << std::endl
+              << "query point = [" << queryPoint << ']' << std::endl
               << "search radius = " << radius << std::endl;
     std::cout << "measurement vector : distance" << std::endl;
     for (const auto neighbor : neighbors)
     {
-      std::cout << "[" << tree->GetMeasurementVector(neighbor)
+      std::cout << '[' << tree->GetMeasurementVector(neighbor)
                 << "] : " << distanceMetric->Evaluate(tree->GetMeasurementVector(neighbor)) << std::endl;
     }
   }
@@ -192,12 +192,12 @@ itkKdTreeGeneratorTest(int, char *[])
     tree->Search(queryPoint, numberOfNeighbors, neighbors);
 
     std::cout << "kd-tree knn search result:" << std::endl
-              << "query point = [" << queryPoint << "]" << std::endl
+              << "query point = [" << queryPoint << ']' << std::endl
               << "k = " << numberOfNeighbors << std::endl;
     std::cout << "measurement vector : distance" << std::endl;
     for (unsigned int i = 0; i < numberOfNeighbors; ++i)
     {
-      std::cout << "[" << tree->GetMeasurementVector(neighbors[i])
+      std::cout << '[' << tree->GetMeasurementVector(neighbors[i])
                 << "] : " << distanceMetric->Evaluate(tree->GetMeasurementVector(neighbors[i])) << std::endl;
     }
 
@@ -206,12 +206,12 @@ itkKdTreeGeneratorTest(int, char *[])
     tree->Search(queryPoint, radius, neighbors);
 
     std::cout << "kd-tree radius search result:" << std::endl
-              << "query point = [" << queryPoint << "]" << std::endl
+              << "query point = [" << queryPoint << ']' << std::endl
               << "search radius = " << radius << std::endl;
     std::cout << "measurement vector : distance" << std::endl;
     for (const auto neighbor : neighbors)
     {
-      std::cout << "[" << tree->GetMeasurementVector(neighbor)
+      std::cout << '[' << tree->GetMeasurementVector(neighbor)
                 << "] : " << distanceMetric->Evaluate(tree->GetMeasurementVector(neighbor)) << std::endl;
     }
   }

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
@@ -125,10 +125,10 @@ itkKdTreeTest1(int argc, char * argv[])
           itk::Math::NotAlmostEquals(distanceFromMetric, searchDistance[i]))
       {
         std::cerr << "kd-tree knn search result:" << std::endl
-                  << "query point = [" << queryPoint << "]" << std::endl
+                  << "query point = [" << queryPoint << ']' << std::endl
                   << "k = " << numberOfNeighbors << std::endl;
         std::cerr << "measurement vector : distance_by_distMetric : distance_by_tree" << std::endl;
-        std::cerr << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distanceFromMetric << " : "
+        std::cerr << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distanceFromMetric << " : "
                   << searchDistance[i] << std::endl;
         numberOfFailedPoints1++;
       }

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
@@ -110,7 +110,7 @@ itkKdTreeTest2(int argc, char * argv[])
     tree->Search(queryPoint, numberOfNeighbors, neighbors);
 
     std::cout << "kd-tree knn search result:" << std::endl
-              << "query point = [" << queryPoint << "]" << std::endl
+              << "query point = [" << queryPoint << ']' << std::endl
               << "k = " << numberOfNeighbors << std::endl;
     std::cout << "measurement vector : distance" << std::endl;
 
@@ -118,7 +118,7 @@ itkKdTreeTest2(int argc, char * argv[])
     {
       const double distance = distanceMetric->Evaluate(tree->GetMeasurementVector(neighbors[i]));
 
-      std::cout << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
+      std::cout << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
 
       if (distance > itk::Math::eps)
       {

--- a/Modules/Numerics/Statistics/test/itkKdTreeTestSamplePoints.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTestSamplePoints.cxx
@@ -109,10 +109,10 @@ itkKdTreeTestSamplePoints(int, char *[])
       if (distance > itk::Math::eps)
       {
         std::cerr << "kd-tree knn search result:" << std::endl
-                  << "query point = [" << queryPoint << "]" << std::endl
+                  << "query point = [" << queryPoint << ']' << std::endl
                   << "k = " << numberOfNeighbors << std::endl;
         std::cerr << "measurement vector : distance" << std::endl;
-        std::cerr << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
+        std::cerr << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
       }
     }
   }

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -181,7 +181,7 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
     {
       std::cerr << "Error" << std::endl;
       std::cerr << "The calculated bin sizes are incorrect" << std::endl;
-      std::cerr << "Expected [255, 256), got [" << min << ", " << max << ")" << std::endl << std::endl;
+      std::cerr << "Expected [255, 256), got [" << min << ", " << max << ')' << std::endl << std::endl;
       passed = false;
     }
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -213,7 +213,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans[counter] << "." << std::endl;
+                  << expectedMeans[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -223,7 +223,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations[counter] << "." << std::endl;
+                  << expectedDeviations[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -242,7 +242,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error2. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans2[counter] << "." << std::endl;
+                  << expectedMeans2[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -252,7 +252,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error2. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations2[counter] << "." << std::endl;
+                  << expectedDeviations2[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -303,7 +303,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error3. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans3[counter] << "." << std::endl;
+                  << expectedMeans3[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -313,7 +313,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error3. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations3[counter] << "." << std::endl;
+                  << expectedDeviations3[counter] << '.' << std::endl;
         passed = false;
       }
     }

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
@@ -154,8 +154,7 @@ itkScalarImageToRunLengthMatrixFilterTest(int, char *[])
         index[1] = j;
         if (hist->GetFrequency(index) != frequencies[j][i])
         {
-          std::cerr << "Expected frequency  (i,j)= "
-                    << "(" << i << "," << j << ")" << frequencies[j][i]
+          std::cerr << "Expected frequency  (i,j)= " << '(' << i << ',' << j << ')' << frequencies[j][i]
                     << ", calculated = " << hist->GetFrequency(index) << std::endl;
           passed = false;
         }
@@ -250,8 +249,7 @@ itkScalarImageToRunLengthMatrixFilterTest(int, char *[])
         index[1] = j;
         if (hist->GetFrequency(index) != frequencies2[j][i])
         {
-          std::cerr << "Expected frequency2  (i,j)= "
-                    << "(" << i << "," << j << ")" << frequencies2[j][i]
+          std::cerr << "Expected frequency2  (i,j)= " << '(' << i << ',' << j << ')' << frequencies2[j][i]
                     << ", calculated = " << hist->GetFrequency(index) << std::endl;
           passed = false;
         }

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -212,7 +212,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans[counter] << "." << std::endl;
+                  << expectedMeans[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -222,7 +222,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations[counter] << "." << std::endl;
+                  << expectedDeviations[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -241,7 +241,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans2[counter] << "." << std::endl;
+                  << expectedMeans2[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -251,7 +251,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations2[counter] << "." << std::endl;
+                  << expectedDeviations2[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -295,7 +295,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans3[counter] << "." << std::endl;
+                  << expectedMeans3[counter] << '.' << std::endl;
         passed = false;
       }
     }
@@ -305,7 +305,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
       {
         std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations3[counter] << "." << std::endl;
+                  << expectedDeviations3[counter] << '.' << std::endl;
         passed = false;
       }
     }

--- a/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
@@ -152,7 +152,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
       (itk::Math::abs(standardDeviation[2] - standardDeviation2[2]) > epsilon))
   {
     std::cerr << "Standard Deviation value retrieved using Get() and the decorator are not the same:: "
-              << standardDeviation << "," << standardDeviation2 << std::endl;
+              << standardDeviation << ',' << standardDeviation2 << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -180,7 +180,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
 
   if (!pass)
   {
-    std::cerr << "Test failed in " << whereFail << "." << std::endl;
+    std::cerr << "Test failed in " << whereFail << '.' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
@@ -260,7 +260,7 @@ itkSubsampleTest(int, char *[])
 
   if (!pass)
   {
-    std::cout << "Test failed in " << whereFail << "." << std::endl;
+    std::cout << "Test failed in " << whereFail << '.' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
@@ -116,10 +116,10 @@ itkWeightedCentroidKdTreeGeneratorTest1(int argc, char * argv[])
       if (distance > itk::Math::eps)
       {
         std::cout << "kd-tree knn search result:" << std::endl
-                  << "query point = [" << queryPoint << "]" << std::endl
+                  << "query point = [" << queryPoint << ']' << std::endl
                   << "k = " << numberOfNeighbors << std::endl;
         std::cout << "measurement vector : distance" << std::endl;
-        std::cout << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
+        std::cout << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
         testFailed = true;
       }
     }

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -119,10 +119,10 @@ itkWeightedCentroidKdTreeGeneratorTest8(int argc, char * argv[])
       if (distance > itk::Math::eps)
       {
         std::cout << "kd-tree knn search result:" << std::endl
-                  << "query point = [" << queryPoint << "]" << std::endl
+                  << "query point = [" << queryPoint << ']' << std::endl
                   << "k = " << numberOfNeighbors << std::endl;
         std::cout << "measurement vector : distance" << std::endl;
-        std::cout << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
+        std::cout << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
         testFailed = true;
       }
     }

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -120,10 +120,10 @@ itkWeightedCentroidKdTreeGeneratorTest9(int argc, char * argv[])
       if (distance > itk::Math::eps)
       {
         std::cout << "kd-tree knn search result:" << std::endl
-                  << "query point = [" << queryPoint << "]" << std::endl
+                  << "query point = [" << queryPoint << ']' << std::endl
                   << "k = " << numberOfNeighbors << std::endl;
         std::cout << "measurement vector : distance" << std::endl;
-        std::cout << "[" << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
+        std::cout << '[' << tree->GetMeasurementVector(neighbors[i]) << "] : " << distance << std::endl;
         testFailed = true;
       }
     }

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -166,7 +166,7 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
 
   if (this->m_PointsCount < 1)
   {
-    itkExceptionMacro("Invalid number of feature points: " << this->m_PointsCount << ".");
+    itkExceptionMacro("Invalid number of feature points: " << this->m_PointsCount << '.');
   }
 
   this->m_DisplacementsVectorsArray = make_unique_for_overwrite<DisplacementsVector[]>(this->m_PointsCount);

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -188,7 +188,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const Tran
   if (m_DerivativeStepLengthScales.size() != ParametersDimension)
   {
     itkExceptionMacro(<< "The size of DerivativesStepLengthScales is " << m_DerivativeStepLengthScales.size()
-                      << ", but the Number of Parameters is " << ParametersDimension << ".");
+                      << ", but the Number of Parameters is " << ParametersDimension << '.');
   }
 
   // Calculate gradient.

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -73,7 +73,7 @@ public:
     }
     else if (typeid(event) == typeid(itk::IterationEvent))
     {
-      std::cout << "#" << m_Optimizer->GetCurrentIteration()
+      std::cout << '#' << m_Optimizer->GetCurrentIteration()
                 << " Current parameters = " << m_Optimizer->GetCurrentPosition() << std::endl;
     }
     else if (typeid(event) == typeid(itk::EndEvent))

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -216,7 +216,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
       std::cerr << "Error !" << std::endl;
       std::cerr << "Expected: [" << static_cast<double>(gradIt.Get()[0]) << ", " << static_cast<double>(gradIt.Get()[1])
                 << "], but got [" << static_cast<double>(xGradIt.Get()) << ", " << static_cast<double>(yGradIt.Get())
-                << "]" << std::endl;
+                << ']' << std::endl;
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
@@ -239,7 +239,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
     {
       std::cerr << "Error !" << std::endl;
       std::cerr << "Expected: " << expectedDerivativeMeasure << " but got " << static_cast<double>(derivative[i])
-                << " at index [" << i << "]" << std::endl;
+                << " at index [" << i << ']' << std::endl;
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
@@ -263,7 +263,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
     {
       std::cerr << "Error !" << std::endl;
       std::cerr << "Expected: " << expectedDerivativeMeasure << " but got " << static_cast<double>(derivative[i])
-                << " at index [" << i << "]" << std::endl;
+                << " at index [" << i << ']' << std::endl;
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }

--- a/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
@@ -121,7 +121,7 @@ itkMeanReciprocalSquareDifferencePointSetToImageMetricTest(int, char *[])
     if (counter == 0)
     {
       fixedImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
-      std::cout << "******************* " << pointId << ":" << point << std::endl;
+      std::cout << "******************* " << pointId << ':' << point << std::endl;
       fixedPointSet->SetPoint(pointId, point);
       fixedPointSet->SetPointData(pointId, it.Get());
       ++pointId;

--- a/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
@@ -120,7 +120,7 @@ itkMeanSquaresPointSetToImageMetricTest(int, char *[])
     if (counter == 0)
     {
       fixedImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
-      std::cout << "******************* " << pointId << ":" << point << std::endl;
+      std::cout << "******************* " << pointId << ':' << point << std::endl;
       fixedPointSet->SetPoint(pointId, point);
       fixedPointSet->SetPointData(pointId, it.Get());
       ++pointId;

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -351,7 +351,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
                   << " at pixel spacing level "
                   << pyramid->GetOutput(testLevel)->GetDirection() * pyramid->GetOutput(testLevel)->GetSpacing()
                   << std::endl;
-        std::cout << "ERROR PERCENT:  " << ErrorCenterOfMass.GetNorm() << "/"
+        std::cout << "ERROR PERCENT:  " << ErrorCenterOfMass.GetNorm() << '/'
                   << pyramid->GetOutput(testLevel)->GetSpacing().GetNorm() << " = " << ErrorPercentage << std::endl;
       }
       else
@@ -360,7 +360,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
                   << " != " << InputCenterOfMass << " at pixel spacing level "
                   << pyramid->GetOutput(testLevel)->GetDirection() * pyramid->GetOutput(testLevel)->GetSpacing()
                   << std::endl;
-        std::cout << "OFFSET DIFF PERCENT:  " << ErrorCenterOfMass.GetNorm() << "/"
+        std::cout << "OFFSET DIFF PERCENT:  " << ErrorCenterOfMass.GetNorm() << '/'
                   << pyramid->GetOutput(testLevel)->GetSpacing().GetNorm() << " = " << ErrorPercentage << std::endl;
       }
       // break;

--- a/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
@@ -202,7 +202,7 @@ itkPointSetToPointSetRegistrationTest(int, char *[])
   psToImageFilter->SetOrigin(origin);
 
   std::cout << "Spacing and origin: [" << psToImageFilter->GetSpacing() << "], ,[" << psToImageFilter->GetOrigin()
-            << "]" << std::endl;
+            << ']' << std::endl;
 
 
   ITK_TRY_EXPECT_NO_EXCEPTION(psToImageFilter->Update());

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -182,7 +182,7 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
       {
         itkExceptionMacro(
           "Expected exactly one transform set to be optimized within the composite transform. Error with metric "
-          << j << ".");
+          << j << '.');
       }
     }
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -53,7 +53,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4Test_PrintDerivativeAsVectorImage
       std::cout << '[';
       for (itk::SizeValueType d = 0; d < vecdim - 1; ++d)
       {
-        std::cout << derivative[cnt * vecdim + d] << ",";
+        std::cout << derivative[cnt * vecdim + d] << ',';
       }
       std::cout << derivative[cnt * vecdim + vecdim - 1] << ']' << "\t";
       ++it;

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -98,7 +98,7 @@ public:
     ostrm << name << "_jointpdf_" << this->m_Count << ext;
     std::cout << "Writing joint pdf to:        " << ostrm.str() << std::endl;
     ostrm.str("");
-    ostrm << path << "/" << name << "_jointpdf_" << this->m_Count << ext;
+    ostrm << path << '/' << name << "_jointpdf_" << this->m_Count << ext;
     this->m_Writer->SetFileName(ostrm.str());
 
     using JointPDFType = typename MIMetricType::JointPDFType;

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -246,7 +246,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   {
     os << m_NumberOfIterations[ilevel] << ", ";
   }
-  os << m_NumberOfIterations[ilevel] << "]" << std::endl;
+  os << m_NumberOfIterations[ilevel] << ']' << std::endl;
 
   os << indent << "RegistrationFilter: ";
   os << m_RegistrationFilter.GetPointer() << std::endl;

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -145,7 +145,7 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   {
     os << ", " << m_StandardDeviations[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
   os << indent << "Smooth update field: " << (m_SmoothUpdateField ? "on" : "off") << std::endl;
   j = 0;
   os << indent << "Update field standard deviations: [" << m_UpdateFieldStandardDeviations[j];
@@ -153,7 +153,7 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   {
     os << ", " << m_UpdateFieldStandardDeviations[j];
   }
-  os << "]" << std::endl;
+  os << ']' << std::endl;
   os << indent << "StopRegistrationFlag: ";
   os << m_StopRegistrationFlag << std::endl;
   os << indent << "MaximumError: ";

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -102,7 +102,7 @@ public:
     {
       itkExceptionMacro("Internal transforms should be consistent with input image size at each iteration.  "
                         << "Image size = " << ImageSize << ".  Fixed field size = " << FixedDisplacementFieldSize
-                        << ".  Moving field size = " << MovingDisplacementFieldSize << ".");
+                        << ".  Moving field size = " << MovingDisplacementFieldSize << '.');
     }
   }
 };

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -159,7 +159,7 @@ itkImageClassifierFilterTest(int argc, char * argv[])
 
   for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
-    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "Cluster[" << i << ']' << std::endl;
     std::cout << "    Parameters:" << std::endl;
     std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
     std::cout << "    Proportion: ";

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
@@ -156,7 +156,7 @@ itkSampleClassifierFilterTest7(int argc, char * argv[])
   bool passed = true;
   for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
-    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "Cluster[" << i << ']' << std::endl;
     std::cout << "    Parameters:" << std::endl;
     std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
     std::cout << "    Proportion: ";

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -1184,13 +1184,11 @@ test_regiongrowKLM2D()
       std::cout << "Test FAILED" << std::endl;
       if (itk::Math::NotAlmostEquals(pixelOut[0], pixelOutZero))
       {
-        std::cout << "pixelOut[0]: " << pixelOut[0] << " != "
-                  << "0" << std::endl;
+        std::cout << "pixelOut[0]: " << pixelOut[0] << " != " << '0' << std::endl;
       }
       if (itk::Math::NotAlmostEquals(pixelOut[1], pixelOutZero))
       {
-        std::cout << "pixelOut[1]: " << pixelOut[1] << " != "
-                  << "0" << std::endl;
+        std::cout << "pixelOut[1]: " << pixelOut[1] << " != " << '0' << std::endl;
       }
       return EXIT_FAILURE;
     }
@@ -1690,13 +1688,11 @@ test_regiongrowKLM3D()
       std::cout << "Test FAILED" << std::endl;
       if (itk::Math::NotAlmostEquals(pixelOut[0], pixelOutZero))
       {
-        std::cout << "pixelOut[0]: " << pixelOut[0] << " != "
-                  << "0" << std::endl;
+        std::cout << "pixelOut[0]: " << pixelOut[0] << " != " << '0' << std::endl;
       }
       if (itk::Math::NotAlmostEquals(pixelOut[1], pixelOutZero))
       {
-        std::cout << "pixelOut[1]: " << pixelOut[1] << " != "
-                  << "0" << std::endl;
+        std::cout << "pixelOut[1]: " << pixelOut[1] << " != " << '0' << std::endl;
       }
       return EXIT_FAILURE;
     }
@@ -2088,8 +2084,7 @@ test_regiongrowKLM4D()
     if (itk::Math::NotAlmostEquals(pixelOut[0], pixelOutZero))
     {
       std::cout << "Test FAILED" << std::endl;
-      std::cout << "pixelOut[0]: " << pixelOut[0] << " != "
-                << "0" << std::endl;
+      std::cout << "pixelOut[0]: " << pixelOut[0] << " != " << '0' << std::endl;
       return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.hxx
@@ -51,7 +51,7 @@ LevelSetVelocityNeighborhoodExtractor<TLevelSet, TAuxValue, VAuxDimension>::Prin
   {
     os << m_AuxImage[j].GetPointer() << ", ";
   }
-  os << m_AuxImage[j].GetPointer() << "]" << std::endl;
+  os << m_AuxImage[j].GetPointer() << ']' << std::endl;
   os << indent << "AuxInsideValues: " << m_AuxInsideValues.GetPointer() << std::endl;
   os << indent << "AuxOutsideValues: " << m_AuxOutsideValues.GetPointer() << std::endl;
 }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -1266,7 +1266,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::PrintSelf(std::ostream & os, Indent in
   os << indent << "ELHash: " << std::endl;
   for (unsigned int i = 0; i < m_ELHash.size(); ++i)
   {
-    os << indent << "[" << i << "]: " << m_ELHash[i] << std::endl;
+    os << indent << '[' << i << "]: " << m_ELHash[i] << std::endl;
   }
 }
 } // namespace itk

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DTest.cxx
@@ -68,14 +68,14 @@ itkVoronoiDiagram2DTest(int argc, char * argv[])
   for (unsigned int i = 0; i < voronoiDiagramGenerator->GetNumberOfSeeds(); ++i)
   {
     PointType currP = voronoiDiagram->GetSeed(i);
-    std::cout << "Seed No." << i << ": At (" << currP[0] << "," << currP[1] << ")" << std::endl;
+    std::cout << "Seed No." << i << ": At (" << currP[0] << ',' << currP[1] << ')' << std::endl;
     std::cout << "Boundary Vertices List (in order): ";
     CellAutoPointer currCell;
     voronoiDiagram->GetCellId(i, currCell);
     PointIdIterator currCellP;
     for (currCellP = currCell->PointIdsBegin(); currCellP != currCell->PointIdsEnd(); ++currCellP)
     {
-      std::cout << *currCellP << ",";
+      std::cout << *currCellP << ',';
     }
     std::cout << std::endl;
     std::cout << " Neighbors (Seed No.): ";
@@ -83,7 +83,7 @@ itkVoronoiDiagram2DTest(int argc, char * argv[])
     for (currNeibor = voronoiDiagram->NeighborIdsBegin(i); currNeibor != voronoiDiagram->NeighborIdsEnd(i);
          ++currNeibor)
     {
-      std::cout << *currNeibor << ",";
+      std::cout << *currNeibor << ',';
     }
     std::cout << std::endl << std::endl;
   }
@@ -95,7 +95,7 @@ itkVoronoiDiagram2DTest(int argc, char * argv[])
   {
     std::cout << "Vertices No. " << j;
     j++;
-    std::cout << ": At (" << allVerts.Value()[0] << "," << allVerts.Value()[1] << ")" << std::endl;
+    std::cout << ": At (" << allVerts.Value()[0] << ',' << allVerts.Value()[1] << ')' << std::endl;
   }
 
   using WriterType = itk::MeshFileWriter<VoronoiDiagram>;

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -179,7 +179,7 @@ CheckResults(SegmentationType::Pointer outputImage)
   std::cout << "False Interior: " << falseInterior << std::endl;
   std::cout << "False Exterior: " << falseExterior << std::endl;
   double percentCorrect = static_cast<double>(correctInterior + correctExterior) / static_cast<double>(width * height);
-  std::cout << "Percent Correct = " << percentCorrect * 100 << "%" << std::endl;
+  std::cout << "Percent Correct = " << percentCorrect * 100 << '%' << std::endl;
 
   return percentCorrect;
 }
@@ -410,12 +410,12 @@ itkVoronoiSegmentationRGBImageFilterTest(int, char *[])
   // test get mean/std tolerance
   double meanTolerance[6];
   filter->GetMeanTolerance(meanTolerance);
-  std::cout << "Mean Tolerance = (" << meanTolerance[0] << "," << meanTolerance[1] << "," << meanTolerance[2] << ","
-            << meanTolerance[3] << "," << meanTolerance[4] << "," << meanTolerance[5] << ")" << std::endl;
+  std::cout << "Mean Tolerance = (" << meanTolerance[0] << ',' << meanTolerance[1] << ',' << meanTolerance[2] << ','
+            << meanTolerance[3] << ',' << meanTolerance[4] << ',' << meanTolerance[5] << ')' << std::endl;
   double stdTolerance[6];
   filter->GetSTDTolerance(stdTolerance);
-  std::cout << "STD Tolerance = (" << stdTolerance[0] << "," << stdTolerance[1] << "," << stdTolerance[2] << ","
-            << stdTolerance[3] << "," << stdTolerance[4] << "," << stdTolerance[5] << ")" << std::endl;
+  std::cout << "STD Tolerance = (" << stdTolerance[0] << ',' << stdTolerance[1] << ',' << stdTolerance[2] << ','
+            << stdTolerance[3] << ',' << stdTolerance[4] << ',' << stdTolerance[5] << ')' << std::endl;
 
   // test type information
   if (strcmp(filter->GetNameOfClass(), "VoronoiSegmentationRGBImageFilter") != 0)

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -643,7 +643,7 @@ OpenCVVideoIO::PrintSelf(std::ostream & os, Indent indent) const
 
   if (this->m_CVImage != nullptr)
   {
-    os << indent << "Image dimensions : [" << this->m_CVImage->width << "," << this->m_CVImage->height << "]"
+    os << indent << "Image dimensions : [" << this->m_CVImage->width << ',' << this->m_CVImage->height << ']'
        << std::endl;
     os << indent << "Origin : " << this->m_CVImage->origin << std::endl;
     os << indent << "Image spacing (in bits) : " << this->m_CVImage->depth << std::endl;

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
@@ -194,7 +194,7 @@ MatrixConversionTest()
     {
       if (cvA(i, j) != ITKA[i][j])
       {
-        std::cerr << "cvA(" << i << ", " << j << ") != ITKA[" << i << "][" << j << "]" << std::endl;
+        std::cerr << "cvA(" << i << ", " << j << ") != ITKA[" << i << "][" << j << ']' << std::endl;
         std::cerr << cvA(i, j) << " != " << ITKA[i][j] << std::endl;
 
         std::cerr << "***" << std::endl;
@@ -229,7 +229,7 @@ VectorConversionTest()
   {
     if (cvA[i] != ITKA[i])
     {
-      std::cerr << "cvA[" << i << "] != ITKA[" << i << "]" << std::endl;
+      std::cerr << "cvA[" << i << "] != ITKA[" << i << ']' << std::endl;
       std::cerr << cvA[i] << " != " << ITKA[i] << std::endl;
 
       std::cerr << "***" << std::endl;
@@ -467,7 +467,7 @@ MatrixConversionTest()
     {
       if (cvA(i, j) != itkA[i][j])
       {
-        std::cerr << "cvA(" << i << ", " << j << ") != itkA[" << i << "][" << j << "]" << std::endl;
+        std::cerr << "cvA(" << i << ", " << j << ") != itkA[" << i << "][" << j << ']' << std::endl;
         std::cerr << cvA(i, j) << " != " << itkA[i][j] << std::endl;
 
         std::cerr << "***" << std::endl;
@@ -502,7 +502,7 @@ VectorConversionTest()
   {
     if (cvA[i] != itkA[i])
     {
-      std::cerr << "cvA[" << i << "] != itkA[" << i << "]" << std::endl;
+      std::cerr << "cvA[" << i << "] != itkA[" << i << ']' << std::endl;
       std::cerr << cvA[i] << " != " << itkA[i] << std::endl;
 
       std::cerr << "***" << std::endl;

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
@@ -91,9 +91,9 @@ itkOpenCVVideoCaptureTest(int argc, char * argv[])
   if (static_cast<int>(scalarCap->get(CV_CAP_PROP_FRAME_WIDTH)) != std::stoi(argv[4]) ||
       static_cast<int>(scalarCap->get(CV_CAP_PROP_FRAME_HEIGHT)) != std::stoi(argv[5]))
   {
-    std::cerr << "Frame dimensions not reporting correctly. Got [" << scalarCap->get(CV_CAP_PROP_FRAME_WIDTH) << ","
-              << scalarCap->get(CV_CAP_PROP_FRAME_HEIGHT) << "] Expected: [" << std::stoi(argv[4]) << ","
-              << std::stoi(argv[5]) << "]" << std::endl;
+    std::cerr << "Frame dimensions not reporting correctly. Got [" << scalarCap->get(CV_CAP_PROP_FRAME_WIDTH) << ','
+              << scalarCap->get(CV_CAP_PROP_FRAME_HEIGHT) << "] Expected: [" << std::stoi(argv[4]) << ','
+              << std::stoi(argv[5]) << ']' << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
+++ b/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
@@ -54,7 +54,7 @@ VXLVideoIO::PrintSelf(std::ostream & os, Indent indent) const
 
   os << indent << "Reader Open: " << this->m_ReaderOpen << std::endl;
   os << indent << "Writer Open: " << this->m_WriterOpen << std::endl;
-  os << indent << "Image dimensions: [" << this->m_Dimensions[0] << "," << this->m_Dimensions[1] << "]" << std::endl;
+  os << indent << "Image dimensions: [" << this->m_Dimensions[0] << ',' << this->m_Dimensions[1] << ']' << std::endl;
   os << indent << "Frame Total: " << this->m_FrameTotal << std::endl;
 }
 

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
@@ -85,7 +85,7 @@ readCorrectly(itk::VXLVideoIO::Pointer vxlIO, vidl_ffmpeg_istream * stream, Size
   // Make sure buffers are same sized
   if (vxlFrame->size() != bufferSize)
   {
-    std::cerr << "Frame buffer sizes don't match (" << vxlFrame->size() << " != " << bufferSize << ")" << std::endl;
+    std::cerr << "Frame buffer sizes don't match (" << vxlFrame->size() << " != " << bufferSize << ')' << std::endl;
     ret = false;
   }
 

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -255,7 +255,7 @@ VideoSource<TOutputVideoStream>::ThreadedGenerateData(
   const typename TOutputVideoStream::SpatialRegionType & itkNotUsed(outputRegionForThread),
   int                                                    itkNotUsed(threadId))
 {
-  itkExceptionMacro(<< "itk::ERROR: " << this->GetNameOfClass() << "(" << this << "): "
+  itkExceptionMacro(<< "itk::ERROR: " << this->GetNameOfClass() << '(' << this << "): "
                     << "Subclass should override this method!!!");
 }
 

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -493,7 +493,7 @@ TemporalProcessObject::GenerateData()
 void
 TemporalProcessObject::TemporalStreamingGenerateData()
 {
-  itkExceptionMacro(<< "itk::Error: " << this->GetNameOfClass() << "(" << this
+  itkExceptionMacro(<< "itk::Error: " << this->GetNameOfClass() << '(' << this
                     << "): Subclass should override this method!!!");
 }
 

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -60,7 +60,7 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
   {
     itkExceptionMacro(<< "Output dimension doesn't match dimension of read "
                       << "data. Expected " << FrameDimension << " but the IO "
-                      << "method has " << m_VideoIO->GetNumberOfDimensions() << ".");
+                      << "method has " << m_VideoIO->GetNumberOfDimensions() << '.');
   }
 
   //
@@ -184,7 +184,7 @@ VideoFileReader<TOutputVideoStream>::InitializeVideoIO()
     itkExceptionMacro("Cannot convert " << m_VideoIO->GetNumberOfDimensions()
                                         << "D "
                                            "image set to "
-                                        << FrameType::ImageDimension << "D");
+                                        << FrameType::ImageDimension << 'D');
   }
 
   // See if a buffer conversion is needed


### PR DESCRIPTION
Using Notepad++ v8.4.8, Replace in Files, Regular expression:

    Find what: << "([^\\])"
    Replace with: << '$1'

Afterwards, replaced `<< '''` with `<< '\''` (normal find and replace, without
regular expression).

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3889 commit e8773472ddc1cd3bb0a6b638e1cd70a6b4616160
"STYLE: Replace double quotes around a space character with single quotes"