### PR TITLE
COMP: Remove use of C++17 CTAD from `lock_guard` variable declarations

### DIFF
--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -30,7 +30,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetPriorityLevel(PriorityLevelEnum level)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(OperationEnum::SET_PRIORITY_LEVEL);
   this->m_LevelQ.push(level);
 }
@@ -42,8 +42,8 @@ template <typename SimpleLoggerType>
 typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetPriorityLevel() const
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  PriorityLevelEnum     level = this->m_PriorityLevel;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_PriorityLevel;
   return level;
 }
 
@@ -51,7 +51,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetLevelForFlushing(PriorityLevelEnum level)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_LevelForFlushing = level;
   this->m_OperationQ.push(OperationEnum::SET_LEVEL_FOR_FLUSHING);
   this->m_LevelQ.push(level);
@@ -61,8 +61,8 @@ template <typename SimpleLoggerType>
 typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetLevelForFlushing() const
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  PriorityLevelEnum     level = this->m_LevelForFlushing;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_LevelForFlushing;
   return level;
 }
 
@@ -70,7 +70,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::SetDelay(DelayType delay)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_Delay = delay;
 }
 
@@ -78,8 +78,8 @@ template <typename SimpleLoggerType>
 auto
 LoggerThreadWrapper<SimpleLoggerType>::GetDelay() const -> DelayType
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  DelayType             delay = this->m_Delay;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  DelayType                         delay = this->m_Delay;
   return delay;
 }
 
@@ -88,7 +88,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::AddLogOutput(OutputType * output)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(OperationEnum::ADD_LOG_OUTPUT);
   this->m_OutputQ.push(output);
 }
@@ -97,7 +97,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::Write(PriorityLevelEnum level, std::string const & content)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_PriorityLevel >= level)
   {
     this->m_OperationQ.push(OperationEnum::WRITE);
@@ -148,7 +148,7 @@ template <typename SimpleLoggerType>
 void
 LoggerThreadWrapper<SimpleLoggerType>::Flush()
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->PrivateFlush();
 }
 
@@ -178,7 +178,7 @@ LoggerThreadWrapper<SimpleLoggerType>::ThreadFunction()
   while (!m_TerminationRequested)
   {
     {
-      const std::lock_guard lockGuard(m_Mutex);
+      const std::lock_guard<std::mutex> lockGuard(m_Mutex);
       while (!m_OperationQ.empty())
       {
         switch (m_OperationQ.front())

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -337,7 +337,7 @@ private:
 inline void
 MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
 {
-  const std::lock_guard mutexHolder(m_InstanceLock);
+  const std::lock_guard<std::mutex> mutexHolder(m_InstanceLock);
   this->m_Seed = seed;
   // Initialize generator state with seed
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -187,7 +187,7 @@ protected:
   {
     if (m_Process)
     {
-      const std::lock_guard outputSerializer(m_ProgressOutput);
+      const std::lock_guard<std::mutex> outputSerializer(m_ProgressOutput);
       ++m_Steps;
       if (!m_Quiet)
       {

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -70,7 +70,7 @@ MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
 
   if (!m_PimplGlobals->m_StaticInstance)
   {

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -124,7 +124,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
 
   MultiThreaderBase::SetGlobalDefaultThreaderPrivate(threaderType);
 }
@@ -180,7 +180,7 @@ MultiThreaderBase::GetGlobalDefaultThreader()
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
 
   return MultiThreaderBase::GetGlobalDefaultThreaderPrivate();
 }
@@ -237,7 +237,7 @@ MultiThreaderBase::SetGlobalDefaultNumberOfThreads(ThreadIdType val)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
 
   m_PimplGlobals->m_GlobalDefaultNumberOfThreads = val;
 
@@ -289,7 +289,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
 
   if (m_PimplGlobals->m_GlobalDefaultNumberOfThreads == 0) // need to initialize
   {

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -96,7 +96,7 @@ OutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 void
 OutputWindow::DisplayText(const char * txt)
 {
-  const std::lock_guard cerrLock(m_cerrMutex);
+  const std::lock_guard<std::mutex> cerrLock(m_cerrMutex);
   std::cerr << txt;
   if (m_PromptUser)
   {
@@ -117,7 +117,7 @@ OutputWindow::Pointer
 OutputWindow::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
   if (!m_PimplGlobals->m_Instance)
   {
     // Try the factory first
@@ -145,7 +145,7 @@ OutputWindow::SetInstance(OutputWindow * instance)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
   if (m_PimplGlobals->m_Instance == instance)
   {
     return;

--- a/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
+++ b/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
@@ -47,7 +47,7 @@ StdStreamLogOutput::SetStream(StreamType & Stream)
 void
 StdStreamLogOutput::Flush()
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     this->m_Stream->flush();
@@ -58,7 +58,7 @@ StdStreamLogOutput::Flush()
 void
 StdStreamLogOutput::Write(double timestamp)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << timestamp;
@@ -69,7 +69,7 @@ StdStreamLogOutput::Write(double timestamp)
 void
 StdStreamLogOutput::Write(std::string const & content)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << content;
@@ -80,7 +80,7 @@ StdStreamLogOutput::Write(std::string const & content)
 void
 StdStreamLogOutput::Write(std::string const & content, double timestamp)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   if (this->m_Stream)
   {
     (*this->m_Stream) << timestamp << "  :  " << content;

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -41,7 +41,7 @@ ThreadLogger::~ThreadLogger()
 void
 ThreadLogger::SetPriorityLevel(PriorityLevelEnum level)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(SET_PRIORITY_LEVEL);
   this->m_LevelQ.push(level);
 }
@@ -49,15 +49,15 @@ ThreadLogger::SetPriorityLevel(PriorityLevelEnum level)
 Logger::PriorityLevelEnum
 ThreadLogger::GetPriorityLevel() const
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  PriorityLevelEnum     level = this->m_PriorityLevel;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_PriorityLevel;
   return level;
 }
 
 void
 ThreadLogger::SetLevelForFlushing(PriorityLevelEnum level)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_LevelForFlushing = level;
   this->m_OperationQ.push(SET_LEVEL_FOR_FLUSHING);
   this->m_LevelQ.push(level);
@@ -66,30 +66,30 @@ ThreadLogger::SetLevelForFlushing(PriorityLevelEnum level)
 Logger::PriorityLevelEnum
 ThreadLogger::GetLevelForFlushing() const
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  PriorityLevelEnum     level = this->m_LevelForFlushing;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  PriorityLevelEnum                 level = this->m_LevelForFlushing;
   return level;
 }
 
 void
 ThreadLogger::SetDelay(DelayType delay)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_Delay = delay;
 }
 
 ThreadLogger::DelayType
 ThreadLogger::GetDelay() const
 {
-  const std::lock_guard lockGuard(m_Mutex);
-  DelayType             delay = this->m_Delay;
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
+  DelayType                         delay = this->m_Delay;
   return delay;
 }
 
 void
 ThreadLogger::AddLogOutput(OutputType * output)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(ADD_LOG_OUTPUT);
   this->m_OutputQ.push(output);
 }
@@ -97,7 +97,7 @@ ThreadLogger::AddLogOutput(OutputType * output)
 void
 ThreadLogger::Write(PriorityLevelEnum level, std::string const & content)
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(WRITE);
   this->m_MessageQ.push(content);
   this->m_LevelQ.push(level);
@@ -110,7 +110,7 @@ ThreadLogger::Write(PriorityLevelEnum level, std::string const & content)
 void
 ThreadLogger::Flush()
 {
-  const std::lock_guard lockGuard(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(FLUSH);
   this->InternalFlush();
 }
@@ -159,7 +159,7 @@ ThreadLogger::ThreadFunction()
   while (!m_TerminationRequested)
   {
     {
-      const std::lock_guard lockGuard(m_Mutex);
+      const std::lock_guard<std::mutex> lockGuard(m_Mutex);
       while (!m_OperationQ.empty())
       {
         switch (m_OperationQ.front())

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -63,7 +63,7 @@ GPUImageDataManager<ImageType>::MakeCPUBufferUpToDate()
 {
   if (m_Image.IsNotNull())
   {
-    const std::lock_guard lockGuard(m_Mutex);
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
 
     ModifiedTimeType gpu_time = this->GetMTime();
     TimeStamp        cpu_time_stamp = m_Image->GetTimeStamp();
@@ -105,7 +105,7 @@ GPUImageDataManager<ImageType>::MakeGPUBufferUpToDate()
 {
   if (m_Image.IsNotNull())
   {
-    const std::lock_guard lockGuard(m_Mutex);
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
 
     ModifiedTimeType gpu_time = this->GetMTime();
     TimeStamp        cpu_time_stamp = m_Image->GetTimeStamp();

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -234,7 +234,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
       ItE.Set(-displacement);
     }
     {
-      const std::lock_guard holder(m_Mutex);
+      const std::lock_guard<std::mutex> holder(m_Mutex);
       this->m_MeanErrorNorm += localMean;
       if (this->m_MaxErrorNorm < localMax)
       {

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -183,7 +183,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DynamicThreade
 
     progress.CompletedPixel();
   }
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   m_MaxDistance = std::max(m_MaxDistance, maxDistance);
   m_Sum += sum;
   m_PixelCount += pixelCount;

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -364,9 +364,9 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ComputeValue(const Inp
       {
         PixelRealType val = itk::Math::abs(grad[n]) * m_Spacing[n] / norm / diff;
 
-        PixelRealType         valNew0 = val0 * val;
-        PixelRealType         valNew1 = val1 * val;
-        const std::lock_guard mutexHolder(m_Mutex);
+        PixelRealType                     valNew0 = val0 * val;
+        PixelRealType                     valNew1 = val1 * val;
+        const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
         if (itk::Math::abs(static_cast<double>(valNew0)) < itk::Math::abs(static_cast<double>(outNeigIt.GetNext(n, 0))))
         {
           outNeigIt.SetNext(n, 0, static_cast<PixelType>(valNew0));

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -133,7 +133,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -233,7 +233,7 @@ public:
   {
     //
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -335,7 +335,7 @@ public:
            bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -388,7 +388,7 @@ public:
   DestroyPlan(PlanType p)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
 #  endif
     fftwf_destroy_plan(p);
   }
@@ -469,7 +469,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -568,7 +568,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -670,7 +670,7 @@ public:
            bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -723,7 +723,7 @@ public:
   DestroyPlan(PlanType p)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
 #  endif
     fftw_destroy_plan(p);
   }

--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -65,7 +65,7 @@ public:
   Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -77,7 +77,7 @@ public:
   Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -89,7 +89,7 @@ public:
   Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -101,7 +101,7 @@ public:
   Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -114,7 +114,7 @@ public:
   Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -126,7 +126,7 @@ public:
   Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -138,7 +138,7 @@ public:
   Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -150,7 +150,7 @@ public:
   Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -162,7 +162,7 @@ public:
   Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -201,7 +201,7 @@ public:
   Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -213,7 +213,7 @@ public:
   Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -225,7 +225,7 @@ public:
   Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -237,7 +237,7 @@ public:
   Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -250,7 +250,7 @@ public:
   Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -263,7 +263,7 @@ public:
   Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -276,7 +276,7 @@ public:
   Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -289,7 +289,7 @@ public:
   Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -301,7 +301,7 @@ public:
   Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
@@ -83,7 +83,7 @@ ShiftScaleImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     progress.Completed(outputRegion.GetSize()[0]);
   }
 
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   m_OverflowCount += overflow;
   m_UnderflowCount += underflow;
 }

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -188,9 +188,9 @@ protected:
   void
   LinkLabels(const InternalLabelType label1, const InternalLabelType label2)
   {
-    const std::lock_guard mutexHolder(m_Mutex);
-    InternalLabelType     E1 = this->LookupSet(label1);
-    InternalLabelType     E2 = this->LookupSet(label2);
+    const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+    InternalLabelType                 E1 = this->LookupSet(label1);
+    InternalLabelType                 E2 = this->LookupSet(label2);
 
     if (E1 < E2)
     {

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
@@ -112,7 +112,7 @@ MinimumMaximumImageFilter<TInputImage>::ThreadedStreamedGenerateData(const Regio
     it.NextLine();
   }
 
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   m_ThreadMin = std::min(localMin, m_ThreadMin);
   m_ThreadMax = std::max(localMax, m_ThreadMax);
 }

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -125,7 +125,7 @@ StatisticsImageFilter<TInputImage>::ThreadedStreamedGenerateData(const RegionTyp
     it.NextLine();
   }
 
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   m_ThreadSum += sum;
   m_SumOfSquares += sumOfSquares;
   m_Count += count;

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -195,7 +195,7 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   }
 
   this->m_NumberOfLabels.fetch_add(nbOfLabels, std::memory_order_relaxed);
-  const std::lock_guard mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
   this->m_WorkUnitResults.push_back(workUnitData);
 }
 

--- a/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
@@ -136,7 +136,7 @@ ChangeRegionLabelMapFilter<TInputImage>::ThreadedProcessLabelObject(LabelObjectT
   // remove the object if it is empty
   if (labelObject->Empty())
   {
-    const std::lock_guard mutexHolder(this->m_LabelObjectContainerLock);
+    const std::lock_guard<std::mutex> mutexHolder(this->m_LabelObjectContainerLock);
     this->GetOutput()->RemoveLabelObject(labelObject);
   }
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
@@ -89,7 +89,7 @@ LabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const Out
     LabelObjectType * labelObject;
     // begin mutex lock
     {
-      const std::lock_guard lock(m_LabelObjectContainerLock);
+      const std::lock_guard<std::mutex> lock(m_LabelObjectContainerLock);
 
       if (m_LabelObjectIterator.IsAtEnd())
       {

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -949,7 +949,7 @@ ImageIOBase::GetImageRegionSplitter() const
   {
     // thread safe lazy initialization,  prevent race condition on
     // setting, with an atomic set if null.
-    const std::lock_guard lock(ioDefaultSplitterLock);
+    const std::lock_guard<std::mutex> lock(ioDefaultSplitterLock);
     if (ioDefaultSplitter.IsNull())
     {
       ioDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer();

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -34,7 +34,7 @@ ImageIOFactory::CreateImageIO(const char * path, IOFileModeEnum mode)
 {
   std::list<ImageIOBase::Pointer> possibleImageIO;
 
-  const std::lock_guard mutexHolder(createImageIOLock);
+  const std::lock_guard<std::mutex> mutexHolder(createImageIOLock);
 
   for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
   {

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -219,7 +219,7 @@ ImageToHistogramFilter<TImage>::ThreadedComputeMinimumAndMaximum(const RegionTyp
     ++inputIt;
   }
 
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   for (unsigned int i = 0; i < nbOfComponents; ++i)
   {
     m_Minimum[i] = std::min(m_Minimum[i], min[i]);

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -66,7 +66,7 @@ MaskedImageToHistogramFilter<TImage, TMaskImage>::ThreadedComputeMinimumAndMaxim
     ++inputIt;
     ++maskIt;
   }
-  const std::lock_guard mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
   for (unsigned int i = 0; i < nbOfComponents; ++i)
   {
     this->m_Minimum[i] = std::min(this->m_Minimum[i], min[i]);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -652,7 +652,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
 {
   if (m_CurrentFillSize > 0)
   {
-    const std::lock_guard LockHolder(*this->m_ParentJointPDFDerivativesLockPtr);
+    const std::lock_guard<std::mutex> LockHolder(*this->m_ParentJointPDFDerivativesLockPtr);
     ReduceBuffer();
   }
 }

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -207,7 +207,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThr
   }
 
   this->m_NumberOfLabels.fetch_add(nbOfLabels, std::memory_order_relaxed);
-  const std::lock_guard mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
   this->m_WorkUnitResults.push_back(workUnitData);
 }
 

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -322,7 +322,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateCluste
   }
 
   // TODO improve merge algorithm
-  const std::lock_guard mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
   m_UpdateClusterPerThread.push_back(clusterMap);
 }
 


### PR DESCRIPTION
Addressed `-Wctad-maybe-unsupported` warnings from Mac10.15-AppleClang-rel (AppleClang 12.0.0.12000032), saying:

> warning: 'lock_guard' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]

Revert pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3986 commit 3bfdc2890844900e703d69a9cc435a21321bcc91 "STYLE: Use C++17 class template argument deduction (CTAD) for lock_guard"
