### PR TITLE
STYLE: Use trailing return type instead of typename + dependent type

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -149,24 +149,24 @@ ResourceProbe<ValueType, MeanType>::Stop()
 
 
 template <typename ValueType, typename MeanType>
-typename ResourceProbe<ValueType, MeanType>::CountType
-ResourceProbe<ValueType, MeanType>::GetNumberOfStarts() const
+auto
+ResourceProbe<ValueType, MeanType>::GetNumberOfStarts() const -> CountType
 {
   return this->m_NumberOfStarts;
 }
 
 
 template <typename ValueType, typename MeanType>
-typename ResourceProbe<ValueType, MeanType>::CountType
-ResourceProbe<ValueType, MeanType>::GetNumberOfStops() const
+auto
+ResourceProbe<ValueType, MeanType>::GetNumberOfStops() const -> CountType
 {
   return this->m_NumberOfStops;
 }
 
 
 template <typename ValueType, typename MeanType>
-typename ResourceProbe<ValueType, MeanType>::CountType
-ResourceProbe<ValueType, MeanType>::GetNumberOfIteration() const
+auto
+ResourceProbe<ValueType, MeanType>::GetNumberOfIteration() const -> CountType
 {
   return this->m_NumberOfIteration;
 }

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -256,8 +256,8 @@ AffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) co
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename AffineTransform<TParametersValueType, VDimension>::InverseTransformBasePointer
-AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
+auto
+AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -293,8 +293,9 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::ArrayOfIma
 
 // Transform a point
 template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
-typename BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::OutputPointType
+auto
 BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::TransformPoint(const InputPointType & point) const
+  -> OutputPointType
 {
   WeightsType             weights;
   ParameterIndexArrayType indices;

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -442,8 +442,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::InverseTransformBasePointer
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetInverseTransform() const
+  -> InverseTransformBasePointer
 {
   auto inv = InverseTransformType::New();
 

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -261,8 +261,8 @@ ScaleTransform<TParametersValueType, VDimension>::ComputeMatrix()
 
 // Back transform a point
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename ScaleTransform<TParametersValueType, VDimension>::InputPointType
-ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputPointType & point) const
+inline auto
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputPointType & point) const -> InputPointType
 {
   InputPointType         result;
   const InputPointType & center = this->GetCenter();
@@ -276,8 +276,8 @@ ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputPoin
 
 // Back transform a vector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename ScaleTransform<TParametersValueType, VDimension>::InputVectorType
-ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVectorType & vect) const
+inline auto
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVectorType & vect) const -> InputVectorType
 {
   InputVectorType result;
 
@@ -290,8 +290,9 @@ ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVect
 
 // Back transform a vnl_vector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename ScaleTransform<TParametersValueType, VDimension>::InputVnlVectorType
+inline auto
 ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVnlVectorType & vect) const
+  -> InputVnlVectorType
 {
   InputVnlVectorType result;
 
@@ -304,8 +305,9 @@ ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVnlV
 
 // Back Transform a CovariantVector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename ScaleTransform<TParametersValueType, VDimension>::InputCovariantVectorType
+inline auto
 ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputCovariantVectorType & vect) const
+  -> InputCovariantVectorType
 {
   // Covariant Vectors are scaled by the inverse
   InputCovariantVectorType result;

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -77,8 +77,8 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GetKernelSize() const ->
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename DiscreteGaussianImageFilter<TInputImage, TOutputImage>::ArrayType
-DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GetKernelVarianceArray() const
+auto
+DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GetKernelVarianceArray() const -> ArrayType
 {
   if (m_UseImageSpacing)
   {

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
@@ -320,8 +320,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetSolutionAccuracy(
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetSolutionAccuracy() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetSolutionAccuracy() const -> PrecisionType
 {
   return m_Parameters.epsilon;
 }
@@ -351,8 +351,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetDeltaConvergenceTol
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetDeltaConvergenceTolerance() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetDeltaConvergenceTolerance() const -> PrecisionType
 {
   return m_Parameters.delta;
 }
@@ -410,8 +410,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetLineSearch(
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::LineSearchMethodEnum
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearch() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearch() const -> LineSearchMethodEnum
 {
   LineSearchMethodEnum linesearch = LineSearchMethodEnum::LINESEARCH_DEFAULT;
   int                  lbfgsLineSearch = m_Parameters.linesearch;
@@ -464,8 +464,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetMinimumLineSearchSt
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMinimumLineSearchStep() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMinimumLineSearchStep() const -> PrecisionType
 {
   return m_Parameters.min_step;
 }
@@ -481,8 +481,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetMaximumLineSearchSt
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMaximumLineSearchStep() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMaximumLineSearchStep() const -> PrecisionType
 {
   return m_Parameters.max_step;
 }
@@ -497,8 +497,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetLineSearchAccuracy(
   this->Modified();
 }
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearchAccuracy() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearchAccuracy() const -> PrecisionType
 {
   return m_Parameters.ftol;
 }
@@ -513,8 +513,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetWolfeCoefficient(
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetWolfeCoefficient() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetWolfeCoefficient() const -> PrecisionType
 {
   return m_Parameters.wolfe;
 }
@@ -529,8 +529,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetLineSearchGradientA
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearchGradientAccuracy() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetLineSearchGradientAccuracy() const -> PrecisionType
 {
   return m_Parameters.gtol;
 }
@@ -546,8 +546,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetMachinePrecisionTol
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMachinePrecisionTolerance() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetMachinePrecisionTolerance() const -> PrecisionType
 {
   return m_Parameters.xtol;
 }
@@ -562,8 +562,8 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::SetOrthantwiseCoeffici
 }
 
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
-LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetOrthantwiseCoefficient() const
+auto
+LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetOrthantwiseCoefficient() const -> PrecisionType
 {
   return m_Parameters.orthantwise_c;
 }

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -544,8 +544,8 @@ Histogram<TMeasurement, TFrequencyContainer>::IncreaseFrequencyOfMeasurement(con
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-inline typename Histogram<TMeasurement, TFrequencyContainer>::AbsoluteFrequencyType
-Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(const IndexType & index) const
+inline auto
+Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(const IndexType & index) const -> AbsoluteFrequencyType
 {
   return (this->GetFrequency(this->GetInstanceIdentifier(index)));
 }
@@ -587,8 +587,8 @@ Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(InstanceIdentifier n,
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-inline typename Histogram<TMeasurement, TFrequencyContainer>::TotalAbsoluteFrequencyType
-Histogram<TMeasurement, TFrequencyContainer>::GetTotalFrequency() const
+inline auto
+Histogram<TMeasurement, TFrequencyContainer>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   return m_FrequencyContainer->GetTotalFrequency();
 }

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
@@ -107,22 +107,23 @@ MembershipSample<TSample>::GetMeasurementVector(const InstanceIdentifier & id) c
 }
 
 template <typename TSample>
-inline typename MembershipSample<TSample>::MeasurementType
+inline auto
 MembershipSample<TSample>::GetMeasurement(const InstanceIdentifier & id, const unsigned int dimension)
+  -> MeasurementType
 {
   return m_Sample->GetMeasurement(id, dimension);
 }
 
 template <typename TSample>
-inline typename MembershipSample<TSample>::AbsoluteFrequencyType
-MembershipSample<TSample>::GetFrequency(const InstanceIdentifier & id) const
+inline auto
+MembershipSample<TSample>::GetFrequency(const InstanceIdentifier & id) const -> AbsoluteFrequencyType
 {
   return m_Sample->GetFrequency(id);
 }
 
 template <typename TSample>
-inline typename MembershipSample<TSample>::TotalAbsoluteFrequencyType
-MembershipSample<TSample>::GetTotalFrequency() const
+inline auto
+MembershipSample<TSample>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   return m_Sample->GetTotalFrequency();
 }

--- a/Modules/Numerics/Statistics/include/itkSubsample.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsample.hxx
@@ -133,8 +133,8 @@ Subsample<TSample>::GetMeasurementVector(InstanceIdentifier id) const -> const M
 }
 
 template <typename TSample>
-inline typename Subsample<TSample>::AbsoluteFrequencyType
-Subsample<TSample>::GetFrequency(InstanceIdentifier id) const
+inline auto
+Subsample<TSample>::GetFrequency(InstanceIdentifier id) const -> AbsoluteFrequencyType
 {
   if (id >= m_IdHolder.size())
   {
@@ -147,8 +147,8 @@ Subsample<TSample>::GetFrequency(InstanceIdentifier id) const
 }
 
 template <typename TSample>
-inline typename Subsample<TSample>::TotalAbsoluteFrequencyType
-Subsample<TSample>::GetTotalFrequency() const
+inline auto
+Subsample<TSample>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   return m_TotalFrequency;
 }
@@ -180,8 +180,8 @@ Subsample<TSample>::GetMeasurementVectorByIndex(unsigned int index) const
 }
 
 template <typename TSample>
-inline typename Subsample<TSample>::AbsoluteFrequencyType
-Subsample<TSample>::GetFrequencyByIndex(unsigned int index) const
+inline auto
+Subsample<TSample>::GetFrequencyByIndex(unsigned int index) const -> AbsoluteFrequencyType
 {
   if (index >= m_IdHolder.size())
   {


### PR DESCRIPTION
This is a follow-up to b18668b639becf9e3dc6324ca68f915ab7bf0a1e and b37ac532060361739a2653bbbd2176dee0282d09.

It reapplied regex replace from b18668b639becf9e3dc6324ca68f915ab7bf0a1e.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
