### PR TITLE
Remove local ImageScanlineIterator type aliases, using C++17 CTAD, and extend `ImageScanlineConstIterator` deduction guide

### DIFF
--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -19,6 +19,7 @@
 #define itkImageScanlineConstIterator_h
 
 #include "itkImageIterator.h"
+#include <type_traits> // For remove_const_t.
 
 namespace itk
 {
@@ -263,8 +264,8 @@ protected:
 
 // Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageScanlineConstIterator(SmartPointer<const TImage>, const typename TImage::RegionType &)
-  ->ImageScanlineConstIterator<TImage>;
+ImageScanlineConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  ->ImageScanlineConstIterator<std::remove_const_t<TImage>>;
 
 } // end namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -178,8 +178,7 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
   const TransformType * transform = this->GetInput()->Get();
 
   // Create an iterator that will walk the output region for this thread.
-  using OutputIteratorType = ImageScanlineIterator<TOutputImage>;
-  OutputIteratorType outIt(output, outputRegionForThread);
+  ImageScanlineIterator outIt(output, outputRegionForThread);
 
   // Define a few variables that will be used to translate from an input pixel
   // to an output pixel
@@ -228,8 +227,7 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::LinearTh
   const OutputImageRegionType & largestPossibleRegion = outputPtr->GetLargestPossibleRegion();
 
   // Create an iterator that will walk the output region for this thread.
-  using OutputIteratorType = ImageScanlineIterator<TOutputImage>;
-  OutputIteratorType outIt(outputPtr, outputRegionForThread);
+  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -107,11 +107,8 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   using OutputPixelType = typename OutputImageType::PixelType;
   using AccumulatePixelType = typename NumericTraits<InputPixelType>::RealType;
 
-  using InputConstIteratorType = ImageScanlineConstIterator<InputImageType>;
-  using OutputIteratorType = ImageScanlineIterator<OutputImageType>;
-
-  InputConstIteratorType inputIterator(inputPtr, inputPtr->GetRequestedRegion());
-  OutputIteratorType     outputIterator(outputPtr, outputRegionForThread);
+  ImageScanlineConstIterator inputIterator(inputPtr, inputPtr->GetRequestedRegion());
+  ImageScanlineIterator      outputIterator(outputPtr, outputRegionForThread);
 
   // Set up shaped neighbor hood by defining the offsets
   OutputOffsetType negativeOffset, positiveOffset, iOffset;

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -113,9 +113,7 @@ ExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   OutputImagePointer outputPtr = this->GetOutput();
 
   // Iterator for walking the output
-  using OutputIterator = ImageScanlineIterator<TOutputImage>;
-
-  OutputIterator outIt(outputPtr, outputRegionForThread);
+  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
 
   // Report progress on a per scanline basis
   const SizeValueType ln = outputRegionForThread.GetSize(0);

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -435,8 +435,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   const TransformType *  transformPtr = this->GetTransform();
 
   // Create an iterator that will walk the output region for this thread.
-  using OutputIterator = ImageScanlineIterator<TOutputImage>;
-  OutputIterator outIt(outputPtr, outputRegionForThread);
+  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -125,11 +125,9 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData
   OutputImageType *      output = this->GetOutput();
   const InputImageType * input = this->GetInput();
 
-  using InputLineIteratorType = ImageScanlineConstIterator<InputImageType>;
-  InputLineIteratorType inLineIt(input, outputRegionForThread);
+  ImageScanlineConstIterator inLineIt(input, outputRegionForThread);
 
-  using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
-  OutputLineIteratorType outLineIt(output, outputRegionForThread);
+  ImageScanlineIterator outLineIt(output, outputRegionForThread);
 
   for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine(), outLineIt.NextLine())
   {
@@ -197,8 +195,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(const
 {
   OutputImagePointer output = this->GetOutput();
 
-  using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
-  OutputLineIteratorType outLineIt(output, outputRegionForThread);
+  ImageScanlineIterator outLineIt(output, outputRegionForThread);
 
   OffsetValueType linecount = m_ForegroundLineMap.size();
 

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -115,11 +115,9 @@ LabelContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   OutputImageType *      output = this->GetOutput();
   const InputImageType * input = this->GetInput();
 
-  using InputLineIteratorType = ImageScanlineConstIterator<InputImageType>;
-  InputLineIteratorType inLineIt(input, outputRegionForThread);
+  ImageScanlineConstIterator inLineIt(input, outputRegionForThread);
 
-  using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
-  OutputLineIteratorType outLineIt(output, outputRegionForThread);
+  ImageScanlineIterator outLineIt(output, outputRegionForThread);
 
   for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine(), outLineIt.NextLine())
   {
@@ -158,8 +156,7 @@ LabelContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(
 {
   OutputImageType * output = this->GetOutput();
 
-  using OutputLineIteratorType = ImageScanlineIterator<OutputImageType>;
-  OutputLineIteratorType outLineIt(output, outputRegionForThread);
+  ImageScanlineIterator outLineIt(output, outputRegionForThread);
 
   SizeValueType   pixelcount = output->GetRequestedRegion().GetNumberOfPixels();
   SizeValueType   xsize = output->GetRequestedRegion().GetSize()[0];

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -153,8 +153,8 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   const RegionType & outputRegionForThread)
 {
   const TInputImage * input = this->GetInput();
-  using InputLineIteratorType = ImageScanlineConstIterator<InputImageType>;
-  InputLineIteratorType inLineIt(input, outputRegionForThread);
+
+  ImageScanlineConstIterator inLineIt(input, outputRegionForThread);
 
   WorkUnitData  workUnitData = this->CreateWorkUnitData(outputRegionForThread);
   SizeValueType lineId = workUnitData.firstLine;

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -102,11 +102,8 @@ ThresholdImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegio
 
   // Define/declare an iterator that will walk the output region for this
   // thread.
-  using InputIterator = ImageScanlineConstIterator<TImage>;
-  using OutputIterator = ImageScanlineIterator<TImage>;
-
-  InputIterator  inIt(inputPtr, outputRegionForThread);
-  OutputIterator outIt(outputPtr, outputRegionForThread);
+  ImageScanlineConstIterator inIt(inputPtr, outputRegionForThread);
+  ImageScanlineIterator      outIt(outputPtr, outputRegionForThread);
 
   // Walk the regions; threshold each pixel
   while (!outIt.IsAtEnd())

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -166,8 +166,7 @@ void
 ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThreadedGenerateData(
   const RegionType & outputRegionForThread)
 {
-  using InputLineIteratorType = ImageScanlineConstIterator<InputImageType>;
-  InputLineIteratorType inLineIt(m_Input, outputRegionForThread);
+  ImageScanlineConstIterator inLineIt(m_Input, outputRegionForThread);
 
   WorkUnitData  workUnitData = this->CreateWorkUnitData(outputRegionForThread);
   SizeValueType lineId = workUnitData.firstLine;

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -141,9 +141,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::BeforeThreadedGenera
   m_OldClusters.resize(numberOfClusters * numberOfClusterComponents);
 
 
-  using InputConstIteratorType = ImageScanlineConstIterator<InputImageType>;
-
-  InputConstIteratorType it(shrunkImage, shrunkImage->GetLargestPossibleRegion());
+  ImageScanlineConstIterator it(shrunkImage, shrunkImage->GetLargestPossibleRegion());
 
   // Initialize cluster centers
   size_t cnt = 0;
@@ -197,9 +195,6 @@ void
 SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateDistanceAndLabel(
   const OutputImageRegionType & outputRegionForThread)
 {
-  using InputConstIteratorType = ImageScanlineConstIterator<InputImageType>;
-  using DistanceIteratorType = ImageScanlineIterator<DistanceImageType>;
-
   const InputImageType * inputImage = this->GetInput();
   OutputImageType *      outputImage = this->GetOutput();
   const unsigned int     numberOfComponents = inputImage->GetNumberOfComponentsPerPixel();
@@ -234,8 +229,8 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateDistan
 
     const size_t ln = localRegion.GetSize(0);
 
-    InputConstIteratorType inputIter(inputImage, localRegion);
-    DistanceIteratorType   distanceIter(m_DistanceImage, localRegion);
+    ImageScanlineConstIterator inputIter(inputImage, localRegion);
+    ImageScanlineIterator      distanceIter(m_DistanceImage, localRegion);
 
 
     while (!inputIter.IsAtEnd())
@@ -275,15 +270,12 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateCluste
   const unsigned int numberOfComponents = inputImage->GetNumberOfComponentsPerPixel();
   const unsigned int numberOfClusterComponents = numberOfComponents + ImageDimension;
 
-  using InputConstIteratorType = ImageScanlineConstIterator<InputImageType>;
-  using OutputIteratorType = ImageScanlineIterator<OutputImageType>;
-
   UpdateClusterMap clusterMap;
 
   itkDebugMacro("Estimating Centers");
   // calculate new centers
-  OutputIteratorType     itOut(outputImage, updateRegionForThread);
-  InputConstIteratorType itIn(inputImage, updateRegionForThread);
+  ImageScanlineIterator      itOut(outputImage, updateRegionForThread);
+  ImageScanlineConstIterator itIn(inputImage, updateRegionForThread);
   while (!itOut.IsAtEnd())
   {
     const size_t ln = updateRegionForThread.GetSize(0);
@@ -540,13 +532,8 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::SingleThreadedConnec
   // a new label, otherwise it just gets the previously encountered
   // label id.
 
-
-  using OutputIteratorType = ImageScanlineIterator<OutputImageType>;
-  OutputIteratorType outputIter(outputImage, outputImage->GetRequestedRegion());
-
-  using MarkerIteratorType = ImageScanlineIterator<MarkerImageType>;
-  MarkerIteratorType markerIter(m_MarkerImage, outputImage->GetRequestedRegion());
-
+  ImageScanlineIterator outputIter(outputImage, outputImage->GetRequestedRegion());
+  ImageScanlineIterator markerIter(m_MarkerImage, outputImage->GetRequestedRegion());
 
   while (!markerIter.IsAtEnd())
   {


### PR DESCRIPTION
Removed the local type aliases of `ImageScanlineIterator` and `ImageScanlineConstIterator` that were previously only used to declare a single local variable, and used C++17 class template argument deduction instead.