### PR TITLE
COMP: Fix declaration and syntax errors in Review class `PrintSelf`

### DIFF
--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1411,7 +1411,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
      << std::endl;
 
   os << indent << "SparseData: ";
-  for (IdCellType i = 0; i < m_FunctionCount; ++i)
+  for (IdCellType i = 0; i < this->m_FunctionCount; ++i)
   {
     SparseDataStruct * sparsePtr = this->m_SparseData[i];
 
@@ -1439,8 +1439,8 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 
     os << indent.GetNextIndent() << "UpdateBuffer: " << sparsePtr->m_UpdateBuffer << std::endl;
 
-    os << indent.GetNextIndent() << "Index: " << static_cast <
-      typename NumericTraits<IdCellType>::PrintType(sparsePtr->m_Index) << std::endl;
+    os << indent.GetNextIndent()
+       << "Index: " << static_cast<typename NumericTraits<IdCellType>::PrintType>(sparsePtr->m_Index) << std::endl;
   }
 
   os << indent << "NumberOfLayers: " << m_NumberOfLayers << std::endl;


### PR DESCRIPTION
Fix declaration and syntax errors in Review module class `PrintSelf` method.

Fixes:
```
Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx:1414:30:
error: 'm_FunctionCount' was not declared in this scope; did you mean 'SetFunctionCount'?

 1414 |   for (IdCellType i = 0; i < m_FunctionCount; ++i)
      |                              ^~~~~~~~~~~~~~~
      |                              SetFunctionCount
```

and
```
Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx:1443:52:
error: expected '>' before '(' token

 1443 |       typename NumericTraits<IdCellType>::PrintType(sparsePtr->m_Index) << std::endl;
      |                                                    ^
```

raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=8456002

Inadvertently introduced in c47ed1c1b3e26051de655f7ad03e975fae93b73b.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)