### PR TITLE
STYLE: Use `lock_guard<mutex>` in Logger classes and GPUImageDataManager

### DIFF
--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -30,10 +30,9 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetPriorityLevel(PriorityLevelEnum level)
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(OperationEnum::SET_PRIORITY_LEVEL);
   this->m_LevelQ.push(level);
-  this->m_Mutex.unlock();
 }
 
 /** Get the priority level for the current logger. Only messages that have
@@ -43,9 +42,8 @@ template <typename SimpleLoggerType>
 typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetPriorityLevel() const
 {
-  this->m_Mutex.lock();
-  PriorityLevelEnum level = this->m_PriorityLevel;
-  this->m_Mutex.unlock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_PriorityLevel;
   return level;
 }
 
@@ -53,20 +51,18 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetLevelForFlushing(PriorityLevelEnum level)
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_LevelForFlushing = level;
   this->m_OperationQ.push(OperationEnum::SET_LEVEL_FOR_FLUSHING);
   this->m_LevelQ.push(level);
-  this->m_Mutex.unlock();
 }
 
 template <typename SimpleLoggerType>
 typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetLevelForFlushing() const
 {
-  this->m_Mutex.lock();
-  PriorityLevelEnum level = this->m_LevelForFlushing;
-  this->m_Mutex.unlock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_LevelForFlushing;
   return level;
 }
 
@@ -74,18 +70,16 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetDelay(DelayType delay)
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_Delay = delay;
-  this->m_Mutex.unlock();
 }
 
 template <typename SimpleLoggerType>
 auto
 LoggerThreadWrapper<SimpleLoggerType>::GetDelay() const -> DelayType
 {
-  this->m_Mutex.lock();
-  DelayType delay = this->m_Delay;
-  this->m_Mutex.unlock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  DelayType                         delay = this->m_Delay;
   return delay;
 }
 
@@ -94,17 +88,16 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::AddLogOutput(OutputType * output)
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(OperationEnum::ADD_LOG_OUTPUT);
   this->m_OutputQ.push(output);
-  this->m_Mutex.unlock();
 }
 
 template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::Write(PriorityLevelEnum level, std::string const & content)
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_PriorityLevel >= level)
   {
     this->m_OperationQ.push(OperationEnum::WRITE);
@@ -115,7 +108,6 @@ LoggerThreadWrapper<SimpleLoggerType>::Write(PriorityLevelEnum level, std::strin
   {
     this->PrivateFlush();
   }
-  this->m_Mutex.unlock();
 }
 
 template <typename SimpleLoggerType>
@@ -156,9 +148,8 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::Flush()
 {
-  this->m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->PrivateFlush();
-  this->m_Mutex.unlock();
 }
 
 template <typename SimpleLoggerType>
@@ -186,36 +177,39 @@ LoggerThreadWrapper<SimpleLoggerType>::ThreadFunction()
 {
   while (!m_TerminationRequested)
   {
-    m_Mutex.lock();
-    while (!m_OperationQ.empty())
     {
-      switch (m_OperationQ.front())
+      const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+      while (!m_OperationQ.empty())
       {
-        case OperationEnum::SET_PRIORITY_LEVEL:
-          this->m_PriorityLevel = m_LevelQ.front();
-          m_LevelQ.pop();
-          break;
+        switch (m_OperationQ.front())
+        {
+          case OperationEnum::SET_PRIORITY_LEVEL:
+            this->m_PriorityLevel = m_LevelQ.front();
+            m_LevelQ.pop();
+            break;
 
-        case OperationEnum::SET_LEVEL_FOR_FLUSHING:
-          this->m_LevelForFlushing = m_LevelQ.front();
-          m_LevelQ.pop();
-          break;
+          case OperationEnum::SET_LEVEL_FOR_FLUSHING:
+            this->m_LevelForFlushing = m_LevelQ.front();
+            m_LevelQ.pop();
+            break;
 
-        case OperationEnum::ADD_LOG_OUTPUT:
-          this->m_Output->AddLogOutput(m_OutputQ.front());
-          m_OutputQ.pop();
-          break;
+          case OperationEnum::ADD_LOG_OUTPUT:
+            this->m_Output->AddLogOutput(m_OutputQ.front());
+            m_OutputQ.pop();
+            break;
 
-        case OperationEnum::WRITE:
-          SimpleLoggerType::Write(m_LevelQ.front(), m_MessageQ.front());
-          m_LevelQ.pop();
-          m_MessageQ.pop();
-          break;
+          case OperationEnum::WRITE:
+            SimpleLoggerType::Write(m_LevelQ.front(), m_MessageQ.front());
+            m_LevelQ.pop();
+            m_MessageQ.pop();
+            break;
+        }
+        m_OperationQ.pop();
       }
-      m_OperationQ.pop();
-    }
-    SimpleLoggerType::PrivateFlush();
-    m_Mutex.unlock();
+      SimpleLoggerType::PrivateFlush();
+
+    } // end of scope of lockGuard (unlocking m_Mutex automatically)
+
     itksys::SystemTools::Delay(this->GetDelay());
   }
 }

--- a/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
+++ b/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
@@ -47,48 +47,44 @@ StdStreamLogOutput::SetStream(StreamType & Stream)
 void
 StdStreamLogOutput::Flush()
 {
-  StdStreamLogOutput::m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     this->m_Stream->flush();
   }
-  StdStreamLogOutput::m_Mutex.unlock();
 }
 
 /** Write to a buffer */
 void
 StdStreamLogOutput::Write(double timestamp)
 {
-  StdStreamLogOutput::m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << timestamp;
   }
-  StdStreamLogOutput::m_Mutex.unlock();
 }
 
 /** Write to a buffer */
 void
 StdStreamLogOutput::Write(std::string const & content)
 {
-  StdStreamLogOutput::m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << content;
   }
-  StdStreamLogOutput::m_Mutex.unlock();
 }
 
 /** Write to a buffer */
 void
 StdStreamLogOutput::Write(std::string const & content, double timestamp)
 {
-  StdStreamLogOutput::m_Mutex.lock();
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << timestamp << "  :  " << content;
   }
-  StdStreamLogOutput::m_Mutex.unlock();
 }
 
 void

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -63,7 +63,7 @@ GPUImageDataManager<ImageType>::MakeCPUBufferUpToDate()
 {
   if (m_Image.IsNotNull())
   {
-    m_Mutex.lock();
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
 
     ModifiedTimeType gpu_time = this->GetMTime();
     TimeStamp        cpu_time_stamp = m_Image->GetTimeStamp();
@@ -96,8 +96,6 @@ GPUImageDataManager<ImageType>::MakeCPUBufferUpToDate()
       m_IsCPUBufferDirty = false;
       m_IsGPUBufferDirty = false;
     }
-
-    m_Mutex.unlock();
   }
 }
 
@@ -107,7 +105,7 @@ GPUImageDataManager<ImageType>::MakeGPUBufferUpToDate()
 {
   if (m_Image.IsNotNull())
   {
-    m_Mutex.lock();
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
 
     ModifiedTimeType gpu_time = this->GetMTime();
     TimeStamp        cpu_time_stamp = m_Image->GetTimeStamp();
@@ -139,8 +137,6 @@ GPUImageDataManager<ImageType>::MakeGPUBufferUpToDate()
       m_IsCPUBufferDirty = false;
       m_IsGPUBufferDirty = false;
     }
-
-    m_Mutex.unlock();
   }
 }
 


### PR DESCRIPTION
Replaced `m_Mutex.lock()`/`m_Mutex.unlock()` pairs, following C++ Core Guidelines, September 23, 2022, "Use RAII, never plain `lock()`/`unlock()`" https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp20-use-raii-never-plain-lockunlock
