### PR TITLE
COMP: Add `template` to TransformPhysicalPointToContinuousIndex in tests

### DIFF
--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -161,7 +161,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
 
       inputImage->TransformIndexToPhysicalPoint(it.GetIndex(), point);
       const ContinuousIndexType cindex =
-        inputImage->TransformPhysicalPointToContinuousIndex<ContinuousValueIndexType>(point);
+        inputImage->template TransformPhysicalPointToContinuousIndex<ContinuousValueIndexType>(point);
       out.Set(function->EvaluateAtContinuousIndex(cindex));
     }
     ++it;

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -153,7 +153,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
 
       reader->GetOutput()->TransformIndexToPhysicalPoint(it.GetIndex(), point);
       const ContinuousIndexType cindex =
-        reader->GetOutput()->TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
+        reader->GetOutput()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(point);
       hessian = function->EvaluateAtContinuousIndex(cindex);
     }
 


### PR DESCRIPTION
Added missing `template` keywords to TransformPhysicalPointToContinuousIndex calls in Nonunit/Review tests.

Addressed compile errors from Ubuntu-22.04-gcc11.2-TBB-Debug saying:

> error: expected primary-expression before '>' token

These compile errors were introduced by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4000 commit 7cda5badd0ae7802103421b6625e46bc956f6cb9
"COMP: Fix TransformPhysicalPointToContinuousIndex `nodiscard` warnings"

- Follow-up to pull request #4004