### PR TITLE
STYLE: Add in-class `{}` initializers to classes with virtual functions

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
@@ -231,7 +231,7 @@ private:
 
 private:
   /** PipelineMTime from the last call to PipelineModifiedCallback. */
-  ModifiedTimeType m_LastPipelineMTime;
+  ModifiedTimeType m_LastPipelineMTime{};
 };
 } // end namespace itk
 

--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.h
@@ -81,8 +81,8 @@ protected:
   HasNext() const override;
 
 private:
-  mutable ChildIdentifier m_ListPosition;
-  TreeNodeType *          m_ParentNode;
+  mutable ChildIdentifier m_ListPosition{};
+  TreeNodeType *          m_ParentNode{};
 };
 
 } // end namespace itk

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.h
@@ -106,9 +106,9 @@ private:
   int
   GetLevel(const TreeNodeType * node) const;
 
-  int                                      m_StartLevel;
-  int                                      m_EndLevel;
-  mutable std::queue<const TreeNodeType *> m_Queue;
+  int                                      m_StartLevel{};
+  int                                      m_EndLevel{};
+  mutable std::queue<const TreeNodeType *> m_Queue{};
 };
 
 } // end namespace itk

--- a/Modules/Compatibility/Deprecated/include/itkMutexLock.h
+++ b/Modules/Compatibility/Deprecated/include/itkMutexLock.h
@@ -102,7 +102,7 @@ public:
   }
 
 protected:
-  MutexType m_MutexLock;
+  MutexType m_MutexLock{};
 };
 
 /**

--- a/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
@@ -85,7 +85,7 @@ public:
   {}
 
 protected:
-  const TreeIteratorBase<TTreeType> * m_ChangePosition;
+  const TreeIteratorBase<TTreeType> * m_ChangePosition{};
 };
 
 /**  \class TreeNodeChangeEvent

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
@@ -274,9 +274,9 @@ protected:
   TreeIteratorBase(const TTreeType * tree, const TreeNodeType * start);
 
   mutable TreeNodeType * m_Position; // Current position of the iterator
-  mutable TreeNodeType * m_Begin;
-  const TreeNodeType *   m_Root;
-  TTreeType *            m_Tree;
+  mutable TreeNodeType * m_Begin{};
+  const TreeNodeType *   m_Root{};
+  TTreeType *            m_Tree{};
 
   virtual bool
   HasNext() const = 0;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -490,7 +490,7 @@ public:
 
 protected:
   /** Store the set of cells using this boundary. */
-  UsingCellsContainer m_UsingCells;
+  UsingCellsContainer m_UsingCells{};
 };
 
 /** \class CellTraitsInfo

--- a/Modules/Core/Common/include/itkConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkConditionalConstIterator.h
@@ -112,10 +112,10 @@ public:
 protected: // made protected so other iterators can access
   /** Smart pointer to the source image. */
   // SmartPointer<const ImageType> m_Image;
-  typename ImageType::ConstWeakPointer m_Image;
+  typename ImageType::ConstWeakPointer m_Image{};
 
   /** Region type to iterate over. */
-  RegionType m_Region;
+  RegionType m_Region{};
 
   /** Is the iterator at the end of its walk? */
   bool m_IsAtEnd{ false };

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -590,7 +590,7 @@ protected:
   const InternalPixelType * m_Begin{ nullptr };
 
   /** The image on which iteration is defined. */
-  typename ImageType::ConstWeakPointer m_ConstImage;
+  typename ImageType::ConstWeakPointer m_ConstImage{};
 
   /** A pointer to one past the last pixel in the iteration region. */
   const InternalPixelType * m_End{ nullptr };
@@ -603,7 +603,7 @@ protected:
   IndexType m_Loop{ { 0 } };
 
   /** The region over which iteration is defined. */
-  RegionType m_Region;
+  RegionType m_Region{};
 
   /** The internal array of offsets that provide support for regions of
    *  interest.
@@ -616,7 +616,7 @@ protected:
    * By default this points to m_BoundaryCondition, but
    * OverrideBoundaryCondition allows a user to point this variable an external
    * boundary condition.  */
-  ImageBoundaryConditionPointerType m_BoundaryCondition;
+  ImageBoundaryConditionPointerType m_BoundaryCondition{};
 
   /** Denotes which of the iterators dimensional sides spill outside
    * region of interest boundaries. By default `false` for each dimension. */
@@ -631,19 +631,19 @@ protected:
   mutable bool m_IsInBoundsValid{ false };
 
   /** Lower threshold of in-bounds loop counter values. */
-  IndexType m_InnerBoundsLow;
+  IndexType m_InnerBoundsLow{};
 
   /** Upper threshold of in-bounds loop counter values. */
-  IndexType m_InnerBoundsHigh;
+  IndexType m_InnerBoundsHigh{};
 
   /** Default boundary condition. */
-  TBoundaryCondition m_InternalBoundaryCondition;
+  TBoundaryCondition m_InternalBoundaryCondition{};
 
   /** Does the specified region need to worry about boundary conditions? */
   bool m_NeedToUseBoundaryCondition{ false };
 
   /** Functor type used to access neighborhoods of pixel pointers */
-  NeighborhoodAccessorFunctorType m_NeighborhoodAccessorFunctor;
+  NeighborhoodAccessorFunctorType m_NeighborhoodAccessorFunctor{};
 };
 
 template <typename TImage>

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -375,7 +375,7 @@ protected:
   IndexType m_Bound{ { 0 } };
 
   /** The image on which iteration is defined. */
-  typename ImageType::ConstPointer m_ConstImage;
+  typename ImageType::ConstPointer m_ConstImage{};
 
   /** The end index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIteratorWithOnlyIndex is defined. */
@@ -385,7 +385,7 @@ protected:
   IndexType m_Loop{ { 0 } };
 
   /** The region over which iteration is defined. */
-  RegionType m_Region;
+  RegionType m_Region{};
 
   /** Denotes which of the iterators dimensional sides spill outside
    * region of interest boundaries. By default `false` for each dimension. */
@@ -400,10 +400,10 @@ protected:
   mutable bool m_IsInBoundsValid{ false };
 
   /** Lower threshold of in-bounds loop counter values. */
-  IndexType m_InnerBoundsLow;
+  IndexType m_InnerBoundsLow{};
 
   /** Upper threshold of in-bounds loop counter values. */
-  IndexType m_InnerBoundsHigh;
+  IndexType m_InnerBoundsHigh{};
 
   /** Does the specified region need to worry about boundary conditions? */
   bool m_NeedToUseBoundaryCondition{ false };

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -421,7 +421,7 @@ protected:
 
 
   bool          m_CenterIsActive{ false };
-  IndexListType m_ActiveIndexList;
+  IndexListType m_ActiveIndexList{};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.h
@@ -157,7 +157,7 @@ public:
   GetPixel(const IndexType & index, const TInputImage * image) const override;
 
 private:
-  OutputPixelType m_Constant;
+  OutputPixelType m_Constant{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.h
+++ b/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.h
@@ -95,19 +95,19 @@ public:
     return m_CorrespondingListPointer;
   }
 
-  CorrespondingListIterator m_CorrespondingListIterator;
-  SecondaryNodeListIterator m_SecondaryListIterator;
+  CorrespondingListIterator m_CorrespondingListIterator{};
+  SecondaryNodeListIterator m_SecondaryListIterator{};
 
-  typename TStructureType::NodeListType::iterator m_NodeListIterator;
+  typename TStructureType::NodeListType::iterator m_NodeListIterator{};
 
 protected:
   /** Is the iterator at the end of its walk? */
-  bool                    m_IsAtEnd;
-  TStructureType *        m_Structure;
-  ItemType *              m_CorrespondingNodePointer;
-  CorrespondingListType * m_CorrespondingListPointer;
-  SecondaryNodeListType * m_SecondaryListPointer;
-  NodeListType *          m_NodeListPointer;
+  bool                    m_IsAtEnd{};
+  TStructureType *        m_Structure{};
+  ItemType *              m_CorrespondingNodePointer{};
+  CorrespondingListType * m_CorrespondingListPointer{};
+  SecondaryNodeListType * m_SecondaryListPointer{};
+  NodeListType *          m_NodeListPointer{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkDomainThreader.h
+++ b/Modules/Core/Common/include/itkDomainThreader.h
@@ -163,7 +163,7 @@ protected:
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
   ThreaderCallback(void * arg);
 
-  AssociateType * m_Associate;
+  AssociateType * m_Associate{};
 
 private:
   void
@@ -180,10 +180,10 @@ private:
    * well into that number.
    * This value is determined at the beginning of \c Execute(). */
   ThreadIdType                            m_NumberOfWorkUnitsUsed{ 0 };
-  ThreadIdType                            m_NumberOfWorkUnits;
-  typename DomainPartitionerType::Pointer m_DomainPartitioner;
-  DomainType                              m_CompleteDomain;
-  MultiThreaderBase::Pointer              m_MultiThreader;
+  ThreadIdType                            m_NumberOfWorkUnits{};
+  typename DomainPartitionerType::Pointer m_DomainPartitioner{};
+  DomainType                              m_CompleteDomain{};
+  MultiThreaderBase::Pointer              m_MultiThreader{};
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -132,7 +132,7 @@ public:
 private:
   class ExceptionData;
 
-  std::shared_ptr<const ExceptionData> m_ExceptionData;
+  std::shared_ptr<const ExceptionData> m_ExceptionData{};
 };
 
 /** Generic inserter operator for ExceptionObject and its subclasses. */

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -239,7 +239,7 @@ public:
 
 protected: // made protected so other iterators can access
   /** Smart pointer to the function we're evaluating */
-  SmartPointer<FunctionType> m_Function;
+  SmartPointer<FunctionType> m_Function{};
 
   /** A temporary image used for storing info about indices
    * 0 = pixel has not yet been processed
@@ -247,32 +247,32 @@ protected: // made protected so other iterators can access
    * 2 = pixel is inside the function, neighbor check incomplete
    * 3 = pixel is inside the function, neighbor check complete */
   using TTempImage = Image<unsigned char, Self::NDimensions>;
-  typename TTempImage::Pointer m_TemporaryPointer;
+  typename TTempImage::Pointer m_TemporaryPointer{};
 
   /** A list of locations to start the recursive fill */
-  SeedsContainerType m_Seeds;
+  SeedsContainerType m_Seeds{};
 
   /** The origin of the source image */
-  typename ImageType::PointType m_ImageOrigin;
+  typename ImageType::PointType m_ImageOrigin{};
 
   /** The spacing of the source image */
-  typename ImageType::SpacingType m_ImageSpacing;
+  typename ImageType::SpacingType m_ImageSpacing{};
 
   /** Region of the source image */
-  RegionType m_ImageRegion;
+  RegionType m_ImageRegion{};
 
   /** Stack used to hold the path of the iterator through the image */
-  std::queue<IndexType> m_IndexStack;
+  std::queue<IndexType> m_IndexStack{};
 
   /** Location vector used in the flood algorithm */
-  FunctionInputType m_LocationVector;
+  FunctionInputType m_LocationVector{};
 
   /** Indicates whether or not we've found a neighbor that needs to be
    * checked.  */
-  bool m_FoundUncheckedNeighbor;
+  bool m_FoundUncheckedNeighbor{};
 
   /** Indicates whether or not an index is valid (inside an image)/ */
-  bool m_IsValidIndex;
+  bool m_IsValidIndex{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
@@ -125,7 +125,7 @@ protected: // made protected so other iterators can access
    * 3) Intersect: if any of the corners of the pixel in physical space are inside the function,
    * then the pixel is inside the function */
 
-  unsigned char m_InclusionStrategy;
+  unsigned char m_InclusionStrategy{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -377,18 +377,18 @@ public:
   }
 
 protected: // made protected so other iterators can access
-  typename TImage::ConstWeakPointer m_Image;
+  typename TImage::ConstWeakPointer m_Image{};
 
   RegionType m_Region; // region to iterate over
 
-  OffsetValueType m_Offset;
+  OffsetValueType m_Offset{};
   OffsetValueType m_BeginOffset; // offset to first pixel in region
   OffsetValueType m_EndOffset;   // offset to one pixel past last pixel in region
 
-  const InternalPixelType * m_Buffer;
+  const InternalPixelType * m_Buffer{};
 
-  AccessorType        m_PixelAccessor;
-  AccessorFunctorType m_PixelAccessorFunctor;
+  AccessorType        m_PixelAccessor{};
+  AccessorFunctorType m_PixelAccessorFunctor{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageKernelOperator.h
+++ b/Modules/Core/Common/include/itkImageKernelOperator.h
@@ -87,7 +87,7 @@ protected:
   Fill(const CoefficientVector & coeff) override;
 
 private:
-  typename ImageType::ConstPointer m_ImageKernel;
+  typename ImageType::ConstPointer m_ImageKernel{};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkImageReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseConstIterator.h
@@ -391,18 +391,18 @@ public:
   }
 
 protected: // made protected so other iterators can access
-  typename ImageType::ConstWeakPointer m_Image;
+  typename ImageType::ConstWeakPointer m_Image{};
 
   RegionType m_Region; // region to iterate over
 
-  SizeValueType m_Offset;
+  SizeValueType m_Offset{};
   SizeValueType m_BeginOffset; // offset to last pixel in region
   SizeValueType m_EndOffset;   // offset to one pixel before first pixel
 
-  const InternalPixelType * m_Buffer;
+  const InternalPixelType * m_Buffer{};
 
-  AccessorType        m_PixelAccessor;
-  AccessorFunctorType m_PixelAccessorFunctor;
+  AccessorType        m_PixelAccessor{};
+  AccessorFunctorType m_PixelAccessorFunctor{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -189,8 +189,8 @@ protected:
 
 private:
   unsigned int          m_NumberOfStreamDivisions{ 1 };
-  RegionSplitterPointer m_RegionSplitter;
-  InputImageRegionType  m_CurrentInputRegion;
+  RegionSplitterPointer m_RegionSplitter{};
+  InputImageRegionType  m_CurrentInputRegion{};
 
   /**
    *  Tolerances for checking whether input images are defined to

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -399,7 +399,7 @@ protected:
   itkSetMacro(DynamicMultiThreading, bool);
   itkBooleanMacro(DynamicMultiThreading);
 
-  bool m_DynamicMultiThreading;
+  bool m_DynamicMultiThreading{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -378,8 +378,8 @@ private:
    *  Tolerances for checking whether input images are defined to
    *  occupy the same physical space.
    */
-  double m_CoordinateTolerance;
-  double m_DirectionTolerance;
+  double m_CoordinateTolerance{};
+  double m_DirectionTolerance{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
@@ -74,7 +74,7 @@ public:
 
 private:
   /** The parameter image used by the class */
-  ParameterImagePointer m_ParameterImage;
+  ParameterImagePointer m_ParameterImage{};
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -118,7 +118,7 @@ protected:
 
 private:
   /** Weights applied to derivatives in each axial direction */
-  double m_DerivativeScalings[VDimension];
+  double m_DerivativeScalings[VDimension]{};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkLightObject.h
+++ b/Modules/Core/Common/include/itkLightObject.h
@@ -160,7 +160,7 @@ protected:
   InternalClone() const;
 
   /** Number of uses of this object by other objects. */
-  mutable std::atomic<int> m_ReferenceCount;
+  mutable std::atomic<int> m_ReferenceCount{};
 };
 
 /**

--- a/Modules/Core/Common/include/itkLineConstIterator.h
+++ b/Modules/Core/Common/include/itkLineConstIterator.h
@@ -154,41 +154,41 @@ public:
 
 protected: // made protected so other iterators can access
   /** Smart pointer to the source image. */
-  typename ImageType::ConstWeakPointer m_Image;
+  typename ImageType::ConstWeakPointer m_Image{};
 
   /** Region type to iterate over. */
-  RegionType m_Region;
+  RegionType m_Region{};
 
   /** Is the iterator at the end of its walk? */
-  bool m_IsAtEnd;
+  bool m_IsAtEnd{};
 
   /** Start, end and current ND index position in the image of the line */
-  IndexType m_CurrentImageIndex;
-  IndexType m_StartIndex;
-  IndexType m_LastIndex;
+  IndexType m_CurrentImageIndex{};
+  IndexType m_StartIndex{};
+  IndexType m_LastIndex{};
   IndexType m_EndIndex; // one past the end of the line in the m_MainDirection
 
   /** Variables that drive the Bresenham-Algorithm */
   // The dimension with the largest difference between start and end
-  unsigned int m_MainDirection;
+  unsigned int m_MainDirection{};
 
   // Accumulated error for the other dimensions
-  IndexType m_AccumulateError;
+  IndexType m_AccumulateError{};
 
   // Increment for the error for each step. Two times the difference between
   // start and end
-  IndexType m_IncrementError;
+  IndexType m_IncrementError{};
 
   // If enough is accumulated for a dimension, the index has to be
   // incremented. Will be the number of pixels in the line
-  IndexType m_MaximalError;
+  IndexType m_MaximalError{};
 
   // Direction of increment. -1 or 1
-  IndexType m_OverflowIncrement;
+  IndexType m_OverflowIncrement{};
 
   // After an overflow, the accumulated error is reduced again. Will be
   // two times the number of pixels in the line
-  IndexType m_ReduceErrorAfterIncrement;
+  IndexType m_ReduceErrorAfterIncrement{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkLoggerBase.h
+++ b/Modules/Core/Common/include/itkLoggerBase.h
@@ -234,20 +234,20 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 protected:
-  PriorityLevelEnum m_PriorityLevel;
+  PriorityLevelEnum m_PriorityLevel{};
 
-  PriorityLevelEnum m_LevelForFlushing;
+  PriorityLevelEnum m_LevelForFlushing{};
 
-  MultipleLogOutput::Pointer m_Output;
+  MultipleLogOutput::Pointer m_Output{};
 
-  RealTimeClock::Pointer m_Clock;
+  RealTimeClock::Pointer m_Clock{};
 
-  TimeStampFormatEnum m_TimeStampFormat;
+  TimeStampFormatEnum m_TimeStampFormat{};
 
-  std::string m_HumanReadableFormat;
+  std::string m_HumanReadableFormat{};
 
 private:
-  std::string m_Name;
+  std::string m_Name{};
 }; // class LoggerBase
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkMemoryProbe.h
+++ b/Modules/Core/Common/include/itkMemoryProbe.h
@@ -53,7 +53,7 @@ protected:
   GetInstantValue() const override;
 
 private:
-  mutable MemoryUsageObserver m_MemoryObserver;
+  mutable MemoryUsageObserver m_MemoryObserver{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -307,13 +307,13 @@ protected:
   IntegerType state[StateVectorLength];
 
   // Next value to get from state
-  IntegerType * m_PNext;
+  IntegerType * m_PNext{};
 
   // Number of values left before reload is needed
-  int m_Left;
+  int m_Left{};
 
   // Seed value
-  std::atomic<IntegerType> m_Seed;
+  std::atomic<IntegerType> m_Seed{};
 
 private:
   /** Only used to synchronize the global variable across static libraries.*/
@@ -324,7 +324,7 @@ private:
   CreateInstance();
 
   // Local lock to enable concurrent access to singleton
-  std::mutex m_InstanceLock;
+  std::mutex m_InstanceLock{};
 
   // Static/Global Variable need to be thread-safely accessed
 

--- a/Modules/Core/Common/include/itkMetaDataDictionary.h
+++ b/Modules/Core/Common/include/itkMetaDataDictionary.h
@@ -176,7 +176,7 @@ private:
   bool
   MakeUnique();
 
-  std::shared_ptr<MetaDataDictionaryMapType> m_Dictionary;
+  std::shared_ptr<MetaDataDictionaryMapType> m_Dictionary{};
 };
 
 inline void

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -449,7 +449,7 @@ protected:
   ParallelizeImageRegionHelper(void * arg);
 
   /** The number of work units to create. */
-  ThreadIdType m_NumberOfWorkUnits;
+  ThreadIdType m_NumberOfWorkUnits{};
 
   /** The number of threads to use.
    *  The m_MaximumNumberOfThreads must always be less than or equal to
@@ -459,7 +459,7 @@ protected:
    *  to the current m_GlobalMaximumNumberOfThreads in the
    *  SingleMethodExecute() method.
    */
-  ThreadIdType m_MaximumNumberOfThreads;
+  ThreadIdType m_MaximumNumberOfThreads{};
 
   /** Static function used as a "proxy callback" by multi-threaders.  The
    * threading library will call this routine for each thread, which

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -313,14 +313,14 @@ private:
   SizeType m_Size{ { 0 } };
 
   /** The buffer in which data is stored. */
-  AllocatorType m_DataBuffer;
+  AllocatorType m_DataBuffer{};
 
   /** A lookup table for keeping track of stride lengths in a neighborhood
       i.e. the memory offsets between pixels along each dimensional axis */
   OffsetValueType m_StrideTable[VDimension]{ 0 };
 
   /** */
-  std::vector<OffsetType> m_OffsetTable;
+  std::vector<OffsetType> m_OffsetTable{};
 };
 
 template <typename TPixel, unsigned int VDimension, typename TContainer>

--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -270,7 +270,7 @@ private:
   mutable bool m_Debug{ false };
 
   /** Keep track of modification time. */
-  mutable TimeStamp m_MTime;
+  mutable TimeStamp m_MTime{};
 
   /** Global object debug flag. */
   static bool * m_GlobalWarningDisplay;
@@ -291,7 +291,7 @@ private:
    */
   mutable std::unique_ptr<MetaDataDictionary> m_MetaDataDictionary{ nullptr };
 
-  std::string m_ObjectName;
+  std::string m_ObjectName{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -288,9 +288,9 @@ private:
 
   /** Member variables for a factory set by the base class
    * at load or register time */
-  void *        m_LibraryHandle;
-  unsigned long m_LibraryDate;
-  std::string   m_LibraryPath;
+  void *        m_LibraryHandle{};
+  unsigned long m_LibraryDate{};
+  std::string   m_LibraryPath{};
 
   static ObjectFactoryBasePrivate * m_PimplGlobals;
 };

--- a/Modules/Core/Common/include/itkOctreeNode.h
+++ b/Modules/Core/Common/include/itkOctreeNode.h
@@ -138,8 +138,8 @@ private:
   /**
    * Each element holds COLOR or pointer to another octree node
    */
-  OctreeNodeBranch * m_Branch;
-  OctreeBase *       m_Parent;
+  OctreeNodeBranch * m_Branch{};
+  OctreeBase *       m_Parent{};
 };
 
 class ITKCommon_EXPORT OctreeNodeBranch

--- a/Modules/Core/Common/include/itkOutputWindow.h
+++ b/Modules/Core/Common/include/itkOutputWindow.h
@@ -134,8 +134,8 @@ protected:
 private:
   itkGetGlobalDeclarationMacro(OutputWindowGlobals, PimplGlobals);
 
-  std::atomic<bool>            m_PromptUser;
-  std::mutex                   m_cerrMutex;
+  std::atomic<bool>            m_PromptUser{};
+  std::mutex                   m_cerrMutex{};
   static OutputWindowGlobals * m_PimplGlobals;
 };
 } // end namespace itk

--- a/Modules/Core/Common/include/itkPolyLineCell.h
+++ b/Modules/Core/Common/include/itkPolyLineCell.h
@@ -136,7 +136,7 @@ public:
 
 protected:
   /** For storing the points needed for a line segment. */
-  std::vector<PointIdentifier> m_PointIds;
+  std::vector<PointIdentifier> m_PointIds{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPolygonCell.h
+++ b/Modules/Core/Common/include/itkPolygonCell.h
@@ -157,8 +157,8 @@ public:
   ~PolygonCell() override = default;
 
 protected:
-  std::vector<EdgeInfo>        m_Edges;
-  std::vector<PointIdentifier> m_PointIds;
+  std::vector<EdgeInfo>        m_Edges{};
+  std::vector<PointIdentifier> m_PointIds{};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -931,10 +931,10 @@ protected:
 
   /** This flag indicates when the pipeline is executing.
    * It prevents infinite recursion when pipelines have loops. */
-  bool m_Updating;
+  bool m_Updating{};
 
   /** Time when GenerateOutputInformation was last called. */
-  TimeStamp m_OutputInformationMTime;
+  TimeStamp m_OutputInformationMTime{};
 
 private:
   DataObjectIdentifierType MakeNameFromIndex(DataObjectPointerArraySizeType) const;
@@ -946,40 +946,40 @@ private:
 
 
   /** Named input and outputs containers */
-  DataObjectPointerMap m_Inputs;
-  DataObjectPointerMap m_Outputs;
+  DataObjectPointerMap m_Inputs{};
+  DataObjectPointerMap m_Outputs{};
 
-  std::vector<DataObjectPointerMap::iterator> m_IndexedInputs;
-  std::vector<DataObjectPointerMap::iterator> m_IndexedOutputs;
+  std::vector<DataObjectPointerMap::iterator> m_IndexedInputs{};
+  std::vector<DataObjectPointerMap::iterator> m_IndexedOutputs{};
 
   /** An array that caches the ReleaseDataFlags of the inputs */
-  std::map<DataObjectIdentifierType, bool> m_CachedInputReleaseDataFlags;
+  std::map<DataObjectIdentifierType, bool> m_CachedInputReleaseDataFlags{};
 
-  DataObjectPointerArraySizeType m_NumberOfRequiredInputs;
-  DataObjectPointerArraySizeType m_NumberOfRequiredOutputs;
+  DataObjectPointerArraySizeType m_NumberOfRequiredInputs{};
+  DataObjectPointerArraySizeType m_NumberOfRequiredOutputs{};
 
   /** STL map to store the named inputs and outputs */
   using NameSet = std::set<DataObjectIdentifierType>;
 
   /** The required inputs */
-  NameSet m_RequiredInputNames;
+  NameSet m_RequiredInputNames{};
 
   /** These support the progress method and aborting filter execution. */
-  bool                  m_AbortGenerateData;
-  std::atomic<uint32_t> m_Progress;
+  bool                  m_AbortGenerateData{};
+  std::atomic<uint32_t> m_Progress{};
 
 
-  std::thread::id m_UpdateThreadID;
+  std::thread::id m_UpdateThreadID{};
 
   /** Support processing data in multiple threads. Used by subclasses
    * (e.g., ImageSource). */
-  itk::SmartPointer<MultiThreaderType> m_MultiThreader;
-  ThreadIdType                         m_NumberOfWorkUnits;
+  itk::SmartPointer<MultiThreaderType> m_MultiThreader{};
+  ThreadIdType                         m_NumberOfWorkUnits{};
 
   bool m_ThreaderUpdateProgress{ true };
 
   /** Memory management ivars */
-  bool m_ReleaseDataBeforeUpdateFlag;
+  bool m_ReleaseDataBeforeUpdateFlag{};
 
   /** Friends of ProcessObject */
   friend class DataObject;

--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -180,22 +180,22 @@ protected:
   itkLegacyMacro(virtual void GetSystemInformation());
 
 private:
-  ValueType m_StartValue;
-  ValueType m_TotalValue;
-  ValueType m_MinimumValue;
-  ValueType m_MaximumValue;
-  ValueType m_StandardDeviation;
-  ValueType m_StandardError;
+  ValueType m_StartValue{};
+  ValueType m_TotalValue{};
+  ValueType m_MinimumValue{};
+  ValueType m_MaximumValue{};
+  ValueType m_StandardDeviation{};
+  ValueType m_StandardError{};
 
-  CountType m_NumberOfStarts;
-  CountType m_NumberOfStops;
-  CountType m_NumberOfIteration;
+  CountType m_NumberOfStarts{};
+  CountType m_NumberOfStops{};
+  CountType m_NumberOfIteration{};
 
-  std::vector<ValueType> m_ProbeValueList;
+  std::vector<ValueType> m_ProbeValueList{};
 
-  std::string m_NameOfProbe;
-  std::string m_TypeString;
-  std::string m_UnitString;
+  std::string m_NameOfProbe{};
+  std::string m_TypeString{};
+  std::string m_UnitString{};
 
   static constexpr unsigned int tabwidth = 15;
 };

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.h
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.h
@@ -101,7 +101,7 @@ public:
 
 
 protected:
-  MapType m_Probes;
+  MapType m_Probes{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -249,7 +249,7 @@ public:
 
 protected: // made protected so other iterators can access
   /** Smart pointer to the function we're evaluating */
-  SmartPointer<FunctionType> m_Function;
+  SmartPointer<FunctionType> m_Function{};
 
   /** A temporary image used for storing info about indices
    * 0 = pixel has not yet been processed
@@ -258,42 +258,42 @@ protected: // made protected so other iterators can access
    * 3 = pixel is inside the function, neighbor check complete */
   using TTempImage = Image<unsigned char, Self::NDimensions>;
 
-  typename TTempImage::Pointer m_TempPtr;
+  typename TTempImage::Pointer m_TempPtr{};
 
   /** A list of locations to start the recursive fill */
-  SeedsContainerType m_Seeds;
+  SeedsContainerType m_Seeds{};
 
   /** The origin of the source image */
-  typename ImageType::PointType m_ImageOrigin;
+  typename ImageType::PointType m_ImageOrigin{};
 
   /** The spacing of the source image */
-  typename ImageType::SpacingType m_ImageSpacing;
+  typename ImageType::SpacingType m_ImageSpacing{};
 
   /** The neighborhood iterator */
-  NeighborhoodIteratorType m_NeighborhoodIterator;
+  NeighborhoodIteratorType m_NeighborhoodIterator{};
 
   /** Region of the source image */
-  RegionType m_ImageRegion;
+  RegionType m_ImageRegion{};
 
   /** Stack used to hold the path of the iterator through the image */
-  std::queue<IndexType> m_IndexStack;
+  std::queue<IndexType> m_IndexStack{};
 
   /** Location vector used in the flood algorithm */
-  FunctionInputType m_LocationVector;
+  FunctionInputType m_LocationVector{};
 
   /** Indicates whether or not we've found a neighbor that needs to be
    * checked.  */
-  bool m_FoundUncheckedNeighbor;
+  bool m_FoundUncheckedNeighbor{};
 
   /** Indicates whether or not an index is valid (inside an image)/ */
-  bool m_IsValidIndex;
+  bool m_IsValidIndex{};
 
   /** Defines the connectivity of the neighborhood iterator.
    * In case of 2D the default connectivity is 4 (6 in 3D) and
    * when m_FullyConnected is set to true the connectivity is
    * 8 (26 in 3D).
    */
-  bool m_FullyConnected;
+  bool m_FullyConnected{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -285,21 +285,21 @@ protected:
   }
 
 private:
-  TimeProbe                   m_TimeProbe;
+  TimeProbe                   m_TimeProbe{};
   int                         m_Steps{ 0 };
   int                         m_Iterations{ 0 };
   bool                        m_Quiet{ false };
   bool                        m_TestAbort{ false };
-  std::string                 m_Comment;
-  itk::ProcessObject::Pointer m_Process;
-  std::mutex                  m_ProgressOutput;
+  std::string                 m_Comment{};
+  itk::ProcessObject::Pointer m_Process{};
+  std::mutex                  m_ProgressOutput{};
 
   using CommandType = SimpleMemberCommand<SimpleFilterWatcher>;
-  CommandType::Pointer m_StartFilterCommand;
-  CommandType::Pointer m_EndFilterCommand;
-  CommandType::Pointer m_ProgressFilterCommand;
-  CommandType::Pointer m_IterationFilterCommand;
-  CommandType::Pointer m_AbortFilterCommand;
+  CommandType::Pointer m_StartFilterCommand{};
+  CommandType::Pointer m_EndFilterCommand{};
+  CommandType::Pointer m_ProgressFilterCommand{};
+  CommandType::Pointer m_IterationFilterCommand{};
+  CommandType::Pointer m_AbortFilterCommand{};
 
   unsigned long m_StartTag{ 0 };
   unsigned long m_EndTag{ 0 };

--- a/Modules/Core/Common/include/itkSmapsFileParser.h
+++ b/Modules/Core/Common/include/itkSmapsFileParser.h
@@ -47,13 +47,13 @@ public:
 
   /** Optional record name
    */
-  std::string m_RecordName;
+  std::string m_RecordName{};
 
   /** Contains a list of token with the associated memory allocated, tokens
    *  could be typically: Size, Rss, Shared_Clean, Shared_Dirty, Private_Clean,
    *  Private_Dirty, Referenced.
    */
-  std::map<std::string, MemoryLoadType> m_Tokens;
+  std::map<std::string, MemoryLoadType> m_Tokens{};
 };
 
 /** \class SmapsRecord
@@ -163,7 +163,7 @@ protected:
   using MapRecordVectorType = std::vector<MapRecord *>;
 
   /** contains all the segment records */
-  MapRecordVectorType m_Records;
+  MapRecordVectorType m_Records{};
 };
 
 /** \class SmapsData_2_6
@@ -191,7 +191,7 @@ public:
                           operator>>(std::istream & smapsStream, SmapsData_2_6 & data);
 
 protected:
-  bool m_HeapRecordFound;
+  bool m_HeapRecordFound{};
 };
 
 /** \class VMMapData_10_2

--- a/Modules/Core/Common/include/itkTimeProbe.h
+++ b/Modules/Core/Common/include/itkTimeProbe.h
@@ -69,7 +69,7 @@ public:
   itkGetConstObjectMacro(RealTimeClock, RealTimeClock);
 
 private:
-  RealTimeClock::Pointer m_RealTimeClock;
+  RealTimeClock::Pointer m_RealTimeClock{};
 };
 } // end namespace itk
 

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
@@ -188,7 +188,7 @@ private:
   CalculateChangeThreaderCallback(void * arg);
 
   /** The buffer that holds the updates for an iteration of the algorithm. */
-  typename UpdateBufferType::Pointer m_UpdateBuffer;
+  typename UpdateBufferType::Pointer m_UpdateBuffer{};
 };
 } // end namespace itk
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.h
@@ -199,8 +199,8 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  RadiusType    m_Radius;
-  PixelRealType m_ScaleCoefficients[ImageDimension];
+  RadiusType    m_Radius{};
+  PixelRealType m_ScaleCoefficients[ImageDimension]{};
 };
 } // end namespace itk
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -348,18 +348,18 @@ protected:
   {}
 
   /** The maximum number of iterations this filter will run */
-  IdentifierType m_NumberOfIterations;
+  IdentifierType m_NumberOfIterations{};
 
   /** A counter for keeping track of the number of elapsed
       iterations during filtering. */
-  IdentifierType m_ElapsedIterations;
+  IdentifierType m_ElapsedIterations{};
 
   /** Indicates whether the filter automatically resets to UNINITIALIZED state
       after completing, or whether filter must be manually reset */
-  bool m_ManualReinitialization;
+  bool m_ManualReinitialization{};
 
-  double m_RMSChange;
-  double m_MaximumRMSError;
+  double m_RMSChange{};
+  double m_MaximumRMSError{};
 
 private:
   /** Initialize the values of the Function coefficients. This function will
@@ -370,10 +370,10 @@ private:
 
   /** Control whether derivatives use spacing of the input image in
       its calculation. */
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{};
 
   /** The function that will be used in calculating updates for each pixel. */
-  typename FiniteDifferenceFunctionType::Pointer m_DifferenceFunction;
+  typename FiniteDifferenceFunctionType::Pointer m_DifferenceFunction{};
 };
 } // end namespace itk
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
@@ -203,14 +203,14 @@ protected:
 
 private:
   /** Flag to let the class know whether or not to call PrecalculateChange. */
-  bool m_PrecomputeFlag;
+  bool m_PrecomputeFlag{};
 
   /** The Sparse function type. */
-  SparseFunctionType * m_SparseFunction;
+  SparseFunctionType * m_SparseFunction{};
 
   /** A list of subregions of the active set of pixels in the sparse image
       which are passed to each thread for parallel processing. */
-  typename NodeListType::RegionListType m_RegionList;
+  typename NodeListType::RegionListType m_RegionList{};
 };
 } // end namespace itk
 

--- a/Modules/Core/GPUCommon/include/itkGPUContextManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUContextManager.h
@@ -62,12 +62,12 @@ private:
   GPUContextManager();
   ~GPUContextManager() override;
 
-  cl_platform_id     m_Platform;
-  cl_context         m_Context;
-  cl_device_id *     m_Devices;
+  cl_platform_id     m_Platform{};
+  cl_context         m_Context{};
+  cl_device_id *     m_Devices{};
   cl_command_queue * m_CommandQueue; // one queue per device
 
-  cl_uint m_NumberOfDevices, m_NumberOfPlatforms;
+  cl_uint m_NumberOfDevices, m_NumberOfPlatforms{};
 
   static GPUContextManager * m_Instance;
 };

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
@@ -137,7 +137,7 @@ protected:
   AllocateUpdateBuffer() override;
 
   /* GPU kernel handle for GPUApplyUpdate */
-  int m_ApplyUpdateGPUKernelHandle;
+  int m_ApplyUpdateGPUKernelHandle{};
 };
 } // end namespace itk
 

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
@@ -117,10 +117,10 @@ protected:
   ~GPUFiniteDifferenceFunction() override = default;
 
   /** GPU kernel manager for GPUFiniteDifferenceFunction class */
-  typename GPUKernelManager::Pointer m_GPUKernelManager;
+  typename GPUKernelManager::Pointer m_GPUKernelManager{};
 
   /** GPU kernel handle for GPUComputeUpdate() */
-  int m_ComputeUpdateGPUKernelHandle;
+  int m_ComputeUpdateGPUKernelHandle{};
 };
 } // end namespace itk
 

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -254,7 +254,7 @@ protected:
   {}
 
   /** Timers for statistics */
-  TimeProbe m_InitTime, m_ComputeUpdateTime, m_ApplyUpdateTime, m_SmoothFieldTime;
+  TimeProbe m_InitTime, m_ComputeUpdateTime, m_ApplyUpdateTime, m_SmoothFieldTime{};
 
 private:
   /** Initialize the values of the Function coefficients. This function will
@@ -264,14 +264,14 @@ private:
   InitializeFunctionCoefficients();
 
   /** The function that will be used in calculating updates for each pixel. */
-  typename FiniteDifferenceFunctionType::Pointer m_DifferenceFunction;
+  typename FiniteDifferenceFunctionType::Pointer m_DifferenceFunction{};
 
   /** Control whether derivatives use spacing of the input image in
       its calculation. */
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{};
 
   /** State that the filter is in, i.e. UNINITIALIZED or INITIALIZED */
-  GPUFiniteDifferenceFilterEnum m_State;
+  GPUFiniteDifferenceFilterEnum m_State{};
 };
 
 } // end namespace itk

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -214,14 +214,14 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Const pointer to the input image. */
-  InputImageConstPointer m_Image;
+  InputImageConstPointer m_Image{};
 
   /** Cache some values for testing if indices are inside buffered region. */
-  IndexType m_StartIndex;
-  IndexType m_EndIndex;
+  IndexType m_StartIndex{};
+  IndexType m_EndIndex{};
 
-  ContinuousIndexType m_StartContinuousIndex;
-  ContinuousIndexType m_EndContinuousIndex;
+  ContinuousIndexType m_StartContinuousIndex{};
+  ContinuousIndexType m_EndContinuousIndex{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Mesh/include/itkMeshRegion.h
+++ b/Modules/Core/Mesh/include/itkMeshRegion.h
@@ -110,10 +110,10 @@ public:
 
 private:
   // The maximum number of regions possible.
-  SizeValueType m_NumberOfRegions;
+  SizeValueType m_NumberOfRegions{};
 
   // The specified region.
-  SizeValueType m_Region;
+  SizeValueType m_Region{};
 };
 } // end namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -210,17 +210,17 @@ protected:
 
 protected:
   /** Mesh on which we propagate the front */
-  MeshType * m_Mesh;
+  MeshType * m_Mesh{};
   /** Initial seed of the front */
-  QEType * m_Seed;
+  QEType * m_Seed{};
   /** Whether the iterator is active */
-  bool m_Start;
+  bool m_Start{};
   /** The active front */
-  FrontTypePointer m_Front;
+  FrontTypePointer m_Front{};
   /** The already visited points */
-  IsVisitedPointerType m_IsPointVisited;
+  IsVisitedPointerType m_IsPointVisited{};
   /** The current edge at this stage of iteration */
-  QEType * m_CurrentEdge;
+  QEType * m_CurrentEdge{};
 };
 
 /**

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
@@ -94,7 +94,7 @@ protected:
 private:
 protected:
   /** Mesh on which to apply the modification */
-  MeshType * m_Mesh;
+  MeshType * m_Mesh{};
 };
 } // end namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
@@ -232,9 +232,9 @@ private:
    * In order to have constant time access at the itk level instead of
    * of doing a search in the Mesh::Cell container.
    */
-  CellIdentifier          m_Identifier;
-  QEType *                m_QuadEdgeGeom;
-  mutable PointIdentifier m_PointIds[2];
+  CellIdentifier          m_Identifier{};
+  QEType *                m_QuadEdgeGeom{};
+  mutable PointIdentifier m_PointIds[2]{};
 };
 } // end namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -280,7 +280,7 @@ public:
 
 protected:
   using PointIDListType = std::vector<PointIdentifier>;
-  mutable PointIDListType m_PointIds;
+  mutable PointIDListType m_PointIds{};
 
 private:
   void
@@ -301,17 +301,17 @@ private:
   /** In order to have constant time access at the itk level instead of
    * doing a search in the Mesh::Cell container.
    */
-  CellIdentifier m_Ident;
+  CellIdentifier m_Ident{};
 
   /**
    * Entry point into the edge ring.
    */
-  QuadEdgeType * m_EdgeRingEntry;
+  QuadEdgeType * m_EdgeRingEntry{};
 
   /**
    * List of EdgeCells created by the constructor for proper deletion
    */
-  EdgeCellListType m_EdgeCellList;
+  EdgeCellListType m_EdgeCellList{};
 };
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
@@ -78,8 +78,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  CovariantVectorType m_NormalInObjectSpace;
-  PointType           m_PickedPointInObjectSpace;
+  CovariantVectorType m_NormalInObjectSpace{};
+  PointType           m_PickedPointInObjectSpace{};
 };
 } // end of namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -232,22 +232,22 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const;
 
   /** A unique ID assigned to this SpatialObjectPoint */
-  int m_Id;
+  int m_Id{};
 
   /** Position of the point */
-  PointType m_PositionInObjectSpace;
+  PointType m_PositionInObjectSpace{};
 
   /** Color of the point */
-  ColorType m_Color;
+  ColorType m_Color{};
 
   /** Additional scalar properties of the point */
-  std::map<std::string, double> m_ScalarDictionary;
+  std::map<std::string, double> m_ScalarDictionary{};
 
 
   // The SpatialObjectPoint keeps a reference to its owning parent
   // spatial object for its spatial context. A WeakPointer is used to
   // avoid a memory leak.
-  WeakPointer<SpatialObjectType> m_SpatialObject;
+  WeakPointer<SpatialObjectType> m_SpatialObject{};
 };
 
 } // end of namespace itk

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -146,12 +146,12 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const;
 
 private:
-  ColorType m_Color;
+  ColorType m_Color{};
 
-  std::string m_Name;
+  std::string m_Name{};
 
-  std::map<std::string, double>      m_ScalarDictionary;
-  std::map<std::string, std::string> m_StringDictionary;
+  std::map<std::string, double>      m_ScalarDictionary{};
+  std::map<std::string, std::string> m_StringDictionary{};
 };
 
 } // namespace itk

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -392,13 +392,13 @@ protected:
    *  in each dimension wrapped from the flat parameters in
    *  m_InternalParametersBuffer
    */
-  CoefficientImageArray m_CoefficientImages;
+  CoefficientImageArray m_CoefficientImages{};
 
   /** Internal parameters buffer. */
-  ParametersType m_InternalParametersBuffer;
+  ParametersType m_InternalParametersBuffer{};
 
   /** Pointer to function used to compute Bspline interpolation weights. */
-  typename WeightsFunctionType::Pointer m_WeightsFunction;
+  typename WeightsFunctionType::Pointer m_WeightsFunction{};
 
 private:
   static CoefficientImageArray

--- a/Modules/Core/Transform/include/itkMultiTransform.h
+++ b/Modules/Core/Transform/include/itkMultiTransform.h
@@ -334,11 +334,11 @@ protected:
   }
 
   /** Transform container object. */
-  mutable TransformQueueType m_TransformQueue;
+  mutable TransformQueueType m_TransformQueue{};
 
   /** Cache to save time returning the number of local parameters */
-  mutable NumberOfParametersType m_NumberOfLocalParameters;
-  mutable ModifiedTimeType       m_LocalParametersUpdateTime;
+  mutable NumberOfParametersType m_NumberOfLocalParameters{};
+  mutable ModifiedTimeType       m_LocalParametersUpdateTime{};
 };
 
 } // end namespace itk

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -599,16 +599,16 @@ protected:
 #else
   ~Transform() override = default;
 #endif
-  mutable ParametersType      m_Parameters;
-  mutable FixedParametersType m_FixedParameters;
+  mutable ParametersType      m_Parameters{};
+  mutable FixedParametersType m_FixedParameters{};
 
   OutputDiffusionTensor3DType
   PreservationOfPrincipalDirectionDiffusionTensor3DReorientation(const InputDiffusionTensor3DType &,
                                                                  const InverseJacobianPositionType &) const;
 
 private:
-  std::string m_InputSpaceName;
-  std::string m_OutputSpaceName;
+  std::string m_InputSpaceName{};
+  std::string m_OutputSpaceName{};
 
   template <typename TType>
   static std::string

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
@@ -253,9 +253,9 @@ protected:
   }
 
 private:
-  double       m_AverageGradientMagnitudeSquared;
-  double       m_ConductanceParameter;
-  TimeStepType m_TimeStep;
+  double       m_AverageGradientMagnitudeSquared{};
+  double       m_ConductanceParameter{};
+  TimeStepType m_TimeStep{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.h
@@ -149,15 +149,15 @@ protected:
   void
   InitializeIteration() override;
 
-  bool m_GradientMagnitudeIsFixed;
+  bool m_GradientMagnitudeIsFixed{};
 
 private:
-  double       m_ConductanceParameter;
-  double       m_ConductanceScalingParameter;
-  unsigned int m_ConductanceScalingUpdateInterval;
-  double       m_FixedAverageGradientMagnitude;
+  double       m_ConductanceParameter{};
+  double       m_ConductanceScalingParameter{};
+  unsigned int m_ConductanceScalingUpdateInterval{};
+  double       m_FixedAverageGradientMagnitude{};
 
-  TimeStepType m_TimeStep;
+  TimeStepType m_TimeStep{};
 };
 } // namespace itk
 

--- a/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
@@ -141,7 +141,7 @@ private:
   SizeValueType m_NumberOfSamples{ 0 };
 
   /** Storage for the precalculated function values. */
-  MeasureArrayType m_CacheTable;
+  MeasureArrayType m_CacheTable{};
 
   /** The upper-bound of domain that is used for filling the cache table. */
   double m_CacheUpperBound{ 0.0 };

--- a/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
@@ -186,15 +186,15 @@ protected:
 
 private:
   /** Storage for tissue classes' statistics. */
-  std::vector<TargetClass> m_Targets;
+  std::vector<TargetClass> m_Targets{};
 
   /** The highest mean value + the sigma of the tissue class
    * which has the highest mean value * 9. */
-  double m_UpperBound;
+  double m_UpperBound{};
 
   /** The lowest mean value - the sigma of the tissue class
    * which has the lowest mean value * 9. */
-  double m_LowerBound;
+  double m_LowerBound{};
 }; // end of class
 } // end of namespace itk
 #endif

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
@@ -207,19 +207,19 @@ protected:
 
   /** Pointer to a persistent boundary condition object used
    * for the image iterator. */
-  ImageBoundaryConditionPointerType m_BoundaryCondition;
+  ImageBoundaryConditionPointerType m_BoundaryCondition{};
 
   /** Default boundary condition */
-  DefaultBoundaryConditionType m_DefaultBoundaryCondition;
+  DefaultBoundaryConditionType m_DefaultBoundaryCondition{};
 
   /** Defaults to false */
-  bool m_UseBoundaryCondition;
+  bool m_UseBoundaryCondition{};
 
   /** kernel or structuring element to use. */
-  KernelType m_Kernel;
+  KernelType m_Kernel{};
 
   /** Pixel value that indicates the object be operated upon */
-  PixelType m_ObjectValue;
+  PixelType m_ObjectValue{};
 
   void
   BeforeThreadedGenerateData() override;

--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -133,11 +133,11 @@ protected:
   }
 
 private:
-  ScalarType m_MinimumInputValue;
-  ScalarType m_MaximumInputValue;
+  ScalarType m_MinimumInputValue{};
+  ScalarType m_MaximumInputValue{};
 
-  RGBComponentType m_MinimumRGBComponentValue;
-  RGBComponentType m_MaximumRGBComponentValue;
+  RGBComponentType m_MinimumRGBComponentValue{};
+  RGBComponentType m_MaximumRGBComponentValue{};
 };
 } // end namespace Function
 } // end namespace itk

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -156,8 +156,8 @@ protected:
 private:
   bool m_Normalize{ false };
 
-  DefaultBoundaryConditionType m_DefaultBoundaryCondition;
-  BoundaryConditionPointerType m_BoundaryCondition;
+  DefaultBoundaryConditionType m_DefaultBoundaryCondition{};
+  BoundaryConditionPointerType m_BoundaryCondition{};
 
   OutputRegionModeEnum m_OutputRegionMode{ ConvolutionImageFilterBaseEnums::ConvolutionImageFilterOutputRegion::SAME };
 };

--- a/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.h
@@ -131,10 +131,10 @@ protected:
   GenerateData() override;
 
   /** Discrete Fourier transform of the padded kernel. */
-  InternalComplexImagePointerType m_TransferFunction;
+  InternalComplexImagePointerType m_TransferFunction{};
 
   /** Intermediate results. Protected for easy access by subclasses. */
-  InternalImagePointerType m_CurrentEstimate;
+  InternalImagePointerType m_CurrentEstimate{};
 
   using typename Superclass::FFTFilterType;
   using typename Superclass::IFFTFilterType;
@@ -144,17 +144,17 @@ protected:
 
 private:
   /** Number of iterations to run. */
-  unsigned int m_NumberOfIterations;
+  unsigned int m_NumberOfIterations{};
 
   /** The current iteration. */
-  unsigned int m_Iteration;
+  unsigned int m_Iteration{};
 
   /** Flag indicating whether iteration should be stopped. */
-  bool m_StopIteration;
+  bool m_StopIteration{};
 
   /** Modified times for the input and kernel. */
-  ModifiedTimeType m_InputMTime;
-  ModifiedTimeType m_KernelMTime;
+  ModifiedTimeType m_InputMTime{};
+  ModifiedTimeType m_KernelMTime{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -405,13 +405,13 @@ protected:
 
   // Cache input and output pointer to get rid of thousands of calls
   // to GetInput and GetOutput.
-  const InputImageType * m_InputImage;
-  OutputImageType *      m_OutputImage;
+  const InputImageType * m_InputImage{};
+  OutputImageType *      m_OutputImage{};
 
 private:
   /** Parameters that define patch size and patch weights (mask). */
   unsigned int     m_PatchRadius{ 4 };
-  PatchWeightsType m_PatchWeights;
+  PatchWeightsType m_PatchWeights{};
 
   /** Parameters that define the strategy for kernel-bandwidth estimation. */
   bool         m_KernelBandwidthEstimation{ false };

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -97,7 +97,7 @@ public:
   GenerateWisdomFilename(const std::string & baseCacheDirectory) const override;
 
 private:
-  std::string m_WisdomFilename;
+  std::string m_WisdomFilename{};
 };
 
 class ITKFFT_EXPORT SimpleWisdomFilenameGenerator : public WisdomFilenameGeneratorBase

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
@@ -152,16 +152,16 @@ protected:
   }
 
   // GPU buffer for Computing Average Squared Gradient Magnitude
-  typename GPUDataManager::Pointer   m_AnisotropicDiffusionFunctionGPUBuffer;
-  typename GPUKernelManager::Pointer m_AnisotropicDiffusionFunctionGPUKernelManager;
+  typename GPUDataManager::Pointer   m_AnisotropicDiffusionFunctionGPUBuffer{};
+  typename GPUKernelManager::Pointer m_AnisotropicDiffusionFunctionGPUKernelManager{};
 
   // GPU Kernel Handles
-  int m_AverageGradientMagnitudeSquaredGPUKernelHandle;
+  int m_AverageGradientMagnitudeSquaredGPUKernelHandle{};
 
 private:
-  double       m_AverageGradientMagnitudeSquared;
-  double       m_ConductanceParameter;
-  TimeStepType m_TimeStep;
+  double       m_AverageGradientMagnitudeSquared{};
+  double       m_ConductanceParameter{};
+  TimeStepType m_TimeStep{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -77,10 +77,10 @@ public:
   }
 
 private:
-  TInput  m_LowerThreshold;
-  TInput  m_UpperThreshold;
-  TOutput m_InsideValue;
-  TOutput m_OutsideValue;
+  TInput  m_LowerThreshold{};
+  TInput  m_UpperThreshold{};
+  TOutput m_InsideValue{};
+  TOutput m_OutsideValue{};
 };
 } // end of namespace Functor
 

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
@@ -142,36 +142,36 @@ protected:
 
 protected:
   /** Causal coefficients that multiply the input data. */
-  ScalarRealType m_N0;
-  ScalarRealType m_N1;
-  ScalarRealType m_N2;
-  ScalarRealType m_N3;
+  ScalarRealType m_N0{};
+  ScalarRealType m_N1{};
+  ScalarRealType m_N2{};
+  ScalarRealType m_N3{};
 
   /** Recursive coefficients that multiply previously computed values
    * at the output. These are the same for the causal and
    * anti-causal parts of the filter. */
-  ScalarRealType m_D1;
-  ScalarRealType m_D2;
-  ScalarRealType m_D3;
-  ScalarRealType m_D4;
+  ScalarRealType m_D1{};
+  ScalarRealType m_D2{};
+  ScalarRealType m_D3{};
+  ScalarRealType m_D4{};
 
   /** Anti-causal coefficients that multiply the input data. */
-  ScalarRealType m_M1;
-  ScalarRealType m_M2;
-  ScalarRealType m_M3;
-  ScalarRealType m_M4;
+  ScalarRealType m_M1{};
+  ScalarRealType m_M2{};
+  ScalarRealType m_M3{};
+  ScalarRealType m_M4{};
 
   /** Recursive coefficients to be used at the boundaries to simulate
    * edge extension boundary conditions. */
-  ScalarRealType m_BN1;
-  ScalarRealType m_BN2;
-  ScalarRealType m_BN3;
-  ScalarRealType m_BN4;
+  ScalarRealType m_BN1{};
+  ScalarRealType m_BN2{};
+  ScalarRealType m_BN3{};
+  ScalarRealType m_BN4{};
 
-  ScalarRealType m_BM1;
-  ScalarRealType m_BM2;
-  ScalarRealType m_BM3;
-  ScalarRealType m_BM4;
+  ScalarRealType m_BM1{};
+  ScalarRealType m_BM2{};
+  ScalarRealType m_BM3{};
+  ScalarRealType m_BM4{};
 
 
   template <typename T1, typename T2>

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
@@ -135,10 +135,10 @@ protected:
 
 private:
   SizeType      m_Size; // size of the output image
-  SpacingType   m_Spacing;
-  PointType     m_Origin;
-  DirectionType m_Direction;
-  IndexType     m_StartIndex;
+  SpacingType   m_Spacing{};
+  PointType     m_Origin{};
+  DirectionType m_Direction{};
+  IndexType     m_StartIndex{};
   bool          m_UseReferenceImage{ false };
 };
 

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
@@ -91,7 +91,7 @@ protected:
 
 private:
   /** Target histogram data pointer */
-  typename TInputHistogram::ConstPointer m_InputHistogram;
+  typename TInputHistogram::ConstPointer m_InputHistogram{};
 }; // end of class
 } // end of namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
@@ -78,7 +78,7 @@ private:
   EstimateShapeModels() = 0;
 
   /** Container for holding the training image. */
-  InputImagePointer m_InputImage;
+  InputImagePointer m_InputImage{};
 
 }; // class ImageShapeModelEstimator
 } // namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
@@ -97,8 +97,8 @@ protected:
   PrintTrailer(std::ostream & os, Indent indent) const;
 
 private:
-  IndexType  m_Index;
-  LengthType m_Length;
+  IndexType  m_Index{};
+  LengthType m_Length{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -224,9 +224,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool m_Decomposable;
+  bool m_Decomposable{};
 
-  DecompType m_Lines;
+  DecompType m_Lines{};
 
   template <unsigned int VDimension3>
   struct StructuringElementFacet
@@ -246,7 +246,7 @@ private:
   using LType3 = Vector<float, 3>;
   using FacetType3 = StructuringElementFacet<3>;
 
-  bool m_RadiusIsParametric;
+  bool m_RadiusIsParametric{};
 
   /** Check for correct odd size image.
    *  Return image size. Called in constructor FromImage.*/

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.h
@@ -154,10 +154,10 @@ protected:
 private:
   /** Pointer to a persistent boundary condition object used
    * for the image iterator. */
-  ImageBoundaryConditionPointerType m_BoundaryCondition;
+  ImageBoundaryConditionPointerType m_BoundaryCondition{};
 
   /** Default boundary condition */
-  DefaultBoundaryConditionType m_DefaultBoundaryCondition;
+  DefaultBoundaryConditionType m_DefaultBoundaryCondition{};
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkParametricPath.h
+++ b/Modules/Filtering/Path/include/itkParametricPath.h
@@ -138,7 +138,7 @@ protected:
    * either 1 or 0.1 are probably good values.  This value should be set in the
    * constructor of all instantiable children.  Values set in child constructors
    * overwrite values set in parent constructors. */
-  InputType m_DefaultInputStepSize;
+  InputType m_DefaultInputStepSize{};
 };
 
 } // namespace itk

--- a/Modules/Filtering/Path/include/itkPathConstIterator.h
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.h
@@ -208,37 +208,37 @@ protected: // made protected so other iterators can access
   OffsetType m_ZeroOffset; // = 0 for all dimensions
 
   /** Smart pointer to the source image. */
-  typename ImageType::ConstWeakPointer m_Image;
+  typename ImageType::ConstWeakPointer m_Image{};
 
   /** Smart pointer to the path we're following */
-  typename PathType::ConstPointer m_Path;
+  typename PathType::ConstPointer m_Path{};
 
   /** Region type to iterate over. */
-  RegionType m_Region;
+  RegionType m_Region{};
 
   /** The origin of the source image */
-  PointType m_ImageOrigin;
+  PointType m_ImageOrigin{};
 
   /** The spacing of the source image */
-  SpacingType m_ImageSpacing;
+  SpacingType m_ImageSpacing{};
 
   /** Size of the source image */
-  const SizeValueType * m_ImageSize;
+  const SizeValueType * m_ImageSize{};
 
   /** Should GoToBegin() initially skip the first index of a closed path so that
    * the first index will only be visited once--at the end of the path?  If
    * false, then GoToBegin() will always move to the 1'st index.  The default
    * value is true, which is set the constructor. */
-  bool m_VisitStartIndexAsLastIndexIfClosed;
+  bool m_VisitStartIndexAsLastIndexIfClosed{};
 
   /** Is the iterator at the end of its walk? */
-  bool m_IsAtEnd;
+  bool m_IsAtEnd{};
 
   /** Current 1D position along the path, such as time or arc length */
-  PathInputType m_CurrentPathPosition;
+  PathInputType m_CurrentPathPosition{};
 
   /** Current ND index position in the image of the path */
-  IndexType m_CurrentImageIndex;
+  IndexType m_CurrentImageIndex{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
@@ -119,7 +119,7 @@ protected:
   }
 
   /** Cache pointer to output to use in inner loops */
-  OutputMeshType * m_OutputMesh;
+  OutputMeshType * m_OutputMesh{};
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
@@ -121,7 +121,7 @@ protected:
 
 private:
   /** Cache output pointer to avoid calls in inner loop to GetOutput() */
-  OutputMeshType * m_OutputMesh;
+  OutputMeshType * m_OutputMesh{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -93,11 +93,11 @@ protected:
   bool m_Relocate{ true };
   bool m_CheckOrientation{ false };
 
-  PriorityQueuePointer m_PriorityQueue;
-  QueueMapType         m_QueueMapper;
-  OutputQEType *       m_Element;
-  PriorityType         m_Priority;
-  OperatorPointer      m_JoinVertexFunction;
+  PriorityQueuePointer m_PriorityQueue{};
+  QueueMapType         m_QueueMapper{};
+  OutputQEType *       m_Element{};
+  PriorityType         m_Priority{};
+  OperatorPointer      m_JoinVertexFunction{};
 
   /**
    * \brief Compute the measure value for iEdge

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -93,12 +93,12 @@ protected:
     os << indent << "MeasureBound: " << m_MeasureBound << std::endl;
   }
 
-  bool m_TopologicalChange;
-  bool m_SizeCriterion;
+  bool m_TopologicalChange{};
+  bool m_SizeCriterion{};
 
-  SizeValueType m_NumberOfElements;
+  SizeValueType m_NumberOfElements{};
 
-  MeasureType m_MeasureBound;
+  MeasureType m_MeasureBound{};
 };
 
 /**

--- a/Modules/IO/CSV/include/itkCSVFileReaderBase.h
+++ b/Modules/IO/CSV/include/itkCSVFileReaderBase.h
@@ -164,15 +164,15 @@ public:
   Parse() = 0;
 
 protected:
-  std::string   m_FileName;
-  char          m_FieldDelimiterCharacter;
-  char          m_StringDelimiterCharacter;
-  bool          m_UseStringDelimiterCharacter;
-  bool          m_HasRowHeaders;
-  bool          m_HasColumnHeaders;
-  std::ifstream m_InputStream;
-  int           m_EndOfColumnHeadersLine;
-  std::string   m_Line;
+  std::string   m_FileName{};
+  char          m_FieldDelimiterCharacter{};
+  char          m_StringDelimiterCharacter{};
+  bool          m_UseStringDelimiterCharacter{};
+  bool          m_HasRowHeaders{};
+  bool          m_HasColumnHeaders{};
+  std::ifstream m_InputStream{};
+  int           m_EndOfColumnHeadersLine{};
+  std::string   m_Line{};
 
   CSVFileReaderBase();
   ~CSVFileReaderBase() override = default;

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -102,12 +102,12 @@ public:
   IPLGetMacroDeclaration(Data, const void *);
 
 private:
-  std::string  m_ImageFileName;
-  float        m_SliceLocation;
-  int          m_SliceOffset;
-  int          m_EchoNumber;
-  int          m_ImageNumber;
-  const void * m_Data;
+  std::string  m_ImageFileName{};
+  float        m_SliceLocation{};
+  int          m_SliceOffset{};
+  int          m_EchoNumber{};
+  int          m_ImageNumber{};
+  const void * m_Data{};
 };
 
 /**
@@ -280,16 +280,16 @@ public:
   IPLSetMacroDeclaration(SortOrder, int);
 
 private:
-  ListType m_List;
-  int      m_XDim;
-  int      m_YDim;
-  float    m_XRes;
-  float    m_YRes;
+  ListType m_List{};
+  int      m_XDim{};
+  int      m_YDim{};
+  float    m_XRes{};
+  float    m_YRes{};
   int      m_Key1; /** Key that must be matched for image to be used,
                      i.e. seriesNumber, extensionkey */
   int m_Key2;      /** Key that must be matched for image to be used,
                      i.e. echoNumber */
-  int m_SortOrder;
+  int m_SortOrder{};
 };
 } // namespace itk
 #endif /* itkIPLFileNameList_h */

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -708,14 +708,14 @@ protected:
   IOFileEnum m_FileType{ IOFileEnum::TypeNotApplicable };
 
   /** Does the ImageIOBase object have enough info to be of use? */
-  bool m_Initialized;
+  bool m_Initialized{};
 
   /** Filename to read */
-  std::string m_FileName;
+  std::string m_FileName{};
 
   /** Stores the number of components per pixel. This will be 1 for
    * grayscale images, 3 for RGBPixel images, and 4 for RGBPixelA images. */
-  unsigned int m_NumberOfComponents;
+  unsigned int m_NumberOfComponents{};
 
   /** The number of independent dimensions in the image. */
   unsigned int m_NumberOfDimensions{ 0 };
@@ -740,41 +740,41 @@ protected:
   InternalSetCompressor(const std::string & _compressor);
 
   /** Should we use streaming for reading */
-  bool m_UseStreamedReading;
+  bool m_UseStreamedReading{};
 
   /** Should we use streaming for writing */
-  bool m_UseStreamedWriting;
+  bool m_UseStreamedWriting{};
 
   /** Should we expand RGB palette or stay scalar */
-  bool m_ExpandRGBPalette;
+  bool m_ExpandRGBPalette{};
 
   /** true if a RGB palette has been read and the image
    * kept scalar */
-  bool m_IsReadAsScalarPlusPalette;
+  bool m_IsReadAsScalarPlusPalette{};
 
   /** Should we try to include a RGB palette while writing the image  */
-  bool m_WritePalette;
+  bool m_WritePalette{};
 
   /** The region to read or write. The region contains information about the
    * data within the region to read or write. */
-  ImageIORegion m_IORegion;
+  ImageIORegion m_IORegion{};
 
   /** The array which stores the number of pixels in the x, y, z directions. */
-  std::vector<SizeValueType> m_Dimensions;
+  std::vector<SizeValueType> m_Dimensions{};
 
   /** The array which stores the spacing of pixels in the
    * x, y, z directions. */
-  std::vector<double> m_Spacing;
+  std::vector<double> m_Spacing{};
 
   /** The array which stores the origin of the image. */
-  std::vector<double> m_Origin;
+  std::vector<double> m_Origin{};
 
   /** The arrays which store the direction cosines of the image. */
-  std::vector<std::vector<double>> m_Direction;
+  std::vector<std::vector<double>> m_Direction{};
 
   /** Stores the number of bytes it takes to get to the next 'thing'
    * e.g. component, pixel, row, slice, etc. */
-  std::vector<SizeType> m_Strides;
+  std::vector<SizeType> m_Strides{};
 
   /** Return the object to an initialized state, ready to be used */
   virtual void
@@ -891,8 +891,8 @@ private:
   bool
   HasSupportedExtension(const char *, const ArrayOfExtensionsType &, bool ignoreCase = true);
 
-  ArrayOfExtensionsType m_SupportedReadExtensions;
-  ArrayOfExtensionsType m_SupportedWriteExtensions;
+  ArrayOfExtensionsType m_SupportedReadExtensions{};
+  ArrayOfExtensionsType m_SupportedWriteExtensions{};
 };
 
 /** Utility function for writing RAW bytes */

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -824,7 +824,7 @@ protected:
   IOFileEnum      m_FileType{ IOFileEnum::ASCII };
 
   /** Filename to read */
-  std::string m_FileName;
+  std::string m_FileName{};
 
   /** Should we compress the data? */
   bool m_UseCompression{ false };
@@ -848,13 +848,13 @@ protected:
   unsigned int m_PointDimension{ 3 };
 
   /** The number of points and cells */
-  SizeValueType m_NumberOfPoints;
-  SizeValueType m_NumberOfCells;
-  SizeValueType m_NumberOfPointPixels;
-  SizeValueType m_NumberOfCellPixels;
+  SizeValueType m_NumberOfPoints{};
+  SizeValueType m_NumberOfCells{};
+  SizeValueType m_NumberOfPointPixels{};
+  SizeValueType m_NumberOfCellPixels{};
 
   /** The buffer size of cells */
-  SizeValueType m_CellBufferSize;
+  SizeValueType m_CellBufferSize{};
 
   /** Flags indicate whether read or write points, cells, point data and cell
     data */
@@ -864,8 +864,8 @@ protected:
   bool m_UpdateCellData{ false };
 
 private:
-  ArrayOfExtensionsType m_SupportedReadExtensions;
-  ArrayOfExtensionsType m_SupportedWriteExtensions;
+  ArrayOfExtensionsType m_SupportedReadExtensions{};
+  ArrayOfExtensionsType m_SupportedWriteExtensions{};
 };
 #define MESHIOBASE_TYPEMAP(type, ctype)             \
   template <>                                       \

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -169,9 +169,9 @@ protected:
   }
 
 private:
-  std::string            m_FileName;
-  TransformListType      m_ReadTransformList;
-  ConstTransformListType m_WriteTransformList;
+  std::string            m_FileName{};
+  TransformListType      m_ReadTransformList{};
+  ConstTransformListType m_WriteTransformList{};
   bool                   m_AppendMode{ false };
   /** Should we compress the data? */
   bool m_UseCompression{ false };

--- a/Modules/IO/XML/include/itkDOMReader.h
+++ b/Modules/IO/XML/include/itkDOMReader.h
@@ -140,18 +140,18 @@ private:
   itkGetModifiableObjectMacro(IntermediateDOM, DOMNodeType);
 
   /** Variable to hold the input XML file name. */
-  std::string m_FileName;
+  std::string m_FileName{};
 
   /** Variable to hold the output object, created internally or supplied by the user. */
-  OutputType * m_Output;
+  OutputType * m_Output{};
   /** Variable to hold the output object if it is a smart object. */
-  typename LightObject::Pointer m_OutputHolder;
+  typename LightObject::Pointer m_OutputHolder{};
 
   /** Variable to hold the intermediate DOM object. */
-  DOMNodePointer m_IntermediateDOM;
+  DOMNodePointer m_IntermediateDOM{};
 
   /** Variable to log various messages during the reading process. */
-  mutable LoggerPointer m_Logger;
+  mutable LoggerPointer m_Logger{};
 };
 
 } // namespace itk

--- a/Modules/IO/XML/include/itkDOMWriter.h
+++ b/Modules/IO/XML/include/itkDOMWriter.h
@@ -135,18 +135,18 @@ private:
   itkGetModifiableObjectMacro(IntermediateDOM, DOMNodeType);
 
   /** Variable to hold the output XML file name. */
-  std::string m_FileName;
+  std::string m_FileName{};
 
   /** Variable to hold the input object. */
-  const InputType * m_Input;
+  const InputType * m_Input{};
   /** Variable to hold the input object if it is a smart object. */
-  typename LightObject::ConstPointer m_InputHolder;
+  typename LightObject::ConstPointer m_InputHolder{};
 
   /** Variable to hold the intermediate DOM object. */
-  DOMNodePointer m_IntermediateDOM;
+  DOMNodePointer m_IntermediateDOM{};
 
   /** Variable to log various messages during the writing process. */
-  mutable LoggerPointer m_Logger;
+  mutable LoggerPointer m_Logger{};
 };
 
 } // namespace itk

--- a/Modules/IO/XML/include/itkXMLFile.h
+++ b/Modules/IO/XML/include/itkXMLFile.h
@@ -84,7 +84,7 @@ protected:
   void
   parse();
 
-  std::string m_Filename;
+  std::string m_Filename{};
 };
 
 /**

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
@@ -228,7 +228,7 @@ private:
   CalculateChange() override;
 
   /** The buffer that holds the updates for an iteration of the algorithm. */
-  std::vector<InputImagePointer> m_UpdateBuffers;
+  std::vector<InputImagePointer> m_UpdateBuffers{};
 };
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -398,22 +398,22 @@ protected:
 
   ~MultiphaseFiniteDifferenceImageFilter() override = default;
 
-  IdCellType                     m_FunctionCount;
-  std::vector<InputImagePointer> m_LevelSet;
-  VectorIdCellType               m_Lookup;
-  KdTreePointer                  m_KdTree;
+  IdCellType                     m_FunctionCount{};
+  std::vector<InputImagePointer> m_LevelSet{};
+  VectorIdCellType               m_Lookup{};
+  KdTreePointer                  m_KdTree{};
 
-  unsigned int m_ElapsedIterations;
-  double       m_MaximumRMSError;
-  double       m_RMSChange;
-  unsigned int m_NumberOfIterations;
+  unsigned int m_ElapsedIterations{};
+  double       m_MaximumRMSError{};
+  double       m_RMSChange{};
+  unsigned int m_NumberOfIterations{};
 
   /** The function that will be used in calculating updates for each pixel. */
-  std::vector<FiniteDifferenceFunctionPointer> m_DifferenceFunctions;
+  std::vector<FiniteDifferenceFunctionPointer> m_DifferenceFunctions{};
 
   /** Control whether derivatives use spacing of the input image in its
    * calculation. */
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{};
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -531,10 +531,10 @@ protected:
 private:
   /** Indicates whether the filter automatically resets to UNINITIALIZED state
       after completing, or whether filter must be manually reset */
-  bool m_ManualReinitialization;
+  bool m_ManualReinitialization{};
 
   /** State that the filter is in, i.e. UNINITIALIZED or INITIALIZED */
-  bool m_InitializedState;
+  bool m_InitializedState{};
 };
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
@@ -380,47 +380,47 @@ protected:
   ~RegionBasedLevelSetFunction() override = default;
 
   /** The initial level set image */
-  InputImageConstPointer m_InitialImage;
+  InputImageConstPointer m_InitialImage{};
 
   /** The feature image */
-  FeatureImageConstPointer m_FeatureImage;
+  FeatureImageConstPointer m_FeatureImage{};
 
-  SharedDataPointer m_SharedData;
+  SharedDataPointer m_SharedData{};
 
-  HeavisideFunctionConstPointer m_DomainFunction;
+  HeavisideFunctionConstPointer m_DomainFunction{};
 
   /** Area regularization weight */
-  ScalarValueType m_AreaWeight;
+  ScalarValueType m_AreaWeight{};
 
   /** Internal functional of the level set weight */
-  ScalarValueType m_Lambda1;
+  ScalarValueType m_Lambda1{};
 
   /** External functional of the level set weight */
-  ScalarValueType m_Lambda2;
+  ScalarValueType m_Lambda2{};
 
   /** Overlap Penalty Weight */
-  ScalarValueType m_OverlapPenaltyWeight;
+  ScalarValueType m_OverlapPenaltyWeight{};
 
   /** Volume Regularization Weight */
-  ScalarValueType m_VolumeMatchingWeight;
+  ScalarValueType m_VolumeMatchingWeight{};
 
   /** Volume Constraint in pixels */
-  ScalarValueType m_Volume;
+  ScalarValueType m_Volume{};
 
   /** Curvature Regularization Weight */
-  ScalarValueType m_CurvatureWeight;
+  ScalarValueType m_CurvatureWeight{};
 
-  ScalarValueType m_AdvectionWeight;
+  ScalarValueType m_AdvectionWeight{};
 
   /** Laplacian Regularization Weight */
-  ScalarValueType m_ReinitializationSmoothingWeight;
+  ScalarValueType m_ReinitializationSmoothingWeight{};
 
-  unsigned int m_FunctionId;
+  unsigned int m_FunctionId{};
 
   std::slice      x_slice[Self::ImageDimension];
-  OffsetValueType m_Center;
-  OffsetValueType m_xStride[Self::ImageDimension];
-  double          m_InvSpacing[Self::ImageDimension];
+  OffsetValueType m_Center{};
+  OffsetValueType m_xStride[Self::ImageDimension]{};
+  double          m_InvSpacing[Self::ImageDimension]{};
 
   static double m_WaveDT;
   static double m_DT;
@@ -488,7 +488,7 @@ protected:
   virtual void
   UpdateSharedDataParameters() = 0;
 
-  bool m_UpdateC;
+  bool m_UpdateC{};
 
   /** This method's only purpose is to initialize the zero vector
    * constant. */

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -172,12 +172,12 @@ public:
   virtual void
   PopulateListImage() = 0;
 
-  LevelSetDataPointerVector m_LevelSetDataPointerVector;
+  LevelSetDataPointerVector m_LevelSetDataPointerVector{};
 
-  unsigned int     m_FunctionCount;
+  unsigned int     m_FunctionCount{};
   unsigned int     m_NumberOfNeighbors{ 6 };
-  ListImagePointer m_NearestNeighborListImage;
-  KdTreePointer    m_KdTree;
+  ListImagePointer m_NearestNeighborListImage{};
+  KdTreePointer    m_KdTree{};
 
 protected:
   RegionBasedLevelSetFunctionSharedData()

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
@@ -122,7 +122,7 @@ protected:
   /**
    * Pointer to material properties of the element
    */
-  MaterialLinearElasticity::ConstPointer m_Mat;
+  MaterialLinearElasticity::ConstPointer m_Mat{};
 };
 
 } // end namespace fem

--- a/Modules/Numerics/FEM/include/itkFEMElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementBase.h
@@ -717,7 +717,7 @@ public:
 
 protected:
   // to store edge connectivity data
-  std::vector<std::vector<int>> m_EdgeIds;
+  std::vector<std::vector<int>> m_EdgeIds{};
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.h
@@ -156,7 +156,7 @@ protected:
   }
 
   // Array of pointers to point objects that define the element
-  const Node * m_node[NumberOfNodes];
+  const Node * m_node[NumberOfNodes]{};
 };
 
 } // end namespace fem

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -138,8 +138,8 @@ public:
   /**
    * Base class of the searched object.
    */
-  std::string m_baseClassName;
-  int         m_GlobalNumber;
+  std::string m_baseClassName{};
+  int         m_GlobalNumber{};
 };
 
 /**

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
@@ -726,30 +726,30 @@ public:
 
 private:
   /** pointer to vector of matrices */
-  MatrixHolder * m_Matrices;
+  MatrixHolder * m_Matrices{};
 
   /** pointer to vector of force arrays */
-  VectorHolder * m_Vectors;
+  VectorHolder * m_Vectors{};
 
   /** pointer to vector of solution arrays */
-  VectorHolder * m_Solutions;
+  VectorHolder * m_Solutions{};
 
   /** pointer to array of unsigned int's indicating max number of entries in
     each matrix */
   // UnsignedIntegerArrayPtr m_MaximumNonZeroValues;
-  unsigned int m_MaximumNonZeroValues;
+  unsigned int m_MaximumNonZeroValues{};
 
   /** Array of pointers to available solver functions */
-  ItkItpackSolverFunction m_Methods[7];
+  ItkItpackSolverFunction m_Methods[7]{};
 
   /** flag indicating which solver function should be used */
-  integer m_Method;
+  integer m_Method{};
 
   /** vector of length 12 used to initialize various parameters on input */
-  integer m_IPARM[12];
+  integer m_IPARM[12]{};
 
   /** vector of length 12 used to initialize various parameters on input */
-  doublereal m_RPARM[12];
+  doublereal m_RPARM[12]{};
 };
 
 /**

--- a/Modules/Numerics/FEM/include/itkFEMLoadBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBase.h
@@ -99,7 +99,7 @@ protected:
    * Pointer to an element in a system that contains the DOF
    * on which the external force is applied.
    */
-  Element::ConstPointer m_Element;
+  Element::ConstPointer m_Element{};
 };
 } // end namespace fem
 } // end namespace itk

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -231,7 +231,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  NarrowBandPointer m_NarrowBand;
+  NarrowBandPointer m_NarrowBand{};
 
   /** \struct ThreadRegionType
   The type of region used in multithreading.
@@ -247,7 +247,7 @@ protected:
 
   /** A list of subregions of the narrowband which are passed to each thread
    * for parallel processing. */
-  std::vector<RegionType> m_RegionList;
+  std::vector<RegionType> m_RegionList{};
 
   /** This function returns a single region (of the narrow band list) for use
       in multi-threading */
@@ -288,14 +288,14 @@ protected:
   GenerateData() override;
 
   /* Variables to control reinitialization */
-  IdentifierType m_ReinitializationFrequency;
-  IdentifierType m_Step;
+  IdentifierType m_ReinitializationFrequency{};
+  IdentifierType m_Step{};
 
-  bool m_Touched;
+  bool m_Touched{};
 
-  BooleanStdVectorType m_TouchedForThread;
+  BooleanStdVectorType m_TouchedForThread{};
 
-  ValueType m_IsoSurfaceValue;
+  ValueType m_IsoSurfaceValue{};
 
 private:
   /* This class does not use AllocateUpdateBuffer to allocate memory for its

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
@@ -126,14 +126,14 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor;
-  bool                      m_UseGradient;
+  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
+  bool                      m_UseGradient{};
 
-  CommandType::Pointer m_Command;
+  CommandType::Pointer m_Command{};
 
-  mutable ParametersType m_CachedCurrentPosition;
-  mutable MeasureType    m_CachedValue;
-  mutable DerivativeType m_CachedDerivative;
+  mutable ParametersType m_CachedCurrentPosition{};
+  mutable MeasureType    m_CachedValue{};
+  mutable DerivativeType m_CachedDerivative{};
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedVnlCostFunctionAdaptor.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedVnlCostFunctionAdaptor.h
@@ -148,15 +148,15 @@ private:
   /** Get current parameters scaling. */
   itkGetConstReferenceMacro(InverseScales, ScalesType);
 
-  MultipleValuedCostFunction::Pointer m_CostFunction;
+  MultipleValuedCostFunction::Pointer m_CostFunction{};
 
-  bool            m_ScalesInitialized;
-  ScalesType      m_InverseScales;
-  Object::Pointer m_Reporter;
+  bool            m_ScalesInitialized{};
+  ScalesType      m_InverseScales{};
+  Object::Pointer m_Reporter{};
 
-  mutable MeasureType    m_CachedValue;
-  mutable DerivativeType m_CachedDerivative;
-  mutable ParametersType m_CachedCurrentParameters;
+  mutable MeasureType    m_CachedValue{};
+  mutable DerivativeType m_CachedDerivative{};
+  mutable ParametersType m_CachedCurrentParameters{};
 }; // end of Class CostFunction
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -230,23 +230,23 @@ protected:
   void
   FileInitialization();
 
-  bool                                    m_PrintSwarm;
-  std::ostringstream                      m_StopConditionDescription;
-  bool                                    m_InitializeNormalDistribution;
-  NumberOfParticlesType                   m_NumberOfParticles;
-  NumberOfIterationsType                  m_MaximalNumberOfIterations;
-  NumberOfGenerationsType                 m_NumberOfGenerationsWithMinimalImprovement;
-  ParameterBoundsType                     m_ParameterBounds;
-  ParametersType                          m_ParametersConvergenceTolerance;
-  double                                  m_PercentageParticlesConverged;
-  CostFunctionType::MeasureType           m_FunctionConvergenceTolerance;
-  std::vector<ParticleData>               m_Particles;
+  bool                                    m_PrintSwarm{};
+  std::ostringstream                      m_StopConditionDescription{};
+  bool                                    m_InitializeNormalDistribution{};
+  NumberOfParticlesType                   m_NumberOfParticles{};
+  NumberOfIterationsType                  m_MaximalNumberOfIterations{};
+  NumberOfGenerationsType                 m_NumberOfGenerationsWithMinimalImprovement{};
+  ParameterBoundsType                     m_ParameterBounds{};
+  ParametersType                          m_ParametersConvergenceTolerance{};
+  double                                  m_PercentageParticlesConverged{};
+  CostFunctionType::MeasureType           m_FunctionConvergenceTolerance{};
+  std::vector<ParticleData>               m_Particles{};
   CostFunctionType::MeasureType           m_FunctionBestValue{ 0 };
-  std::vector<MeasureType>                m_FunctionBestValueMemory;
-  ParametersType                          m_ParametersBestValue;
+  std::vector<MeasureType>                m_FunctionBestValueMemory{};
+  ParametersType                          m_ParametersBestValue{};
   NumberOfIterationsType                  m_IterationIndex{ 0 };
-  RandomVariateGeneratorType::IntegerType m_Seed;
-  bool                                    m_UseSeed;
+  RandomVariateGeneratorType::IntegerType m_Seed{};
+  bool                                    m_UseSeed{};
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
@@ -139,15 +139,15 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor;
+  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
 
-  bool m_Maximize;
+  bool m_Maximize{};
 
-  CommandType::Pointer m_Command;
+  CommandType::Pointer m_Command{};
 
-  mutable ParametersType m_CachedCurrentPosition;
-  mutable MeasureType    m_CachedValue;
-  mutable DerivativeType m_CachedDerivative;
+  mutable ParametersType m_CachedCurrentPosition{};
+  mutable MeasureType    m_CachedValue{};
+  mutable DerivativeType m_CachedDerivative{};
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedVnlCostFunctionAdaptor.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedVnlCostFunctionAdaptor.h
@@ -150,15 +150,15 @@ private:
   /** Get current parameters scaling. */
   itkGetConstReferenceMacro(InverseScales, ScalesType);
 
-  SingleValuedCostFunction::Pointer m_CostFunction;
-  bool                              m_ScalesInitialized;
-  ScalesType                        m_InverseScales;
-  bool                              m_NegateCostFunction;
-  Object::Pointer                   m_Reporter;
+  SingleValuedCostFunction::Pointer m_CostFunction{};
+  bool                              m_ScalesInitialized{};
+  ScalesType                        m_InverseScales{};
+  bool                              m_NegateCostFunction{};
+  Object::Pointer                   m_Reporter{};
 
-  mutable MeasureType    m_CachedValue;
-  mutable DerivativeType m_CachedDerivative;
-  mutable ParametersType m_CachedCurrentParameters;
+  mutable MeasureType    m_CachedValue{};
+  mutable DerivativeType m_CachedDerivative{};
+  mutable ParametersType m_CachedCurrentParameters{};
 }; // end of Class CostFunction
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
@@ -115,7 +115,7 @@ protected:
     os << std::endl;
   }
 
-  EnergyValueContainerType m_EnergyValues;
+  EnergyValueContainerType m_EnergyValues{};
 };
 } // end namespace Function
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -167,12 +167,12 @@ protected:
   /** Flag to control use of the ScalesEstimator (if set) for
    * automatic learning step estimation at *each* iteration.
    */
-  bool m_DoEstimateLearningRateAtEachIteration;
+  bool m_DoEstimateLearningRateAtEachIteration{};
 
   /** Flag to control use of the ScalesEstimator (if set) for
    * automatic learning step estimation only *once*, during first iteration.
    */
-  bool m_DoEstimateLearningRateOnce;
+  bool m_DoEstimateLearningRateOnce{};
 
   /** The maximum step size in physical units, to restrict learning rates.
    * Only used with automatic learning rate estimation.
@@ -180,33 +180,33 @@ protected:
    * manually or by using m_ScalesEstimator automatically, and the former has
    * higher priority than the latter. See main documentation.
    */
-  TInternalComputationValueType m_MaximumStepSizeInPhysicalUnits;
+  TInternalComputationValueType m_MaximumStepSizeInPhysicalUnits{};
 
   /** Flag to control using the convergence monitoring for stop condition.
    *  This flag should be always set to true except for regular step gradient
    *  descent optimizer that uses minimum step length to check the convergence.
    */
-  bool m_UseConvergenceMonitoring;
+  bool m_UseConvergenceMonitoring{};
 
   /** Window size for the convergence checker.
    *  The convergence checker calculates convergence value by fitting to
    *  a window of the energy (metric value) profile.
    */
-  SizeValueType m_ConvergenceWindowSize;
+  SizeValueType m_ConvergenceWindowSize{};
 
   /** The convergence checker. */
-  typename ConvergenceMonitoringType::Pointer m_ConvergenceMonitoring;
+  typename ConvergenceMonitoringType::Pointer m_ConvergenceMonitoring{};
 
-  typename DomainThreader<ThreadedIndexedContainerPartitioner, Self>::Pointer m_ModifyGradientByScalesThreader;
-  typename DomainThreader<ThreadedIndexedContainerPartitioner, Self>::Pointer m_ModifyGradientByLearningRateThreader;
+  typename DomainThreader<ThreadedIndexedContainerPartitioner, Self>::Pointer m_ModifyGradientByScalesThreader{};
+  typename DomainThreader<ThreadedIndexedContainerPartitioner, Self>::Pointer m_ModifyGradientByLearningRateThreader{};
 
   /* Common variables for optimization control and reporting */
   bool                                     m_Stop{ false };
-  StopConditionObjectToObjectOptimizerEnum m_StopCondition;
-  StopConditionDescriptionType             m_StopConditionDescription;
+  StopConditionObjectToObjectOptimizerEnum m_StopCondition{};
+  StopConditionDescriptionType             m_StopConditionDescription{};
 
   /** Current gradient */
-  DerivativeType m_Gradient;
+  DerivativeType m_Gradient{};
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
@@ -152,9 +152,9 @@ protected:
   bool m_OptimizerInitialized{ false };
 
   using InternalOptimizerAutoPointer = std::unique_ptr<InternalOptimizerType>;
-  InternalOptimizerAutoPointer m_VnlOptimizer;
+  InternalOptimizerAutoPointer m_VnlOptimizer{};
 
-  mutable std::ostringstream m_StopConditionDescription;
+  mutable std::ostringstream m_StopConditionDescription{};
 
   bool         m_Trace{ false };
   unsigned int m_MaximumNumberOfFunctionEvaluations{ 2000 };

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
@@ -357,14 +357,14 @@ protected:
   VerifyNumberOfValidPoints(MeasureType & value, DerivativeType & derivative) const;
 
   /** Transforms */
-  FixedTransformPointer  m_FixedTransform;
-  MovingTransformPointer m_MovingTransform;
+  FixedTransformPointer  m_FixedTransform{};
+  MovingTransformPointer m_MovingTransform{};
 
-  VirtualImagePointer m_VirtualImage;
+  VirtualImagePointer m_VirtualImage{};
 
   /** Flag that is set when user provides a virtual domain, either via
    * SetVirtualDomain() or SetVirtualDomainFromImage(). */
-  bool m_UserHasSetVirtualDomain;
+  bool m_UserHasSetVirtualDomain{};
 
   /** Store the number of points used during most recent value and derivative
    * calculation.

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
@@ -253,13 +253,13 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Fixed and Moving Objects */
-  ObjectConstPointer m_FixedObject;
-  ObjectConstPointer m_MovingObject;
+  ObjectConstPointer m_FixedObject{};
+  ObjectConstPointer m_MovingObject{};
 
-  GradientSourceEnum m_GradientSource;
+  GradientSourceEnum m_GradientSource{};
 
   /** Metric value, stored after evaluating */
-  mutable MeasureType m_Value;
+  mutable MeasureType m_Value{};
 };
 
 /** This helps to meet backward compatibility */

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -276,37 +276,37 @@ protected:
   ObjectToObjectOptimizerBaseTemplate();
   ~ObjectToObjectOptimizerBaseTemplate() override;
 
-  MetricTypePointer m_Metric;
-  ThreadIdType      m_NumberOfWorkUnits;
-  SizeValueType     m_CurrentIteration;
-  SizeValueType     m_NumberOfIterations;
+  MetricTypePointer m_Metric{};
+  ThreadIdType      m_NumberOfWorkUnits{};
+  SizeValueType     m_CurrentIteration{};
+  SizeValueType     m_NumberOfIterations{};
 
   /** Metric measure value at a given iteration, as most recently evaluated. */
-  MeasureType m_CurrentMetricValue;
+  MeasureType m_CurrentMetricValue{};
 
   /** Scales. Size is expected to be == metric->GetNumberOfLocalParameters().
    * See the main documentation for more details. */
-  ScalesType m_Scales;
+  ScalesType m_Scales{};
 
   /** Parameter weights. These are applied to local parameters, at the same time
    * as scales. See main documentation.
    * If not set by user, the array remains empty and treated as identity to simplify
    * the reuse of an optimizer with transforms with different numbers of parameters. */
-  ScalesType m_Weights;
+  ScalesType m_Weights{};
 
   /** Flag to avoid unnecessary arithmetic when scales are identity. */
-  bool m_ScalesAreIdentity;
+  bool m_ScalesAreIdentity{};
 
   /** Scales estimator. Optionally provided by user. */
-  typename ScalesEstimatorType::Pointer m_ScalesEstimator;
+  typename ScalesEstimatorType::Pointer m_ScalesEstimator{};
 
   /** Flag to avoid unnecessary arithmetic when weights are identity. */
-  bool m_WeightsAreIdentity;
+  bool m_WeightsAreIdentity{};
 
   /** Flag to control use of the ScalesEstimator (if set) for
    * automatic scale estimation during StartOptimization()
    */
-  bool m_DoEstimateScales;
+  bool m_DoEstimateScales{};
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -323,21 +323,21 @@ protected:
   itkGetMacro(SamplingStrategy, SamplingStrategyType);
 
   /** the metric object */
-  MetricPointer m_Metric;
+  MetricPointer m_Metric{};
 
   /** the samples in the virtual domain */
-  SamplePointContainerType m_SamplePoints;
+  SamplePointContainerType m_SamplePoints{};
 
   /** Keep track of the last sampling time. */
-  mutable TimeStamp m_SamplingTime;
+  mutable TimeStamp m_SamplingTime{};
 
   /**  the number of samples in the virtual domain */
-  SizeValueType m_NumberOfRandomSamples;
+  SizeValueType m_NumberOfRandomSamples{};
 
   /** the radius of the central region for sampling */
-  IndexValueType m_CentralRegionRadius;
+  IndexValueType m_CentralRegionRadius{};
 
-  typename VirtualPointSetType::ConstPointer m_VirtualDomainPointSet;
+  typename VirtualPointSetType::ConstPointer m_VirtualDomainPointSet{};
 
   // the threshold to decide if the number of random samples uses logarithm
   static constexpr SizeValueType SizeOfSmallDomain = 1000;
@@ -347,10 +347,10 @@ private:
    * m_TransformForward = true (default) for the moving transform parameters.
    * m_TransformForward = false for the fixed transform parameters.
    */
-  bool m_TransformForward;
+  bool m_TransformForward{};
 
   // sampling strategy
-  SamplingStrategyType m_SamplingStrategy;
+  SamplingStrategyType m_SamplingStrategy{};
 
 }; // class RegistrationParameterScalesEstimator
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.h
@@ -106,7 +106,7 @@ protected:
 
 private:
   // A small variation of parameters
-  ParametersValueType m_SmallParameterVariation;
+  ParametersValueType m_SmallParameterVariation{};
 
 }; // class RegistrationParameterScalesFromShiftBase
 

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
@@ -124,12 +124,12 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor;
+  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
 
-  CommandType::Pointer m_Command;
+  CommandType::Pointer m_Command{};
 
-  mutable ParametersType m_CachedCurrentPosition;
-  mutable DerivativeType m_CachedDerivative;
+  mutable ParametersType m_CachedCurrentPosition{};
+  mutable DerivativeType m_CachedDerivative{};
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedVnlCostFunctionAdaptorv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedVnlCostFunctionAdaptorv4.h
@@ -121,13 +121,13 @@ protected:
   ReportIteration(const EventObject & event) const;
 
 private:
-  ObjectToObjectMetricBase::Pointer m_ObjectMetric;
-  bool                              m_ScalesInitialized;
-  ScalesType                        m_Scales;
-  Object::Pointer                   m_Reporter;
+  ObjectToObjectMetricBase::Pointer m_ObjectMetric{};
+  bool                              m_ScalesInitialized{};
+  ScalesType                        m_Scales{};
+  Object::Pointer                   m_Reporter{};
 
-  mutable MeasureType    m_CachedValue;
-  mutable DerivativeType m_CachedDerivative;
+  mutable MeasureType    m_CachedValue{};
+  mutable DerivativeType m_CachedDerivative{};
 
 }; // end of Class CostFunction
 

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -304,19 +304,19 @@ protected:
   CalculateYCoef(double norm_z, const CoefficientArrayType & coef);
 
 private:
-  DomainSizeType m_DomainSize;
-  unsigned int   m_Dimension;
-  unsigned int   m_Degree;
-  unsigned int   m_NumberOfCoefficients;
+  DomainSizeType m_DomainSize{};
+  unsigned int   m_Dimension{};
+  unsigned int   m_Degree{};
+  unsigned int   m_NumberOfCoefficients{};
 
-  CoefficientArrayType m_CoefficientArray;
-  CoefficientArrayType m_CachedXCoef;
-  CoefficientArrayType m_CachedYCoef;
-  CoefficientArrayType m_CachedZCoef;
+  CoefficientArrayType m_CoefficientArray{};
+  CoefficientArrayType m_CachedXCoef{};
+  CoefficientArrayType m_CachedYCoef{};
+  CoefficientArrayType m_CachedZCoef{};
 
-  DoubleArrayType m_NormFactor;
-  IndexValueType  m_PrevY;
-  IndexValueType  m_PrevZ;
+  DoubleArrayType m_NormFactor{};
+  IndexValueType  m_PrevY{};
+  IndexValueType  m_PrevZ{};
 }; // end of class
 
 ITKPolynomials_EXPORT std::ostream &

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -134,10 +134,10 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  OriginType m_Origin;
+  OriginType m_Origin{};
 
   /** Number of components in the MeasurementVectorType */
-  MeasurementVectorSizeType m_MeasurementVectorSize;
+  MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -237,11 +237,11 @@ struct ITK_TEMPLATE_EXPORT KdTreeNonterminalNode : public KdTreeNode<TSample>
   }
 
 private:
-  unsigned int       m_PartitionDimension;
-  MeasurementType    m_PartitionValue;
-  InstanceIdentifier m_InstanceIdentifier;
-  Superclass *       m_Left;
-  Superclass *       m_Right;
+  unsigned int       m_PartitionDimension{};
+  MeasurementType    m_PartitionValue{};
+  InstanceIdentifier m_InstanceIdentifier{};
+  Superclass *       m_Left{};
+  Superclass *       m_Right{};
 }; // end of class
 
 /**
@@ -366,15 +366,15 @@ struct ITK_TEMPLATE_EXPORT KdTreeWeightedCentroidNonterminalNode : public KdTree
   }
 
 private:
-  MeasurementVectorSizeType m_MeasurementVectorSize;
-  unsigned int              m_PartitionDimension;
-  MeasurementType           m_PartitionValue;
-  CentroidType              m_WeightedCentroid;
-  CentroidType              m_Centroid;
-  InstanceIdentifier        m_InstanceIdentifier;
-  unsigned int              m_Size;
-  Superclass *              m_Left;
-  Superclass *              m_Right;
+  MeasurementVectorSizeType m_MeasurementVectorSize{};
+  unsigned int              m_PartitionDimension{};
+  MeasurementType           m_PartitionValue{};
+  CentroidType              m_WeightedCentroid{};
+  CentroidType              m_Centroid{};
+  InstanceIdentifier        m_InstanceIdentifier{};
+  unsigned int              m_Size{};
+  Superclass *              m_Left{};
+  Superclass *              m_Right{};
 }; // end of class
 
 /**
@@ -486,7 +486,7 @@ struct ITK_TEMPLATE_EXPORT KdTreeTerminalNode : public KdTreeNode<TSample>
   }
 
 private:
-  std::vector<InstanceIdentifier> m_InstanceIdentifiers;
+  std::vector<InstanceIdentifier> m_InstanceIdentifiers{};
 }; // end of class
 
 /**

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -139,7 +139,7 @@ protected:
   }
 
 private:
-  MeasurementVectorSizeType m_MeasurementVectorSize;
+  MeasurementVectorSizeType m_MeasurementVectorSize{};
 
 }; // end of class
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
@@ -157,20 +157,20 @@ protected:
 
 private:
   /** target sample data pointer */
-  const TSample * m_Sample;
+  const TSample * m_Sample{};
 
-  double m_MinimalParametersChange;
+  double m_MinimalParametersChange{};
 
-  ParametersType m_Parameters;
+  ParametersType m_Parameters{};
 
   /** SmartPointer to the memberhip function - usually density function */
-  MembershipFunctionType * m_MembershipFunction;
+  MembershipFunctionType * m_MembershipFunction{};
 
   /** weights array */
-  WeightArrayType m_Weights;
+  WeightArrayType m_Weights{};
 
   /** indicative flag of membership function's parameter changes */
-  bool m_ParametersModified;
+  bool m_ParametersModified{};
 }; // end of class
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
@@ -164,7 +164,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  ParametersType m_Parameters;
+  ParametersType m_Parameters{};
 }; // end of class
 } // end of namespace Statistics
 } // end namespace itk

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -128,10 +128,10 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  RegionType m_RegionConstraint;
-  bool       m_RegionConstraintInitialized;
-  RegionType m_SampleRegion;
-  bool       m_SampleRegionInitialized;
+  RegionType m_RegionConstraint{};
+  bool       m_RegionConstraintInitialized{};
+  RegionType m_SampleRegion{};
+  bool       m_SampleRegionInitialized{};
 }; // end of class RegionConstrainedSubsampler
 
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -182,7 +182,7 @@ protected:
   }
 
 private:
-  MeasurementVectorSizeType m_MeasurementVectorSize;
+  MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -129,10 +129,10 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  SampleConstPointer m_Sample;
-  bool               m_RequestMaximumNumberOfResults;
-  bool               m_CanSelectQuery;
-  SeedType           m_Seed;
+  SampleConstPointer m_Sample{};
+  bool               m_RequestMaximumNumberOfResults{};
+  bool               m_CanSelectQuery{};
+  SeedType           m_Seed{};
 }; // end of class SubsamplerBase
 
 } // end of namespace Statistics

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
@@ -153,12 +153,12 @@ protected:
   EvaluateMeasure(HistogramType & histogram) const override = 0;
 
 private:
-  FixedImageConstPointer  m_TrainingFixedImage;
-  MovingImageConstPointer m_TrainingMovingImage;
-  TransformPointer        m_TrainingTransform;
-  InterpolatorPointer     m_TrainingInterpolator;
-  FixedImageRegionType    m_TrainingFixedImageRegion;
-  HistogramPointerType    m_TrainingHistogram;
+  FixedImageConstPointer  m_TrainingFixedImage{};
+  MovingImageConstPointer m_TrainingMovingImage{};
+  TransformPointer        m_TrainingTransform{};
+  InterpolatorPointer     m_TrainingInterpolator{};
+  FixedImageRegionType    m_TrainingFixedImageRegion{};
+  HistogramPointerType    m_TrainingHistogram{};
 };
 
 } // end namespace itk

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
@@ -171,21 +171,21 @@ protected:
   ~HistogramImageToImageMetric() override = default;
 
   /** The histogram size. */
-  HistogramSizeType m_HistogramSize;
+  HistogramSizeType m_HistogramSize{};
   /** The lower bound for samples in the histogram. */
-  mutable MeasurementVectorType m_LowerBound;
+  mutable MeasurementVectorType m_LowerBound{};
   /** The upper bound for samples in the histogram. */
-  mutable MeasurementVectorType m_UpperBound;
+  mutable MeasurementVectorType m_UpperBound{};
   /** The increase in the upper bound. */
-  double m_UpperBoundIncreaseFactor;
+  double m_UpperBoundIncreaseFactor{};
 
   /** Boolean flag to indicate whether the user supplied lower bounds or
    * whether they should be computed from the min of image intensities */
-  bool m_LowerBoundSetByUser;
+  bool m_LowerBoundSetByUser{};
 
   /** Boolean flag to indicate whether the user supplied upper bounds or
    * whether they should be computed from the max of image intensities */
-  bool m_UpperBoundSetByUser;
+  bool m_UpperBoundSetByUser{};
 
   /** Computes the joint histogram from the transformation parameters
       passed to the function. */
@@ -215,22 +215,22 @@ protected:
 
 private:
   /** The padding value. */
-  FixedImagePixelType m_PaddingValue;
+  FixedImagePixelType m_PaddingValue{};
 
   /** True if those pixels in the fixed image with the same value as the
       padding value should be ignored when calculating the similarity
       measure. */
-  bool m_UsePaddingValue;
+  bool m_UsePaddingValue{};
 
   /** The step length used to calculate the derivative. */
-  double m_DerivativeStepLength;
+  double m_DerivativeStepLength{};
 
   /** The derivative step length scales. */
-  ScalesType m_DerivativeStepLengthScales;
+  ScalesType m_DerivativeStepLengthScales{};
 
   /** Pointer to the joint histogram. This is updated during every call to
    * GetValue() */
-  HistogramPointer m_Histogram;
+  HistogramPointer m_Histogram{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -374,10 +374,10 @@ protected:
   };
 
   bool                     m_UseFixedImageIndexes{ false };
-  FixedImageIndexContainer m_FixedImageIndexes;
+  FixedImageIndexContainer m_FixedImageIndexes{};
 
   bool                m_UseFixedImageSamplesIntensityThreshold{ false };
-  FixedImagePixelType m_FixedImageSamplesIntensityThreshold;
+  FixedImagePixelType m_FixedImageSamplesIntensityThreshold{};
 
   /** FixedImageSamplePoint type alias support */
   using FixedImageSampleContainer = std::vector<FixedImageSamplePoint>;
@@ -401,7 +401,7 @@ protected:
   SampleFullFixedImageRegion(FixedImageSampleContainer & samples) const;
 
   /** Container to store a set of points and fixed image values. */
-  FixedImageSampleContainer m_FixedImageSamples;
+  FixedImageSampleContainer m_FixedImageSamples{};
 
   SizeValueType m_NumberOfParameters{ 0 };
 
@@ -411,22 +411,22 @@ protected:
   // onto this accumulator variable.
   mutable SizeValueType m_NumberOfPixelsCounted{ 0 };
 
-  FixedImageConstPointer  m_FixedImage;
-  MovingImageConstPointer m_MovingImage;
+  FixedImageConstPointer  m_FixedImage{};
+  MovingImageConstPointer m_MovingImage{};
 
   /** Main transform to be used in thread = 0 */
-  TransformPointer m_Transform;
+  TransformPointer m_Transform{};
   /** Copies of Transform helpers per thread (N-1 of them, since m_Transform
    * will do the work for thread=0. */
   std::unique_ptr<TransformPointer[]> m_ThreaderTransform;
 
-  InterpolatorPointer m_Interpolator;
+  InterpolatorPointer m_Interpolator{};
 
   bool                 m_ComputeGradient{ true };
-  GradientImagePointer m_GradientImage;
+  GradientImagePointer m_GradientImage{};
 
-  FixedImageMaskConstPointer  m_FixedImageMask;
-  MovingImageMaskConstPointer m_MovingImageMask;
+  FixedImageMaskConstPointer  m_FixedImageMask{};
+  MovingImageMaskConstPointer m_MovingImageMask{};
 
   ThreadIdType m_NumberOfWorkUnits{ 1 };
 
@@ -435,7 +435,7 @@ protected:
 
   bool m_ReseedIterator{ false };
 
-  mutable int m_RandomSeed;
+  mutable int m_RandomSeed{};
 
   /** Types and variables related to BSpline deformable transforms.
    * If the transform is of type third order BSplineBaseTransform,
@@ -476,20 +476,20 @@ protected:
   using DerivativeFunctionType = CentralDifferenceImageFunction<MovingImageType, CoordinateRepresentationType>;
   using ImageDerivativesType = CovariantVector<double, Self::MovingImageDimension>;
 
-  typename BSplineTransformType::Pointer m_BSplineTransform;
+  typename BSplineTransformType::Pointer m_BSplineTransform{};
 
-  BSplineTransformWeightsArrayType m_BSplineTransformWeightsArray;
-  BSplineTransformIndicesArrayType m_BSplineTransformIndicesArray;
-  MovingImagePointArrayType        m_BSplinePreTransformPointsArray;
-  BooleanArrayType                 m_WithinBSplineSupportRegionArray;
+  BSplineTransformWeightsArrayType m_BSplineTransformWeightsArray{};
+  BSplineTransformIndicesArrayType m_BSplineTransformIndicesArray{};
+  MovingImagePointArrayType        m_BSplinePreTransformPointsArray{};
+  BooleanArrayType                 m_WithinBSplineSupportRegionArray{};
 
-  BSplineParametersOffsetType m_BSplineParametersOffset;
+  BSplineParametersOffsetType m_BSplineParametersOffset{};
 
   // Variables needed for optionally caching values when using a BSpline
   // transform.
   bool                                   m_UseCachingOfBSplineWeights{ true };
-  mutable BSplineTransformWeightsType    m_BSplineTransformWeights;
-  mutable BSplineTransformIndexArrayType m_BSplineTransformIndices;
+  mutable BSplineTransformWeightsType    m_BSplineTransformWeights{};
+  mutable BSplineTransformIndexArrayType m_BSplineTransformIndices{};
 
   mutable std::unique_ptr<BSplineTransformWeightsType[]>    m_ThreaderBSplineTransformWeights;
   mutable std::unique_ptr<BSplineTransformIndexArrayType[]> m_ThreaderBSplineTransformIndices;
@@ -524,10 +524,10 @@ protected:
   /** Boolean to indicate if the interpolator BSpline. */
   bool m_InterpolatorIsBSpline{ false };
   /** Pointer to BSplineInterpolator. */
-  typename BSplineInterpolatorType::Pointer m_BSplineInterpolator;
+  typename BSplineInterpolatorType::Pointer m_BSplineInterpolator{};
 
   /** Pointer to central difference calculator. */
-  typename DerivativeFunctionType::Pointer m_DerivativeCalculator;
+  typename DerivativeFunctionType::Pointer m_DerivativeCalculator{};
 
   /** Compute image derivatives at a point using a central difference function if we are not using a
    * BSplineInterpolator, which includes derivatives.
@@ -593,7 +593,7 @@ protected:
     const typename MultiThreaderType::WorkUnitInfo * m_WorkUnitInfo;
   };
 
-  MultiThreaderType::Pointer              m_Threader;
+  MultiThreaderType::Pointer              m_Threader{};
   std::unique_ptr<ConstantPointerWrapper> m_ConstSelfWrapper;
   mutable std::unique_ptr<unsigned int[]> m_ThreaderNumberOfMovingImageSamples;
   bool                                    m_WithinThreadPreProcess{ false };
@@ -673,7 +673,7 @@ protected:
   SynchronizeTransforms() const;
 
 private:
-  FixedImageRegionType m_FixedImageRegion;
+  FixedImageRegionType m_FixedImageRegion{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -167,13 +167,13 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   MeasureType              m_MatchMeasure{ 0 };
-  DerivativeType           m_MatchMeasureDerivatives;
-  mutable TransformPointer m_Transform;
-  InterpolatorPointer      m_Interpolator;
+  DerivativeType           m_MatchMeasureDerivatives{};
+  mutable TransformPointer m_Transform{};
+  InterpolatorPointer      m_Interpolator{};
 
-  MovingSpatialObjectConstPointer m_MovingSpatialObject;
-  FixedImageConstPointer          m_FixedImage;
-  ParametersType                  m_LastTransformParameters;
+  MovingSpatialObjectConstPointer m_MovingSpatialObject{};
+  FixedImageConstPointer          m_FixedImage{};
+  ParametersType                  m_LastTransformParameters{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
@@ -162,19 +162,19 @@ protected:
   }
 
   /** The moving image. */
-  MovingImagePointer m_MovingImage;
+  MovingImagePointer m_MovingImage{};
 
   /** The fixed image. */
-  FixedImagePointer m_FixedImage;
+  FixedImagePointer m_FixedImage{};
 
   /** The deformation field. */
-  DisplacementFieldTypePointer m_DisplacementField;
+  DisplacementFieldTypePointer m_DisplacementField{};
 
-  mutable double m_Energy;
+  mutable double m_Energy{};
 
-  bool m_NormalizeGradient;
+  bool m_NormalizeGradient{};
 
-  mutable double m_GradientStep;
+  mutable double m_GradientStep{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.h
@@ -168,19 +168,19 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  mutable SizeValueType m_NumberOfPixelsCounted;
+  mutable SizeValueType m_NumberOfPixelsCounted{};
 
-  FixedPointSetConstPointer m_FixedPointSet;
+  FixedPointSetConstPointer m_FixedPointSet{};
 
-  MovingImageConstPointer m_MovingImage;
+  MovingImageConstPointer m_MovingImage{};
 
-  mutable TransformPointer m_Transform;
+  mutable TransformPointer m_Transform{};
 
-  InterpolatorPointer m_Interpolator;
+  InterpolatorPointer m_Interpolator{};
 
-  bool m_ComputeGradient;
+  bool m_ComputeGradient{};
 
-  GradientImagePointer m_GradientImage;
+  GradientImagePointer m_GradientImage{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
@@ -132,11 +132,11 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  FixedPointSetConstPointer m_FixedPointSet;
+  FixedPointSetConstPointer m_FixedPointSet{};
 
-  MovingPointSetConstPointer m_MovingPointSet;
+  MovingPointSetConstPointer m_MovingPointSet{};
 
-  mutable TransformPointer m_Transform;
+  mutable TransformPointer m_Transform{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -62,8 +62,8 @@ public:
   }
 
 protected:
-  typename TRegistrator::Pointer m_Registrator;
-  unsigned long                  m_Tag;
+  typename TRegistrator::Pointer m_Registrator{};
+  unsigned long                  m_Tag{};
 };
 
 
@@ -132,8 +132,8 @@ public:
   }
 
 private:
-  itk::Array<unsigned int> m_NumberOfIterations;
-  itk::Array<double>       m_LearningRates;
+  itk::Array<unsigned int> m_NumberOfIterations{};
+  itk::Array<double>       m_LearningRates{};
 };
 
 

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
@@ -100,7 +100,7 @@ protected:
     os << "Fixed parameters" << this->m_RequiredFixedParameters << std::endl;
   }
 
-  FixedParametersType m_RequiredFixedParameters;
+  FixedParametersType m_RequiredFixedParameters{};
 }; // class TransformParametersAdaptorBase
 } // namespace itk
 

--- a/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
@@ -167,19 +167,19 @@ protected:
   }
 
   /** The moving image. */
-  MovingImagePointer m_MovingImage;
+  MovingImagePointer m_MovingImage{};
 
   /** The fixed image. */
-  FixedImagePointer m_FixedImage;
+  FixedImagePointer m_FixedImage{};
 
   /** The deformation field. */
-  DisplacementFieldTypePointer m_DisplacementField;
+  DisplacementFieldTypePointer m_DisplacementField{};
 
-  mutable double m_Energy;
+  mutable double m_Energy{};
 
-  bool m_NormalizeGradient;
+  bool m_NormalizeGradient{};
 
-  mutable double m_GradientStep;
+  mutable double m_GradientStep{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -691,41 +691,41 @@ protected:
   /** Get accessor for flag to calculate derivative. */
   itkGetConstMacro(ComputeDerivative, bool);
 
-  FixedImageConstPointer  m_FixedImage;
-  MovingImageConstPointer m_MovingImage;
+  FixedImageConstPointer  m_FixedImage{};
+  MovingImageConstPointer m_MovingImage{};
 
   /** Pointers to interpolators */
-  FixedInterpolatorPointer                              m_FixedInterpolator;
-  MovingInterpolatorPointer                             m_MovingInterpolator;
-  typename FixedImageGradientInterpolatorType::Pointer  m_FixedImageGradientInterpolator;
-  typename MovingImageGradientInterpolatorType::Pointer m_MovingImageGradientInterpolator;
+  FixedInterpolatorPointer                              m_FixedInterpolator{};
+  MovingInterpolatorPointer                             m_MovingInterpolator{};
+  typename FixedImageGradientInterpolatorType::Pointer  m_FixedImageGradientInterpolator{};
+  typename MovingImageGradientInterpolatorType::Pointer m_MovingImageGradientInterpolator{};
 
   /** Flag to control use of precomputed gradient filter image or gradient
    * calculator for image gradient calculations. */
-  bool m_UseFixedImageGradientFilter;
-  bool m_UseMovingImageGradientFilter;
+  bool m_UseFixedImageGradientFilter{};
+  bool m_UseMovingImageGradientFilter{};
 
   /** Gradient filters */
-  FixedImageGradientFilterPointer  m_FixedImageGradientFilter;
-  MovingImageGradientFilterPointer m_MovingImageGradientFilter;
+  FixedImageGradientFilterPointer  m_FixedImageGradientFilter{};
+  MovingImageGradientFilterPointer m_MovingImageGradientFilter{};
 
   /** Pointer to default gradient filter. Used for easier
    * initialization of the default filter. */
-  typename DefaultFixedImageGradientFilter::Pointer  m_DefaultFixedImageGradientFilter;
-  typename DefaultMovingImageGradientFilter::Pointer m_DefaultMovingImageGradientFilter;
+  typename DefaultFixedImageGradientFilter::Pointer  m_DefaultFixedImageGradientFilter{};
+  typename DefaultMovingImageGradientFilter::Pointer m_DefaultMovingImageGradientFilter{};
 
   /** Pointer to default gradient calculators. Used for easier
    * initialization of the default filter. */
-  typename DefaultFixedImageGradientCalculator::Pointer  m_DefaultFixedImageGradientCalculator;
-  typename DefaultMovingImageGradientCalculator::Pointer m_DefaultMovingImageGradientCalculator;
+  typename DefaultFixedImageGradientCalculator::Pointer  m_DefaultFixedImageGradientCalculator{};
+  typename DefaultMovingImageGradientCalculator::Pointer m_DefaultMovingImageGradientCalculator{};
 
   /** Gradient images to store gradient filter output. */
-  mutable FixedImageGradientImagePointer  m_FixedImageGradientImage;
-  mutable MovingImageGradientImagePointer m_MovingImageGradientImage;
+  mutable FixedImageGradientImagePointer  m_FixedImageGradientImage{};
+  mutable MovingImageGradientImagePointer m_MovingImageGradientImage{};
 
   /** Image gradient calculators */
-  FixedImageGradientCalculatorPointer  m_FixedImageGradientCalculator;
-  MovingImageGradientCalculatorPointer m_MovingImageGradientCalculator;
+  FixedImageGradientCalculatorPointer  m_FixedImageGradientCalculator{};
+  MovingImageGradientCalculatorPointer m_MovingImageGradientCalculator{};
 
   /** Derivative results holder. Uses a raw pointer so we can point it
    * to a user-provided object. This is used in internal methods so
@@ -733,22 +733,22 @@ protected:
    * safely sharing a derivative object between metrics during multi-variate
    * analysis, for memory efficiency.
    * Will be nullptr if not set. */
-  mutable DerivativeType * m_DerivativeResult;
+  mutable DerivativeType * m_DerivativeResult{};
 
   /** Masks */
-  FixedImageMaskConstPointer  m_FixedImageMask;
-  MovingImageMaskConstPointer m_MovingImageMask;
+  FixedImageMaskConstPointer  m_FixedImageMask{};
+  MovingImageMaskConstPointer m_MovingImageMask{};
 
   /** Sampled point sets */
-  FixedSampledPointSetConstPointer m_FixedSampledPointSet;
-  VirtualPointSetPointer           m_VirtualSampledPointSet;
+  FixedSampledPointSetConstPointer m_FixedSampledPointSet{};
+  VirtualPointSetPointer           m_VirtualSampledPointSet{};
 
   /** Flag to use a SampledPointSet, i.e. Sparse sampling. */
-  bool m_UseSampledPointSet;
+  bool m_UseSampledPointSet{};
 
   /** Flag to indicate the user set VirtualSampledPointSet over
   FixedSampledPointSet */
-  bool m_UseVirtualSampledPointSet;
+  bool m_UseVirtualSampledPointSet{};
 
   ImageToImageMetricv4();
   ~ImageToImageMetricv4() override = default;
@@ -808,20 +808,20 @@ private:
 
   /** Flag for warning about use of GetValue. Will be removed when
    *  GetValue implementation is improved. */
-  mutable bool m_HaveMadeGetValueWarning;
+  mutable bool m_HaveMadeGetValueWarning{};
 
   /** Keep track of the number of sampled fixed points that are
    * deemed invalid during conversion to virtual domain.
    * For informational purposes. */
-  SizeValueType m_NumberOfSkippedFixedSampledPoints;
+  SizeValueType m_NumberOfSkippedFixedSampledPoints{};
 
-  bool                m_UseFloatingPointCorrection;
-  DerivativeValueType m_FloatingPointCorrectionResolution;
+  bool                m_UseFloatingPointCorrection{};
+  DerivativeValueType m_FloatingPointCorrectionResolution{};
 
-  MetricTraits m_MetricTraits;
+  MetricTraits m_MetricTraits{};
 
   /** Flag to know if derivative should be calculated */
-  mutable bool m_ComputeDerivative;
+  mutable bool m_ComputeDerivative{};
 
 /** Only floating-point images are currently supported. To support integer images,
  * several small changes must be made */

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -197,8 +197,8 @@ protected:
 
   /** Cached values to avoid call overhead.
    *  These will only be set once threading has been started. */
-  mutable NumberOfParametersType m_CachedNumberOfParameters;
-  mutable NumberOfParametersType m_CachedNumberOfLocalParameters;
+  mutable NumberOfParametersType m_CachedNumberOfParameters{};
+  mutable NumberOfParametersType m_CachedNumberOfLocalParameters{};
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -112,7 +112,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Const pointer to the input image. */
-  InputPointSetConstPointer m_PointSet;
+  InputPointSetConstPointer m_PointSet{};
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -320,24 +320,24 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  typename FixedPointSetType::ConstPointer               m_FixedPointSet;
-  mutable typename FixedTransformedPointSetType::Pointer m_FixedTransformedPointSet;
+  typename FixedPointSetType::ConstPointer               m_FixedPointSet{};
+  mutable typename FixedTransformedPointSetType::Pointer m_FixedTransformedPointSet{};
 
-  mutable typename PointsLocatorType::Pointer m_FixedTransformedPointsLocator;
+  mutable typename PointsLocatorType::Pointer m_FixedTransformedPointsLocator{};
 
-  typename MovingPointSetType::ConstPointer               m_MovingPointSet;
-  mutable typename MovingTransformedPointSetType::Pointer m_MovingTransformedPointSet;
+  typename MovingPointSetType::ConstPointer               m_MovingPointSet{};
+  mutable typename MovingTransformedPointSetType::Pointer m_MovingTransformedPointSet{};
 
-  mutable typename PointsLocatorType::Pointer m_MovingTransformedPointsLocator;
+  mutable typename PointsLocatorType::Pointer m_MovingTransformedPointsLocator{};
 
   /** Holds the fixed points after transformation into virtual domain. */
-  mutable VirtualPointSetPointer m_VirtualTransformedPointSet;
+  mutable VirtualPointSetPointer m_VirtualTransformedPointSet{};
 
   /**
    * Bool set by derived classes on whether the point set data (i.e. \c PixelType)
    * should be used.  Default = false.
    */
-  bool m_UsePointSetData;
+  bool m_UsePointSetData{};
 
   /**
    * Flag to calculate value and/or derivative at tangent space.  This is needed
@@ -346,7 +346,7 @@ protected:
    * set metrics might have associated gradient information which will need to be
    * warped if this flag is true.  Default = false.
    */
-  bool m_CalculateValueAndDerivativeInTangentSpace;
+  bool m_CalculateValueAndDerivativeInTangentSpace{};
 
   /**
    * Prepare point sets for use. */
@@ -455,19 +455,19 @@ protected:
                                                   const PixelType & pixel) const = 0;
 
 private:
-  mutable bool m_MovingTransformPointLocatorsNeedInitialization;
-  mutable bool m_FixedTransformPointLocatorsNeedInitialization;
+  mutable bool m_MovingTransformPointLocatorsNeedInitialization{};
+  mutable bool m_FixedTransformPointLocatorsNeedInitialization{};
 
   // Flag to keep track of whether a warning has already been issued
   // regarding the number of valid points.
-  mutable bool m_HaveWarnedAboutNumberOfValidPoints;
+  mutable bool m_HaveWarnedAboutNumberOfValidPoints{};
 
   // Flag to store derivatives at fixed point locations with the rest being zero gradient
   // (default = true).
-  bool m_StoreDerivativeAsSparseFieldForLocalSupportTransforms;
+  bool m_StoreDerivativeAsSparseFieldForLocalSupportTransforms{};
 
-  mutable ModifiedTimeType m_MovingTransformedPointSetTime;
-  mutable ModifiedTimeType m_FixedTransformedPointSetTime;
+  mutable ModifiedTimeType m_MovingTransformedPointSetTime{};
+  mutable ModifiedTimeType m_FixedTransformedPointSetTime{};
 
   // Create ranges over the point set for multithreaded computation of value and derivatives
   using PointIdentifierPair = std::pair<PointIdentifier, PointIdentifier>;

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
@@ -168,13 +168,13 @@ protected:
 
 private:
   /** Number of classes */
-  unsigned int m_NumberOfClasses;
+  unsigned int m_NumberOfClasses{};
 
   /** Pointer to the decision rule to be used for classification. */
-  typename DecisionRuleType::Pointer m_DecisionRule;
+  typename DecisionRuleType::Pointer m_DecisionRule{};
 
   /** Container to hold the membership functions */
-  MembershipFunctionPointerVector m_MembershipFunctions;
+  MembershipFunctionPointerVector m_MembershipFunctions{};
 }; // class Classifier
 } // namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
@@ -150,10 +150,10 @@ private:
   unsigned int m_NumberOfModels{ 0 };
 
   /** Container to hold the membership functions */
-  MembershipFunctionPointerVector m_MembershipFunctions;
+  MembershipFunctionPointerVector m_MembershipFunctions{};
 
   /**Container for holding the training image */
-  InputImagePointer m_InputImage;
+  InputImagePointer m_InputImage{};
 
   /** The core virtual function to perform modelling of the input data */
   virtual void

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
@@ -137,9 +137,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_MaximumNumberOfRegions;
+  unsigned int m_MaximumNumberOfRegions{};
 
-  GridSizeType m_GridSize;
+  GridSizeType m_GridSize{};
 }; // class RegionGrowImageFilter
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -412,19 +412,19 @@ protected:
 
   /** Flag which sets the inward/outward direction of propagation speed. See
       SetReverseExpansionDirection for more information. */
-  bool m_ReverseExpansionDirection;
+  bool m_ReverseExpansionDirection{};
 
   /** Reinitialization filters **/
   /** Internal filter types used for reinitialization */
   using IsoFilterType = IsoContourDistanceImageFilter<OutputImageType, OutputImageType>;
   using ChamferFilterType = FastChamferDistanceImageFilter<OutputImageType, OutputImageType>;
 
-  typename IsoFilterType::Pointer m_IsoFilter;
+  typename IsoFilterType::Pointer m_IsoFilter{};
 
-  typename ChamferFilterType::Pointer m_ChamferFilter;
+  typename ChamferFilterType::Pointer m_ChamferFilter{};
 
 private:
-  SegmentationFunctionType * m_SegmentationFunction;
+  SegmentationFunctionType * m_SegmentationFunction{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.h
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.h
@@ -122,7 +122,7 @@ protected:
 
 private:
   /** The time step for normal vector finite difference computations. */
-  TimeStepType m_TimeStep;
+  TimeStepType m_TimeStep{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
@@ -163,13 +163,13 @@ public:
 
 protected:
   /** The image whose features will be used to create a speed image */
-  typename FeatureImageType::ConstPointer m_FeatureImage;
+  typename FeatureImageType::ConstPointer m_FeatureImage{};
 
   /** The image holding the speed values for front propagation */
-  typename ImageType::Pointer m_SpeedImage;
+  typename ImageType::Pointer m_SpeedImage{};
 
   /** The image holding the advection field for front propagation */
-  typename VectorImageType::Pointer m_AdvectionImage;
+  typename VectorImageType::Pointer m_AdvectionImage{};
 
   /** Returns the propagation speed from the precalculated speed image.*/
   ScalarValueType
@@ -188,9 +188,9 @@ protected:
     m_VectorInterpolator = VectorInterpolatorType::New();
   }
 
-  typename InterpolatorType::Pointer m_Interpolator;
+  typename InterpolatorType::Pointer m_Interpolator{};
 
-  typename VectorInterpolatorType::Pointer m_VectorInterpolator;
+  typename VectorInterpolatorType::Pointer m_VectorInterpolator{};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -535,16 +535,16 @@ protected:
 
   /** Flag which sets the inward/outward direction of propagation speed. See
       SetReverseExpansionDirection for more information. */
-  bool m_ReverseExpansionDirection;
+  bool m_ReverseExpansionDirection{};
 
   /** Flag to indicate whether Speed and Advection images are automatically
    *  generated when running the filter.  Otherwise, a pointer to images must
    *  be explicitly set or GenerateSpeedImage() and/or GenerateAdvectionImage()
    *  called directly before updating the filter */
-  bool m_AutoGenerateSpeedAdvection;
+  bool m_AutoGenerateSpeedAdvection{};
 
 private:
-  SegmentationFunctionType * m_SegmentationFunction;
+  SegmentationFunctionType * m_SegmentationFunction{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
@@ -156,10 +156,10 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  ShapeFunctionPointer m_ShapeFunction;
-  NodeContainerPointer m_ActiveRegion;
+  ShapeFunctionPointer m_ShapeFunction{};
+  NodeContainerPointer m_ActiveRegion{};
 
-  FeatureImagePointer m_FeatureImage;
+  FeatureImagePointer m_FeatureImage{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
@@ -191,13 +191,13 @@ protected:
   ExtractActiveRegion(NodeContainerType * ptr);
 
 private:
-  ShapeFunctionPointer m_ShapeFunction;
-  CostFunctionPointer  m_CostFunction;
-  OptimizerPointer     m_Optimizer;
-  ParametersType       m_InitialParameters;
-  ParametersType       m_CurrentParameters;
+  ShapeFunctionPointer m_ShapeFunction{};
+  CostFunctionPointer  m_CostFunction{};
+  OptimizerPointer     m_Optimizer{};
+  ParametersType       m_InitialParameters{};
+  ParametersType       m_CurrentParameters{};
 
-  ShapePriorSegmentationFunctionType * m_ShapePriorSegmentationFunction;
+  ShapePriorSegmentationFunctionType * m_ShapePriorSegmentationFunction{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -308,51 +308,51 @@ protected:
 private:
   /** This is a iteration counter that gets reset to 0 every time
       ProcessNormals method is called. */
-  unsigned int m_RefitIteration;
+  unsigned int m_RefitIteration{};
 
   /** This parameter determines the maximum number of
       SparseFieldLevelSetImageFilter iterations that will be executed between
       calls to ProcessNormals. */
-  unsigned int m_MaxRefitIteration;
+  unsigned int m_MaxRefitIteration{};
 
   /** This parameter is used to set the corresponding parameter in
       ImplicitManifoldNormalDiffusionfFilter. */
-  unsigned int m_MaxNormalIteration;
+  unsigned int m_MaxNormalIteration{};
 
   /** This is used to trigger a call to the ProcessNormals method
       before m_RefitIteration reaches m_MaxRefitIteration if the RMSChange falls
       below this parameter. */
-  ValueType m_RMSChangeNormalProcessTrigger;
+  ValueType m_RMSChangeNormalProcessTrigger{};
 
   /** This flag is set to true to signal final convergence. It can be used by
       subclasses that define a Halt method. */
-  bool m_ConvergenceFlag;
+  bool m_ConvergenceFlag{};
 
   /** The level set function with the term for refitting the level set to the
       processed normal vectors. */
-  LevelSetFunctionType * m_LevelSetFunction;
+  LevelSetFunctionType * m_LevelSetFunction{};
 
   /** This parameter determines the width of the band where we compute
    * curvature from the processed normals. The wider the band, the more level set
    * iterations that can be performed between calls to ProcessNormals. It is
    * qsuggested that this value is left at its default. */
-  ValueType m_CurvatureBandWidth;
+  ValueType m_CurvatureBandWidth{};
 
   /** The parameter that chooses between isotropic/anisotropic filtering of the
       normal vectors. */
-  int m_NormalProcessType;
+  int m_NormalProcessType{};
 
   /** The conductance parameter used if anisotropic filtering of the normal
       vectors is chosen. */
-  ValueType m_NormalProcessConductance;
+  ValueType m_NormalProcessConductance{};
 
   /** The parameter that turns on/off the unsharp mask enhancement of the
       normals. */
-  bool m_NormalProcessUnsharpFlag;
+  bool m_NormalProcessUnsharpFlag{};
 
   /** The weight that controls the extent of enhancement if the
       NormalProcessUnsharpFlag is ON. */
-  ValueType m_NormalProcessUnsharpWeight;
+  ValueType m_NormalProcessUnsharpWeight{};
 
   /** Constants used in the computations. */
   static const SizeValueType m_NumVertex;

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptorBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptorBase.h
@@ -74,8 +74,8 @@ protected:
   /** Destructor */
   ~BinaryImageToLevelSetImageAdaptorBase() override = default;
 
-  InputImagePointer m_InputImage;
-  LevelSetPointer   m_LevelSet;
+  InputImagePointer m_InputImage{};
+  LevelSetPointer   m_LevelSet{};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
@@ -65,7 +65,7 @@ protected:
   using IdentifierListIterator = typename IdentifierListType::iterator;
   using IdentifierListConstIterator = typename IdentifierListType::const_iterator;
 
-  IdentifierType m_NumberOfLevelSetFunctions;
+  IdentifierType m_NumberOfLevelSetFunctions{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
@@ -74,8 +74,8 @@ protected:
   AllocateListDomain();
 
 private:
-  MeshPointer  m_Mesh;
-  ListMeshType m_ListDomain;
+  MeshPointer  m_Mesh{};
+  ListMeshType m_ListDomain{};
 };
 
 } // end namespace itk

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.h
@@ -160,35 +160,35 @@ protected:
   Value(const LevelSetInputIndexType & iP, const LevelSetDataType & iData) = 0;
 
   /** Input image */
-  InputImagePointer m_Input;
+  InputImagePointer m_Input{};
 
   /** Container of level-set function */
-  LevelSetContainerPointer m_LevelSetContainer;
+  LevelSetContainerPointer m_LevelSetContainer{};
 
   /** Id of the current level-set function */
-  LevelSetIdentifierType m_CurrentLevelSetId;
+  LevelSetIdentifierType m_CurrentLevelSetId{};
 
-  LevelSetPointer m_CurrentLevelSetPointer;
+  LevelSetPointer m_CurrentLevelSetPointer{};
 
   /** Coefficient \f$ \alpha_i \f$ */
-  LevelSetOutputRealType m_Coefficient;
+  LevelSetOutputRealType m_Coefficient{};
 
   /** Contribution to the CFL condition (which will be used to compute the
    *  the time step at the next iteration
    */
-  LevelSetOutputRealType m_CFLContribution;
+  LevelSetOutputRealType m_CFLContribution{};
 
   /** Heaviside function to be used. Depending on the term expression,
    *  this one may need to be provided
    */
-  HeavisideConstPointer m_Heaviside;
+  HeavisideConstPointer m_Heaviside{};
 
   /** Name to be given to the term. Note by default, one name is provided,
    *  but end-users may rename differently each term.
    */
-  std::string m_TermName;
+  std::string m_TermName{};
 
-  RequiredDataType m_RequiredData;
+  RequiredDataType m_RequiredData{};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
@@ -157,20 +157,20 @@ protected:
   virtual void
   UpdateEquations() = 0;
 
-  StoppingCriterionPointer m_StoppingCriterion;
+  StoppingCriterionPointer m_StoppingCriterion{};
 
-  EquationContainerPointer                m_EquationContainer;
-  typename LevelSetContainerType::Pointer m_LevelSetContainer;
+  EquationContainerPointer                m_EquationContainer{};
+  typename LevelSetContainerType::Pointer m_LevelSetContainer{};
 
-  LevelSetOutputRealType m_Alpha;
-  LevelSetOutputRealType m_Dt;
-  LevelSetOutputRealType m_RMSChangeAccumulator;
-  bool                   m_UserGloballyDefinedTimeStep;
-  IdentifierType         m_NumberOfIterations;
+  LevelSetOutputRealType m_Alpha{};
+  LevelSetOutputRealType m_Dt{};
+  LevelSetOutputRealType m_RMSChangeAccumulator{};
+  bool                   m_UserGloballyDefinedTimeStep{};
+  IdentifierType         m_NumberOfIterations{};
 
   /** Helper members for threading. */
-  typename LevelSetContainerType::Iterator m_LevelSetContainerIteratorToProcessWhenThreading;
-  typename LevelSetContainerType::Iterator m_LevelSetUpdateContainerIteratorToProcessWhenThreading;
+  typename LevelSetContainerType::Iterator m_LevelSetContainerIteratorToProcessWhenThreading{};
+  typename LevelSetContainerType::Iterator m_LevelSetUpdateContainerIteratorToProcessWhenThreading{};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.h
@@ -116,9 +116,9 @@ protected:
   LevelSetSparseImage() = default;
   ~LevelSetSparseImage() override = default;
 
-  LayerMapType    m_Layers;
-  LabelMapPointer m_LabelMap;
-  LayerIdListType m_InternalLabelList;
+  LayerMapType    m_Layers{};
+  LabelMapPointer m_LabelMap{};
+  LayerIdListType m_InternalLabelList{};
 
   /** Initialize the sparse field layers */
   virtual void

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -127,7 +127,7 @@ protected:
     // FIX    os << indent << "Parameters: " << m_Parameters << std::endl;
   }
 
-  ParametersType m_Parameters;
+  ParametersType m_Parameters{};
 };
 } // end namespace itk
 

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
@@ -139,11 +139,11 @@ public:
 
 protected:
   /** Internal VideoStream */
-  VideoStreamType * m_VideoStream;
+  VideoStreamType * m_VideoStream{};
 
   /** Property members */
-  double m_FpS;
-  int    m_FourCC;
+  double m_FpS{};
+  int    m_FourCC{};
 
 }; // end class VideoCapture
 

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -106,10 +106,10 @@ protected:
 
   /** Time boundaries */
   /** Timestamp corresponding to the first frame in the region. */
-  RealTimeStamp m_RealStart;
+  RealTimeStamp m_RealStart{};
   /** Time interval corresponding to the entire length of time
    *  represented by the region over ALL frames */
-  RealTimeInterval m_RealDuration;
+  RealTimeInterval m_RealDuration{};
   /** Index of the first frame in the region */
   FrameOffsetType m_FrameStart{ 0 };
   /** Total number of frames represented by the region (NOT individual frame duration) */

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -161,10 +161,10 @@ protected:
   /** Member Variables */
   ReadFromEnum       m_ReadFrom{ ReadFromEnum::ReadFromFile };
   TemporalRatioType  m_FramesPerSecond{ 0.0 };
-  FrameOffsetType    m_FrameTotal;
-  FrameOffsetType    m_CurrentFrame;
-  FrameOffsetType    m_IFrameInterval;
-  FrameOffsetType    m_LastIFrame;
+  FrameOffsetType    m_FrameTotal{};
+  FrameOffsetType    m_CurrentFrame{};
+  FrameOffsetType    m_IFrameInterval{};
+  FrameOffsetType    m_LastIFrame{};
   TemporalRatioType  m_Ratio{ 0.0 };
   TemporalOffsetType m_PositionInMSec{ 0.0 };
   bool               m_WriterOpen{ false };


### PR DESCRIPTION
Added in-class `{}` default member initializers to data members of classes that have one or more virtual member functions.

For an object that has one or more virtual member functions, the performance cost of adding a `{}` default member initializer to each of its non-static data members should be acceptable, relative to cost of the initialization of its virtual table.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3851 commit 5e2c49f9eb80e78903ce8f9fd2b5952062653cab "STYLE: Add in-class `{}` member initializers to objects created by New()"