### PR TITLE
COMP: Fix `Regitration::FEM` module `PrintSelf` compiler errors

### DIFF
--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -299,7 +299,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::PrintSelf(std::ostream & os, Ind
   os << indent << "NumberOfElements: " << m_NumberOfElements << std::endl;
   os << indent << "PixelsPerElement: " << m_PixelsPerElement << std::endl;
 
-  itkPrintSelfObject(Material);
+  itkPrintSelfObjectMacro(Material);
   itkPrintSelfObjectMacro(Element);
 }
 

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -355,7 +355,15 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Inde
   os << indent << "SolutionIndex2: " << m_SolutionIndex2 << std::endl;
   os << indent << "Gamma: " << m_Gamma << std::endl;
 
-  itkPrintSelfObjectMacro(Solution);
+  os << indent << "Solution: ";
+  if (m_Solution != nullptr)
+  {
+    os << m_Solution << std::endl;
+  }
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 
   os << indent << "GradSigma: " << static_cast<typename NumericTraits<Float>::PrintType>(m_GradSigma) << std::endl;
   os << indent << "Sign: " << m_Sign << std::endl;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1468,7 +1468,8 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   os << indent << "FileCount: " << m_FileCount << std::endl;
   os << indent << "CurrentLevel: " << m_CurrentLevel << std::endl;
   os << indent << "CurrentLevelImageSize: "
-     << static_cast<typename NumericTraits<typename FixedImageType::SizeType>::PrintType>(m_CurrentLevel) << std::endl;
+     << static_cast<typename NumericTraits<typename FixedImageType::SizeType>::PrintType>(m_CurrentLevelImageSize)
+     << std::endl;
   os << indent << "WhichMetric: " << m_WhichMetric << std::endl;
 
   os << indent << "MeshPixelsPerElementAtEachResolution: " << m_MeshPixelsPerElementAtEachResolution << std::endl;
@@ -1526,7 +1527,11 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   itkPrintSelfObjectMacro(Metric);
   itkPrintSelfObjectMacro(FEMObject);
 
-  os << indent << "LandmarkArray: " << m_LandmarkArray << std::endl;
+  os << indent << "LandmarkArray: ";
+  for (const auto & elem : m_LandmarkArray)
+  {
+    os << indent.GetNextIndent() << "[" << &elem - &*(m_LandmarkArray.begin()) << "]: " << *elem << std::endl;
+  }
 
   itkPrintSelfObjectMacro(Interpolator);
 


### PR DESCRIPTION
Fix miscellaneous compiler errors in `Registration::FEM` module classes' `PrintSelf` methods.

Fixes:
```
ITK\Modules\Registration\FEM\include\itkFEMFiniteDifferenceFunctionLoad.hxx(358,3):
error C2440:
'static_cast':
cannot convert from 'const itk::fem::Solution::ConstPointer' to 'const itk::LightObject *'
```

```
ITK\Modules\Registration\FEM\include\itkFEMFiniteDifferenceFunctionLoad.hxx(358,3):
error C2039:
'Print': is not a member of 'itk::fem::Solution'
```

and
```
ITK\Modules\Numerics\FEM\include\itkImageToRectilinearFEMObjectFilter.hxx(302,22):
error C2275:
'itk::fem::Material': expected an expression instead of a type
```

```
ITK\Modules\Numerics\FEM\include\itkImageToRectilinearFEMObjectFilter.hxx(302,3):
error C3861:
'itkPrintSelfObject': identifier not found
```

and
```
ITK\Modules\Registration\FEM\include\itkFEMRegistrationFilter.hxx(1471,9):
error C2440:
'static_cast': cannot convert from 'const unsigned int' to 'itk::Size<3>'
```

```
ITK\Modules\Registration\FEM\include\itkFEMRegistrationFilter.hxx(1529,16):
error C2679:
binary '<<': no operator found which takes a right-hand operand of type
'const itk::fem::FEMRegistrationFilter<InputImageType,InputImageType,FEMObjectType>::LandmarkArrayType'
(or there is no acceptable conversion)
```

raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=8462352

Inadvertently introduced in c47ed1c1b3e26051de655f7ad03e975fae93b73b.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)