### PR TITLE
COMP: Fix BinomialBlurImageFilter error, num_reps undeclared identifier

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -246,8 +246,6 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     outIt.Set(static_cast<PixelType>(tempIt2.Get()));
   }
-
-  itkDebugMacro(<< "Binomial blur filter executed " << num_reps << " times");
 }
 
 template <typename TInputImage, typename TOutputImage>


### PR DESCRIPTION
Fixed Debug compilation erors saying:

> error C2065: 'num_reps': undeclared identifier

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3996 commit cd97879e6bfec6cd9a33a3dd374d68cf4ff4303e "COMP: Remove unused variables"

The `itkDebugMacro` statement that got this error does not seem to be of interest anymore.