### PR TITLE
ENH: Add C++17 `[[nodiscard]]` to Image "Transform" member functions

### DIFF
--- a/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
+++ b/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
@@ -102,9 +102,15 @@ main(int argc, char * argv[])
   point[0] = origin[0] + spacing[0] * size[0];
   point[1] = origin[1] + spacing[1] * size[1];
 
-  image->TransformPhysicalPointToContinuousIndex(origin, cindex);
+  using ContinuousIndexValueType = ContinuousIndexType::ValueType;
+
+  cindex =
+    image->TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
+      origin);
   path->AddVertex(cindex);
-  image->TransformPhysicalPointToContinuousIndex(point, cindex);
+  cindex =
+    image->TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
+      point);
   path->AddVertex(cindex);
   // Software Guide : EndCodeSnippet
 

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -439,7 +439,7 @@ public:
      \endcode
    * \sa Transform */
   template <typename TCoordRep>
-  IndexType
+  [[nodiscard]] IndexType
   TransformPhysicalPointToIndex(const Point<TCoordRep, VImageDimension> & point) const
   {
     IndexType index;
@@ -465,7 +465,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToIndex(const Point<TCoordRep, VImageDimension> & point, IndexType & index) const
   {
     index = TransformPhysicalPointToIndex(point);
@@ -491,7 +491,7 @@ public:
      \endcode
    * \sa Transform */
   template <typename TIndexRep, typename TCoordRep>
-  ContinuousIndex<TIndexRep, VImageDimension>
+  [[nodiscard]] ContinuousIndex<TIndexRep, VImageDimension>
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, VImageDimension> & point) const
   {
     ContinuousIndex<TIndexRep, VImageDimension> index;
@@ -518,7 +518,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep, typename TIndexRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, VImageDimension> &     point,
                                           ContinuousIndex<TIndexRep, VImageDimension> & index) const
   {
@@ -554,7 +554,7 @@ public:
    * from a continuous index (in the index space)
    * \sa Transform */
   template <typename TCoordRep, typename TIndexRep>
-  Point<TCoordRep, VImageDimension>
+  [[nodiscard]] Point<TCoordRep, VImageDimension>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, VImageDimension> & index) const
   {
     Point<TCoordRep, VImageDimension> point;
@@ -587,7 +587,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep>
-  Point<TCoordRep, VImageDimension>
+  [[nodiscard]] Point<TCoordRep, VImageDimension>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
     Point<TCoordRep, VImageDimension> point;
@@ -637,7 +637,7 @@ public:
    * \sa Image
    */
   template <typename TVector>
-  TVector
+  [[nodiscard]] TVector
   TransformLocalVectorToPhysicalVector(const TVector & inputGradient) const
   {
     TVector outputGradient;
@@ -686,7 +686,7 @@ public:
    *
    */
   template <typename TVector>
-  TVector
+  [[nodiscard]] TVector
   TransformPhysicalVectorToLocalVector(const TVector & inputGradient) const
   {
     TVector outputGradient;

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -459,6 +459,10 @@ public:
   /** Get the index (discrete) of a voxel from a physical point.
    * Floating point index results are rounded to integers
    * Returns true if the resulting index is within the image, false otherwise
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the index.
+   *
    * \sa Transform */
   template <typename TCoordRep>
   bool
@@ -508,6 +512,10 @@ public:
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the continuous index.
+   *
    * \sa Transform */
   template <typename TCoordRep, typename TIndexRep>
   bool

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -211,6 +211,10 @@ public:
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the continuous index.
+   *
    * \sa Transform */
   template <typename TCoordRep, typename TIndexRep>
   bool
@@ -257,6 +261,10 @@ public:
   /** Get the index (discrete) from a physical point.
    * Floating point index results are truncated to integers.
    * Returns true if the resulting index is within the image, false otherwise
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the index.
+   *
    * \sa Transform */
   template <typename TCoordRep>
   bool

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -183,7 +183,7 @@ public:
 
   /** Returns the continuous index from a physical point */
   template <typename TIndexRep, typename TCoordRep>
-  ContinuousIndex<TIndexRep, 3>
+  [[nodiscard]] ContinuousIndex<TIndexRep, 3>
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, 3> & point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
@@ -217,7 +217,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep, typename TIndexRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, 3> &     point,
                                           ContinuousIndex<TIndexRep, 3> & index) const
   {
@@ -233,7 +233,7 @@ public:
    * Floating point index results are truncated to integers.
    */
   template <typename TCoordRep>
-  IndexType
+  [[nodiscard]] IndexType
   TransformPhysicalPointToIndex(const Point<TCoordRep, 3> & point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
@@ -267,7 +267,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToIndex(const Point<TCoordRep, 3> & point, IndexType & index) const
   {
     index = this->TransformPhysicalPointToIndex(point);
@@ -308,7 +308,7 @@ public:
 
   /** Returns a physical point from a continuous index. */
   template <typename TCoordRep, typename TIndexRep>
-  Point<TCoordRep, 3>
+  [[nodiscard]] Point<TCoordRep, 3>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, 3> & index) const
   {
     Point<TCoordRep, 3> point;
@@ -346,7 +346,7 @@ public:
 
   /** Returns a physical point from a discrete index. */
   template <typename TCoordRep>
-  Point<TCoordRep, 3>
+  [[nodiscard]] Point<TCoordRep, 3>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
     Point<TCoordRep, 3> point;

--- a/Modules/Core/Common/test/itkImageTransformTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformTest.cxx
@@ -61,11 +61,13 @@ TestTransform()
   std::cout << "    Image:         " << index << " -> " << point << std::endl;
 
   std::cout << "TransformPhysicalPointToIndex..." << std::endl;
-  orientedImage->TransformPhysicalPointToIndex(point, index);
-  std::cout << "    Image: " << point << " -> " << index << std::endl;
+  const bool isInsideOrientedImage = orientedImage->TransformPhysicalPointToIndex(point, index);
+  std::cout << "    Image: " << point << " -> " << index << (isInsideOrientedImage ? " inside" : " outside")
+            << std::endl;
 
-  image->TransformPhysicalPointToIndex(point, index);
-  std::cout << "    Image:         " << point << " -> " << index << std::endl;
+  const bool isInsideImage = image->TransformPhysicalPointToIndex(point, index);
+  std::cout << "    Image:         " << point << " -> " << index << (isInsideImage ? " inside" : " outside")
+            << std::endl;
 }
 
 int

--- a/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -64,10 +64,11 @@ itkPhasedArray3DSpecialCoordinatesImageTest(int, char *[])
 
   point.Fill(0.05);
   point[2] = 3.1;
-  image->TransformPhysicalPointToIndex(point, index);
-  std::cout << "Point " << point << " -> Index " << index << std::endl;
-  image->TransformPhysicalPointToContinuousIndex(point, continuousIndex);
-  std::cout << "Point " << point << " -> Continuous Index " << continuousIndex << std::endl;
+  const bool isIndexInside = image->TransformPhysicalPointToIndex(point, index);
+  std::cout << "Point " << point << " -> Index " << index << (isIndexInside ? " inside" : " outside") << std::endl;
+  const bool isContinuousIndexInside = image->TransformPhysicalPointToContinuousIndex(point, continuousIndex);
+  std::cout << "Point " << point << " -> Continuous Index " << continuousIndex
+            << (isContinuousIndexInside ? " inside" : " outside") << std::endl;
 
   if (index[0] != 2 || index[1] != 2 || index[2] != 1)
   {

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -383,7 +383,7 @@ public:
 
   /** Returns the continuous index from a physical point. */
   template <typename TIndexRep, typename TCoordRep>
-  ContinuousIndex<TIndexRep, TImage::ImageDimension>
+  [[nodiscard]] ContinuousIndex<TIndexRep, TImage::ImageDimension>
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, TImage::ImageDimension> & point) const
   {
     return m_Image->template TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
@@ -398,7 +398,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, Self::ImageDimension> &     point,
                                           ContinuousIndex<TCoordRep, Self::ImageDimension> & index) const
   {
@@ -407,7 +407,7 @@ public:
 
   /** Returns the index (discrete) of a voxel from a physical point. */
   template <typename TCoordRep>
-  IndexType
+  [[nodiscard]] IndexType
   TransformPhysicalPointToIndex(const Point<TCoordRep, Self::ImageDimension> & point) const
   {
     return m_Image->TransformPhysicalPointToIndex(point);
@@ -422,7 +422,7 @@ public:
    *
    * \sa Transform */
   template <typename TCoordRep>
-  bool
+  [[nodiscard]] bool
   TransformPhysicalPointToIndex(const Point<TCoordRep, Self::ImageDimension> & point, IndexType & index) const
   {
     return m_Image->TransformPhysicalPointToIndex(point, index);
@@ -442,7 +442,7 @@ public:
 
   /** Returns a physical point from a continuous index (in the index space) */
   template <typename TCoordRep, typename TIndexRep>
-  Point<TCoordRep, TImage::ImageDimension>
+  [[nodiscard]] Point<TCoordRep, TImage::ImageDimension>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, Self::ImageDimension> & index) const
   {
     return m_Image->template TransformContinuousIndexToPhysicalPoint<TIndexRep>(index);
@@ -462,7 +462,7 @@ public:
 
   /** Returns a physical point from a discrete index (in the index space) */
   template <typename TCoordRep>
-  Point<TCoordRep, Self::ImageDimension>
+  [[nodiscard]] Point<TCoordRep, Self::ImageDimension>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
     return m_Image->template TransformIndexToPhysicalPoint<TCoordRep>(index);
@@ -477,7 +477,7 @@ public:
   }
 
   template <typename TVector>
-  TVector
+  [[nodiscard]] TVector
   TransformLocalVectorToPhysicalVector(const TVector & inputGradient) const
   {
     TVector outputGradient;
@@ -494,7 +494,7 @@ public:
   }
 
   template <typename TVector>
-  TVector
+  [[nodiscard]] TVector
   TransformPhysicalVectorToLocalVector(const TVector & inputGradient) const
   {
     TVector outputGradient;

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -392,6 +392,10 @@ public:
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the continuous index.
+   *
    * \sa Transform */
   template <typename TCoordRep>
   bool
@@ -412,6 +416,10 @@ public:
   /** Get the index (discrete) from a physical point.
    * Floating point index results are truncated to integers.
    * Returns true if the resulting index is within the image, false otherwise
+   *
+   * \note For performance reasons, if you do not need to use the `bool` return value, please call the corresponding
+   * overload instead, which has only one parameter (the point), and returns the index.
+   *
    * \sa Transform */
   template <typename TCoordRep>
   bool

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -160,8 +160,8 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::BeforeThreadedGenera
       const IndexType &                  idx = it.GetIndex();
       typename InputImageType::PointType pt;
       shrunkImage->TransformIndexToPhysicalPoint(idx, pt);
-      ContinuousIndexType cidx;
-      inputImage->TransformPhysicalPointToContinuousIndex(pt, cidx);
+      const ContinuousIndexType cidx =
+        inputImage->template TransformPhysicalPointToContinuousIndex<typename PointType::ValueType>(pt);
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         cluster[numberOfComponents + i] = cidx[i];


### PR DESCRIPTION
It would usually be a mistake when a user would unintentionally ignore the return value of those member functions. Specifically, the overloads of `TransformPhysicalPointToIndex` and `TransformPhysicalPointToContinuousIndex` that have two parameters both return a `bool` value. If this return value can be ignored, it is preferable (for performance reasons) to call the corresponding overload that has one parameter instead.

The compiler may now produce a warning when the return value of any of those member functions is unintentionally ignored.