### PR TITLE
COMP: Enable warning on C++17 class template argument deduction (CTAD)

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -122,6 +122,7 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
     -Wno-invalid-offsetof
     -Wno-undefined-var-template  # suppress invalid warning when explicitly instantiated in another translation unit
     -Woverloaded-virtual
+    -Wctad-maybe-unsupported
     -Wstrict-null-sentinel
   )
 ##-Wno-c++0x-static-nonintegral-init


### PR DESCRIPTION
Enabled a compiler warning from both GCC and Clang on possibly unintended use of CTAD.

Triggered by our discussions at
 - https://github.com/InsightSoftwareConsortium/ITK/pull/3997
 - https://github.com/InsightSoftwareConsortium/ITK/pull/3986