### PR TITLE
ENH: Upgrade ITK from C++14 to C++17

### DIFF
--- a/CMake/ITKInitializeCXXStandard.cmake
+++ b/CMake/ITKInitializeCXXStandard.cmake
@@ -1,6 +1,6 @@
 ##  Set the default target properties for ITK
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
+  set(CMAKE_CXX_STANDARD 17) # Supported values are 17, 20, and 23.
 endif()
 if(NOT CMAKE_CXX_STANDARD_REQUIRED)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -1,31 +1,31 @@
 # Minimum compiler version check: GCC
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-  message(FATAL_ERROR "GCC 5.1 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
+  message(FATAL_ERROR "GCC 7 or later is required.")
 endif ()
 
 # Minimum compiler version check: LLVM Clang
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4)
-  message(FATAL_ERROR "LLVM Clang 3.4 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
+  message(FATAL_ERROR "LLVM Clang 5 or later is required.")
 endif ()
 
-# Minimum compiler version check: Apple Clang >= 7.0.2 (Xcode 7.2.1)
+# Minimum compiler version check: Apple Clang >= 10.0.0 (Xcode 10.0)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.2)
-  message(FATAL_ERROR "Apple Clang 7.0.2 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0.0)
+  message(FATAL_ERROR "Apple Clang 10.0.0 or later is required.")
 endif ()
 
-# Minimum compiler version check: Microsoft C/C++ >= 19.10 (MSVC 14.1, Visual Studio 15 2017)
+# Minimum compiler version check: Microsoft C/C++
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-  message(FATAL_ERROR "Microsoft Visual Studio 2017 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.14)
+  message(FATAL_ERROR "Microsoft Visual Studio 2017 15.7 (MSVC 19.14) or later is required.")
 endif ()
 
 # Minimum compiler version check: Intel C++ (ICC)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
-  message(FATAL_ERROR "Intel C++ (ICC) 17.0 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.1)
+  message(FATAL_ERROR "Intel C++ (ICC) 19.1 or later is required.")
 endif ()
 
 # Make sure we have C++17 enabled.

--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -28,13 +28,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
   message(FATAL_ERROR "Intel C++ (ICC) 17.0 or later is required.")
 endif ()
 
-# Make sure we have C++14 enabled.
-if(NOT ITK_IGNORE_CMAKE_CXX14_CHECKS)
+# Make sure we have C++17 enabled.
+if(NOT ITK_IGNORE_CMAKE_CXX17_CHECKS)
   # Needed to make sure libraries and executables not built by the
-  # itkModuleMacros still have the C++14 compiler flags enabled
+  # itkModuleMacros still have the C++17 compiler flags enabled
   # Wrap this in an escape hatch for unknown compilers
   if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
+    set(CMAKE_CXX_STANDARD 17) # Supported values are 17, 20, and 23.
   endif()
   if(NOT CMAKE_CXX_STANDARD_REQUIRED)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ endforeach()
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeCXXStandard.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeBuildType.cmake)
 
-# ==== Define language standard configurations requiring at least c++14 standard
-if(CMAKE_CXX_STANDARD EQUAL "98" OR CMAKE_CXX_STANDARD LESS "14")
-   message(FATAL_ERROR "C++98 to C++11 are no longer supported in ITK version 5.3 and greater.")
+# ==== Define language standard configurations requiring at least c++17 standard
+if(CMAKE_CXX_STANDARD EQUAL "98" OR CMAKE_CXX_STANDARD LESS "17")
+   message(FATAL_ERROR "C++98 to C++14 are no longer supported in ITK version 5.4 and greater.")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake ${CMAKE_MODULE_PATH})

--- a/Documentation/SupportedCompilers.md
+++ b/Documentation/SupportedCompilers.md
@@ -1,21 +1,22 @@
-ITK requires a compiler with C++14 support.
+ITK requires a compiler with C++17 support.
 
 # Visual Studio
 * VS2015 and earlier: **NOT supported**
-* MSVC toolset v141 (first shipped with VS2017): supported
+* MSVC toolset v141 (first shipped with VS2017): supported from VS2017 version 15.7
 * MSVC toolset v142 (first shipped with VS2019): supported
+* MSVC toolset v143 (first shipped with VS2022): supported
 
 # GNU Compile Collection
-* GCC 5.1 and later [should be supported](https://www.gnu.org/software/gcc/projects/cxx-status.html).
+* GCC 7 and later [should be supported](https://www.gnu.org/software/gcc/projects/cxx-status.html).
 
 # LLVM Clang
-* Clang 3.4 and later [should be supported](https://clang.llvm.org/cxx_status.html)
+* Clang 5 and later [should be supported](https://clang.llvm.org/cxx_status.html)
 
 # AppleClang
-* AppleClang 7.0.2 and later (from Xcode 7.2.1) [should be supported](https://en.wikipedia.org/wiki/Xcode#Version_history)
+* AppleClang 10.0.0 and later (from Xcode 10.0) [should be supported](https://en.wikipedia.org/wiki/Xcode#Version_history)
 
 # Intel C++ Compiler
-* Intel C++ 17.0 and later
+* Intel C++ 19.1 and later
 
 # Future versions
 Future versions of these compilers should be backwards compatible, and thus ITK is expected to work with them.

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -151,19 +151,14 @@ namespace itk
 #endif
 
 /*
- * ITK only supports MSVC++ 14.0 and greater
- * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015 version 14.0)
- * MSVC++ 14.1 _MSC_VER == 1910 (Visual Studio 2017 version 15.0)
- * MSVC++ 14.11 _MSC_VER == 1911 (Visual Studio 2017 version 15.3)
- * MSVC++ 14.12 _MSC_VER == 1912 (Visual Studio 2017 version 15.5)
- * MSVC++ 14.13 _MSC_VER == 1913 (Visual Studio 2017 version 15.6)
+ * ITK only supports MSVC++ 14.14 and greater
  * MSVC++ 14.14 _MSC_VER == 1914 (Visual Studio 2017 version 15.7)
  * MSVC++ 14.15 _MSC_VER == 1915 (Visual Studio 2017 version 15.8)
  * MSVC++ 14.16 _MSC_VER == 1916 (Visual Studio 2017 version 15.9)
  * MSVC++ 14.2 _MSC_VER == 1920 (Visual Studio 2019 Version 16.0)
  */
-#if defined(_MSC_VER) && (_MSC_VER < 1910)
-#  error "Visual Studio < 2017 is not supported under ITKv5.3"
+#if defined(_MSC_VER) && (_MSC_VER < 1914)
+#  error "MSVC version before Visual Studio 2017 version 15.7 is not supported under ITKv5.4"
 #endif
 #if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5140)
 #  error "SUNPro C++ < 5.14.0 is not supported under ITKv5 and above"
@@ -177,9 +172,8 @@ namespace itk
 #if defined(__MWERKS__)
 #  error "The MetroWerks compiler is not supported in ITKv4 and above"
 #endif
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && \
-  ((__GNUC__ < 5) || ((__GNUC__ == 5) && (__GNUC_MINOR__ < 1)))
-#  error "GCC < 5.1 is not supported under ITKv5.3"
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (__GNUC__ < 7)
+#  error "GCC < 7 is not supported under ITKv5.4"
 #endif
 #if defined(__sgi)
 // This is true for IRIX 6.5.18m with MIPSPro 7.3.1.3m.
@@ -188,14 +182,14 @@ namespace itk
 #  error "The SGI compiler is not supported under ITKv4 and above"
 #endif
 #if defined(__APPLE__)
-#  if defined(__clang__) && (__cplusplus < 201402L)
-#    error "Apple LLVM < 5.1 (clang < 3.4) or compiling with a standard less than C++14 is not supported under ITKv5.3"
+#  if defined(__clang__) && (__cplusplus < 201703L)
+#    error "Apple LLVM compiling with a standard less than C++17 is not supported under ITKv5.4"
 #  endif
-#elif defined(__clang__) && ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 4)))
-#  error "Clang < 3.4 is not supported under ITKv5.3"
+#elif defined(__clang__) && (__clang_major__ < 5)
+#  error "Clang < 5 is not supported under ITKv5.4"
 #endif
-#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1700)
-#  error "Intel C++ < 17.0 is not supported under ITKv5.3"
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1910)
+#  error "Intel C++ < 19.1 is not supported under ITKv5.4"
 #endif
 
 // Setup symbol exports

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -84,9 +84,9 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
    * std::cout << result.get() << std::endl; */
   template <class Function, class... Arguments>
   auto
-  AddWork(Function && function, Arguments &&... arguments) -> std::future<std::result_of_t<Function(Arguments...)>>
+  AddWork(Function && function, Arguments &&... arguments) -> std::future<std::invoke_result_t<Function, Arguments...>>
   {
-    using return_type = std::result_of_t<Function(Arguments...)>;
+    using return_type = std::invoke_result_t<Function, Arguments...>;
 
     auto task = std::make_shared<std::packaged_task<return_type()>>(
       std::bind(std::forward<Function>(function), std::forward<Arguments>(arguments)...));

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -115,7 +115,12 @@ TEST(Size, Fill)
                                   itk::SizeValueType{ 2 },
                                   std::numeric_limits<itk::SizeValueType>::max() })
     {
-      itk::Size<dimensionConstant> actualSize;
+      // Added {} initializer to work around warnings from GCC "-Wextra -std=c++17" (before GCC 10), saying:
+      // "note: 'struct itk::Size' has no user-provided default constructor"
+      // as reported by Ignacy Gawedzki "Spurious notes about uninitialized members in C++17"
+      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91070
+      itk::Size<dimensionConstant> actualSize{};
+
       actualSize.Fill(sizeValue);
       const auto expectedSize = itk::Size<dimensionConstant>::Filled(sizeValue);
       EXPECT_EQ(actualSize, expectedSize);

--- a/Wrapping/macro_files/itk_auto_load_submodules.cmake
+++ b/Wrapping/macro_files/itk_auto_load_submodules.cmake
@@ -22,9 +22,9 @@ function(generate_castxml_commandline_flags)
     # Avoid missing omp.h include
     set(_castxml_cc_flags ${CMAKE_CXX_FLAGS})
     if(CMAKE_CXX_EXTENSIONS)
-        set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX14_EXTENSION_COMPILE_OPTION}")
+        set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX17_EXTENSION_COMPILE_OPTION}")
     else()
-        set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
+        set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX17_STANDARD_COMPILE_OPTION}")
     endif()
 
     # Aggressive optimization flags cause cast_xml to give invalid error conditions


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2563 commit daec0fdd703b1bca16aeb07bc4e0a01101da950a "ENH: Upgrade ITK from C++11 to C++14"

Suggested by Dženan Zukić (@dzenanz) 😃 at https://github.com/InsightSoftwareConsortium/ITK/pull/3933#discussion_r1128770848 Still to be discussed.

More information about C++17:
- https://en.cppreference.com/w/cpp/17
- https://en.wikipedia.org/wiki/C%2B%2B17 
- https://isocpp.org/files/papers/p0636r0.html
- https://www.cppstories.com/2017/11/cpp17summary/
- etc...!

Discussion "Shall we start using C++17 at the master branch?" opened at https://discourse.itk.org/t/shall-we-start-using-c-17-at-the-master-branch/5828 