### PR TITLE
STYLE: Replace `sizeof(array) / sizeof(array[0])` with C++17 `std::size`

### DIFF
--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -336,7 +336,7 @@ OpenCLCheckError(cl_int error, const char * filename, int lineno, const char * l
       "CL_INVALID_GLOBAL_WORK_SIZE",
     };
     // print error message
-    const int          errorCount = sizeof(errorString) / sizeof(errorString[0]);
+    constexpr int      errorCount = std::size(errorString);
     const int          index = -error;
     std::ostringstream errorMsg;
 

--- a/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
+++ b/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
@@ -42,7 +42,7 @@ itkConvertBufferTest(int, char *[])
   for (int j = 0; j < 3; ++j)
   {
     std::cerr << p[j] << ", ";
-    for (unsigned long k = 0; k < sizeof(p) / sizeof(itk::RGBPixel<int>); ++k)
+    for (unsigned long k = 0; k < std::size(p); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(p[j][k], ipa[j]);
     }
@@ -57,7 +57,7 @@ itkConvertBufferTest(int, char *[])
   for (unsigned int j = 0; j < 3; ++j)
   {
     std::cerr << pf[j] << ' ';
-    for (unsigned int k = 0; k < sizeof(pf) / sizeof(itk::RGBPixel<float>); ++k)
+    for (unsigned int k = 0; k < std::size(pf); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(pf[k][j], ipa3com[j + k * 3]);
     }
@@ -70,7 +70,7 @@ itkConvertBufferTest(int, char *[])
   for (unsigned int j = 0; j < 3; ++j)
   {
     std::cerr << pa[j] << ' ';
-    for (unsigned int k = 0; k < sizeof(pa) / sizeof(itk::RGBAPixel<float>); ++k)
+    for (unsigned int k = 0; k < std::size(pa); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(pa[k][j], ipa3com[j + k * 3]);
     }
@@ -89,7 +89,7 @@ itkConvertBufferTest(int, char *[])
   for (unsigned int j = 0; j < 3; ++j)
   {
     std::cerr << ucpa[j] << ' ';
-    for (unsigned int k = 0; k < sizeof(ucpa) / sizeof(itk::RGBAPixel<unsigned char>); ++k)
+    for (unsigned int k = 0; k < std::size(ucpa); ++k)
     {
       ITK_TEST_EXPECT_EQUAL(ucpa[k][j], ucipa3com[j + k * 3]);
     }
@@ -99,9 +99,9 @@ itkConvertBufferTest(int, char *[])
   // create an initial array of floats
   float farray[] = { 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.4f, 7.4f, 8.8f, 9.9f };
   // set the size of the array in number of elements
-  const int arraySize = sizeof(farray) / sizeof(farray[0]);
-  double    darray[arraySize]; // create a double array
-  int       iarray[arraySize]; // create an int array
+  constexpr int arraySize = std::size(farray);
+  double        darray[arraySize]; // create a double array
+  int           iarray[arraySize]; // create an int array
   // convert the float array to a double array
   itk::ConvertPixelBuffer<float, double, itk::DefaultConvertPixelTraits<double>>::Convert(farray, 1, darray, arraySize);
   std::cerr << "\nfloat array  : ";

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -29,7 +29,7 @@
 // as it tries to create an array of size(-1)
 // https://scaryreasoner.wordpress.com/2009/02/28/checking-sizeof-at-compile-time/
 #define CHECK_ARRAYS_HAVE_SAME_SIZE_AT_COMPILE_TIME(array1, array2) \
-  ((void)sizeof(char[1 - 2 * !!(sizeof(array1) / sizeof(*array1) - sizeof(array2) / sizeof(*array2))]))
+  ((void)sizeof(char[1 - 2 * !!(std::size(array1) - std::size(array2))]))
 
 int
 itkImageIOBaseTest(int, char *[])
@@ -170,8 +170,8 @@ itkImageIOBaseTest(int, char *[])
                                              "matrix" };
     CHECK_ARRAYS_HAVE_SAME_SIZE_AT_COMPILE_TIME(listComponentTypeString, listComponentType);
     CHECK_ARRAYS_HAVE_SAME_SIZE_AT_COMPILE_TIME(listIOPixelType, listIOPixelTypeString);
-    size_t listComponentSize = sizeof(listComponentType) / sizeof(*listComponentType);
-    size_t listPixelSize = sizeof(listIOPixelType) / sizeof(*listIOPixelType);
+    constexpr size_t listComponentSize = std::size(listComponentType);
+    constexpr size_t listPixelSize = std::size(listIOPixelType);
     { // Test the static version of the string <-> type conversions
       for (size_t i = 0; i < listComponentSize; ++i)
       {

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -52,7 +52,7 @@ extern "C"
                                                           1,
                                                           const_cast<char *>("LSM Private Tag") } };
 
-    TIFFMergeFieldInfo(tiff, xtiffFieldInfo, sizeof(xtiffFieldInfo) / sizeof(xtiffFieldInfo[0]));
+    TIFFMergeFieldInfo(tiff, xtiffFieldInfo, std::size(xtiffFieldInfo));
   }
 }
 
@@ -291,7 +291,7 @@ LSMImageIO::Write(const void * buffer)
     TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
     char zeiss[TIF_CZ_LSMINFO_SIZE];
     FillZeissStruct(zeiss);
-    unsigned int iCount = sizeof(zeiss) / sizeof(zeiss[0]);
+    constexpr unsigned int iCount = std::size(zeiss);
     // Zeiss field is only on the first TIFF image
     if (page == 0)
     {


### PR DESCRIPTION
By Visual Studio, Replace in Files, using the following regular expression:

    Find what: sizeof\((\w+)\) / sizeof\(\1\[0\]\)
    Find what: sizeof\((.+)\) / sizeof\(\*\1\)
    Find what: sizeof\((\w+)\) / sizeof\(.*\)
    Replace with: std::size($1)

(The third regular expression, `sizeof\((\w+)\) / sizeof\(.*\)` was only applied to itkConvertBufferTest.cxx, as it cannot be generally applied).

`std::size(array)` appears to be a more readable and safer way to retrieve the number of elements of a C-style array. It is also `constexpr`.