### PR TITLE
Use C++17 class template argument deduction for `ImageBufferRange` and `ImageRegionRange`

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * The following example adds 42 to each pixel, using a range-based for loop:
    \code
-   ImageBufferRange<ImageType> range{ *image };
+   ImageBufferRange range{ *image };
 
    for (auto&& pixel : range)
    {

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -333,7 +333,7 @@ public:
    * region, within the specified image.
    */
   explicit ImageRegionRange(TImage & image, const RegionType & iterationRegion)
-    : m_BufferBegin{ std::begin(ImageBufferRange<TImage>{ image }) }
+    : m_BufferBegin{ std::begin(ImageBufferRange{ image }) }
     ,
     // Note: Use parentheses instead of curly braces to initialize data members,
     // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -43,7 +43,7 @@ namespace itk
  *
  * The following example adds 42 to each pixel, using a range-based for loop:
    \code
-   ImageRegionRange<ImageType> range{ *image, imageRegion };
+   ImageRegionRange range{ *image, imageRegion };
 
    for (auto&& pixel : range)
    {

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -108,8 +108,8 @@ typename TImage::Pointer
 CreateImageFilledWithSequenceOfNaturalNumbers(const unsigned int sizeX, const unsigned int sizeY)
 {
   using PixelType = typename TImage::PixelType;
-  const auto                          image = CreateImage<TImage>(sizeX, sizeY);
-  const itk::ImageBufferRange<TImage> imageBufferRange{ *image };
+  const auto                  image = CreateImage<TImage>(sizeX, sizeY);
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }
@@ -587,7 +587,7 @@ TEST(ImageRegionRange, IteratesForwardOverSamePixelsAsImageRegionIterator)
   const auto image = ImageType::New();
   image->SetRegions(RegionType{ IndexType{ { -1, -2 } }, SizeType{ { 9, 11 } } });
   image->Allocate();
-  const itk::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
 
   Expect_ImageRegionRange_iterates_forward_over_same_pixels_as_ImageRegionIterator(
@@ -607,7 +607,7 @@ TEST(ImageRegionRange, IteratesBackwardOverSamePixelsAsImageRegionIterator)
   const auto image = ImageType::New();
   image->SetRegions(RegionType{ IndexType{ { -1, -2 } }, SizeType{ { 9, 11 } } });
   image->Allocate();
-  const itk::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
 
   Expect_ImageRegionRange_iterates_backward_over_same_pixels_as_ImageRegionIterator(

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -46,7 +46,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::SizeType & 
   const auto image = TImage::New();
   image->SetRegions(imageSize);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange<TImage>{ *image };
+  const auto imageBufferRange = itk::ImageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }
@@ -158,7 +158,7 @@ TEST(SumOfSquaresImageFunction, EvaluateAtCenterPixelOfImageOfSize3x3)
 
   imageFunction->SetInputImage(image);
 
-  const auto imageBufferRange = itk::ImageBufferRange<const ImageType>{ *image };
+  const auto imageBufferRange = itk::ImageBufferRange{ *image };
 
   // Sum of squares of all pixels of the image:
   const auto expectedResult = std::accumulate(

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -142,7 +142,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
   const ImageType & image = *imagePointer;
 
   const auto HasForegroundPixels = [&image](const RegionType & region) {
-    for (const PixelType pixelValue : ImageRegionRange<const ImageType>{ image, region })
+    for (const PixelType pixelValue : ImageRegionRange{ image, region })
     {
       constexpr auto zeroValue = NumericTraits<PixelType>::ZeroValue();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -125,7 +125,7 @@ Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel
   // Set all pixels to non-zero.
   image->FillBuffer(1);
 
-  const itk::ImageBufferRange<ImageType> imageRange{ *image };
+  const itk::ImageBufferRange imageRange{ *image };
 
   for (auto && pixel : imageRange)
   {

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -120,8 +120,8 @@ CLANG_SUPPRESS_Wfloat_equal
     const MaskPixelType maskLabel = this->GetMaskLabel();
     const bool          useMaskLabel = this->GetUseMaskLabel();
 
-    const ImageBufferRange<RealImageType> logInputImageBufferRange{ *logInputImage };
-    const size_t                          numberOfPixels = logInputImageBufferRange.size();
+    const ImageBufferRange logInputImageBufferRange{ *logInputImage };
+    const size_t           numberOfPixels = logInputImageBufferRange.size();
 
     // Number of pixels of the input image that are included with the filter.
     size_t numberOfIncludedPixels = 0;
@@ -445,7 +445,7 @@ CLANG_SUPPRESS_Wfloat_equal
     // Sharpen the image with the new mapping, E(u|v)
     sharpenedImage->FillBuffer(0);
 
-    const ImageBufferRange<RealImageType> sharpenedImageBufferRange{ *sharpenedImage };
+    const ImageBufferRange sharpenedImageBufferRange{ *sharpenedImage };
 
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -83,7 +83,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
 
   auto neighborhoodRange = ShapedImageNeighborhoodRange<const InputImageType, TPixelAccessPolicy>(
     inputImage, Index<InputImageDimension>(), neighborhoodOffsets);
-  auto outputIterator = ImageRegionRange<OutputImageType>(outputImage, imageRegion).begin();
+  auto outputIterator = ImageRegionRange(outputImage, imageRegion).begin();
 
   for (const auto & index : ImageRegionIndexRange<InputImageDimension>(imageRegion))
   {
@@ -116,7 +116,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
 
   auto neighborhoodRange = ShapedImageNeighborhoodRange<const InputImageType, TPixelAccessPolicy>(
     inputImage, Index<InputImageDimension>(), neighborhoodOffsets);
-  auto outputIterator = ImageRegionRange<OutputImageType>(outputImage, imageRegion).begin();
+  auto outputIterator = ImageRegionRange(outputImage, imageRegion).begin();
 
   // These temp variable are needed outside the loop for
   // VariableLengthVectors to avoid memory allocations on a per-pixel

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
@@ -72,7 +72,7 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType, BufferedImageNeighborhoodPixelAccessPolicy<InputImageType>>(
         *input, Index<InputImageDimension>(), neighborhoodOffsets);
-    auto outputIterator = ImageRegionRange<OutputImageType>(*output, nonBoundaryRegion).begin();
+    auto outputIterator = ImageRegionRange(*output, nonBoundaryRegion).begin();
 
     for (const auto & index : ImageRegionIndexRange<InputImageDimension>(nonBoundaryRegion))
     {
@@ -91,7 +91,7 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   {
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType>(*input, Index<InputImageDimension>(), neighborhoodOffsets);
-    auto outputIterator = ImageRegionRange<OutputImageType>(*output, boundaryFace).begin();
+    auto outputIterator = ImageRegionRange(*output, boundaryFace).begin();
 
     for (const auto & index : ImageRegionIndexRange<InputImageDimension>(boundaryFace))
     {

--- a/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
@@ -68,7 +68,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
   const auto image = TImage::New();
   image->SetRegions(imageRegion);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange<TImage>{ *image };
+  const auto imageBufferRange = itk::ImageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
@@ -66,7 +66,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
   const auto image = TImage::New();
   image->SetRegions(imageRegion);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange<TImage>{ *image };
+  const auto imageBufferRange = itk::ImageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }


### PR DESCRIPTION
Removed the template argument from the initialization of `ImageBufferRange` and `ImageRegionRange` objects, using C++17 class template argument deduction (CTAD).
