### PR TITLE
STYLE: Default default-constructor SimpleDataObjectDecorator

### DIFF
--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
@@ -100,7 +100,7 @@ public:
   }
 
 protected:
-  SimpleDataObjectDecorator();
+  SimpleDataObjectDecorator() = default;
   ~SimpleDataObjectDecorator() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
@@ -36,25 +36,6 @@ namespace itk
  *
  */
 template <typename T>
-SimpleDataObjectDecorator<T>::SimpleDataObjectDecorator()
-{
-#if defined(__GNUC__) && (__GNUC__ > 6)
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-  ITK_GCC_PRAGMA_DIAG(ignored "-Wmaybe-uninitialized")
-#endif                                 // defined( __GNUC__ ) && ( __GNUC__ > 6 )
-  this->m_Component = ComponentType(); // initialize here to avoid Purify UMR
-#if defined(__GNUC__) && (__GNUC__ > 6)
-  ITK_GCC_PRAGMA_DIAG_POP()
-#endif                         // defined( __GNUC__ ) && ( __GNUC__ > 6 )
-  this->m_Initialized = false; // Still needed since not all objects
-                               // are initialized at construction time.
-                               // for example the itkArray.
-}
-
-/**
- *
- */
-template <typename T>
 void
 SimpleDataObjectDecorator<T>::Set(const T & val)
 {


### PR DESCRIPTION
Removed obsolete "-Wmaybe-uninitialized" and Purify UMR (uninitialized memory read) workarounds.

The Purify workaround is from commit 7001c5ceefb92ffc5745682d61960368dfab6585 "FIX: attempt at purify UMR fix", Jim Miller, March 18, 2004. The "-Wmaybe-uninitialized" workaround is from commit 3495d7f60afafc0c05809ea8ea8ec98125ec1334 "COMP: Suppress maybe-uninitialized in SimpleDataObjectDecorator Component", Matt McCormick (@thewtex), May 11, 2018. Neither of these two workarounds should be necessary anymore, now that `m_Component` has an in-class `{}` default member initializer. 