### PR TITLE
STYLE: Add in-class `{}` member initializers having trailing comments

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
@@ -273,7 +273,7 @@ protected:
   TreeIteratorBase(TTreeType * tree, const TreeNodeType * start);
   TreeIteratorBase(const TTreeType * tree, const TreeNodeType * start);
 
-  mutable TreeNodeType * m_Position; // Current position of the iterator
+  mutable TreeNodeType * m_Position{}; // Current position of the iterator
   mutable TreeNodeType * m_Begin{};
   const TreeNodeType *   m_Root{};
   TTreeType *            m_Tree{};

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -202,8 +202,8 @@ private:
   PointsContainerPointer m_CornersContainer{ PointsContainer::New() };
 #endif
   mutable BoundsArrayType m_Bounds{};
-  mutable TimeStamp       m_BoundsMTime; // The last time the bounds
-                                         // were computed.
+  mutable TimeStamp       m_BoundsMTime{}; // The last time the bounds
+                                           // were computed.
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -568,8 +568,8 @@ private:
   /** When, in real time, this data was generated. */
   RealTimeStamp m_RealTimeStamp{};
 
-  bool m_ReleaseDataFlag; // Data will release after use by a filter if on
-  bool m_DataReleased;    // Keep track of data release during pipeline execution
+  bool m_ReleaseDataFlag{}; // Data will release after use by a filter if on
+  bool m_DataReleased{};    // Keep track of data release during pipeline execution
 
   /** The maximum MTime of all upstream filters and data objects.
    * This does not include the MTime of this data object. */

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -379,11 +379,11 @@ public:
 protected: // made protected so other iterators can access
   typename TImage::ConstWeakPointer m_Image{};
 
-  RegionType m_Region; // region to iterate over
+  RegionType m_Region{}; // region to iterate over
 
   OffsetValueType m_Offset{};
-  OffsetValueType m_BeginOffset; // offset to first pixel in region
-  OffsetValueType m_EndOffset;   // offset to one pixel past last pixel in region
+  OffsetValueType m_BeginOffset{}; // offset to first pixel in region
+  OffsetValueType m_EndOffset{};   // offset to one pixel past last pixel in region
 
   const InternalPixelType * m_Buffer{};
 

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.h
@@ -258,9 +258,9 @@ public:
   }
 
 protected:
-  OffsetValueType m_SpanBeginOffset; // one pixel before the beginning of the span
-                                     // (row)
-  OffsetValueType m_SpanEndOffset;   // one pixel past the end of the span (row)
+  OffsetValueType m_SpanBeginOffset{}; // one pixel before the beginning of the span
+                                       // (row)
+  OffsetValueType m_SpanEndOffset{};   // one pixel past the end of the span (row)
 
 private:
   void

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -353,8 +353,8 @@ public:
   }
 
 protected:
-  SizeValueType m_SpanBeginOffset; // offset to last pixel in the row
-  SizeValueType m_SpanEndOffset;   // offset to one pixel before the row
+  SizeValueType m_SpanBeginOffset{}; // offset to last pixel in the row
+  SizeValueType m_SpanEndOffset{};   // offset to one pixel before the row
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseConstIterator.h
@@ -393,11 +393,11 @@ public:
 protected: // made protected so other iterators can access
   typename ImageType::ConstWeakPointer m_Image{};
 
-  RegionType m_Region; // region to iterate over
+  RegionType m_Region{}; // region to iterate over
 
   SizeValueType m_Offset{};
-  SizeValueType m_BeginOffset; // offset to last pixel in region
-  SizeValueType m_EndOffset;   // offset to one pixel before first pixel
+  SizeValueType m_BeginOffset{}; // offset to last pixel in region
+  SizeValueType m_EndOffset{};   // offset to one pixel before first pixel
 
   const InternalPixelType * m_Buffer{};
 

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -257,8 +257,8 @@ public:
 
 
 protected:
-  OffsetValueType m_SpanBeginOffset; // one pixel the beginning of the scanline
-  OffsetValueType m_SpanEndOffset;   // one pixel past the end of the scanline
+  OffsetValueType m_SpanBeginOffset{}; // one pixel the beginning of the scanline
+  OffsetValueType m_SpanEndOffset{};   // one pixel past the end of the scanline
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkLineConstIterator.h
+++ b/Modules/Core/Common/include/itkLineConstIterator.h
@@ -166,7 +166,7 @@ protected: // made protected so other iterators can access
   IndexType m_CurrentImageIndex{};
   IndexType m_StartIndex{};
   IndexType m_LastIndex{};
-  IndexType m_EndIndex; // one past the end of the line in the m_MainDirection
+  IndexType m_EndIndex{}; // one past the end of the line in the m_MainDirection
 
   /** Variables that drive the Bresenham-Algorithm */
   // The dimension with the largest difference between start and end

--- a/Modules/Core/Common/include/itkOctree.h
+++ b/Modules/Core/Common/include/itkOctree.h
@@ -217,8 +217,8 @@ private:
   // and large enough to contain MAX(DIMS[1,2,3])
   unsigned int m_Width{ 0 };
 
-  unsigned int        m_Depth{ 0 };  // The depth of the Octree
-  unsigned int        m_TrueDims[3]; // The true dimensions of the image
+  unsigned int        m_Depth{ 0 };    // The depth of the Octree
+  unsigned int        m_TrueDims[3]{}; // The true dimensions of the image
   OctreeNodeBranch    m_ColorTable[ColorTableSize];
   OctreeNode          m_Tree{};
   MappingFunctionType m_MappingFunction{};

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -411,8 +411,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  double m_AzimuthAngularSeparation;   // in radians
-  double m_ElevationAngularSeparation; // in radians
+  double m_AzimuthAngularSeparation{};   // in radians
+  double m_ElevationAngularSeparation{}; // in radians
   double m_RadiusSampleSize{};
   double m_FirstSampleDistance{};
 };

--- a/Modules/Core/Common/include/itkSmapsFileParser.h
+++ b/Modules/Core/Common/include/itkSmapsFileParser.h
@@ -277,8 +277,8 @@ public:
   GetMemoryUsage(const char * filter, const char * token = "Size");
 
 protected:
-  std::string m_MapFilePath; //< location of the last loaded Map file
-  TMapData    m_MapData;     //< data of the loaded smap file
+  std::string m_MapFilePath{}; //< location of the last loaded Map file
+  TMapData    m_MapData{};     //< data of the loaded smap file
 };
 
 /** \class SmapsFileParser

--- a/Modules/Core/GPUCommon/include/itkGPUContextManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUContextManager.h
@@ -65,7 +65,7 @@ private:
   cl_platform_id     m_Platform{};
   cl_context         m_Context{};
   cl_device_id *     m_Devices{};
-  cl_command_queue * m_CommandQueue; // one queue per device
+  cl_command_queue * m_CommandQueue{}; // one queue per device
 
   cl_uint m_NumberOfDevices, m_NumberOfPlatforms{};
 

--- a/Modules/Core/GPUCommon/include/itkGPUDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUDataManager.h
@@ -147,7 +147,7 @@ protected:
 protected:
   /* NOTE: ivars are protected instead of private to improve performance access in child classes*/
 
-  unsigned int m_BufferSize; // # of bytes
+  unsigned int m_BufferSize{}; // # of bytes
 
   GPUContextManager * m_ContextManager{};
 

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
@@ -86,8 +86,8 @@ protected:
   ~GPUImageDataManager() override = default;
 
 private:
-  WeakPointer<ImageType> m_Image; // WeakPointer has to be used here
-                                  // to avoid SmartPointer loop
+  WeakPointer<ImageType> m_Image{}; // WeakPointer has to be used here
+                                    // to avoid SmartPointer loop
   int                              m_BufferedRegionIndex[ImageType::ImageDimension]{};
   int                              m_BufferedRegionSize[ImageType::ImageDimension]{};
   typename GPUDataManager::Pointer m_GPUBufferedRegionIndex{};

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -396,17 +396,17 @@ private:
   void
   ApplyMirrorBoundaryConditions(vnl_matrix<long> & evaluateIndex, unsigned int splineOrder) const;
 
-  Iterator m_CIterator;                         // Iterator for
-                                                // traversing spline
-                                                // coefficients.
-  unsigned long m_MaxNumberInterpolationPoints; // number of
-                                                // neighborhood
-                                                // points used for
-                                                // interpolation
-  std::vector<IndexType> m_PointsToIndex;       // Preallocation of
-                                                // interpolation
-                                                // neighborhood
-                                                // indices
+  Iterator m_CIterator{};                         // Iterator for
+                                                  // traversing spline
+                                                  // coefficients.
+  unsigned long m_MaxNumberInterpolationPoints{}; // number of
+                                                  // neighborhood
+                                                  // points used for
+                                                  // interpolation
+  std::vector<IndexType> m_PointsToIndex{};       // Preallocation of
+                                                  // interpolation
+                                                  // neighborhood
+                                                  // indices
 
   CoefficientFilterPointer m_CoefficientFilter{};
 

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
@@ -414,7 +414,7 @@ private:
 
   PointHashMap m_PointsHashTable{};
   CellHashMap  m_CellsHashTable{};
-  MeshPointer  m_OutputMesh; // Retained for convenience.
+  MeshPointer  m_OutputMesh{}; // Retained for convenience.
 };
 } // end namespace itk
 

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
@@ -215,7 +215,7 @@ private:
   IdentifierType
   SearchThroughLastFrame(int index, int start, int end);
 
-  unsigned char m_LUT[256][2]; // the two lookup tables
+  unsigned char m_LUT[256][2]{}; // the two lookup tables
 
   IdentifierType m_LastVoxel[14]{};
   IdentifierType m_CurrentVoxel[14]{};

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
@@ -236,7 +236,7 @@ protected:
 
   SpacingType m_Spacing{};
 
-  PointType m_Origin; // start value
+  PointType m_Origin{}; // start value
 
   double m_Tolerance{};
 

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -358,8 +358,8 @@ public:
   static const OriginRefType m_NoPoint;
 
 protected:
-  OriginRefType      m_Origin;           // Geometrical information
-  PrimalDataType     m_Data;             // User data associated to this edge.
+  OriginRefType      m_Origin{};         // Geometrical information
+  PrimalDataType     m_Data{};           // User data associated to this edge.
   bool               m_DataSet{ false }; // Indicates if the data is set.
   LineCellIdentifier m_LineCellIdent{};
 };

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -433,8 +433,8 @@ public:
   GetOrder() const;
 
 private:
-  Self * m_Onext; /**< Onext ring */
-  Self * m_Rot;   /**< Rot ring */
+  Self * m_Onext{}; /**< Onext ring */
+  Self * m_Rot{};   /**< Rot ring */
 };
 } // namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -214,10 +214,10 @@ protected:
   }
 
 protected:
-  QuadEdgeType * m_StartEdge; /**< Start edge */
-  QuadEdgeType * m_Iterator;  /**< Current iteration position */
-  int            m_OpType;    /**< Operation type */
-  bool           m_Start;     /**< Indicates iteration has just started */
+  QuadEdgeType * m_StartEdge{}; /**< Start edge */
+  QuadEdgeType * m_Iterator{};  /**< Current iteration position */
+  int            m_OpType{};    /**< Operation type */
+  bool           m_Start{};     /**< Indicates iteration has just started */
 };
 
 /**

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
@@ -77,7 +77,7 @@ protected:
   ~QuadEdgeMeshEulerOperatorSplitVertexFunction() override = default;
 
 private:
-  PointIdentifier m_NewPoint; // stock newly created point ID for user.
+  PointIdentifier m_NewPoint{}; // stock newly created point ID for user.
 };
 } // end namespace itk
 

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.h
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.h
@@ -151,13 +151,13 @@ protected:
   GenerateOutputInformation() override;
 
 private:
-  SizeType      m_Size;      // size of the output image
-  SpacingType   m_Spacing;   // spacing
-  PointType     m_Origin;    // origin
-  DirectionType m_Direction; // direction
+  SizeType      m_Size{};      // size of the output image
+  SpacingType   m_Spacing{};   // spacing
+  PointType     m_Origin{};    // origin
+  DirectionType m_Direction{}; // direction
 
-  typename TOutputImage::PixelType m_Min; // minimum possible value
-  typename TOutputImage::PixelType m_Max; // maximum possible value
+  typename TOutputImage::PixelType m_Min{}; // minimum possible value
+  typename TOutputImage::PixelType m_Max{}; // maximum possible value
 
   // The following variables are deprecated, and provided here just for
   // backward compatibility. It use is discouraged.

--- a/Modules/Core/Transform/include/itkScaleTransform.h
+++ b/Modules/Core/Transform/include/itkScaleTransform.h
@@ -214,7 +214,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  ScaleType m_Scale; // Scales of the transformation
+  ScaleType m_Scale{}; // Scales of the transformation
 
 }; // class ScaleTransform
 

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -252,8 +252,8 @@ protected:
 
 private:
   JacobianType     m_IdentityJacobian{};
-  OutputVectorType m_Offset; // Offset of the transformation
-};                           // class TranslationTransform
+  OutputVectorType m_Offset{}; // Offset of the transformation
+};                             // class TranslationTransform
 
 // Back transform a point
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
@@ -195,14 +195,14 @@ protected:
   PrepareKernelBaseSpline();
 
 private:
-  SizeType                   m_Size;            // Size of the output image
-  KernelTransformPointerType m_KernelTransform; // Coordinate transform to
-                                                // use
-  SpacingType     m_OutputSpacing;              // output image spacing
-  OriginPointType m_OutputOrigin;               // output image origin
+  SizeType                   m_Size{};            // Size of the output image
+  KernelTransformPointerType m_KernelTransform{}; // Coordinate transform to
+                                                  // use
+  SpacingType     m_OutputSpacing{};              // output image spacing
+  OriginPointType m_OutputOrigin{};               // output image origin
 
-  unsigned int m_SubsamplingFactor; // factor to subsample the
-                                    // input field.
+  unsigned int m_SubsamplingFactor{}; // factor to subsample the
+                                      // input field.
 };
 } // end namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
@@ -187,11 +187,11 @@ protected:
 
 private:
   /** Member variables. */
-  SizeType      m_Size;             // size of the output region
-  IndexType     m_OutputStartIndex; // start index of the output region
-  SpacingType   m_OutputSpacing;    // output image spacing
-  OriginType    m_OutputOrigin;     // output image origin
-  DirectionType m_OutputDirection;  // output image direction cosines
+  SizeType      m_Size{};             // size of the output region
+  IndexType     m_OutputStartIndex{}; // start index of the output region
+  SpacingType   m_OutputSpacing{};    // output image spacing
+  OriginType    m_OutputOrigin{};     // output image origin
+  DirectionType m_OutputDirection{};  // output image direction cosines
   bool          m_UseReferenceImage{ false };
 };
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -234,9 +234,9 @@ protected:
 private:
   bool m_SquaredDistance{};
   bool m_UseImageSpacing{};
-  bool m_InsideIsPositive; // ON is treated as inside pixels
-};                         // end of SignedDanielssonDistanceMapImageFilter
-                           // class
+  bool m_InsideIsPositive{}; // ON is treated as inside pixels
+};                           // end of SignedDanielssonDistanceMapImageFilter
+                             // class
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
@@ -251,8 +251,8 @@ private:
   ArrayType m_Variance{};
   ArrayType m_MaximumError{};
 
-  OutputImagePixelType m_UpperThreshold; // should be float here?
-  OutputImagePixelType m_LowerThreshold; // should be float here?
+  OutputImagePixelType m_UpperThreshold{}; // should be float here?
+  OutputImagePixelType m_LowerThreshold{}; // should be float here?
 
   typename OutputImageType::Pointer m_UpdateBuffer1{};
 

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
@@ -145,22 +145,22 @@ protected:
 
 private:
   // parameters;
-  double m_TimeStep;                               // the timestep of each
-                                                   // iteration
-  double m_Steps[Superclass::InputImageDimension]; // set to be 1 in all
-                                                   // directions in most cases
-  double m_NoiseLevel;                             // the noise level of the
-                                                   // image
-  int m_IterationNum;                              // the iteration number
+  double m_TimeStep{};                               // the timestep of each
+                                                     // iteration
+  double m_Steps[Superclass::InputImageDimension]{}; // set to be 1 in all
+                                                     // directions in most cases
+  double m_NoiseLevel{};                             // the noise level of the
+                                                     // image
+  int m_IterationNum{};                              // the iteration number
 
   LaplacianFilterPointer                 m_LaplacianFilter{};
   typename Superclass::InputImagePointer m_IntermediateImage{};
 
   InternalImagePointer m_InternalImages[Superclass::InputImageDimension]{};
-  InternalImagePointer m_BImage; // store the "b" value for every pixel
+  InternalImagePointer m_BImage{}; // store the "b" value for every pixel
 
-  typename Superclass::InputImagePointer m_CImage; // store the $c_i$ value for
-                                                   // every pixel
+  typename Superclass::InputImagePointer m_CImage{}; // store the $c_i$ value for
+                                                     // every pixel
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
@@ -173,12 +173,12 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  int m_SplineOrder; // User specified spline order
-  int m_GSize;       // downsampling filter size
-  int m_HSize;       // upsampling filter size
+  int m_SplineOrder{}; // User specified spline order
+  int m_GSize{};       // downsampling filter size
+  int m_HSize{};       // upsampling filter size
 
-  std::vector<double> m_G; // downsampling filter coefficients
-  std::vector<double> m_H; // upsampling filter coefficients
+  std::vector<double> m_G{}; // downsampling filter coefficients
+  std::vector<double> m_H{}; // upsampling filter coefficients
 
 private:
   /** Allocate scratch space based on image sizes. */
@@ -195,8 +195,8 @@ private:
   void
   CopyLineToScratch(ConstInputImageIterator & Iter);
 
-  std::vector<double> m_Scratch; // temp storage for processing
-                                 // of Coefficients
+  std::vector<double> m_Scratch{}; // temp storage for processing
+                                   // of Coefficients
 };
 } // namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -189,8 +189,8 @@ private:
   using CoordImageRegionType = typename CoordImageType::RegionType;
 
   InterpolatorPointer m_Interpolator{};
-  PixelType           m_DefaultPixelValue; // default pixel value if the
-                                           // point is outside the image
+  PixelType           m_DefaultPixelValue{}; // default pixel value if the
+                                             // point is outside the image
 };
 } // namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -367,18 +367,18 @@ private:
   void
   InitializeTransform();
 
-  SizeType                m_Size;         // Size of the output image
-  InterpolatorPointerType m_Interpolator; // Image function for
-                                          // interpolation
-  ExtrapolatorPointerType m_Extrapolator; // Image function for
-                                          // extrapolation
-  PixelType m_DefaultPixelValue;          // default pixel value
-                                          // if the point is
-                                          // outside the image
-  SpacingType     m_OutputSpacing;        // output image spacing
-  OriginPointType m_OutputOrigin;         // output image origin
-  DirectionType   m_OutputDirection;      // output image direction cosines
-  IndexType       m_OutputStartIndex;     // output image start index
+  SizeType                m_Size{};         // Size of the output image
+  InterpolatorPointerType m_Interpolator{}; // Image function for
+                                            // interpolation
+  ExtrapolatorPointerType m_Extrapolator{}; // Image function for
+                                            // extrapolation
+  PixelType m_DefaultPixelValue{};          // default pixel value
+                                            // if the point is
+                                            // outside the image
+  SpacingType     m_OutputSpacing{};        // output image spacing
+  OriginPointType m_OutputOrigin{};         // output image origin
+  DirectionType   m_OutputDirection{};      // output image direction cosines
+  IndexType       m_OutputStartIndex{};     // output image start index
   bool            m_UseReferenceImage{ false };
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -283,8 +283,8 @@ private:
   DirectionType m_OutputDirection{};
 
   InterpolatorPointer m_Interpolator{};
-  SizeType            m_OutputSize;       // Size of the output image
-  IndexType           m_OutputStartIndex; // output image start index
+  SizeType            m_OutputSize{};       // Size of the output image
+  IndexType           m_OutputStartIndex{}; // output image start index
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.h
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.h
@@ -99,8 +99,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool m_Valid; // Have moments been computed
-                // yet?
+  bool m_Valid{}; // Have moments been computed
+                  // yet?
   double m_Output{};
 
   InputImageConstPointer m_Image{};

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
@@ -134,7 +134,7 @@ protected:
   GenerateOutputInformation() override;
 
 private:
-  SizeType      m_Size; // size of the output image
+  SizeType      m_Size{}; // size of the output image
   SpacingType   m_Spacing{};
   PointType     m_Origin{};
   DirectionType m_Direction{};

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.h
@@ -217,14 +217,14 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool       m_Valid; // Have moments been computed yet?
-  ScalarType m_M0;    // Zeroth moment
-  VectorType m_M1;    // First moments about origin
-  MatrixType m_M2;    // Second moments about origin
-  VectorType m_Cg;    // Center of gravity (physical units)
-  MatrixType m_Cm;    // Second central moments (physical)
-  VectorType m_Pm;    // Principal moments (physical)
-  MatrixType m_Pa;    // Principal axes (physical)
+  bool       m_Valid{}; // Have moments been computed yet?
+  ScalarType m_M0{};    // Zeroth moment
+  VectorType m_M1{};    // First moments about origin
+  MatrixType m_M2{};    // Second moments about origin
+  VectorType m_Cg{};    // Center of gravity (physical units)
+  MatrixType m_Cm{};    // Second central moments (physical)
+  VectorType m_Pm{};    // Principal moments (physical)
+  MatrixType m_Pa{};    // Principal axes (physical)
 
   ImageConstPointer         m_Image{};
   SpatialObjectConstPointer m_SpatialObjectMask{};

--- a/Modules/Filtering/Path/include/itkChainCodePath.h
+++ b/Modules/Filtering/Path/include/itkChainCodePath.h
@@ -157,8 +157,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  IndexType     m_Start; // origin image index for the path
-  ChainCodeType m_Chain; // the chain code (vector of offsets)
+  IndexType     m_Start{}; // origin image index for the path
+  ChainCodeType m_Chain{}; // the chain code (vector of offsets)
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkChainCodePath2D.h
+++ b/Modules/Filtering/Path/include/itkChainCodePath2D.h
@@ -171,7 +171,7 @@ protected:
   }
 
 private:
-  ChainCode2DType m_Chain2D; // the Freeman-encoded chain code
+  ChainCode2DType m_Chain2D{}; // the Freeman-encoded chain code
 
   // FreemanCode[][] implements a lookup table for converting offsets to a
   // Freeman code.  Within each dimension, the only allowable offset values are

--- a/Modules/Filtering/Path/include/itkPath.h
+++ b/Modules/Filtering/Path/include/itkPath.h
@@ -127,8 +127,8 @@ protected:
 
 private:
   // These "constants" are initialized in the constructor
-  OffsetType m_ZeroOffset; // = 0 for all dimensions
-  IndexType  m_ZeroIndex;  // = 0 for all dimensions
+  OffsetType m_ZeroOffset{}; // = 0 for all dimensions
+  IndexType  m_ZeroIndex{};  // = 0 for all dimensions
 };
 } // namespace itk
 

--- a/Modules/Filtering/Path/include/itkPathConstIterator.h
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.h
@@ -205,7 +205,7 @@ public:
 
 protected: // made protected so other iterators can access
   // This "constant" is initialized in the constructor
-  OffsetType m_ZeroOffset; // = 0 for all dimensions
+  OffsetType m_ZeroOffset{}; // = 0 for all dimensions
 
   /** Smart pointer to the source image. */
   typename ImageType::ConstWeakPointer m_Image{};

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -285,9 +285,9 @@ private:
   int      m_YDim{};
   float    m_XRes{};
   float    m_YRes{};
-  int      m_Key1; /** Key that must be matched for image to be used,
+  int      m_Key1{}; /** Key that must be matched for image to be used,
                      i.e. seriesNumber, extensionkey */
-  int m_Key2;      /** Key that must be matched for image to be used,
+  int m_Key2{};      /** Key that must be matched for image to be used,
                      i.e. echoNumber */
   int m_SortOrder{};
 };

--- a/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
@@ -121,8 +121,8 @@ private:
   std::string m_Archetype{};
 
   std::vector<StringVectorType> m_Groupings{};
-  StringVectorType              m_FileNames; // ivar for returning by
-                                             // reference
+  StringVectorType              m_FileNames{}; // ivar for returning by
+                                               // reference
 
   TimeStamp m_ArchetypeMTime{};
   TimeStamp m_ScanTime{};

--- a/Modules/IO/ImageBase/include/itkImageFileReader.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.h
@@ -155,8 +155,8 @@ protected:
 
   ImageIOBase::Pointer m_ImageIO{};
 
-  bool m_UserSpecifiedImageIO; // keep track whether the
-                               // ImageIO is user specified
+  bool m_UserSpecifiedImageIO{}; // keep track whether the
+                                 // ImageIO is user specified
 
   bool m_UseStreaming{};
 

--- a/Modules/IO/MRC/include/itkMRCHeaderObject.h
+++ b/Modules/IO/MRC/include/itkMRCHeaderObject.h
@@ -270,8 +270,8 @@ public:
   IsOriginalHeaderBigEndian() const;
 
   /** Public available data : FIXME : NO MEMBER VARIABLES SHOULD BE PUBLIC. */
-  Header m_Header; // FIXME : This should be private and
-                   // should have Get/Set Methods.
+  Header m_Header{}; // FIXME : This should be private and
+                     // should have Get/Set Methods.
 
 protected:
   MRCHeaderObject();

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -182,9 +182,9 @@ protected:
   GenerateData() override;
 
   MeshIOBase::Pointer m_MeshIO{};
-  bool                m_UserSpecifiedMeshIO; // keep track whether the MeshIO is
-                                             // user specified
-  std::string m_FileName;                    // The file to be read
+  bool                m_UserSpecifiedMeshIO{}; // keep track whether the MeshIO is
+                                               // user specified
+  std::string m_FileName{};                    // The file to be read
 
 private:
   template <typename T>

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -178,10 +178,10 @@ protected:
 private:
   std::string         m_FileName{};
   MeshIOBase::Pointer m_MeshIO{};
-  bool                m_UserSpecifiedMeshIO; // track whether the MeshIO is
-                                             // user specified
-  bool m_FactorySpecifiedMeshIO;             // track whether the factory
-                                             // mechanism set the MeshIO
+  bool                m_UserSpecifiedMeshIO{}; // track whether the MeshIO is
+                                               // user specified
+  bool m_FactorySpecifiedMeshIO{};             // track whether the factory
+                                               // mechanism set the MeshIO
   bool m_UseCompression{};
   bool m_FileTypeIsBINARY{};
 };

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
@@ -186,8 +186,8 @@ protected:
 
 private:
   std::ifstream  m_InputFile{};
-  std::streampos m_PointsStartPosition; // file position for points relative to
-                                        // std::ios::beg
+  std::streampos m_PointsStartPosition{}; // file position for points relative to
+                                          // std::ios::beg
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
+++ b/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
@@ -204,8 +204,8 @@ protected:
 
 private:
   std::ifstream    m_InputFile{};
-  StreamOffsetType m_PointsStartPosition; // file position for points relative to std::ios::beg
-  bool             m_TriangleCellType;    // if all cells are triangle it is true. otherwise, it is false.
+  StreamOffsetType m_PointsStartPosition{}; // file position for points relative to std::ios::beg
+  bool             m_TriangleCellType{};    // if all cells are triangle it is true. otherwise, it is false.
 };
 } // end namespace itk
 

--- a/Modules/IO/XML/include/itkXMLFile.h
+++ b/Modules/IO/XML/include/itkXMLFile.h
@@ -216,8 +216,8 @@ public:
 #endif
 
 protected:
-  T *         m_InputObject; // object to write out to an XML file
-  std::string m_Filename;    // name of file to write.
+  T *         m_InputObject{}; // object to write out to an XML file
+  std::string m_Filename{};    // name of file to write.
 };
 } // namespace itk
 #endif

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.h
@@ -165,24 +165,24 @@ private:
   /** 2D output slice iterator */
   using OutputSliceIteratorType = ImageRegionIteratorWithIndex<OutputSliceType>;
 
-  unsigned short m_ZeroPadding;  /**< n-fold zero-padding */
-  unsigned short m_OverSampling; /**< n-fold oversampling */
+  unsigned short m_ZeroPadding{};  /**< n-fold zero-padding */
+  unsigned short m_OverSampling{}; /**< n-fold oversampling */
 
-  double m_Cutoff;     /**< Radial lowpass cut-off frequency
-                        */
-  double m_AlphaRange; /**< Covered angular range */
+  double m_Cutoff{};     /**< Radial lowpass cut-off frequency
+                          */
+  double m_AlphaRange{}; /**< Covered angular range */
 
-  unsigned short m_ZDirection;        /**< Axial index in the input image */
-  unsigned short m_AlphaDirection;    /**< Angular index in the input image
-                                       */
-  unsigned short m_RDirection;        /**< Radial index in the input image
-                                       */
-  unsigned short m_RadialSplineOrder; /**< Spline order for the radial
+  unsigned short m_ZDirection{};        /**< Axial index in the input image */
+  unsigned short m_AlphaDirection{};    /**< Angular index in the input image
+                                         */
+  unsigned short m_RDirection{};        /**< Radial index in the input image
+                                         */
+  unsigned short m_RadialSplineOrder{}; /**< Spline order for the radial
                                             BSpline interpolation  */
 
-  double m_PI; /**< The constant pi....  */
+  double m_PI{}; /**< The constant pi....  */
 
-  RegionType m_InputRequestedRegion; /**< The region requested from* the input
+  RegionType m_InputRequestedRegion{}; /**< The region requested from* the input
                                        image   */
 };
 } // namespace itk

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
@@ -212,7 +212,7 @@ protected:
   void
   ApplyUpdate(TimeStepType dt) override;
 
-  unsigned int m_ReinitializeCounter; // FIXME: Should this be a boolean ?
+  unsigned int m_ReinitializeCounter{}; // FIXME: Should this be a boolean ?
   // unsigned int m_UpdateCounter;        // FIXME: Should this be a boolean ?
 
 private:

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
@@ -358,7 +358,7 @@ private:
   GradientImageType * m_MetricGradientImage{};
   MovingPointer       m_RefImage{};
   FixedPointer        m_TarImage{};
-  MovingRadiusType    m_MetricRadius; /** used by the metric to set
+  MovingRadiusType    m_MetricRadius{}; /** used by the metric to set
                                         region size for fixed image*/
   typename MovingType::SizeType m_RefSize{};
   typename FixedType::SizeType  m_TarSize{};

--- a/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
@@ -116,7 +116,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
   void
                             AddNextElementInternal(const Element * e);
-  ElementPointersVectorType m_Element; /** pointers to element objects on which the
+  ElementPointersVectorType m_Element{}; /** pointers to element objects on which the
                                   load acts */
 };
 } // end namespace fem

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
@@ -126,8 +126,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  MeanVectorType       m_Mean;       // mean
-  CovarianceMatrixType m_Covariance; // covariance matrix
+  MeanVectorType       m_Mean{};       // mean
+  CovarianceMatrixType m_Covariance{}; // covariance matrix
 
   // inverse covariance matrix. automatically calculated
   // when covariance matrix is set.

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -130,8 +130,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  MeanVectorType       m_Mean;       // mean
-  CovarianceMatrixType m_Covariance; // covariance matrix
+  MeanVectorType       m_Mean{};       // mean
+  CovarianceMatrixType m_Covariance{}; // covariance matrix
 
   // inverse covariance matrix. automatically calculated
   // when covariance matrix is set.

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
@@ -122,8 +122,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  MeanVectorType       m_Mean;       // mean
-  CovarianceMatrixType m_Covariance; // covariance matrix
+  MeanVectorType       m_Mean{};       // mean
+  CovarianceMatrixType m_Covariance{}; // covariance matrix
 
   // inverse covariance matrix which is automatically calculated
   // when covariance matrix is set.  This speeds up the GetProbability()

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -666,8 +666,8 @@ private:
   unsigned int m_LineSearchMaximumIterations{ 100 };
 
   /** Parameters used to define Multi-resolution registration. */
-  vnl_vector<unsigned int> m_NumberOfIntegrationPoints; // resolution of integration
-  vnl_vector<unsigned int> m_MetricWidth;               // number of iterations at each level
+  vnl_vector<unsigned int> m_NumberOfIntegrationPoints{}; // resolution of integration
+  vnl_vector<unsigned int> m_MetricWidth{};               // number of iterations at each level
   vnl_vector<unsigned int> m_Maxiters{};
   unsigned int             m_TotalIterations{ 0 }; // total number of iterations that were run
   unsigned int             m_MaxLevel{ 1 };
@@ -687,7 +687,7 @@ private:
   vnl_vector<Float> m_Rho{};
   vnl_vector<Float> m_Gamma{};
   Float             m_Energy{ 0.0 };      // current value of energy
-  Float             m_MinE;               // minimum recorded energy
+  Float             m_MinE{};             // minimum recorded energy
   Float             m_MinJacobian{ 1.0 }; // minimum recorded energy
   Float             m_Alpha{ 1.0 };
 
@@ -711,7 +711,7 @@ private:
 
   // Only use TotalField if re-gridding is employed.
   typename FieldType::Pointer           m_TotalField{};
-  typename ImageMetricLoadType::Pointer m_Load; // Defines the load to use
+  typename ImageMetricLoadType::Pointer m_Load{}; // Defines the load to use
 
   // Define the warper
   typename WarperType::Pointer m_Warper{};

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -227,10 +227,10 @@ protected:
 private:
   using InputImageSizeType = typename TInputImage::SizeType;
 
-  InputImageConstPointer m_InputImage;            /** the input */
-  TrainingImageType      m_TrainingImage;         /** image to train the
-                                                    filter. */
-  LabelledImageType m_LabelledImage;              /** output */
+  InputImageConstPointer m_InputImage{};          /** the input */
+  TrainingImageType      m_TrainingImage{};       /** image to train the
+                                                  filter. */
+  LabelledImageType m_LabelledImage{};            /** output */
   unsigned int      m_NumberOfClasses{ 0 };       /** the number of class
                                                  need to be classified.
                                                  */
@@ -247,11 +247,11 @@ private:
   int                          m_RecursiveNumber{ 0 };   /** number of SA iterations. */
   std::unique_ptr<LabelType[]> m_LabelStatus{ nullptr }; /** array for the state of each pixel. */
 
-  InputImagePointer m_MediumImage; /** the medium image to store intermedium
+  InputImagePointer m_MediumImage{}; /** the medium image to store intermedium
                                      result */
 
-  unsigned int m_Temp{ 0 };  /** for SA algo. */
-  IndexType    m_StartPoint; /** the seed of object */
+  unsigned int m_Temp{ 0 };    /** for SA algo. */
+  IndexType    m_StartPoint{}; /** the seed of object */
 
   unsigned int m_ImageWidth{ 0 }; /** image size. */
   unsigned int m_ImageHeight{ 0 };
@@ -260,8 +260,8 @@ private:
                                    be erased. */
   LabelType      m_ObjectLabel{ 1 }; /** the label for object region. */
   unsigned int   m_VecDim{ 0 };      /** the channel number in the image. */
-  InputPixelType m_LowPoint;         /** the point give lowest value of H-1 in
-                                       neighbor. */
+  InputPixelType m_LowPoint{};       /** the point give lowest value of H-1 in
+                                     neighbor. */
 
   std::unique_ptr<unsigned short[]> m_Region{ nullptr };      /** for region erase. */
   std::unique_ptr<unsigned short[]> m_RegionCount{ nullptr }; /** for region erase. */


### PR DESCRIPTION
Previous commits that added `{}` initializers to data members by means of regular expressions had overlooked member declarations that had a trailing comment.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3851 commit 5e2c49f9eb80e78903ce8f9fd2b5952062653cab
"STYLE: Add in-class `{}` member initializers to objects created by New()"