### PR TITLE
STYLE: Add `const` to TransformPhysicalPointToIndex results in "Review"

### DIFF
--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -49,7 +49,7 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
 
     // Find the index of the target image where this Level Set
     // should be pasted.
-    OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
+    const OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
 
     OutputRegionType region;
     region.SetSize(size);

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1353,7 +1353,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     ImageRegionIterator<InputImageType> inIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
 
     // In the context of the global coordinates
-    OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
+    const OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
 
     // Defining sub-region in the global coordinates
     OutputRegionType region;

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
@@ -33,7 +33,7 @@ ScalarChanAndVeseDenseLevelSetImageFilter<TInputImage, TFeatureImage, TOutputIma
     InputPointType    origin = input->GetOrigin();
 
     // In the context of the global coordinates
-    FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
+    const FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
 
     // Defining roi region
     FeatureRegionType region;

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
@@ -38,7 +38,7 @@ ScalarChanAndVeseSparseLevelSetImageFilter<TInputImage, TFeatureImage, TOutputIm
     InputPointType    origin = input->GetOrigin();
 
     // In the context of the global coordinates
-    FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
+    const FeatureIndexType start = this->GetInput()->TransformPhysicalPointToIndex(origin);
 
     // Defining roi region
     FeatureRegionType region;


### PR DESCRIPTION
Declared local "IndexType" variables in "Nonunit/Review" that are initialized by the result of a TransformPhysicalPointToIndex(point) call `const`.

Follow-up to commit 49ece7f60841b79c306b9a709ffcee228ce9c347 "COMP: Fix TransformPhysicalPointToIndex `nodiscard` warnings"

Suggested by Matt McCormick (@thewtex) at https://github.com/InsightSoftwareConsortium/ITK/pull/4000#discussion_r1160226814