### PR TITLE
STYLE: Use range-based `for` in MultipleLogOutput and LoggerManager

### DIFF
--- a/Modules/Core/Common/include/itkLoggerManager.h
+++ b/Modules/Core/Common/include/itkLoggerManager.h
@@ -108,9 +108,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  using ContainerType = std::map<NameType, LoggerPointer>;
-
-  ContainerType m_LoggerSet{};
+  std::map<NameType, LoggerPointer> m_LoggerSet{};
 }; // class Logger
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.h
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.h
@@ -152,25 +152,17 @@ protected:
   ThreadFunction();
 
 private:
-  using OperationContainerType = std::queue<OperationEnum>;
-
-  using MessageContainerType = std::queue<std::string>;
-
-  using LevelContainerType = std::queue<PriorityLevelEnum>;
-
-  using OutputContainerType = std::queue<typename OutputType::Pointer>;
-
   std::thread m_Thread{};
 
   std::atomic<bool> m_TerminationRequested{};
 
-  OperationContainerType m_OperationQ{};
+  std::queue<OperationEnum> m_OperationQ{};
 
-  MessageContainerType m_MessageQ{};
+  std::queue<std::string> m_MessageQ{};
 
-  LevelContainerType m_LevelQ{};
+  std::queue<PriorityLevelEnum> m_LevelQ{};
 
-  OutputContainerType m_OutputQ{};
+  std::queue<typename OutputType::Pointer> m_OutputQ{};
 
   mutable std::mutex m_Mutex{};
 

--- a/Modules/Core/Common/include/itkMultipleLogOutput.h
+++ b/Modules/Core/Common/include/itkMultipleLogOutput.h
@@ -83,9 +83,7 @@ protected:
   ~MultipleLogOutput() override;
 
 private:
-  using ContainerType = std::set<OutputType::Pointer>;
-
-  ContainerType m_Output{};
+  std::set<OutputType::Pointer> m_Output{};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkThreadLogger.h
+++ b/Modules/Core/Common/include/itkThreadLogger.h
@@ -126,25 +126,17 @@ private:
   void
   InternalFlush();
 
-  using OperationContainerType = std::queue<OperationType>;
-
-  using MessageContainerType = std::queue<std::string>;
-
-  using LevelContainerType = std::queue<PriorityLevelEnum>;
-
-  using OutputContainerType = std::queue<OutputType::Pointer>;
-
   std::thread m_Thread{};
 
   std::atomic<bool> m_TerminationRequested{};
 
-  OperationContainerType m_OperationQ{};
+  std::queue<OperationType> m_OperationQ{};
 
-  MessageContainerType m_MessageQ{};
+  std::queue<std::string> m_MessageQ{};
 
-  LevelContainerType m_LevelQ{};
+  std::queue<PriorityLevelEnum> m_LevelQ{};
 
-  OutputContainerType m_OutputQ{};
+  std::queue<OutputType::Pointer> m_OutputQ{};
 
   mutable std::mutex m_Mutex{};
 

--- a/Modules/Core/Common/src/itkLoggerManager.cxx
+++ b/Modules/Core/Common/src/itkLoggerManager.cxx
@@ -68,60 +68,45 @@ LoggerManager::GetLogger(const NameType & name)
 void
 LoggerManager::SetPriorityLevel(PriorityLevelEnum level)
 {
-  auto itr = this->m_LoggerSet.begin();
-
-  while (itr != this->m_LoggerSet.end())
+  for (const auto & logger : m_LoggerSet)
   {
-    itr->second->SetPriorityLevel(level);
-    ++itr;
+    logger.second->SetPriorityLevel(level);
   }
 }
 
 void
 LoggerManager::SetLevelForFlushing(PriorityLevelEnum level)
 {
-  auto itr = this->m_LoggerSet.begin();
-
-  while (itr != this->m_LoggerSet.end())
+  for (const auto & logger : m_LoggerSet)
   {
-    itr->second->SetLevelForFlushing(level);
-    ++itr;
+    logger.second->SetLevelForFlushing(level);
   }
 }
 
 void
 LoggerManager::AddLogOutput(OutputType * output)
 {
-  auto itr = this->m_LoggerSet.begin();
-
-  while (itr != this->m_LoggerSet.end())
+  for (const auto & logger : m_LoggerSet)
   {
-    itr->second->AddLogOutput(output);
-    ++itr;
+    logger.second->AddLogOutput(output);
   }
 }
 
 void
 LoggerManager::Write(PriorityLevelEnum level, std::string const & content)
 {
-  auto itr = this->m_LoggerSet.begin();
-
-  while (itr != this->m_LoggerSet.end())
+  for (const auto & logger : m_LoggerSet)
   {
-    itr->second->Write(level, content);
-    ++itr;
+    logger.second->Write(level, content);
   }
 }
 
 void
 LoggerManager::Flush()
 {
-  auto itr = this->m_LoggerSet.begin();
-
-  while (itr != this->m_LoggerSet.end())
+  for (const auto & logger : m_LoggerSet)
   {
-    itr->second->Flush();
-    ++itr;
+    logger.second->Flush();
   }
 }
 

--- a/Modules/Core/Common/src/itkMultipleLogOutput.cxx
+++ b/Modules/Core/Common/src/itkMultipleLogOutput.cxx
@@ -20,15 +20,9 @@
 
 namespace itk
 {
-MultipleLogOutput::MultipleLogOutput()
-{
-  this->m_Output.clear();
-}
+MultipleLogOutput::MultipleLogOutput() = default;
 
-MultipleLogOutput::~MultipleLogOutput()
-{
-  //  this->Flush();
-}
+MultipleLogOutput::~MultipleLogOutput() = default;
 
 /** Adds an output stream to the MultipleLogOutput for writing. */
 void
@@ -41,13 +35,9 @@ MultipleLogOutput::AddLogOutput(OutputType * output)
 void
 MultipleLogOutput::Flush()
 {
-  auto itr = m_Output.begin();
-  auto end = m_Output.end();
-
-  while (itr != end)
+  for (const auto & output : m_Output)
   {
-    (*itr)->Flush();
-    ++itr;
+    output->Flush();
   }
 }
 
@@ -55,13 +45,9 @@ MultipleLogOutput::Flush()
 void
 MultipleLogOutput::Write(double timestamp)
 {
-  auto itr = m_Output.begin();
-  auto end = m_Output.end();
-
-  while (itr != end)
+  for (const auto & output : m_Output)
   {
-    (*itr)->Write(timestamp);
-    ++itr;
+    output->Write(timestamp);
   }
 }
 
@@ -69,13 +55,9 @@ MultipleLogOutput::Write(double timestamp)
 void
 MultipleLogOutput::Write(const std::string & content)
 {
-  auto itr = m_Output.begin();
-  auto end = m_Output.end();
-
-  while (itr != end)
+  for (const auto & output : m_Output)
   {
-    (*itr)->Write(content);
-    ++itr;
+    output->Write(content);
   }
 }
 
@@ -83,13 +65,9 @@ MultipleLogOutput::Write(const std::string & content)
 void
 MultipleLogOutput::Write(const std::string & content, double timestamp)
 {
-  auto itr = m_Output.begin();
-  auto end = m_Output.end();
-
-  while (itr != end)
+  for (const auto & output : m_Output)
   {
-    (*itr)->Write(content, timestamp);
-    ++itr;
+    output->Write(content, timestamp);
   }
 }
 } // namespace itk


### PR DESCRIPTION
Also defaulted the default-constructor and destructor of MultipleLogOutput.