### PR TITLE
ENH: Use a macro to print numeric traits values of objects

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1271,6 +1271,14 @@ compilers.
   ITK_MACROEND_NOOP_STATEMENT
 
 
+// A useful macro in the PrintSelf method for printing member variables
+// that require to be casted to the corresponding numeric value so that
+// their numeric value gets printed.
+#define itkPrintSelfNumericTraitsMacro(name, type)                                                                    \
+  os << indent << #name << ": " << static_cast<typename NumericTraits<type>::PrintType>(this->m_##name) << std::endl; \
+  ITK_MACROEND_NOOP_STATEMENT
+
+
 /** Set a decorated output. This defines the Set"name"() and a Set"name"Output() method */
 #define itkSetDecoratedOutputMacro(name, type)                                                                       \
   virtual void Set##name##Output(const SimpleDataObjectDecorator<type> * _arg)                                       \


### PR DESCRIPTION
Use a macro to print numeric traits values of objects. Avoids boilerplate code.

Printed instances found using the regex:
```
os << indent << "(.*): " << static_cast<typename NumericTraits<(.*)>::PrintType>(m_(.*)) << std::endl;
```

and substituted using itkPrintSelfNumericTraitsMacro\($3\, \$2\);.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)