### PR TITLE
COMP: MSVC Code Analysis warning, "redundant code" in ImageIORegionGTest

### DIFF
--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -43,7 +43,6 @@ IsDefaultConstructibleCopyableNoThrowMovableAndDestructible()
          StaticAssertValueOfTypeTrait<std::is_copy_constructible<T>>() &&
          StaticAssertValueOfTypeTrait<std::is_copy_assignable<T>>() &&
          StaticAssertValueOfTypeTrait<std::is_nothrow_move_constructible<T>>() &&
-         StaticAssertValueOfTypeTrait<std::is_nothrow_move_assignable<T>>() &&
          StaticAssertValueOfTypeTrait<std::is_nothrow_move_assignable<T>>();
 }
 


### PR DESCRIPTION
Fixed a Visual C++ 2022 Code Analysis warning, saying:

> warning C6287: Redundant code.
