### PR TITLE
STYLE: Remove pre-C++17 definition constexpr data member `SupportSize`

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -87,7 +87,6 @@ public:
 
   /** The support region size: a hypercube of length SplineOrder + 1 */
   static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };
-  // Declaration here, definition must be outside of class until C++17, see .hxx file for linker definition
 
   /** Evaluate the weights at specified ContinuousIndex position.
    * Subclasses must provide this method. */

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -25,20 +25,6 @@
 
 namespace itk
 {
-
-#if __cplusplus < 201703L
-// For compatibility with pre C++17 International Standards, a constexpr static
-// data member may be redundantly redeclared outside the class with no
-// initializer. This usage is deprecated.
-//
-// For C++14 and earlier, the definition of static constexpr must be outside of
-// class until C++17, see .h file for declaration & initialization
-
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-constexpr typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::SizeType
-  BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::SupportSize;
-#endif
-
 /** Compute weights for interpolation at continuous index position */
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType


### PR DESCRIPTION
With C++17, it is deprecated to redeclare a `constexpr` static data member outside the class definition (although it was required for C++11 and C++14).

This reverts pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2859 commit ad86850385455cecb1e3ce952ebfb0eb1c270809 "BUG: Fix constexpr linkage issue", Hans Johnson (@hjmjohnson), November 11, 2021.