### PR TITLE
Remove private `ImageBufferRange::ImageType` alias, add note to CTAD supporting constructors

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -564,6 +564,7 @@ public:
 
 
   /** Specifies a range of the pixels of an image.
+   * \note This constructor supports class template argument deduction (CTAD).
    */
   explicit ImageBufferRange(ImageType & image)
     : // Note: Use parentheses instead of curly braces to initialize data members,

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -73,7 +73,6 @@ template <typename TImage>
 class ImageBufferRange final
 {
 private:
-  using ImageType = TImage;
   using PixelType = typename TImage::PixelType;
   using InternalPixelType = typename TImage::InternalPixelType;
   using AccessorFunctorType = typename TImage::AccessorFunctorType;
@@ -237,7 +236,7 @@ private:
     friend class ImageBufferRange;
 
     // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
-    using QualifiedImageType = std::conditional_t<VIsConst, const ImageType, ImageType>;
+    using QualifiedImageType = std::conditional_t<VIsConst, const TImage, TImage>;
 
     static constexpr bool IsImageTypeConst = std::is_const_v<QualifiedImageType>;
 
@@ -490,10 +489,10 @@ private:
   class AccessorFunctorInitializer final
   {
   private:
-    ImageType & m_Image;
+    TImage & m_Image;
 
   public:
-    explicit AccessorFunctorInitializer(ImageType & image) noexcept
+    explicit AccessorFunctorInitializer(TImage & image) noexcept
       : m_Image(image)
     {}
 
@@ -503,7 +502,7 @@ private:
     {
       AccessorFunctorType result = {};
       result.SetPixelAccessor(m_Image.GetPixelAccessor());
-      result.SetBegin(m_Image.ImageType::GetBufferPointer());
+      result.SetBegin(m_Image.TImage::GetBufferPointer());
       return result;
     }
   };
@@ -566,12 +565,12 @@ public:
   /** Specifies a range of the pixels of an image.
    * \note This constructor supports class template argument deduction (CTAD).
    */
-  explicit ImageBufferRange(ImageType & image)
+  explicit ImageBufferRange(TImage & image)
     : // Note: Use parentheses instead of curly braces to initialize data members,
       // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
     m_OptionalAccessorFunctor(AccessorFunctorInitializer{ image })
-    , m_ImageBufferPointer{ image.ImageType::GetBufferPointer() }
-    , m_NumberOfPixels{ image.ImageType::GetBufferedRegion().GetNumberOfPixels() }
+    , m_ImageBufferPointer{ image.TImage::GetBufferPointer() }
+    , m_NumberOfPixels{ image.TImage::GetBufferedRegion().GetNumberOfPixels() }
   {}
 
 

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -331,6 +331,7 @@ public:
 
   /** Constructs an object, representing the range of pixels of the specified
    * region, within the specified image.
+   * \note This constructor supports class template argument deduction (CTAD).
    */
   explicit ImageRegionRange(TImage & image, const RegionType & iterationRegion)
     : m_BufferBegin{ std::begin(ImageBufferRange{ image }) }
@@ -362,6 +363,7 @@ public:
 
 
   /** Constructs a range of the pixels of the requested region of an image.
+   * \note This constructor supports class template argument deduction (CTAD).
    */
   explicit ImageRegionRange(TImage & image)
     : ImageRegionRange(image, image.GetRequestedRegion())


### PR DESCRIPTION
Both `ImageBufferRange` and `ImageRegionRange` support CTAD for their `TImage` template parameter. This PR aims to make it clearer which of their constructors support CTAD. And it aims to use `TImage` consistently (instead of _sometimes_ using an `ImageType` alias) for both of them.