### PR TITLE
ENH: Remove `itkMath.h` duplicate include

### DIFF
--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkNeighborhood.h"
-#include "itkMath.h"
 #include "itkMacro.h"
 #include "itkMath.h"
 


### PR DESCRIPTION
Remove `itkMath.h` duplicate include from
`itk::ScalarImageToRunLengthMatrixFilter.h`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)