### PR TITLE
COMP: Fix uninitialized memory Valgrind defects

### DIFF
--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -704,8 +704,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
     }
   }
 
-  os << indent << "TempMeasurementVector: "
-     << static_cast<typename NumericTraits<MeasurementVectorType>::PrintType>(m_TempMeasurementVector) << std::endl;
+  os << indent << "TempMeasurementVector: " << m_TempMeasurementVector << std::endl;
   os << indent << "TempIndex: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
   os << indent << "ClipBinsAtEnds: " << (m_ClipBinsAtEnds ? "On" : "Off") << std::endl;
 }

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -176,8 +176,6 @@ Histogram<TMeasurement, TFrequencyContainer>::Initialize(const SizeType & size)
     this->m_OffsetTable[i + 1] = num;
   }
 
-  this->m_TempIndex.SetSize(this->GetMeasurementVectorSize());
-
   m_NumberOfInstances = num;
 
   // adjust the sizes of min max value containers

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -196,7 +196,10 @@ Histogram<TMeasurement, TFrequencyContainer>::Initialize(const SizeType & size)
 
   // initialize auxiliary variables
   this->m_TempIndex.SetSize(this->GetMeasurementVectorSize());
+  m_TempIndex.Fill(0);
+
   this->m_TempMeasurementVector.SetSize(this->GetMeasurementVectorSize());
+  m_TempMeasurementVector.Fill(0);
 
   // initialize the frequency container
   m_FrequencyContainer->Initialize(this->m_OffsetTable[this->GetMeasurementVectorSize()]);

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -124,7 +124,7 @@ public:
   Print(std::ostream & os, Indent indent) const;
 
 private:
-  char                      m_Pad1[128];
+  char                      m_Pad1[128]{};
   unsigned int              m_Size;
   RadiusType                m_Radius;
   std::vector<unsigned int> m_ArrayIndex;
@@ -133,7 +133,7 @@ private:
   /** An internal table for keeping track of stride lengths in a neighborhood,
    *  i.e. the memory offsets between pixels along each dimensional axis. */
   unsigned int m_StrideTable[Dimension];
-  char         m_Pad2[128];
+  char         m_Pad2[128]{};
 };
 
 /**

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -125,14 +125,14 @@ public:
 
 private:
   char                      m_Pad1[128]{};
-  unsigned int              m_Size;
-  RadiusType                m_Radius;
-  std::vector<unsigned int> m_ArrayIndex;
-  std::vector<OffsetType>   m_NeighborhoodOffset;
+  unsigned int              m_Size{ 2 * Dimension };
+  RadiusType                m_Radius{};
+  std::vector<unsigned int> m_ArrayIndex{};
+  std::vector<OffsetType>   m_NeighborhoodOffset{};
 
   /** An internal table for keeping track of stride lengths in a neighborhood,
    *  i.e. the memory offsets between pixels along each dimensional axis. */
-  unsigned int m_StrideTable[Dimension];
+  unsigned int m_StrideTable[Dimension]{};
   char         m_Pad2[128]{};
 };
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -82,7 +82,7 @@ ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream 
 
   os << "ParallelSparseFieldCityBlockNeighborList: " << std::endl;
 
-  os << indent << "m_Pad1: " << m_Pad1 << std::endl;
+  os << indent << "Pad1: " << m_Pad1 << std::endl;
   os << indent << "Size: " << m_Size << std::endl;
   os << indent << "Radius: " << m_Radius << std::endl;
   os << indent << "ArrayIndex: " << m_ArrayIndex << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -49,7 +49,6 @@ ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::ParallelSparseField
   NeighborhoodType it(m_Radius, dummy_image, dummy_image->GetRequestedRegion());
   nCenter = it.Size() / 2;
 
-  m_Size = 2 * Dimension;
   m_ArrayIndex.reserve(m_Size);
   m_NeighborhoodOffset.reserve(m_Size);
 


### PR DESCRIPTION
- COMP: Fix itkParallelSparseFieldLevelSetImageFilter uninitialized memory 
- COMP: Fix `itk::Histogram` uninitialized memory
- STYLE: Remove an unnecessary static_cast from Histogram::PrintSelf
- STYLE: Prefer in-class `{}` member initializers
- STYLE: Make `PrintSelf` implementation style consistent
- STYLE: Remove duplicate statement in `itk::Histogram::Initialize`

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)