### PR TITLE
Fix TransformPhysicalPointToIndex, TransformPhysicalPointToContinuousIndex  `[[nodiscard]]` warnings

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.hxx
@@ -114,7 +114,6 @@ VectorResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>
   PointType inputPoint;  // Coordinates of current input pixel
 
   using ContinuousIndexType = ContinuousIndex<TInterpolatorPrecisionType, ImageDimension>;
-  ContinuousIndexType inputIndex;
 
   // Doc says this only works for VectorImage, but Image implementation says otherwise...
   const unsigned int numberOfComponents = this->GetInput()->GetNumberOfComponentsPerPixel();
@@ -131,7 +130,8 @@ VectorResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>
 
     // Compute corresponding input pixel position
     inputPoint = m_Transform->TransformPoint(outputPoint);
-    inputPtr->TransformPhysicalPointToContinuousIndex(inputPoint, inputIndex);
+    const ContinuousIndexType inputIndex =
+      inputPtr->template TransformPhysicalPointToContinuousIndex<TInterpolatorPrecisionType>(inputPoint);
 
     // Evaluate input at right position and copy to the output
     if (m_Interpolator->IsInsideBuffer(inputIndex))

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -180,9 +180,9 @@ public:
   CovariantVectorType
   EvaluateDerivative(const PointType & point) const
   {
-    ContinuousIndexType index;
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
 
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
     // No thread info passed in, so call method that doesn't need thread ID.
     return (this->EvaluateDerivativeAtContinuousIndex(index));
   }
@@ -222,9 +222,8 @@ public:
   void
   EvaluateValueAndDerivative(const PointType & point, OutputType & value, CovariantVectorType & deriv) const
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
 
     // No thread info passed in, so call method that doesn't need thread ID.
     this->EvaluateValueAndDerivativeAtContinuousIndex(index, value, deriv);

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -191,7 +191,7 @@ public:
   void
   ConvertPointToContinuousIndex(const PointType & point, ContinuousIndexType & cindex) const
   {
-    m_Image->TransformPhysicalPointToContinuousIndex(point, cindex);
+    cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
   }
 
   /** Convert continuous index to nearest index. */

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -49,8 +49,7 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
 
     // Find the index of the target image where this Level Set
     // should be pasted.
-    OutputIndexType start;
-    output->TransformPhysicalPointToIndex(origin, start);
+    OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
 
     OutputRegionType region;
     region.SetSize(size);

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1353,8 +1353,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     ImageRegionIterator<InputImageType> inIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
 
     // In the context of the global coordinates
-    OutputIndexType start;
-    output->TransformPhysicalPointToIndex(origin, start);
+    OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
 
     // Defining sub-region in the global coordinates
     OutputRegionType region;

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
@@ -46,7 +46,7 @@ RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::CreateHeavisideFunc
 
   const InputPointType origin = image->GetOrigin();
 
-  this->m_HeavisideFunctionOfLevelSetImage->TransformPhysicalPointToIndex(origin, this->m_Start);
+  this->m_Start = this->m_HeavisideFunctionOfLevelSetImage->TransformPhysicalPointToIndex(origin);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
@@ -33,8 +33,7 @@ ScalarChanAndVeseDenseLevelSetImageFilter<TInputImage, TFeatureImage, TOutputIma
     InputPointType    origin = input->GetOrigin();
 
     // In the context of the global coordinates
-    FeatureIndexType start;
-    this->GetInput()->TransformPhysicalPointToIndex(origin, start);
+    FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
 
     // Defining roi region
     FeatureRegionType region;

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
@@ -38,8 +38,7 @@ ScalarChanAndVeseSparseLevelSetImageFilter<TInputImage, TFeatureImage, TOutputIm
     InputPointType    origin = input->GetOrigin();
 
     // In the context of the global coordinates
-    FeatureIndexType start;
-    this->GetInput()->TransformPhysicalPointToIndex(origin, start);
+    FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
 
     // Defining roi region
     FeatureRegionType region;

--- a/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -138,9 +138,7 @@ itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
   out.GoToBegin();
 
   using PointType = typename GaussianDerivativeImageFunctionType::PointType;
-  PointType point;
-  using ContinuousIndexType = typename GaussianDerivativeImageFunctionType::ContinuousIndexType;
-  ContinuousIndexType cindex;
+  PointType           point;
   const unsigned long nop = inputImage->GetRequestedRegion().GetNumberOfPixels();
   unsigned long       pixelNumber = 0;
   while (!it.IsAtEnd())
@@ -157,8 +155,12 @@ itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
     }
     else
     {
+      using ContinuousIndexType = typename GaussianDerivativeImageFunctionType::ContinuousIndexType;
+      using ContinuousIndexValueType = typename ContinuousIndexType::ValueType;
+
       inputImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
-      inputImage->TransformPhysicalPointToContinuousIndex(point, cindex);
+      const ContinuousIndexType cindex =
+        inputImage->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
       out.Set(function->EvaluateAtContinuousIndex(cindex));
     }
     ++it;

--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -139,9 +139,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
   out.GoToBegin();
 
   using PointType = typename DiscreteGradientMagnitudeGaussianFunctionType::PointType;
-  PointType point;
-  using ContinuousIndexType = typename DiscreteGradientMagnitudeGaussianFunctionType::ContinuousIndexType;
-  ContinuousIndexType cindex;
+  PointType           point;
   const unsigned long nop = inputImage->GetRequestedRegion().GetNumberOfPixels();
   unsigned long       pixelNumber = 0;
   while (!it.IsAtEnd())
@@ -158,8 +156,12 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
     }
     else
     {
+      using ContinuousIndexType = typename DiscreteGradientMagnitudeGaussianFunctionType::ContinuousIndexType;
+      using ContinuousValueIndexType = typename ContinuousIndexType::ContinuousIndexType;
+
       inputImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
-      inputImage->TransformPhysicalPointToContinuousIndex(point, cindex);
+      const ContinuousIndexType cindex =
+        inputImage->TransformPhysicalPointToContinuousIndex<ContinuousValueIndexType>(point);
       out.Set(function->EvaluateAtContinuousIndex(cindex));
     }
     ++it;

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -132,9 +132,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   IteratorType outIter(output, output->GetRequestedRegion());
 
   using PointType = typename HessianGaussianImageFunctionType::PointType;
-  PointType point;
-  using ContinuousIndexType = typename HessianGaussianImageFunctionType::ContinuousIndexType;
-  ContinuousIndexType cindex;
+  PointType           point;
   const unsigned long nop = reader->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
   unsigned long       pixelNumber = 0;
   while (!it.IsAtEnd())
@@ -150,8 +148,12 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     }
     else
     {
+      using ContinuousIndexType = typename HessianGaussianImageFunctionType::ContinuousIndexType;
+      using ContinuousIndexValueType = typename ContinuousIndexType::ValueType;
+
       reader->GetOutput()->TransformIndexToPhysicalPoint(it.GetIndex(), point);
-      reader->GetOutput()->TransformPhysicalPointToContinuousIndex(point, cindex);
+      const ContinuousIndexType cindex =
+        reader->GetOutput()->TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
       hessian = function->EvaluateAtContinuousIndex(cindex);
     }
 

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -243,7 +243,7 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::Fe(FEMVectorType Gpos) -> FEMVect
     physicalPoint[k] = Gpos[k];
   }
 
-  m_FixedImage->TransformPhysicalPointToIndex(physicalPoint, oindex);
+  oindex = m_FixedImage->TransformPhysicalPointToIndex(physicalPoint);
 
   for (unsigned int k = 0; k < ImageDimension; ++k)
   {

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -316,7 +316,7 @@ RunTest(InputImageType *            fixedImage,
       {
         coords[d] = element->GetNodeCoordinates(n)[d];
       }
-      fixedImage->TransformPhysicalPointToIndex(coords, index);
+      index = fixedImage->TransformPhysicalPointToIndex(coords);
       if (!region.IsInside(index))
       {
         continue;


### PR DESCRIPTION
Replacing `TransformPhysicalPointToIndex(point, index)` with `index = TransformPhysicalPointToIndex(point)` appeared to be a no-brainer, while replacing the `TransformPhysicalPointToContinuousIndex` calls was somewhat more challenging... but still no rocket science.