### PR TITLE
Fix Nonunit/Review/test compile errors introduced by pull request 4000 

### DIFF
--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -157,7 +157,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
     else
     {
       using ContinuousIndexType = typename DiscreteGradientMagnitudeGaussianFunctionType::ContinuousIndexType;
-      using ContinuousValueIndexType = typename ContinuousIndexType::ContinuousIndexType;
+      using ContinuousValueIndexType = typename ContinuousIndexType::ValueType;
 
       inputImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
       const ContinuousIndexType cindex =

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -132,7 +132,8 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   IteratorType outIter(output, output->GetRequestedRegion());
 
   using PointType = typename HessianGaussianImageFunctionType::PointType;
-  PointType           point;
+  PointType point;
+  using ContinuousIndexType = typename HessianGaussianImageFunctionType::ContinuousIndexType;
   const unsigned long nop = reader->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
   unsigned long       pixelNumber = 0;
   while (!it.IsAtEnd())
@@ -148,7 +149,6 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     }
     else
     {
-      using ContinuousIndexType = typename HessianGaussianImageFunctionType::ContinuousIndexType;
       using ContinuousIndexValueType = typename ContinuousIndexType::ValueType;
 
       reader->GetOutput()->TransformIndexToPhysicalPoint(it.GetIndex(), point);
@@ -239,6 +239,8 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     hessian = function->EvaluateAtIndex(index);
     inputImage->TransformIndexToPhysicalPoint(index, point);
     hessian = function->Evaluate(point);
+
+    ContinuousIndexType cindex;
 
     // Exercise the fractional computation of the linear interpolator
     for (unsigned int i = 0; i < Dimension; ++i)


### PR DESCRIPTION
Fixed compile errors saying:

> error C2065: 'cindex': undeclared identifier

and:

> error C2039: 'ContinuousIndexType': is not a member of 'itk::ContinuousIndex'

These compile errors were introduced by pull request #4000 commit 7cda5badd0ae7802103421b6625e46bc956f6cb9 "COMP: Fix TransformPhysicalPointToContinuousIndex `nodiscard` warnings"
