### PR TITLE
COMP: Fix GPU modules `PrintSelf` compiler errors

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -19,6 +19,7 @@
 #define itkResourceProbe_h
 
 #include "itkMacro.h"
+#include "itkIndent.h"
 #include "itkIntTypes.h"
 
 #include <iostream> // For cout.
@@ -178,6 +179,10 @@ protected:
 
   /** Obsolete member function from ITK 4.8 - 4.13. Does not do anything anymore. */
   itkLegacyMacro(virtual void GetSystemInformation());
+
+  /** Cause the object to print itself out. */
+  virtual void
+  Print(std::ostream & os, Indent indent) const;
 
 private:
   ValueType m_StartValue{};

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -39,6 +39,7 @@
 #include "itksys/SystemInformation.hxx"
 #include "itkMath.h"
 #include "itkIsNumber.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -49,6 +50,41 @@ ResourceProbe<ValueType, MeanType>::ResourceProbe(std::string type, std::string 
   , m_UnitString(std::move(unit))
 {
   this->Reset();
+}
+
+template <typename ValueType, typename MeanType>
+void
+ResourceProbe<ValueType, MeanType>::Print(std::ostream & os, Indent indent) const
+{
+  using namespace print_helper;
+
+  os << indent << "StartValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StartValue)
+     << std::endl;
+  os << indent << "TotalValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_TotalValue)
+     << std::endl;
+  os << indent << "MinimumValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_MinimumValue)
+     << std::endl;
+  os << indent << "MaximumValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_MaximumValue)
+     << std::endl;
+  os << indent
+     << "StandardDeviation: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StandardDeviation)
+     << std::endl;
+  os << indent << "StandardError: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StandardError)
+     << std::endl;
+
+  os << indent << "NumberOfStarts: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfStarts)
+     << std::endl;
+  os << indent << "NumberOfStops: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfStops)
+     << std::endl;
+  os << indent
+     << "NumberOfIteration: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfIteration)
+     << std::endl;
+
+  os << indent << "ProbeValueList: " << m_ProbeValueList << std::endl;
+
+  os << indent << "NameOfProbe: " << m_NameOfProbe << std::endl;
+  os << indent << "TypeString: " << m_TypeString << std::endl;
+  os << indent << "UnitString: " << m_UnitString << std::endl;
 }
 
 template <typename ValueType, typename MeanType>

--- a/Modules/Core/Common/include/itkTimeProbe.h
+++ b/Modules/Core/Common/include/itkTimeProbe.h
@@ -44,6 +44,8 @@ namespace itk
 class ITKCommon_EXPORT TimeProbe : public ResourceProbe<RealTimeClock::TimeStampType, RealTimeClock::TimeStampType>
 {
 public:
+  using Superclass = ResourceProbe<RealTimeClock::TimeStampType, RealTimeClock::TimeStampType>;
+
   /** Type for counting how many times the probe has been started and stopped.
    */
   using CountType = unsigned long;
@@ -58,6 +60,9 @@ public:
 
   /** Destructor */
   ~TimeProbe() override;
+
+  void
+  Print(std::ostream & os, Indent indent) const override;
 
   /** Get the current time.
    *  Warning: the returned value is not the elapsed time since the last Start() call.

--- a/Modules/Core/Common/src/itkTimeProbe.cxx
+++ b/Modules/Core/Common/src/itkTimeProbe.cxx
@@ -27,6 +27,14 @@ TimeProbe::TimeProbe()
 
 TimeProbe::~TimeProbe() = default;
 
+void
+TimeProbe::Print(std::ostream & os, Indent indent) const
+{
+  Superclass::Print(os, indent);
+
+  itkPrintSelfObjectMacro(RealTimeClock);
+}
+
 TimeProbe::TimeStampType
 TimeProbe::GetInstantValue() const
 {

--- a/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
@@ -273,7 +273,7 @@ GPUDataManager::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "GPUBuffer: " << m_GPUBuffer << std::endl;
   os << indent << "CPUBuffer: " << m_CPUBuffer << std::endl;
   os << indent << "IsGPUBufferDirty: " << (m_IsGPUBufferDirty ? "On" : "Off") << std::endl;
-  os << indent << "IsCPUBufferDirty: " << m_IsCPUBufferDirty ? "On" : "Off") << std::endl;
+  os << indent << "IsCPUBufferDirty: " << (m_IsCPUBufferDirty ? "On" : "Off") << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -295,14 +295,14 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::P
 {
   GPUSuperclass::PrintSelf(os, indent);
 
-  os << indent << "InitTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_InitTime) << std::endl;
-  os << indent
-     << "ComputeUpdateTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_ComputeUpdateTime)
-     << std::endl;
-  os << indent << "ApplyUpdateTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_ApplyUpdateTime)
-     << std::endl;
-  os << indent << "SmoothFieldTime: " << static_cast<typename NumericTraits<TimeProbe>::PrintType>(m_SmoothFieldTime)
-     << std::endl;
+  os << indent << "InitTime: " << std::endl;
+  m_InitTime.Print(os, indent.GetNextIndent());
+  os << indent << "ComputeUpdateTime: " << std::endl;
+  m_ComputeUpdateTime.Print(os, indent.GetNextIndent());
+  os << indent << "ApplyUpdateTime: " << std::endl;
+  m_ApplyUpdateTime.Print(os, indent.GetNextIndent());
+  os << indent << "SmoothFieldTime: " << std::endl;
+  m_SmoothFieldTime.Print(os, indent.GetNextIndent());
 
   itkPrintSelfObjectMacro(DifferenceFunction);
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
@@ -54,6 +54,7 @@ public:
 
   /** Standard class type aliases. */
   using Self = GPUGradientAnisotropicDiffusionImageFilter;
+  using Superclass = GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter>;
   using GPUSuperclass = GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -24,6 +24,7 @@
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkTimeProbe.h"
 #include "itkImageRegionIterator.h"
+#include "itkTestingMacros.h"
 
 #include "itkOpenCLUtil.h"
 #include "itkGPUImage.h"
@@ -57,6 +58,9 @@ runGPUGradientAnisotropicDiffusionImageFilterTest(const std::string & inFile, co
 
   auto CPUFilter = CPUAnisoDiffFilterType::New();
   auto GPUFilter = GPUAnisoDiffFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    GPUFilter, GPUGradientAnisotropicDiffusionImageFilter, GPUAnisotropicDiffusionImageFilter);
 
   reader->Update();
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
@@ -144,6 +144,9 @@ protected:
   GPUPDEDeformableRegistrationFilter();
   ~GPUPDEDeformableRegistrationFilter() override = default;
 
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
   /** Copy the data from the input to the output.
    *
    * If the input does not exist, a zero field is written to the output. */

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -141,7 +141,7 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
     os << "(null)" << std::endl;
   }
 
-  itkPrintSelfObjectMacro(m_GPUImageSizes);
+  itkPrintSelfObjectMacro(GPUImageSizes);
 
   os << indent << "SmoothDisplacementFieldGPUKernelHandle: " << m_SmoothDisplacementFieldGPUKernelHandle << std::endl;
 }

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -83,34 +83,63 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
 
   itkPrintSelfObjectMacro(TempField);
 
-  os << indent << "SmoothingKernelSizes: " << m_SmoothingKernelSizes << std::endl;
+  os << indent << "SmoothingKernelSizes: ";
+  for (unsigned d = 0; d < ImageDimension; ++d)
+  {
+    os << indent.GetNextIndent() << m_SmoothingKernelSizes[d] << std::endl;
+  }
 
   os << indent << "SmoothingKernels: ";
   if (m_SmoothingKernels != nullptr)
   {
-    os << static_cast<typename NumericTraits<DeformationScalarType>::PrintType>(*m_SmoothingKernels);
+    for (unsigned d = 0; d < ImageDimension; ++d)
+    {
+      os << indent.GetNextIndent() << m_SmoothingKernels[d] << std::endl;
+    }
   }
-  os << std::endl;
 
-  itkPrintSelfObjectMacro(GPUSmoothingKernels);
+  os << indent << "GPUSmoothingKernels: ";
+  if (m_GPUSmoothingKernels != nullptr)
+  {
+    for (unsigned d = 0; d < ImageDimension; ++d)
+    {
+      os << indent.GetNextIndent() << m_GPUSmoothingKernels[d] << std::endl;
+    }
+  }
 
-  os << indent << "UpdateFieldSmoothingKernelSizes: " << m_UpdateFieldSmoothingKernelSizes << std::endl;
+  os << indent << "UpdateFieldSmoothingKernelSizes: ";
+  for (unsigned d = 0; d < ImageDimension; ++d)
+  {
+    os << indent.GetNextIndent() << m_UpdateFieldSmoothingKernelSizes[d] << std::endl;
+  }
 
   os << indent << "UpdateFieldSmoothingKernels: ";
   if (m_UpdateFieldSmoothingKernels != nullptr)
   {
-    os << static_cast<typename NumericTraits<DeformationScalarType>::PrintType>(*m_UpdateFieldSmoothingKernels);
+    for (unsigned d = 0; d < ImageDimension; ++d)
+    {
+      os << indent.GetNextIndent() << m_UpdateFieldSmoothingKernels[d] << std::endl;
+    }
   }
-  os << std::endl;
 
-  itkPrintSelfObjectMacro(UpdateFieldGPUSmoothingKernels);
+  os << indent << "UpdateFieldGPUSmoothingKernels: ";
+  if (m_UpdateFieldGPUSmoothingKernels != nullptr)
+  {
+    for (unsigned d = 0; d < ImageDimension; ++d)
+    {
+      os << indent.GetNextIndent() << m_UpdateFieldGPUSmoothingKernels[d] << std::endl;
+    }
+  }
 
   os << indent << "ImageSizes: ";
   if (m_ImageSizes != nullptr)
   {
-    os << *m_ImageSizes;
+    os << *m_ImageSizes << std::endl;
   }
-  os << std::endl;
+  else
+  {
+    os << "(null)" << std::endl;
+  }
 
   itkPrintSelfObjectMacro(m_GPUImageSizes);
 


### PR DESCRIPTION
- COMP: Restore `PrintSelf` in itkGPUPDEDeformableRegistrationFilter.h
- COMP: Provide prefix-less member name to `itkPrintSelfObjectMacro`
- COMP: Fix boolean member print statement in `itk::GPUDataManager`
- ENH: Provide printing ability to time resource classes
- COMP: Add Superclass alias to GPUGradientAnisotropicDiffusionImageFilter 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)