### PR TITLE
STYLE: Remove GCC 5.2 specific code from IntensityLinearTransform

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
@@ -38,13 +38,6 @@ public:
     m_Offset = 0.0;
     m_Minimum = NumericTraits<TOutput>::NonpositiveMin();
     m_Maximum = NumericTraits<TOutput>::max();
-#if defined(__GNUC__) && (__GNUC__ == 5) && (__GNUC_MINOR__ == 2) && defined(NDEBUG) && defined(__i386__)
-    m_EpsilonCompensation = static_cast<RealType>(std::numeric_limits<TOutput>::epsilon());
-    if (m_EpsilonCompensation == 0)
-    {
-      m_EpsilonCompensation = std::numeric_limits<RealType>::epsilon();
-    }
-#endif
   }
 
   ~IntensityLinearTransform() = default;
@@ -81,13 +74,9 @@ public:
   inline TOutput
   operator()(const TInput & x) const
   {
-#if defined(__GNUC__) && (__GNUC__ == 5) && (__GNUC_MINOR__ == 2) && defined(NDEBUG) && defined(__i386__)
-    RealType value = static_cast<RealType>(x) * m_Factor + m_Offset + m_EpsilonCompensation;
-    TOutput  result = static_cast<TOutput>(value) - static_cast<TOutput>(m_EpsilonCompensation);
-#else
     RealType value = static_cast<RealType>(x) * m_Factor + m_Offset;
     auto     result = static_cast<TOutput>(value);
-#endif
+
     result = (result > m_Maximum) ? m_Maximum : result;
     result = (result < m_Minimum) ? m_Minimum : result;
     return result;
@@ -98,9 +87,6 @@ private:
   RealType m_Offset;
   TOutput  m_Maximum;
   TOutput  m_Minimum;
-#if defined(__GNUC__) && (__GNUC__ == 5) && (__GNUC_MINOR__ == 2) && defined(NDEBUG) && defined(__i386__)
-  RealType m_EpsilonCompensation;
-#endif
 };
 } // end namespace Functor
 


### PR DESCRIPTION
GCC 5.2 was dropped with commit 45407f3560d91af247c95a1f48d21cbbb8ff6b8d "COMP: Require compiler versions that support C++17"

This reverts commit 114b902aac9282505efc386f93eeb46b3c5945c5 "BUG: Avoid an unexpected output of static_cast" by Hyun Jae Kang, September 29, 2015.
