### PR TITLE
ENH: Use a macro to print boolean objects

### DIFF
--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -32,7 +32,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostr
   }
   os << "] ";
 
-  os << indent << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(CenterIsActive);
 }
 
 template <typename TImage, typename TBoundaryCondition>

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -88,7 +88,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::PrintSelf(s
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Scale: " << m_Scale << std::endl;
-  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Normalized);
   os << indent << "Direction: " << m_Direction << std::endl;
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
@@ -66,7 +66,7 @@ GaussianSpatialFunction<TOutput, VImageDimension, TInput>::PrintSelf(std::ostrea
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Scale: " << m_Scale << std::endl;
-  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Normalized);
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -291,7 +291,7 @@ void
 ImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DynamicMultiThreading: " << (m_DynamicMultiThreading ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(DynamicMultiThreading);
 }
 
 } // end namespace itk

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -38,8 +38,8 @@ InPlaceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "InPlace: " << (m_InPlace ? "On" : "Off") << std::endl;
-  os << indent << "RunningInPlace: " << (m_RunningInPlace ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InPlace);
+  itkPrintSelfBooleanMacro(RunningInPlace);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1276,6 +1276,13 @@ compilers.
   ITK_MACROEND_NOOP_STATEMENT
 
 
+// A useful macro in the PrintSelf method for printing boolean member
+// variables.
+#define itkPrintSelfBooleanMacro(name)                                           \
+  os << indent << #name << ": " << (this->m_##name ? "On" : "Off") << std::endl; \
+  ITK_MACROEND_NOOP_STATEMENT
+
+
 /** Set a decorated output. This defines the Set"name"() and a Set"name"Output() method */
 #define itkSetDecoratedOutputMacro(name, type)                                                                       \
   virtual void Set##name##Output(const SimpleDataObjectDecorator<type> * _arg)                                       \

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1269,8 +1269,8 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
 
   os << indent << "NumberOfRequiredOutputs: " << m_NumberOfRequiredOutputs << std::endl;
   os << indent << "NumberOfWorkUnits: " << m_NumberOfWorkUnits << std::endl;
-  os << indent << "ReleaseDataBeforeUpdateFlag: " << (m_ReleaseDataBeforeUpdateFlag ? "On" : "Off") << std::endl;
-  os << indent << "AbortGenerateData: " << (m_AbortGenerateData ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ReleaseDataBeforeUpdateFlag);
+  itkPrintSelfBooleanMacro(AbortGenerateData);
   os << indent << "Progress: " << progressFixedToFloat(m_Progress) << std::endl;
   os << indent << "Multithreader: " << std::endl;
   m_MultiThreader->PrintSelf(os, indent.GetNextIndent());

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -283,7 +283,7 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ElapsedIterations: " << m_ElapsedIterations << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "State: " << (m_IsInitialized ? "INITIALIZED" : "UNINITIALIZED") << std::endl;
   os << indent << "MaximumRMSError: " << m_MaximumRMSError << std::endl;
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -57,7 +57,7 @@ GPUReduction<TElement>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "TestGPUKernelHandle: " << m_TestGPUKernelHandle << std::endl;
 
   os << indent << "Size: " << m_Size << std::endl;
-  os << indent << "SmallBlock: " << (m_SmallBlock ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(SmallBlock);
 
   os << indent << "GPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_GPUResult) << std::endl;
   os << indent << "CPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_CPUResult) << std::endl;

--- a/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
@@ -272,8 +272,8 @@ GPUDataManager::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "MemFlags: " << m_MemFlags << std::endl;
   os << indent << "GPUBuffer: " << m_GPUBuffer << std::endl;
   os << indent << "CPUBuffer: " << m_CPUBuffer << std::endl;
-  os << indent << "IsGPUBufferDirty: " << (m_IsGPUBufferDirty ? "On" : "Off") << std::endl;
-  os << indent << "IsCPUBufferDirty: " << (m_IsCPUBufferDirty ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(IsGPUBufferDirty);
+  itkPrintSelfBooleanMacro(IsCPUBufferDirty);
 }
 
 } // namespace itk

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -306,7 +306,7 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::P
 
   itkPrintSelfObjectMacro(DifferenceFunction);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "State: " << m_State << std::endl;
 }
 

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -75,7 +75,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintS
 
   itkPrintSelfObjectMacro(CoefficientFilter);
 
-  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageDirection);
 
   os << indent
      << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -81,7 +81,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(s
 {
   this->Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageDirection);
 
   itkPrintSelfObjectMacro(Interpolator);
 }

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -68,7 +68,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, In
     os << indent << "Extent[" << i << "] : " << m_Extent[i] << std::endl;
   }
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 
   os << indent << "Internal Image : " << m_InternalImage << std::endl;
 }

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -251,7 +251,7 @@ void
 GaussianDerivativeImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Extent: " << m_Extent << std::endl;

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -2694,7 +2694,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "RegionOfInterestProvidedByUser: " << (m_RegionOfInterestProvidedByUser ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(RegionOfInterestProvidedByUser);
   os << indent << "RegionOfInterest: " << m_RegionOfInterest << std::endl;
 
   os << indent << "LUT: " << m_LUT << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -158,7 +158,7 @@ ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
   // os << indent << "ControlPoints: " << m_ControlPoints << std::endl;
   os << indent << "InterpolationMethod: " << m_InterpolationMethod << std::endl;
   os << indent << "InterpolationFactor: " << m_InterpolationFactor << std::endl;
-  os << indent << "IsClosed: " << (m_IsClosed ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(IsClosed);
   os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
   os << indent << "OrientationInObjectSpaceMTime: "
      << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_OrientationInObjectSpaceMTime) << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -308,7 +308,7 @@ PolygonSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
   Superclass::PrintSelf(os, indent);
   os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
   os << indent << "OrientationInObjectSpaceMTime: " << m_OrientationInObjectSpaceMTime << std::endl;
-  os << indent << "IsClosed: " << (m_IsClosed ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(IsClosed);
   os << indent << "ThicknessInObjectSpace: " << m_ThicknessInObjectSpace << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -112,8 +112,8 @@ TubeSpatialObject<TDimension, TTubePointType>::PrintSelf(std::ostream & os, Inde
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ParentPoint : " << m_ParentPoint << std::endl;
-  os << indent << "EndRounded: " << (m_EndRounded ? "On" : "Off") << std::endl;
-  os << indent << "Root: " << (m_Root ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(EndRounded);
+  itkPrintSelfBooleanMacro(Root);
 }
 
 template <unsigned int TDimension, typename TTubePointType>

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -300,9 +300,7 @@ PipelineMonitorImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ClearPipelineOnGenerateOutputInformation: " << (m_ClearPipelineOnGenerateOutputInformation ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(ClearPipelineOnGenerateOutputInformation);
   os << indent << "NumberOfUpdates: " << m_NumberOfUpdates << std::endl;
   os << indent << "NumberOfClearPipeline: " << m_NumberOfClearPipeline << std::endl;
 

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -49,8 +49,7 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::PrintSel
   os << indent << "AzimuthAngularSeparation: " << m_AzimuthAngularSeparation << std::endl;
   os << indent << "ElevationAngularSeparation: " << m_ElevationAngularSeparation << std::endl;
   os << indent << "FirstSampleDistance: " << m_FirstSampleDistance << std::endl;
-  os << indent << "ForwardAzimuthElevationToPhysical: " << (m_ForwardAzimuthElevationToPhysical ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(ForwardAzimuthElevationToPhysical);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -363,7 +363,7 @@ Euler3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inde
   os << indent << "AngleX: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleX) << std::endl;
   os << indent << "AngleY: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleY) << std::endl;
   os << indent << "AngleZ: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleZ) << std::endl;
-  os << indent << "ComputeZYX: " << (m_ComputeZYX ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeZYX);
 }
 
 } // namespace itk

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -947,12 +947,11 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(s
 
   os << indent << "SlicingDirection: " << m_SlicingDirection << std::endl;
 
-  os << indent << "BiasFieldMultiplicative: " << (m_BiasFieldMultiplicative ? "On" : "Off") << std::endl;
-  os << indent << "UsingInterSliceIntensityCorrection: " << (m_UsingInterSliceIntensityCorrection ? "On" : "Off")
-     << std::endl;
-  os << indent << "UsingSlabIdentification: " << (m_UsingSlabIdentification ? "On" : "Off") << std::endl;
-  os << indent << "UsingBiasFieldCorrection: " << (m_UsingBiasFieldCorrection ? "On" : "Off") << std::endl;
-  os << indent << "GeneratingOutput: " << (m_GeneratingOutput ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(BiasFieldMultiplicative);
+  itkPrintSelfBooleanMacro(UsingInterSliceIntensityCorrection);
+  itkPrintSelfBooleanMacro(UsingSlabIdentification);
+  itkPrintSelfBooleanMacro(UsingBiasFieldCorrection);
+  itkPrintSelfBooleanMacro(GeneratingOutput);
 
   os << indent << "SlabNumberOfSamples: " << m_SlabNumberOfSamples << std::endl;
   os << indent << "SlabBackgroundMinimumThreshold: "

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -114,7 +114,7 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -97,7 +97,7 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
      << std::endl;
   os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -224,7 +224,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::
 
   m_DefaultBoundaryCondition.Print(os, indent);
 
-  os << indent << "UseBoundaryCondition: " << (m_UseBoundaryCondition ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseBoundaryCondition);
   os << indent << "Kernel: " << static_cast<typename NumericTraits<KernelType>::PrintType>(m_Kernel) << std::endl;
   os << indent << "ObjectValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ObjectValue)
      << std::endl;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -257,17 +257,16 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
 
   os << indent << "State: " << m_State << std::endl;
   os << indent << "PatchRadius: " << m_PatchRadius << std::endl;
-  os << indent << "KernelBandwidthEstimation: " << (m_KernelBandwidthEstimation ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(KernelBandwidthEstimation);
   os << indent << "KernelBandwidthUpdateFrequency: " << m_KernelBandwidthUpdateFrequency << std::endl;
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent << "ElapsedIterations: " << m_ElapsedIterations << std::endl;
   os << indent << "NoiseModel: " << m_NoiseModel << std::endl;
   os << indent << "SmoothingWeight: " << m_SmoothingWeight << std::endl;
   os << indent << "NoiseModelFidelityWeight: " << m_NoiseModelFidelityWeight << std::endl;
-  os << indent << "AlwaysTreatComponentsAsEuclidean: " << (m_AlwaysTreatComponentsAsEuclidean ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(AlwaysTreatComponentsAsEuclidean);
   os << indent << "ComponentSpace: " << m_ComponentSpace << std::endl;
-  os << indent << "ManualReinitialization: " << (m_ManualReinitialization ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ManualReinitialization);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2388,11 +2388,11 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
     os << "(Cannot be computed: input not set)" << std::endl;
   }
 
-  os << indent << "UseSmoothDiscPatchWeights: " << (m_UseSmoothDiscPatchWeights ? "On" : "Off") << std::endl;
-  os << indent << "UseFastTensorComputations: " << (m_UseFastTensorComputations ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseSmoothDiscPatchWeights);
+  itkPrintSelfBooleanMacro(UseFastTensorComputations);
 
   os << indent << "KernelBandwidthSigma: " << m_KernelBandwidthSigma << std::endl;
-  os << indent << "KernelBandwidthSigmaIsSet: " << (m_KernelBandwidthSigmaIsSet ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(KernelBandwidthSigmaIsSet);
 
   os << indent << "IntensityRescaleInvFactor: " << m_IntensityRescaleInvFactor << std::endl;
 
@@ -2403,7 +2403,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   os << indent << "KernelBandwidthFractionPixelsForEstimation: " << m_KernelBandwidthFractionPixelsForEstimation
      << std::endl;
 
-  os << indent << "ComputeConditionalDerivatives: " << (m_ComputeConditionalDerivatives ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeConditionalDerivatives);
 
   os << indent << "MinSigma: " << m_MinSigma << std::endl;
   os << indent << "MinProbability: " << m_MinProbability << std::endl;
@@ -2415,7 +2415,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
 
   os << indent << "NoiseSigma: " << m_NoiseSigma << std::endl;
   os << indent << "NoiseSigmaSquared: " << m_NoiseSigmaSquared << std::endl;
-  os << indent << "NoiseSigmaIsSet: " << (m_NoiseSigmaIsSet ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NoiseSigmaIsSet);
 
   itkPrintSelfObjectMacro(Sampler);
   itkPrintSelfObjectMacro(UpdateBuffer);

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -216,7 +216,7 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 
   os << indent << "SplineOrder: " << static_cast<typename NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder)
      << std::endl;
-  os << indent << "EnforceStationaryBoundary: " << (m_EnforceStationaryBoundary ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(EnforceStationaryBoundary);
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;
 }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -237,7 +237,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 
   os << indent << "DerivativeWeights: " << m_DerivativeWeights << std::endl;
   os << indent << "HalfDerivativeWeights: " << m_HalfDerivativeWeights << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "RequestedNumberOfThreads: "
      << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
   os << indent << "RealValuedInputImage: " << m_RealValuedInputImage.GetPointer() << std::endl;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -389,14 +389,14 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "EstimateInverse: " << (m_EstimateInverse ? "On" : "Off") << std::endl;
-  os << indent << "EnforceStationaryBoundary: " << (m_EnforceStationaryBoundary ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(EstimateInverse);
+  itkPrintSelfBooleanMacro(EnforceStationaryBoundary);
   os << indent << "NumberOfControlPoints: " << m_NumberOfControlPoints << std::endl;
   os << indent << "NumberOfFittingLevels: " << m_NumberOfFittingLevels << std::endl;
 
   itkPrintSelfObjectMacro(PointWeights);
 
-  os << indent << "UsePointWeights: " << (m_UsePointWeights ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UsePointWeights);
 
   os << indent
      << "BSplineDomainOrigin: " << static_cast<typename NumericTraits<OriginType>::PrintType>(m_BSplineDomainOrigin)
@@ -409,9 +409,8 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
   os << indent << "BSplineDomainDirection: "
      << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_BSplineDomainDirection) << std::endl;
 
-  os << indent << "BSplineDomainIsDefined: " << (m_BSplineDomainIsDefined ? "On" : "Off") << std::endl;
-  os << indent << "UseInputFieldToDefineTheBSplineDomain: " << (m_UseInputFieldToDefineTheBSplineDomain ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(BSplineDomainIsDefined);
+  itkPrintSelfBooleanMacro(UseInputFieldToDefineTheBSplineDomain);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -239,7 +239,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(st
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "ContourDirectedMeanDistance: " << m_ContourDirectedMeanDistance << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -150,7 +150,7 @@ ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std::ostre
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "MeanDistance: " << m_MeanDistance << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -210,7 +210,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std:
      << static_cast<typename NumericTraits<RealType>::PrintType>(m_DirectedHausdorffDistance) << std::endl;
   os << indent << "AverageHausdorffDistance: "
      << static_cast<typename NumericTraits<RealType>::PrintType>(m_AverageHausdorffDistance) << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -58,7 +58,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
   os << indent << "FarValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_FarValue) << std::endl;
   os << indent << "Spacing: " << static_cast<typename NumericTraits<InputSpacingType>::PrintType>(m_Spacing)
      << std::endl;
-  os << indent << "NarrowBanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NarrowBanding);
 
   itkPrintSelfObjectMacro(NarrowBand);
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -49,7 +49,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::os
   itkPrintSelfObjectMacro(ReachedTargetPoints);
   itkPrintSelfObjectMacro(GradientImage);
 
-  os << indent << "GenerateGradientImage: " << (m_GenerateGradientImage ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(GenerateGradientImage);
   os << indent << "TargetOffset: " << m_TargetOffset << std::endl;
   os << indent << "TargetReachedMode: " << m_TargetReachedMode << std::endl;
   os << indent << "TargetValue: " << m_TargetValue << std::endl;

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -147,7 +147,7 @@ DerivativeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, I
 
   os << indent << "Order: " << m_Order << std::endl;
   os << indent << "Direction: " << m_Direction << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -282,7 +282,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::PrintSelf(std:
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "InternalNumberOfStreamDivisions: " << m_InternalNumberOfStreamDivisions << std::endl;
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -292,7 +292,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   os << indent << "Disc Radius Ratio: " << m_DiscRadiusRatio << std::endl;
   os << indent << "Accumulator blur variance: " << m_Variance << std::endl;
   os << indent << "Sweep angle : " << m_SweepAngle << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 
   itkPrintSelfObjectMacro(RadiusImage);
 

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
@@ -30,7 +30,7 @@ LaplacianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -161,7 +161,7 @@ LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -53,7 +53,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::PrintSelf(std::ostrea
   os << indent << "BlockRadius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BlockRadius)
      << std::endl;
   os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
-  os << indent << "ComputeStructureTensors: " << (m_ComputeStructureTensors ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeStructureTensors);
 }
 
 template <typename TImage, typename TMask, typename TFeatures>

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -208,8 +208,8 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
-  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
+  itkPrintSelfBooleanMacro(UseImageDirection);
 
   os << indent << "BoundaryCondition: ";
   if (m_BoundaryCondition != nullptr)

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -43,7 +43,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -81,7 +81,7 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintS
   itkPrintSelfObjectMacro(SqrSpacingFilter);
   itkPrintSelfObjectMacro(SqrtFilter);
 
-  os << indent << "NormalizeAcrossScale: " << (m_NormalizeAcrossScale ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NormalizeAcrossScale);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -334,8 +334,8 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
   itkPrintSelfObjectMacro(DerivativeFilter);
   itkPrintSelfObjectMacro(ImageAdaptor);
 
-  os << indent << "NormalizeAcrossScale: " << (m_NormalizeAcrossScale ? "On" : "Off") << std::endl;
-  os << indent << "UseImageDirection: " << (m_UseImageDirection ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NormalizeAcrossScale);
+  itkPrintSelfBooleanMacro(UseImageDirection);
   os << indent << "Sigma: " << m_Sigma << std::endl;
 }
 

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -51,7 +51,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::PrintS
   os << indent << "DerivativeWeights: " << m_DerivativeWeights << std::endl;
   os << indent << "ComponentWeights: " << m_ComponentWeights << std::endl;
   os << indent << "SqrtComponentWeights: " << m_SqrtComponentWeights << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "UsePrincipleComponents: " << m_UsePrincipleComponents << std::endl;
   os << indent << "RequestedNumberOfThreads: "
      << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -182,12 +182,12 @@ ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
 
   itkPrintSelfObjectMacro(ReferenceImage);
 
-  os << indent << "CenterImage: " << (m_CenterImage ? "On" : "Off") << std::endl;
-  os << indent << "ChangeSpacing: " << (m_ChangeSpacing ? "On" : "Off") << std::endl;
-  os << indent << "ChangeOrigin: " << (m_ChangeOrigin ? "On" : "Off") << std::endl;
-  os << indent << "ChangeDirection: " << (m_ChangeDirection ? "On" : "Off") << std::endl;
-  os << indent << "ChangeRegion: " << (m_ChangeRegion ? "On" : "Off") << std::endl;
-  os << indent << "UseReferenceImage: " << (m_UseReferenceImage ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(CenterImage);
+  itkPrintSelfBooleanMacro(ChangeSpacing);
+  itkPrintSelfBooleanMacro(ChangeOrigin);
+  itkPrintSelfBooleanMacro(ChangeDirection);
+  itkPrintSelfBooleanMacro(ChangeRegion);
+  itkPrintSelfBooleanMacro(UseReferenceImage);
 
   os << indent << "OutputSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_OutputSpacing)
      << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -671,7 +671,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   os << indent << "Transform: " << this->GetTransform() << std::endl;
   os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
   os << indent << "Extrapolator: " << m_Extrapolator.GetPointer() << std::endl;
-  os << indent << "UseReferenceImage: " << (m_UseReferenceImage ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseReferenceImage);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -85,7 +85,7 @@ GaborImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CalculateImaginaryPart: " << (m_CalculateImaginaryPart ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(CalculateImaginaryPart);
   os << indent << "Frequency: " << this->GetFrequency() << std::endl;
   os << indent << "PhaseOffset: " << m_PhaseOffset << std::endl;
   os << indent << "Sigma: " << this->GetSigma() << std::endl;

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -123,7 +123,7 @@ GaussianImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) c
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Scale: " << m_Scale << std::endl;
-  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Normalized);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -212,7 +212,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, I
   Superclass::PrintSelf(os, indent);
 
   os << indent << "AccumulateDimension: " << m_AccumulateDimension << std::endl;
-  os << indent << "Average: " << (m_Average ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Average);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
@@ -66,7 +66,7 @@ AdaptiveHistogramEqualizationImageFilter<TImageType, TKernel>::PrintSelf(std::os
   os << indent << "InputMaximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMaximum)
      << std::endl;
 
-  os << indent << "UseLookupTable: " << (m_UseLookupTable ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseLookupTable);
 }
 } // namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -157,7 +157,7 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::PrintSelf(std::ostrea
   itkPrintSelfObjectMacro(Image);
 
   os << indent << "BasisMatrix: " << m_BasisMatrix << std::endl;
-  os << indent << "BasisMatrixCalculated: " << (m_BasisMatrixCalculated ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(BasisMatrixCalculated);
   os << indent << "NumPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumPixels)
      << std::endl;
 }

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -516,7 +516,7 @@ LabelStatisticsImageFilter<TImage, TLabelImage>::PrintSelf(std::ostream & os, In
   }
 
   os << indent << "ValidLabelValues: " << m_ValidLabelValues << std::endl;
-  os << indent << "UseHistograms: " << (m_UseHistograms ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseHistograms);
   os << indent << "NumBins: " << m_NumBins << std::endl;
   os << indent << "LowerBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LowerBound) << std::endl;
   os << indent << "UpperBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_UpperBound) << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -133,7 +133,7 @@ BinaryFillholeImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent inde
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -110,7 +110,7 @@ BinaryGrindPeakImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent ind
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
@@ -94,7 +94,7 @@ BinaryImageToShapeLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "BackgroundValue: "
      << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
   os << indent << "ForegroundValue: "

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -100,7 +100,7 @@ BinaryImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>:
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "OutputBackgroundValue: "
      << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
   os << indent << "InputForegroundValue: "

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
@@ -116,7 +116,7 @@ BinaryReconstructionByDilationImageFilter<TInputImage>::PrintSelf(std::ostream &
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
@@ -132,7 +132,7 @@ BinaryReconstructionByErosionImageFilter<TInputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -111,7 +111,7 @@ BinaryShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
@@ -115,7 +115,7 @@ BinaryShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -115,7 +115,7 @@ BinaryStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(s
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
@@ -118,7 +118,7 @@ BinaryStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
@@ -37,7 +37,7 @@ void
 InPlaceLabelMapFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "InPlace: " << (this->m_InPlace ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InPlace);
   if (this->CanRunInPlace())
   {
     os << indent << "The input and output to this filter are the same type. The filter can be run in place."

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -141,7 +141,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::PrintSel
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Kernel: " << m_Kernel << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "PreserveIntensities: " << m_PreserveIntensities << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -134,7 +134,7 @@ DoubleThresholdImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
   os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
      << std::endl;
   os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1163,7 +1163,7 @@ FlatStructuringElement<VDimension>::PrintSelf(std::ostream & os, Indent indent) 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Decomposable: " << (m_Decomposable ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Decomposable);
 
   os << "Lines: " << std::endl;
   for (unsigned int i = 0; i < m_Lines.size(); ++i)
@@ -1171,7 +1171,7 @@ FlatStructuringElement<VDimension>::PrintSelf(std::ostream & os, Indent indent) 
     os << indent.GetNextIndent() << m_Lines[i] << std::endl;
   }
 
-  os << indent << "RadiusIsParametric: " << (m_RadiusIsParametric ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(RadiusIsParametric);
 }
 
 template <unsigned int VDimension>

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -144,7 +144,7 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
 
   os << indent << "Seed point: " << m_Seed << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -143,7 +143,7 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
 
   os << indent << "Seed point: " << m_Seed << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -144,7 +144,7 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -381,9 +381,9 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "RunOneIteration: " << (m_RunOneIteration ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(RunOneIteration);
   os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -379,9 +379,9 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "RunOneIteration: " << (m_RunOneIteration ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(RunOneIteration);
   os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -154,7 +154,7 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -105,7 +105,7 @@ HConcaveImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Ind
   os << indent << "Depth of local minima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -106,7 +106,7 @@ HConvexImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Height of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -113,7 +113,7 @@ HMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Height of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -113,7 +113,7 @@ HMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Depth of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -141,7 +141,7 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::PrintSel
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Kernel: " << m_Kernel << std::endl;
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "PreserveIntensities: " << m_PreserveIntensities << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -342,7 +342,7 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "MarkerValue: " << m_MarkerValue << std::endl;
   os << indent << "UseInternalCopy: " << m_UseInternalCopy << std::endl;
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -130,7 +130,7 @@ RegionalMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "FlatIsMaxima: " << m_FlatIsMaxima << std::endl;
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -134,7 +134,7 @@ RegionalMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "FlatIsMinima: " << m_FlatIsMinima << std::endl;
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -214,7 +214,7 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "Flat: " << m_Flat << std::endl;
   os << indent << "MarkerValue: " << m_MarkerValue << std::endl;
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -87,8 +87,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "TopologicalChange: " << (m_TopologicalChange ? "On" : "Off") << std::endl;
-    os << indent << "SizeCriterion: " << (m_SizeCriterion ? "On" : "Off") << std::endl;
+    itkPrintSelfBooleanMacro(TopologicalChange);
+    itkPrintSelfBooleanMacro(SizeCriterion);
     os << indent << "NumberOfElements: " << m_NumberOfElements << std::endl;
     os << indent << "MeasureBound: " << m_MeasureBound << std::endl;
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
@@ -175,7 +175,7 @@ SmoothingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "DelaunayConforming: " << (m_DelaunayConforming ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(DelaunayConforming);
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent << "RelaxationFactor: " << m_RelaxationFactor << std::endl;
 }

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -345,7 +345,7 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
   os << indent << "FilterDimensionality: " << m_FilterDimensionality << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "RealBoundaryCondition: " << m_RealBoundaryCondition << std::endl;
 }
 } // end namespace itk

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -210,10 +210,10 @@ DCMTKSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "SeriesUIDs[" << i << "]: " << m_SeriesUIDs[i] << std::endl;
   }
 
-  os << indent << "UseSeriesDetails: " << (m_UseSeriesDetails ? "On" : "Off") << std::endl;
-  os << indent << "Recursive: " << (m_Recursive ? "On" : "Off") << std::endl;
-  os << indent << "LoadSequences: " << (m_LoadSequences ? "On" : "Off") << std::endl;
-  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseSeriesDetails);
+  itkPrintSelfBooleanMacro(Recursive);
+  itkPrintSelfBooleanMacro(LoadSequences);
+  itkPrintSelfBooleanMacro(LoadPrivateTags);
 }
 
 void

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1621,13 +1621,13 @@ GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "StudyInstanceUID: " << m_StudyInstanceUID << std::endl;
   os << indent << "SeriesInstanceUID: " << m_SeriesInstanceUID << std::endl;
   os << indent << "FrameOfReferenceInstanceUID: " << m_FrameOfReferenceInstanceUID << std::endl;
-  os << indent << "KeepOriginalUID: " << (m_KeepOriginalUID ? "On" : "Off") << std::endl;
-  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
-  os << indent << "ReadYBRtoRGB: " << (m_ReadYBRtoRGB ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(KeepOriginalUID);
+  itkPrintSelfBooleanMacro(LoadPrivateTags);
+  itkPrintSelfBooleanMacro(ReadYBRtoRGB);
 
   os << indent << "GlobalNumberOfDimensions: " << m_GlobalNumberOfDimensions << std::endl;
   os << indent << "CompressionType: " << m_CompressionType << std::endl;
-  os << indent << "SingleBit: " << (m_SingleBit ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(SingleBit);
   os << indent << "InternalComponentType: " << m_InternalComponentType << std::endl;
 
   os << indent << "DICOMHeader: ";

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -287,10 +287,10 @@ GDCMSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 
   os << indent << "SeriesUIDs: " << m_SeriesUIDs << std::endl;
 
-  os << indent << "UseSeriesDetails: " << (m_UseSeriesDetails ? "On" : "Off") << std::endl;
-  os << indent << "Recursive: " << (m_Recursive ? "On" : "Off") << std::endl;
-  os << indent << "LoadSequences: " << (m_LoadSequences ? "On" : "Off") << std::endl;
-  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseSeriesDetails);
+  itkPrintSelfBooleanMacro(Recursive);
+  itkPrintSelfBooleanMacro(LoadSequences);
+  itkPrintSelfBooleanMacro(LoadPrivateTags);
 }
 
 void

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -48,8 +48,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::PrintSelf(std::ostream & os, 
 
   itkPrintSelfObjectMacro(ImageIO);
 
-  os << indent << "UserSpecifiedImageIO: " << (m_UserSpecifiedImageIO ? "On" : "Off") << std::endl;
-  os << indent << "UseStreaming: " << (m_UseStreaming ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UserSpecifiedImageIO);
+  itkPrintSelfBooleanMacro(UseStreaming);
 
   os << indent << "ExceptionMessage: " << m_ExceptionMessage << std::endl;
   os << indent << "ActualIORegion: " << m_ActualIORegion << std::endl;

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -392,9 +392,9 @@ ImageFileWriter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "PasteIORegion: " << m_PasteIORegion << std::endl;
   os << indent << "NumberOfStreamDivisions: " << m_NumberOfStreamDivisions << std::endl;
   os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
-  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
-  os << indent << "UseInputMetaDataDictionary: " << (m_UseInputMetaDataDictionary ? "On" : "Off") << std::endl;
-  os << indent << "FactorySpecifiedImageIO: " << (m_FactorySpecifiedImageIO ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseCompression);
+  itkPrintSelfBooleanMacro(UseInputMetaDataDictionary);
+  itkPrintSelfBooleanMacro(FactorySpecifiedImageIO);
 }
 } // end namespace itk
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -357,7 +357,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   itkPrintSelfObjectMacro(ImageIO);
 
-  os << indent << "UserSpecifiedImageIO: " << (m_UserSpecifiedImageIO ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UserSpecifiedImageIO);
   for (unsigned int i = 0; i < m_FileNames.size(); ++i)
   {
     os << indent << "FileNames[" << i << "]: " << m_FileNames[i] << std::endl;
@@ -365,7 +365,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
   os << indent << "SeriesFormat: " << m_SeriesFormat << std::endl;
   os << indent << "StartIndex: " << m_StartIndex << std::endl;
   os << indent << "IncrementIndex: " << m_IncrementIndex << std::endl;
-  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseCompression);
   os << indent << "MetaDataDictionaryArray: " << m_MetaDataDictionaryArray << std::endl;
 }
 } // end namespace itk

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -1175,15 +1175,15 @@ ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
   {
     os << indent << direction << std::endl;
   }
-  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseCompression);
   os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
   os << indent << "MaximumCompressionLevel: " << m_MaximumCompressionLevel << std::endl;
   os << indent << "Compressor: " << m_Compressor << std::endl;
-  os << indent << "UseStreamedReading: " << (m_UseStreamedReading ? "On" : "Off") << std::endl;
-  os << indent << "UseStreamedWriting: " << (m_UseStreamedWriting ? "On" : "Off") << std::endl;
-  os << indent << "ExpandRGBPalette: " << (m_ExpandRGBPalette ? "On" : "Off") << std::endl;
-  os << indent << "IsReadAsScalarPlusPalette: " << (m_IsReadAsScalarPlusPalette ? "On" : "Off") << std::endl;
-  os << indent << "WritePalette: " << (m_WritePalette ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseStreamedReading);
+  itkPrintSelfBooleanMacro(UseStreamedWriting);
+  itkPrintSelfBooleanMacro(ExpandRGBPalette);
+  itkPrintSelfBooleanMacro(IsReadAsScalarPlusPalette);
+  itkPrintSelfBooleanMacro(WritePalette);
 }
 
 } // namespace itk

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -468,10 +468,10 @@ MeshFileWriter<TInputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 
   itkPrintSelfObjectMacro(MeshIO);
 
-  os << indent << "UserSpecifiedMeshIO: " << (m_UserSpecifiedMeshIO ? "On" : "Off") << std::endl;
-  os << indent << "FactorySpecifiedMeshIO: " << (m_FactorySpecifiedMeshIO ? "On" : "Off") << std::endl;
-  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
-  os << indent << "FileTypeIsBINARY: " << (m_FileTypeIsBINARY ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UserSpecifiedMeshIO);
+  itkPrintSelfBooleanMacro(FactorySpecifiedMeshIO);
+  itkPrintSelfBooleanMacro(UseCompression);
+  itkPrintSelfBooleanMacro(FileTypeIsBINARY);
 }
 } // end namespace itk
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -446,9 +446,9 @@ NiftiImageIO::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "NiftiImage: " << m_NiftiImage << std::endl;
   os << indent << "RescaleSlope: " << m_RescaleSlope << std::endl;
   os << indent << "RescaleIntercept: " << m_RescaleIntercept << std::endl;
-  os << indent << "ConvertRAS: " << (m_ConvertRAS ? "On" : "Off") << std::endl;
-  os << indent << "ConvertRASVectors: " << (m_ConvertRASVectors ? "On" : "Off") << std::endl;
-  os << indent << "ConvertRASDisplacementVectors: " << (m_ConvertRASDisplacementVectors ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ConvertRAS);
+  itkPrintSelfBooleanMacro(ConvertRASVectors);
+  itkPrintSelfBooleanMacro(ConvertRASDisplacementVectors);
   os << indent << "OnDiskComponentType: " << m_OnDiskComponentType << std::endl;
   os << indent << "LegacyAnalyze75Mode: " << m_LegacyAnalyze75Mode << std::endl;
   os << indent << "SFORM permissive: " << (m_SFORM_Permissive ? "On" : "Off") << std::endl;

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -123,7 +123,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+    itkPrintSelfBooleanMacro(UseImageSpacing);
   }
 
 private:

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -125,7 +125,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+    itkPrintSelfBooleanMacro(UseImageSpacing);
   }
 
 private:

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -237,7 +237,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "Lambda: " << static_cast<typename NumericTraits<AttributeType>::PrintType>(m_Lambda) << std::endl;
 }
 } // end namespace itk

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -38,7 +38,7 @@ void
 DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "Order: " << m_Order << std::endl;

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -36,7 +36,7 @@ void
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -36,7 +36,7 @@ void
 DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -276,7 +276,7 @@ MultiphaseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputImage, 
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ElapsedIterations: " << this->m_ElapsedIterations << std::endl;
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "State: " << this->m_InitializedState << std::endl;
   os << indent << "MaximumRMSError: " << m_MaximumRMSError << std::endl;
   os << indent << "NumberOfIterations: " << this->m_NumberOfIterations << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -53,7 +53,7 @@ AmoebaOptimizer::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "MaximumNumberOfIterations: " << this->m_MaximumNumberOfIterations << std::endl;
   os << indent << "ParametersConvergenceTolerance: " << this->m_ParametersConvergenceTolerance << std::endl;
   os << indent << "FunctionConvergenceTolerance: " << this->m_FunctionConvergenceTolerance << std::endl;
-  os << indent << "AutomaticInitialSimplex: " << (this->m_AutomaticInitialSimplex ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(AutomaticInitialSimplex);
   os << indent << "InitialSimplexDelta: " << this->m_InitialSimplexDelta << std::endl;
 }
 

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -394,7 +394,7 @@ CumulativeGaussianOptimizer::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "UpperAsymptote: " << m_UpperAsymptote << std::endl;
   os << indent << "LowerAsymptote: " << m_LowerAsymptote << std::endl;
   os << indent << "OffsetForMean: " << m_OffsetForMean << std::endl;
-  os << indent << "Verbose: " << (m_Verbose ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Verbose);
   os << indent << "FitError: " << m_FitError << std::endl;
 
   os << indent << "FinalSampledArray: ";

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -202,7 +202,7 @@ ExhaustiveOptimizer::PrintSelf(std::ostream & os, Indent indent) const
   os << indent
      << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
      << std::endl;
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
   os << indent << "CurrentParameter: " << m_CurrentParameter << std::endl;
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -218,7 +218,7 @@ FRPROptimizer::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "OptimizationType: " << m_OptimizationType << std::endl;
-  os << indent << "UseUnitLengthGradient: " << (m_UseUnitLengthGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseUnitLengthGradient);
 }
 
 std::ostream &

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -53,7 +53,7 @@ SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
      << std::endl;
   os << indent << "LearningRate: " << m_LearningRate << std::endl;
   os << indent << "Delta: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Delta) << std::endl;
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StateOfConvergence: " << m_StateOfConvergence << std::endl;
   os << indent
@@ -68,7 +68,7 @@ SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
      << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
   os << indent << "StateOfConvergenceDecayRate: " << m_StateOfConvergenceDecayRate << std::endl;
   os << indent << "Tolerance: " << m_Tolerance << std::endl;
-  os << indent << "Maximize: " << (m_Maximize ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Maximize);
   os << indent << "GradientMagnitude: " << m_GradientMagnitude << std::endl;
   os << indent << "NumberOfPerturbations: "
      << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPerturbations) << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -98,7 +98,7 @@ void
 SingleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Maximize flag: " << (m_Maximize ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Maximize);
   os << indent << "Cached Value: " << m_CachedValue << std::endl;
   os << indent << "Cached Derivative: " << m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << m_CachedCurrentPosition << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -228,7 +228,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::PrintSelf(std::ostream & o
      << std::endl;
   os << indent << "NumberOfSteps: " << static_cast<typename NumericTraits<StepsType>::PrintType>(m_NumberOfSteps)
      << std::endl;
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
   os << indent

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -58,13 +58,12 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "DoEstimateLearningRateAtEachIteration: " << (m_DoEstimateLearningRateAtEachIteration ? "On" : "Off")
-     << std::endl;
-  os << indent << "DoEstimateLearningRateOnce: " << (m_DoEstimateLearningRateOnce ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(DoEstimateLearningRateAtEachIteration);
+  itkPrintSelfBooleanMacro(DoEstimateLearningRateOnce);
   os << indent << "MaximumStepSizeInPhysicalUnits: "
      << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_MaximumStepSizeInPhysicalUnits)
      << std::endl;
-  os << indent << "UseConvergenceMonitoring: " << (m_UseConvergenceMonitoring ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseConvergenceMonitoring);
   os << indent << "ConvergenceWindowSize: "
      << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_ConvergenceWindowSize) << std::endl;
 
@@ -72,7 +71,7 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
   itkPrintSelfObjectMacro(ModifyGradientByScalesThreader);
   itkPrintSelfObjectMacro(ModifyGradientByLearningRateThreader);
 
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
   os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Gradient)

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -281,8 +281,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std
   os << indent
      << "BestParameters: " << static_cast<typename NumericTraits<ParametersType>::PrintType>(this->m_BestParameters)
      << std::endl;
-  os << indent << "ReturnBestParametersAndValue: " << (this->m_ReturnBestParametersAndValue ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(ReturnBestParametersAndValue);
   os << indent
      << "PreviousGradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(this->m_PreviousGradient)
      << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -44,7 +44,7 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
   os << indent << "OptimizersList: " << m_OptimizersList << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -566,7 +566,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   itkPrintSelfObjectMacro(MovingTransform);
   itkPrintSelfObjectMacro(VirtualImage);
 
-  os << indent << "UserHasSetVirtualDomain: " << (m_UserHasSetVirtualDomain ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UserHasSetVirtualDomain);
   os << indent
      << "NumberOfValidPoints: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfValidPoints)
      << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -650,7 +650,7 @@ RegistrationParameterScalesEstimator<TMetric>::PrintSelf(std::ostream & os, Inde
 
   itkPrintSelfObjectMacro(VirtualDomainPointSet);
 
-  os << indent << "TransformForward: " << (m_TransformForward ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(TransformForward);
   os << indent << "SamplingStrategy: " << m_SamplingStrategy << std::endl;
 }
 

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -51,7 +51,7 @@ AmoebaOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
   os << indent << "ParametersConvergenceTolerance: " << this->m_ParametersConvergenceTolerance << std::endl;
   os << indent << "FunctionConvergenceTolerance: " << this->m_FunctionConvergenceTolerance << std::endl;
-  os << indent << "AutomaticInitialSimplex: " << (this->m_AutomaticInitialSimplex ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(AutomaticInitialSimplex);
   os << indent << "InitialSimplexDelta: " << this->m_InitialSimplexDelta << std::endl;
 }
 

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -66,12 +66,12 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::PrintSelf(st
   os << indent << "Scales: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Scales) << std::endl;
   os << indent << "Weights: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Weights) << std::endl;
 
-  os << indent << "ScalesAreIdentity: " << (m_ScalesAreIdentity ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ScalesAreIdentity);
 
   itkPrintSelfObjectMacro(ScalesEstimator);
 
-  os << indent << "WeightsAreIdentity: " << (m_WeightsAreIdentity ? "On" : "Off") << std::endl;
-  os << indent << "DoEstimateScales: " << (m_DoEstimateScales ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(WeightsAreIdentity);
+  itkPrintSelfBooleanMacro(DoEstimateScales);
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -706,7 +706,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
 
   os << indent << "TempMeasurementVector: " << m_TempMeasurementVector << std::endl;
   os << indent << "TempIndex: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
-  os << indent << "ClipBinsAtEnds: " << (m_ClipBinsAtEnds ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ClipBinsAtEnds);
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -113,7 +113,7 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::PrintSelf(std::ost
      << std::endl;
   os << indent << "Region: " << m_Region << std::endl;
   os << indent << "OffsetTable: " << m_OffsetTable << std::endl;
-  os << indent << "UseImageRegion: " << (m_UseImageRegion ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageRegion);
   os << indent << "Neighborhood Radius: " << m_Radius << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -128,7 +128,7 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::PrintSelf(s
   itkPrintSelfObjectMacro(FixedImage);
   itkPrintSelfObjectMacro(MovingImage);
 
-  os << indent << "UseMoments: " << (m_UseMoments ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseMoments);
 
   itkPrintSelfObjectMacro(MovingCalculator);
   itkPrintSelfObjectMacro(FixedCalculator);

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -157,7 +157,7 @@ EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::Pri
 
   itkPrintSelfObjectMacro(DistanceMap);
 
-  os << indent << "ComputeSquaredDistance: " << (m_ComputeSquaredDistance ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeSquaredDistance);
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -229,7 +229,7 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os,
 
   os << indent << "InitialTransformParameters: " << m_InitialTransformParameters << std::endl;
   os << indent << "LastTransformParameters: " << m_LastTransformParameters << std::endl;
-  os << indent << "FixedImageRegionDefined: " << (m_FixedImageRegionDefined ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FixedImageRegionDefined);
   os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1212,11 +1212,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseFixedImageIndexes: " << (m_UseFixedImageIndexes ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseFixedImageIndexes);
   os << indent << "FixedImageIndexes: " << m_FixedImageIndexes << std::endl;
-  os << indent
-     << "UseFixedImageSamplesIntensityThreshold: " << (m_UseFixedImageSamplesIntensityThreshold ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(UseFixedImageSamplesIntensityThreshold);
   os << indent << "FixedImageSamplesIntensityThreshold: "
      << static_cast<typename NumericTraits<FixedImagePixelType>::PrintType>(m_FixedImageSamplesIntensityThreshold)
      << std::endl;
@@ -1245,7 +1243,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
 
   itkPrintSelfObjectMacro(Interpolator);
 
-  os << indent << "ComputeGradient: " << (m_ComputeGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeGradient);
 
   itkPrintSelfObjectMacro(GradientImage);
   itkPrintSelfObjectMacro(MovingImageMask);
@@ -1254,13 +1252,13 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   os << indent
      << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
      << std::endl;
-  os << indent << "UseAllPixels: " << (m_UseAllPixels ? "On" : "Off") << std::endl;
-  os << indent << "UseSequentialSampling: " << (m_UseSequentialSampling ? "On" : "Off") << std::endl;
-  os << indent << "ReseedIterator: " << (m_ReseedIterator ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseAllPixels);
+  itkPrintSelfBooleanMacro(UseSequentialSampling);
+  itkPrintSelfBooleanMacro(ReseedIterator);
   os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  os << indent << "TransformIsBSpline: " << (m_TransformIsBSpline ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(TransformIsBSpline);
 #endif
 
   os << indent
@@ -1277,7 +1275,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
      << static_cast<typename NumericTraits<BSplineParametersOffsetType>::PrintType>(m_BSplineParametersOffset)
      << std::endl;
 
-  os << indent << "UseCachingOfBSplineWeights: " << (m_UseCachingOfBSplineWeights ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseCachingOfBSplineWeights);
   os << indent << "BSplineTransformWeights: "
      << static_cast<typename NumericTraits<BSplineTransformWeightsType>::PrintType>(m_BSplineTransformWeights)
      << std::endl;
@@ -1306,7 +1304,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   }
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  os << indent << "InterpolatorIsBSpline: " << (m_InterpolatorIsBSpline ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InterpolatorIsBSpline);
 #endif
 
   itkPrintSelfObjectMacro(BSplineInterpolator);
@@ -1334,8 +1332,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
     os << "(null)" << std::endl;
   }
 
-  os << indent << "WithinThreadPreProcess: " << (m_WithinThreadPreProcess ? "On" : "Off") << std::endl;
-  os << indent << "WithinThreadPostProcess: " << (m_WithinThreadPostProcess ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(WithinThreadPreProcess);
+  itkPrintSelfBooleanMacro(WithinThreadPostProcess);
 
   os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
 }

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -368,7 +368,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Complement: " << (m_Complement ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Complement);
   os << indent << "ForegroundValue: " << m_ForegroundValue << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -267,7 +267,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::os
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MeasureMatches: " << (m_MeasureMatches ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(MeasureMatches);
 
   os << indent << "ThreadMatches: " << m_ThreadMatches << std::endl;
   os << indent << "ThreadCounts: " << m_ThreadCounts << std::endl;

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -297,15 +297,15 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std
   os << indent << "CurrentLevel: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel)
      << std::endl;
 
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
 
   os << indent << "FixedImagePyramidSchedule: "
      << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_FixedImagePyramidSchedule) << std::endl;
   os << indent << "MovingImagePyramidSchedule: "
      << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_MovingImagePyramidSchedule) << std::endl;
 
-  os << indent << "ScheduleSpecified: " << (m_ScheduleSpecified ? "On" : "Off") << std::endl;
-  os << indent << "NumberOfLevelsSpecified: " << (m_Stop ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ScheduleSpecified);
+  itkPrintSelfBooleanMacro(Stop);
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -297,7 +297,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
   os << indent << "Schedule: " << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
-  os << indent << "UseShrinkImageFilter: " << (m_UseShrinkImageFilter ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseShrinkImageFilter);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -115,7 +115,7 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os
   itkPrintSelfObjectMacro(Transform);
   itkPrintSelfObjectMacro(Interpolator);
 
-  os << indent << "ComputeGradient: " << (m_ComputeGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ComputeGradient);
 
   itkPrintSelfObjectMacro(GradientImage);
 }

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1482,10 +1482,10 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   os << indent << "MinJacobian: " << m_MinJacobian << std::endl;
   os << indent << "Alpha: " << m_Alpha << std::endl;
 
-  os << indent << "UseLandmarks: " << (m_UseLandmarks ? "On" : "Off") << std::endl;
-  os << indent << "UseMassMatrix: " << (m_UseNormalizedGradient ? "On" : "Off") << std::endl;
-  os << indent << "UseNormalizedGradient: " << (m_UseNormalizedGradient ? "On" : "Off") << std::endl;
-  os << indent << "CreateMeshFromImage: " << (m_CreateMeshFromImage ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseLandmarks);
+  itkPrintSelfBooleanMacro(UseNormalizedGradient);
+  itkPrintSelfBooleanMacro(UseNormalizedGradient);
+  itkPrintSelfBooleanMacro(CreateMeshFromImage);
   os << indent << "EmployRegridding: " << m_EmployRegridding << std::endl;
   os << indent << "DescentDirection: " << m_DescentDirection << std::endl;
   os << indent << "EnergyReductionFactor: " << m_EnergyReductionFactor << std::endl;

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -541,7 +541,7 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf
   os << indent << "NumberOfSamples: " << m_NumberOfSamples << std::endl;
   os << indent << "NumberOfBins: " << m_NumberOfBins << std::endl;
   os << indent << "Minnorm: " << m_Minnorm << std::endl;
-  os << indent << "DoInverse: " << (m_DoInverse ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(DoInverse);
 }
 } // end namespace itk
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -42,7 +42,7 @@ GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TPare
 {
   GPUSuperclass::PrintSelf(os, indent);
 
-  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseMovingImageGradient);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -105,7 +105,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MovingImageGradientCalculator);
 
-  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseMovingImageGradient);
 
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -199,7 +199,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseAnisotropicCovariances: " << (m_UseAnisotropicCovariances ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseAnisotropicCovariances);
 
   os << indent << "PointSetSigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_PointSetSigma)
      << std::endl;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -665,19 +665,13 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   itkPrintSelfObjectMacro(MovingTransformedPointsLocator);
   itkPrintSelfObjectMacro(VirtualTransformedPointSet);
 
-  os << indent << "UsePointSetData: " << (m_UsePointSetData ? "On" : "Off") << std::endl;
-  os << indent
-     << "CalculateValueAndDerivativeInTangentSpace: " << (m_CalculateValueAndDerivativeInTangentSpace ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(UsePointSetData);
+  itkPrintSelfBooleanMacro(CalculateValueAndDerivativeInTangentSpace);
 
-  os << indent << "MovingTransformPointLocatorsNeedInitialization: "
-     << (m_MovingTransformPointLocatorsNeedInitialization ? "On" : "Off") << std::endl;
-  os << indent << "FixedTransformPointLocatorsNeedInitialization: "
-     << (m_FixedTransformPointLocatorsNeedInitialization ? "On" : "Off") << std::endl;
-  os << indent << "HaveWarnedAboutNumberOfValidPoints: " << (m_HaveWarnedAboutNumberOfValidPoints ? "On" : "Off")
-     << std::endl;
-  os << indent << "StoreDerivativeAsSparseFieldForLocalSupportTransforms: "
-     << (m_StoreDerivativeAsSparseFieldForLocalSupportTransforms ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(MovingTransformPointLocatorsNeedInitialization);
+  itkPrintSelfBooleanMacro(FixedTransformPointLocatorsNeedInitialization);
+  itkPrintSelfBooleanMacro(HaveWarnedAboutNumberOfValidPoints);
+  itkPrintSelfBooleanMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms);
 
   os << indent << "MovingTransformedPointSetTime: "
      << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_MovingTransformedPointSetTime) << std::endl;

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -39,7 +39,7 @@ DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::PrintSe
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseMovingImageGradient: " << (m_UseMovingImageGradient ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseMovingImageGradient);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -90,7 +90,7 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 
-  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -255,7 +255,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   }
   os << m_NumberOfIterations[ilevel] << ']' << std::endl;
 
-  os << indent << "StopRegistrationFlag: " << (m_StopRegistrationFlag ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(StopRegistrationFlag);
 }
 
 template <typename TFixedImage,

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -142,14 +142,14 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   os << indent << "StandardDeviations: " << m_StandardDeviations << std::endl;
   os << indent << "UpdateFieldStandardDeviations: " << m_UpdateFieldStandardDeviations << std::endl;
 
-  os << indent << "SmoothDisplacementField: " << (m_SmoothDisplacementField ? "On" : "Off") << std::endl;
-  os << indent << "SmoothUpdateField: " << (m_SmoothUpdateField ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(SmoothDisplacementField);
+  itkPrintSelfBooleanMacro(SmoothUpdateField);
 
   itkPrintSelfObjectMacro(TempField);
 
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
-  os << indent << "StopRegistrationFlag: " << (m_StopRegistrationFlag ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(StopRegistrationFlag);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1157,7 +1157,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
      << std::endl;
   os << indent << "CurrentConvergenceValue: "
      << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentConvergenceValue) << std::endl;
-  os << indent << "IsConverged: " << (m_IsConverged ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(IsConverged);
 
   os << indent << "FixedSmoothImages: " << m_FixedSmoothImages << std::endl;
   os << indent << "MovingSmoothImages: " << m_MovingSmoothImages << std::endl;
@@ -1179,7 +1179,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent
      << "OptimizerWeights: " << static_cast<typename NumericTraits<OptimizerWeightsType>::PrintType>(m_OptimizerWeights)
      << std::endl;
-  os << indent << "OptimizerWeightsAreIdentity: " << (m_OptimizerWeightsAreIdentity ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(OptimizerWeightsAreIdentity);
 
   itkPrintSelfObjectMacro(Metric);
 
@@ -1191,11 +1191,9 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent << "FirstImageMetricIndex: " << m_FirstImageMetricIndex << std::endl;
   os << indent << "ShrinkFactorsPerLevel: " << m_ShrinkFactorsPerLevel << std::endl;
   os << indent << "SmoothingSigmasPerLevel: " << m_SmoothingSigmasPerLevel << std::endl;
-  os << indent
-     << "SmoothingSigmasAreSpecifiedInPhysicalUnits: " << (m_SmoothingSigmasAreSpecifiedInPhysicalUnits ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(SmoothingSigmasAreSpecifiedInPhysicalUnits);
 
-  os << indent << "ReseedIterator: " << (m_ReseedIterator ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ReseedIterator);
   os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
   os << indent << "CurrentRandomSeed: " << m_CurrentRandomSeed << std::endl;
 
@@ -1209,11 +1207,9 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   itkPrintSelfObjectMacro(CompositeTransform);
   itkPrintSelfObjectMacro(OutputTransform);
 
-  os << indent << "InPlace: " << (m_InPlace ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InPlace);
 
-  os << indent
-     << "InitializeCenterOfLinearOutputTransform: " << (m_InitializeCenterOfLinearOutputTransform ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(InitializeCenterOfLinearOutputTransform);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -367,7 +367,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UserProvidedPriors: " << (m_UserProvidedPriors ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UserProvidedPriors);
   os << indent << "UserProvidedSmoothingFilter " << (m_UserProvidedSmoothingFilter ? "On" : "Off") << std::endl;
 
   itkPrintSelfObjectMacro(SmoothingFilter);

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -293,8 +293,7 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UserSuppliesMembershipFunctions: " << (m_UserSuppliesMembershipFunctions ? "On" : "Off")
-     << std::endl;
+  itkPrintSelfBooleanMacro(UserSuppliesMembershipFunctions);
   os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
 
   itkPrintSelfObjectMacro(MembershipFunctionContainer);

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -152,7 +152,7 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, 
 
   os << indent << "LabelForUndecidedPixels: "
      << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_HasLabelForUndecidedPixels) << std::endl;
-  os << indent << "HasLabelForUndecidedPixels: " << (m_HasLabelForUndecidedPixels ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(HasLabelForUndecidedPixels);
   os << indent << "TotalLabelCount: " << m_TotalLabelCount << std::endl;
 }
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -153,8 +153,8 @@ CollidingFrontsImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
   itkPrintSelfObjectMacro(SeedPoints1);
   itkPrintSelfObjectMacro(SeedPoints2);
 
-  os << indent << "StopOnTargets: " << (m_StopOnTargets ? "On" : "Off") << std::endl;
-  os << indent << "ApplyConnectivity: " << (m_ApplyConnectivity ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(StopOnTargets);
+  itkPrintSelfBooleanMacro(ApplyConnectivity);
 
   os << indent << "NegativeEpsilon: " << m_NegativeEpsilon << std::endl;
 }

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -50,7 +50,7 @@ LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent in
   os << indent << "InsidePoints: " << m_InsidePoints << std::endl;
   os << indent << "OutsidePoints: " << m_OutsidePoints << std::endl;
   os << indent << "InputLevelSet: " << m_InputLevelSet << std::endl;
-  os << indent << "NarrowBanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NarrowBanding);
   os << indent << "NarrowBandwidth: " << m_NarrowBandwidth << std::endl;
   os << indent << "InputNarrowBand: " << m_InputNarrowBand << std::endl;
   os << indent << "ImageRegion: " << m_ImageRegion << std::endl;
@@ -58,7 +58,7 @@ LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent in
      << std::endl;
   // ToDo
   // os << indent << "NodesUsed: " << m_NodesUsed << std::endl;
-  os << indent << "LastPointIsInside: " << (m_LastPointIsInside ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(LastPointIsInside);
 }
 
 template <typename TLevelSet>

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -2544,7 +2544,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
 
   os << indent << "SplitAxis: " << m_SplitAxis << std::endl;
   os << indent << "ZSize: " << m_ZSize << std::endl;
-  os << indent << "BoundaryChanged: " << (m_BoundaryChanged ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(BoundaryChanged);
 
   os << indent << "Boundary: ";
   if (m_Boundary != nullptr)
@@ -2601,9 +2601,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
   }
   os << std::endl;
 
-  os << indent << "Stop: " << (m_Stop ? "On" : "Off") << std::endl;
-  os << indent << "InterpolateSurfaceLocation: " << (m_InterpolateSurfaceLocation ? "On" : "Off") << std::endl;
-  os << indent << "BoundsCheckingActive: " << (m_BoundsCheckingActive ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(Stop);
+  itkPrintSelfBooleanMacro(InterpolateSurfaceLocation);
+  itkPrintSelfBooleanMacro(BoundsCheckingActive);
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -61,7 +61,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::PrintSelf(std::ostream & os, Indent 
   itkPrintSelfObjectMacro(Locator);
   itkPrintSelfObjectMacro(Marcher);
 
-  os << indent << "Narrowbanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(NarrowBanding);
   os << indent << "InputNarrowBandwidth: " << m_InputNarrowBandwidth << std::endl;
   os << indent << "OutputNarrowBandwidth: " << m_OutputNarrowBandwidth << std::endl;
 

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
@@ -109,8 +109,8 @@ SegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType>::P
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ReverseExpansionDirection: " << (m_ReverseExpansionDirection ? "On" : "Off") << std::endl;
-  os << indent << "AutoGenerateSpeedAdvection: " << (m_AutoGenerateSpeedAdvection ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(ReverseExpansionDirection);
+  itkPrintSelfBooleanMacro(AutoGenerateSpeedAdvection);
 
   os << indent << "SegmentationFunction: ";
   if (m_SegmentationFunction != nullptr)

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -1162,12 +1162,12 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
      << std::endl;
   os << indent << "UpdateBuffer: " << static_cast<typename NumericTraits<UpdateBufferType>::PrintType>(m_UpdateBuffer)
      << std::endl;
-  os << indent << "InterpolateSurfaceLocation: " << (m_InterpolateSurfaceLocation ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InterpolateSurfaceLocation);
 
   itkPrintSelfObjectMacro(InputImage);
   itkPrintSelfObjectMacro(OutputImage);
 
-  os << indent << "BoundsCheckingActive: " << (m_BoundsCheckingActive ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(BoundsCheckingActive);
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -69,8 +69,8 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   os << indent << "IsolatedValueTolerance: "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_IsolatedValueTolerance) << std::endl;
 
-  os << indent << "FindUpperThreshold: " << (m_FindUpperThreshold ? "On" : "Off") << std::endl;
-  os << indent << "ThresholdingFailed: " << (m_ThresholdingFailed ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FindUpperThreshold);
+  itkPrintSelfBooleanMacro(ThresholdingFailed);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -57,10 +57,10 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   os << indent << "Label: " << m_Label << std::endl;
 
   os << indent << "MeanDeviation: " << m_MeanDeviation << std::endl;
-  os << indent << "UseBackgroundInAPrior: " << (m_UseBackgroundInAPrior ? "On" : "Off") << std::endl;
-  os << indent << "OutputBoundary: " << (m_OutputBoundary ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(UseBackgroundInAPrior);
+  itkPrintSelfBooleanMacro(OutputBoundary);
 
-  os << indent << "InteractiveSegmentation: " << (m_InteractiveSegmentation ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(InteractiveSegmentation);
 
   itkPrintSelfObjectMacro(WorkingVD);
   itkPrintSelfObjectMacro(VDGenerator);

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -430,7 +430,7 @@ MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "MarkWatershedLine: " << m_MarkWatershedLine << std::endl;
 }
 

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -143,7 +143,7 @@ MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
+  itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "MarkWatershedLine: " << m_MarkWatershedLine << std::endl;
   os << indent << "Level: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Level)
      << std::endl;

--- a/Utilities/Maintenance/ReplaceBooleanPrintMacro.sh
+++ b/Utilities/Maintenance/ReplaceBooleanPrintMacro.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+# Find all patterns of the type, e.g.
+#
+# os << indent << "Minimize: " << (m_Minimize ? "On" : "Off") << std::endl;
+# os << indent << "ForwardAzimuthElevationToPhysical: " << (m_ForwardAzimuthElevationToPhysical ? "On" : "Off")
+#    << std::endl;
+#
+# And substitute them the contents captured in the second group, e.g.
+#
+# itkPrintSelfBooleanMacro(Minimize);
+# itkPrintSelfBooleanMacro(ForwardAzimuthElevationToPhysical);
+#
+
+function adopt_boolean_macro_pattern() {
+
+  local _pattern="$1"
+
+  # Find relevant filenames
+  fnames=($(find ${dir} -type f \( -name "*.cxx" -o -name "*.h" -o -name "*.hxx" \) -exec grep -lzP "(?m)\s*${_pattern}\s*" {} + | sort))
+
+  echo "Files identified containing the regex pattern:"
+  echo ${_pattern}
+  printf '%s\n' "${fnames[@]}"
+  echo "File count:" "${#fnames[@]}"
+
+  replacement='itkPrintSelfBooleanMacro'
+
+  # Make the substitution in each file
+  echo "Applying substitution..."
+  for fname in "${fnames[@]}"; do
+
+    echo ${fname}
+
+    perl -0777 -i -pe "s/${_pattern}/${replacement}(\6);/g" "${fname}"
+
+  done
+
+  echo "Finished"
+}
+
+# Define the patterns of interest
+pattern1='os << indent((\r\n|\r|\n).*| )<< \"(.*): \"((\r\n|\r|\n).*| )<< \(m_([a-zA-Z0-9]+) \? \"On\" : \"Off\"\)((\r\n|\r|\n).*| )<< std::endl;'
+
+adopt_boolean_macro_pattern "${pattern1}"
+
+pattern2='os << indent((\r\n|\r|\n).*| )<< \"(.*): \"((\r\n|\r|\n).*| )<< \(this->m_([a-zA-Z0-9]+) \? \"On\" : \"Off\"\)((\r\n|\r|\n).*| )<< std::endl;'
+
+adopt_boolean_macro_pattern "${pattern2}"


### PR DESCRIPTION
Use a macro to print boolean objects. Avoids boilerplate code.

Appearances of the form:
```
os << indent << "{name}: " << (m_{name} ? "On" : "Off") << std::endl;
```

and
```
os << indent << "{name}: " << (this->m_{name} ? "On" : "Off") << std::endl;
```

are substituted by `itkPrintSelfBooleanMacro({name});. The cases where
the statement is broken into multiple lines were also considered.

Add the script used to perform automatically the substitution.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)