### PR TITLE
STYLE: Add in-class `{}` member initializers to 3-letter data members

### DIFF
--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -375,7 +375,7 @@ protected:
   bool m_WMatrixComputed{};
 
   /** Identity matrix. */
-  IMatrixType m_I;
+  IMatrixType m_I{};
 
   /** The list of source landmarks, denoted 'p'. */
   PointSetPointer m_SourceLandmarks{};

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.h
@@ -133,7 +133,7 @@ private:
   DerivativeOperator<PixelType, Self::ImageDimension> m_DerivativeOperator{};
 
   /** Modified global average gradient magnitude term. */
-  PixelType m_K;
+  PixelType m_K{};
 
   /** */
   static double m_MIN_NORM;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.h
@@ -119,7 +119,7 @@ protected:
   DerivativeOperator<PixelType, Self::ImageDimension> m_DerivativeOperator{};
 
   /** Modified global average gradient magnitude term. */
-  PixelType m_K;
+  PixelType m_K{};
 
   NeighborhoodSizeValueType m_Center{};
   NeighborhoodSizeValueType m_Stride[ImageDimension]{};

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.h
@@ -105,7 +105,7 @@ private:
   DerivativeOperator<ScalarValueType, Self::ImageDimension> m_DerivativeOperator{};
 
   /** Modified global average gradient magnitude term. */
-  ScalarValueType m_K;
+  ScalarValueType m_K{};
 
   static double m_MIN_NORM;
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
@@ -120,7 +120,7 @@ protected:
   DerivativeOperator<PixelType, Self::ImageDimension> m_DerivativeOperator{};
 
   /** Modified global average gradient magnitude term. */
-  PixelType m_K;
+  PixelType m_K{};
 
   NeighborhoodSizeValueType m_Center{};
   NeighborhoodSizeValueType m_Stride[ImageDimension]{};

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -320,7 +320,7 @@ private:
   /** Parameters, as described by Spall.*/
   double m_Sa{};
   double m_Sc{};
-  double m_A;
+  double m_A{};
   double m_Alpha{};
   double m_Gamma{};
 }; // end class SPSAOptimizer

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
@@ -141,7 +141,7 @@ public:
   }
 
 private:
-  MatrixType m_A;
+  MatrixType m_A{};
   VectorType m_Intercept{};
 };
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -683,7 +683,7 @@ private:
   vnl_vector<unsigned int> m_MeshPixelsPerElementAtEachResolution{};
 
   Float             m_TimeStep{ 1 };
-  vnl_vector<Float> m_E;
+  vnl_vector<Float> m_E{};
   vnl_vector<Float> m_Rho{};
   vnl_vector<Float> m_Gamma{};
   Float             m_Energy{ 0.0 };      // current value of energy


### PR DESCRIPTION
Previous commits that added `{}` initializers to data members by means of regular expressions had overlooked three-letter identifiers, like `m_E` and `m_I`.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3851 commit 5e2c49f9eb80e78903ce8f9fd2b5952062653cab
"STYLE: Add in-class `{}` member initializers to objects created by New()"