### PR TITLE
STYLE: Replace `T var{ NumericTraits<T>::ZeroValue() }` with `T var{}`

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -245,9 +245,9 @@ private:
   double      m_Thickness{ 1.0 };
   bool        m_Normalize{ false };
   bool        m_BrightCenter{ false };
-  PixelType   m_InteriorValue{ NumericTraits<PixelType>::ZeroValue() };
+  PixelType   m_InteriorValue{};
   PixelType   m_AnnulusValue{ NumericTraits<PixelType>::OneValue() };
-  PixelType   m_ExteriorValue{ NumericTraits<PixelType>::ZeroValue() };
+  PixelType   m_ExteriorValue{};
   SpacingType m_Spacing{ MakeFilled<SpacingType>(1.0) };
 };
 } // namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
@@ -181,13 +181,13 @@ private:
 
   DistanceMapPointer m_DistanceMap{ nullptr };
 
-  RealType       m_MaxDistance{ NumericTraits<RealType>::ZeroValue() };
+  RealType       m_MaxDistance{};
   IdentifierType m_PixelCount{};
 
   CompensatedSummationType m_Sum{};
 
-  RealType m_DirectedHausdorffDistance{ NumericTraits<RealType>::ZeroValue() };
-  RealType m_AverageHausdorffDistance{ NumericTraits<RealType>::ZeroValue() };
+  RealType m_DirectedHausdorffDistance{};
+  RealType m_AverageHausdorffDistance{};
   bool     m_UseImageSpacing{ true };
 
   std::mutex m_Mutex{};

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -105,7 +105,7 @@ private:
     return VariableLengthVector<TValue>(0);
   }
   TOutput m_OutsideValue{ DefaultOutsideValue(static_cast<TOutput *>(nullptr)) };
-  TMask   m_MaskingValue{ NumericTraits<TMask>::ZeroValue() };
+  TMask   m_MaskingValue{};
 };
 } // namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -105,7 +105,7 @@ private:
     return VariableLengthVector<TValue>(0);
   }
   TOutput m_OutsideValue{ DefaultOutsideValue(static_cast<TOutput *>(nullptr)) };
-  TMask   m_MaskingValue{ NumericTraits<TMask>::ZeroValue() };
+  TMask   m_MaskingValue{};
 };
 } // namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
@@ -117,7 +117,7 @@ protected:
   DynamicThreadedGenerateData(const OutputImageRegionType &) override;
 
 private:
-  RealType m_Shift{ NumericTraits<RealType>::ZeroValue() };
+  RealType m_Shift{};
   RealType m_Scale{ NumericTraits<RealType>::OneValue() };
 
   SizeValueType m_UnderflowCount{ 0 };

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -156,8 +156,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  FeatureImagePixelType m_Minimum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
-  FeatureImagePixelType m_Maximum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
+  FeatureImagePixelType m_Minimum{};
+  FeatureImagePixelType m_Maximum{};
   unsigned int          m_NumberOfBins{ GetDefaultNumberOfBins() };
   bool                  m_ComputeHistogram{ true };
 }; // end of class


### PR DESCRIPTION
Replaced brace-initialization by `NumericTraits<T>::ZeroValue()` with empty `{}` initializers. Did so by Replace in Files, using regular expressions:

    Find what: (\w.+)( .+){ NumericTraits<\1>::ZeroValue\(\) };
    Replace with:  $1$2{};

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3958 commit 42b0bfc0771652ade6a1055b00efbcf94376c20b
"STYLE: Replace `T var = NumericTraits<T>::ZeroValue()` with `T var{}`"