### PR TITLE
STYLE: Move ITK iterator declarations into init-statement of `for` loops

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -107,12 +107,11 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (IRIType it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {
@@ -132,13 +131,12 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
   bool found = false;
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (IRIType it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -117,12 +117,11 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (IRIType it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {
@@ -142,13 +141,12 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
 {
   // Create an iterator that will walk the input image
   using IRIType = typename itk::ImageRegionConstIterator<TImage>;
-  IRIType it(this->m_Image, this->m_Image->GetBufferedRegion());
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
   bool found = false;
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (IRIType it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -116,9 +116,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::EvaluateAtContinuousInd
   dsum_me.Fill(0.0);
   dw.Fill(0.0);
 
-
-  ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region);
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
   {
     unsigned int j = It.GetIndex()[0] - region.GetIndex()[0];
     RealType     w = erfArray[0][j];

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -60,8 +60,7 @@ LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordRep, TPixelCompare
   using WeightMapType = std::map<OutputType, RealType, TPixelCompare>;
   WeightMapType weightMap;
 
-  ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region);
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
   {
     unsigned int j = It.GetIndex()[0] - region.GetIndex()[0];
     RealType     w = erfArray[0][j];

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -590,9 +590,9 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Comp
 
   SizeValueType numberOfParametersPerDimension = this->GetNumberOfParametersPerDimension();
 
-  ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion);
-  unsigned long                                counter = 0;
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  unsigned long counter = 0;
+  for (ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd();
+       ++It)
   {
     typename ImageType::OffsetType currentIndex = It.GetIndex() - startIndex;
 

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -641,9 +641,9 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::ComputeJacobia
 
   SizeValueType numberOfParametersPerDimension = this->GetNumberOfParametersPerDimension();
 
-  ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion);
-  unsigned long                                counter = 0;
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  unsigned long counter = 0;
+  for (ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd();
+       ++It)
   {
     typename ImageType::OffsetType currentIndex = It.GetIndex() - startIndex;
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -485,9 +485,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
   typename WeightsImageType::IndexType centerIndex;
   centerIndex.Fill(patchRadius);
 
-  ImageRegionIteratorWithIndex<WeightsImageType> pwIt(physicalWeightsImage, physicalRegion);
-  unsigned int                                   pos = 0;
-  for (pwIt.GoToBegin(); !pwIt.IsAtEnd(); ++pwIt)
+  unsigned int pos = 0;
+  for (ImageRegionIteratorWithIndex<WeightsImageType> pwIt(physicalWeightsImage, physicalRegion); !pwIt.IsAtEnd();
+       ++pwIt)
   {
     typename WeightsImageType::IndexType curIndex;
     curIndex = pwIt.GetIndex();

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -62,9 +62,8 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
   negField->Allocate();
 
   InputConstIterator InputIt(inputPtr, inputPtr->GetRequestedRegion());
-  InputIterator      negImageIt(negField, negField->GetRequestedRegion());
 
-  for (negImageIt.GoToBegin(); !negImageIt.IsAtEnd(); ++negImageIt)
+  for (InputIterator negImageIt(negField, negField->GetRequestedRegion()); !negImageIt.IsAtEnd(); ++negImageIt)
   {
     negImageIt.Set(-InputIt.Get());
     ++InputIt;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -145,9 +145,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
   typename DisplacementFieldType::Pointer outputField = this->GetOutput();
 
-  ImageRegionIteratorWithIndex<DisplacementFieldType> It(outputField, region);
-
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<DisplacementFieldType> It(outputField, region); !It.IsAtEnd(); ++It)
   {
     PointType point;
     outputField->TransformIndexToPhysicalPoint(It.GetIndex(), point);

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
@@ -71,8 +71,8 @@ VnlForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   vnlfft.transform(signal.data_block(), -1);
 
   // Copy the VNL output back to the ITK image.
-  ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion());
-  for (oIt.GoToBegin(); !oIt.IsAtEnd(); ++oIt)
+  for (ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd();
+       ++oIt)
   {
     typename OutputImageType::IndexType       index = oIt.GetIndex();
     typename OutputImageType::OffsetValueType offset = inputPtr->ComputeOffset(index);

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -64,12 +64,13 @@ VnlHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Generate
 
   // VNL requires the full complex result of the transform, so we
   // produce it here from the half complex image assumed when the output is real.
-  SignalVectorType                              signal(vectorSize);
-  ImageRegionIteratorWithIndex<OutputImageType> oIt(outputPtr, outputPtr->GetLargestPossibleRegion());
+  SignalVectorType signal(vectorSize);
 
   OutputIndexValueType maxXIndex = inputIndex[0] + static_cast<OutputIndexValueType>(inputSize[0]);
   unsigned int         si = 0;
-  for (oIt.GoToBegin(); !oIt.IsAtEnd(); ++oIt)
+  for (ImageRegionIteratorWithIndex<OutputImageType> oIt(outputPtr, outputPtr->GetLargestPossibleRegion());
+       !oIt.IsAtEnd();
+       ++oIt)
   {
     typename OutputImageType::IndexType index = oIt.GetIndex();
     if (index[0] >= maxXIndex)

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -71,8 +71,8 @@ VnlRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::Generate
   vnlfft.transform(signal.data_block(), -1);
 
   // Copy the VNL output back to the ITK image.
-  ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion());
-  for (oIt.GoToBegin(); !oIt.IsAtEnd(); ++oIt)
+  for (ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd();
+       ++oIt)
   {
     typename OutputImageType::IndexType       index = oIt.GetIndex();
     typename OutputImageType::OffsetValueType offset = inputPtr->ComputeOffset(index);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -231,8 +231,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
     epsilon[i] = r * this->m_Spacing[i] * this->m_BSplineEpsilon;
   }
 
-  ImageRegionIteratorWithIndex<OutputImageType> It(outputPtr, region);
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<OutputImageType> It(outputPtr, region); !It.IsAtEnd(); ++It)
   {
     typename OutputImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -278,9 +277,10 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::CollapsePhiLattice(Po
                                                                               const RealType       u,
                                                                               const unsigned int   dimension)
 {
-  ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice, collapsedLattice->GetLargestPossibleRegion());
-
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice,
+                                                           collapsedLattice->GetLargestPossibleRegion());
+       !It.IsAtEnd();
+       ++It)
   {
     PointDataType data;
     data.Fill(0.0);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -238,9 +238,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTy
   OutputType data;
   data.Fill(0.0);
 
-  ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
-                                                  this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
-  for (ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW)
+  for (ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
+                                                       this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
+       !ItW.IsAtEnd();
+       ++ItW)
   {
     CoordRepType                      B = 1.0;
     typename RealImageType::IndexType idx = ItW.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -614,8 +614,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
   typename ImageType::IndexType          startIndex = this->GetOutput()->GetRequestedRegion().GetIndex();
   typename PointDataImageType::IndexType startPhiIndex = this->m_PhiLattice->GetLargestPossibleRegion().GetIndex();
 
-  ImageRegionIteratorWithIndex<ImageType> It(this->GetOutput(), region);
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<ImageType> It(this->GetOutput(), region); !It.IsAtEnd(); ++It)
   {
     typename ImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -1004,9 +1003,10 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Collaps
   const RealType       u,
   const unsigned int   dimension)
 {
-  ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice, collapsedLattice->GetLargestPossibleRegion());
-
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice,
+                                                           collapsedLattice->GetLargestPossibleRegion());
+       !It.IsAtEnd();
+       ++It)
   {
     PointDataType data;
     data.Fill(0.0);

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -63,8 +63,8 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 
   // Now iterate over the pixels of the output region for this thread.
-  ImageRegionIteratorWithIndex<OutputImageType> outIt(this->GetOutput(), outputRegionForThread);
-  for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex<OutputImageType> outIt(this->GetOutput(), outputRegionForThread); !outIt.IsAtEnd();
+       ++outIt)
   {
     IndexType index = outIt.GetIndex();
 

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -206,13 +206,12 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
 
   // Setup output region iterator
   using OutputIterator = ImageRegionIteratorWithIndex<TImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
   typename TImage::IndexType outputIndex;
   typename TImage::IndexType inputIndex;
 
   // walk the output region, and sample the input image
-  for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // determine the index of the output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -55,14 +55,12 @@ GaborImageSource<TOutputImage>::GenerateData()
   gabor->SetPhaseOffset(this->m_PhaseOffset);
   gabor->SetCalculateImaginaryPart(this->m_CalculateImaginaryPart);
 
-  // Create an iterator that will walk the output region
-  ImageRegionIteratorWithIndex<OutputImageType> outIt(outputPtr, outputPtr->GetRequestedRegion());
-
-
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Walk the output image, evaluating the spatial function at each pixel
-  for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex<OutputImageType> outIt(outputPtr, outputPtr->GetRequestedRegion());
+       !outIt.IsAtEnd();
+       ++outIt)
   {
     const typename OutputImageType::IndexType index = outIt.GetIndex();
     // The position at which the function is evaluated

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -95,9 +95,7 @@ GridImageSource<TOutputImage>::DynamicThreadedGenerateData(const ImageRegionType
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageRegionIteratorWithIndex<ImageType> It(output, outputRegionForThread);
-
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex<ImageType> It(output, outputRegionForThread); !It.IsAtEnd(); ++It)
   {
     RealType                      val = 1.0;
     typename ImageType::IndexType index = It.GetIndex();

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -175,8 +175,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateData()
   interpolator->SetInputImage(inputImagePtr);
 
   // Iterate through the output image
-  OutputIterator outputIt(outputPtr, outputPtr->GetRequestedRegion());
-  for (outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt)
+  for (OutputIterator outputIt(outputPtr, outputPtr->GetRequestedRegion()); !outputIt.IsAtEnd(); ++outputIt)
   {
     index = outputIt.GetIndex();
 

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -265,14 +265,12 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   OutputImage->SetOrigin(origin); //   and origin
   OutputImage->Allocate();        // allocate the image
 
-  ImageRegionIteratorWithIndex<OutputImageType> imageIt(OutputImage, region);
-  for (imageIt.GoToBegin(); !imageIt.IsAtEnd(); ++imageIt)
+  for (ImageRegionIteratorWithIndex<OutputImageType> imageIt(OutputImage, region); !imageIt.IsAtEnd(); ++imageIt)
   {
     imageIt.Set(m_BackgroundValue);
   }
 
-  PathIterator<OutputImageType, InputPathType> pathIt(OutputImage, InputPath);
-  for (pathIt.GoToBegin(); !pathIt.IsAtEnd(); ++pathIt)
+  for (PathIterator<OutputImageType, InputPathType> pathIt(OutputImage, InputPath); !pathIt.IsAtEnd(); ++pathIt)
   {
     pathIt.Set(m_PathValue);
   }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -197,12 +197,10 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, 
   auto * output = static_cast<HistogramType *>(this->ProcessObject::GetOutput(0));
 
   using NeighborhoodIteratorType = ConstNeighborhoodIterator<ImageType>;
-  NeighborhoodIteratorType neighborIt;
-  neighborIt = NeighborhoodIteratorType(radius, input, region);
 
   MeasurementVectorType cooccur(output->GetMeasurementVectorSize());
 
-  for (neighborIt.GoToBegin(); !neighborIt.IsAtEnd(); ++neighborIt)
+  for (NeighborhoodIteratorType neighborIt(radius, input, region); !neighborIt.IsAtEnd(); ++neighborIt)
   {
     const PixelType centerPixelIntensity = neighborIt.GetCenterPixel();
     if (centerPixelIntensity < m_Min || centerPixelIntensity > m_Max)

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
@@ -32,8 +32,7 @@ JointHistogramMutualInformationComputeJointPDFThreader<
   VirtualPointType virtualPoint;
   VirtualIndexType virtualIndex;
   using IteratorType = ImageRegionConstIteratorWithIndex<VirtualImageType>;
-  IteratorType it(this->m_Associate->GetVirtualImage(), imageSubRegion);
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (IteratorType it(this->m_Associate->GetVirtualImage(), imageSubRegion); !it.IsAtEnd(); ++it)
   {
     virtualIndex = it.GetIndex();
     this->m_Associate->TransformVirtualIndexToPhysicalPoint(virtualIndex, virtualPoint);

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -631,10 +631,10 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   gradientField->SetRegions(virtualDomainImage->GetRequestedRegion());
   gradientField->Allocate();
 
-  ImageRegionIterator<DisplacementFieldType> ItG(gradientField, gradientField->GetRequestedRegion());
-
   SizeValueType count = 0;
-  for (ItG.GoToBegin(); !ItG.IsAtEnd(); ++ItG)
+  for (ImageRegionIterator<DisplacementFieldType> ItG(gradientField, gradientField->GetRequestedRegion());
+       !ItG.IsAtEnd();
+       ++ItG)
   {
     DisplacementVectorType displacement;
     for (SizeValueType d = 0; d < ImageDimension; ++d)
@@ -657,11 +657,12 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtualImage, TPointSet>::ScaleUpdateField(
     const DisplacementFieldType * updateField)
 {
-  typename DisplacementFieldType::SpacingType     spacing = updateField->GetSpacing();
-  ImageRegionConstIterator<DisplacementFieldType> ItF(updateField, updateField->GetLargestPossibleRegion());
+  typename DisplacementFieldType::SpacingType spacing = updateField->GetSpacing();
 
   RealType maxNorm = NumericTraits<RealType>::NonpositiveMin();
-  for (ItF.GoToBegin(); !ItF.IsAtEnd(); ++ItF)
+  for (ImageRegionConstIterator<DisplacementFieldType> ItF(updateField, updateField->GetLargestPossibleRegion());
+       !ItF.IsAtEnd();
+       ++ItF)
   {
     DisplacementVectorType vector = ItF.Get();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -779,10 +779,11 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   typename DisplacementFieldType::IndexType gradientFieldIndex = gradientField->GetRequestedRegion().GetIndex();
   typename DisplacementFieldType::SizeType  gradientFieldSize = gradientField->GetRequestedRegion().GetSize();
 
-  ImageRegionConstIteratorWithOnlyIndex<DisplacementFieldType> ItG(gradientField, gradientField->GetRequestedRegion());
-
   SizeValueType localCount = 0;
-  for (ItG.GoToBegin(); !ItG.IsAtEnd(); ++ItG)
+  for (ImageRegionConstIteratorWithOnlyIndex<DisplacementFieldType> ItG(gradientField,
+                                                                        gradientField->GetRequestedRegion());
+       !ItG.IsAtEnd();
+       ++ItG)
   {
     typename DisplacementFieldType::IndexType index = ItG.GetIndex();
 

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -106,8 +106,7 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   std::vector<unsigned int> votesByLabel(this->m_TotalLabelCount);
 
-  OutIteratorType out(output, outputRegionForThread);
-  for (out.GoToBegin(); !out.IsAtEnd(); ++out)
+  for (OutIteratorType out(output, outputRegionForThread); !out.IsAtEnd(); ++out)
   {
     // Reset number of votes per label for all labels
     std::fill_n(votesByLabel.begin(), this->m_TotalLabelCount, 0);

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -378,9 +378,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     it[k].GoToBegin();
   }
 
-  // reset output iterator to start
-  OutputIteratorType out(output, output->GetRequestedRegion());
-  for (out.GoToBegin(); !out.IsAtEnd(); ++out)
+  for (OutputIteratorType out(output, output->GetRequestedRegion()); !out.IsAtEnd(); ++out)
   {
     // basically, we'll repeat the E step from above
     for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -342,8 +342,6 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
 
   NeighborhoodIterator<OutputImageType> shiftedIt(
     m_NeighborList.GetRadius(), m_ShiftedImage, m_OutputImage->GetRequestedRegion());
-  NeighborhoodIterator<OutputImageType> outputIt(
-    m_NeighborList.GetRadius(), m_OutputImage, m_OutputImage->GetRequestedRegion());
   NeighborhoodIterator<StatusImageType> statusIt(
     m_NeighborList.GetRadius(), m_StatusImage, m_OutputImage->GetRequestedRegion());
 
@@ -357,7 +355,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
   typename OutputImageType::IndexType startIndex = m_OutputImage->GetRequestedRegion().GetIndex();
   using StartIndexValueType = IndexValueType;
 
-  for (outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt)
+  for (NeighborhoodIterator<OutputImageType> outputIt(
+         m_NeighborList.GetRadius(), m_OutputImage, m_OutputImage->GetRequestedRegion());
+       !outputIt.IsAtEnd();
+       ++outputIt)
   {
     bounds_status = true;
     if (Math::ExactlyEquals(outputIt.GetCenterPixel(), m_ValueZero))

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -658,8 +658,6 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
   //
   NeighborhoodIterator<OutputImageType> shiftedIt(
     m_NeighborList.GetRadius(), m_ShiftedImage, this->m_OutputImage->GetRequestedRegion());
-  NeighborhoodIterator<OutputImageType> outputIt(
-    m_NeighborList.GetRadius(), this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
   NeighborhoodIterator<StatusImageType> statusIt(
     m_NeighborList.GetRadius(), m_StatusImage, this->m_OutputImage->GetRequestedRegion());
   IndexType       center_index, offset_index;
@@ -673,7 +671,10 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
   upperBounds =
     this->m_OutputImage->GetRequestedRegion().GetIndex() + this->m_OutputImage->GetRequestedRegion().GetSize();
 
-  for (outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt)
+  for (NeighborhoodIterator<OutputImageType> outputIt(
+         m_NeighborList.GetRadius(), this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
+       !outputIt.IsAtEnd();
+       ++outputIt)
   {
     if (Math::ExactlyEquals(outputIt.GetCenterPixel(), m_ValueZero))
     {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
@@ -42,9 +42,8 @@ LevelSetDomainPartitionImage<TImage>::PopulateListDomain()
   this->AllocateListDomain();
 
   const ListRegionType & region = this->m_ListDomain->GetLargestPossibleRegion();
-  ListIteratorType       lIt(this->m_ListDomain, region);
 
-  for (lIt.GoToBegin(); !lIt.IsAtEnd(); ++lIt)
+  for (ListIteratorType lIt(this->m_ListDomain, region); !lIt.IsAtEnd(); ++lIt)
   {
     ListIndexType      listIndex = lIt.GetIndex();
     IdentifierListType identifierList;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
@@ -48,9 +48,7 @@ LevelSetDomainPartitionImageWithKdTree<TImage>::PopulateDomainWithKdTree()
 
   const ListRegionType region = this->m_ListDomain->GetLargestPossibleRegion();
 
-  ListIteratorType lIt(this->m_ListDomain, region);
-
-  for (lIt.GoToBegin(); !lIt.IsAtEnd(); ++lIt)
+  for (ListIteratorType lIt(this->m_ListDomain, region); !lIt.IsAtEnd(); ++lIt)
   {
     const ListIndexType & index = lIt.GetIndex();
     ListPointType         pt;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -853,13 +853,12 @@ Segmenter<TInputImage>::GradientDescent(InputImageTypePointer img, ImageRegionTy
   }
   ConstNeighborhoodIterator<InputImageType> valueIt(rad, img, region);
   NeighborhoodIterator<OutputImageType>     labelIt(zeroRad, output, region);
-  ImageRegionIterator<OutputImageType>      it(output, region);
 
   //
   // Sweep through the image and trace all unlabeled
   // pixels to a labeled region
   //
-  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  for (ImageRegionIterator<OutputImageType> it(output, region); !it.IsAtEnd(); ++it)
   {
     if (it.Get() == NULL_LABEL)
     {


### PR DESCRIPTION
Replaced `GoToBegin()` calls from `for` loops by the declaration of the corresponding ITK iterators. Doing so appears preferable because those function calls appear unnecessary, and because it limits the scope of those iterators to where they are actually being used.

Cases found by Visual Studio 2022, Find in Files, using the following regular expression:

    ^  for \((\w+)\.GoToBegin\(\); !\1\.IsAtEnd\(\); \+\+\1\)

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3953 "Remove unnecessary and duplicate iterator `GoToBegin()` calls from Modules/Filtering"