### PR TITLE
STYLE: Replace `T var = T()` with modern `T var{}` value-initialization

### DIFF
--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -444,7 +444,7 @@ private:
   // IndexRange data members:
 
   // Minimum (N-dimensional) index.
-  MinIndexType m_MinIndex = MinIndexType();
+  MinIndexType m_MinIndex{};
 
   // Maximum (N-dimensional) index.
   IndexType m_MaxIndex = IndexType::Filled(-1);

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -41,7 +41,7 @@ template <unsigned int VDimension>
 FlatStructuringElement<VDimension>
 FlatStructuringElement<VDimension>::Polygon(RadiusType radius, unsigned int lines)
 {
-  Self res = Self();
+  Self res{};
   GeneratePolygon(res, radius, lines);
   return res;
 }
@@ -854,7 +854,7 @@ FlatStructuringElement<VDimension>
 FlatStructuringElement<VDimension>::Box(RadiusType radius)
 {
   // this should work for any number of dimensions
-  Self res = Self();
+  Self res{};
 
   res.SetDecomposable(true);
   res.SetRadius(radius);
@@ -885,7 +885,7 @@ FlatStructuringElement<VDimension>
 FlatStructuringElement<VDimension>::Cross(RadiusType radius)
 {
   // this should work for any number of dimensions
-  Self res = Self();
+  Self res{};
 
   res.m_Decomposable = false;
   res.SetRadius(radius);
@@ -912,7 +912,7 @@ template <unsigned int VDimension>
 FlatStructuringElement<VDimension>
 FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParametric)
 {
-  Self res = Self();
+  Self res{};
 
   res.SetRadius(radius);
   res.m_Decomposable = false;
@@ -1020,7 +1020,7 @@ FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
                                             bool         includeCenter,
                                             bool         radiusIsParametric)
 {
-  Self result = Self();
+  Self result{};
 
   result.SetRadius(radius);
   result.m_Decomposable = false;
@@ -1269,7 +1269,7 @@ template <unsigned int VDimension>
 FlatStructuringElement<VDimension>
 FlatStructuringElement<VDimension>::FromImage(const typename FlatStructuringElement<VDimension>::ImageType * image)
 {
-  Self              res = Self();
+  Self              res{};
   RadiusType        size = res.CheckImageSize(image);
   Index<VDimension> centerIdx;
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -35,7 +35,7 @@ itkFlatStructuringElementTest(int, char *[])
   SE2Type::RadiusType r2;
   r2.Fill(scalarRadius);
 
-  SE2Type::Self result2 = SE2Type::Self();
+  SE2Type::Self result2{};
   result2.RadiusIsParametricOn();
   ITK_TEST_SET_GET_VALUE(true, result2.GetRadiusIsParametric());
 
@@ -75,7 +75,7 @@ itkFlatStructuringElementTest(int, char *[])
   using SE3Type = itk::FlatStructuringElement<3>;
   SE3Type::RadiusType r3;
 
-  SE3Type::Self result3 = SE3Type::Self();
+  SE3Type::Self result3{};
   result3.RadiusIsParametricOff();
   ITK_TEST_SET_GET_VALUE(false, result3.GetRadiusIsParametric());
 
@@ -133,7 +133,7 @@ itkFlatStructuringElementTest(int, char *[])
   using SE4Type = itk::FlatStructuringElement<4>;
   SE4Type::RadiusType r4;
 
-  SE4Type::Self result4 = SE4Type::Self();
+  SE4Type::Self result4{};
   result4.RadiusIsParametricOn();
   ITK_TEST_SET_GET_VALUE(true, result4.GetRadiusIsParametric());
 

--- a/Modules/IO/XML/include/itkStringTools.hxx
+++ b/Modules/IO/XML/include/itkStringTools.hxx
@@ -49,7 +49,7 @@ StringTools::ToData(std::string & s, std::vector<T> & data, int count)
     // compute the number of elements to be read from the input stream
     while (iss.good()) // loop until error occurred or reach end of stream
     {
-      T value = T();
+      T value{};
       if (iss >> value)
       {
         data.push_back(value);
@@ -75,7 +75,7 @@ StringTools::ToData(std::string & s, std::vector<T> & data, int count)
     }
     for (size_t i = 0; i < static_cast<size_t>(count); ++i)
     {
-      T value = T();
+      T value{};
       iss >> value;
       data[i] = value;
     }
@@ -128,7 +128,7 @@ StringTools::ToData(std::string & s, Array<T> & data, int count)
     std::vector<T> v;
     while (iss.good()) // loop until error occurred or reach end of stream
     {
-      T value = T();
+      T value{};
       if (iss >> value)
       {
         v.push_back(value);
@@ -162,7 +162,7 @@ StringTools::ToData(std::string & s, Array<T> & data, int count)
     }
     for (unsigned int i = 0; i < static_cast<unsigned int>(count); ++i)
     {
-      T value = T();
+      T value{};
       iss >> value;
       data[i] = value;
     }


### PR DESCRIPTION
Avoided mentioning the very same type twice in a single variable declaration. Did so using Notepad++ v8.4.8, Find in Files, Regular expression:

    Find what:  (\w[^ ]*)[ ]+(\w+) = \1(\(\);)
    Replace with:  $1 $2{};