### PR TITLE
COMP: Exclude README, Utilities/Maintenance and other files from AZP CI

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -5,6 +5,21 @@ trigger:
     include:
     - master
     - release*
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
+pr:
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - NOTICE
+    - Documentation/*
+    - Utilities/Maintenance/*
 variables:
   ExternalDataVersion: 5.3.0
 jobs:

--- a/Utilities/Maintenance/README.md
+++ b/Utilities/Maintenance/README.md
@@ -3,3 +3,8 @@ maintaining the ITK source code tree.  These are not intended
 to be run all the time, but these little utility scripts
 can be useful as new code is being incorporated into ITK to
 help configure the code into an ITK style, or ITK best practices.
+
+Note that the files in this directory are not tested automatically
+by the continuous integration (CI) of the ITK git repository. So a
+git commit that only modifies files in this directory should not
+trigger a run of the CI.


### PR DESCRIPTION
Excluded various files and directories from triggering a CI run, according to Azure Pipelines "trigger definition" at https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-batch-branches-paths-tags

These are files that are not tested by the CI anyway.

This pull request aims to avoid running the virtual machines of the CI unnecessarily, to save energy and to reduce the time waiting for the CI.  