### PR TITLE
COMP: Add CTAD deduction guides to ImageBufferRange and ImageRegionRange

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -664,6 +664,12 @@ public:
   }
 };
 
+
+// Deduction guide to avoid compiler warnings (-wctad-maybe-unsupported) when using class template argument deduction.
+template <typename TImage>
+ImageBufferRange(TImage &)->ImageBufferRange<TImage>;
+
+
 /** Creates a range to iterate over the pixels of the specified image.
  * Returns an empty range when the specified argument is a nullptr (which
  * is a valid use case).

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -461,6 +461,11 @@ public:
   ~ImageRegionRange() = default;
 };
 
+
+// Deduction guide to avoid compiler warnings (-wctad-maybe-unsupported) when using class template argument deduction.
+template <typename TImage>
+ImageRegionRange(TImage &)->ImageRegionRange<TImage>;
+
 } // namespace itk
 
 #endif


### PR DESCRIPTION
Addressed `-Wctad-maybe-unsupported` warnings from Mac10.15-AppleClang-rel (AppleClang 12.0.0.12000032), saying:

> warning: 'ImageBufferRange' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]
> note: add a deduction guide to suppress this warning