### PR TITLE
STYLE: Change some declarations to use trailing return type

### DIFF
--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -129,10 +129,9 @@ template <typename TInputImage,
           typename TWindowFunction,
           typename TBoundaryCondition,
           typename TCoordRep>
-typename WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
-  OutputType
-  WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
-    EvaluateAtContinuousIndex(const ContinuousIndexType & index) const
+auto
+WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
+  EvaluateAtContinuousIndex(const ContinuousIndexType & index) const -> OutputType
 {
   IndexType baseIndex;
   double    distance[ImageDimension];

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -265,8 +265,8 @@ AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AffineTransform<TParametersValueType, VDimension>::ScalarType
-AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const
+auto
+AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const -> ScalarType
 {
   ScalarType result = 0.0, term;
 
@@ -284,8 +284,8 @@ AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) co
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AffineTransform<TParametersValueType, VDimension>::ScalarType
-AffineTransform<TParametersValueType, VDimension>::Metric() const
+auto
+AffineTransform<TParametersValueType, VDimension>::Metric() const -> ScalarType
 {
   ScalarType result = 0.0, term;
 

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -54,9 +54,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::PrintSel
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+auto
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   OutputPointType result;
 
@@ -72,9 +72,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::Transfor
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+auto
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformAzElToCartesian(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   OutputPointType result;
   ScalarType      Azimuth =
@@ -93,9 +93,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::Transfor
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+auto
 AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformCartesianToAzEl(
-  const OutputPointType & point) const
+  const OutputPointType & point) const -> OutputPointType
 {
   InputPointType result; // Converted point
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -91,9 +91,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformVector(const Inpu
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorType & inputVector,
                                                                       const InputPointType &  inputPoint) const
+  -> OutputVectorType
 {
   OutputVectorType outputVector(inputVector);
   OutputPointType  outputPoint(inputPoint);
@@ -110,9 +111,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformVector(const Inpu
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVnlVectorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVnlVectorType & inputVector,
                                                                       const InputPointType &     inputPoint) const
+  -> OutputVnlVectorType
 {
   OutputVnlVectorType outputVector(inputVector);
   OutputPointType     outputPoint(inputPoint);
@@ -163,9 +165,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformVector(const Inpu
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorPixelType & inputVector,
                                                                       const InputPointType &       inputPoint) const
+  -> OutputVectorPixelType
 {
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
@@ -182,9 +185,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformVector(const Inpu
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
-  const InputCovariantVectorType & inputVector) const
+  const InputCovariantVectorType & inputVector) const -> OutputCovariantVectorType
 {
   OutputCovariantVectorType outputVector(inputVector);
 
@@ -199,10 +202,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
   const InputCovariantVectorType & inputVector,
-  const InputPointType &           inputPoint) const
+  const InputPointType &           inputPoint) const -> OutputCovariantVectorType
 {
   OutputCovariantVectorType outputVector(inputVector);
   OutputPointType           outputPoint(inputPoint);
@@ -219,9 +222,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
-  const InputVectorPixelType & inputVector) const
+  const InputVectorPixelType & inputVector) const -> OutputVectorPixelType
 {
   OutputVectorPixelType outputVector(inputVector);
 
@@ -236,9 +239,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(const InputVectorPixelType & inputVector,
                                                                                const InputPointType & inputPoint) const
+  -> OutputVectorPixelType
 {
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
@@ -255,10 +259,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(c
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputDiffusionTensor3DType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputDiffusionTensor3DType & inputTensor,
-  const InputPointType &             inputPoint) const
+  const InputPointType &             inputPoint) const -> OutputDiffusionTensor3DType
 {
   OutputDiffusionTensor3DType outputTensor(inputTensor);
   OutputPointType             outputPoint(inputPoint);
@@ -275,10 +279,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & inputTensor,
-  const InputPointType &       inputPoint) const
+  const InputPointType &       inputPoint) const -> OutputVectorPixelType
 {
   OutputVectorPixelType outputTensor(inputTensor);
   OutputPointType       outputPoint(inputPoint);
@@ -295,9 +299,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputDiffusionTensor3DType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
-  const InputDiffusionTensor3DType & inputTensor) const
+  const InputDiffusionTensor3DType & inputTensor) const -> OutputDiffusionTensor3DType
 {
   OutputDiffusionTensor3DType outputTensor(inputTensor);
 
@@ -312,9 +316,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
-  const InputVectorPixelType & inputTensor) const
+  const InputVectorPixelType & inputTensor) const -> OutputVectorPixelType
 {
   OutputVectorPixelType outputTensor(inputTensor);
 
@@ -329,10 +333,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputSymmetricSecondRankTensorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputSymmetricSecondRankTensorType & inputTensor,
-  const InputPointType &                     inputPoint) const
+  const InputPointType &                     inputPoint) const -> OutputSymmetricSecondRankTensorType
 {
   OutputSymmetricSecondRankTensorType outputTensor(inputTensor);
   OutputPointType                     outputPoint(inputPoint);
@@ -349,10 +353,10 @@ CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRa
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputVectorPixelType & inputTensor,
-  const InputPointType &       inputPoint) const
+  const InputPointType &       inputPoint) const -> OutputVectorPixelType
 {
   OutputVectorPixelType outputTensor(inputTensor);
   OutputPointType       outputPoint(inputPoint);
@@ -369,9 +373,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRa
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputSymmetricSecondRankTensorType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
-  const InputSymmetricSecondRankTensorType & inputTensor) const
+  const InputSymmetricSecondRankTensorType & inputTensor) const -> OutputSymmetricSecondRankTensorType
 {
   OutputSymmetricSecondRankTensorType outputTensor(inputTensor);
 
@@ -386,9 +390,9 @@ CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRa
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
-  const InputVectorPixelType & inputTensor) const
+  const InputVectorPixelType & inputTensor) const -> OutputVectorPixelType
 {
   OutputVectorPixelType outputTensor(inputTensor);
 

--- a/Modules/Core/Transform/include/itkRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.h
@@ -296,8 +296,8 @@ private:
 
 // Back transform a point
 template <typename TParametersValueType>
-inline typename Rigid2DTransform<TParametersValueType>::InputPointType
-Rigid2DTransform<TParametersValueType>::BackTransform(const OutputPointType & point) const
+inline auto
+Rigid2DTransform<TParametersValueType>::BackTransform(const OutputPointType & point) const -> InputPointType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -306,8 +306,8 @@ Rigid2DTransform<TParametersValueType>::BackTransform(const OutputPointType & po
 
 // Back transform a vector
 template <typename TParametersValueType>
-inline typename Rigid2DTransform<TParametersValueType>::InputVectorType
-Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVectorType & vect) const
+inline auto
+Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVectorType & vect) const -> InputVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -316,8 +316,8 @@ Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVectorType & v
 
 // Back transform a vnl_vector
 template <typename TParametersValueType>
-inline typename Rigid2DTransform<TParametersValueType>::InputVnlVectorType
-Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVnlVectorType & vect) const
+inline auto
+Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVnlVectorType & vect) const -> InputVnlVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");
@@ -326,8 +326,9 @@ Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVnlVectorType 
 
 // Back Transform a CovariantVector
 template <typename TParametersValueType>
-inline typename Rigid2DTransform<TParametersValueType>::InputCovariantVectorType
+inline auto
 Rigid2DTransform<TParametersValueType>::BackTransform(const OutputCovariantVectorType & vect) const
+  -> InputCovariantVectorType
 {
   itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
                      "to generate an inverse transform and then perform the transform using that inverted transform.");

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -365,8 +365,8 @@ Histogram<TMeasurement, TFrequencyContainer>::IsIndexOutOfBounds(const IndexType
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-inline typename Histogram<TMeasurement, TFrequencyContainer>::InstanceIdentifier
-Histogram<TMeasurement, TFrequencyContainer>::GetInstanceIdentifier(const IndexType & index) const
+inline auto
+Histogram<TMeasurement, TFrequencyContainer>::GetInstanceIdentifier(const IndexType & index) const -> InstanceIdentifier
 {
   InstanceIdentifier instanceId = 0;
 
@@ -469,8 +469,9 @@ Histogram<TMeasurement, TFrequencyContainer>::GetHistogramMaxFromIndex(const Ind
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-inline const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementVectorType &
+inline auto
 Histogram<TMeasurement, TFrequencyContainer>::GetMeasurementVector(const IndexType & index) const
+  -> const MeasurementVectorType &
 {
   const unsigned int measurementVectorSize = this->GetMeasurementVectorSize();
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
@@ -482,8 +483,9 @@ Histogram<TMeasurement, TFrequencyContainer>::GetMeasurementVector(const IndexTy
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-inline const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementVectorType &
+inline auto
 Histogram<TMeasurement, TFrequencyContainer>::GetMeasurementVector(InstanceIdentifier id) const
+  -> const MeasurementVectorType &
 {
   return this->GetMeasurementVector(this->GetIndex(id));
 }

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -82,8 +82,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::Size() const -> In
 }
 
 template <typename TImage, typename TBoundaryCondition>
-inline typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::AbsoluteFrequencyType
-  ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetFrequency(InstanceIdentifier) const
+inline auto ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetFrequency(InstanceIdentifier) const
+  -> AbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {


### PR DESCRIPTION
This fixes some of the compile errors on VS2017.
They were introduced around the time C++17 was enabled. The first error message was:

```log
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): error C2244: 'itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::GetMeasurementVector': unable to match function definition to an existing declaration
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(473): note: see declaration of 'itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::GetMeasurementVector'
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): note: definition
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): note: 'const Histogram<TMeasurement,TFrequencyContainer>::MeasurementVectorType &itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::GetMeasurementVector(const itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::IndexType &) const'
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): note: existing declarations
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): note: 'const Histogram<TMeasurement,TFrequencyContainer>::Sample<itk::Array<TValue>>::MeasurementVectorType &itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::GetMeasurementVector(const itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::IndexType &) const'
m:\dashboard\itk\modules\numerics\statistics\include\itkHistogram.hxx(474): note: 'const Histogram<TMeasurement,TFrequencyContainer>::Sample<itk::Array<TValue>>::MeasurementVectorType &itk::Statistics::Histogram<TMeasurement,TFrequencyContainer>::GetMeasurementVector(Histogram<TMeasurement,TFrequencyContainer>::Sample<itk::Array<TValue>>::InstanceIdentifier) const'
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)