### PR TITLE
COMP: Fix deprecation warning for PyEval_CallObject

### DIFF
--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
@@ -39,6 +39,7 @@ namespace itk
 PyCommand::PyCommand()
 {
   this->m_Object = nullptr;
+  this->m_EmptyArgumentList = Py_BuildValue("()", 0);
 }
 
 
@@ -50,6 +51,13 @@ PyCommand::~PyCommand()
     Py_DECREF(this->m_Object);
   }
   this->m_Object = nullptr;
+
+  if (this->m_EmptyArgumentList)
+  {
+    PyGILStateEnsure gil;
+    Py_DECREF(this->m_EmptyArgumentList);
+  }
+  this->m_EmptyArgumentList = nullptr;
 }
 
 
@@ -114,7 +122,7 @@ PyCommand::PyExecute()
   else
   {
     PyGILStateEnsure gil;
-    PyObject *       result = PyEval_CallObject(this->m_Object, (PyObject *)nullptr);
+    PyObject *       result = PyObject_Call(this->m_Object, this->m_EmptyArgumentList, (PyObject *)nullptr);
 
     if (result)
     {

--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.h
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.h
@@ -81,6 +81,7 @@ protected:
 
 private:
   PyObject * m_Object;
+  PyObject * m_EmptyArgumentList;
 };
 
 


### PR DESCRIPTION
M:\Dashboard\ITK\Wrapping\Generators\Python\PyUtils\itkPyCommand.cxx(117,31): warning C4996: 'PyEval_CallObjectWithKeywords': deprecated in 3.9 [M:\Dashboard\ITK-build\Wrapping\Generators\Python\PyUtils\ITKPyUtilsPython.vcxproj]

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

