### PR TITLE
STYLE: Replace `std::min` and `std::max` calls with C++17 `std::clamp`

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -174,7 +174,7 @@ public:
     constexpr double Min = 0.00001;
     const double     Max = 1.0 - Min;
 
-    m_MaximumError = std::max(Min, std::min(Max, maxerror));
+    m_MaximumError = std::clamp(maxerror, Min, Max);
   }
   double
   GetMaximumError()

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -92,7 +92,7 @@ TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, co
 
   CoordRepType bound(0.999999);
 
-  CoordRepType cos_theta = std::max(-bound, std::min(bound, v21 * v23));
+  CoordRepType cos_theta = std::clamp(v21 * v23, -bound, bound);
 
   return 1.0 / std::tan(std::acos(cos_theta));
 }
@@ -152,7 +152,7 @@ TriangleHelper<TPoint>::ComputeAngle(const PointType & iP1, const PointType & iP
 
   CoordRepType bound(0.999999);
 
-  CoordRepType cos_theta = std::max(-bound, std::min(bound, v21 * v23));
+  CoordRepType cos_theta = std::clamp(v21 * v23, -bound, bound);
 
   return std::acos(cos_theta);
 }

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -521,7 +521,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
       const unsigned int interval = (patchRadius + 1) - discRadius;
       const float        weight = (-2.0 / pow(interval, 3.0)) * pow((patchRadius + 1) - distanceFromCenter, 3.0f) +
                            (3.0 / pow(interval, 2.0)) * pow((patchRadius + 1) - distanceFromCenter, 2.0f);
-      pwIt.Set(std::max(static_cast<float>(0), std::min(static_cast<float>(1), weight)));
+      pwIt.Set(std::clamp(weight, 0.0f, 1.0f));
     }
   }
 

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -242,7 +242,7 @@ TestStreamRead(char * file1, unsigned int numberOfStreams = 0)
   }
 
   // Simulate streaming and compares regions
-  numberOfStreams = std::max(1u, std::min(static_cast<unsigned int>(size[TDimension - 1]), numberOfStreams));
+  numberOfStreams = std::clamp(numberOfStreams, 1u, static_cast<unsigned int>(size[TDimension - 1]));
   typename ImageType::SizeValueType width = (size[TDimension - 1] + numberOfStreams - 1) / numberOfStreams;
   typename ImageType::RegionType    totalRegion = consValueImage->GetLargestPossibleRegion();
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -751,7 +751,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       distance = outputIt.GetCenterPixel() / gradientMagnitude;
 
       // Insert in the update buffer
-      sparsePtr->m_UpdateBuffer.push_back(std::min(std::max(-MIN_NORM, distance), MIN_NORM));
+      sparsePtr->m_UpdateBuffer.push_back(std::clamp(distance, -MIN_NORM, MIN_NORM));
       ++activeIt;
     }
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -519,7 +519,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeAct
     length = std::sqrt(length) + MIN_NORM;
     distance = shiftedIt.GetCenterPixel() / length;
 
-    m_OutputImage->SetPixel(activeIt->m_Index, std::min(std::max(-CHANGE_FACTOR, distance), CHANGE_FACTOR));
+    m_OutputImage->SetPixel(activeIt->m_Index, std::clamp(distance, -CHANGE_FACTOR, CHANGE_FACTOR));
   }
 }
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -830,7 +830,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeActiveLayer
     length = std::sqrt(static_cast<double>(length)) + MIN_NORM;
     distance = shiftedIt.GetCenterPixel() / length;
 
-    output->SetPixel(activeIt->m_Value, std::min(std::max(-CHANGE_FACTOR, distance), CHANGE_FACTOR));
+    output->SetPixel(activeIt->m_Value, std::clamp(distance, -CHANGE_FACTOR, CHANGE_FACTOR));
   }
 }
 


### PR DESCRIPTION
The `clamp` algorithm was added to the Standard Library of C++17 as proposed by the paper `An algorithm to "clamp" a value between a pair of boundary values`, 2015-05-17, by Martin Moene (@martinmoene) and Niels Dekker (who happens to be the author of this commit 😸): https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4536.html
