### PR TITLE
STYLE: Add in-class `{}` initializers to classes with override = default

### DIFF
--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -224,10 +224,10 @@ private:
   RandomJump();
 
   using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
-  GeneratorPointer m_Generator;
-  SizeValueType    m_NumberOfSamplesRequested;
-  SizeValueType    m_NumberOfSamplesDone;
-  SizeValueType    m_NumberOfPixelsInRegion;
+  GeneratorPointer m_Generator{};
+  SizeValueType    m_NumberOfSamplesRequested{};
+  SizeValueType    m_NumberOfSamplesDone{};
+  SizeValueType    m_NumberOfPixelsInRegion{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -226,10 +226,10 @@ private:
   RandomJump();
 
   using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
-  GeneratorPointer m_Generator;
-  SizeValueType    m_NumberOfSamplesRequested;
-  SizeValueType    m_NumberOfSamplesDone;
-  SizeValueType    m_NumberOfPixelsInRegion;
+  GeneratorPointer m_Generator{};
+  SizeValueType    m_NumberOfSamplesRequested{};
+  SizeValueType    m_NumberOfSamplesDone{};
+  SizeValueType    m_NumberOfPixelsInRegion{};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.h
+++ b/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.h
@@ -73,8 +73,8 @@ protected:
   ~RegularizedHeavisideStepFunction() override = default;
 
 private:
-  RealType m_Epsilon;
-  RealType m_OneOverEpsilon;
+  RealType m_Epsilon{};
+  RealType m_OneOverEpsilon{};
 };
 } // namespace itk
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -233,7 +233,7 @@ protected:
   ~FiniteDifferenceImageFilter() override = default;
 
   /** State that the filter is in, i.e. UNINITIALIZED or INITIALIZED */
-  bool m_IsInitialized;
+  bool m_IsInitialized{};
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -361,7 +361,7 @@ protected:
   OriginRefType      m_Origin;           // Geometrical information
   PrimalDataType     m_Data;             // User data associated to this edge.
   bool               m_DataSet{ false }; // Indicates if the data is set.
-  LineCellIdentifier m_LineCellIdent;
+  LineCellIdentifier m_LineCellIdent{};
 };
 } // namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -151,8 +151,8 @@ public:
   GetField(DTITubeSpatialObjectPointFieldEnum name) const;
 
 protected:
-  float         m_TensorMatrix[6];
-  FieldListType m_Fields;
+  float         m_TensorMatrix[6]{};
+  FieldListType m_Fields{};
 
   /** Print the object */
   void

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -71,7 +71,7 @@ public:
   operator=(const LineSpatialObjectPoint & rhs);
 
 protected:
-  NormalArrayType m_NormalArrayInObjectSpace;
+  NormalArrayType m_NormalArrayInObjectSpace{};
 
   /** Method to print the object. */
   void

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -75,7 +75,7 @@ public:
   operator=(const SurfaceSpatialObjectPoint & rhs);
 
 protected:
-  CovariantVectorType m_NormalInObjectSpace;
+  CovariantVectorType m_NormalInObjectSpace{};
 
   /** Method to print the object. */
   void

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -268,23 +268,23 @@ public:
   operator=(const TubeSpatialObjectPoint & rhs);
 
 protected:
-  VectorType          m_TangentInObjectSpace;
-  CovariantVectorType m_Normal1InObjectSpace;
-  CovariantVectorType m_Normal2InObjectSpace;
+  VectorType          m_TangentInObjectSpace{};
+  CovariantVectorType m_Normal1InObjectSpace{};
+  CovariantVectorType m_Normal2InObjectSpace{};
 
-  double m_Branchness;
-  double m_Medialness;
-  double m_Ridgeness;
-  double m_Curvature;
-  double m_Levelness;
-  double m_Roundness;
-  double m_Intensity;
-  double m_Alpha1;
-  double m_Alpha2;
-  double m_Alpha3;
+  double m_Branchness{};
+  double m_Medialness{};
+  double m_Ridgeness{};
+  double m_Curvature{};
+  double m_Levelness{};
+  double m_Roundness{};
+  double m_Intensity{};
+  double m_Alpha1{};
+  double m_Alpha2{};
+  double m_Alpha3{};
 
   /** The radius of the tube point */
-  double m_RadiusInObjectSpace;
+  double m_RadiusInObjectSpace{};
 
   /** Print the object */
   void

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
@@ -180,9 +180,9 @@ public:
   FillOffsets(const OffsetValueType & value);
 
 private:
-  bool       m_IsFirstPass[TImage::ImageDimension];
-  OffsetType m_BeginOffset;
-  OffsetType m_EndOffset;
+  bool       m_IsFirstPass[TImage::ImageDimension]{};
+  OffsetType m_BeginOffset{};
+  OffsetType m_EndOffset{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
@@ -237,22 +237,22 @@ protected:
   /** \brief Destructor */
   ~FastMarchingBase() override = default;
 
-  StoppingCriterionPointer m_StoppingCriterion;
+  StoppingCriterionPointer m_StoppingCriterion{};
 
-  double m_SpeedConstant;
-  double m_InverseSpeed;
-  double m_NormalizationFactor;
+  double m_SpeedConstant{};
+  double m_InverseSpeed{};
+  double m_NormalizationFactor{};
 
-  OutputPixelType m_TargetReachedValue;
-  OutputPixelType m_LargeValue;
-  OutputPixelType m_TopologyValue;
+  OutputPixelType m_TargetReachedValue{};
+  OutputPixelType m_LargeValue{};
+  OutputPixelType m_TopologyValue{};
 
-  NodePairContainerPointer m_TrialPoints;
-  NodePairContainerPointer m_AlivePoints;
-  NodePairContainerPointer m_ProcessedPoints;
-  NodePairContainerPointer m_ForbiddenPoints;
+  NodePairContainerPointer m_TrialPoints{};
+  NodePairContainerPointer m_AlivePoints{};
+  NodePairContainerPointer m_ProcessedPoints{};
+  NodePairContainerPointer m_ForbiddenPoints{};
 
-  bool m_CollectPoints;
+  bool m_CollectPoints{};
 
   // PriorityQueuePointer m_Heap;
   using HeapContainerType = std::vector<NodePairType>;
@@ -260,9 +260,9 @@ protected:
 
   using PriorityQueueType = std::priority_queue<NodePairType, HeapContainerType, NodeComparerType>;
 
-  PriorityQueueType m_Heap;
+  PriorityQueueType m_Heap{};
 
-  TopologyCheckEnum m_TopologyCheck;
+  TopologyCheckEnum m_TopologyCheck{};
 
   /** \brief Get the total number of nodes in the domain */
   virtual IdentifierType

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
@@ -86,10 +86,10 @@ protected:
   /** Destructor */
   ~FastMarchingStoppingCriterionBase() override = default;
 
-  OutputDomainPointer m_Domain;
+  OutputDomainPointer m_Domain{};
 
-  OutputPixelType m_PreviousValue;
-  OutputPixelType m_CurrentValue;
+  OutputPixelType m_PreviousValue{};
+  OutputPixelType m_CurrentValue{};
 
   /** Inherited classes must implement this method and make sure member variables
   got reinitialized. */

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
@@ -65,8 +65,8 @@ protected:
 
   ~DecimationQuadEdgeMeshFilter() override = default;
 
-  CriterionPointer m_Criterion;
-  SizeValueType    m_Iteration;
+  CriterionPointer m_Criterion{};
+  SizeValueType    m_Iteration{};
 
   void
   GenerateData() override

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -77,8 +77,8 @@ protected:
   {}
   ~DiscretePrincipalCurvaturesQuadEdgeMeshFilter() override = default;
 
-  OutputCurvatureType m_Gaussian;
-  OutputCurvatureType m_Mean;
+  OutputCurvatureType m_Gaussian{};
+  OutputCurvatureType m_Mean{};
 
   void
   ComputeMeanAndGaussianCurvatures(const OutputPointType & iP)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -229,12 +229,12 @@ protected:
   using RowIterator = typename RowType::iterator;
   using RowConstIterator = typename RowType::const_iterator;
 
-  OutputMapPointIdentifier m_InternalMap;
-  ConstraintMapType        m_Constraints;
-  CoefficientMapType       m_CoefficientMap;
-  AreaMapType              m_MixedAreaMap;
+  OutputMapPointIdentifier m_InternalMap{};
+  ConstraintMapType        m_Constraints{};
+  CoefficientMapType       m_CoefficientMap{};
+  AreaMapType              m_MixedAreaMap{};
 
-  CoefficientsComputationType * m_CoefficientsMethod;
+  CoefficientsComputationType * m_CoefficientsMethod{};
 
   unsigned int m_Order{ 1 };
   AreaEnum     m_AreaComputationType{ AreaEnum::NONE };

--- a/Modules/IO/XML/include/itkXMLFile.h
+++ b/Modules/IO/XML/include/itkXMLFile.h
@@ -127,7 +127,7 @@ protected:
 
   ~XMLReader() override = default;
 
-  T * m_OutputObject;
+  T * m_OutputObject{};
 };
 
 /**

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
@@ -178,9 +178,9 @@ protected:
   {}
   ~BinaryImageToSparseLevelSetImageAdaptorBase() override = default;
 
-  LevelSetLabelMapPointer m_LabelMap;
+  LevelSetLabelMapPointer m_LabelMap{};
 
-  InternalImagePointer m_InternalImage;
+  InternalImagePointer m_InternalImage{};
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
@@ -313,9 +313,9 @@ protected:
   SetContainer(const LevelSetContainerType & iContainer);
 
 private:
-  HeavisideConstPointer       m_Heaviside;
-  DomainMapImageFilterPointer m_DomainMapFilter;
-  LevelSetContainerType       m_Container;
+  HeavisideConstPointer       m_Heaviside{};
+  DomainMapImageFilterPointer m_DomainMapFilter{};
+  LevelSetContainerType       m_Container{};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.h
@@ -81,10 +81,10 @@ protected:
   /** Destructor */
   ~LevelSetEvolutionStoppingCriterion() override = default;
 
-  LevelSetContainerPointer m_LevelSetContainer;
-  OutputRealType           m_RMSChangeAccumulator;
-  IterationIdType          m_NumberOfIterations;
-  IterationIdType          m_CurrentIteration;
+  LevelSetContainerPointer m_LevelSetContainer{};
+  OutputRealType           m_RMSChangeAccumulator{};
+  IterationIdType          m_NumberOfIterations{};
+  IterationIdType          m_CurrentIteration{};
 };
 } // namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.h
@@ -72,8 +72,8 @@ protected:
   ~LevelSetImage() override = default;
 
   using ScalingType = GradientType;
-  ScalingType m_NeighborhoodScales;
-  OffsetType  m_DomainOffset;
+  ScalingType m_NeighborhoodScales{};
+  OffsetType  m_DomainOffset{};
 
   virtual bool
   IsInsideDomain(const InputType & iP) const = 0;


### PR DESCRIPTION
Added in-class `{}` default member initializers to data members of classes that have a destructor declared `override = default`.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3913 commit 5c97b7605e5bec4e9443b57314b50d4e090a845e
"STYLE: Add in-class `{}` initializers to classes with virtual functions"
