### PR TITLE
STYLE: Use C++17 `_v` variable templates from `std` library type traits

### DIFF
--- a/Modules/Core/Common/include/itkBitCast.h
+++ b/Modules/Core/Common/include/itkBitCast.h
@@ -34,8 +34,8 @@ bit_cast(const TSource & source)
 {
   static_assert(sizeof(TDestination) == sizeof(TSource),
                 "The destination type should have the same size as the source type.");
-  static_assert(std::is_trivially_copyable<TDestination>::value, "The destination type should be trivially copyable");
-  static_assert(std::is_trivially_copyable<TSource>::value, "The source type should be trivially copyable.");
+  static_assert(std::is_trivially_copyable_v<TDestination>, "The destination type should be trivially copyable");
+  static_assert(std::is_trivially_copyable_v<TSource>, "The source type should be trivially copyable.");
 
   std::remove_const_t<TDestination> result;
   std::memcpy(&result, &source, sizeof(TSource));

--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -852,7 +852,7 @@ template <typename T>
 struct IsInteger
 {
   using Self = IsInteger;
-  static constexpr bool Integral = std::is_integral<T>::value;
+  static constexpr bool Integral = std::is_integral_v<T>;
   struct Constraints
   {
     using TrueT = Detail::UniqueType_bool<true>;
@@ -898,7 +898,7 @@ template <typename T>
 struct IsNonInteger
 {
   using Self = IsNonInteger;
-  static constexpr bool NonIntegral = std::is_integral<T>::value;
+  static constexpr bool NonIntegral = std::is_integral_v<T>;
   struct Constraints
   {
     using FalseT = Detail::UniqueType_bool<false>;
@@ -920,7 +920,7 @@ template <typename T>
 struct IsFloatingPoint
 {
   using Self = IsFloatingPoint;
-  static constexpr bool Integral = std::is_integral<T>::value;
+  static constexpr bool Integral = std::is_integral_v<T>;
   static constexpr bool IsExact = std::numeric_limits<typename NumericTraits<T>::ValueType>::is_exact;
   struct Constraints
   {
@@ -946,7 +946,7 @@ template <typename T>
 struct IsFixedPoint
 {
   using Self = IsFixedPoint;
-  static constexpr bool Integral = std::is_integral<T>::value;
+  static constexpr bool Integral = std::is_integral_v<T>;
   static constexpr bool IsExact = std::numeric_limits<typename NumericTraits<T>::ValueType>::is_exact;
   struct Constraints
   {

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -45,7 +45,7 @@ namespace itk
 template <typename TCoordRep = double, unsigned int VIndexDimension = 2>
 class ITK_TEMPLATE_EXPORT ContinuousIndex : public Point<TCoordRep, VIndexDimension>
 {
-  static_assert(std::is_floating_point<TCoordRep>::value,
+  static_assert(std::is_floating_point_v<TCoordRep>,
                 "The coordinates of a continuous index must be represented by floating point numbers.");
 
 public:

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -326,7 +326,7 @@ public:
    * `itk::Image` for non-EqualityComparable pixel types.
    */
   template <typename TEqualityComparable>
-  friend std::enable_if_t<std::is_same<TEqualityComparable, TPixel>::value, bool>
+  friend std::enable_if_t<std::is_same_v<TEqualityComparable, TPixel>, bool>
   operator==(const Image<TEqualityComparable, VImageDimension> & lhs,
              const Image<TEqualityComparable, VImageDimension> & rhs)
   {
@@ -366,7 +366,7 @@ public:
 
   /** Returns (image1 != image2). */
   template <typename TEqualityComparable>
-  friend std::enable_if_t<std::is_same<TEqualityComparable, TPixel>::value, bool>
+  friend std::enable_if_t<std::is_same_v<TEqualityComparable, TPixel>, bool>
   operator!=(const Image<TEqualityComparable, VImageDimension> & lhs,
              const Image<TEqualityComparable, VImageDimension> & rhs)
   {

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -83,9 +83,9 @@ private:
   // otherwise iterator::operator*() returns a proxy, which internally uses the
   // AccessorFunctor of the image to access the pixel indirectly.
   static constexpr bool SupportsDirectPixelAccess =
-    std::is_same<PixelType, InternalPixelType>::value &&
-    std::is_same<typename TImage::AccessorType, DefaultPixelAccessor<PixelType>>::value &&
-    std::is_same<AccessorFunctorType, DefaultPixelAccessorFunctor<std::remove_const_t<TImage>>>::value;
+    std::is_same_v<PixelType, InternalPixelType> &&
+    std::is_same_v<typename TImage::AccessorType, DefaultPixelAccessor<PixelType>> &&
+    std::is_same_v<AccessorFunctorType, DefaultPixelAccessorFunctor<std::remove_const_t<TImage>>>;
 
   // Tells whether or not this range is using a pointer as iterator.
   static constexpr bool UsingPointerAsIterator = SupportsDirectPixelAccess;
@@ -239,7 +239,7 @@ private:
     // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
     using QualifiedImageType = std::conditional_t<VIsConst, const ImageType, ImageType>;
 
-    static constexpr bool IsImageTypeConst = std::is_const<QualifiedImageType>::value;
+    static constexpr bool IsImageTypeConst = std::is_const_v<QualifiedImageType>;
 
     using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
@@ -483,7 +483,7 @@ private:
     operator=(const QualifiedIterator &) noexcept = default;
   };
 
-  static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
+  static constexpr bool IsImageTypeConst = std::is_const_v<TImage>;
 
   using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -76,7 +76,7 @@ private:
   using ImageDimensionType = typename TImage::ImageDimensionType;
   using PixelType = typename TImage::PixelType;
 
-  static constexpr bool               IsImageTypeConst = std::is_const<TImage>::value;
+  static constexpr bool               IsImageTypeConst = std::is_const_v<TImage>;
   static constexpr ImageDimensionType ImageDimension = TImage::ImageDimension;
 
   using BufferIteratorType = typename ImageBufferRange<TImage>::iterator;

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.h
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.h
@@ -147,7 +147,7 @@ protected:
   void
   AllocateOutputs() override
   {
-    if (std::is_same<TInputImage, TOutputImage>::value)
+    if (std::is_same_v<TInputImage, TOutputImage>)
     {
       this->InternalAllocateOutputs();
     }

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -120,7 +120,7 @@ template <typename TInputImage, typename TOutputImage>
 bool
 InPlaceImageFilter<TInputImage, TOutputImage>::CanRunInPlace() const
 {
-  return std::is_same<TInputImage, TOutputImage>::value;
+  return std::is_same_v<TInputImage, TOutputImage>;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -589,7 +589,7 @@ auto
 MakeIndex(const T... values)
 {
   const auto toValueType = [](const auto value) {
-    static_assert(std::is_integral<decltype(value)>::value, "Each value must have an integral type!");
+    static_assert(std::is_integral_v<decltype(value)>, "Each value must have an integral type!");
     return static_cast<IndexValueType>(value);
   };
   return Index<sizeof...(T)>{ { toValueType(values)... } };

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -319,7 +319,7 @@ public:
     // Three compile-time asserts, just to check if SFINAE worked properly:
     static_assert(!VIsSubstitutionFailure,
                   "This template should (of course) be instantiated without substitution failure.");
-    static_assert(std::is_same<TVoid, void>::value,
+    static_assert(std::is_same_v<TVoid, void>,
                   "std::enable_if<!VIsSubstitutionFailure> should yield void, by definition.");
     static_assert(!VBeginAtZero, "This constructor should only be is available when VBeginAtZero is false.");
   }

--- a/Modules/Core/Common/include/itkIsBaseOf.h
+++ b/Modules/Core/Common/include/itkIsBaseOf.h
@@ -42,7 +42,7 @@ namespace mpl
 template <typename TBase, typename TDerived>
 struct IsBaseOf
 {
-  static constexpr bool Value = std::is_base_of<const TDerived *, const TBase *>::value;
+  static constexpr bool Value = std::is_base_of_v<const TDerived *, const TBase *>;
 };
 } // end namespace mpl
 

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -520,10 +520,10 @@ struct AlmostEqualsFunctionSelector<true, false, true, false>
 template <typename TInputType1, typename TInputType2>
 struct AlmostEqualsScalarImplementer
 {
-  static constexpr bool TInputType1IsInteger = std::is_integral<TInputType1>::value;
-  static constexpr bool TInputType1IsSigned = std::is_signed<TInputType1>::value;
-  static constexpr bool TInputType2IsInteger = std::is_integral<TInputType2>::value;
-  static constexpr bool TInputType2IsSigned = std::is_signed<TInputType2>::value;
+  static constexpr bool TInputType1IsInteger = std::is_integral_v<TInputType1>;
+  static constexpr bool TInputType1IsSigned = std::is_signed_v<TInputType1>;
+  static constexpr bool TInputType2IsInteger = std::is_integral_v<TInputType2>;
+  static constexpr bool TInputType2IsSigned = std::is_signed_v<TInputType2>;
 
   using SelectedVersion = typename AlmostEqualsFunctionSelector<TInputType1IsInteger,
                                                                 TInputType1IsSigned,
@@ -781,7 +781,7 @@ template <typename TReturnType = uintmax_t>
 constexpr TReturnType
 UnsignedProduct(const uintmax_t a, const uintmax_t b) noexcept
 {
-  static_assert(std::is_unsigned<TReturnType>::value, "UnsignedProduct only supports unsigned return types");
+  static_assert(std::is_unsigned_v<TReturnType>, "UnsignedProduct only supports unsigned return types");
 
   // Note that numeric overflow is not "undefined behavior", for unsigned numbers.
   // This function checks if the result of a*b is mathematically correct.
@@ -803,7 +803,7 @@ template <typename TReturnType = uintmax_t>
 constexpr TReturnType
 UnsignedPower(const uintmax_t base, const uintmax_t exponent) noexcept
 {
-  static_assert(std::is_unsigned<TReturnType>::value, "UnsignedPower only supports unsigned return types");
+  static_assert(std::is_unsigned_v<TReturnType>, "UnsignedPower only supports unsigned return types");
 
   // Uses recursive function calls because C++11 does not support other ways of
   // iterations for a constexpr function.

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -233,7 +233,7 @@ public:
   explicit Matrix(const TElement (&elements)[VRows][VColumns])
     : m_Matrix(&elements[0][0])
   {
-    static_assert(std::is_same<TElement, T>::value,
+    static_assert(std::is_same_v<TElement, T>,
                   "The type of an element should correspond with this itk::Matrix instantiation.");
   }
 

--- a/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
+++ b/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
@@ -234,9 +234,9 @@ struct IsSmartPointer<const SmartPointer<T>> : TrueType
  * Identifies if "static_cast<TToType>(TFromType)" can be done.
  */
 template <typename TFromType, typename TToType>
-using is_static_castable = std::integral_constant<bool,
-                                                  std::is_constructible<TToType, TFromType>::value ||
-                                                    std::is_convertible<TFromType, TToType>::value>;
+using is_static_castable =
+  std::integral_constant<bool,
+                         std::is_constructible_v<TToType, TFromType> || std::is_convertible_v<TFromType, TToType>>;
 } // namespace mpl
 
 

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -1925,7 +1925,7 @@ public:
     return val.real() >= 0;
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
   static constexpr bool IsInteger = false;
   static constexpr bool IsComplex = true;
   static Self
@@ -1982,7 +1982,7 @@ public:
   }
 
 #if defined(ITK_LEGACY_REMOVE)
-  static_assert(std::is_floating_point<TComponent>::value,
+  static_assert(std::is_floating_point_v<TComponent>,
                 "As per https://en.cppreference.com/w/cpp/numeric/complex the behavior is unspecified and may fail to "
                 "compile if TComponent is not float, double, or long double and undefined if T is not NumericType.");
 #endif // defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -112,8 +112,8 @@ public:
     return b;
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Set the length of the input array and fill it with zeros. */

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -143,8 +143,8 @@ public:
     return OneValue();
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Fixed length vectors cannot be resized, so an exception will

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -144,8 +144,8 @@ public:
     return OneValue();
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Fixed length vectors cannot be resized, so an exception will

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -130,8 +130,8 @@ public:
     return OneValue();
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Fixed length vectors cannot be resized, so an exception will

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -170,8 +170,8 @@ public:
     return NumericTraits<typename Self::LuminanceType>::IsNonnegative(val.GetLuminance());
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** RGBA pixels must have 4 components, so the size cannot be

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -170,8 +170,8 @@ public:
     return NumericTraits<typename Self::LuminanceType>::IsNonnegative(val.GetLuminance());
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** RGB pixels must have 3 components, so the size cannot be

--- a/Modules/Core/Common/include/itkNumericTraitsStdVector.h
+++ b/Modules/Core/Common/include/itkNumericTraitsStdVector.h
@@ -131,8 +131,8 @@ public:
     return b;
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Resize the input vector to the specified size */

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -143,8 +143,8 @@ public:
     return OneValue();
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Fixed length vectors cannot be resized, so an exception will

--- a/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
@@ -192,8 +192,8 @@ public:
     return flag;
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
 

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -185,8 +185,8 @@ public:
     return flag;
   }
 
-  static constexpr bool IsSigned = std::is_signed<ValueType>::value;
-  static constexpr bool IsInteger = std::is_integral<ValueType>::value;
+  static constexpr bool IsSigned = std::is_signed_v<ValueType>;
+  static constexpr bool IsInteger = std::is_integral_v<ValueType>;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
 
   /** Fixed length vectors cannot be resized, so an exception will

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -367,7 +367,7 @@ MakePoint(const TValue firstValue, const TVariadic... otherValues)
 {
   // Assert that the other values have the same type as the first value.
   const auto assertSameType = [](const auto value) {
-    static_assert(std::is_same<decltype(value), const TValue>::value, "Each value must have the same type!");
+    static_assert(std::is_same_v<decltype(value), const TValue>, "Each value must have the same type!");
     return true;
   };
   const bool assertions[] = { true, assertSameType(otherValues)... };

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -116,8 +116,8 @@ private:
   public:
     // This constant tells whether the policy has a PixelAccessParameterType:
     static constexpr bool HasPixelAccessParameterType =
-      !std::is_same<decltype(Test<TImageNeighborhoodPixelAccessPolicy>(nullptr)),
-                    decltype(Test<TImageNeighborhoodPixelAccessPolicy>())>::value;
+      !std::is_same_v<decltype(Test<TImageNeighborhoodPixelAccessPolicy>(nullptr)),
+                      decltype(Test<TImageNeighborhoodPixelAccessPolicy>())>;
   };
 
 
@@ -296,7 +296,7 @@ private:
     // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
     using QualifiedImageType = std::conditional_t<VIsConst, const ImageType, ImageType>;
 
-    static constexpr bool IsImageTypeConst = std::is_const<QualifiedImageType>::value;
+    static constexpr bool IsImageTypeConst = std::is_const_v<QualifiedImageType>;
 
     using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
@@ -358,9 +358,9 @@ private:
     TImageNeighborhoodPixelAccessPolicy
     CreatePixelAccessPolicy(const TPixelAccessParameter pixelAccessParameter) const
     {
-      static_assert(std::is_same<TPixelAccessParameter, OptionalPixelAccessParameterType>::value,
+      static_assert(std::is_same_v<TPixelAccessParameter, OptionalPixelAccessParameterType>,
                     "This helper function should only be used for OptionalPixelAccessParameterType!");
-      static_assert(!std::is_same<TPixelAccessParameter, EmptyPixelAccessParameter>::value,
+      static_assert(!std::is_same_v<TPixelAccessParameter, EmptyPixelAccessParameter>,
                     "EmptyPixelAccessParameter indicates that there is no pixel access parameter specified!");
       return TImageNeighborhoodPixelAccessPolicy{
         m_ImageSize, m_OffsetTable, m_NeighborhoodAccessor, m_RelativeLocation + *m_CurrentOffset, pixelAccessParameter
@@ -576,7 +576,7 @@ private:
     operator=(const QualifiedIterator &) noexcept = default;
   };
 
-  static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
+  static constexpr bool IsImageTypeConst = std::is_const_v<TImage>;
 
   using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -490,7 +490,7 @@ auto
 MakeSize(const T... values)
 {
   const auto toValueType = [](const auto value) {
-    static_assert(std::is_integral<decltype(value)>::value, "Each value must have an integral type!");
+    static_assert(std::is_integral_v<decltype(value)>, "Each value must have an integral type!");
     return static_cast<SizeValueType>(value);
   };
   return Size<sizeof...(T)>{ { toValueType(values)... } };

--- a/Modules/Core/Common/include/itkSmartPointer.h
+++ b/Modules/Core/Common/include/itkSmartPointer.h
@@ -54,7 +54,7 @@ public:
   using ObjectType = TObjectType;
 
   template <typename T>
-  using EnableIfConvertible = typename std::enable_if<std::is_convertible<T *, TObjectType *>::value>;
+  using EnableIfConvertible = typename std::enable_if<std::is_convertible_v<T *, TObjectType *>>;
 
   /** Default-constructor  */
   constexpr SmartPointer() noexcept = default;

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -1204,7 +1204,7 @@ struct VariableLengthVectorExpression
   {
     // Not necessary actually as end-user/developer is not expected to
     // provide new BinaryOperations
-    static_assert(std::is_base_of<Details::op::BinaryOperationConcept, TBinaryOp>::value,
+    static_assert(std::is_base_of_v<Details::op::BinaryOperationConcept, TBinaryOp>,
                   "The Binary Operation shall inherit from BinaryOperationConcept");
   }
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -262,10 +262,10 @@ void
 VariableLengthVector<TValue>::SetSize(unsigned int sz, TReallocatePolicy reallocatePolicy, TKeepValuesPolicy keepValues)
 {
   static_assert(
-    std::is_base_of<AllocateRootPolicy, TReallocatePolicy>::value,
+    std::is_base_of_v<AllocateRootPolicy, TReallocatePolicy>,
     "The allocation policy does not inherit from itk::VariableLengthVector::AllocateRootPolicy as expected");
   static_assert(
-    std::is_base_of<KeepValuesRootPolicy, TKeepValuesPolicy>::value,
+    std::is_base_of_v<KeepValuesRootPolicy, TKeepValuesPolicy>,
     "The old values keeping policy does not inherit from itk::VariableLengthVector::KeepValuesRootPolicy as expected");
 
   if (reallocatePolicy(sz, m_NumElements) || !m_LetArrayManageMemory)

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -333,7 +333,7 @@ MakeVector(const TValue firstValue, const TVariadic... otherValues)
 {
   // Assert that the other values have the same type as the first value.
   const auto assertSameType = [](const auto value) {
-    static_assert(std::is_same<decltype(value), const TValue>::value, "Each value must have the same type!");
+    static_assert(std::is_same_v<decltype(value), const TValue>, "Each value must have the same type!");
     return true;
   };
   const bool assertions[] = { true, assertSameType(otherValues)... };

--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -133,7 +133,7 @@ public:
     const AggregateType knownAll7s{ { 7, 7, 7, 7 } };
     const AggregateType knownAll6s{ { 6, 6, 6, 6 } };
 
-    EXPECT_EQ(std::is_pod<AggregateType>::value, true);
+    EXPECT_EQ(std::is_pod_v<AggregateType>, true);
     EXPECT_EQ(AggregateType::Dimension, 4);
 
     AggregateType index1 = { { 10, 20, 30, 40 } };
@@ -327,7 +327,7 @@ TEST(Specialized, IndexOffset)
 
 TEST(Specialized, Index)
 {
-  EXPECT_EQ(std::is_pod<itk::Index<13>>::value, true);
+  EXPECT_EQ(std::is_pod_v<itk::Index<13>>, true);
   EXPECT_EQ(itk::Index<2>::GetIndexDimension(), 2);
 
   using IndexType = itk::Index<4>;
@@ -351,7 +351,7 @@ TEST(Specialized, Index)
 TEST(Specialized, Offset)
 {
 
-  EXPECT_EQ(std::is_pod<itk::Offset<13>>::value, true);
+  EXPECT_EQ(std::is_pod_v<itk::Offset<13>>, true);
   EXPECT_EQ(itk::Offset<13>::GetOffsetDimension(), 13);
 
   using OffsetType = itk::Offset<4>;
@@ -374,7 +374,7 @@ TEST(Specialized, Offset)
 
 TEST(Specialized, Size)
 {
-  EXPECT_EQ(std::is_pod<itk::Size<13>>::value, true);
+  EXPECT_EQ(std::is_pod_v<itk::Size<13>>, true);
   EXPECT_EQ(itk::Size<7>::GetSizeDimension(), 7);
 
   using SizeType = itk::Size<4>;

--- a/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
@@ -37,7 +37,7 @@ static_assert(bool{ ValueType{ false } } == false,
               "The value type of BooleanStdVectorType should support a lossless round-trip from bool value false.");
 static_assert(bool{ ValueType{ true } } == true,
               "The value type of BooleanStdVectorType should support a lossless round-trip from bool value true.");
-static_assert(std::is_same<decltype(*itk::BooleanStdVectorType{}.data()), ValueType &>::value,
+static_assert(std::is_same_v<decltype(*itk::BooleanStdVectorType{}.data()), ValueType &>,
               "BooleanStdVectorType should have a valid data() member function (unlike std::vector<bool>).");
 
 } // namespace

--- a/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
+++ b/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
@@ -35,53 +35,53 @@
 TEST(CommonTypeTraits, FixedArrayIsPOD)
 {
   using T = itk::FixedArray<float, 3>;
-  EXPECT_TRUE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 /************ First Generation FixedArray *************/
 TEST(CommonTypeTraits, VectorIsPOD)
 {
   using T = itk::Vector<float, 3>;
-  EXPECT_TRUE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 TEST(CommonTypeTraits, CovariantVectorIsPOD)
 {
   using T = itk::CovariantVector<float, 3>;
-  EXPECT_TRUE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 TEST(CommonTypeTraits, PointIsPOD)
 {
   using T = itk::Point<float>;
-  EXPECT_TRUE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 TEST(CommonTypeTraits, RGBAPixelIsNotPOD)
 {
   using T = itk::RGBAPixel<unsigned int>;
   // Because initialized to zero
-  EXPECT_FALSE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_FALSE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 TEST(CommonTypeTraits, RGBPixelIsNotPOD)
 {
   using T = itk::RGBPixel<unsigned int>;
   // Because initialized to zero
-  EXPECT_FALSE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_FALSE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 TEST(CommonTypeTraits, SymmetricSecondRankTensorIsNotPOD)
 {
   using T = itk::SymmetricSecondRankTensor<float, 3>;
   // Because initialized to zero
-  EXPECT_FALSE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_FALSE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 /************ Second Generation FixedArray *************/
@@ -89,8 +89,8 @@ TEST(CommonTypeTraits, SymmetricSecondRankTensorIsNotPOD)
 TEST(CommonTypeTraits, ContinuousIndexIsPOD)
 {
   using T = itk::ContinuousIndex<float, 2>;
-  EXPECT_TRUE(std::is_trivial<T>::value);
-  EXPECT_TRUE(std::is_standard_layout<T>::value);
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
 /************ FixedArray: noexcept move checks *************/
@@ -114,9 +114,9 @@ struct NotNoexceptMove
 TEST(CommonTypeTraits, FixedArrayIsNoExceptMovable)
 {
   using IntArrayType = itk::FixedArray<int, 3>;
-  EXPECT_TRUE(std::is_nothrow_move_constructible<IntArrayType>::value);
-  EXPECT_TRUE(std::is_copy_constructible<IntArrayType>::value);
+  EXPECT_TRUE(std::is_nothrow_move_constructible_v<IntArrayType>);
+  EXPECT_TRUE(std::is_copy_constructible_v<IntArrayType>);
   using NotNoexceptMoveArrayType = itk::FixedArray<NotNoexceptMove, 3>;
-  EXPECT_FALSE(std::is_nothrow_move_constructible<NotNoexceptMoveArrayType>::value);
-  EXPECT_TRUE(std::is_copy_constructible<NotNoexceptMoveArrayType>::value);
+  EXPECT_FALSE(std::is_nothrow_move_constructible_v<NotNoexceptMoveArrayType>);
+  EXPECT_TRUE(std::is_copy_constructible_v<NotNoexceptMoveArrayType>);
 }

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -20,10 +20,10 @@
 #include <iostream>
 #include <type_traits>
 
-static_assert(std::is_nothrow_default_constructible<itk::ExceptionObject>::value,
+static_assert(std::is_nothrow_default_constructible_v<itk::ExceptionObject>,
               "ExceptionObject must have a noexcept default-constructor!");
-static_assert(std::is_nothrow_copy_assignable<itk::ExceptionObject>::value &&
-                std::is_nothrow_copy_constructible<itk::ExceptionObject>::value,
+static_assert(std::is_nothrow_copy_assignable_v<itk::ExceptionObject> &&
+                std::is_nothrow_copy_constructible_v<itk::ExceptionObject>,
               "An exception type must have noexcept copy semantics!");
 
 class mammal

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -134,7 +134,7 @@ Check_const_and_non_const_reverse_iterators_retrieve_same_values()
   using ConstIteratorType = typename FixedArrayType::const_reverse_iterator;
   using NonConstIteratorType = typename FixedArrayType::reverse_iterator;
 
-  static_assert(!std::is_same<ConstIteratorType, NonConstIteratorType>::value,
+  static_assert(!std::is_same_v<ConstIteratorType, NonConstIteratorType>,
                 "Const and non-const reverse_iterator types must be different!");
 
   FixedArrayType fixedArray{};

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -33,7 +33,7 @@ template <typename T1, typename T2>
 void
 Expect_same_type_and_equal_value(T1 && value1, T2 && value2)
 {
-  static_assert(std::is_same<T1, T2>::value, "Expect the same type!");
+  static_assert(std::is_same_v<T1, T2>, "Expect the same type!");
   EXPECT_EQ(value1, value2);
 }
 

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -53,7 +53,7 @@ DoesImageBufferRangeIteratorDereferenceOperatorReturnReference()
 {
   using IteratorType = typename ImageBufferRange<TImage>::iterator;
 
-  return std::is_reference<decltype(*std::declval<IteratorType>())>::value;
+  return std::is_reference_v<decltype(*std::declval<IteratorType>())>;
 }
 
 
@@ -75,7 +75,7 @@ IsIteratorTypeTheSameAsConstIteratorType()
 {
   using RangeType = ImageBufferRange<TImage>;
 
-  return std::is_same<typename RangeType::iterator, typename RangeType::const_iterator>::value;
+  return std::is_same_v<typename RangeType::iterator, typename RangeType::const_iterator>;
 }
 
 
@@ -684,14 +684,14 @@ TEST(ImageBufferRange, IteratorsSupportRandomAccess)
     r = initialIterator;
     auto && actualResult = r += n;
     EXPECT_EQ(actualResult, expectedResult);
-    static_assert(std::is_same<decltype(actualResult), X &>::value, "Type of result 'r += n' tested");
+    static_assert(std::is_same_v<decltype(actualResult), X &>, "Type of result 'r += n' tested");
   }
   {
     // Expressions to be tested: 'a + n' and 'n + a'
     difference_type n = 3;
 
-    static_assert(std::is_same<decltype(a + n), X>::value, "Return type tested");
-    static_assert(std::is_same<decltype(n + a), X>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(a + n), X>, "Return type tested");
+    static_assert(std::is_same_v<decltype(n + a), X>, "Return type tested");
 
     const auto expectedResult = [a, n] {
       // Operational semantics, as specified by the C++11 Standard:
@@ -714,13 +714,13 @@ TEST(ImageBufferRange, IteratorsSupportRandomAccess)
     r = initialIterator;
     auto && actualResult = r -= n;
     EXPECT_EQ(actualResult, expectedResult);
-    static_assert(std::is_same<decltype(actualResult), X &>::value, "Type of result 'r -= n' tested");
+    static_assert(std::is_same_v<decltype(actualResult), X &>, "Type of result 'r -= n' tested");
   }
   {
     // Expression to be tested: 'a - n'
     difference_type n = -3;
 
-    static_assert(std::is_same<decltype(a - n), X>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(a - n), X>, "Return type tested");
 
     const auto expectedResult = [a, n] {
       // Operational semantics, as specified by the C++11 Standard:
@@ -732,7 +732,7 @@ TEST(ImageBufferRange, IteratorsSupportRandomAccess)
   }
   {
     // Expression to be tested: 'b - a'
-    static_assert(std::is_same<decltype(b - a), difference_type>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(b - a), difference_type>, "Return type tested");
 
     difference_type n = b - a;
     EXPECT_TRUE(a + n == b);
@@ -741,15 +741,15 @@ TEST(ImageBufferRange, IteratorsSupportRandomAccess)
   {
     // Expression to be tested: 'a[n]'
     difference_type n = 3;
-    static_assert(std::is_convertible<decltype(a[n]), reference>::value, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a[n]), reference>, "Return type tested");
     EXPECT_EQ(a[n], *(a + n));
   }
   {
     // Expressions to be tested: 'a < b', 'a > b', 'a >= b', and 'a <= b':
-    static_assert(std::is_convertible<decltype(a < b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a > b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a >= b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a <= b), bool>::value, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a < b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a > b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a >= b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a <= b), bool>, "Return type tested");
     EXPECT_EQ(a<b, b - a> 0);
     EXPECT_EQ(a > b, b < a);
     EXPECT_EQ(a >= b, !(a < b));

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -56,7 +56,7 @@ DoesImageRegionRangeIteratorDereferenceOperatorReturnReference()
 {
   using IteratorType = typename ImageRegionRange<TImage>::iterator;
 
-  return std::is_reference<decltype(*std::declval<IteratorType>())>::value;
+  return std::is_reference_v<decltype(*std::declval<IteratorType>())>;
 }
 
 
@@ -78,7 +78,7 @@ IsIteratorTypeTheSameAsConstIteratorType()
 {
   using RangeType = ImageRegionRange<TImage>;
 
-  return std::is_same<typename RangeType::iterator, typename RangeType::const_iterator>::value;
+  return std::is_same_v<typename RangeType::iterator, typename RangeType::const_iterator>;
 }
 
 

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -51,11 +51,11 @@ static_assert(UnsignedPower(2, std::numeric_limits<uintmax_t>::digits - 1) ==
                 (uintmax_t{ 1 } << (std::numeric_limits<uintmax_t>::digits - 1)),
               "Check 2^63 (at least when uintmax_t is 64 bits)");
 
-static_assert(std::is_same<decltype(UnsignedPower(1, 1)), uintmax_t>::value,
+static_assert(std::is_same_v<decltype(UnsignedPower(1, 1)), uintmax_t>,
               "The return type of UnsignedPower should be uintmax_t by default.");
-static_assert(std::is_same<decltype(UnsignedPower<uint8_t>(1, 1)), uint8_t>::value &&
-                std::is_same<decltype(UnsignedPower<uint16_t>(1, 1)), uint16_t>::value &&
-                std::is_same<decltype(UnsignedPower<uint32_t>(1, 1)), uint32_t>::value,
+static_assert(std::is_same_v<decltype(UnsignedPower<uint8_t>(1, 1)), uint8_t> &&
+                std::is_same_v<decltype(UnsignedPower<uint16_t>(1, 1)), uint16_t> &&
+                std::is_same_v<decltype(UnsignedPower<uint32_t>(1, 1)), uint32_t>,
               "UnsignedPower allows specifying the return type by its template argument.");
 
 static_assert((UnsignedProduct(0, 0) == 0) && (UnsignedProduct(0, 1) == 0) && (UnsignedProduct(1, 0) == 0) &&

--- a/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
@@ -42,19 +42,19 @@ itkMetaProgrammingLibraryTest(int, char *[])
   static_assert(OrC<false, false>::Value == false, "Unit test failed");
 
   // Or between types
-  static_assert(std::is_same<Or<TrueType, TrueType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<TrueType, TrueType, FalseType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<TrueType, FalseType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<TrueType, FalseType, FalseType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, TrueType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, TrueType, FalseType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, FalseType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, FalseType, FalseType>::Type, FalseType>::value, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, TrueType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, TrueType, FalseType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, FalseType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, FalseType, FalseType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, TrueType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, TrueType, FalseType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, FalseType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, FalseType, FalseType>::Type, FalseType>, "Unit test failed");
 
-  static_assert(std::is_same<Or<TrueType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<TrueType, FalseType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Or<FalseType, FalseType>::Type, FalseType>::value, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<TrueType, FalseType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Or<FalseType, FalseType>::Type, FalseType>, "Unit test failed");
 
   // And between constants
   static_assert(AndC<true, true>::Value == true, "Unit test failed");
@@ -63,10 +63,10 @@ itkMetaProgrammingLibraryTest(int, char *[])
   static_assert(AndC<false, false>::Value == false, "Unit test failed");
 
   // And between types
-  static_assert(std::is_same<And<TrueType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<And<TrueType, FalseType>::Type, FalseType>::value, "Unit test failed");
-  static_assert(std::is_same<And<FalseType, TrueType>::Type, FalseType>::value, "Unit test failed");
-  static_assert(std::is_same<And<FalseType, FalseType>::Type, FalseType>::value, "Unit test failed");
+  static_assert(std::is_same_v<And<TrueType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<And<TrueType, FalseType>::Type, FalseType>, "Unit test failed");
+  static_assert(std::is_same_v<And<FalseType, TrueType>::Type, FalseType>, "Unit test failed");
+  static_assert(std::is_same_v<And<FalseType, FalseType>::Type, FalseType>, "Unit test failed");
 
   // Xor between constants
   static_assert(XorC<true, true>::Value == false, "Unit test failed");
@@ -75,18 +75,18 @@ itkMetaProgrammingLibraryTest(int, char *[])
   static_assert(XorC<false, false>::Value == false, "Unit test failed");
 
   // Xor between types
-  static_assert(std::is_same<Xor<TrueType, TrueType>::Type, FalseType>::value, "Unit test failed");
-  static_assert(std::is_same<Xor<TrueType, FalseType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Xor<FalseType, TrueType>::Type, TrueType>::value, "Unit test failed");
-  static_assert(std::is_same<Xor<FalseType, FalseType>::Type, FalseType>::value, "Unit test failed");
+  static_assert(std::is_same_v<Xor<TrueType, TrueType>::Type, FalseType>, "Unit test failed");
+  static_assert(std::is_same_v<Xor<TrueType, FalseType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Xor<FalseType, TrueType>::Type, TrueType>, "Unit test failed");
+  static_assert(std::is_same_v<Xor<FalseType, FalseType>::Type, FalseType>, "Unit test failed");
 
   // Not between constants
   static_assert(NotC<true>::Value == false, "Unit test failed");
   static_assert(NotC<false>::Value == true, "Unit test failed");
 
   // Not between types
-  static_assert(std::is_same<Not<TrueType>::Type, FalseType>::value, "Unit test failed");
-  static_assert(std::is_same<Not<FalseType>::Type, TrueType>::value, "Unit test failed");
+  static_assert(std::is_same_v<Not<TrueType>::Type, FalseType>, "Unit test failed");
+  static_assert(std::is_same_v<Not<FalseType>::Type, TrueType>, "Unit test failed");
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
@@ -29,10 +29,10 @@ template <typename T>
 void
 Expect_data_returns_pointer_to_first_element(T & container)
 {
-  static_assert(std::is_pointer<decltype(container.data())>::value, "data() must return a pointer");
+  static_assert(std::is_pointer_v<decltype(container.data())>, "data() must return a pointer");
 
-  static_assert(std::is_const<std::remove_reference_t<decltype(*(container.data()))>>::value ==
-                  std::is_const<std::remove_reference_t<decltype(container[0])>>::value,
+  static_assert(std::is_const_v<std::remove_reference_t<decltype(*(container.data()))>> ==
+                  std::is_const_v<std::remove_reference_t<decltype(container[0])>>,
                 "*container.data() and container[0] must have the same const-ness");
 
   EXPECT_EQ(container.data(), &container[0]);

--- a/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
@@ -36,14 +36,14 @@ template <typename T>
 constexpr bool
 IsDefaultConstructibleCopyableNoThrowMovableAndDestructible()
 {
-  return std::is_default_constructible<T>::value && std::is_copy_constructible<T>::value &&
-         std::is_copy_assignable<T>::value && std::is_nothrow_move_constructible<T>::value &&
-         std::is_nothrow_move_assignable<T>::value && std::is_nothrow_destructible<T>::value;
+  return std::is_default_constructible_v<T> && std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T> &&
+         std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T> &&
+         std::is_nothrow_destructible_v<T>;
 }
 
-static_assert(std::is_copy_assignable<itk::NeighborhoodOperator<int, 3>>::value,
+static_assert(std::is_copy_assignable_v<itk::NeighborhoodOperator<int, 3>>,
               "NeighborhoodOperator should be copy-assignable.");
-static_assert(std::is_nothrow_move_assignable<itk::NeighborhoodOperator<int, 3>>::value,
+static_assert(std::is_nothrow_move_assignable_v<itk::NeighborhoodOperator<int, 3>>,
               "NeighborhoodOperator should be noexcept move-assignable.");
 
 static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::AnnulusOperator<int>>(),

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -217,7 +217,7 @@ CheckSignedAndIntegerTraitsSameAsSTDNumericLimits(const char * const name)
     std::cout << "\tERROR:  IsSigned definitions for itk::NumericTraits and std::numeric_limits do not match!! ERROR!!"
               << std::endl;
     std::cout << "\tFor type: \t" << name << std::endl;
-    std::cout << "\tITK signed Value for:\t<  " << name << "  >\tis:\t" << (std::is_signed<T>::value ? "true" : "false")
+    std::cout << "\tITK signed Value for:\t<  " << name << "  >\tis:\t" << (std::is_signed_v<T> ? "true" : "false")
               << std::endl;
     std::cout << "\tstd signed Value for:\t<  " << name << "  >\tis:\t"
               << (std::numeric_limits<T>::is_signed ? "true" : "false") << std::endl;
@@ -226,13 +226,13 @@ CheckSignedAndIntegerTraitsSameAsSTDNumericLimits(const char * const name)
   else
   {
     std::cout << "\tSUCCESS:  IsSigned definition for itk::NumericTraits matches std::numeric_limits" << std::endl;
-    std::cout << "\tSigned Value for:\t<  " << name << "  >\tis:\t" << (std::is_signed<T>::value ? "true" : "false")
+    std::cout << "\tSigned Value for:\t<  " << name << "  >\tis:\t" << (std::is_signed_v<T> ? "true" : "false")
               << std::endl;
   }
 
   // test for IsInteger
   if ((itk::NumericTraits<T>::IsInteger != std::numeric_limits<T>::is_integer) ||
-      (itk::NumericTraits<T>::IsInteger != std::is_integral<T>::value))
+      (itk::NumericTraits<T>::IsInteger != std::is_integral_v<T>))
   {
     std::cout << "\tERROR:  IsInteger definitions for itk::NumericTraits and std::numeric_limits do not match!! ERROR!!"
               << std::endl;
@@ -242,13 +242,13 @@ CheckSignedAndIntegerTraitsSameAsSTDNumericLimits(const char * const name)
     std::cout << "\tstd numeric_limists::is_integer value for:\t<  " << name << "  >\tis:\t"
               << (std::numeric_limits<T>::is_integer ? "true" : "false") << std::endl;
     std::cout << "\tstd is_integral value for:\t<  " << name << "  >\tis:\t"
-              << (std::is_integral<T>::value ? "true" : "false") << std::endl;
+              << (std::is_integral_v<T> ? "true" : "false") << std::endl;
     didTestPass = false;
   }
   else
   {
     std::cout << "\tSUCCESS:  IsInteger definition for itk::NumericTraits matches std::numeric_limits" << std::endl;
-    std::cout << "\tInteger Value for:\t<  " << name << "  >\tis:\t" << (std::is_integral<T>::value ? "true" : "false")
+    std::cout << "\tInteger Value for:\t<  " << name << "  >\tis:\t" << (std::is_integral_v<T> ? "true" : "false")
               << std::endl;
   }
   std::cout << std::endl;

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -60,8 +60,8 @@ TEST(Point, CanBeConstructedByStdArray)
 
 TEST(Point, Make)
 {
-  static_assert(std::is_same<decltype(itk::MakePoint(0))::ValueType, int>::value &&
-                  std::is_same<decltype(itk::MakePoint(0.0))::ValueType, double>::value,
+  static_assert(std::is_same_v<decltype(itk::MakePoint(0))::ValueType, int> &&
+                  std::is_same_v<decltype(itk::MakePoint(0.0))::ValueType, double>,
                 "The value type of the created point should be the same as the type of the (first) argument");
 
   static_assert((decltype(itk::MakePoint(1, 1))::Dimension == 2) && (decltype(itk::MakePoint(1, 1, 1))::Dimension == 3),

--- a/Modules/Core/Common/test/itkPromoteType.cxx
+++ b/Modules/Core/Common/test/itkPromoteType.cxx
@@ -54,22 +54,21 @@ itkPromoteType(int, char *[])
   //   the following list able to hold their entire value range: int, unsigned
   //   int, long, unsigned long, long long, unsigned long long.
 
-  static_assert(std::is_same<PromoteType<signed char, int>::Type, int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<signed char, short>::Type, int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<unsigned char, int>::Type, int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<unsigned char, unsigned int>::Type, unsigned int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<int, int>::Type, int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<short, int>::Type, int>::value, "test failed");
-  static_assert(std::is_same<PromoteType<double, int>::Type, double>::value, "test failed");
-  static_assert(std::is_same<PromoteType<float, int>::Type, float>::value, "test failed");
-  static_assert(std::is_same<PromoteType<long, int>::Type, long>::value, "test failed");
-  static_assert(std::is_same<PromoteType<long long, int>::Type, long long>::value, "test failed");
-  static_assert(std::is_same<PromoteType<int, long long>::Type, long long>::value, "test failed");
-  static_assert(std::is_same<PromoteType<long, long double>::Type, long double>::value, "test failed");
-  static_assert(std::is_same<PromoteType<double, std::complex<double>>::Type, std::complex<double>>::value,
-                "test failed");
+  static_assert(std::is_same_v<PromoteType<signed char, int>::Type, int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<signed char, short>::Type, int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<unsigned char, int>::Type, int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<unsigned char, unsigned int>::Type, unsigned int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<int, int>::Type, int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<short, int>::Type, int>, "test failed");
+  static_assert(std::is_same_v<PromoteType<double, int>::Type, double>, "test failed");
+  static_assert(std::is_same_v<PromoteType<float, int>::Type, float>, "test failed");
+  static_assert(std::is_same_v<PromoteType<long, int>::Type, long>, "test failed");
+  static_assert(std::is_same_v<PromoteType<long long, int>::Type, long long>, "test failed");
+  static_assert(std::is_same_v<PromoteType<int, long long>::Type, long long>, "test failed");
+  static_assert(std::is_same_v<PromoteType<long, long double>::Type, long double>, "test failed");
+  static_assert(std::is_same_v<PromoteType<double, std::complex<double>>::Type, std::complex<double>>, "test failed");
 
-  static_assert(std::is_same<PromoteType<std::complex<int>, std::complex<double>>::Type, std::complex<double>>::value,
+  static_assert(std::is_same_v<PromoteType<std::complex<int>, std::complex<double>>::Type, std::complex<double>>,
                 "test failed");
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -130,20 +130,20 @@ public:
     using ConstContainerType = const TContainer;
     using ValueType = std::remove_reference_t<decltype(*(TContainer().begin()))>;
 
-    static_assert(std::is_same<decltype(*(TContainer().begin())), ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(TContainer().begin())), ValueType &>,
                   "For a non-const container, begin() should return a non-const reference");
-    static_assert(std::is_same<decltype(*(ConstContainerType().begin())), const ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(ConstContainerType().begin())), const ValueType &>,
                   "For a const container, begin() should return a const reference");
-    static_assert(std::is_same<decltype(*(TContainer().cbegin())), const ValueType &>::value &&
-                    std::is_same<decltype(*(ConstContainerType().cbegin())), const ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(TContainer().cbegin())), const ValueType &> &&
+                    std::is_same_v<decltype(*(ConstContainerType().cbegin())), const ValueType &>,
                   "For any container, cbegin() should return a const reference");
 
-    static_assert(std::is_same<decltype(*(TContainer().end())), ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(TContainer().end())), ValueType &>,
                   "For a non-const container, end() should return a non-const reference");
-    static_assert(std::is_same<decltype(*(ConstContainerType().end())), const ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(ConstContainerType().end())), const ValueType &>,
                   "For a const container, end() should return a const reference");
-    static_assert(std::is_same<decltype(*(TContainer().cend())), const ValueType &>::value &&
-                    std::is_same<decltype(*(ConstContainerType().cend())), const ValueType &>::value,
+    static_assert(std::is_same_v<decltype(*(TContainer().cend())), const ValueType &> &&
+                    std::is_same_v<decltype(*(ConstContainerType().cend())), const ValueType &>,
                   "For any container, cend() should return a const reference");
 
     constexpr TContainer container{};
@@ -168,7 +168,7 @@ private:
   static void
   ExpectIteratorEqualsItself(const TIterator & it)
   {
-    static_assert(!std::is_pointer<TIterator>::value,
+    static_assert(!std::is_pointer_v<TIterator>,
                   "There should be a specific `ExpectIteratorEqualsItself` overload for a pointer as argument");
 
     // Checks the (typically) user-defined `operator==` and `operator!=` of TIterator.

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -67,7 +67,7 @@ IsIteratorTypeTheSameAsConstIteratorType()
 {
   using RangeType = ShapedImageNeighborhoodRange<TImage>;
 
-  return std::is_same<typename RangeType::iterator, typename RangeType::const_iterator>::value;
+  return std::is_same_v<typename RangeType::iterator, typename RangeType::const_iterator>;
 }
 
 
@@ -770,7 +770,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
     // Expression to be tested: 'r += n'
     difference_type n = 3;
 
-    static_assert(std::is_same<decltype(r += n), X &>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(r += n), X &>, "Return type tested");
 
     r = initialIterator;
     const auto expectedResult = [&r, n] {
@@ -792,8 +792,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
     // Expressions to be tested: 'a + n' and 'n + a'
     difference_type n = 3;
 
-    static_assert(std::is_same<decltype(a + n), X>::value, "Return type tested");
-    static_assert(std::is_same<decltype(n + a), X>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(a + n), X>, "Return type tested");
+    static_assert(std::is_same_v<decltype(n + a), X>, "Return type tested");
 
     const auto expectedResult = [a, n] {
       // Operational semantics, as specified by the C++11 Standard:
@@ -808,7 +808,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
     // Expression to be tested: 'r -= n'
     difference_type n = 3;
 
-    static_assert(std::is_same<decltype(r -= n), X &>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(r -= n), X &>, "Return type tested");
 
     r = initialIterator;
     const auto expectedResult = [&r, n] {
@@ -823,7 +823,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
     // Expression to be tested: 'a - n'
     difference_type n = -3;
 
-    static_assert(std::is_same<decltype(a - n), X>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(a - n), X>, "Return type tested");
 
     const auto expectedResult = [a, n] {
       // Operational semantics, as specified by the C++11 Standard:
@@ -835,7 +835,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
   }
   {
     // Expression to be tested: 'b - a'
-    static_assert(std::is_same<decltype(b - a), difference_type>::value, "Return type tested");
+    static_assert(std::is_same_v<decltype(b - a), difference_type>, "Return type tested");
 
     difference_type n = b - a;
     EXPECT_TRUE(a + n == b);
@@ -844,15 +844,15 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
   {
     // Expression to be tested: 'a[n]'
     difference_type n = 3;
-    static_assert(std::is_convertible<decltype(a[n]), reference>::value, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a[n]), reference>, "Return type tested");
     EXPECT_EQ(a[n], *(a + n));
   }
   {
     // Expressions to be tested: 'a < b', 'a > b', 'a >= b', and 'a <= b':
-    static_assert(std::is_convertible<decltype(a < b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a > b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a >= b), bool>::value, "Return type tested");
-    static_assert(std::is_convertible<decltype(a <= b), bool>::value, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a < b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a > b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a >= b), bool>, "Return type tested");
+    static_assert(std::is_convertible_v<decltype(a <= b), bool>, "Return type tested");
     EXPECT_EQ(a<b, b - a> 0);
     EXPECT_EQ(a > b, b < a);
     EXPECT_EQ(a >= b, !(a < b));

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -194,13 +194,13 @@ TEST(SmartPointer, Converting)
   EXPECT_TRUE(rcd1ptr == cd1ptr);
 
   // is_convertible<From,To>
-  static_assert(std::is_convertible<Derived1Pointer, BasePointer>::value, "conversion check");
-  static_assert(std::is_convertible<Derived1Pointer, ConstBasePointer>::value, "conversion check");
+  static_assert(std::is_convertible_v<Derived1Pointer, BasePointer>, "conversion check");
+  static_assert(std::is_convertible_v<Derived1Pointer, ConstBasePointer>, "conversion check");
 
-  static_assert(!std::is_convertible<ConstDerived1Pointer, Derived1Pointer>::value, "conversion check");
+  static_assert(!std::is_convertible_v<ConstDerived1Pointer, Derived1Pointer>, "conversion check");
 
-  static_assert(!std::is_convertible<Derived1Pointer, Derived2::Pointer>::value, "conversion check");
-  static_assert(!std::is_convertible<Derived1Pointer, Derived2::ConstPointer>::value, "conversion check");
+  static_assert(!std::is_convertible_v<Derived1Pointer, Derived2::Pointer>, "conversion check");
+  static_assert(!std::is_convertible_v<Derived1Pointer, Derived2::ConstPointer>, "conversion check");
 }
 
 

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -23,10 +23,10 @@
 #include <memory> // For make_unique.
 #include <type_traits>
 
-static_assert(std::is_nothrow_default_constructible<itk::TimeStamp>::value, "Check TimeStamp default-constructibility");
-static_assert(std::is_trivially_copy_constructible<itk::TimeStamp>::value, "Check TimeStamp copy-constructibility");
-static_assert(std::is_trivially_copy_assignable<itk::TimeStamp>::value, "Check TimeStamp copy-assignability");
-static_assert(std::is_trivially_destructible<itk::TimeStamp>::value, "Check TimeStamp destructibility");
+static_assert(std::is_nothrow_default_constructible_v<itk::TimeStamp>, "Check TimeStamp default-constructibility");
+static_assert(std::is_trivially_copy_constructible_v<itk::TimeStamp>, "Check TimeStamp copy-constructibility");
+static_assert(std::is_trivially_copy_assignable_v<itk::TimeStamp>, "Check TimeStamp copy-assignability");
+static_assert(std::is_trivially_destructible_v<itk::TimeStamp>, "Check TimeStamp destructibility");
 
 // A helper struct for the test, the idea is to have one timestamp per thread.
 // To ease the writing of the test, we use  MultiThreaderBase::SingleMethodExecute

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -60,8 +60,8 @@ TEST(Vector, CanBeConstructedByStdArray)
 
 TEST(Vector, Make)
 {
-  static_assert(std::is_same<decltype(itk::MakeVector(0))::ValueType, int>::value &&
-                  std::is_same<decltype(itk::MakeVector(0.0))::ValueType, double>::value,
+  static_assert(std::is_same_v<decltype(itk::MakeVector(0))::ValueType, int> &&
+                  std::is_same_v<decltype(itk::MakeVector(0.0))::ValueType, double>,
                 "The value type of the created itk::Vector should be the same as the type of the (first) argument");
 
   static_assert((decltype(itk::MakeVector(1, 1))::Dimension == 2) &&

--- a/Modules/Core/Common/test/itkWeakPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkWeakPointerGTest.cxx
@@ -31,9 +31,9 @@ template <typename T>
 constexpr bool
 AllSpecialMemberFunctionsNoThrow()
 {
-  return std::is_nothrow_default_constructible<T>::value && std::is_nothrow_copy_constructible<T>::value &&
-         std::is_nothrow_copy_assignable<T>::value && std::is_nothrow_move_constructible<T>::value &&
-         std::is_nothrow_move_assignable<T>::value && std::is_nothrow_destructible<T>::value;
+  return std::is_nothrow_default_constructible_v<T> && std::is_nothrow_copy_constructible_v<T> &&
+         std::is_nothrow_copy_assignable_v<T> && std::is_nothrow_move_constructible_v<T> &&
+         std::is_nothrow_move_assignable_v<T> && std::is_nothrow_destructible_v<T>;
 }
 
 } // namespace

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
@@ -55,7 +55,7 @@ template <typename T1, typename T2>
 void
 Expect_same_type_and_equal_value(T1 && value1, T2 && value2)
 {
-  static_assert(std::is_same<T1, T2>::value, "Expect the same type!");
+  static_assert(std::is_same_v<T1, T2>, "Expect the same type!");
   EXPECT_EQ(value1, value2);
 }
 

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -163,11 +163,11 @@ itkGaussianDerivativeImageFunctionTest(int, char *[])
 #if !defined(ITK_LEGACY_REMOVE)
   static_assert(DoGFunctionType::ImageDimension2 == DoGFunctionType::ImageDimension,
                 "Check legacy support for ImageDimension2");
-  static_assert(std::is_same<DoGFunctionType::GaussianDerivativeFunctionType,
-                             DoGFunctionType::GaussianDerivativeSpatialFunctionType>::value,
+  static_assert(std::is_same_v<DoGFunctionType::GaussianDerivativeFunctionType,
+                               DoGFunctionType::GaussianDerivativeSpatialFunctionType>,
                 "Check legacy support for GaussianDerivativeFunctionType");
-  static_assert(std::is_same<DoGFunctionType::GaussianDerivativeFunctionPointer,
-                             DoGFunctionType::GaussianDerivativeSpatialFunctionPointer>::value,
+  static_assert(std::is_same_v<DoGFunctionType::GaussianDerivativeFunctionPointer,
+                               DoGFunctionType::GaussianDerivativeSpatialFunctionPointer>,
                 "Check legacy support for GaussianDerivativeFunctionPointer");
 #endif
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTypeTraitsGTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTypeTraitsGTest.cxx
@@ -26,6 +26,6 @@
 TEST(QuadEdgeMeshTypeTraits, QuadEdgeMeshPointIsNotPOD)
 {
   using T = itk::QuadEdgeMeshPoint<float, 3>;
-  EXPECT_EQ(std::is_trivial<T>::value, false);
-  EXPECT_EQ(std::is_standard_layout<T>::value, false);
+  EXPECT_EQ(std::is_trivial_v<T>, false);
+  EXPECT_EQ(std::is_standard_layout_v<T>, false);
 }

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -232,12 +232,10 @@ protected:
   GenerateInputRequestedRegion() override;
 
   template <typename T, typename U = void>
-  using DisableIfMultiComponent =
-    typename std::enable_if<std::is_same<T, typename NumericTraits<T>::ValueType>::value, U>;
+  using DisableIfMultiComponent = typename std::enable_if<std::is_same_v<T, typename NumericTraits<T>::ValueType>, U>;
 
   template <typename T, typename U = void>
-  using EnableIfMultiComponent =
-    typename std::enable_if<!std::is_same<T, typename NumericTraits<T>::ValueType>::value, U>;
+  using EnableIfMultiComponent = typename std::enable_if<!std::is_same_v<T, typename NumericTraits<T>::ValueType>, U>;
 
 
   /** \brief A method to generically get a component.

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
@@ -29,7 +29,7 @@ template <typename TInputImage, typename TOutputImage, typename TInternalPrecisi
 UnsharpMaskImageFilter<TInputImage, TOutputImage, TInternalPrecision>::UnsharpMaskImageFilter()
   : m_Amount(0.5)
   , m_Threshold(0)
-  , m_Clamp(std::is_integral<OutputPixelType>::value)
+  , m_Clamp(std::is_integral_v<OutputPixelType>)
 // clamping is on for integral types, and off for floating types
 // this gives intuitive behavior for integral types
 // and skips min/max checks for floating types

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
@@ -66,7 +66,7 @@ RunTest(int argc, char * argv[])
     filter->SetThreshold(std::stod(argv[6]));
   }
 
-  const bool clamp = std::is_integral<typename FilterType::OutputPixelType>::value;
+  const bool clamp = std::is_integral_v<typename FilterType::OutputPixelType>;
   filter->SetClamp(clamp);
   ITK_TEST_SET_GET_VALUE(clamp, filter->GetClamp());
 

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
@@ -132,7 +132,7 @@ itkUnsharpMaskImageFilterTestSimple(int, char *[])
   filter->SetThreshold(threshold);
   ITK_TEST_SET_GET_VALUE(threshold, filter->GetThreshold());
 
-  const bool clamp = std::is_integral<UnsharpMaskImageFilterFilterType::OutputPixelType>::value;
+  const bool clamp = std::is_integral_v<UnsharpMaskImageFilterFilterType::OutputPixelType>;
   filter->SetClamp(clamp);
   ITK_TEST_SET_GET_VALUE(clamp, filter->GetClamp());
 

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -119,7 +119,7 @@ CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatche
   // Implementation for non-implicit convertible pixels which are
   // itk-array-like.
 
-  static_assert(std::is_convertible<typename InputPixelType::ValueType, typename OutputPixelType::ValueType>::value,
+  static_assert(std::is_convertible_v<typename InputPixelType::ValueType, typename OutputPixelType::ValueType>,
                 "Component types are required to be convertible.");
 
   const typename OutputImageRegionType::SizeType & regionSize = outputRegionForThread.GetSize();

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -94,15 +94,15 @@ GetCastTypeName()
 // static_cast_is_well_defined function returns true if the result of the static cast is well defined
 // and false if the result is undefined.
 template <typename TInput, typename TOutput>
-static std::enable_if_t<std::is_integral<TOutput>::value && std::is_integral<TInput>::value, bool>
-  static_cast_is_well_defined(TInput)
+static std::enable_if_t<std::is_integral_v<TOutput> && std::is_integral_v<TInput>, bool> static_cast_is_well_defined(
+  TInput)
 {
   return true; // casting from int to int types employes deterministic 2's complement behavior
 }
 
 template <typename TInput, typename TOutput>
-static std::enable_if_t<std::is_floating_point<TOutput>::value &&
-                          (std::is_floating_point<TInput>::value || std::is_integral<TInput>::value),
+static std::enable_if_t<std::is_floating_point_v<TOutput> &&
+                          (std::is_floating_point_v<TInput> || std::is_integral_v<TInput>),
                         bool>
   static_cast_is_well_defined(TInput)
 {
@@ -110,8 +110,7 @@ static std::enable_if_t<std::is_floating_point<TOutput>::value &&
 }
 
 template <typename TInput, typename TOutput>
-static std::enable_if_t<std::is_integral<TOutput>::value && std::is_unsigned<TOutput>::value &&
-                          std::is_floating_point<TInput>::value,
+static std::enable_if_t<std::is_integral_v<TOutput> && std::is_unsigned_v<TOutput> && std::is_floating_point_v<TInput>,
                         bool>
 static_cast_is_well_defined(TInput value)
 {
@@ -123,8 +122,7 @@ static_cast_is_well_defined(TInput value)
 }
 
 template <typename TInput, typename TOutput>
-static std::enable_if_t<std::is_integral<TOutput>::value && std::is_signed<TOutput>::value &&
-                          std::is_floating_point<TInput>::value,
+static std::enable_if_t<std::is_integral_v<TOutput> && std::is_signed_v<TOutput> && std::is_floating_point_v<TInput>,
                         bool>
 static_cast_is_well_defined(TInput value)
 {

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -303,9 +303,8 @@ auto
 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   CastComponentWithBoundsChecking(const TComponent value) -> PixelComponentType
 {
-  static_assert(std::is_same<TComponent, ComponentType>::value,
-                "TComponent should just be the same as the ComponentType!");
-  static_assert(!std::is_same<TComponent, PixelComponentType>::value,
+  static_assert(std::is_same_v<TComponent, ComponentType>, "TComponent should just be the same as the ComponentType!");
+  static_assert(!std::is_same_v<TComponent, PixelComponentType>,
                 "For PixelComponentType there is a more appropriate overload, that should be called instead!");
 
   // Retrieve minimum and maximum values at compile-time:
@@ -341,9 +340,9 @@ auto
 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   CastPixelWithBoundsChecking(const TPixel value) -> PixelType
 {
-  static_assert(std::is_same<TPixel, InterpolatorOutputType>::value,
+  static_assert(std::is_same_v<TPixel, InterpolatorOutputType>,
                 "TPixel should just be the same as the InterpolatorOutputType!");
-  static_assert(!std::is_same<TPixel, ComponentType>::value,
+  static_assert(!std::is_same_v<TPixel, ComponentType>,
                 "For ComponentType there is a more efficient overload, that should be called instead!");
 
   const unsigned int nComponents = InterpolatorConvertType::GetNumberOfComponents(value);

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -311,7 +311,7 @@ public:
   operator()(const TInput1 & A, const TInput2 & B) const
   {
     const double temp = std::floor(static_cast<double>(A) / static_cast<double>(B));
-    if (std::is_integral<TOutput>::value && Math::isinf(temp))
+    if (std::is_integral_v<TOutput> && Math::isinf(temp))
     {
       if (temp > 0)
       {

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -81,7 +81,7 @@ TestClampFromTo()
   auto filter = FilterType::New();
 
   filter->SetInput(source->GetOutput());
-  if (std::is_same<TInputPixelType, typename itk::NumericTraits<TOutputPixelType>::ValueType>::value)
+  if (std::is_same_v<TInputPixelType, typename itk::NumericTraits<TOutputPixelType>::ValueType>)
   {
     filter->InPlaceOn();
   }
@@ -194,7 +194,7 @@ TestClampFromToWithCustomBounds()
 
   filter->SetBounds(static_cast<TOutputPixelType>(5), static_cast<TOutputPixelType>(15));
   filter->SetInput(source->GetOutput());
-  if (std::is_same<TInputPixelType, typename itk::NumericTraits<TOutputPixelType>::ValueType>::value)
+  if (std::is_same_v<TInputPixelType, typename itk::NumericTraits<TOutputPixelType>::ValueType>)
   {
     filter->InPlaceOn();
   }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -139,8 +139,7 @@ public:
   {
     constexpr size_t bitsShift = std::min(8 * sizeof(FeatureImagePixelType), 8 * sizeof(m_NumberOfBins) - 1);
 
-    return std::is_integral<FeatureImagePixelType>::value && sizeof(FeatureImagePixelType) <= 2 ? 1u << bitsShift
-                                                                                                : 128u;
+    return std::is_integral_v<FeatureImagePixelType> && sizeof(FeatureImagePixelType) <= 2 ? 1u << bitsShift : 128u;
   }
 
 protected:

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -73,7 +73,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
 
 
   constexpr size_t bitsShift = std::min(8 * sizeof(FeatureImagePixelType), 8 * sizeof(m_NumberOfBins) - 1);
-  if (std::is_integral<FeatureImagePixelType>::value && sizeof(FeatureImagePixelType) <= 2 &&
+  if (std::is_integral_v<FeatureImagePixelType> && sizeof(FeatureImagePixelType) <= 2 &&
       m_NumberOfBins == 1u << bitsShift)
   {
     // Add padding so the center of bins are integers

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -308,11 +308,11 @@ ContourExtractor2DImageFilter<TInputImage>::GenerateDataForLabels()
        checkedLabel != allLabels.cend() && m_UnusedLabel == *checkedLabel;
        ++checkedLabel)
   {
-    if /* constexpr */ (std::is_integral<InputPixelType>::value)
+    if /* constexpr */ (std::is_integral_v<InputPixelType>)
     {
       ++m_UnusedLabel;
     }
-    else if /* constexpr */ (std::is_floating_point<InputPixelType>::value)
+    else if /* constexpr */ (std::is_floating_point_v<InputPixelType>)
     {
       m_UnusedLabel = std::nextafter(m_UnusedLabel, NumericTraits<InputPixelType>::max());
     }

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
@@ -174,11 +174,11 @@ protected:
    *  world of rgb<float> or rgb<double> alpha would have to be 1.0
    */
   template <typename UComponentType>
-  static std::enable_if_t<!std::is_integral<UComponentType>::value, UComponentType>
+  static std::enable_if_t<!std::is_integral_v<UComponentType>, UComponentType>
   DefaultAlphaValue();
 
   template <typename UComponentType>
-  static std::enable_if_t<std::is_integral<UComponentType>::value, UComponentType>
+  static std::enable_if_t<std::is_integral_v<UComponentType>, UComponentType>
   DefaultAlphaValue();
 };
 } // namespace itk

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -28,7 +28,7 @@ namespace itk
 
 template <typename InputPixelType, typename OutputPixelType, typename OutputConvertTraits>
 template <typename UComponentType>
-std::enable_if_t<!std::is_integral<UComponentType>::value, UComponentType>
+std::enable_if_t<!std::is_integral_v<UComponentType>, UComponentType>
 ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::DefaultAlphaValue()
 {
   return NumericTraits<UComponentType>::One;
@@ -36,7 +36,7 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Defaul
 
 template <typename InputPixelType, typename OutputPixelType, typename OutputConvertTraits>
 template <typename UComponentType>
-std::enable_if_t<std::is_integral<UComponentType>::value, UComponentType>
+std::enable_if_t<std::is_integral_v<UComponentType>, UComponentType>
 ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::DefaultAlphaValue()
 {
   return NumericTraits<UComponentType>::max();

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -247,8 +247,7 @@ ITK_TEMPLATE_EXPORT void
 WriteImage(TImagePointer && image, const std::string & filename, bool compress = false)
 {
   using NonReferenceImagePointer = std::remove_reference_t<TImagePointer>;
-  static_assert(std::is_pointer<NonReferenceImagePointer>::value ||
-                  mpl::IsSmartPointer<NonReferenceImagePointer>::Value,
+  static_assert(std::is_pointer_v<NonReferenceImagePointer> || mpl::IsSmartPointer<NonReferenceImagePointer>::Value,
                 "WriteImage requires a raw pointer or SmartPointer.");
 
   using ImageType = std::remove_const_t<std::remove_reference_t<decltype(*image)>>;

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -196,7 +196,7 @@ ITK_TEMPLATE_EXPORT void
 WriteMesh(TMeshPointer && mesh, const std::string & filename, bool compress = false)
 {
   using NonReferenceMeshPointer = std::remove_reference_t<TMeshPointer>;
-  static_assert(std::is_pointer<NonReferenceMeshPointer>::value || mpl::IsSmartPointer<NonReferenceMeshPointer>::Value,
+  static_assert(std::is_pointer_v<NonReferenceMeshPointer> || mpl::IsSmartPointer<NonReferenceMeshPointer>::Value,
                 "WriteMesh requires a raw pointer or SmartPointer.");
 
   using MeshType = std::remove_const_t<std::remove_reference_t<decltype(*mesh)>>;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -175,7 +175,7 @@ Segmenter<TInputImage>::GenerateData()
   Self::MinMax(input, regionToProcess, minimum, maximum);
   // cap the maximum in the image so that we can always define a pixel
   // value that is one greater than the maximum value in the image.
-  if (std::is_integral<InputPixelType>::value
+  if (std::is_integral_v<InputPixelType>
         // clang-format off
 CLANG_PRAGMA_PUSH
 CLANG_SUPPRESS_Wfloat_equal


### PR DESCRIPTION
Did Visual Studio 2022 Replace in Files, having selected "Match case", "Match whole word", and "Use regular expressions", doing:

    Find what: std::(\w+)<([^<>]+)>::value
    Find what: std::(is_same)<(.+)>::value
    Find what: std::(is_same)<(.+\r\n.+)>::value
    Find what: std::(is_const)<(.+)>::value
    Replace with: std::$1_v<$2>

    Find what: \(std::(\w+)<(.+)>::value,
    Replace with: (std::$1_v<$2>,

    Find what: return std::(\w+)<(.+)>::value;
    Replace with: return std::$1_v<$2>;

Following Alisdair Meredith, 2015-09-28, "Adopt Type Traits Variable Templates from Library Fundamentals TS for C++17",
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0006r0.html