### PR TITLE
ENH: Remove ivar memberless `PrintSelf`

### DIFF
--- a/Modules/Core/Common/include/itkKernelFunctionBase.h
+++ b/Modules/Core/Common/include/itkKernelFunctionBase.h
@@ -67,11 +67,6 @@ public:
 protected:
   KernelFunctionBase() = default;
   ~KernelFunctionBase() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override
-  {
-    Superclass::PrintSelf(os, indent);
-  }
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -120,12 +120,6 @@ public:
    * \sa CreateDirectional \sa Fill */
   // virtual void CreateToRadius(const unsigned long);
 
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override
-  {
-    Superclass::PrintSelf(os, indent);
-  }
-
 protected:
   /** Type alias support for coefficient vector type.*/
   using typename Superclass::CoefficientVector;

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -77,10 +77,6 @@ protected:
   BlobSpatialObject();
   ~BlobSpatialObject() override = default;
 
-  /** Method to print the object. */
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
-
   typename LightObject::Pointer
   InternalClone() const override;
 };

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
@@ -51,14 +51,6 @@ BlobSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-template <unsigned int TDimension>
-void
-BlobSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
-{
-  os << indent << "BlobSpatialObject(" << this << ')' << std::endl;
-  Superclass::PrintSelf(os, indent);
-}
-
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
@@ -67,10 +67,6 @@ protected:
   LandmarkSpatialObject();
   ~LandmarkSpatialObject() override = default;
 
-  /** Method to print the object. */
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
-
   typename LightObject::Pointer
   InternalClone() const override;
 };

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
@@ -52,16 +52,6 @@ LandmarkSpatialObject<TDimension>::InternalClone() const
   return loPtr;
 }
 
-template <unsigned int TDimension>
-void
-LandmarkSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
-{
-  os << indent << "LandmarkSpatialObject(" << this << ')' << std::endl;
-  os << indent << "ID: " << this->GetId() << std::endl;
-  os << indent << "nb of points: " << static_cast<SizeValueType>(this->m_Points.size()) << std::endl;
-  Superclass::PrintSelf(os, indent);
-}
-
 } // end namespace itk
 
 #endif


### PR DESCRIPTION
Remove `PrintSelf` re-implementations in classes that do not contain instance variable members as their parent class re-implementation prints the necessary information.

Follow-up to d2ff3110f198d9a3daa56a8e88c6e2b6faabad3a.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)