### PR TITLE
STYLE: Replace `while (!outIt.IsAtEnd())` with `for` loops, in Filtering

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -218,8 +218,6 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   OutputImageRegionType region = outputPtr->GetRequestedRegion();
 
-  OutputIterator outIt(outputPtr, region);
-
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
   IndexType outputIndex; // Index to current output pixel
@@ -233,7 +231,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
 
   // Walk the output region
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
     outputIndex = outIt.GetIndex();
@@ -250,7 +248,6 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
     }
 
     outIt.Set(inverseDisplacement); // set inverse displacement.
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -120,8 +120,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
 
   OutputImageRegionType region = outputPtr->GetRequestedRegion();
 
-  OutputIterator outIt(outputPtr, region);
-
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
   OutputIndexType outputIndex; // Index to current output pixel
@@ -135,7 +133,7 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
 
   // Walk the output region
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
     outputIndex = outIt.GetIndex();
@@ -151,7 +149,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
     }
 
     outIt.Set(displacement);
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -141,15 +141,12 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * 
   // set all output value to infinity
   using OutputIterator = ImageRegionIterator<LevelSetImageType>;
 
-  OutputIterator outIt(output, output->GetBufferedRegion());
-
   PixelType outputPixel;
   outputPixel = m_LargeValue;
 
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(output, output->GetBufferedRegion()); !outIt.IsAtEnd(); ++outIt)
   {
     outIt.Set(outputPixel);
-    ++outIt;
   }
 
   // set all points type to FarPoint

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -153,7 +153,6 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 {
   OutputImagePointer outputPtr = this->GetOutput();
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
   using OutputPixelType = typename TOutputImage::PixelType;
   using IndexType = typename TOutputImage::IndexType;
@@ -165,7 +164,7 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Walk the output region
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the intermediate image index
     outputIndex = outIt.GetIndex();
@@ -186,7 +185,6 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       itkExceptionMacro(<< "Index not within the intermediate buffer");
     }
 
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -383,7 +383,6 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
 
   // Create an iterator that will walk the output region for this thread.
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
@@ -395,7 +394,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   using OutputType = typename InterpolatorType::OutputType;
 
   // Walk the output region
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
     outputPtr->TransformIndexToPhysicalPoint(outIt.GetIndex(), outputPoint);
@@ -424,7 +423,6 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
       }
     }
     progress.CompletedPixel();
-    ++outIt;
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -154,9 +154,8 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // Define/declare an iterator that will walk the output region for this
   // thread.
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index and physical location of the output pixel
     outputIndex = outIt.GetIndex();
@@ -169,7 +168,6 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
     // Copy the input pixel to the output
     outIt.Set(inputPtr->GetPixel(inputIndex));
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -136,12 +136,11 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   // Define/declare an iterator that will walk the output region for this thread
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
   OutputIndexType destIndex;
   InputIndexType  srcIndex;
 
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index and physical location of the output pixel
     destIndex = outIt.GetIndex();
@@ -153,7 +152,6 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
     // Copy the input pixel to the output
     outIt.Set(inputPtr->GetPixel(srcIndex));
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -113,7 +113,6 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 {
   OutputImagePointer outputPtr = this->GetOutput();
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
@@ -128,7 +127,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   InterpolatedType interpolatedValue;
 
   // Walk the output region, and interpolate the input image
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the output pixel
     outputIndex = outIt.GetIndex();
@@ -157,7 +156,6 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     {
       itkExceptionMacro(<< "Interpolator outside buffer should never occur ");
     }
-    ++outIt;
     progress.CompletedPixel();
   }
 }

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -97,12 +97,10 @@ GaussianImageSource<TOutputImage>::GenerateData()
 
   // Create an iterator that will walk the output region
   using OutputIterator = ImageRegionIterator<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
-
 
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());
   // Walk the output image, evaluating the spatial function at each pixel
-  while (!outIt.IsAtEnd())
+  for (OutputIterator outIt(outputPtr, outputPtr->GetRequestedRegion()); !outIt.IsAtEnd(); ++outIt)
   {
     const typename TOutputImage::IndexType index = outIt.GetIndex();
     // The position at which the function is evaluated
@@ -113,8 +111,6 @@ GaussianImageSource<TOutputImage>::GenerateData()
     // Set the pixel value to the function value
     outIt.Set(static_cast<typename TOutputImage::PixelType>(value));
     progress.CompletedPixel();
-
-    ++outIt;
   }
 }
 


### PR DESCRIPTION
Looked for iterations in "Modules/Filtering" of the following form:

    OutputIterator outIt(...);
    while (!outIt.IsAtEnd())
    {
      ...
      ++outIt;
    }

And replaced them with the corresponding `for` loops:

    for (OutputIterator outIt(...); !outIt.IsAtEnd(); ++outIt)
    {
      ...
    }

Such `for` loops appear preferable because they limits the scope of those `outIt` variables to where they are actually being used.