### PR TITLE
Add missing `const` to binary operators implemented as member function

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -451,7 +451,7 @@ public:
 
   /** Distance between two iterators */
   OffsetType
-  operator-(const Self & b)
+  operator-(const Self & b) const
   {
     return m_Loop - b.m_Loop;
   }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -288,7 +288,7 @@ public:
 
   /** Distance between two iterators */
   OffsetType
-  operator-(const Self & b)
+  operator-(const Self & b) const
   {
     return m_Loop - b.m_Loop;
   }

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -139,7 +139,7 @@ public:
 
   /** Subtract two offsets. */
   const Self
-  operator-(const Self & vec)
+  operator-(const Self & vec) const
   {
     Self result;
 

--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -116,7 +116,7 @@ public:
    * is only true if the slice iterators have the same stride and
    * start location. */
   bool
-  operator<(const SliceIterator & orig)
+  operator<(const SliceIterator & orig) const
   {
     return this->m_Pos < orig.m_Pos && this->m_Slice.stride() == orig.m_Slice.stride() &&
            this->m_Slice.start() == orig.m_Slice.start();

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -101,7 +101,7 @@ public:
   }
 
   /** Matrix by scalar multiplication.  */
-  Self operator*(const T & value)
+  Self operator*(const T & value) const
   {
     Self result(*this);
 
@@ -118,7 +118,7 @@ public:
 
   /** Matrix by scalar division.  */
   Self
-  operator/(const T & value)
+  operator/(const T & value) const
   {
     Self result(*this);
 


### PR DESCRIPTION
Declared those member functions `const`, to allowed evaluating an expression of the form `lhs @ rhs` (for an operator `@`), even when `lhs` is a `const` object or a `const` reference.