### PR TITLE
STYLE: Construct local variables by passing their arguments directly

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -107,7 +107,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it = IRIType(this->m_Image, this->m_Image->GetBufferedRegion());
+  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
@@ -132,7 +132,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it = IRIType(this->m_Image, this->m_Image->GetBufferedRegion());
+  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -117,7 +117,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it = IRIType(this->m_Image, this->m_Image->GetBufferedRegion());
+  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
@@ -142,7 +142,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it = IRIType(this->m_Image, this->m_Image->GetBufferedRegion());
+  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest

--- a/Modules/Core/Common/test/itkFloodFillIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFillIteratorTest.cxx
@@ -96,7 +96,7 @@ itkFloodFillIteratorTest(int, char *[])
   seedPos.SetIndex(pos);
 
   using TItType = itk::FloodFilledSpatialFunctionConditionalIterator<TImageType, TFunctionType>;
-  TItType sfi = TItType(sourceImage, spatialFunc, seedPos);
+  TItType sfi(sourceImage, spatialFunc, seedPos);
 
   // Iterate through the entire image and set interior pixels to 255
   for (; !(sfi.IsAtEnd()); ++sfi)

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
@@ -97,7 +97,7 @@ itkFloodFilledSpatialFunctionTest(int, char *[])
 
     using ItType = itk::FloodFilledSpatialFunctionConditionalIterator<ImageType, FunctionType>;
 
-    ItType sfi = ItType(sourceImage, spatialFunc, seedPos);
+    ItType sfi(sourceImage, spatialFunc, seedPos);
 
     switch (strat)
     {

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -45,7 +45,7 @@ CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   }
 
   const unsigned int VectorDimension = this->GetInputImage()->GetNumberOfComponentsPerPixel();
-  RealType           covariance = RealType(VectorDimension, VectorDimension);
+  RealType           covariance(VectorDimension, VectorDimension);
 
   if (!this->IsInsideBuffer(index))
   {
@@ -57,7 +57,7 @@ CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   covariance.fill(NumericTraits<PixelComponentRealType>::ZeroValue());
 
   using MeanVectorType = vnl_vector<PixelComponentRealType>;
-  MeanVectorType mean = MeanVectorType(VectorDimension);
+  MeanVectorType mean(VectorDimension);
   mean.fill(NumericTraits<PixelComponentRealType>::ZeroValue());
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -68,7 +68,7 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   radius.Fill(VRadius);
 
   // Initialize the neighborhood
-  IteratorType it = IteratorType(radius, image, image->GetBufferedRegion());
+  IteratorType it(radius, image, image->GetBufferedRegion());
 
   // Compute the offset tables (we ignore all the zero indices
   // in the neighborhood)
@@ -148,7 +148,7 @@ typename WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunct
   // Position the neighborhood at the index of interest
   Size<ImageDimension> radius;
   radius.Fill(VRadius);
-  IteratorType nit = IteratorType(radius, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());
+  IteratorType nit(radius, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());
   nit.SetLocation(baseIndex);
 
   // Compute the sinc function for each dimension

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -187,7 +187,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
     const RegionType region(indMin, size);
 
     using IteratorType = ImageRegionConstIteratorWithIndex<ImageType>;
-    IteratorType it = IteratorType(m_Image, region);
+    IteratorType it(m_Image, region);
     it.GoToBegin();
     IndexType  ind;
     PointType  pnt;

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -272,7 +272,7 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::
 
   using IteratorType = ImageRegionIterator<ImageType>;
 
-  IteratorType                coeffIterator = IteratorType(this->m_CoefficientImages[0], supportRegion);
+  IteratorType                coeffIterator(this->m_CoefficientImages[0], supportRegion);
   const ParametersValueType * basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
   while (!coeffIterator.IsAtEnd())
   {

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
@@ -92,7 +92,7 @@ ExponentialDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData
     }
 
     using InputConstIterator = ImageRegionConstIterator<InputImageType>;
-    InputConstIterator InputIt = InputConstIterator(inputPtr, inputPtr->GetRequestedRegion());
+    InputConstIterator InputIt(inputPtr, inputPtr->GetRequestedRegion());
 
     for (InputIt.GoToBegin(); !InputIt.IsAtEnd(); ++InputIt)
     {

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -61,8 +61,8 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
   negField->SetDirection(inputPtr->GetDirection());
   negField->Allocate();
 
-  InputConstIterator InputIt = InputConstIterator(inputPtr, inputPtr->GetRequestedRegion());
-  InputIterator      negImageIt = InputIterator(negField, negField->GetRequestedRegion());
+  InputConstIterator InputIt(inputPtr, inputPtr->GetRequestedRegion());
+  InputIterator      negImageIt(negField, negField->GetRequestedRegion());
 
   for (negImageIt.GoToBegin(); !negImageIt.IsAtEnd(); ++negImageIt)
   {
@@ -112,7 +112,7 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
     }
 
     ProgressReporter         progress(this, 0, inputPtr->GetLargestPossibleRegion().GetNumberOfPixels());
-    OutputIterator           OutputIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
+    OutputIterator           OutputIt(outputPtr, outputPtr->GetRequestedRegion());
     FieldInterpolatorPointer inputFieldInterpolator = FieldInterpolatorType::New();
     inputFieldInterpolator->SetInputImage(inputPtr);
 

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
@@ -65,7 +65,7 @@ DifferenceOfGaussiansGradientImageFilter<TInputImage, TDataType>::GenerateData()
   // Create an iterator that will walk the output region
   using OutputIterator = ImageRegionIterator<TOutputImage>;
 
-  OutputIterator outIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
+  OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel

--- a/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
@@ -105,7 +105,7 @@ itkDifferenceOfGaussiansGradientTest(int, char *[])
   seedPos.SetIndex(pos);
 
   using TItType = itk::FloodFilledSpatialFunctionConditionalIterator<TImageType, TFunctionType>;
-  TItType sfi = TItType(sourceImage, spatialFunc, seedPos);
+  TItType sfi(sourceImage, spatialFunc, seedPos);
 
   //
   // show seed indices

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -47,7 +47,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::Generate
   outputPtr->Allocate();
 
   // Iterator for walking the output region is defined in the Superclass
-  OutputImageIterator outIt = OutputImageIterator(outputPtr, outputPtr->GetRequestedRegion());
+  OutputImageIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // Calculate actual output
   // TODO:  Need to verify outIt is correctly sized.

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -58,7 +58,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateDa
   outputPtr->Allocate();
 
   // Iterator for walking the output region is defined in the Superclass
-  OutputImageIterator outIt = OutputImageIterator(outputPtr, outputPtr->GetRequestedRegion());
+  OutputImageIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // Calculate actual output
   // TODO:  Need to verify outIt is correctly sized.

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -771,8 +771,8 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
             RegionIsOdd(inputIndex[dimCtr], outputRegion.GetIndex()[dimCtr], static_cast<long>(inputSize[dimCtr]));
         }
 
-        OutputIterator outIt = OutputIterator(outputPtr, outputRegion);
-        InputIterator  inIt = InputIterator(inputPtr, inputRegion);
+        OutputIterator outIt(outputPtr, outputRegion);
+        InputIterator  inIt(inputPtr, inputRegion);
         double         decayFactor = 1.0;
 
         // Do the actual copy of the input pixels to the output pixels here.

--- a/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
@@ -67,7 +67,7 @@ PrintImageData(ImageTypePtr2D imgPtr)
     std::cout << imgPtr->GetSpacing()[n] << ", ";
   }
   std::cout << std::endl;
-  Iterator outIt = Iterator(imgPtr, imgPtr->GetLargestPossibleRegion());
+  Iterator outIt(imgPtr, imgPtr->GetLargestPossibleRegion());
   outIt.SetDirection(0);
 
   SizeType2D size = imgPtr->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -97,7 +97,7 @@ GaussianImageSource<TOutputImage>::GenerateData()
 
   // Create an iterator that will walk the output region
   using OutputIterator = ImageRegionIterator<TOutputImage>;
-  OutputIterator outIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
+  OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
 
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1105,8 +1105,8 @@ FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
 
   // Define the iterators for each ellipsoid
   using FloodIteratorType = FloodFilledSpatialFunctionConditionalIterator<ImageType, EllipsoidType>;
-  FloodIteratorType itEllipsoidOuter = FloodIteratorType(kernelImage, ellipsoidOuter, seed);
-  FloodIteratorType itEllipsoidInner = FloodIteratorType(kernelImage, ellipsoidInner, seed);
+  FloodIteratorType itEllipsoidOuter(kernelImage, ellipsoidOuter, seed);
+  FloodIteratorType itEllipsoidInner(kernelImage, ellipsoidInner, seed);
   itEllipsoidOuter.SetCenterInclusionStrategy();
   itEllipsoidInner.SetCenterInclusionStrategy();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -238,7 +238,7 @@ public:
 
   Self operator*(const CoordType & iV) const
   {
-    Self oElement = Self(this->m_Coefficients * iV);
+    Self oElement(this->m_Coefficients * iV);
 
     return oElement;
   }

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -132,8 +132,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     this, 0, (outputPtr->GetRequestedRegion().GetNumberOfPixels()) * m_Repetitions * 2 * NDimensions);
 
   // Copy the input image to the temporary image
-  TempIterator  tempIt = TempIterator(tempPtr, tempPtr->GetRequestedRegion());
-  InputIterator inputIt = InputIterator(inputPtr, inputPtr->GetRequestedRegion());
+  TempIterator  tempIt(tempPtr, tempPtr->GetRequestedRegion());
+  InputIterator inputIt(inputPtr, inputPtr->GetRequestedRegion());
 
   for (inputIt.GoToBegin(), tempIt.GoToBegin(); !tempIt.IsAtEnd(); ++tempIt, ++inputIt)
   {
@@ -161,7 +161,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     // blur each dimension
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
-      TempIterator tempItDir = TempIterator(tempPtr, tempPtr->GetRequestedRegion());
+      TempIterator tempItDir(tempPtr, tempPtr->GetRequestedRegion());
       tempItDir.GoToBegin();
       while (!tempItDir.IsAtEnd())
       {
@@ -200,7 +200,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
       itkDebugMacro(<< "End processing forward dimension " << dim);
 
       //----------------------Reverse pass----------------------
-      TempReverseIterator tempReverseIt = TempReverseIterator(tempPtr, tempPtr->GetRequestedRegion());
+      TempReverseIterator tempReverseIt(tempPtr, tempPtr->GetRequestedRegion());
 
       tempReverseIt.GoToBegin();
 
@@ -246,8 +246,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   // buffer iterator walks a region defined by the output
   using OutputIterator = ImageRegionIterator<TOutputImage>;
 
-  OutputIterator outIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
-  TempIterator   tempIt2 = TempIterator(tempPtr, outputPtr->GetRequestedRegion());
+  OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
+  TempIterator   tempIt2(tempPtr, outputPtr->GetRequestedRegion());
 
   for (outIt.GoToBegin(), tempIt2.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++tempIt2)
   {

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
@@ -45,7 +45,7 @@ SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>
   // Create an iterator that will walk the output region
   using OutputIterator = ImageRegionIterator<TOutputImage>;
 
-  OutputIterator outIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
+  OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // The value produced by the spatial function
   // The type is the range of the spatial function

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -262,9 +262,9 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, 
   // Iterate over all of those pixels and offsets, adding each
   // co-occurrence pair to the histogram
   using NeighborhoodIteratorType = ConstNeighborhoodIterator<ImageType>;
-  NeighborhoodIteratorType neighborIt = NeighborhoodIteratorType(radius, input, region);
+  NeighborhoodIteratorType neighborIt(radius, input, region);
   using MaskNeighborhoodIteratorType = ConstNeighborhoodIterator<MaskImageType>;
-  MaskNeighborhoodIteratorType maskNeighborIt = MaskNeighborhoodIteratorType(radius, maskImage, region);
+  MaskNeighborhoodIteratorType maskNeighborIt(radius, maskImage, region);
 
   MeasurementVectorType             cooccur(output->GetMeasurementVectorSize());
   typename HistogramType::IndexType index;

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -184,10 +184,10 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
 
   using ArrayType = Array<double>;
 
-  ArrayType sum1 = ArrayType(ParametersDimension);
+  ArrayType sum1(ParametersDimension);
   sum1.Fill(NumericTraits<typename ArrayType::ValueType>::ZeroValue());
 
-  ArrayType sum2 = ArrayType(ParametersDimension);
+  ArrayType sum2(ParametersDimension);
   sum2.Fill(NumericTraits<typename ArrayType::ValueType>::ZeroValue());
 
   int fixedArea = 0;

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -163,10 +163,10 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
   derivative = DerivativeType(ParametersDimension);
   derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeF = DerivativeType(ParametersDimension);
+  DerivativeType derivativeF(ParametersDimension);
   derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeM = DerivativeType(ParametersDimension);
+  DerivativeType derivativeM(ParametersDimension);
   derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
   ti.GoToBegin();
@@ -346,13 +346,13 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
   derivative = DerivativeType(ParametersDimension);
   derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeF = DerivativeType(ParametersDimension);
+  DerivativeType derivativeF(ParametersDimension);
   derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeM = DerivativeType(ParametersDimension);
+  DerivativeType derivativeM(ParametersDimension);
   derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeM1 = DerivativeType(ParametersDimension);
+  DerivativeType derivativeM1(ParametersDimension);
   derivativeM1.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
   ti.GoToBegin();

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -143,13 +143,13 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
   derivative = DerivativeType(ParametersDimension);
   derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeF = DerivativeType(ParametersDimension);
+  DerivativeType derivativeF(ParametersDimension);
   derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeM = DerivativeType(ParametersDimension);
+  DerivativeType derivativeM(ParametersDimension);
   derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeO = DerivativeType(ParametersDimension);
+  DerivativeType derivativeO(ParametersDimension);
   derivativeO.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
@@ -286,13 +286,13 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
   derivative = DerivativeType(ParametersDimension);
   derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeF = DerivativeType(ParametersDimension);
+  DerivativeType derivativeF(ParametersDimension);
   derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeM = DerivativeType(ParametersDimension);
+  DerivativeType derivativeM(ParametersDimension);
   derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
-  DerivativeType derivativeO = DerivativeType(ParametersDimension);
+  DerivativeType derivativeO(ParametersDimension);
   derivativeO.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -107,7 +107,7 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   filter->Update();
 
   using inputIterator = itk::ImageRegionIterator<InputImageType>;
-  inputIterator it = inputIterator(inputimg, region);
+  inputIterator it(inputimg, region);
 
   std::cout << "Input Image" << std::endl;
   it.GoToBegin();
@@ -123,7 +123,7 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   std::cout << std::endl;
 
   using outputIterator = itk::ImageRegionIterator<OutputImageType>;
-  outputIterator ot = outputIterator(filter->GetOutput(), region);
+  outputIterator ot(filter->GetOutput(), region);
 
   std::cout << std::endl << "Output Image" << std::endl;
   ot.GoToBegin();

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -106,7 +106,7 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   std::vector<unsigned int> votesByLabel(this->m_TotalLabelCount);
 
-  OutIteratorType out = OutIteratorType(output, outputRegionForThread);
+  OutIteratorType out(output, outputRegionForThread);
   for (out.GoToBegin(); !out.IsAtEnd(); ++out)
   {
     // Reset number of votes per label for all labels

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -133,13 +133,13 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
     votingOutput = votingFilter->GetOutput();
   } // begin scope for local filter allocation; de-allocate filter
 
-  OutputIteratorType out = OutputIteratorType(votingOutput, votingOutput->GetRequestedRegion());
+  OutputIteratorType out(votingOutput, votingOutput->GetRequestedRegion());
 
   for (unsigned int k = 0; k < numberOfInputs; ++k)
   {
     this->m_ConfusionMatrixArray[k].Fill(0.0);
 
-    InputConstIteratorType in = InputConstIteratorType(this->GetInput(k), votingOutput->GetRequestedRegion());
+    InputConstIteratorType in(this->GetInput(k), votingOutput->GetRequestedRegion());
 
     for (out.GoToBegin(); !out.IsAtEnd(); ++out, ++in)
     {
@@ -193,7 +193,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializePrio
     const size_t numberOfInputs = this->GetNumberOfInputs();
     for (size_t k = 0; k < numberOfInputs; ++k)
     {
-      InputConstIteratorType in = InputConstIteratorType(this->GetInput(k), this->GetOutput()->GetRequestedRegion());
+      InputConstIteratorType in(this->GetInput(k), this->GetOutput()->GetRequestedRegion());
       for (in.GoToBegin(); !in.IsAtEnd(); ++in)
       {
         ++(this->m_PriorProbabilities[in.Get()]);
@@ -379,7 +379,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
   }
 
   // reset output iterator to start
-  OutputIteratorType out = OutputIteratorType(output, output->GetRequestedRegion());
+  OutputIteratorType out(output, output->GetRequestedRegion());
   for (out.GoToBegin(); !out.IsAtEnd(); ++out)
   {
     // basically, we'll repeat the E step from above

--- a/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
@@ -82,7 +82,7 @@ itkLabelVotingImageFilterTest(int, char *[])
   inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
-  IteratorType it = IteratorType(inputImageA, inputImageA->GetBufferedRegion());
+  IteratorType it(inputImageA, inputImageA->GetBufferedRegion());
 
   for (int i = 0; i < 8; ++i, ++it)
   {

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -85,7 +85,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   inputImageA->SetRegions(region);
   inputImageA->Allocate();
 
-  IteratorType it = IteratorType(inputImageA, inputImageA->GetBufferedRegion());
+  IteratorType it(inputImageA, inputImageA->GetBufferedRegion());
 
   for (unsigned int i = 0; i < imageSize; ++i, ++it)
   {

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -74,7 +74,7 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int argc, char * argv[])
 
   // Mean values hand coded for the VisibleWomanSlice.png color file
   using MeanVectorType = FilterType::MeanVectorType;
-  MeanVectorType mean = MeanVectorType(3);
+  MeanVectorType mean(3);
 
   mean[0] = 44.7504;
   mean[1] = 37.5443;
@@ -84,7 +84,7 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int argc, char * argv[])
 
   // Covariance values hand coded for the VisibleWomanSlice.png color file
   using CovarianceMatrixType = FilterType::CovarianceMatrixType;
-  CovarianceMatrixType covariance = CovarianceMatrixType(3, 3);
+  CovarianceMatrixType covariance(3, 3);
 
   covariance[0][0] = 79.2225;
   covariance[1][1] = 81.0314;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -289,7 +289,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // the [lower, upper] bounds prescribed, the pixel is added to the
   // output segmentation and its neighbors become candidates for the
   // iterator to walk.
-  IteratorType it = IteratorType(outputImage, function, m_Seeds);
+  IteratorType it(outputImage, function, m_Seeds);
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
@@ -316,7 +316,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     sumOfSquares = NumericTraits<InputRealType>::ZeroValue();
     typename TOutputImage::SizeValueType numberOfSamples = 0;
 
-    SecondIteratorType sit = SecondIteratorType(inputImage, secondFunction, m_Seeds);
+    SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
     sit.GoToBegin();
     while (!sit.IsAtEnd())
     {
@@ -377,7 +377,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     // segmentation and its neighbors become candidates for the
     // iterator to walk.
     outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
-    IteratorType thirdIt = IteratorType(outputImage, function, m_Seeds);
+    IteratorType thirdIt(outputImage, function, m_Seeds);
     thirdIt.GoToBegin();
     try
     {

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -197,7 +197,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   float             progressWeight = 0.0f;
   float             cumulatedProgress = 0.0f;
-  IteratorType      it = IteratorType(outputImage, function, m_Seeds1);
+  IteratorType      it(outputImage, function, m_Seeds1);
   IterationReporter iterate(this, 0, 1);
 
   // If the upper threshold has not been set, find it.

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -120,7 +120,7 @@ NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   function->SetInputImage(inputImage);
   function->ThresholdBetween(m_Lower, m_Upper);
   function->SetRadius(m_Radius);
-  IteratorType it = IteratorType(outputImage, function, m_Seeds);
+  IteratorType it(outputImage, function, m_Seeds);
 
   ProgressReporter progress(this, 0, outputImage->GetRequestedRegion().GetNumberOfPixels());
   while (!it.IsAtEnd())

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -241,7 +241,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // the [lower, upper] bounds prescribed, the pixel is added to the
   // output segmentation and its neighbors become candidates for the
   // iterator to walk.
-  IteratorType it = IteratorType(outputImage, m_ThresholdFunction, m_Seeds);
+  IteratorType it(outputImage, m_ThresholdFunction, m_Seeds);
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
@@ -271,7 +271,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     SizeValueType num = NumericTraits<SizeValueType>::ZeroValue();
 
-    SecondIteratorType sit = SecondIteratorType(inputImage, secondFunction, m_Seeds);
+    SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
     sit.GoToBegin();
     while (!sit.IsAtEnd())
     {
@@ -320,7 +320,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     // segmentation and its neighbors become candidates for the
     // iterator to walk.
     outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
-    IteratorType thirdIt = IteratorType(outputImage, m_ThresholdFunction, m_Seeds);
+    IteratorType thirdIt(outputImage, m_ThresholdFunction, m_Seeds);
     thirdIt.GoToBegin();
     try
     {

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -282,8 +282,8 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateCluste
 
   itkDebugMacro("Estimating Centers");
   // calculate new centers
-  OutputIteratorType     itOut = OutputIteratorType(outputImage, updateRegionForThread);
-  InputConstIteratorType itIn = InputConstIteratorType(inputImage, updateRegionForThread);
+  OutputIteratorType     itOut(outputImage, updateRegionForThread);
+  InputConstIteratorType itIn(inputImage, updateRegionForThread);
   while (!itOut.IsAtEnd())
   {
     const size_t ln = updateRegionForThread.GetSize(0);


### PR DESCRIPTION
Replaced local variable initializations of the form `T var = T(args)` with the equivalent `T var(args)`, passing the `args` directly to the variable. (These two forms are semantically equivalent, but the latter one appears more to the point.)

Did so by Visual Studio 2022, Find and Replace, using regular expressions:

    Find what:  (\w+)[ ]+(\w+) = \1(\([^\)]+\);)
    Find what:  (\w+)[ ]+(\w+) = \1(\([^\)]+\)\);)
    Find what:  (\w+)[ ]+(\w+) = \1(\(.+,.+\);)
    Replace with:  $1 $2$3