### PR TITLE
Remove unnecessary and duplicate iterator `GoToBegin()` calls from Modules/Filtering

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -555,7 +555,6 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImag
   this->GetBiasFieldSize(region, biasSize);
 
   bIter.Begin();
-  iIter.GoToBegin();
   if (m_OutputMask.IsNotNull())
   {
     itkDebugMacro(<< "Output mask is being used");
@@ -802,8 +801,6 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::Log1PImage(
   ImageRegionIterator<InternalImageType> t_iter(target, region);
 
   InternalImagePixelType pixel;
-  s_iter.GoToBegin();
-  t_iter.GoToBegin();
   while (!s_iter.IsAtEnd())
   {
     pixel = s_iter.Get();
@@ -833,9 +830,6 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::ExpImage(In
 
   ImageRegionIterator<InternalImageType> s_iter(source, region);
   ImageRegionIterator<InternalImageType> t_iter(target, region);
-
-  s_iter.GoToBegin();
-  t_iter.GoToBegin();
 
   double temp;
   while (!s_iter.IsAtEnd())

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -390,7 +390,6 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
   // iterator on output image
   ImageRegionIteratorWithIndex<OutputImageType> ouRegIndexIt(output, outputRegion);
-  ouRegIndexIt.GoToBegin();
 
   // InputRegionForThread is the output region for thread padded by
   // kerne lradius We must traverse this padded region because some

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -384,7 +384,6 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
   // iterator on output image
   ImageRegionIteratorWithIndex<OutputImageType> ouRegIndexIt(output, outputRegion);
-  ouRegIndexIt.GoToBegin();
 
   // InputRegionForThread is the output region for thread padded by
   // kerne lradius We must traverse this padded region because some

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -140,8 +140,6 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   // iterator on output image
   ImageRegionIterator<OutputImageType> outIt =
     ImageRegionIterator<OutputImageType>(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
-  outIt.GoToBegin();
-  inIt.GoToBegin();
 
   ProgressReporter progress2(this, 0, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels(), 20, 0.9, 0.1);
   while (!outIt.IsAtEnd())

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -120,7 +120,6 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   ImageRegionIterator<BoolImageType> kernelImageIt; // iterator on image
   kernelImageIt = ImageRegionIterator<BoolImageType>(tmpSEImage, tmpSEImage->GetRequestedRegion());
 
-  kernelImageIt.GoToBegin();
   kernel_it = KernelBegin;
 
   while (!kernelImageIt.IsAtEnd())
@@ -157,7 +156,6 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   // iterator. use the "image" iterator to keep track of
   // components. use the kernel iterator for quick access of offsets
   kernel_it = KernelBegin;
-  kernelImageItIndex.GoToBegin();
   while (!kernelImageItIndex.IsAtEnd())
   {
     // If a ON element is found track the CC

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -68,9 +68,6 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
   ImageRegionIterator<TOutputImage>     ot(pruneImage, region);
 
-  it.GoToBegin();
-  ot.GoToBegin();
-
   itkDebugMacro(<< "PrepareData: Copy input to output");
 
   while (!ot.IsAtEnd())

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -69,9 +69,6 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
   ImageRegionIterator<TOutputImage>     ot(thinImage, region);
 
-  it.GoToBegin();
-  ot.GoToBegin();
-
   itkDebugMacro(<< "PrepareData: Copy input to output");
 
   // Copy the input to the output, changing all foreground pixels to

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -113,8 +113,6 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
   oRegIter = ImageRegionIterator<OutputImageType>(this->GetOutput(), outputRegionForThread);
   /* Copy the input image to the output image - then only boundary pixels
    * need to be changed in the output image */
-  iRegIter.GoToBegin();
-  oRegIter.GoToBegin();
   while (!oRegIter.IsAtEnd())
   {
     if (Math::NotExactlyEquals(oRegIter.Get(), m_ObjectValue))

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -113,9 +113,6 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
   ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageRegionIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   while (!inputIt.IsAtEnd())
   {
     outputIt.Set(this->m_Colormap->operator()(inputIt.Get()));

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -172,7 +172,6 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   typename OutputImageType::Pointer outputImage = static_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 
   ImageRegionIterator<OutputImageType> oit(outputImage, outputRegionForThread);
-  oit.GoToBegin();
 
   vnl_vector<double> B(m_NumberOfGradientDirections);
   vnl_vector<double> D(6);

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -156,7 +156,6 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
   unsigned int landmarkId = 0;
 
   IteratorType ot(sampledInput, subsampledRegion);
-  ot.GoToBegin();
 
   OutputPixelType               value;
   Point<double, ImageDimension> sourcePoint;
@@ -232,8 +231,6 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Support for progress methods/callbacks
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
-
-  outIt.GoToBegin();
 
   // Walk the output region
   while (!outIt.IsAtEnd())

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -134,8 +134,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
   // Support for progress methods/callbacks
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
 
-  outIt.GoToBegin();
-
   // Walk the output region
   while (!outIt.IsAtEnd())
   {

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -191,7 +191,6 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   // Walk the output region
-  outIt.GoToBegin();
   while (!outIt.IsAtEnd())
   {
     while (!outIt.IsAtEndOfLine())

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -129,9 +129,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
   ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, region);
   ImageRegionIteratorWithIndex<VoronoiImageType>    ot(voronoiMap, region);
 
-  it.GoToBegin();
-  ot.GoToBegin();
-
   itkDebugMacro(<< "PrepareData: Copy input to output");
   if (m_InputIsBinary)
   {
@@ -187,7 +184,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
   // Wherever the input image is non-zero, initialize the distanceComponents image to the minValue.
   // Wherever the input image is zero, initialize the distanceComponents image to the maxValue.
   it.GoToBegin();
-  ct.GoToBegin();
   while (!it.IsAtEnd())
   {
     if (it.Get())
@@ -220,9 +216,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Comp
   ImageRegionIteratorWithIndex<OutputImageType>  dt(distanceMap, region);
 
   itkDebugMacro(<< "ComputeVoronoiMap Region: " << region);
-  ot.GoToBegin();
-  ct.GoToBegin();
-  dt.GoToBegin();
   while (!ot.IsAtEnd())
   {
     IndexType index = ct.GetIndex() + ct.Get();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -146,8 +146,6 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * 
   PixelType outputPixel;
   outputPixel = m_LargeValue;
 
-  outIt.GoToBegin();
-
   while (!outIt.IsAtEnd())
   {
     outIt.Set(outputPixel);
@@ -159,8 +157,6 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * 
 
   LabelIterator typeIt(m_LabelImage, m_LabelImage->GetBufferedRegion());
 
-
-  typeIt.GoToBegin();
   while (!typeIt.IsAtEnd())
   {
     typeIt.Set(LabelEnum::FarPoint);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
@@ -76,8 +76,6 @@ FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::InitializeOutput(Out
   using GradientPixelValueType = typename GradientPixelType::ValueType;
   zeroGradient.Fill(NumericTraits<GradientPixelValueType>::ZeroValue());
 
-  gradientIt.GoToBegin();
-
   while (!gradientIt.IsAtEnd())
   {
     gradientIt.Set(zeroGradient);

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
@@ -66,10 +66,6 @@ CheckerBoardImageFilter<TImage>::DynamicThreadedGenerateData(const ImageRegionTy
   InputIterator  in1Itr(input1Ptr, outputRegionForThread);
   InputIterator  in2Itr(input2Ptr, outputRegionForThread);
 
-  outItr.GoToBegin();
-  in1Itr.GoToBegin();
-  in2Itr.GoToBegin();
-
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   typename InputImageType::SizeType size = input2Ptr->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
@@ -114,7 +114,6 @@ ComposeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const
   TotalProgressReporter progress(this, outputImage->GetRequestedRegion().GetNumberOfPixels());
 
   ImageRegionIterator<OutputImageType> oit(outputImage, outputRegionForThread);
-  oit.GoToBegin();
 
   InputIteratorContainerType inputItContainer;
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -282,10 +282,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::HysteresisThresholding
   // fix me
   ImageRegionIterator<TOutputImage> oit(input, input->GetRequestedRegion());
 
-  oit.GoToBegin();
-
   ImageRegionIterator<TOutputImage> uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
-  uit.GoToBegin();
   while (!uit.IsAtEnd())
   {
     uit.Value() = NumericTraits<OutputImagePixelType>::ZeroValue();

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -129,10 +129,6 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::InitIn
 
   InputImageIterator CIt(m_CImage, m_CImage->GetBufferedRegion());
 
-  BIt.GoToBegin();
-  CIt.GoToBegin();
-  inputIt.GoToBegin();
-
   /* Calculate b(x, y), c1(x, y), c2(x, y), etc.... (eqn 15) */
   while (!inputIt.IsAtEnd())
   {
@@ -197,11 +193,6 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::Update
   InputImageConstIterator CIt(m_CImage, m_CImage->GetBufferedRegion());
 
   InternalImageConstIterator BIt(m_BImage, m_BImage->GetBufferedRegion());
-
-  outputIt.GoToBegin();
-  intermediateIt.GoToBegin();
-  BIt.GoToBegin();
-  CIt.GoToBegin();
 
   while (!outputIt.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -58,8 +58,6 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
   ImageRegionIterator<OutputImageType> oit;
   this->AllocateOutputs();
   oit = ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());
-  oit.GoToBegin();
-  it.GoToBegin();
   while (!it.IsAtEnd())
   {
     // Get the eigen value

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -67,9 +67,6 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
   ImageRegionConstIterator<InputImageType> it(input, outputRegionForThread);
   ImageRegionIterator<OutputImageType>     oit(output, outputRegionForThread);
 
-  oit.GoToBegin();
-  it.GoToBegin();
-
   while (!it.IsAtEnd())
   {
     // Compute eigen values

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -106,7 +106,6 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   m_RadiusImage->Allocate(true); // initialize buffer to zero
 
   ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
-  image_it.GoToBegin();
 
   const ImageRegion<2> & region = outputImage->GetRequestedRegion();
 
@@ -164,8 +163,6 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   // Compute the average radius
   ImageRegionConstIterator<OutputImageType> output_it(outputImage, outputImage->GetLargestPossibleRegion());
   ImageRegionIterator<RadiusImageType>      radius_it(m_RadiusImage, m_RadiusImage->GetLargestPossibleRegion());
-  output_it.GoToBegin();
-  radius_it.GoToBegin();
   while (!output_it.IsAtEnd())
   {
     if (output_it.Get() > 1)

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -102,7 +102,6 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GenerateDat
   const double nPI = 4.0 * std::atan(1.0);
 
   ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
-  image_it.GoToBegin();
 
   Index<2> index;
 
@@ -160,7 +159,6 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
   typename OutputImageType::PixelType valuemax;
 
   ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
-  image_it.GoToBegin();
 
   const double nPI = 4.0 * std::atan(1.0);
 
@@ -201,9 +199,6 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
   ImageRegionConstIteratorWithIndex<OutputImageType> accusimple_it(m_SimplifyAccumulator,
                                                                    m_SimplifyAccumulator->GetRequestedRegion());
   ImageRegionIteratorWithIndex<OutputImageType>      accu_it(outputImage, outputImage->GetRequestedRegion());
-
-  accusimple_it.GoToBegin();
-  accu_it.GoToBegin();
 
   while (!accusimple_it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -202,7 +202,6 @@ LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   ImageRegionIterator<OutputImageType> outIt =
     ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());
-  outIt.GoToBegin();
   it.GoToBegin();
   while (!outIt.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -198,10 +198,8 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   // image, therefore we iterate over the desired output region
   OutputRegionType                      outputRegion = this->GetOutput()->GetBufferedRegion();
   ImageRegionIterator<UpdateBufferType> it(m_UpdateBuffer, outputRegion);
-  it.GoToBegin();
 
   ImageRegionIterator<TOutputImage> oit(this->GetOutput(), outputRegion);
-  oit.GoToBegin();
 
   while (!oit.IsAtEnd())
   {
@@ -230,7 +228,6 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   typename HessianImageType::Pointer hessianImage = static_cast<HessianImageType *>(this->ProcessObject::GetOutput(2));
   ImageRegionIterator<HessianImageType> ohit;
 
-  oit.GoToBegin();
   if (m_GenerateScalesOutput)
   {
     osit = ImageRegionIterator<ScalesImageType>(scalesImage, outputRegion);
@@ -246,9 +243,6 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
 
   ImageRegionIterator<HessianToMeasureOutputImageType> it(m_HessianToMeasureFilter->GetOutput(), outputRegion);
   ImageRegionIterator<HessianImageType>                hit(m_HessianFilter->GetOutput(), outputRegion);
-
-  it.GoToBegin();
-  hit.GoToBegin();
 
   while (!oit.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -144,8 +144,6 @@ CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatche
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
   OutputPixelType value{ outputIt.Get() };
   while (!inputIt.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -98,7 +98,6 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   InLineIt.GoToBegin();
   IndexType LineStart;
   // PrevLineStart = InLineIt.GetIndex();
-  InLineIt.GoToBegin();
 
   using HistVecType = typename std::vector<HistogramType>;
   HistVecType HistVec(ImageDimension);

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -54,7 +54,6 @@ MovingHistogramImageFilterBase<TInputImage, TOutputImage, TKernel>::SetKernel(co
   RegionType                                  tmpSEImageRegion = tmpSEImage->GetRequestedRegion();
   ImageRegionIteratorWithIndex<BoolImageType> kernelImageIt;
   kernelImageIt = ImageRegionIteratorWithIndex<BoolImageType>(tmpSEImage, tmpSEImageRegion);
-  kernelImageIt.GoToBegin();
   KernelIteratorType kernel_it = kernel.Begin();
   OffsetListType     kernelOffsets;
 

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -96,8 +96,6 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -785,7 +785,6 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::RefineC
 
   ImageRegionIteratorWithIndex<PointDataImageType> It(refinedLattice, refinedLattice->GetLargestPossibleRegion());
 
-  It.GoToBegin();
   while (!It.IsAtEnd())
   {
     idx = It.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -188,7 +188,6 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  outputIt.GoToBegin();
   while (!outputIt.IsAtEnd())
   {
     // Determine the index of the output line

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -395,8 +395,6 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   using OutputType = typename InterpolatorType::OutputType;
 
   // Walk the output region
-  outIt.GoToBegin();
-
   while (!outIt.IsAtEnd())
   {
     // Determine the index of the current output pixel

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -66,7 +66,6 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->FillBuffer(defaultPixelValue);
 
   ImageRegionIterator<TileImageType> it(m_TileImage, m_TileImage->GetBufferedRegion());
-  it.GoToBegin();
 
   SizeValueType numPastes = 0;
   while (!it.IsAtEnd())
@@ -237,7 +236,6 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // image number to -1.
   ImageRegionIteratorWithIndex<TileImageType> it(m_TileImage, m_TileImage->GetBufferedRegion());
 
-  it.GoToBegin();
   unsigned int input = 0;
   TileInfo     info;
   while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -191,7 +191,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   }
 
   LineIteratorType it(outputImagePtr, startImageIndex, endImageIndex);
-  it.GoToBegin();
 
   while (!it.IsAtEnd())
   {
@@ -221,8 +220,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   /* Mask the input image with the mask generated */
   InputImageConstIteratorType inputI(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
   OutputImageIteratorType     outputI(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
-  inputI.GoToBegin();
-  outputI.GoToBegin();
   while (!outputI.IsAtEnd())
   {
     if (outputI.Get() == f_val)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -436,7 +436,6 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   }
 
   LineIteratorType it(projectionImagePtr, startImageIndex, endImageIndex);
-  it.GoToBegin();
 
   while (!it.IsAtEnd())
   {
@@ -465,8 +464,6 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
 
   // Mask the input image using the binary image defined by the region
   // demarcated by the polyline contour
-  outputIt.GoToBegin();
-  inputIt.GoToBegin();
 
   InputImageSpacingType inputImageSpacing;
   InputImagePointType   inputImageOrigin;

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
@@ -54,8 +54,6 @@ ShiftScaleImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  it.GoToBegin();
-  ot.GoToBegin();
   // do the work
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -56,8 +56,6 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
 
   InputIterator it(inputImage, inputImage->GetBufferedRegion());
 
-  it.GoToBegin();
-
   InputRealType maximumSquaredMagnitude = NumericTraits<InputRealType>::ZeroValue();
 
   while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -131,7 +131,6 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData
   using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
   OutputLineIteratorType outLineIt(output, outputRegionForThread);
 
-  outLineIt.GoToBegin();
   for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine(), outLineIt.NextLine())
   {
     SizeValueType    lineId = this->IndexToLinearIndex(inLineIt.GetIndex());

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -121,7 +121,6 @@ LabelContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
   OutputLineIteratorType outLineIt(output, outputRegionForThread);
 
-  outLineIt.GoToBegin();
   for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine(), outLineIt.NextLine())
   {
     SizeValueType    lineId = this->IndexToLinearIndex(inLineIt.GetIndex());

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -66,9 +66,6 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDat
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -64,9 +64,6 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   while (!inputIt.IsAtEnd())

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -67,9 +67,6 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   while (!inputIt.IsAtEnd())

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -64,9 +64,6 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Choose the value of the gamma distribution so that the mean is 1 and the

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
@@ -56,9 +56,7 @@ PeakSignalToNoiseRatioCalculator<TInputImage>::Compute()
   }
 
   ImageRegionConstIteratorWithIndex<InputImageType> iIt(m_Image, m_Image->GetRequestedRegion());
-  iIt.GoToBegin();
   ImageRegionConstIteratorWithIndex<InputImageType> nIt(m_NoisyImage, m_NoisyImage->GetRequestedRegion());
-  nIt.GoToBegin();
 
   // init the values
   double         mse = 0;

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -102,7 +102,6 @@ GaussianImageSource<TOutputImage>::GenerateData()
 
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());
   // Walk the output image, evaluating the spatial function at each pixel
-  outIt.GoToBegin();
   while (!outIt.IsAtEnd())
   {
     const typename TOutputImage::IndexType index = outIt.GetIndex();

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -170,7 +170,6 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
       AccumulatedSize[i] = 1;
     }
   }
-  outputIter.GoToBegin();
   while (!outputIter.IsAtEnd())
   {
     typename TOutputImage::IndexType OutputIndex = outputIter.GetIndex();

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -133,7 +133,6 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   OutputIterator                       outIter(this->GetOutput(0), region);
 
   unsigned int i = 0;
-  outIter.GoToBegin();
   while (!outIter.IsAtEnd())
   {
     outIter.Set(static_cast<typename OutputImageType::PixelType>(m_Means[i]));

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -188,7 +188,6 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   InLineIt.SetDirection(BestDirection);
   InLineIt.GoToBegin();
   IndexType LineStart;
-  InLineIt.GoToBegin();
 
   using HistVecType = typename std::vector<HistogramType>;
   HistVecType HistVec(ImageDimension);

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -80,8 +80,6 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
 
   InputIterator  inIt(input, output->GetRequestedRegion());
   OutputIterator outIt(output, output->GetRequestedRegion());
-  inIt.GoToBegin();
-  outIt.GoToBegin();
 
   InputImagePixelType firstValue = inIt.Get();
   this->m_Flat = true;


### PR DESCRIPTION
When an iterator is just constructed, it is usually already at its begin position.