### PR TITLE
BUG: Update UpdateRequiredITKVersionInRemoteModules.sh script to remove unencrypted git protocol 

### DIFF
--- a/Utilities/Maintenance/UpdateRequiredITKVersionInRemoteModules.sh
+++ b/Utilities/Maintenance/UpdateRequiredITKVersionInRemoteModules.sh
@@ -70,7 +70,7 @@ fi
 
 # Get the latest ITK git tag
 latest_git_tag=$(git ls-remote --tags \
-git://github.com/InsightSoftwareConsortium/ITK.git | \
+https://github.com/InsightSoftwareConsortium/ITK.git | \
 awk -F/ '{ print $3 }' | egrep -v 'a0|b0|rc|}' | \
 sort -n - | tail -n1)
 
@@ -88,7 +88,7 @@ rm "${azure_pipelines_ci_filename}.bak"
 
 # Get the latest ITK Python git tag
 latest_git_tag=$(git ls-remote --tags \
-git://github.com/InsightSoftwareConsortium/ITKPythonBuilds.git | \
+https://github.com/InsightSoftwareConsortium/ITKPythonBuilds.git | \
 awk -F/ '{ print $3 }' | egrep -v 'a0|b0|rc|}' | \
 sort -n - | tail -n1)
 


### PR DESCRIPTION
### Description

GitHub has updated Git protocol security, and the usage of the unencrypted git protocol has been retired permanently on March 15th 2022. But, there are few instances of such in `UpdateRequiredITKVersionInRemoteModules.sh`. Hence, may lead to bunch of unauthenticated git protocol errors.

### Proposed Solution

Use https protocol in place of unencrypted git protocol

`git://github.com/InsightSoftwareConsortium/ITKPythonBuilds.git` should be changed to
`https://github.com/InsightSoftwareConsortium/ITKPythonBuilds.git`

and `git://github.com/InsightSoftwareConsortium/ITK.git` should be changed to
`https://github.com/InsightSoftwareConsortium/ITK.git`


### Reference

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Fixes  #3942