### PR TITLE
COMP: Remove CTAD because of clang "error: member reference base" bug

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -83,7 +83,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
 
   auto neighborhoodRange = ShapedImageNeighborhoodRange<const InputImageType, TPixelAccessPolicy>(
     inputImage, Index<InputImageDimension>(), neighborhoodOffsets);
-  auto outputIterator = ImageRegionRange(outputImage, imageRegion).begin();
+  auto outputIterator = ImageRegionRange<OutputImageType>(outputImage, imageRegion).begin();
 
   for (const auto & index : ImageRegionIndexRange<InputImageDimension>(imageRegion))
   {
@@ -116,7 +116,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
 
   auto neighborhoodRange = ShapedImageNeighborhoodRange<const InputImageType, TPixelAccessPolicy>(
     inputImage, Index<InputImageDimension>(), neighborhoodOffsets);
-  auto outputIterator = ImageRegionRange(outputImage, imageRegion).begin();
+  auto outputIterator = ImageRegionRange<OutputImageType>(outputImage, imageRegion).begin();
 
   // These temp variable are needed outside the loop for
   // VariableLengthVectors to avoid memory allocations on a per-pixel

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
@@ -72,7 +72,7 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType, BufferedImageNeighborhoodPixelAccessPolicy<InputImageType>>(
         *input, Index<InputImageDimension>(), neighborhoodOffsets);
-    auto outputIterator = ImageRegionRange(*output, nonBoundaryRegion).begin();
+    auto outputIterator = ImageRegionRange<OutputImageType>(*output, nonBoundaryRegion).begin();
 
     for (const auto & index : ImageRegionIndexRange<InputImageDimension>(nonBoundaryRegion))
     {
@@ -91,7 +91,7 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   {
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType>(*input, Index<InputImageDimension>(), neighborhoodOffsets);
-    auto outputIterator = ImageRegionRange(*output, boundaryFace).begin();
+    auto outputIterator = ImageRegionRange<OutputImageType>(*output, boundaryFace).begin();
 
     for (const auto & index : ImageRegionIndexRange<InputImageDimension>(boundaryFace))
     {


### PR DESCRIPTION
Removed a few cases of class template argument deduction, because of compile errors from [RogueResearch17/Mac10.15-AppleClang-rel](https://open.cdash.org/viewBuildError.php?buildid=8602009), saying:

> error: member reference base type 'ImageRegionRange' is not a structure or union

Caused by clang Bug 39663 "Class template argument deduction with deduced type fails when accessing member", reported by Baruch, 2018-11-14 at https://bugs.llvm.org/show_bug.cgi?id=39663 and fixed on 2020-10-08. The fix appears to be included with LLVM Clang 12.0.0.

This partially reverts pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3989 commit 8ee4d9a410556cd1619c188e8e588710805b2da8 "STYLE: Use C++17 CTAD for `ImageRegionRange`"