### PR TITLE
STYLE: Replace `T var = NumericTraits<T>::ZeroValue()` with `T var{}`

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -200,7 +200,7 @@ template <typename TImage, typename TBoundaryCondition>
 auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
-  const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
+  const IndexValueType zero{};
   const RegionType     ans(this->GetIndex(zero), this->GetSize());
 
   return ans;

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -120,7 +120,7 @@ template <typename TImage>
 auto
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
-  const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
+  const IndexValueType zero{};
   const RegionType     ans(this->GetIndex(zero), this->GetSize());
 
   return ans;

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -125,7 +125,7 @@ template <typename T, unsigned int VVectorDimension>
 auto
 CovariantVector<T, VVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
-  RealValueType sum = NumericTraits<RealValueType>::ZeroValue();
+  RealValueType sum{};
 
   for (unsigned int i = 0; i < VVectorDimension; ++i)
   {

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -446,7 +446,7 @@ public:
 
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
-      TCoordRep sum = NumericTraits<TCoordRep>::ZeroValue();
+      TCoordRep sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += this->m_PhysicalPointToIndex[i][j] * (point[j] - this->m_Origin[j]);
@@ -532,7 +532,7 @@ public:
   {
     for (unsigned int r = 0; r < VImageDimension; ++r)
     {
-      TCoordRep sum = NumericTraits<TCoordRep>::ZeroValue();
+      TCoordRep sum{};
       for (unsigned int c = 0; c < VImageDimension; ++c)
       {
         sum += this->m_IndexToPhysicalPoint(r, c) * index[c];
@@ -613,7 +613,7 @@ public:
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
       using CoordSumType = typename NumericTraits<TCoordRep>::AccumulateType;
-      CoordSumType sum = NumericTraits<CoordSumType>::ZeroValue();
+      CoordSumType sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += direction[i][j] * inputGradient[j];
@@ -662,7 +662,7 @@ public:
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
       using CoordSumType = typename NumericTraits<TCoordRep>::AccumulateType;
-      CoordSumType sum = NumericTraits<CoordSumType>::ZeroValue();
+      CoordSumType sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += inverseDirection[i][j] * inputGradient[j];

--- a/Modules/Core/Common/include/itkMatrix.hxx
+++ b/Modules/Core/Common/include/itkMatrix.hxx
@@ -31,7 +31,7 @@ Vector<T, VRows> Matrix<T, VRows, VColumns>::operator*(const Vector<T, VColumns>
   Vector<T, VRows> result;
   for (unsigned int r = 0; r < VRows; ++r)
   {
-    T sum = NumericTraits<T>::ZeroValue();
+    T sum{};
     for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * vect[c];
@@ -50,7 +50,7 @@ Point<T, VRows> Matrix<T, VRows, VColumns>::operator*(const Point<T, VColumns> &
   Point<T, VRows> result;
   for (unsigned int r = 0; r < VRows; ++r)
   {
-    T sum = NumericTraits<T>::ZeroValue();
+    T sum{};
     for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * pnt[c];
@@ -69,7 +69,7 @@ vnl_vector_fixed<T, VRows> Matrix<T, VRows, VColumns>::operator*(const vnl_vecto
   vnl_vector_fixed<T, VRows> result;
   for (unsigned int r = 0; r < VRows; ++r)
   {
-    T sum = NumericTraits<T>::ZeroValue();
+    T sum{};
     for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * inVNLvect[c];
@@ -88,7 +88,7 @@ CovariantVector<T, VRows> Matrix<T, VRows, VColumns>::operator*(const CovariantV
   CovariantVector<T, VRows> result;
   for (unsigned int r = 0; r < VRows; ++r)
   {
-    T sum = NumericTraits<T>::ZeroValue();
+    T sum{};
     for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * covect[c];

--- a/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
@@ -37,7 +37,7 @@ NeighborhoodInnerProduct<TImage, TOperator, TComputation>::Compute(const ConstNe
 
   const typename OperatorType::ConstIterator op_end = op.End();
   typename OperatorType::ConstIterator       o_it = op.Begin();
-  AccumulateRealType                         sum = NumericTraits<AccumulateRealType>::ZeroValue();
+  AccumulateRealType                         sum{};
 
   for (unsigned int i = start; o_it < op_end; i += stride, ++o_it)
   {
@@ -63,7 +63,7 @@ NeighborhoodInnerProduct<TImage, TOperator, TComputation>::Compute(
   using InputPixelRealType = typename NumericTraits<InputPixelType>::RealType;
   using AccumulateRealType = typename NumericTraits<InputPixelRealType>::AccumulateType;
 
-  AccumulateRealType sum = NumericTraits<AccumulateRealType>::ZeroValue();
+  AccumulateRealType sum{};
 
   using OutputPixelValueType = typename NumericTraits<OutputPixelType>::ValueType;
 

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -276,7 +276,7 @@ public:
   RealType
   SquaredEuclideanDistanceTo(const Point<TCoordRepB, VPointDimension> & pa) const
   {
-    RealType sum = NumericTraits<RealType>::ZeroValue();
+    RealType sum{};
 
     for (unsigned int i = 0; i < VPointDimension; ++i)
     {

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -184,7 +184,7 @@ template <typename ValueType, typename MeanType>
 MeanType
 ResourceProbe<ValueType, MeanType>::GetMean() const
 {
-  MeanType meanValue = NumericTraits<MeanType>::ZeroValue();
+  MeanType meanValue{};
 
   if (this->m_NumberOfStops)
   {

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -238,7 +238,7 @@ template <typename T, unsigned int VDimension>
 auto
 SymmetricSecondRankTensor<T, VDimension>::GetTrace() const -> AccumulateValueType
 {
-  AccumulateValueType trace = NumericTraits<AccumulateValueType>::ZeroValue();
+  AccumulateValueType trace{};
   unsigned int        k = 0;
 
   for (unsigned int i = 0; i < Dimension; ++i)
@@ -350,7 +350,7 @@ SymmetricSecondRankTensor<T, VDimension>::PreMultiply(const MatrixType & m) cons
   {
     for (unsigned int c = 0; c < VDimension; ++c)
     {
-      AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
+      AccumulateType sum{};
       for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += m(r, t) * (*this)(t, c);
@@ -375,7 +375,7 @@ SymmetricSecondRankTensor<T, VDimension>::PostMultiply(const MatrixType & m) con
   {
     for (unsigned int c = 0; c < VDimension; ++c)
     {
-      AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
+      AccumulateType sum{};
       for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += (*this)(r, t) * m(t, c);

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -45,7 +45,7 @@ Array<T> VariableSizeMatrix<T>::operator*(const Array<T> & vect) const
   Array<T> result(rows);
   for (unsigned int r = 0; r < rows; ++r)
   {
-    T sum = NumericTraits<T>::ZeroValue();
+    T sum{};
     for (unsigned int c = 0; c < cols; ++c)
     {
       sum += m_Matrix(r, c) * vect[c];

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -169,7 +169,7 @@ typename FiniteDifferenceImageFilter<TInputImage, TOutputImage>::TimeStepType
 FiniteDifferenceImageFilter<TInputImage, TOutputImage>::ResolveTimeStep(const std::vector<TimeStepType> & timeStepList,
                                                                         const BooleanStdVectorType &      valid) const
 {
-  TimeStepType oMin = NumericTraits<TimeStepType>::ZeroValue();
+  TimeStepType oMin{};
   bool         flag = false;
 
   // grab first valid value

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -185,7 +185,7 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::R
   const std::vector<TimeStepType> & timeStepList,
   const BooleanStdVectorType &      valid) const
 {
-  TimeStepType oMin = NumericTraits<TimeStepType>::ZeroValue();
+  TimeStepType oMin{};
   bool         flag = false;
 
   auto t_it = timeStepList.begin();

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -176,7 +176,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
 
   using PixelType = typename InputImageType::PixelType;
   const PixelType *  neighPixels[Self::ImageDimension][2];
-  const PixelType    zeroPixel = NumericTraits<PixelType>::ZeroValue();
+  const PixelType    zeroPixel{};
   const unsigned int MaxDims = Self::ImageDimension;
   bool               dimOutOfBounds[Self::ImageDimension];
 
@@ -343,7 +343,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   bool               dimOutOfBounds[Self::ImageDimension];
   const unsigned int MaxDims = Self::ImageDimension;
   PointValueType     delta[Self::ImageDimension];
-  PixelType          zeroPixel = NumericTraits<PixelType>::ZeroValue();
+  PixelType          zeroPixel{};
 
   ScalarDerivativeType componentDerivativeOut;
   ScalarDerivativeType componentDerivative;
@@ -523,7 +523,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
   PixelType          neighPixels[Self::ImageDimension][2];
   bool               dimOutOfBounds[Self::ImageDimension];
   const unsigned int MaxDims = Self::ImageDimension;
-  PixelType          zeroPixel = NumericTraits<PixelType>::ZeroValue();
+  PixelType          zeroPixel{};
 
   for (unsigned int dim = 0; dim < MaxDims; ++dim)
   {

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -51,7 +51,7 @@ LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordRep, TPixelCompare
   }
 
   RealType   wmax = 0.0;
-  OutputType Vmax = NumericTraits<OutputType>::ZeroValue();
+  OutputType Vmax{};
 
   // Create a map object to store weights for each label encountered
   // inside the search region. This is not as efficient as having a

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -56,7 +56,7 @@ VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuo
   output.Fill(0.0);
 
   using ScalarRealType = typename NumericTraits<PixelType>::ScalarRealType;
-  ScalarRealType totalOverlap = NumericTraits<ScalarRealType>::ZeroValue();
+  ScalarRealType totalOverlap{};
 
   for (unsigned int counter = 0; counter < m_Neighbors; ++counter)
   {

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -186,7 +186,7 @@ typename WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunct
   // Iterate over the neighborhood, taking the correct set
   // of weights in each dimension
   using PixelType = typename NumericTraits<typename TInputImage::PixelType>::RealType;
-  PixelType xPixelValue = NumericTraits<PixelType>::ZeroValue();
+  PixelType xPixelValue{};
   for (unsigned int j = 0; j < m_OffsetTableSize; ++j)
   {
     // Get the offset for this neighbor

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
@@ -105,7 +105,7 @@ InteriorExteriorMeshFilter<TInputMesh, TOutputMesh, TSpatialFunction>::GenerateD
   using ValueType = typename TSpatialFunction::OutputType;
 
   using PointIdType = typename TOutputMesh::PointIdentifier;
-  PointIdType pointId = NumericTraits<PointIdType>::ZeroValue();
+  PointIdType pointId{};
 
   while (inputPoint != inPoints->End())
   {

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -245,7 +245,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
       outputMesh->AddEdge(firstNewIndex, secondNewIndex);
 
       // splitting cell
-      PointIdentifier      newPointIndex = NumericTraits<PointIdentifier>::ZeroValue();
+      PointIdentifier      newPointIndex{};
       auto *               polygon = new OutputPolygonType;
       InputCellAutoPointer newPolygonPointer1;
       newPolygonPointer1.TakeOwnership(polygon);
@@ -341,7 +341,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ModifyNeighborCells(Cel
     {
       m_NewSimplexCellPointer.TakeOwnership(new OutputPolygonType);
       InputPolygonPointIdIterator pointIt = nextCell->PointIdsBegin();
-      PointIdentifier             cnt = NumericTraits<PointIdentifier>::ZeroValue();
+      PointIdentifier             cnt{};
       PointIdentifier             first = *pointIt++;
       PointIdentifier             startId = first;
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -353,7 +353,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
 
     // create a new cell
     m_NewSimplexCellPointer.TakeOwnership(new OutputPolygonType);
-    PointIdentifier       vertexIdx = NumericTraits<PointIdentifier>::ZeroValue();
+    PointIdentifier       vertexIdx{};
     CellIdentifier        nextIdx = startIdx;
     CellFeatureIdentifier featureId = 0;
 
@@ -367,7 +367,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
       EdgeIdentifierType line = std::make_pair(nextIdx, newIdx);
       EdgeIdentifierType lineInv = std::make_pair(newIdx, nextIdx);
 
-      CellIdentifier edgeIdx = NumericTraits<CellIdentifier>::ZeroValue();
+      CellIdentifier edgeIdx{};
 
       if (m_LineCellIndices->IndexExists(line))
       {

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -206,7 +206,7 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
       // mesh can be saved.
       cellIterator = cells->Begin();
 
-      PointIdentifier totalNumberOfPointsInPolygons = NumericTraits<PointIdentifier>::ZeroValue();
+      PointIdentifier totalNumberOfPointsInPolygons{};
       while (cellIterator != cells->End())
       {
         CellType * cellPointer = cellIterator.Value();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -1173,7 +1173,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(const PointIdList & points) -
   {
     typename PointIdList::const_iterator itr = points.begin();
     typename PointIdList::const_iterator end = points.end();
-    PointIdentifier                      count = NumericTraits<PointIdentifier>::ZeroValue();
+    PointIdentifier                      count{};
     const PointIdentifier                pointId = points[i];
     while (itr != end)
     {
@@ -1421,7 +1421,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfPoints() const -> Poin
     return (0);
   }
 
-  PointIdentifier              numberOfPoints = NumericTraits<PointIdentifier>::ZeroValue();
+  PointIdentifier              numberOfPoints{};
   PointsContainerConstIterator pointIterator = points->Begin();
   PointsContainerConstIterator pointEnd = points->End();
 
@@ -1447,7 +1447,7 @@ template <typename TPixel, unsigned int VDimension, typename TTraits>
 auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfFaces() const -> CellIdentifier
 {
-  CellIdentifier              numberOfFaces = NumericTraits<CellIdentifier>::ZeroValue();
+  CellIdentifier              numberOfFaces{};
   CellsContainerConstIterator cellIterator = this->GetCells()->Begin();
   CellsContainerConstIterator cellEnd = this->GetCells()->End();
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -498,7 +498,7 @@ CompositeTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespect
     return;
   }
 
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
   OutputPointType transformedPoint(p);
 
@@ -628,7 +628,7 @@ CompositeTransform<TParametersValueType, VDimension>::GetParameters() const -> c
      * it's efficient. */
     this->m_Parameters.SetSize(this->GetNumberOfParameters());
 
-    NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+    NumberOfParametersType offset{};
 
     for (auto it = transforms.rbegin(); it != transforms.rend(); ++it)
     {
@@ -676,7 +676,7 @@ CompositeTransform<TParametersValueType, VDimension>::SetParameters(const Parame
   }
   else
   {
-    NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+    NumberOfParametersType offset{};
     auto                   it = transforms.end();
 
     do
@@ -713,7 +713,7 @@ CompositeTransform<TParametersValueType, VDimension>::GetFixedParameters() const
    * it's efficient. */
   this->m_FixedParameters.SetSize(this->GetNumberOfFixedParameters());
 
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
   for (auto it = transforms.rbegin(); it != transforms.rend(); ++it)
   {
@@ -735,7 +735,7 @@ CompositeTransform<TParametersValueType, VDimension>::SetFixedParameters(const F
    * sub transforms currently selected for optimization. */
   TransformQueueType transforms = this->GetTransformsToOptimizeQueue();
 
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
 
   /* Verify proper input size. */
@@ -767,7 +767,7 @@ CompositeTransform<TParametersValueType, VDimension>::GetNumberOfParameters() co
    * However, it seems that number of parameter might change for dense
    * field transforms (deformation, bspline) during processing and
    * we wouldn't know that in this class, so this is safest. */
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
 
 
   for (long tind = (long)this->GetNumberOfTransforms() - 1; tind >= 0; tind--)
@@ -795,7 +795,7 @@ CompositeTransform<TParametersValueType, VDimension>::GetNumberOfLocalParameters
    * set to be used for optimized.
    * Note that unlike in GetNumberOfParameters(), we don't expect the
    * number of local parameters to possibly change. */
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
   for (long tind = (long)this->GetNumberOfTransforms() - 1; tind >= 0; tind--)
   {
     if (this->GetNthTransformToOptimize(tind))
@@ -820,7 +820,7 @@ CompositeTransform<TParametersValueType, VDimension>::GetNumberOfFixedParameters
    * set to be used for optimized.
    * NOTE: We might want to optimize this only to store the result and
    * only re-calc when the composite object has been modified. */
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
 
   for (long tind = (long)this->GetNumberOfTransforms() - 1; tind >= 0; tind--)
   {
@@ -858,7 +858,7 @@ CompositeTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
                                                 << numberOfParameters << std::endl);
   }
 
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
 
   for (long tind = (long)this->GetNumberOfTransforms() - 1; tind >= 0; tind--)

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -234,7 +234,7 @@ Euler3DTransform<TParametersValueType>::ComputeMatrix()
   const ScalarType cz = std::cos(m_AngleZ);
   const ScalarType sz = std::sin(m_AngleZ);
   const ScalarType one = NumericTraits<ScalarType>::OneValue();
-  const ScalarType zero = NumericTraits<ScalarType>::ZeroValue();
+  const ScalarType zero{};
 
   Matrix<TParametersValueType, 3, 3> RotationX;
   RotationX[0][0] = one;

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -379,7 +379,7 @@ KernelTransform<TParametersValueType, VDimension>::SetParameters(const Parameter
   if (&parameters != &(this->m_Parameters))
   {
     const size_t                 parameterSize = this->GetParameters().Size();
-    const NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+    const NumberOfParametersType offset{};
     this->CopyInParameters(&(parameters.data_block())[offset], &(parameters.data_block())[offset] + parameterSize);
   }
 

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -84,7 +84,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetParameters(
   /* Resize destructively. But if it's already this size, nothing is done so
    * it's efficient. */
   this->m_Parameters.SetSize(this->GetNumberOfParameters());
-  NumberOfParametersType                      offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType                      offset{};
   TransformQueueType                          transforms = this->GetTransformQueue();
   typename TransformQueueType::const_iterator it;
   it = transforms.begin();
@@ -120,7 +120,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetParameters(
   }
 
   TransformQueueType     transforms = this->GetTransformQueue();
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
   auto                   it = transforms.begin();
 
   do
@@ -155,7 +155,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetFixedParame
    * it's efficient. */
   this->m_FixedParameters.SetSize(this->GetNumberOfFixedParameters());
 
-  NumberOfParametersType                      offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType                      offset{};
   typename TransformQueueType::const_iterator it;
   TransformQueueType                          transforms = this->GetTransformQueue();
   it = transforms.begin();
@@ -189,7 +189,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetFixedParame
   /* Assumes input params are concatenation of the parameters of the
    * sub transforms. */
   TransformQueueType     transforms = this->GetTransformQueue();
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
   /* Why is this done? Seems unnecessary. */
   this->m_FixedParameters = inputParameters;
@@ -218,7 +218,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfPar
    * However, it seems that number of parameter might change for dense
    * field transforms (deformation, bspline) during processing and
    * we wouldn't know that in this class, so this is safest. */
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
 
 
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); ++tind)
@@ -246,7 +246,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfLoc
   /* Note that unlike in GetNumberOfParameters(), we don't expect the
    * number of local parameters to possibly change, so we can cache
    * the value. */
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
 
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); ++tind)
   {
@@ -263,7 +263,7 @@ auto
 MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfFixedParameters() const
   -> NumberOfParametersType
 {
-  NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType result{};
 
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); ++tind)
   {
@@ -299,7 +299,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::UpdateTransfor
                                                 << numberOfParameters << std::endl);
   }
 
-  NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
+  NumberOfParametersType offset{};
 
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); ++tind)
   {

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -90,7 +90,7 @@ VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neigh
   double       Cx[ImageDimension];
   double       Cxd[ImageDimension];
 
-  const ScalarValueType ScalarValueTypeZero = NumericTraits<ScalarValueType>::ZeroValue();
+  const ScalarValueType ScalarValueTypeZero{};
 
   PixelType dx_forward[ImageDimension];
   PixelType dx_backward[ImageDimension];

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -61,7 +61,7 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   // let choose a background value. Background value should not be given by user
   // because closing is extensive so no background pixels will be added
   // it is just needed for internal erosion filter and constant padder
-  InputPixelType backgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  InputPixelType backgroundValue{};
   if (m_ForegroundValue == backgroundValue)
   {
     // current background value is already used for foreground value

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -53,7 +53,7 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   // let choose a background value. Background value should not be given by user
   // because closing is extensive so no background pixels will be added
   // it is just needed for internal erosion filter and constant padder
-  InputPixelType backgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  InputPixelType backgroundValue{};
   if (m_ForegroundValue == backgroundValue)
   {
     // current background value is already used for foreground value

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -120,7 +120,7 @@ auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, const NeighborhoodType & it) const
   -> PixelType
 {
-  PixelType threshold = NumericTraits<PixelType>::ZeroValue();
+  PixelType threshold{};
 
   // Compute gradient
   PixelType     gradient[ImageDimension];
@@ -167,8 +167,8 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
 
   for (neighIter = it.Begin(); neighIter < neighEnd; ++neighIter, ++i)
   {
-    PixelType dotProduct = NumericTraits<PixelType>::ZeroValue();
-    PixelType vectorMagnitude = NumericTraits<PixelType>::ZeroValue();
+    PixelType dotProduct{};
+    PixelType vectorMagnitude{};
 
     for (j = 0; j < ImageDimension; ++j)
     {
@@ -224,7 +224,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
     return it.GetCenterPixel();
   }
 
-  PixelType threshold = NumericTraits<PixelType>::ZeroValue();
+  PixelType threshold{};
 
   // Compute gradient
   double        gradient[imageDimension];
@@ -286,7 +286,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
     return it.GetCenterPixel();
   }
 
-  PixelType threshold = NumericTraits<PixelType>::ZeroValue();
+  PixelType threshold{};
 
   // Compute gradient
   double        gradient[imageDimension];

--- a/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
@@ -142,7 +142,7 @@ public:
   operator()(const TInput1 & I, const TInput2 & H) const
   {
     const double absH = itk::Math::abs(H);
-    TOutput      value = NumericTraits<TOutput>::ZeroValue();
+    TOutput      value{};
     if (absH >= m_KernelZeroMagnitudeThreshold)
     {
       value = static_cast<TOutput>(I / H);

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
@@ -143,7 +143,7 @@ public:
   {
     typename TOutput::value_type normH = std::norm(H);
     typename TOutput::value_type denominator = normH + m_RegularizationConstant;
-    TOutput                      value = NumericTraits<TOutput>::ZeroValue();
+    TOutput                      value{};
     if (denominator >= m_KernelZeroMagnitudeThreshold)
     {
       value = static_cast<TOutput>(I * (std::conj(H) / denominator));

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -173,7 +173,7 @@ public:
     TPixel Pf = std::norm(I);
 
     TPixel denominator = std::norm(H) + (Pn / (Pf - Pn));
-    TPixel value = NumericTraits<TPixel>::ZeroValue();
+    TPixel value{};
     if (itk::Math::abs(denominator) >= m_KernelZeroMagnitudeThreshold)
     {
       value = I * (std::conj(H) / denominator);

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2340,7 +2340,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeGradientJointE
 
     useCachedComputations = true;
 
-    RealValueType gaussianJointEntropy = NumericTraits<RealValueType>::ZeroValue();
+    RealValueType gaussianJointEntropy{};
     for (unsigned int ic = 0; ic < m_NumIndependentComponents; ++ic)
     {
       RealValueType kernelSigma = m_KernelBandwidthSigma[ic];

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -126,7 +126,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
   auto weights = WeightsContainerType::New();
 
-  IdentifierType numberOfPoints = NumericTraits<IdentifierType>::ZeroValue();
+  IdentifierType numberOfPoints{};
 
   const typename WeightsContainerType::Element boundaryWeight = 1.0e10;
 

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -208,8 +208,8 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   else
   {
     VectorType inverseSpacing;
-    RealType   localMean = NumericTraits<RealType>::ZeroValue();
-    RealType   localMax = NumericTraits<RealType>::ZeroValue();
+    RealType   localMean{};
+    RealType   localMax{};
     for (unsigned int d = 0; d < ImageDimension; ++d)
     {
       inverseSpacing[d] = 1.0 / this->m_DisplacementFieldSpacing[d];

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -148,7 +148,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::AfterThreade
 
   // Find mean over all threads
   IdentifierType count = 0;
-  RealType       sum = NumericTraits<RealType>::ZeroValue();
+  RealType       sum{};
 
   for (ThreadIdType i = 0; i < numberOfWorkUnits; ++i)
   {

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -158,7 +158,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DynamicThreade
   ImageRegionConstIterator<TInputImage1>    it1(inputPtr1, regionForThread);
   ImageRegionConstIterator<DistanceMapType> it2(m_DistanceMap, regionForThread);
 
-  RealType                 maxDistance = NumericTraits<RealType>::ZeroValue();
+  RealType                 maxDistance{};
   CompensatedSummationType sum = 0.0;
   IdentifierType           pixelCount = 0;
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -229,7 +229,7 @@ public:
     InternalRegionIterator b_it(iImage, iImage->GetLargestPossibleRegion());
     b_it.GoToBegin();
 
-    TPixel                                    zero_value = NumericTraits<TPixel>::ZeroValue();
+    TPixel                                    zero_value{};
     typename NodeContainer::ElementIdentifier NumberOfPoints = 0;
 
     NodeType node;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -501,7 +501,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     NodePairContainerConstIterator pointsIter = this->m_ForbiddenPoints->Begin();
     NodePairContainerConstIterator pointsEnd = this->m_ForbiddenPoints->End();
 
-    OutputPixelType zero = NumericTraits<OutputPixelType>::ZeroValue();
+    OutputPixelType zero{};
 
     while (pointsIter != pointsEnd)
     {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -54,7 +54,7 @@ const typename FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::OutputPixelT
 FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::GetOutputValue(OutputMeshType * oMesh,
                                                                     const NodeType & iNode) const
 {
-  OutputPixelType outputValue = NumericTraits<OutputPixelType>::ZeroValue();
+  OutputPixelType outputValue{};
   oMesh->GetPointData(iNode, &outputValue);
   return outputValue;
 }
@@ -130,7 +130,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UpdateValue(OutputMeshType 
   OutputPointType p;
   oMesh->GetPoint(iNode, &p);
 
-  InputPixelType F = NumericTraits<InputPixelType>::ZeroValue();
+  InputPixelType F{};
   this->m_InputMesh->GetPointData(iNode, &F);
 
   if (F < 0.)
@@ -645,7 +645,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::InitializeOutput(OutputMesh
     NodePairContainerConstIterator pointsIter = this->m_ForbiddenPoints->Begin();
     NodePairContainerConstIterator pointsEnd = this->m_ForbiddenPoints->End();
 
-    OutputPixelType zero = NumericTraits<OutputPixelType>::ZeroValue();
+    OutputPixelType zero{};
 
     while (pointsIter != pointsEnd)
     {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -265,7 +265,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::ComputeGradient(
   const LevelSetIndexType & lastIndex = this->GetLastIndex();
   const LevelSetIndexType & startIndex = this->GetStartIndex();
 
-  const LevelSetPixelType ZERO = NumericTraits<LevelSetPixelType>::ZeroValue();
+  const LevelSetPixelType ZERO{};
 
   OutputSpacingType spacing = this->GetOutput()->GetSpacing();
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
@@ -109,7 +109,7 @@ FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::ComputeGradient(Outp
   OutputPixelType   dx_backward;
   GradientPixelType gradientPixel;
 
-  const OutputPixelType ZERO = NumericTraits<OutputPixelType>::ZeroValue();
+  const OutputPixelType ZERO{};
 
   OutputSpacingType spacing = oImage->GetSpacing();
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -155,7 +155,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ComputeCannyEdge(const
     dxx[i] = innerProduct(m_ComputeCannyEdgeSlice[i], it, m_ComputeCannyEdge2ndDerivativeOper);
   }
 
-  OutputImagePixelType deriv = NumericTraits<OutputImagePixelType>::ZeroValue();
+  OutputImagePixelType deriv{};
 
   int k = 0;
   // Calculate the 2nd derivative
@@ -405,7 +405,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType faceList =
     bC(input, outputRegionForThread, radius);
 
-  InputImagePixelType zero = NumericTraits<InputImagePixelType>::ZeroValue();
+  InputImagePixelType zero{};
 
   OutputImagePixelType dx[ImageDimension];
   OutputImagePixelType dx1[ImageDimension];

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -54,7 +54,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   }
 
   // Build an operator so that we can determine the kernel size
-  SizeValueType radius = NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType radius{};
 
   // get a copy of the input requested region (should equal the output
   // requested region)
@@ -114,7 +114,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   InputImagePixelType this_one, that, abs_this_one, abs_that;
-  InputImagePixelType zero = NumericTraits<InputImagePixelType>::ZeroValue();
+  InputImagePixelType zero{};
 
   FixedArray<OffsetValueType, 2 * ImageDimension> offset;
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -165,7 +165,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
 
     while (!bit.IsAtEnd())
     {
-      RealType a = NumericTraits<RealType>::ZeroValue();
+      RealType a{};
       for (i = 0; i < ImageDimension; ++i)
       {
         const RealType g = SIP(x_slice[i], bit, op[i]);

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -52,7 +52,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputPixelType defaultPixelValue = m_DefaultPixelValue;
   if (NumericTraits<OutputPixelType>::GetLength(defaultPixelValue) == 0)
   {
-    const OutputPixelComponentType zeroComponent = NumericTraits<OutputPixelComponentType>::ZeroValue();
+    const OutputPixelComponentType zeroComponent{};
     const unsigned int             nComponents = output->GetNumberOfComponentsPerPixel();
     NumericTraits<OutputPixelType>::SetLength(defaultPixelValue, nComponents);
     for (unsigned int n = 0; n < nComponents; ++n)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -110,7 +110,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   bool pflag;
 
   /* define background, foreground pixel values and unlabeled pixel value */
-  PixelType zero_val = NumericTraits<PixelType>::ZeroValue();
+  PixelType zero_val{};
   auto      u_val = static_cast<PixelType>(0);
   auto      b_val = static_cast<PixelType>(2);
   auto      f_val = static_cast<PixelType>(255);

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -56,7 +56,7 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
 
   InputIterator it(inputImage, inputImage->GetBufferedRegion());
 
-  InputRealType maximumSquaredMagnitude = NumericTraits<InputRealType>::ZeroValue();
+  InputRealType maximumSquaredMagnitude{};
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -187,7 +187,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
     const typename TInputImage::RegionType AccumulatedRegion(AccumulatedIndex, AccumulatedSize);
     inputIterType                          inputIter(inputImage, AccumulatedRegion);
     inputIter.GoToBegin();
-    AccumulateType Value = NumericTraits<AccumulateType>::ZeroValue();
+    AccumulateType Value{};
     while (!inputIter.IsAtEnd())
     {
       Value += static_cast<AccumulateType>(inputIter.Get());

--- a/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
@@ -85,7 +85,7 @@ public:
 
     typename NumericTraits<TInputPixel>::RealType mean = ((RealType)m_Sum) / m_Size;
     typename std::vector<TInputPixel>::iterator   it;
-    RealType                                      squaredSum = NumericTraits<RealType>::ZeroValue();
+    RealType                                      squaredSum{};
     for (it = m_Values.begin(); it != m_Values.end(); ++it)
     {
       squaredSum += itk::Math::sqr(*it - mean);

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -101,7 +101,7 @@ StatisticsImageFilter<TInputImage>::ThreadedStreamedGenerateData(const RegionTyp
 
   CompensatedSummation<RealType> sum = NumericTraits<RealType>::ZeroValue();
   CompensatedSummation<RealType> sumOfSquares = NumericTraits<RealType>::ZeroValue();
-  SizeValueType                  count = NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType                  count{};
   PixelType                      min = NumericTraits<PixelType>::max();
   PixelType                      max = NumericTraits<PixelType>::NonpositiveMin();
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -65,7 +65,7 @@ BinaryFillholeImageFilter<TInputImage>::GenerateData()
   // let choose a background value. Background value should not be given by user
   // because closing is extensive so no background pixels will be added
   // it is just needed for internal erosion filter and constant padder
-  InputImagePixelType backgroundValue = NumericTraits<InputImagePixelType>::ZeroValue();
+  InputImagePixelType backgroundValue{};
   if (m_ForegroundValue == backgroundValue)
   {
     // current background value is already used for foreground value

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -152,7 +152,7 @@ protected:
 
     // and put back the objects in the map
     output->ClearLabels();
-    PixelType                           label = NumericTraits<PixelType>::ZeroValue();
+    PixelType                           label{};
     typename VectorType::const_iterator it2 = labelObjects.begin();
     while (it2 != labelObjects.end())
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -43,7 +43,7 @@ template <typename TInputMesh, typename TOutputMesh>
 void
 CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
 {
-  InputCoordRepType zeroValue = NumericTraits<InputCoordRepType>::ZeroValue();
+  InputCoordRepType zeroValue{};
 
   InputCoordRepType absoluteToleranceSquared = this->m_AbsoluteTolerance * this->m_AbsoluteTolerance;
   if ((Math::ExactlyEquals(this->m_AbsoluteTolerance, zeroValue)) &&

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -50,7 +50,7 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
   OutputQEPrimal * qeIt = qe;
   OutputQEPrimal * qeIt2 = qe->GetOnext();
 
-  OutputCoordRepType oW = NumericTraits<OutputCoordRepType>::ZeroValue();
+  OutputCoordRepType oW{};
 
   do
   {
@@ -222,8 +222,8 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
     }
     else
     {
-      OutputCoordRepType ww = NumericTraits<OutputCoordRepType>::ZeroValue();
-      OutputCoordRepType w = NumericTraits<OutputCoordRepType>::ZeroValue();
+      OutputCoordRepType ww{};
+      OutputCoordRepType w{};
 
       qe = output->FindEdge(vId);
       if (qe)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -205,7 +205,7 @@ public:
     InputPointIdentifier id2 = iEdge->GetDestination();
     InputPointType       pt2 = iMesh->GetPoint(id2);
 
-    InputCoordRepType oValue = NumericTraits<InputCoordRepType>::ZeroValue();
+    InputCoordRepType oValue{};
 
     if (iEdge->IsLeftSet())
     {

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -150,7 +150,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   typename TInputHistogram::ConstIterator iter = histogram->Begin();
   typename TInputHistogram::ConstIterator end = histogram->End();
 
-  MeanType            globalMean = NumericTraits<MeanType>::ZeroValue();
+  MeanType            globalMean{};
   const FrequencyType globalFrequency = histogram->GetTotalFrequency();
   while (iter != end)
   {
@@ -173,7 +173,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   InstanceIdentifierVectorType maxVarThresholdIndexes = thresholdIndexes;
 
   // Compute frequency and mean of initial classes
-  FrequencyType       freqSum = NumericTraits<FrequencyType>::ZeroValue();
+  FrequencyType       freqSum{};
   FrequencyVectorType classFrequency(numberOfClasses);
   for (j = 0; j < numberOfClasses - 1; ++j)
   {
@@ -190,7 +190,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
     imgPDF[j] = (WeightType)histogram->GetFrequency(j) / (WeightType)globalFrequency;
   }
 
-  MeanType       meanSum = NumericTraits<MeanType>::ZeroValue();
+  MeanType       meanSum{};
   MeanVectorType classMean(numberOfClasses);
   for (j = 0; j < numberOfClasses - 1; ++j)
   {
@@ -222,9 +222,9 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   // distribution.
   //
 #ifndef ITK_COMPILER_SUPPORTS_SSE2_32
-  volatile VarianceType maxVarBetween = NumericTraits<VarianceType>::ZeroValue();
+  volatile VarianceType maxVarBetween{};
 #else
-  VarianceType maxVarBetween = NumericTraits<VarianceType>::ZeroValue();
+  VarianceType maxVarBetween{};
 #endif
   //
   // The introduction of the "volatile" modifier forces the compiler to keep
@@ -240,7 +240,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   maxVarBetween /= static_cast<VarianceType>(globalFrequency);
 
   // Sum the relevant weights for valley emphasis
-  WeightType valleyEmphasisFactor = NumericTraits<WeightType>::ZeroValue();
+  WeightType valleyEmphasisFactor{};
   if (m_ValleyEmphasis)
   {
     for (j = 0; j < numberOfClasses - 1; ++j)
@@ -263,9 +263,9 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
     // distribution.
     //
 #ifndef ITK_COMPILER_SUPPORTS_SSE2_32
-    volatile VarianceType varBetween = NumericTraits<VarianceType>::ZeroValue();
+    volatile VarianceType varBetween{};
 #else
-    VarianceType varBetween = NumericTraits<VarianceType>::ZeroValue();
+    VarianceType varBetween{};
 #endif
     //
     // The introduction of the "volatile" modifier forces the compiler to keep

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -124,8 +124,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
 {
   typename TOutputMesh::Pointer output = this->GetOutput();
 
-  SizeValueType        index = NumericTraits<SizeValueType>::ZeroValue();
-  OutputCellIdentifier id = NumericTraits<OutputCellIdentifier>::ZeroValue();
+  SizeValueType        index{};
+  OutputCellIdentifier id{};
   while (index < m_MeshIO->GetCellBufferSize())
   {
     auto type = static_cast<CellGeometryEnum>(static_cast<int>(buffer[index++]));

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -318,7 +318,7 @@ MeshFileWriter<TInputMesh>::CopyPointsToBuffer(Output * data)
 {
   const typename InputMeshType::PointsContainer * points = this->GetInput()->GetPoints();
 
-  SizeValueType                                     index = NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType                                     index{};
   typename TInputMesh::PointsContainerConstIterator pter = points->Begin();
 
   while (pter != points->End())
@@ -345,7 +345,7 @@ MeshFileWriter<TInputMesh>::CopyCellsToBuffer(Output * data)
   typename TInputMesh::CellType *              cellPtr;
 
   // For each cell
-  SizeValueType                                    index = NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType                                    index{};
   typename TInputMesh::CellsContainerConstIterator cter = cells->Begin();
   while (cter != cells->End())
   {

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -715,8 +715,8 @@ protected:
   {
     if (input && output)
     {
-      SizeValueType inputIndex = NumericTraits<SizeValueType>::ZeroValue();
-      SizeValueType outputIndex = NumericTraits<SizeValueType>::ZeroValue();
+      SizeValueType inputIndex{};
+      SizeValueType outputIndex{};
       for (SizeValueType ii = 0; ii < m_NumberOfCells; ++ii)
       {
         ++inputIndex; // ignore the cell type
@@ -773,8 +773,8 @@ protected:
   {
     if (input && output)
     {
-      SizeValueType inputIndex = NumericTraits<SizeValueType>::ZeroValue();
-      SizeValueType outputIndex = NumericTraits<SizeValueType>::ZeroValue();
+      SizeValueType inputIndex{};
+      SizeValueType outputIndex{};
       for (SizeValueType ii = 0; ii < numberOfCells; ++ii)
       {
         output[outputIndex++] = static_cast<TOutput>(cellType);
@@ -795,8 +795,8 @@ protected:
   {
     if (input && output)
     {
-      SizeValueType inputIndex = NumericTraits<SizeValueType>::ZeroValue();
-      SizeValueType outputIndex = NumericTraits<SizeValueType>::ZeroValue();
+      SizeValueType inputIndex{};
+      SizeValueType outputIndex{};
       for (SizeValueType ii = 0; ii < numberOfCells; ++ii)
       {
         auto numberOfPoints = static_cast<unsigned int>(input[inputIndex++]);

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -177,7 +177,7 @@ WriteMetaDataAttribute(PolygonGroupSpatialObjectXMLFileWriter * This,
                        const char * const                       attName,
                        std::ofstream &                          output)
 {
-  T value = NumericTraits<T>::ZeroValue();
+  T value{};
 
   if (ExposeMetaData<T>(thisDic, MetaName, value))
   {

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -222,8 +222,8 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtContinu
     // Interpolated value is the weighted sum of each of the surrounding
     // neighbors. The weight for each neighbor is the fraction overlap
     // of the neighbor pixel with respect to a pixel centered on point.
-    TOutput value = NumericTraits<TOutput>::ZeroValue();
-    TOutput totalOverlap = NumericTraits<TOutput>::ZeroValue();
+    TOutput value{};
+    TOutput totalOverlap{};
 
     for (NumberOfNeighborsType counter = 0; counter < numberOfNeighbors; ++counter)
     {

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -256,8 +256,8 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAt
     // Interpolated value is the weighted sum of each of the surrounding
     // neighbors. The weight for each neighbor is the fraction overlap
     // of the neighbor pixel with respect to a pixel centered on point.
-    TOutput value = NumericTraits<TOutput>::ZeroValue();
-    TOutput totalOverlap = NumericTraits<TOutput>::ZeroValue();
+    TOutput value{};
+    TOutput totalOverlap{};
 
     for (NumberOfNeighborsType counter = 0; counter < neighbors; ++counter)
     {

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -254,7 +254,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::EvaluateAtContinuous
     // neighbors. The weight for each neighbor is the fraction overlap
     // of the neighbor pixel with respect to a pixel centered on point.
     OutputType hessian, currentHessian;
-    TOutput    totalOverlap = NumericTraits<TOutput>::ZeroValue();
+    TOutput    totalOverlap{};
 
     for (NumberOfNeighborsType counter = 0; counter < neighbors; ++counter)
     {

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -203,7 +203,7 @@ typename MultiphaseFiniteDifferenceImageFilter<TInputImage,
 MultiphaseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputImage, TFiniteDifferenceFunction, TIdCell>::
   ResolveTimeStep(const TimeStepVectorType & timeStepList, const std::vector<uint8_t> & valid)
 {
-  TimeStepType        oMin = NumericTraits<TimeStepType>::ZeroValue();
+  TimeStepType        oMin{};
   const SizeValueType size = timeStepList.size();
 
   if (size == valid.size())

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -814,7 +814,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 
   unsigned int    i;
   ValueType       value_temp, delta;
-  ValueType       value = NumericTraits<ValueType>::ZeroValue(); // warnings
+  ValueType       value{}; // warnings
   bool            found_neighbor_flag;
   LayerIterator   toIt;
   LayerNodeType * node;

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
@@ -99,7 +99,7 @@ public:
   {
     GlobalDataStruct()
     {
-      ScalarValueType null_value = NumericTraits<ScalarValueType>::ZeroValue();
+      ScalarValueType null_value{};
 
       m_MaxCurvatureChange = null_value;
       m_MaxAdvectionChange = null_value;

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -170,7 +170,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeCurvature(con
                                                                              GlobalDataStruct *      gd)
 {
   // Calculate the mean curvature
-  ScalarValueType curvature = NumericTraits<ScalarValueType>::ZeroValue();
+  ScalarValueType curvature{};
 
   unsigned int i, j;
 
@@ -248,10 +248,10 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
   // Access the neighborhood center pixel of phi
   const ScalarValueType inputValue = it.GetCenterPixel();
 
-  ScalarValueType laplacian_term = NumericTraits<ScalarValueType>::ZeroValue();
-  ScalarValueType curvature_term = NumericTraits<ScalarValueType>::ZeroValue();
-  ScalarValueType curvature = NumericTraits<ScalarValueType>::ZeroValue();
-  ScalarValueType globalTerm = NumericTraits<ScalarValueType>::ZeroValue();
+  ScalarValueType laplacian_term{};
+  ScalarValueType curvature_term{};
+  ScalarValueType curvature{};
+  ScalarValueType globalTerm{};
   VectorType      advection_field;
   ScalarValueType x_energy, advection_term = NumericTraits<ScalarValueType>::ZeroValue();
 

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -539,7 +539,7 @@ RobustSolver<VDimension>::DeleteLandmarksOutOfMesh()
   using VectorContainerType = itk::VectorContainer<LoadIdentifier, Load::Pointer>;
   auto newLoadContainer = VectorContainerType::New();
 
-  LoadIdentifier numToRemoveLoads = NumericTraits<LoadIdentifier>::ZeroValue();
+  LoadIdentifier numToRemoveLoads{};
 
   LoadContainerType * container = this->m_FEMObject->GetModifiableLoadContainer();
 

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
@@ -73,7 +73,7 @@ RegistrationParameterScalesFromJacobian<TMetric>::EstimateStepScale(const Parame
   this->ComputeSampleStepScales(step, sampleScales);
 
   const auto numSamples = static_cast<const SizeValueType>(this->m_SamplePoints.size());
-  FloatType  scaleSum = NumericTraits<FloatType>::ZeroValue();
+  FloatType  scaleSum{};
 
   // checking each sample point
   for (SizeValueType c = 0; c < numSamples; ++c)

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -137,7 +137,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateStepScale(const Param
   // For global transforms, we want a linear approximation of the function
   // of step scale w.r.t "step". This is true only when "step" is close to
   // zero. Therefore, we need to scale "step" down.
-  FloatType maxStep = NumericTraits<FloatType>::ZeroValue();
+  FloatType maxStep{};
   for (typename ParametersType::SizeValueType p = 0; p < step.GetSize(); ++p)
   {
     if (maxStep < itk::Math::abs(step[p]))
@@ -208,7 +208,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::ComputeMaximumVoxelShift(cons
 
   this->ComputeSampleShifts(deltaParameters, sampleShifts);
 
-  FloatType maxShift = NumericTraits<FloatType>::ZeroValue();
+  FloatType maxShift{};
   for (SizeValueType s = 0; s < sampleShifts.size(); ++s)
   {
     if (maxShift < sampleShifts[s])

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -140,7 +140,7 @@ CovarianceSampleFilter<TSample>::GenerateData()
   NumericTraits<MeasurementVectorRealType>::SetLength(diff, measurementVectorSize);
 
   using TotalFrequencyType = typename SampleType::TotalAbsoluteFrequencyType;
-  TotalFrequencyType totalFrequency = NumericTraits<TotalFrequencyType>::ZeroValue();
+  TotalFrequencyType totalFrequency{};
 
   typename SampleType::ConstIterator       iter = input->Begin();
   const typename SampleType::ConstIterator end = input->End();

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -162,7 +162,7 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::CalculateDensities()
 
   using FrequencyType = typename TSample::AbsoluteFrequencyType;
   FrequencyType                           frequency;
-  FrequencyType                           zeroFrequency = NumericTraits<FrequencyType>::ZeroValue();
+  FrequencyType                           zeroFrequency{};
   typename TSample::MeasurementVectorType mvector;
   double                                  density;
   double                                  densitySum;

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -627,7 +627,7 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
   else
   {
     n = size - 1;
-    InstanceIdentifier m = NumericTraits<InstanceIdentifier>::ZeroValue();
+    InstanceIdentifier m{};
     p_n = 1.0;
     do
     {

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
@@ -75,16 +75,16 @@ HistogramToRunLengthFeaturesFilter<THistogram>::GenerateData()
 
   this->m_TotalNumberOfRuns = static_cast<unsigned long>(inputHistogram->GetTotalFrequency());
 
-  MeasurementType shortRunEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType longRunEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType greyLevelNonuniformity = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType runLengthNonuniformity = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType lowGreyLevelRunEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType highGreyLevelRunEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType shortRunLowGreyLevelEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType shortRunHighGreyLevelEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType longRunLowGreyLevelEmphasis = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType longRunHighGreyLevelEmphasis = NumericTraits<MeasurementType>::ZeroValue();
+  MeasurementType shortRunEmphasis{};
+  MeasurementType longRunEmphasis{};
+  MeasurementType greyLevelNonuniformity{};
+  MeasurementType runLengthNonuniformity{};
+  MeasurementType lowGreyLevelRunEmphasis{};
+  MeasurementType highGreyLevelRunEmphasis{};
+  MeasurementType shortRunLowGreyLevelEmphasis{};
+  MeasurementType shortRunHighGreyLevelEmphasis{};
+  MeasurementType longRunLowGreyLevelEmphasis{};
+  MeasurementType longRunHighGreyLevelEmphasis{};
 
   vnl_vector<double> greyLevelNonuniformityVector(inputHistogram->GetSize()[0], 0.0);
   vnl_vector<double> runLengthNonuniformityVector(inputHistogram->GetSize()[1], 0.0);

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -94,16 +94,16 @@ HistogramToTextureFeaturesFilter<THistogram>::GenerateData()
   this->ComputeMeansAndVariances(pixelMean, marginalMean, marginalDevSquared, pixelVariance);
 
   // Finally compute the texture features. Another one pass.
-  MeasurementType energy = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType entropy = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType correlation = NumericTraits<MeasurementType>::ZeroValue();
+  MeasurementType energy{};
+  MeasurementType entropy{};
+  MeasurementType correlation{};
 
-  MeasurementType inverseDifferenceMoment = NumericTraits<MeasurementType>::ZeroValue();
+  MeasurementType inverseDifferenceMoment{};
 
-  MeasurementType inertia = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType clusterShade = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType clusterProminence = NumericTraits<MeasurementType>::ZeroValue();
-  MeasurementType haralickCorrelation = NumericTraits<MeasurementType>::ZeroValue();
+  MeasurementType inertia{};
+  MeasurementType clusterShade{};
+  MeasurementType clusterProminence{};
+  MeasurementType haralickCorrelation{};
 
   double pixelVarianceSquared = pixelVariance * pixelVariance;
   // Variance is only used in correlation. If variance is 0, then

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -124,7 +124,7 @@ MeanSampleFilter<TSample>::GenerateData()
   std::vector<MeasurementRealAccumulateType> sum(measurementVectorSize);
 
   using TotalFrequencyType = typename SampleType::TotalAbsoluteFrequencyType;
-  TotalFrequencyType totalFrequency = NumericTraits<TotalFrequencyType>::ZeroValue();
+  TotalFrequencyType totalFrequency{};
 
   typename SampleType::ConstIterator       iter = input->Begin();
   const typename SampleType::ConstIterator end = input->End();

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
@@ -92,9 +92,9 @@ WeightedCovarianceSampleFilter<TSample>::ComputeCovarianceMatrixWithWeightingFun
   MeasurementVectorRealType diff;
   NumericTraits<MeasurementVectorRealType>::SetLength(diff, measurementVectorSize);
 
-  WeightValueType totalWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalWeight{};
 
-  WeightValueType totalSquaredWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalSquaredWeight{};
 
   typename SampleType::ConstIterator       iter = input->Begin();
   const typename SampleType::ConstIterator end = input->End();
@@ -189,9 +189,9 @@ WeightedCovarianceSampleFilter<TSample>::ComputeCovarianceMatrixWithWeights()
   MeasurementVectorRealType diff;
   NumericTraits<MeasurementVectorRealType>::SetLength(diff, measurementVectorSize);
 
-  WeightValueType totalWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalWeight{};
 
-  WeightValueType totalSquaredWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalSquaredWeight{};
 
   typename SampleType::ConstIterator       iter = input->Begin();
   const typename SampleType::ConstIterator end = input->End();

--- a/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
@@ -81,7 +81,7 @@ WeightedMeanSampleFilter<TSample>::ComputeMeanWithWeights()
 
   const WeightArrayType & weightsArray = this->GetWeights();
 
-  WeightValueType totalWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalWeight{};
 
   typename SampleType::ConstIterator iter = input->Begin();
   typename SampleType::ConstIterator end = input->End();
@@ -142,7 +142,7 @@ WeightedMeanSampleFilter<TSample>::ComputeMeanWithWeightingFunction()
 
   const WeightingFunctionType * const weightFunction = this->GetWeightingFunction();
 
-  WeightValueType totalWeight = NumericTraits<WeightValueType>::ZeroValue();
+  WeightValueType totalWeight{};
 
   typename SampleType::ConstIterator       iter = input->Begin();
   const typename SampleType::ConstIterator end = input->End();

--- a/Modules/Numerics/Statistics/test/itkSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest.cxx
@@ -82,7 +82,7 @@ public:
   TotalAbsoluteFrequencyType
   GetTotalFrequency() const override
   {
-    TotalAbsoluteFrequencyType sum = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+    TotalAbsoluteFrequencyType sum{};
     auto                       itr = m_Frequencies.begin();
     while (itr != m_Frequencies.end())
     {

--- a/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
@@ -89,7 +89,7 @@ public:
   TotalAbsoluteFrequencyType
   GetTotalFrequency() const override
   {
-    TotalAbsoluteFrequencyType sum = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+    TotalAbsoluteFrequencyType sum{};
     auto                       itr = m_Frequencies.begin();
     while (itr != m_Frequencies.end())
     {

--- a/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
@@ -90,7 +90,7 @@ public:
   TotalAbsoluteFrequencyType
   GetTotalFrequency() const override
   {
-    TotalAbsoluteFrequencyType sum = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+    TotalAbsoluteFrequencyType sum{};
     auto                       itr = m_Frequencies.begin();
     while (itr != m_Frequencies.end())
     {

--- a/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
@@ -90,7 +90,7 @@ public:
   TotalAbsoluteFrequencyType
   GetTotalFrequency() const override
   {
-    TotalAbsoluteFrequencyType sum = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+    TotalAbsoluteFrequencyType sum{};
     auto                       itr = m_Frequencies.begin();
     while (itr != m_Frequencies.end())
     {

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -316,7 +316,7 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
     const auto                       movingIndex = movingImage->TransformPhysicalPointToIndex(originalLocation);
 
     // the block is selected for a minimum similarity metric
-    SimilaritiesValue similarity = NumericTraits<SimilaritiesValue>::ZeroValue();
+    SimilaritiesValue similarity{};
 
     // New point location
     DisplacementsVector displacement;
@@ -336,11 +336,11 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
     // iterate over neighborhoods in region window
     for (windowIterator.GoToBegin(); !windowIterator.IsAtEnd(); ++windowIterator)
     {
-      SimilaritiesValue fixedSum = NumericTraits<SimilaritiesValue>::ZeroValue();
-      SimilaritiesValue fixedSumOfSquares = NumericTraits<SimilaritiesValue>::ZeroValue();
-      SimilaritiesValue movingSum = NumericTraits<SimilaritiesValue>::ZeroValue();
-      SimilaritiesValue movingSumOfSquares = NumericTraits<SimilaritiesValue>::ZeroValue();
-      SimilaritiesValue covariance = NumericTraits<SimilaritiesValue>::ZeroValue();
+      SimilaritiesValue fixedSum{};
+      SimilaritiesValue fixedSumOfSquares{};
+      SimilaritiesValue movingSum{};
+      SimilaritiesValue movingSumOfSquares{};
+      SimilaritiesValue covariance{};
 
       // iterate over voxels in blockRadius
       for (SizeValueType i = 0; i < numberOfVoxelInBlock; ++i) // windowIterator.Size() == numberOfVoxelInBlock
@@ -359,7 +359,7 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
       const SimilaritiesValue movingVariance = movingSumOfSquares - numberOfVoxelInBlock * movingMean * movingMean;
       covariance -= numberOfVoxelInBlock * fixedMean * movingMean;
 
-      SimilaritiesValue sim = NumericTraits<SimilaritiesValue>::ZeroValue();
+      SimilaritiesValue sim{};
       if ((fixedVariance * movingVariance) != 0.0)
       {
         sim = (covariance * covariance) / (fixedVariance * movingVariance);

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
@@ -38,7 +38,7 @@ auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeanX(HistogramType & histogram) const
   -> MeasureType
 {
-  MeasureType meanX = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType meanX{};
 
   for (unsigned int i = 0; i < this->m_HistogramSize[0]; ++i)
   {
@@ -57,7 +57,7 @@ auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeanY(HistogramType & histogram) const
   -> MeasureType
 {
-  MeasureType meanY = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType meanY{};
 
   for (unsigned int i = 0; i < this->m_HistogramSize[1]; ++i)
   {
@@ -76,7 +76,7 @@ auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::VarianceX(HistogramType & histogram) const
   -> MeasureType
 {
-  MeasureType varX = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType varX{};
 
   for (unsigned int i = 0; i < this->m_HistogramSize[0]; ++i)
   {
@@ -92,7 +92,7 @@ auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::VarianceY(HistogramType & histogram) const
   -> MeasureType
 {
-  MeasureType varY = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType varY{};
 
   for (unsigned int i = 0; i < this->m_HistogramSize[1]; ++i)
   {
@@ -108,7 +108,7 @@ typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingI
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Covariance(
   HistogramType & histogram) const
 {
-  MeasureType var = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType var{};
   MeasureType meanX = MeanX(histogram);
   MeasureType meanY = MeanY(histogram);
 

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -296,7 +296,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
 
   this->SetTransformParameters(parameters);
   m_TransformMovingImageFilter->UpdateLargestPossibleRegion();
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -73,9 +73,9 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
   // and moving image.
   //
   MeasureType measure;
-  MeasureType intersection = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType movingForegroundArea = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType fixedForegroundArea = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType intersection{};
+  MeasureType movingForegroundArea{};
+  MeasureType fixedForegroundArea{};
 
   // Compute fixedForegroundArea, movingForegroundArea, and
   // intersection. Loop over the fixed image.

--- a/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
@@ -49,7 +49,7 @@ KullbackLeiblerCompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::Ev
   // First the term that measures the entropy of the term
   // p(x,y) log p(x,y) - p(x,y) log q(x,y)
 
-  MeasureType KullbackLeibler = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType KullbackLeibler{};
 
   HistogramIteratorType measured_it = histogram.Begin();
   HistogramIteratorType measured_end = histogram.End();

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -55,7 +55,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
   // Initialize some variables before spawning threads
   //
   //
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
   this->m_NumberOfPixelsCounted = 0;
 
   m_ThreadMatches.clear();
@@ -126,7 +126,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
   typename FixedImageType::IndexType index;
   FixedIteratorType                  ti(fixedImage, regionForThread);
 
-  MeasureType   threadMeasure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType   threadMeasure{};
   SizeValueType threadNumberOfPixelsCounted = 0;
 
   while (!ti.IsAtEnd())

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -63,7 +63,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
 
   typename FixedImageType::IndexType index;
 
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   this->m_NumberOfPixelsCounted = 0;
 

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -48,7 +48,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   PointDataIterator pointDataItr = fixedPointSet->GetPointData()->Begin();
   PointDataIterator pointDataEnd = fixedPointSet->GetPointData()->End();
 
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   this->m_NumberOfPixelsCounted = 0;
   double lambdaSquared = std::pow(this->m_Lambda, 2);
@@ -156,7 +156,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sum = NumericTraits<RealType>::ZeroValue();
+        RealType sum{};
         for (unsigned int dim = 0; dim < Self::FixedPointSetDimension; ++dim)
         {
           // Will it be computationally more efficient to instead calculate the
@@ -204,7 +204,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   }
 
   this->m_NumberOfPixelsCounted = 0;
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   this->SetTransformParameters(parameters);
   double lambdaSquared = std::pow(this->m_Lambda, 2);
@@ -255,7 +255,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sum = NumericTraits<RealType>::ZeroValue();
+        RealType sum{};
         for (unsigned int dim = 0; dim < Self::FixedPointSetDimension; ++dim)
         {
           sum -= jacobian(dim, par) * gradient[dim] * std::pow(lambdaSquared + diffSquared, 2);

--- a/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
@@ -26,10 +26,10 @@ auto
 MeanSquaresHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(HistogramType & histogram) const
   -> MeasureType
 {
-  MeasureType            measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType            measure{};
   HistogramIteratorType  it = histogram.Begin();
   HistogramIteratorType  end = histogram.End();
-  HistogramFrequencyType totalNumberOfSamples = NumericTraits<HistogramFrequencyType>::ZeroValue();
+  HistogramFrequencyType totalNumberOfSamples{};
 
   while (it != end)
   {

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -43,7 +43,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
   PointDataIterator pointDataItr = fixedPointSet->GetPointData()->Begin();
   PointDataIterator pointDataEnd = fixedPointSet->GetPointData()->End();
 
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   this->m_NumberOfPixelsCounted = 0;
 
@@ -150,7 +150,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sum = NumericTraits<RealType>::ZeroValue();
+        RealType sum{};
         for (unsigned int dim = 0; dim < Self::FixedPointSetDimension; ++dim)
         {
           sum += 2.0 * diff * jacobian(dim, par) * gradient[dim];
@@ -199,7 +199,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
   }
 
   this->m_NumberOfPixelsCounted = 0;
-  MeasureType measure = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType measure{};
 
   this->SetTransformParameters(parameters);
 
@@ -250,7 +250,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sum = NumericTraits<RealType>::ZeroValue();
+        RealType sum{};
         for (unsigned int dim = 0; dim < Self::FixedPointSetDimension; ++dim)
         {
           sum += 2.0 * diff * jacobian(dim, par) * gradient[dim];

--- a/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
@@ -27,9 +27,9 @@ typename MutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>
 MutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
   HistogramType & histogram) const
 {
-  MeasureType entropyX = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType entropyY = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType jointEntropy = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType entropyX{};
+  MeasureType entropyY{};
+  MeasureType jointEntropy{};
 
   using HistogramFrequencyRealType = typename NumericTraits<HistogramFrequencyType>::RealType;
 

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -55,11 +55,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   while (!ti.IsAtEnd())
   {
@@ -153,11 +153,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
@@ -257,8 +257,8 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sumF = NumericTraits<RealType>::ZeroValue();
-        RealType sumM = NumericTraits<RealType>::ZeroValue();
+        RealType sumF{};
+        RealType sumM{};
         for (unsigned int dim = 0; dim < dimension; ++dim)
         {
           const RealType differential = jacobian(dim, par) * gradient[dim];
@@ -336,11 +336,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
@@ -442,8 +442,8 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sumF = NumericTraits<RealType>::ZeroValue();
-        RealType sumM = NumericTraits<RealType>::ZeroValue();
+        RealType sumF{};
+        RealType sumM{};
         for (unsigned int dim = 0; dim < dimension; ++dim)
         {
           const RealType differential = jacobian(dim, par) * gradient[dim];

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -55,11 +55,11 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   while (pointItr != pointEnd && pointDataItr != pointDataEnd)
   {
@@ -133,11 +133,11 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
@@ -200,7 +200,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sumD = NumericTraits<RealType>::ZeroValue();
+        RealType sumD{};
         for (unsigned int dim = 0; dim < dimension; ++dim)
         {
           const RealType differential = jacobian(dim, par) * gradient[dim];
@@ -276,11 +276,11 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
 
   using AccumulateType = typename NumericTraits<MeasureType>::AccumulateType;
 
-  AccumulateType sff = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType smm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sfm = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sf = NumericTraits<AccumulateType>::ZeroValue();
-  AccumulateType sm = NumericTraits<AccumulateType>::ZeroValue();
+  AccumulateType sff{};
+  AccumulateType smm{};
+  AccumulateType sfm{};
+  AccumulateType sf{};
+  AccumulateType sm{};
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
@@ -343,7 +343,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
       const GradientPixelType gradient = this->GetGradientImage()->GetPixel(mappedIndex);
       for (unsigned int par = 0; par < ParametersDimension; ++par)
       {
-        RealType sumD = NumericTraits<RealType>::ZeroValue();
+        RealType sumD{};
         for (unsigned int dim = 0; dim < dimension; ++dim)
         {
           const RealType differential = jacobian(dim, par) * gradient[dim];

--- a/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
@@ -27,9 +27,9 @@ typename NormalizedMutualInformationHistogramImageToImageMetric<TFixedImage, TMo
 NormalizedMutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
   HistogramType & histogram) const
 {
-  MeasureType entropyX = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType entropyY = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType jointEntropy = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType entropyX{};
+  MeasureType entropyY{};
+  MeasureType jointEntropy{};
 
   using HistogramFrequencyRealType = typename NumericTraits<HistogramFrequencyType>::RealType;
 

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -42,8 +42,8 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
   std::call_once(this->m_ANTSAssociateOnceFlag, [this, &associate]() { this->m_ANTSAssociate = associate; });
 
   VirtualPointType   virtualPoint;
-  MeasureType        metricValueResult = NumericTraits<MeasureType>::ZeroValue();
-  MeasureType        metricValueSum = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType        metricValueResult{};
+  MeasureType        metricValueSum{};
   bool               pointIsValid;
   ScanIteratorType   scanIt;
   ScanParametersType scanParameters;
@@ -137,7 +137,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   const SizeValueType numberOfFillZero = scanParameters.numberOfFillZero;
   const SizeValueType hoodlen = scanParameters.windowLength;
 
-  InternalComputationValueType zero = NumericTraits<InternalComputationValueType>::ZeroValue();
+  InternalComputationValueType zero{};
   scanMem.QsumFixed2 = SumQueueType(numberOfFillZero, zero);
   scanMem.QsumMoving2 = SumQueueType(numberOfFillZero, zero);
   scanMem.QsumFixed = SumQueueType(numberOfFillZero, zero);
@@ -150,7 +150,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   // Now add the rest of the values from each hyperplane
   SizeValueType diameter = 2 * scanParameters.radius[0];
 
-  const LocalRealType localZero = NumericTraits<LocalRealType>::ZeroValue();
+  const LocalRealType localZero{};
   for (SizeValueType i = numberOfFillZero; i < (diameter + NumericTraits<SizeValueType>::OneValue()); ++i)
   {
     LocalRealType sumFixed2 = localZero;
@@ -234,7 +234,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
   using LocalRealType = InternalComputationValueType;
 
-  const LocalRealType localZero = NumericTraits<LocalRealType>::ZeroValue();
+  const LocalRealType localZero{};
 
   LocalRealType sumFixed2 = localZero;
   LocalRealType sumMoving2 = localZero;
@@ -381,7 +381,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 {
   using LocalRealType = InternalComputationValueType;
 
-  const LocalRealType localZero = NumericTraits<LocalRealType>::ZeroValue();
+  const LocalRealType localZero{};
 
   LocalRealType count = localZero;
 
@@ -587,7 +587,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
                            const ThreadIdType                                  threadId)
 {
 
-  MeasureType        metricValueResult = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType        metricValueResult{};
   bool               pointIsValid;
   ScanIteratorType   scanIt;
   ScanParametersType scanParameters;

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -117,9 +117,9 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
 
   /* Accumulate the metric value from threads and store */
   this->m_CorrelationAssociate->m_Value = NumericTraits<InternalComputationValueType>::ZeroValue();
-  InternalComputationValueType fm = NumericTraits<InternalComputationValueType>::ZeroValue();
-  InternalComputationValueType f2 = NumericTraits<InternalComputationValueType>::ZeroValue();
-  InternalComputationValueType m2 = NumericTraits<InternalComputationValueType>::ZeroValue();
+  InternalComputationValueType fm{};
+  InternalComputationValueType f2{};
+  InternalComputationValueType m2{};
   for (ThreadIdType threadId = 0; threadId < numWorkUnitsUsed; ++threadId)
   {
     fm += this->m_CorrelationMetricValueDerivativePerThreadVariables[threadId].fm;
@@ -315,7 +315,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
     for (unsigned int par = 0; par < this->m_CorrelationAssociate->GetNumberOfLocalParameters(); ++par)
     {
-      InternalComputationValueType sum = NumericTraits<InternalComputationValueType>::ZeroValue();
+      InternalComputationValueType sum{};
       for (SizeValueType dim = 0; dim < ImageToImageMetricv4Type::MovingImageDimension; ++dim)
       {
         sum += movingImageGradient[dim] * jacobian(dim, par);

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
@@ -78,8 +78,8 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
     return;
   }
 
-  InternalComputationValueType sumF = NumericTraits<InternalComputationValueType>::ZeroValue();
-  InternalComputationValueType sumM = NumericTraits<InternalComputationValueType>::ZeroValue();
+  InternalComputationValueType sumF{};
+  InternalComputationValueType sumM{};
 
   for (ThreadIdType threadId = 0; threadId < numWorkUnitsUsed; ++threadId)
   {

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -168,7 +168,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
 
   for (NumberOfParametersType par = 0; par < this->GetCachedNumberOfLocalParameters(); ++par)
   {
-    InternalComputationValueType sum = NumericTraits<InternalComputationValueType>::ZeroValue();
+    InternalComputationValueType sum{};
     for (SizeValueType dim = 0; dim < TImageToImageMetric::MovingImageDimension; ++dim)
     {
       sum += scalingfactor * jacobian(dim, par) * movingImageGradient[dim];
@@ -312,7 +312,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   }
 
   InternalComputationValueType delta = rightpoint[ind] - leftpoint[ind];
-  InternalComputationValueType deriv = NumericTraits<InternalComputationValueType>::ZeroValue();
+  InternalComputationValueType deriv{};
   if (delta > NumericTraits<InternalComputationValueType>::ZeroValue())
   {
     deriv = this->m_JointHistogramMIPerThreadVariables[threadId].JointPDFInterpolator->Evaluate(rightpoint) -

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -217,7 +217,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   /* Prepare histograms for use in GetValueAndDerivative */
 
   // Initialize the joint pdf and the fixed and moving image marginal pdfs
-  PDFValueType pdfzero = NumericTraits<PDFValueType>::ZeroValue();
+  PDFValueType pdfzero{};
   this->m_JointPDF->FillBuffer(pdfzero);
   this->m_FixedImageMarginalPDF->FillBuffer(pdfzero);
   this->m_MovingImageMarginalPDF->FillBuffer(pdfzero);

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -132,7 +132,7 @@ typename LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
   auto fixedPointSet = FixedPointSetType::New();
   fixedPointSet->Initialize();
 
-  typename FixedPointSetType::PointIdentifier count = NumericTraits<PointIdentifier>::ZeroValue();
+  typename FixedPointSetType::PointIdentifier count{};
 
   typename FixedPointSetType::PointsContainerConstIterator It = this->m_FixedPointSet->GetPoints()->Begin();
   typename FixedPointSetType::PointDataContainerIterator   ItD = this->m_FixedPointSet->GetPointData()->Begin();
@@ -158,7 +158,7 @@ typename LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
   auto movingPointSet = MovingPointSetType::New();
   movingPointSet->Initialize();
 
-  typename MovingPointSetType::PointIdentifier count = NumericTraits<PointIdentifier>::ZeroValue();
+  typename MovingPointSetType::PointIdentifier count{};
 
   typename MovingPointSetType::PointsContainerConstIterator It = this->m_MovingPointSet->GetPoints()->Begin();
   typename MovingPointSetType::PointDataContainerIterator   ItD = this->m_MovingPointSet->GetPointData()->Begin();

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -133,7 +133,7 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
                         << this->m_MetricWeights.Size());
     }
     /* normalize the weights */
-    WeightValueType sum = NumericTraits<WeightValueType>::ZeroValue();
+    WeightValueType sum{};
     for (SizeValueType j = 0; j < this->GetNumberOfMetrics(); ++j)
     {
       sum += this->m_MetricWeights[j];
@@ -292,17 +292,17 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
   derivativeResult.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
 
   DerivativeType metricDerivative;
-  MeasureType    metricValue = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType    metricValue{};
 
   // Loop over metrics
-  DerivativeValueType totalMagnitude = NumericTraits<DerivativeValueType>::ZeroValue();
+  DerivativeValueType totalMagnitude{};
   for (SizeValueType j = 0; j < this->GetNumberOfMetrics(); ++j)
   {
     this->m_MetricQueue[j]->GetValueAndDerivative(metricValue, metricDerivative);
     this->m_MetricValueArray[j] = metricValue;
 
     DerivativeValueType magnitude = metricDerivative.magnitude();
-    DerivativeValueType weightOverMagnitude = NumericTraits<DerivativeValueType>::ZeroValue();
+    DerivativeValueType weightOverMagnitude{};
     totalMagnitude += magnitude;
 
     if (magnitude > NumericTraits<DerivativeValueType>::epsilon())
@@ -351,7 +351,7 @@ typename ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtual
   ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TInternalComputationValueType>::
     GetWeightedValue() const
 {
-  MeasureType value = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType value{};
 
   for (SizeValueType j = 0; j < this->GetNumberOfMetrics(); ++j)
   {

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -228,7 +228,7 @@ void
 PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::GetDerivative(
   DerivativeType & derivative) const
 {
-  MeasureType value = NumericTraits<MeasureType>::ZeroValue();
+  MeasureType value{};
   this->CalculateValueAndDerivative(value, derivative, false);
 }
 
@@ -297,7 +297,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
       NumericTraits<PixelType>::SetLength(pixel, 1);
       for (PointIdentifier index = ranges[rangeIndex].first; index < ranges[rangeIndex].second; ++index)
       {
-        MeasureType         pointValue = NumericTraits<MeasureType>::ZeroValue();
+        MeasureType         pointValue{};
         LocalDerivativeType pointDerivative;
 
         /* Verify the virtual point is in the virtual domain.
@@ -421,7 +421,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
 {
   // Determine the number of valid fixed points, using
   // their positions in the virtual domain.
-  SizeValueType       numberOfValidPoints = NumericTraits<SizeValueType>::ZeroValue();
+  SizeValueType       numberOfValidPoints{};
   PointsConstIterator virtualIt = this->m_VirtualTransformedPointSet->GetPoints()->Begin();
   while (virtualIt != this->m_VirtualTransformedPointSet->GetPoints()->End())
   {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -299,8 +299,8 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
 
       if (this->GetDebug())
       {
-        RealType spatialNorm = NumericTraits<RealType>::ZeroValue();
-        RealType spatioTemporalNorm = NumericTraits<RealType>::ZeroValue();
+        RealType spatialNorm{};
+        RealType spatioTemporalNorm{};
 
         typename TimeVaryingVelocityFieldType::SizeType radius;
         radius.Fill(1);
@@ -316,8 +316,8 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
         ConstNeighborhoodIterator<TimeVaryingVelocityFieldType> ItV(radius, velocityField, faceList.front());
         for (ItV.GoToBegin(); !ItV.IsAtEnd(); ++ItV)
         {
-          RealType localSpatialNorm = NumericTraits<RealType>::ZeroValue();
-          RealType localSpatioTemporalNorm = NumericTraits<RealType>::ZeroValue();
+          RealType localSpatialNorm{};
+          RealType localSpatioTemporalNorm{};
           for (unsigned int d = 0; d < ImageDimension + 1; ++d)
           {
             DisplacementVectorType vector = (ItV.GetNext(d) - ItV.GetPrevious(d)) * 0.5 * velocityFieldSpacing[d];
@@ -361,11 +361,11 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   velocityFieldPointSet->Initialize();
   velocityFieldWeights->Initialize();
 
-  IdentifierType numberOfVelocityFieldPoints = NumericTraits<IdentifierType>::ZeroValue();
+  IdentifierType numberOfVelocityFieldPoints{};
 
   for (SizeValueType timePoint = 0; timePoint < this->m_NumberOfTimePointSamples; ++timePoint)
   {
-    RealType t = NumericTraits<RealType>::ZeroValue();
+    RealType t{};
     if (this->m_NumberOfTimePointSamples > 1)
     {
       t = static_cast<RealType>(timePoint) / static_cast<RealType>(this->m_NumberOfTimePointSamples - 1);
@@ -464,7 +464,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
 
       this->m_Metric->Initialize();
       typename ImageMetricType::DerivativeType metricDerivative;
-      MeasureType                              value = NumericTraits<MeasureType>::ZeroValue();
+      MeasureType                              value{};
 
       this->m_Metric->GetValueAndDerivative(value, metricDerivative);
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -144,13 +144,13 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   while (this->m_CurrentIteration++ < this->m_NumberOfIterationsPerLevel[this->m_CurrentLevel] && !this->m_IsConverged)
   {
     updateDerivative.Fill(0);
-    MeasureType value = NumericTraits<MeasureType>::ZeroValue();
+    MeasureType value{};
     this->m_CurrentMetricValue = NumericTraits<MeasureType>::ZeroValue();
 
     // Time index zero brings the moving image closest to the fixed image
     for (IndexValueType timePoint = 0; timePoint < numberOfTimePoints; ++timePoint)
     {
-      RealType t = NumericTraits<RealType>::ZeroValue();
+      RealType t{};
       if (numberOfTimePoints > 1)
       {
         t = static_cast<RealType>(timePoint) / static_cast<RealType>(numberOfTimePoints - 1);
@@ -360,8 +360,8 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
 
       if (this->GetDebug())
       {
-        RealType spatialNorm = NumericTraits<RealType>::ZeroValue();
-        RealType spatioTemporalNorm = NumericTraits<RealType>::ZeroValue();
+        RealType spatialNorm{};
+        RealType spatioTemporalNorm{};
 
         typename TimeVaryingVelocityFieldType::SizeType radius;
         radius.Fill(1);
@@ -377,8 +377,8 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
         ConstNeighborhoodIterator<TimeVaryingVelocityFieldType> ItV(radius, velocityField, faceList.front());
         for (ItV.GoToBegin(); !ItV.IsAtEnd(); ++ItV)
         {
-          RealType localSpatialNorm = NumericTraits<RealType>::ZeroValue();
-          RealType localSpatioTemporalNorm = NumericTraits<RealType>::ZeroValue();
+          RealType localSpatialNorm{};
+          RealType localSpatioTemporalNorm{};
           for (unsigned int d = 0; d < ImageDimension + 1; ++d)
           {
             DisplacementVectorType vector = (ItV.GetNext(d) - ItV.GetPrevious(d)) * 0.5 * velocityFieldSpacing[d];

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -35,7 +35,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
 
   InputPixelType        value, neighborValue;
   OutputPixelType       label, originalLabel, neighborLabel;
-  OutputPixelType       maxLabel = NumericTraits<OutputPixelType>::ZeroValue();
+  OutputPixelType       maxLabel{};
   const OutputPixelType maxPossibleLabel = NumericTraits<OutputPixelType>::max();
 
   typename TOutputImage::Pointer     output = this->GetOutput();

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -197,7 +197,7 @@ protected:
   using WorkUnitData = typename ScanlineFunctions::WorkUnitData;
 
 private:
-  OutputPixelType m_BackgroundValue = NumericTraits<OutputPixelType>::ZeroValue();
+  OutputPixelType m_BackgroundValue{};
   LabelType       m_ObjectCount = 0;
 
   typename TInputImage::ConstPointer m_Input{};

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -78,7 +78,7 @@ public:
   operator()(const TInput & a, const TInput & b) const
   {
     using RealValueType = typename NumericTraits<typename TInput::ValueType>::RealType;
-    RealValueType dotProduct = NumericTraits<RealValueType>::ZeroValue();
+    RealValueType dotProduct{};
     for (unsigned int i = 0; i < NumericTraits<TInput>::GetLength(a); ++i)
     {
       dotProduct += a[i] * b[i];

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -59,7 +59,7 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
   ScalarValueType       gradMag = std::sqrt(gd->m_GradMagSqr);
   ScalarValueType       Pgrad[ImageDimension][ImageDimension];
   ScalarValueType       tmp_matrix[ImageDimension][ImageDimension];
-  const ScalarValueType ZERO = NumericTraits<ScalarValueType>::ZeroValue();
+  const ScalarValueType ZERO{};
 
   vnl_matrix_fixed<ScalarValueType, ImageDimension, ImageDimension> Curve;
   const ScalarValueType                                             MIN_EIG = NumericTraits<ScalarValueType>::min();
@@ -154,7 +154,7 @@ LevelSetFunction<TImageType>::ComputeMeanCurvature(const NeighborhoodType & itkN
                                                    GlobalDataStruct *       gd)
 {
   // Calculate the mean curvature
-  ScalarValueType curvature_term = NumericTraits<ScalarValueType>::ZeroValue();
+  ScalarValueType curvature_term{};
   unsigned int    i, j;
 
   for (i = 0; i < ImageDimension; ++i)
@@ -286,7 +286,7 @@ LevelSetFunction<TImageType>::ComputeUpdate(const NeighborhoodType & it,
                                             const FloatOffsetType &  offset)
 {
   unsigned int          i, j;
-  const ScalarValueType ZERO = NumericTraits<ScalarValueType>::ZeroValue();
+  const ScalarValueType ZERO{};
   const ScalarValueType center_value = it.GetCenterPixel();
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -194,7 +194,7 @@ BinaryImageToLevelSetImageAdaptor<TInput,
 {
   LevelSetLabelObjectPointer labelObject = this->m_LabelMap->GetLabelObject(LevelSetType::MinusThreeLayer());
 
-  const LevelSetOutputType zero = NumericTraits<LevelSetOutputType>::ZeroValue();
+  const LevelSetOutputType zero{};
 
   LevelSetLayerType & layer0 = this->m_LevelSet->GetLayer(LevelSetType::ZeroLayer());
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
@@ -221,7 +221,7 @@ template <typename TOutput, unsigned int VDimension>
 auto
 DiscreteLevelSetImage<TOutput, VDimension>::EvaluateLaplacian(const InputType & inputIndex) const -> OutputRealType
 {
-  OutputRealType oLaplacian = NumericTraits<OutputRealType>::ZeroValue();
+  OutputRealType oLaplacian{};
 
   const auto centerValue = static_cast<OutputRealType>(this->Evaluate(inputIndex));
 
@@ -440,7 +440,7 @@ template <typename TOutput, unsigned int VDimension>
 auto
 DiscreteLevelSetImage<TOutput, VDimension>::EvaluateMeanCurvature(const InputType & inputIndex) const -> OutputRealType
 {
-  OutputRealType oValue = NumericTraits<OutputRealType>::ZeroValue();
+  OutputRealType oValue{};
 
   HessianType  hessian = this->EvaluateHessian(inputIndex);
   GradientType grad = this->EvaluateGradient(inputIndex);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -79,7 +79,7 @@ template <typename TInput, unsigned int VDimension, typename TOutput, typename T
 auto
 LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateMeanCurvature(const InputType & iP) const -> OutputRealType
 {
-  OutputRealType oValue = NumericTraits<OutputRealType>::ZeroValue();
+  OutputRealType oValue{};
 
   HessianType  hessian = this->EvaluateHessian(iP);
   GradientType grad = this->EvaluateGradient(iP);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.hxx
@@ -27,7 +27,7 @@ void
 LevelSetDomainPartition<TImage>::PopulateListImage()
 {
   ListPixelType  pixelList;
-  IdentifierType i = NumericTraits<IdentifierType>::ZeroValue();
+  IdentifierType i{};
   while (i < this->m_NumberOfLevelSetFunctions)
   {
     pixelList.push_back(i++);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
@@ -47,7 +47,7 @@ LevelSetDomainPartitionImage<TImage>::PopulateListDomain()
   {
     ListIndexType      listIndex = lIt.GetIndex();
     IdentifierListType identifierList;
-    IdentifierType     i = NumericTraits<IdentifierType>::ZeroValue();
+    IdentifierType     i{};
     while (i < this->m_NumberOfLevelSetFunctions)
     {
       if (this->m_LevelSetDomainRegionVector[i].IsInside(listIndex))

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
@@ -35,7 +35,7 @@ LevelSetDomainPartitionMesh<TMesh>::PopulateListDomain()
     PointIdentifierType & idx = p_it->Index();
     IdentifierListType    identifierList;
 
-    for (IdentifierType i = NumericTraits<IdentifierType>::ZeroValue(); i < this->m_NumberOfLevelSetFunctions; ++i)
+    for (IdentifierType i{}; i < this->m_NumberOfLevelSetFunctions; ++i)
     {
       if (this->m_LevelSetDataPointerVector[i]->VerifyInsideRegion(idx))
       {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -150,7 +150,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
   -> LevelSetOutputRealType
 {
   VectorType             advectionField = this->AdvectionSpeed(iP);
-  LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType oValue{};
 
   LevelSetGradientType backwardGradient = this->m_CurrentLevelSetPointer->EvaluateBackwardGradient(iP);
   LevelSetGradientType forwardGradient = this->m_CurrentLevelSetPointer->EvaluateForwardGradient(iP);
@@ -178,7 +178,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
                                                                  const LevelSetDataType &       iData)
 {
   VectorType             advectionField = this->AdvectionSpeed(iP);
-  LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType oValue{};
 
   for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -64,7 +64,7 @@ auto
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index)
   -> LevelSetOutputRealType
 {
-  LevelSetOutputRealType value = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType value{};
   this->ComputeSumTerm(index, value);
   return -value;
 }
@@ -74,7 +74,7 @@ typename LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::LevelSe
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index,
                                                                       const LevelSetDataType &       itkNotUsed(data))
 {
-  LevelSetOutputRealType value = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType value{};
   this->ComputeSumTerm(index, value);
   return -value;
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -83,7 +83,7 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
   LevelSetGradientType backwardGradient = this->m_CurrentLevelSetPointer->EvaluateBackwardGradient(iP);
   LevelSetGradientType forwardGradient = this->m_CurrentLevelSetPointer->EvaluateForwardGradient(iP);
 
-  const LevelSetOutputRealType zero = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  const LevelSetOutputRealType zero{};
 
   //
   // Construct upwind gradient values for use in the propagation speed term:
@@ -110,7 +110,7 @@ typename LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagatio
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::Value(const LevelSetInputIndexType & iP,
                                                                                       const LevelSetDataType & iData)
 {
-  const LevelSetOutputRealType zero = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  const LevelSetOutputRealType zero{};
   LevelSetOutputRealType       propagation_gradient = zero;
 
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -265,7 +265,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Evaluate(const L
 
   auto cfl_it = m_TermContribution.begin();
 
-  LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType oValue{};
 
   while (term_it != term_end)
   {
@@ -299,7 +299,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Evaluate(const L
 
   auto cfl_it = m_TermContribution.begin();
 
-  LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType oValue{};
 
   while (term_it != term_end)
   {
@@ -351,7 +351,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ComputeCFLContri
 
   auto cfl_it = m_TermContribution.begin();
 
-  LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  LevelSetOutputRealType oValue{};
 
   while (term_it != term_end)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -141,7 +141,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::FillUpdateContainer
 
     const LevelSetOutputRealType update = termContainer->Evaluate(inputIndex);
 
-    LevelSetOutputType value = NumericTraits<LevelSetOutputType>::ZeroValue();
+    LevelSetOutputType value{};
 
     if (update > NumericTraits<LevelSetOutputRealType>::ZeroValue())
     {

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -625,9 +625,9 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
     m_RegionCount[r] = 1;
   }
 
-  LabelType i = NumericTraits<LabelType>::ZeroValue();
-  LabelType k = NumericTraits<LabelType>::ZeroValue();
-  LabelType l = NumericTraits<LabelType>::ZeroValue();
+  LabelType i{};
+  LabelType k{};
+  LabelType l{};
   LabelType label;
 
   while (!labelledImageIt.IsAtEnd())

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -237,7 +237,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Find the sum of the intensities in m_Seeds2.  If the second
       // seeds are not included, the sum should be zero.  Otherwise,
       // it will be other than zero.
-      InputRealType                               seedIntensitySum = NumericTraits<InputRealType>::ZeroValue();
+      InputRealType                               seedIntensitySum{};
       typename SeedsContainerType::const_iterator si = m_Seeds2.begin();
       typename SeedsContainerType::const_iterator li = m_Seeds2.end();
       while (si != li)
@@ -302,7 +302,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Find the sum of the intensities in m_Seeds2.  If the second
       // seeds are not included, the sum should be zero.  Otherwise,
       // it will be other than zero.
-      InputRealType                               seedIntensitySum = NumericTraits<InputRealType>::ZeroValue();
+      InputRealType                               seedIntensitySum{};
       typename SeedsContainerType::const_iterator si = m_Seeds2.begin();
       typename SeedsContainerType::const_iterator li = m_Seeds2.end();
       while (si != li)
@@ -360,8 +360,8 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Find the sum of the intensities in m_Seeds2.  If the second
   // seeds are not included, the sum should be zero.  Otherwise,
   // it will be other than zero.
-  InputRealType                               seed1IntensitySum = NumericTraits<InputRealType>::ZeroValue();
-  InputRealType                               seed2IntensitySum = NumericTraits<InputRealType>::ZeroValue();
+  InputRealType                               seed1IntensitySum{};
+  InputRealType                               seed2IntensitySum{};
   typename SeedsContainerType::const_iterator si1 = m_Seeds1.begin();
   typename SeedsContainerType::const_iterator li1 = m_Seeds1.end();
   while (si1 != li1)

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -269,7 +269,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     covariance.fill(NumericTraits<ComponentRealType>::ZeroValue());
     mean.fill(NumericTraits<ComponentRealType>::ZeroValue());
 
-    SizeValueType num = NumericTraits<SizeValueType>::ZeroValue();
+    SizeValueType num{};
 
     SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
     sit.GoToBegin();

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -91,9 +91,9 @@ MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::Generate
   //---------------------------------------------------------------------------
 
   // the label used to find background in the marker image
-  static const LabelImagePixelType bgLabel = NumericTraits<LabelImagePixelType>::ZeroValue();
+  static const LabelImagePixelType bgLabel{};
   // the label used to mark the watershed line in the output image
-  static const LabelImagePixelType wsLabel = NumericTraits<LabelImagePixelType>::ZeroValue();
+  static const LabelImagePixelType wsLabel{};
 
   this->AllocateOutputs();
 

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -57,8 +57,8 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
   auto               inputImage = static_cast<InputImageConstPointer>(this->GetInput());
   OutputImagePointer outputImage = this->GetOutput();
 
-  OutputImagePixelType z = NumericTraits<OutputImagePixelType>::ZeroValue();
-  OutputImagePixelType CurrentLabel = NumericTraits<OutputImagePixelType>::ZeroValue();
+  OutputImagePixelType z{};
+  OutputImagePixelType CurrentLabel{};
 
   CurrentLabel += 2;
 


### PR DESCRIPTION
Replaced initialization by `NumericTraits<T>::ZeroValue()` with empty `{}` initializers. Did so by Replace in Files, using regular expressions:

    Find what: (\w+)([ ]+\w+) = NumericTraits<\1>::ZeroValue\(\);
    Replace with: $1$2{};

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3950 commmit ef5cc8c495c5515d5533eae36a6900e6a63c7819
"STYLE: Prefer C++11 zero initializer to ZeroValue", by Hans Johnson (@hjmjohnson).