### PR TITLE
PERF: Use faster TransformPhysicalPointToIndex/ContinuousIndex in Python

### DIFF
--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -476,15 +476,11 @@ str = str
     %rename(__SetDirection_orig__) swig_name::SetDirection;
     %extend swig_name {
         itkIndex##template_params TransformPhysicalPointToIndex( itkPointD##template_params & point ) {
-            itkIndex##template_params idx;
-            self->TransformPhysicalPointToIndex<double>( point, idx );
-            return idx;
+            return self->TransformPhysicalPointToIndex( point );
          }
 
         itkContinuousIndexD##template_params TransformPhysicalPointToContinuousIndex( itkPointD##template_params & point ) {
-            itkContinuousIndexD##template_params idx;
-            self->TransformPhysicalPointToContinuousIndex<double>( point, idx );
-            return idx;
+            return self->TransformPhysicalPointToContinuousIndex<itkContinuousIndexD##template_params::ValueType>( point );
         }
 
         itkPointD##template_params TransformContinuousIndexToPhysicalPoint( itkContinuousIndexD##template_params & idx ) {


### PR DESCRIPTION
Replaced calls to TransformPhysicalPointToIndex(point, idx) and TransformPhysicalPointToContinuousIndex(point, idx) by the corresponding faster overloads.

Aims to address warnings at Windows_NT-Build3495-master-Python https://open.cdash.org/viewBuildError.php?type=1&buildid=8615447 saying:

> s-build\Wrapping\Modules\ITKCommon\itkImagePython.cpp: warning C4834:
> discarding return value of function with 'nodiscard' attribute


----

Please note: I don't really know how this Python wrapping code works, so I'm basically just _guessing_ how it should be fixed! So please review with extra care 😃! 
