### PR TITLE
COMP: Applied gtest PR 4025 to fix build with old clang

### DIFF
--- a/Modules/ThirdParty/GoogleTest/src/itkgoogletest/googletest/include/gtest/internal/gtest-port.h
+++ b/Modules/ThirdParty/GoogleTest/src/itkgoogletest/googletest/include/gtest/internal/gtest-port.h
@@ -770,6 +770,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Ask the compiler not to perform tail call optimization inside
 // the marked function.
 #define GTEST_NO_TAIL_CALL_ __attribute__((disable_tail_calls))
+#else
+#define GTEST_NO_TAIL_CALL_
 #endif
 #elif __GNUC__
 #define GTEST_NO_TAIL_CALL_ \


### PR DESCRIPTION
From: https://github.com/google/googletest/pull/4025
