### PR TITLE
STYLE: Add in-class `{}` initializers to classes with itkSimpleNewMacro

### DIFF
--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -556,24 +556,24 @@ protected:
 
 private:
   /** Who generated this data? */
-  WeakPointer<ProcessObject> m_Source;
-  DataObjectIdentifierType   m_SourceOutputName;
+  WeakPointer<ProcessObject> m_Source{};
+  DataObjectIdentifierType   m_SourceOutputName{};
 
   /** When was this data last generated?
    *  This time stamp is an integer number and it is intended to synchronize the
    *  activities of the pipeline. It doesn't relates to the clock time of
    *  acquiring or processing the data. */
-  TimeStamp m_UpdateMTime;
+  TimeStamp m_UpdateMTime{};
 
   /** When, in real time, this data was generated. */
-  RealTimeStamp m_RealTimeStamp;
+  RealTimeStamp m_RealTimeStamp{};
 
   bool m_ReleaseDataFlag; // Data will release after use by a filter if on
   bool m_DataReleased;    // Keep track of data release during pipeline execution
 
   /** The maximum MTime of all upstream filters and data objects.
    * This does not include the MTime of this data object. */
-  ModifiedTimeType m_PipelineMTime;
+  ModifiedTimeType m_PipelineMTime{};
 
   /** Static member that controls global data release after use by filter. */
   static bool * m_GlobalReleaseDataFlag;

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -353,21 +353,21 @@ private:
    * through the pointers (although it does enforce some
    * internal class synchronization).
    */
-  const RegionType &    m_GridRegion;
-  const OriginType &    m_GridOrigin;
-  const SpacingType &   m_GridSpacing;
+  const RegionType &    m_GridRegion{};
+  const OriginType &    m_GridOrigin{};
+  const SpacingType &   m_GridSpacing{};
   const DirectionType & m_GridDirection;
 
   /** The bulk transform. */
-  BulkTransformPointer m_BulkTransform;
+  BulkTransformPointer m_BulkTransform{};
 
-  RegionType m_ValidRegion;
+  RegionType m_ValidRegion{};
 
   /** Variables defining the interpolation support region. */
-  unsigned long m_Offset;
-  bool          m_SplineOrderOdd;
-  IndexType     m_ValidRegionLast;
-  IndexType     m_ValidRegionFirst;
+  unsigned long m_Offset{};
+  bool          m_SplineOrderOdd{};
+  IndexType     m_ValidRegionLast{};
+  IndexType     m_ValidRegionFirst{};
 
   void
   UpdateValidGridRegion();

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
@@ -355,26 +355,26 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  GradientImageType * m_MetricGradientImage;
-  MovingPointer       m_RefImage;
-  FixedPointer        m_TarImage;
+  GradientImageType * m_MetricGradientImage{};
+  MovingPointer       m_RefImage{};
+  FixedPointer        m_TarImage{};
   MovingRadiusType    m_MetricRadius; /** used by the metric to set
                                         region size for fixed image*/
-  typename MovingType::SizeType m_RefSize;
-  typename FixedType::SizeType  m_TarSize;
-  unsigned int                  m_NumberOfIntegrationPoints;
-  unsigned int                  m_SolutionIndex;
-  unsigned int                  m_SolutionIndex2;
-  Float                         m_Sign;
-  Float                         m_Temp;
-  Float                         m_Gamma;
+  typename MovingType::SizeType m_RefSize{};
+  typename FixedType::SizeType  m_TarSize{};
+  unsigned int                  m_NumberOfIntegrationPoints{};
+  unsigned int                  m_SolutionIndex{};
+  unsigned int                  m_SolutionIndex2{};
+  Float                         m_Sign{};
+  Float                         m_Temp{};
+  Float                         m_Gamma{};
 
-  typename Solution::ConstPointer     m_Solution;
-  MetricBaseTypePointer               m_Metric;
-  typename TransformBaseType::Pointer m_Transform;
-  typename InterpolatorType::Pointer  m_Interpolator;
+  typename Solution::ConstPointer     m_Solution{};
+  MetricBaseTypePointer               m_Metric{};
+  typename TransformBaseType::Pointer m_Transform{};
+  typename InterpolatorType::Pointer  m_Interpolator{};
 
-  mutable double m_Energy;
+  mutable double m_Energy{};
 
 private:
 };

--- a/Modules/Numerics/FEM/include/itkFEMLoadBC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBC.h
@@ -90,7 +90,7 @@ protected:
    *       defined by optional dim parameter (defaults to 0) in AssembleF
    *       function in solver.
    */
-  vnl_vector<Element::Float> m_Value;
+  vnl_vector<Element::Float> m_Value{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
@@ -188,7 +188,7 @@ protected:
   /** used internally by the Solver class */
   int m_Index{ 0 };
 
-  LhsType m_LeftHandSide;
+  LhsType m_LeftHandSide{};
 
   /**
    * Right hand side of the linear equation that defines the constraints.
@@ -196,7 +196,7 @@ protected:
    * Which value is applied to the master force vector is defined by optional
    * dim parameter (defaults to 0) in AssembleF function in solver.
    */
-  vnl_vector<Element::Float> m_RightHandSide;
+  vnl_vector<Element::Float> m_RightHandSide{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
@@ -95,7 +95,7 @@ protected:
    * Local number of the edge (face) of the element on which the load acts.
    * Check the corresponding element class for more info on edge numbering.
    */
-  int m_Edge;
+  int m_Edge{};
 
   /**
    * An edge force matrix. This matrix specifies nodal forces on all
@@ -113,7 +113,7 @@ protected:
    * element. Again check the documentation of the element class to which
    * the force is applied.
    */
-  vnl_matrix<Float> m_Force;
+  vnl_matrix<Float> m_Force{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
@@ -108,7 +108,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  vnl_vector<Float> m_GravityForce;
+  vnl_vector<Float> m_GravityForce{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
@@ -258,16 +258,16 @@ protected:
   /**
    * Point in __local coordinates__ in the undeformed configuration
    */
-  vnl_vector<Float> m_Point;
+  vnl_vector<Float> m_Point{};
 
   /**
    * Point in __global coordinates__ in the deformed configuration
    */
-  vnl_vector<Float> m_Target;
+  vnl_vector<Float> m_Target{};
 
-  vnl_vector<Float> m_Source;
+  vnl_vector<Float> m_Source{};
 
-  vnl_vector<Float> m_Force;
+  vnl_vector<Float> m_Force{};
 
   /**
    * Pointer to the element which contains the undeformed

--- a/Modules/Numerics/FEM/include/itkFEMLoadNode.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNode.h
@@ -108,7 +108,7 @@ protected:
    * Force applied on the node. Dimension of F should equal
    * element->GetNumberOfDegreesOfFreedomPerNode().
    */
-  vnl_vector<Float> m_Force;
+  vnl_vector<Float> m_Force{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
@@ -196,17 +196,17 @@ private:
   /**
    * Real displacement of the landmark
    */
-  VectorType m_RealDisplacement;
+  VectorType m_RealDisplacement{};
 
   /**
    * Simulated displacement of the landmark
    */
-  VectorType m_SimulatedDisplacement;
+  VectorType m_SimulatedDisplacement{};
 
   /**
    * Shape function vector
    */
-  VectorType m_Shape;
+  VectorType m_Shape{};
 
   /**
    * Magnitude of the error
@@ -231,13 +231,13 @@ private:
   /**
    * Structure tensor
    */
-  MatrixType m_StructureTensor;
+  MatrixType m_StructureTensor{};
 
   /**
    * Landmark tensor, which can be the stiffness tensor or the product
    * of the stiffness tensor and the structure tensor
    */
-  MatrixType m_LandmarkTensor;
+  MatrixType m_LandmarkTensor{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
@@ -87,10 +87,10 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Point of which the load acts in global the coordinate system. */
-  vnl_vector<Float> m_Point;
+  vnl_vector<Float> m_Point{};
 
   /** The actual load vector. */
-  vnl_vector<Float> m_ForcePoint;
+  vnl_vector<Float> m_ForcePoint{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
@@ -320,25 +320,25 @@ protected:
 private:
   FiniteDifferenceFunctionLoad(); // cannot be private until we always use smart pointers
 
-  MovingPointer m_MovingImage;
-  FixedPointer  m_FixedImage;
+  MovingPointer m_MovingImage{};
+  FixedPointer  m_FixedImage{};
 
   /** Used by the metric to set the region size for the fixed image. */
-  MovingRadiusType m_MetricRadius;
+  MovingRadiusType m_MetricRadius{};
 
-  typename MovingImageType::SizeType  m_MovingSize;
-  typename FixedImageType::SizeType   m_FixedSize;
+  typename MovingImageType::SizeType  m_MovingSize{};
+  typename FixedImageType::SizeType   m_FixedSize{};
   unsigned int                        m_NumberOfIntegrationPoints{ 0 };
   unsigned int                        m_SolutionIndex{ 1 };
   unsigned int                        m_SolutionIndex2{ 0 };
-  Float                               m_Gamma;
+  Float                               m_Gamma{};
   typename Solution::ConstPointer     m_Solution{ nullptr };
   float                               m_GradSigma{ 0.0f };
   float                               m_Sign{ 1.0f };
   float                               m_WhichMetric{ 0.0f };
-  FiniteDifferenceFunctionTypePointer m_DifferenceFunction;
+  FiniteDifferenceFunctionTypePointer m_DifferenceFunction{};
 
-  typename DisplacementFieldType::Pointer m_DisplacementField;
+  typename DisplacementFieldType::Pointer m_DisplacementField{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -134,9 +134,9 @@ private:
   using VectorType = typename PointType::VectorType;
   using NeighborsIterator = typename NeighborsIdentifierType::const_iterator;
 
-  CoordRepType m_PointSetSigma;
-  MeasureType  m_PreFactor;
-  MeasureType  m_Denominator;
+  CoordRepType m_PointSetSigma{};
+  MeasureType  m_PreFactor{};
+  MeasureType  m_Denominator{};
   unsigned int m_EvaluationKNeighborhood{ 50 };
 };
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -246,21 +246,21 @@ protected:
   }
 
 private:
-  DensityFunctionPointer m_MovingDensityFunction;
+  DensityFunctionPointer m_MovingDensityFunction{};
 
   bool m_UseAnisotropicCovariances{ false };
 
-  RealType     m_PointSetSigma;
-  RealType     m_KernelSigma;
-  unsigned int m_CovarianceKNeighborhood;
-  unsigned int m_EvaluationKNeighborhood;
+  RealType     m_PointSetSigma{};
+  RealType     m_KernelSigma{};
+  unsigned int m_CovarianceKNeighborhood{};
+  unsigned int m_EvaluationKNeighborhood{};
 
-  RealType m_Alpha;
+  RealType m_Alpha{};
 
   /** Precomputed cached values */
-  mutable RealType m_TotalNumberOfPoints;
-  mutable RealType m_Prefactor0;
-  mutable RealType m_Prefactor1;
+  mutable RealType m_TotalNumberOfPoints{};
+  mutable RealType m_Prefactor0{};
+  mutable RealType m_Prefactor1{};
 };
 
 


### PR DESCRIPTION
Added in-class `{}` default member initializers to data members of classes that have a `itkSimpleNewMacro` macro call.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3851 commit 5e2c49f9eb80e78903ce8f9fd2b5952062653cab "STYLE: Add in-class `{}` member initializers to objects created by New()" (which only looked at classes that have a `itkNewMacro`).
