### PR TITLE
STYLE: Prefer C++11 zero initializer to ZeroValue

### DIFF
--- a/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
@@ -160,7 +160,7 @@ main(int argc, char * argv[])
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
-    SumType sum = itk::NumericTraits<SumType>::ZeroValue();
+    SumType sum{};
     it.GoToBeginOfLine();
     index4D = it.GetIndex();
     while (!it.IsAtEndOfLine())

--- a/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
+++ b/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
     targetLandMarks->GetPoints();
   // Software Guide : EndCodeSnippet
 
-  PointIdType id = itk::NumericTraits<PointIdType>::ZeroValue();
+  PointIdType id{};
 
   // Read in the list of landmarks
   std::ifstream infile;

--- a/Modules/Core/Common/test/itkIntTypesTest.cxx
+++ b/Modules/Core/Common/test/itkIntTypesTest.cxx
@@ -44,7 +44,7 @@ bool
 CheckTraits(bool issigned, T * = nullptr)
 {
   // make sure that we have a specialized NumericTraits
-  T t0 = itk::NumericTraits<T>::ZeroValue();
+  T t0{};
   T t1 = itk::NumericTraits<T>::OneValue();
 
   // just here so that we use the variable

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -388,7 +388,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
     tensor3D(2, 1) = 0.0; // overrides (1,2)
     tensor3D(2, 2) = 29.0;
 
-    AccumulateValueType expectedTrace = itk::NumericTraits<AccumulateValueType>::ZeroValue();
+    AccumulateValueType expectedTrace{};
 
     expectedTrace += tensor3D(0, 0);
     expectedTrace += tensor3D(1, 1);

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
@@ -91,7 +91,7 @@ public:
                 void *                   itkNotUsed(globalData),
                 const FloatOffsetType &  itkNotUsed(offset = FloatOffsetType(0.0))) override
   {
-    PixelType pix = itk::NumericTraits<PixelType>::ZeroValue();
+    PixelType pix{};
     return pix;
   }
 #endif

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -199,7 +199,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
     {
       point += incrementVector;
       const bool isInside = maskSO->IsInsideInWorldSpace(point);
-      double     value = itk::NumericTraits<PixelType>::ZeroValue();
+      double     value{};
       maskSO->ValueAtInWorldSpace(point, value);
       const bool isZero = (itk::Math::ExactlyEquals(value, itk::NumericTraits<PixelType>::ZeroValue()));
       if ((isInside && isZero) || (!isInside && !isZero))

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
@@ -360,7 +360,7 @@ itkDiffusionTensor3DTest(int, char *[])
     tensor3(2, 1) = 0.0; // overrides (1,2)
     tensor3(2, 2) = 29.0;
 
-    AccumulateValueType expectedTrace = itk::NumericTraits<AccumulateValueType>::ZeroValue();
+    AccumulateValueType expectedTrace{};
 
     expectedTrace += tensor3(0, 0);
     expectedTrace += tensor3(1, 1);
@@ -430,13 +430,13 @@ itkDiffusionTensor3DTest(int, char *[])
     TensorType nonpositiveMinTensor = itk::NumericTraits<TensorType>::NonpositiveMin();
     std::cout << nonpositiveMinTensor << std::endl;
 
-    TensorType zeroValue = itk::NumericTraits<TensorType>::ZeroValue();
+    TensorType zeroValue{};
     std::cout << zeroValue << std::endl;
 
     TensorType oneValue = itk::NumericTraits<TensorType>::OneValue();
     std::cout << oneValue << std::endl;
 
-    TensorType zero = itk::NumericTraits<TensorType>::ZeroValue();
+    TensorType zero{};
     std::cout << zero << std::endl;
 
     TensorType one = itk::NumericTraits<TensorType>::OneValue();

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -68,7 +68,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   std::cout << "Test SmoothDisplacementFieldGauss" << std::endl;
   DisplacementTransformType::ParametersType params;
   using ParametersValueType = DisplacementTransformType::ParametersValueType;
-  ParametersValueType paramsZero = itk::NumericTraits<itk::NumericTraits<ParametersValueType>::ValueType>::ZeroValue();
+  ParametersValueType                            paramsZero{};
   DisplacementTransformType::ParametersType      paramsFill(displacementTransform->GetNumberOfParameters());
   DisplacementTransformType::ParametersValueType paramsFillValue = 0.0;
   paramsFill.Fill(paramsFillValue);

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -61,7 +61,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   /* Test SmoothDisplacementFieldGauss */
   std::cout << "Test SmoothDisplacementFieldGauss" << std::endl;
   using ParametersValueType = DisplacementTransformType::ParametersValueType;
-  ParametersValueType paramsZero = itk::NumericTraits<itk::NumericTraits<ParametersValueType>::ValueType>::ZeroValue();
+  ParametersValueType                            paramsZero{};
   DisplacementTransformType::ParametersType      params;
   DisplacementTransformType::ParametersType      paramsFill(displacementTransform->GetNumberOfParameters());
   DisplacementTransformType::ParametersValueType paramsFillValue = 0.0;

--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
@@ -65,7 +65,7 @@ itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
   region2.SetIndex(index);
 
   itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count = itk::NumericTraits<Pixel1Type>::ZeroValue();
+  Pixel1Type                           count{};
   while (!it1.IsAtEnd())
   {
     it1.Set(++count);

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -73,7 +73,7 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
   region2.SetIndex(index);
 
   itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count = itk::NumericTraits<Pixel1Type>::ZeroValue();
+  Pixel1Type                           count{};
   while (!it1.IsAtEnd())
   {
     it1.Set(++count);

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -65,7 +65,7 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
   region2.SetIndex(index);
 
   itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count = itk::NumericTraits<Pixel1Type>::ZeroValue();
+  Pixel1Type                           count{};
   while (!it1.IsAtEnd())
   {
     it1.Set(++count);

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
@@ -71,7 +71,7 @@ itkHausdorffDistanceImageFilterTest(int argc, char * argv[])
   region2.SetIndex(index);
 
   itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count = itk::NumericTraits<Pixel1Type>::ZeroValue();
+  Pixel1Type                           count{};
   while (!it1.IsAtEnd())
   {
     it1.Set(++count);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -144,7 +144,7 @@ itkFastMarchingBaseTest(int argc, char * argv[])
     double normalizationFactor = 1.0;
     ITK_TEST_SET_GET_VALUE(normalizationFactor, fmm->GetNormalizationFactor());
 
-    auto targetReachedValue = itk::NumericTraits<typename ImageFastMarching::OutputPixelType>::ZeroValue();
+    typename ImageFastMarching::OutputPixelType targetReachedValue{};
     ITK_TEST_EXPECT_EQUAL(targetReachedValue, fmm->GetTargetReachedValue());
 
     bool collectPoints = false;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
@@ -88,7 +88,7 @@ FastMarchingImageFilter(unsigned int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  LabelType label_zero = itk::NumericTraits<LabelType>::ZeroValue();
+  LabelType label_zero{};
 
   using ContourFilterType = itk::LabelContourImageFilter<LabelImageType, LabelImageType>;
   auto contour = ContourFilterType::New();

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -207,7 +207,7 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
   }
   criterion->SetTargetNodes(TargetNodes);
 
-  auto targetOffset = itk::NumericTraits<typename CriterionType::OutputPixelType>::ZeroValue();
+  typename CriterionType::OutputPixelType targetOffset{};
   criterion->SetTargetOffset(targetOffset);
   ITK_TEST_SET_GET_VALUE(targetOffset, criterion->GetTargetOffset());
 

--- a/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
@@ -72,7 +72,7 @@ itkSimpleContourExtractorImageFilterTest(int argc, char * argv[])
   FilterType::InputPixelType  inputForegroundValue = 255;
   FilterType::InputPixelType  inputBackgroundValue = 0;
   FilterType::OutputPixelType outputForegroundValue = itk::NumericTraits<FilterType::OutputPixelType>::max();
-  FilterType::OutputPixelType outputBackgroundValue = itk::NumericTraits<FilterType::OutputPixelType>::ZeroValue();
+  FilterType::OutputPixelType outputBackgroundValue{};
 
   filter->SetInputForegroundValue(inputForegroundValue);
 

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -107,7 +107,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
   filter1->SetMaskImage(mask1);
   filter1->SetOperator(sobelHorizontal);
 
-  auto defaultValue = itk::NumericTraits<typename FilterType::OutputPixelType>::ZeroValue();
+  typename FilterType::OutputPixelType defaultValue{};
   filter1->SetDefaultValue(defaultValue);
   ITK_TEST_SET_GET_VALUE(defaultValue, filter1->GetDefaultValue());
 

--- a/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
@@ -87,7 +87,7 @@ PolyLineParametricPath<VDimension>::IncrementInput(InputType & input) const -> O
   // Save this input index since we will use it to calculate the offset
   const IndexType originalIndex = this->EvaluateToIndex(input);
 
-  InputType potentialTimestep = itk::NumericTraits<InputType>::ZeroValue();
+  InputType potentialTimestep{};
   bool      timeStepSmallEnough = false;
   while (!timeStepSmallEnough)
   {

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -128,7 +128,7 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
     extractOrthogonalSwath2DImageFilter, ExtractOrthogonalSwath2DImageFilter, ImageAndPathToImageFilter);
 
 
-  auto defaultPixelValue = itk::NumericTraits<typename ImageType::PixelType>::ZeroValue();
+  typename ImageType::PixelType defaultPixelValue{};
   extractOrthogonalSwath2DImageFilter->SetDefaultPixelValue(defaultPixelValue);
 
   extractOrthogonalSwath2DImageFilter->SetImageInput(inputImage);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -66,7 +66,7 @@ itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   filter->SetInput(mesh);
 
-  auto absTol = itk::NumericTraits<typename CleanFilterType::InputCoordRepType>::ZeroValue();
+  typename CleanFilterType::InputCoordRepType absTol{};
   filter->SetAbsoluteTolerance(absTol);
   ITK_TEST_SET_GET_VALUE(absTol, filter->GetAbsoluteTolerance());
 

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -66,7 +66,7 @@ itkLargeImageWriteConvertReadTest(int argc, char * argv[])
     IteratorType itr(image, region);
     itr.GoToBegin();
 
-    OutputPixelType pixelValue = itk::NumericTraits<OutputPixelType>::ZeroValue();
+    OutputPixelType pixelValue{};
 
     chronometer.Start("Initializing");
     while (!itr.IsAtEnd())

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -42,7 +42,6 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
   typename ImageType::RegionType region;
   typename ImageType::IndexType  index;
 
-  PixelType pixelValue;
 
   itk::TimeProbesCollectorBase chronometer;
 
@@ -73,7 +72,7 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
     IteratorType itr(image, region);
     itr.GoToBegin();
 
-    pixelValue = itk::NumericTraits<PixelType>::ZeroValue();
+    PixelType pixelValue{};
 
     chronometer.Start("Initializing");
     while (!itr.IsAtEnd())
@@ -127,7 +126,7 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 
   std::cout << "Comparing the pixel values..." << std::endl;
 
-  pixelValue = itk::NumericTraits<PixelType>::ZeroValue();
+  PixelType pixelValue{};
 
   chronometer.Start("Compare");
   while (!ritr.IsAtEnd())

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -456,7 +456,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     success = EXIT_FAILURE;
   }
 
-  int metaDataInt = itk::NumericTraits<int>::ZeroValue();
+  int metaDataInt{};
   if (!itk::ExposeMetaData<int>(metaDict2, "acquisition:TestInt", metaDataInt) || metaDataInt != 4)
   {
     std::cerr << "Failure reading metaData "
@@ -705,7 +705,7 @@ MINCReadWriteTestVector(const char * fileName,
     success = EXIT_FAILURE;
   }
 
-  int metaDataInt = itk::NumericTraits<int>::ZeroValue();
+  int metaDataInt{};
   if (!itk::ExposeMetaData<int>(metaDict2, "acquisition:TestInt", metaDataInt) || metaDataInt != 4)
   {
     std::cerr << "Failure reading metaData "

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
@@ -119,7 +119,7 @@ protected:
   WritePoints(T * buffer, std::ofstream & outputFile)
   {
     Indent        indent(1);
-    SizeValueType index = itk::NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType index{};
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfPoints; ++ii)
     {
@@ -137,7 +137,7 @@ protected:
   WriteCells(T * buffer, std::ofstream & outputFile)
   {
     Indent        indent(7);
-    SizeValueType index = itk::NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType index{};
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -235,7 +235,7 @@ BYUMeshIO::ReadCells(void * buffer)
   inputFile.precision(12);
   auto *        data = static_cast<unsigned int *>(buffer);
   SizeValueType numPoints = 0;
-  SizeValueType id = itk::NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType id{};
   SizeValueType index = 2;
   int           ptId;
   m_FirstCellId -= 1;

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -738,8 +738,8 @@ protected:
   {
     if (input && output)
     {
-      SizeValueType inputIndex = itk::NumericTraits<SizeValueType>::ZeroValue();
-      SizeValueType outputIndex = itk::NumericTraits<SizeValueType>::ZeroValue();
+      SizeValueType inputIndex{};
+      SizeValueType outputIndex{};
 
       for (SizeValueType ii = 0; ii < m_NumberOfCells; ++ii)
       {

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
@@ -116,7 +116,7 @@ protected:
   void
   WritePoints(T * buffer, std::ofstream & outputFile)
   {
-    SizeValueType index = itk::NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType index{};
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfPoints; ++ii)
     {
@@ -133,7 +133,7 @@ protected:
   void
   WriteCells(T * buffer, std::ofstream & outputFile)
   {
-    SizeValueType index = itk::NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType index{};
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfCells; ++ii)
     {
@@ -154,7 +154,7 @@ protected:
   void
   WritePointData(T * buffer, std::ofstream & outputFile)
   {
-    SizeValueType index = itk::NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType index{};
 
     for (SizeValueType ii = 0; ii < this->m_NumberOfPointPixels; ++ii)
     {

--- a/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
@@ -65,7 +65,7 @@ itkRawImageIOTest3(int argc, char * argv[])
 
   ImageIteratorType ii(image, region);
 
-  PixelType value = itk::NumericTraits<PixelType>::ZeroValue();
+  PixelType value{};
   ii.GoToBegin();
   while (!ii.IsAtEnd())
   {

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -76,7 +76,7 @@ public:
     it.SetDirection(0);
 
 
-    PixelType value = itk::NumericTraits<PixelType>::ZeroValue();
+    PixelType value{};
     while (!it.IsAtEnd())
     {
       while (!it.IsAtEndOfLine())
@@ -121,7 +121,7 @@ itkRawImageIOTest4(int argc, char * argv[])
   using ComponentType = itk::PixelTraits<PixelType>::ValueType;
   using ByteSwapperType = itk::ByteSwapper<ComponentType>;
 
-  PixelType    value = itk::NumericTraits<PixelType>::ZeroValue();
+  PixelType    value{};
   unsigned int numberOfPixels = dims[0] * dims[1];
 
 

--- a/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
@@ -54,7 +54,7 @@ public:
     m_Image->SetRegions(region);
     m_Image->Allocate();
 
-    PixelType value = itk::NumericTraits<PixelType>::ZeroValue();
+    PixelType value{};
 
     // Fill the image with incremental values.
     using IteratorType = itk::ImageRegionIterator<ImageType>;

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -45,8 +45,6 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
   typename ImageType::RegionType region;
   typename ImageType::IndexType  index;
 
-  PixelType pixelValue;
-
   itk::TimeProbesCollectorBase chronometer;
 
   {
@@ -82,7 +80,7 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
     IteratorType itr(image, region);
     itr.GoToBegin();
 
-    pixelValue = itk::NumericTraits<PixelType>::ZeroValue();
+    PixelType pixelValue{};
 
     chronometer.Start("Initializing");
     while (!itr.IsAtEnd())
@@ -129,7 +127,7 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
 
   std::cout << "Comparing the pixel values..." << std::endl;
 
-  pixelValue = itk::NumericTraits<PixelType>::ZeroValue();
+  PixelType pixelValue{};
 
   chronometer.Start("Compare");
   while (!ritr.IsAtEnd())

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -182,7 +182,7 @@ auto
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const
   -> OutputType
 {
-  OutputType gradientMagnitude = itk::NumericTraits<OutputType>::ZeroValue();
+  OutputType gradientMagnitude{};
   OutputType temp;
 
   for (unsigned int i = 0; i < m_KernelArray.Size(); ++i)

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -102,7 +102,7 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, GridForwardWarpImageFilter, ImageToImageFilter);
 
-  FilterType::PixelType backgroundValue = itk::NumericTraits<FilterType::PixelType>::ZeroValue();
+  FilterType::PixelType backgroundValue{};
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
@@ -123,7 +123,7 @@ itkMultiphaseSparseFiniteDifferenceImageFilterTest(int, char *[])
 
   using ValueType = typename FilterType::ValueType;
 
-  ValueType isoSurfaceValue = itk::NumericTraits<ValueType>::ZeroValue();
+  ValueType isoSurfaceValue{};
   filter->SetIsoSurfaceValue(isoSurfaceValue);
   ITK_TEST_SET_GET_VALUE(isoSurfaceValue, filter->GetIsoSurfaceValue());
 

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -60,7 +60,7 @@ ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::A
     this->EstimateLearningRate();
   }
 
-  TInternalComputationValueType gamma = itk::NumericTraits<TInternalComputationValueType>::ZeroValue();
+  TInternalComputationValueType gamma{};
   TInternalComputationValueType gammaDenom = inner_product(this->m_LastGradient, this->m_LastGradient);
   if (gammaDenom > itk::NumericTraits<TInternalComputationValueType>::epsilon())
   {

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -144,7 +144,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::GenerateData()
   typename TSample::AbsoluteFrequencyType frequency;
 
   using TotalAbsoluteFrequencyType = typename TSample::TotalAbsoluteFrequencyType;
-  TotalAbsoluteFrequencyType totalFrequency = itk::NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+  TotalAbsoluteFrequencyType totalFrequency{};
 
   typename TSample::ConstIterator iter = input->Begin();
   typename TSample::ConstIterator end = input->End();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -122,7 +122,7 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   MetricType::MeasureType    valueReturn1;
   MetricType::DerivativeType derivativeReturn;
 
-  MetricType::MeasureType sum = itk::NumericTraits<MetricType::MeasureType>::ZeroValue();
+  MetricType::MeasureType sum{};
   for (int r = 0; r < numberOfReps; ++r)
   {
     metric->GetValueAndDerivative(valueReturn1, derivativeReturn);

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -124,8 +124,8 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
   }
 
   // Evaluate individually
-  MeasureType                     metricValue = itk::NumericTraits<MeasureType>::ZeroValue();
-  MeasureType                     weightedMetricValue = itk::NumericTraits<MeasureType>::ZeroValue();
+  MeasureType                     metricValue{};
+  MeasureType                     weightedMetricValue{};
   MultiMetricType::DerivativeType metricDerivative;
   MultiMetricType::DerivativeType DerivResultOfGetValueAndDerivativeTruth(multiVariateMetric->GetNumberOfParameters());
   DerivResultOfGetValueAndDerivativeTruth.Fill(itk::NumericTraits<MultiMetricType::DerivativeValueType>::ZeroValue());

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -51,7 +51,7 @@ template <typename TInput>
 class SimilarVectorsFunctor
 {
 public:
-  SimilarVectorsFunctor() { m_Threshold = itk::NumericTraits<typename TInput::ValueType>::ZeroValue(); }
+  SimilarVectorsFunctor() = default;
 
   ~SimilarVectorsFunctor() = default;
 
@@ -87,7 +87,7 @@ public:
   }
 
 protected:
-  typename TInput::ValueType m_Threshold;
+  typename TInput::ValueType m_Threshold{};
 };
 } // end namespace Functor
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -89,7 +89,7 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   }
   ITK_TEST_SET_GET_BOOLEAN(filter, FullyConnected, fullyConnected);
 
-  auto backgroundValue = itk::NumericTraits<typename FilterType::OutputPixelType>::ZeroValue();
+  typename FilterType::OutputPixelType backgroundValue{};
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -158,7 +158,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType>(*inputImage, IndexType(), neighborhoodOffsets);
 
-    InputRealType sumOfSquares = itk::NumericTraits<InputRealType>::ZeroValue();
+    InputRealType sumOfSquares{};
 
     typename SeedsContainerType::const_iterator si = m_Seeds.begin();
     typename SeedsContainerType::const_iterator li = m_Seeds.end();
@@ -199,8 +199,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
   else
   {
-    InputRealType sum = itk::NumericTraits<InputRealType>::ZeroValue();
-    InputRealType sumOfSquares = itk::NumericTraits<InputRealType>::ZeroValue();
+    InputRealType sum{};
+    InputRealType sumOfSquares{};
 
     typename SeedsContainerType::const_iterator si = m_Seeds.begin();
     typename SeedsContainerType::const_iterator li = m_Seeds.end();

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -67,7 +67,7 @@ RGBImageTotalAbsDifference(const itk::Image<itk::RGBPixel<TPixelValue>, VDimensi
       return 1;
     }
 
-    TPixelValue localDiff = itk::NumericTraits<TPixelValue>::ZeroValue();
+    TPixelValue localDiff{};
 
     for (unsigned int i = 0; i < 3; ++i)
     {


### PR DESCRIPTION
Prefer to use standard C++ language initializers to the itk::NumericValues<>::ZeroValue() initializers.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
