### PR TITLE
(Not ready) Simpler `TransformPhysicalPointToContinuousIndex(point)` overloads

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -260,8 +260,7 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
         outputPoint[d] = inputPoint[d];
       }
     }
-    outputCorners[count] =
-      outputImage->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(outputPoint);
+    outputCorners[count] = outputImage->TransformPhysicalPointToContinuousIndex(outputPoint);
   }
 
   // Compute a rectangular region from the vector of corner indexes

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -509,6 +509,19 @@ public:
     return index;
   }
 
+
+  /** \brief Returns the continuous index from a physical point
+   * \note This specific overload is easier to use, because it does not have template arguments. It just uses
+   * `itk::SpacePrecisionType`, both for the coordinates of the point and the index values.
+   *
+   * \sa Transform */
+  [[nodiscard]] ContinuousIndex<SpacePrecisionType, VImageDimension>
+  TransformPhysicalPointToContinuousIndex(const PointType & point) const
+  {
+    return TransformPhysicalPointToContinuousIndex<SpacePrecisionType>(point);
+  }
+
+
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -208,6 +208,18 @@ public:
     return index;
   }
 
+  /** \brief Returns the continuous index from a physical point
+   * \note This specific overload is easier to use, because it does not have template arguments. It just uses
+   * `itk::SpacePrecisionType`, both for the coordinates of the point and the index values.
+   *
+   * \sa Transform */
+  [[nodiscard]] ContinuousIndex<SpacePrecisionType, ImageDimension>
+  TransformPhysicalPointToContinuousIndex(const PointType & point) const
+  {
+    return TransformPhysicalPointToContinuousIndex<SpacePrecisionType>(point);
+  }
+
+
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -389,6 +389,18 @@ public:
     return m_Image->template TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
   }
 
+  /** \brief Returns the continuous index from a physical point
+   * \note This specific overload is easier to use, because it does not have template arguments. It just uses
+   * `itk::SpacePrecisionType`, both for the coordinates of the point and the index values.
+   *
+   * \sa Transform */
+  [[nodiscard]] ContinuousIndex<SpacePrecisionType, TImage::ImageDimension>
+  TransformPhysicalPointToContinuousIndex(const PointType & point) const
+  {
+    return m_Image->TransformPhysicalPointToContinuousIndex(point);
+  }
+
+
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -347,8 +347,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()
   {
     PointType p = points.Value();
     // the index value type must match the point value type
-    const ContinuousIndex<PointType::ValueType, 3> ind =
-      OutputImage->template TransformPhysicalPointToContinuousIndex<PointType::ValueType>(p);
+    const ContinuousIndex<PointType::ValueType, 3> ind = OutputImage->TransformPhysicalPointToContinuousIndex(p);
     NewPoints->InsertElement(pointId++, ind);
 
     ++points;

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -233,8 +233,7 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::
                                                          WeightsType &             weights,
                                                          ParameterIndexArrayType & indexes) const
 {
-  ContinuousIndexType index =
-    this->m_CoefficientImages[0]->template TransformPhysicalPointToContinuousIndex<TParametersValueType>(point);
+  ContinuousIndexType index = this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point);
 
   // NOTE: if the support region does not lie totally within the grid
   // we assume zero displacement and return the input point

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -183,9 +183,8 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::EvaluateDisplace
   const DisplacementFieldType * fieldPtr,
   DisplacementType &            output)
 {
-  const ContinuousIndex<double, ImageDimension> index =
-    fieldPtr->template TransformPhysicalPointToContinuousIndex<double>(point);
-  unsigned int dim; // index over dimension
+  const ContinuousIndex<double, ImageDimension> index = fieldPtr->TransformPhysicalPointToContinuousIndex(point);
+  unsigned int                                  dim; // index over dimension
   /**
    * Compute base index = closest index below point
    * Compute distance from point to base index

--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -161,7 +161,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
 
       inputImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
       const ContinuousIndexType cindex =
-        inputImage->TransformPhysicalPointToContinuousIndex<ContinuousValueIndexType>(point);
+        inputImage->template TransformPhysicalPointToContinuousIndex<ContinuousValueIndexType>(point);
       out.Set(function->EvaluateAtContinuousIndex(cindex));
     }
     ++it;

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -153,7 +153,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
 
       reader->GetOutput()->TransformIndexToPhysicalPoint(it.GetIndex(), point);
       const ContinuousIndexType cindex =
-        reader->GetOutput()->TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
+        reader->GetOutput()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
       hessian = function->EvaluateAtContinuousIndex(cindex);
     }
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -990,7 +990,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ComputeImageDerivatives(const Mov
     if (m_ComputeGradient)
     {
       const ContinuousIndex<double, MovingImageDimension> tempIndex =
-        m_MovingImage->template TransformPhysicalPointToContinuousIndex<double>(mappedPoint);
+        m_MovingImage->TransformPhysicalPointToContinuousIndex(mappedPoint);
       MovingImageIndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
       gradient = m_GradientImage->GetPixel(mappedIndex);

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -249,7 +249,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -148,7 +148,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -247,7 +247,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -142,7 +142,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -242,7 +242,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -249,7 +249,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -434,7 +434,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -192,7 +192,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->GetMovingImage()->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -335,7 +335,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->GetMovingImage()->TransformPhysicalPointToContinuousIndex(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -160,8 +160,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::BeforeThreadedGenera
       const IndexType &                  idx = it.GetIndex();
       typename InputImageType::PointType pt;
       shrunkImage->TransformIndexToPhysicalPoint(idx, pt);
-      const ContinuousIndexType cidx =
-        inputImage->template TransformPhysicalPointToContinuousIndex<typename PointType::ValueType>(pt);
+      const ContinuousIndexType cidx = inputImage->TransformPhysicalPointToContinuousIndex(pt);
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         cluster[numberOfComponents + i] = cidx[i];


### PR DESCRIPTION
Added non-template overloads, which allow the user to write:

    index = image->TransformPhysicalPointToContinuousIndex(point);

Instead of calling one of the overload that was added with ITK 5.0, for example:

    index = image->template TransformPhysicalPointToContinuousIndex<typename ContinuousIndexType::ValueType>(point);

I assume that usually (or at least in _most_ common use cases), the user just wants TransformPhysicalPointToContinuousIndex to just yield a `ContinuousIndex<SpacePrecisionType, N>` (with `SpacePrecisionType` = `double`, by default). So in most use cases, the _ValueType_ of ContinuousIndex does not need to be a template argument of this function. Is that OK?