### PR TITLE
COMP: Suppress ubsan in H5detect.c code

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5detect.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5detect.c
@@ -56,7 +56,7 @@ H5_GCC_DIAG_OFF("cast-align")
 
 #if defined(__has_attribute)
 #if __has_attribute(no_sanitize_address)
-#define HDF_NO_UBSAN __attribute__((no_sanitize_address))
+#define HDF_NO_UBSAN __attribute__((no_sanitize("address","undefined","integer","nullability")))
 #else
 #define HDF_NO_UBSAN
 #endif
@@ -828,7 +828,7 @@ done:\n\
 
  *-------------------------------------------------------------------------
  */
-static void
+static void HDF_NO_UBSAN
 iprint(detected_t *d)
 {
     unsigned int pass;


### PR DESCRIPTION
Similar to work previously done: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/4370

The H5detect.c code is used to interrogate the compiler and hardware features.  The tests must be allowed to violate the ubsan checks during the interrogations.

Found when compiling with:
-fsanitize=undefined -fsanitize=integer -fsanitize=nullability -fno-sanitize-recover=undefined

[14/1947] Linking C executable bin/H5detect
ITK/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5detect.c:1277:5: runtime error: store to misaligned address 0x60000211c061 for type 'short', which requires 2 byte alignment 0x60000211c061: note: pointer points here
 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ITK/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5detect.c:1277:5 in
/bin/sh: line 1: 38182 Abort trap: 6           ITK/cmake-build-debug/bin/H5detect H5Tinit.c

no_sanitize_address and no_address_safety_analysis are deprecated ** use **
__attribute__((no_sanitize("address","undefined","integer","nullability"))) instead.

A more heavy handed solution may be:
__attribute__((disable_sanitizer_instrumentation)). This attribute works similar to __attribute__((no_sanitize("address"))), but it also prevents instrumentation performed by other sanitizers.



@phcerdan  This is similar extension to work you did for VTK 4 years ago.   When using ubsan instead of the address sanitizer, the suppression list needs to be expanded.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
