### PR TITLE
WIP: Fix compile errors on VS2017

### DIFF
--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -85,10 +85,10 @@ public:
 
   /** Inherit type alias from superclass */
   using typename Superclass::OffsetType;
-  using OffsetValueType = typename OffsetType::OffsetValueType;
+  using OffsetValueType = itk::OffsetValueType;
   using typename Superclass::RadiusType;
   using typename Superclass::SizeType;
-  using SizeValueType = typename SizeType::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Typedef support for common objects */
   using ImageType = TImage;

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -164,7 +164,7 @@ public:
 
   /** Inherit type alias from superclass */
   using typename Superclass::OffsetType;
-  using OffsetValueType = typename OffsetType::OffsetValueType;
+  using OffsetValueType = itk::OffsetValueType;
   using typename Superclass::RadiusType;
   using typename Superclass::SizeType;
   using typename Superclass::SizeValueType;

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -100,15 +100,15 @@ public:
 
   /** Index type alias support An index is used to access pixel values. */
   using typename Superclass::IndexType;
-  using IndexValueType = typename IndexType::IndexValueType;
+  using IndexValueType = itk::IndexValueType;
 
   /** Size type alias support A size is used to define region bounds. */
   using typename Superclass::SizeType;
-  using SizeValueType = typename SizeType::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Offset type alias support */
   using typename Superclass::OffsetType;
-  using OffsetValueType = typename OffsetType::OffsetValueType;
+  using OffsetValueType = itk::OffsetValueType;
 
   /** Region type alias support A region is used to specify a subset of
    *  an image. */

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -76,7 +76,7 @@ public:
   using typename Superclass::IndexValueType;
 
   /** Size type alias support */
-  using SizeType = typename InputImageType::SizeType;
+  using SizeType = typename Superclass::InputImageType::SizeType;
 
   /** ContinuousIndex type alias support */
   using typename Superclass::ContinuousIndexType;

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -87,7 +87,7 @@ public:
 
   /** ContinuousIndex type alias support */
   using typename Superclass::ContinuousIndexType;
-  using InternalComputationType = typename ContinuousIndexType::ValueType;
+  using InternalComputationType = typename Superclass::ContinuousIndexType::ValueType;
 
   /** Evaluate the function at a ContinuousIndex position
    *

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -69,8 +69,8 @@ public:
 
   /** InputImageType type alias support */
   using typename Superclass::InputImageType;
-  using PixelType = typename InputImageType::PixelType;
-  using ValueType = typename PixelType::ValueType;
+  using PixelType = typename Superclass::InputImageType::PixelType;
+  using ValueType = typename Superclass::InputImageType::PixelType::ValueType;
   using RealType = typename NumericTraits<ValueType>::RealType;
 
   /** Point type alias support */

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
@@ -75,7 +75,7 @@ public:
 
   /** ContinuousIndex type alias support */
   using typename Superclass::ContinuousIndexType;
-  using InternalComputationType = typename ContinuousIndexType::ValueType;
+  using InternalComputationType = typename Superclass::ContinuousIndexType::ValueType;
 
   /** Output type is Vector<double,Dimension> */
   using typename Superclass::OutputType;

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -30,9 +30,9 @@ const unsigned long VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>
 
 
 template <typename TInputImage, typename TCoordRep>
-typename VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> OutputType
 {
   //
   // Compute base index = closet index below point

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -52,10 +52,10 @@ public:
   using typename Superclass::MeshType;
   using typename Superclass::OutputType;
 
-  using PointIdentifier = typename MeshType::PointIdentifier;
-  using PointType = typename MeshType::PointType;
-  using CoordRepType = typename MeshType::CoordRepType;
-  using VectorType = typename MeshType::VectorType;
+  using PointIdentifier = typename Superclass::MeshType::PointIdentifier;
+  using PointType = typename Superclass::MeshType::PointType;
+  using CoordRepType = typename Superclass::MeshType::CoordRepType;
+  using VectorType = typename Superclass::MeshType::VectorType;
 
   /** Evaluate at the specified input position */
   virtual OutputType

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
@@ -76,9 +76,9 @@ public:
   using typename Superclass::MeshType;
   using typename Superclass::OutputType;
 
-  using PointIdentifier = typename MeshType::PointIdentifier;
-  using CellIdentifier = typename MeshType::CellIdentifier;
-  using FaceRefType = typename MeshType::FaceRefType;
+  using PointIdentifier = typename Superclass::MeshType::PointIdentifier;
+  using CellIdentifier = typename Superclass::MeshType::CellIdentifier;
+  using FaceRefType = typename Superclass::MeshType::FaceRefType;
 
   /** Evaluate at the specified input position */
   virtual OutputType

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -174,7 +174,7 @@ public:
   GetFixedParameters() const override;
 
   /** Parameters as SpaceDimension number of images. */
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
   using ImageType = Image<ParametersValueType, Self::SpaceDimension>;
   using ImagePointer = typename ImageType::Pointer;
   using CoefficientImageArray = FixedArray<ImagePointer, VDimension>;

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
@@ -96,7 +96,7 @@ public:
   /** Point type. */
   using typename Superclass::InputPointType;
   using typename Superclass::OutputPointType;
-  using InputPointValueType = typename InputPointType::ValueType;
+  using InputPointValueType = typename Superclass::InputPointType::ValueType;
 
   /** Vector type. */
   using typename Superclass::InputVectorType;

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
@@ -66,9 +66,9 @@ public:
 
   /** Parameters type. */
   using typename Superclass::FixedParametersType;
-  using FixedParametersValueType = typename FixedParametersType::ValueType;
+  using FixedParametersValueType = typename Superclass::FixedParametersType::ValueType;
   using typename Superclass::ParametersType;
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
 
   /** Jacobian types. */
   using typename Superclass::JacobianType;

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
@@ -58,9 +58,9 @@ public:
 
   /** Parameters type. */
   using typename Superclass::ParametersType;
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
   using typename Superclass::FixedParametersType;
-  using FixedParametersValueType = typename FixedParametersType::ValueType;
+  using FixedParametersValueType = typename Superclass::FixedParametersType::ValueType;
 
   /** Jacobian type. */
   using typename Superclass::JacobianType;

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.h
@@ -104,7 +104,7 @@ public:
 
   using ScaleVectorValueType = typename ScaleVectorType::ValueType;
   using SkewVectorValueType = typename SkewVectorType::ValueType;
-  using TranslationValueType = typename TranslationType::ValueType;
+  using TranslationValueType = typename Superclass::TranslationType::ValueType;
 
   using typename Superclass::AxisValueType;
   using typename Superclass::ParametersValueType;

--- a/Modules/Core/Transform/include/itkVersorTransform.h
+++ b/Modules/Core/Transform/include/itkVersorTransform.h
@@ -95,7 +95,7 @@ public:
   using AxisType = typename VersorType::VectorType;
   using AngleType = typename VersorType::ValueType;
   using AxisValueType = typename AxisType::ValueType;
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
 
   /**
    * Set the transformation from a container of parameters

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -148,8 +148,8 @@ public:
   using typename Superclass::OutputDiffusionTensor3DType;
 
   /** Standard tensor type for this class */
-  using InputTensorEigenVectorType = CovariantVector<ScalarType, InputDiffusionTensor3DType::Dimension>;
-  using OutputTensorEigenVectorType = CovariantVector<ScalarType, OutputDiffusionTensor3DType::Dimension>;
+  using InputTensorEigenVectorType = CovariantVector<ScalarType, Superclass::InputDiffusionTensor3DType::Dimension>;
+  using OutputTensorEigenVectorType = CovariantVector<ScalarType, Superclass::OutputDiffusionTensor3DType::Dimension>;
   /** Derivative type */
   using typename Superclass::DerivativeType;
 
@@ -175,7 +175,7 @@ public:
 
   /** Define the internal parameter helper used to access the field */
   using OptimizerParametersHelperType =
-    ImageVectorOptimizerParametersHelper<ScalarType, OutputVectorType::Dimension, Dimension>;
+    ImageVectorOptimizerParametersHelper<ScalarType, Superclass::OutputVectorType::Dimension, Dimension>;
 
   /** Get/Set the displacement field.
    * Set the displacement field. Create special set accessor to update

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
@@ -60,7 +60,7 @@ public:
   /** Types from superclass */
   using typename Superclass::ScalarType;
   using typename Superclass::DerivativeType;
-  using DerivativeValueType = typename DerivativeType::ValueType;
+  using DerivativeValueType = typename Superclass::DerivativeType::ValueType;
   using typename Superclass::VelocityFieldType;
 
   using typename Superclass::TimeVaryingVelocityFieldType;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
@@ -99,9 +99,9 @@ public:
 
   /** Type of the input parameters. */
   using typename Superclass::ParametersType;
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
   using typename Superclass::FixedParametersType;
-  using FixedParametersValueType = typename FixedParametersType::ValueType;
+  using FixedParametersValueType = typename Superclass::FixedParametersType::ValueType;
   using typename Superclass::NumberOfParametersType;
 
   /** Derivative type */

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
@@ -88,9 +88,9 @@ public:
 
   /** Type of the input parameters. */
   using typename Superclass::ParametersType;
-  using ParametersValueType = typename ParametersType::ValueType;
+  using ParametersValueType = typename Superclass::ParametersType::ValueType;
   using typename Superclass::FixedParametersType;
-  using FixedParametersValueType = typename FixedParametersType::ValueType;
+  using FixedParametersValueType = typename Superclass::FixedParametersType::ValueType;
   using typename Superclass::NumberOfParametersType;
 
   /** Derivative type */

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -113,11 +113,11 @@ public:
   using typename Superclass::OutputImagePointer;
   using typename Superclass::InputImageConstPointer;
 
-  using IndexType = typename OutputImageType::IndexType;
-  using SizeType = typename OutputImageType::SizeType;
-  using PixelType = typename OutputImageType::PixelType;
-  using SpacingType = typename OutputImageType::SpacingType;
-  using ValueType = typename OutputImageType::PixelType::ValueType;
+  using IndexType = typename Superclass::OutputImageType::IndexType;
+  using SizeType = typename Superclass::OutputImageType::SizeType;
+  using PixelType = typename Superclass::OutputImageType::PixelType;
+  using SpacingType = typename Superclass::OutputImageType::SpacingType;
+  using ValueType = typename Superclass::OutputImageType::PixelType::ValueType;
 
   /** Determine the image dimension. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
@@ -58,8 +58,8 @@ public:
   using typename Superclass::EnergyValueType;
   using typename Superclass::EnergyValueContainerType;
   using typename Superclass::EnergyValueContainerSizeType;
-  using EnergyValueIterator = typename EnergyValueContainerType::iterator;
-  using EnergyValueConstIterator = typename EnergyValueContainerType::const_iterator;
+  using EnergyValueIterator = typename Superclass::EnergyValueContainerType::iterator;
+  using EnergyValueConstIterator = typename Superclass::EnergyValueContainerType::const_iterator;
 
   /** Add energy value */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
@@ -153,7 +153,7 @@ protected:
   void
   ReinitializeToSignedDistance();
 
-  typename LevelSetContainerType::Pointer m_UpdateBuffer{};
+  typename Superclass::LevelSetContainerType::Pointer m_UpdateBuffer{};
 
   friend class LevelSetEvolutionComputeIterationThreader<LevelSetType,
                                                          ThreadedImageRegionPartitioner<TImage::ImageDimension>,


### PR DESCRIPTION
They were introduced around the time C++17 was enabled. See the list here:
https://open.cdash.org/viewBuildError.php?type=0&buildid=8592346

This only fixes a subset of compile errors, but after these changes compiler complains about something else. Not only do these changes seem unending, but they reduce code readability too. Is it time to drop VS2017 from the list of supported compilers?
