### PR TITLE
STYLE: Replace `T var = NumericTraits<T>::ZeroValue()` having whitespace

### DIFF
--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
@@ -86,8 +86,7 @@ itkPointSetToImageFilterTest1(int argc, char * argv[])
   filter->SetInsideValue(insideValue);
   ITK_TEST_SET_GET_VALUE(insideValue, filter->GetInsideValue());
 
-  typename BinaryImageType::ValueType outsideValue =
-    itk::NumericTraits<typename BinaryImageType::ValueType>::ZeroValue();
+  typename BinaryImageType::ValueType outsideValue{};
   filter->SetOutsideValue(outsideValue);
   ITK_TEST_SET_GET_VALUE(outsideValue, filter->GetOutsideValue());
 

--- a/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
@@ -43,7 +43,7 @@ ProjectedIterativeDeconvolutionImageFilter<TSuperclass>::Initialize(ProgressAccu
   this->Superclass::Initialize(progress, progressWeight, iterationProgressWeight);
 
   m_ProjectionFilter = ProjectionFilterType::New();
-  typename InternalImageType::PixelType zero = NumericTraits<typename InternalImageType::PixelType>::ZeroValue();
+  typename InternalImageType::PixelType zero{};
   m_ProjectionFilter->ThresholdBelow(zero);
 }
 

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -49,8 +49,7 @@ itkZeroCrossingImageFilterTest(int, char *[])
   filter->SetForegroundValue(foregroundValue);
   ITK_TEST_SET_GET_VALUE(foregroundValue, filter->GetForegroundValue());
 
-  typename FilterType::OutputImagePixelType backgroundValue =
-    itk::NumericTraits<typename FilterType::OutputImagePixelType>::ZeroValue();
+  typename FilterType::OutputImagePixelType backgroundValue{};
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
+++ b/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
@@ -127,7 +127,7 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
   std::string pointLine(line, strlen("POINTS "), line.length());
   itkDebugMacro("pointLine " << pointLine);
 
-  unsigned long numberOfPoints = NumericTraits<unsigned long>::ZeroValue();
+  unsigned long numberOfPoints{};
 
   if (sscanf(pointLine.c_str(), "%lu", &numberOfPoints) != 1)
   {
@@ -195,8 +195,8 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
   // Read the number of cells
   //
 
-  unsigned long numberOfCells = NumericTraits<unsigned long>::ZeroValue();
-  unsigned long numberOfIndices = NumericTraits<unsigned long>::ZeroValue();
+  unsigned long numberOfCells{};
+  unsigned long numberOfIndices{};
 
   if (sscanf(cellsLine.c_str(), "%lu %lu", &numberOfCells, &numberOfIndices) != 2)
   {

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -122,8 +122,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
     return false;
   }
   /** the scalingfactor is the MI specific scaling of the image gradient and jacobian terms */
-  InternalComputationValueType scalingfactor =
-    NumericTraits<InternalComputationValueType>::ZeroValue(); // for scaling the jacobian terms
+  InternalComputationValueType scalingfactor{}; // for scaling the jacobian terms
 
   JointPDFPointType jointPDFpoint;
   this->m_JointAssociate->ComputeJointPDFPoint(fixedImageValue, movingImageValue, jointPDFpoint);

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -154,8 +154,7 @@ itkEuclideanDistancePointSetMetricRegistrationTestRun(unsigned int              
     typename TTransform::ParametersType params = transform->GetParameters();
     for (itk::SizeValueType n = 0; n < transform->GetNumberOfParameters(); n += transform->GetNumberOfLocalParameters())
     {
-      typename TTransform::ParametersValueType zero =
-        itk::NumericTraits<typename TTransform::ParametersValueType>::ZeroValue();
+      typename TTransform::ParametersValueType zero{};
       if (itk::Math::NotExactlyEquals(params[n], zero) && itk::Math::NotExactlyEquals(params[n + 1], zero))
       {
         std::cout << n << ", " << n + 1 << " : " << params[n] << ", " << params[n + 1] << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -129,8 +129,7 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
   MultiMetricType::DerivativeType metricDerivative;
   MultiMetricType::DerivativeType DerivResultOfGetValueAndDerivativeTruth(multiVariateMetric->GetNumberOfParameters());
   DerivResultOfGetValueAndDerivativeTruth.Fill(itk::NumericTraits<MultiMetricType::DerivativeValueType>::ZeroValue());
-  MultiMetricType::DerivativeValueType totalMagnitude =
-    itk::NumericTraits<MultiMetricType::DerivativeValueType>::ZeroValue();
+  MultiMetricType::DerivativeValueType totalMagnitude{};
 
   for (itk::SizeValueType i = 0; i < multiVariateMetric->GetNumberOfMetrics(); ++i)
   {

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -959,8 +959,7 @@ test_regiongrowKLM2D()
   using OutputImageData = OutputImageType::PixelType::VectorType;
   ImageData                                      pixelIn;
   OutputImageData                                pixelOut;
-  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero =
-    itk::NumericTraits<itk::NumericTraits<OutputImageData>::ValueType>::ZeroValue();
+  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero{};
 
   while (!inIt.IsAtEnd())
   {
@@ -1471,8 +1470,7 @@ test_regiongrowKLM3D()
   using OutputImageData = OutputImageType::PixelType::VectorType;
   ImageData                                      pixelIn;
   OutputImageData                                pixelOut;
-  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero =
-    itk::NumericTraits<itk::NumericTraits<OutputImageData>::ValueType>::ZeroValue();
+  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero{};
 
   while (!inIt.IsAtEnd())
   {
@@ -1883,8 +1881,7 @@ test_regiongrowKLM4D()
   using OutputImageData = OutputImageType::PixelType::VectorType;
   ImageData                                      pixelIn;
   OutputImageData                                pixelOut;
-  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero =
-    itk::NumericTraits<itk::NumericTraits<OutputImageData>::ValueType>::ZeroValue();
+  itk::NumericTraits<OutputImageData>::ValueType pixelOutZero{};
 
   while (!inIt.IsAtEnd())
   {

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -184,8 +184,7 @@ itkSparseFieldFourthOrderLevelSetImageFilterTest(int, char *[])
   filter->SetNormalProcessType(normalProcessType);
   ITK_TEST_SET_GET_VALUE(normalProcessType, filter->GetNormalProcessType());
 
-  typename FilterType::ValueType normalProcessConductance =
-    itk::NumericTraits<typename FilterType::ValueType>::ZeroValue();
+  typename FilterType::ValueType normalProcessConductance{};
   filter->SetNormalProcessConductance(normalProcessConductance);
   ITK_TEST_SET_GET_VALUE(normalProcessConductance, filter->GetNormalProcessConductance());
 
@@ -193,8 +192,7 @@ itkSparseFieldFourthOrderLevelSetImageFilterTest(int, char *[])
   filter->SetNormalProcessUnsharpFlag(normalProcessUnsharpFlag);
   ITK_TEST_SET_GET_BOOLEAN(filter, NormalProcessUnsharpFlag, normalProcessUnsharpFlag);
 
-  typename FilterType::ValueType normalProcessUnsharpWeight =
-    itk::NumericTraits<typename FilterType::ValueType>::ZeroValue();
+  typename FilterType::ValueType normalProcessUnsharpWeight{};
   filter->SetNormalProcessUnsharpWeight(normalProcessUnsharpWeight);
   ITK_TEST_SET_GET_VALUE(normalProcessUnsharpWeight, filter->GetNormalProcessUnsharpWeight());
 


### PR DESCRIPTION
Replaced initialization by `NumericTraits<T>::ZeroValue()` with empty `{}` initializers. Did so by Replace in Files, using regular expressions:

    Find what: (.+)([ ]+\w+) = NumericTraits<\1>::ZeroValue\(\);
    Find what: (.+)([ ]+\w+) = itk::NumericTraits<\1>::ZeroValue\(\);
    Find what: (.+)([ ]+\w+) =\r\n[ ]+NumericTraits<\1>::ZeroValue\(\);
    Find what: (.+)([ ]+\w+) =\r\n[ ]+itk::NumericTraits<\1>::ZeroValue\(\);
    Replace with: $1$2{};

Follow-up to pull request #3958 commit 42b0bfc0771652ade6a1055b00efbcf94376c20b "STYLE: Replace `T var = NumericTraits<T>::ZeroValue()` with `T var{}`" (which did not yet address initializations of which the specification of `T` has one or more spaces inside, and initializations that took multiple lines of code.)