### PR TITLE
STYLE: Default default-constructors MultiTransform, CompositeTransform

### DIFF
--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -407,7 +407,7 @@ public:
                                                           JacobianType &         cacheJacobian) const override;
 
 protected:
-  CompositeTransform();
+  CompositeTransform() = default;
   ~CompositeTransform() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -22,15 +22,6 @@
 namespace itk
 {
 
-
-template <typename TParametersValueType, unsigned int VDimension>
-CompositeTransform<TParametersValueType, VDimension>::CompositeTransform()
-{
-  this->m_TransformsToOptimizeFlags.clear();
-  this->m_TransformsToOptimizeQueue.clear();
-  this->m_PreviousTransformsToOptimizeUpdateTime = 0;
-}
-
 template <typename TParametersValueType, unsigned int VDimension>
 auto
 CompositeTransform<TParametersValueType, VDimension>::GetTransformCategory() const -> TransformCategoryEnum

--- a/Modules/Core/Transform/include/itkMultiTransform.h
+++ b/Modules/Core/Transform/include/itkMultiTransform.h
@@ -300,7 +300,7 @@ public:
   //  virtual void FlattenTransformQueue();
 
 protected:
-  MultiTransform();
+  MultiTransform() = default;
   ~MultiTransform() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -22,16 +22,6 @@
 namespace itk
 {
 
-
-template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
-MultiTransform<TParametersValueType, VDimension, VSubDimensions>::MultiTransform()
-  : Superclass(0)
-{
-  this->m_NumberOfLocalParameters = NumericTraits<NumberOfParametersType>::ZeroValue();
-  this->m_LocalParametersUpdateTime = NumericTraits<ModifiedTimeType>::ZeroValue();
-  this->m_TransformQueue.clear();
-}
-
 template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
 MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetTransformCategory() const -> TransformCategoryEnum


### PR DESCRIPTION
These default-constructors just simply either zero-initialized, cleared or default-constructed all of their data members.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3878 commit c2c67ac48cdd0206a103ee00962757dafb0714a8
"STYLE: Default default-constructors of class templates in Core/Common"