### PR TITLE
Replace ImageScanlineIterator `while` loops with `for` loops, move iterator declarations into `for` loop init-statements

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -177,9 +177,6 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
   OutputImageType *     output = this->GetOutput();
   const TransformType * transform = this->GetInput()->Get();
 
-  // Create an iterator that will walk the output region for this thread.
-  ImageScanlineIterator outIt(output, outputRegionForThread);
-
   // Define a few variables that will be used to translate from an input pixel
   // to an output pixel
   PointType outputPoint;       // Coordinates of output pixel
@@ -189,8 +186,8 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  // Walk the output region
-  while (!outIt.IsAtEnd())
+  // Walk the output region for this thread.
+  for (ImageScanlineIterator outIt(output, outputRegionForThread); !outIt.IsAtEnd(); outIt.NextLine())
   {
     while (!outIt.IsAtEndOfLine())
     {
@@ -209,7 +206,6 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
       outIt.Set(displacementPixel);
       ++outIt;
     }
-    outIt.NextLine();
     progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
@@ -226,17 +222,13 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::LinearTh
 
   const OutputImageRegionType & largestPossibleRegion = outputPtr->GetLargestPossibleRegion();
 
-  // Create an iterator that will walk the output region for this thread.
-  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
-
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
   PointType outputPoint; // Coordinates of current output pixel
   PointType inputPoint;
 
-
-  // loop over the vector image
-  while (!outIt.IsAtEnd())
+  // Loop over the vector image, walk the output region for this thread.
+  for (ImageScanlineIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); outIt.NextLine())
   {
 
     // Compare with the ResampleImageFilter
@@ -275,8 +267,6 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::LinearTh
       ++outIt;
       ++scanlineIndex;
     }
-
-    outIt.NextLine();
   }
 }
 

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
@@ -105,15 +105,13 @@ ApproximateSignedDistanceMapImageFilter<TInputImage, TOutputImage>::GenerateData
   // flip the sign of the output image.
   if (m_InsideValue > m_OutsideValue)
   {
-    ImageScanlineIterator ot(output, oRegion);
-    while (!ot.IsAtEnd())
+    for (ImageScanlineIterator ot(output, oRegion); !ot.IsAtEnd(); ot.NextLine())
     {
       while (!ot.IsAtEndOfLine())
       {
         ot.Set(ot.Get() * -1);
         ++ot;
       }
-      ot.NextLine();
     }
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -108,7 +108,6 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   using AccumulatePixelType = typename NumericTraits<InputPixelType>::RealType;
 
   ImageScanlineConstIterator inputIterator(inputPtr, inputPtr->GetRequestedRegion());
-  ImageScanlineIterator      outputIterator(outputPtr, outputRegionForThread);
 
   // Set up shaped neighbor hood by defining the offsets
   OutputOffsetType negativeOffset, positiveOffset, iOffset;
@@ -154,7 +153,8 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  while (!outputIterator.IsAtEnd())
+  for (ImageScanlineIterator outputIterator(outputPtr, outputRegionForThread); !outputIterator.IsAtEnd();
+       outputIterator.NextLine())
   {
     const OutputIndexType outputIndex = outputIterator.GetIndex();
 
@@ -204,7 +204,6 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       ++outputIterator;
     }
 
-    outputIterator.NextLine();
     progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -112,9 +112,6 @@ ExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // Get the input and output pointers
   OutputImagePointer outputPtr = this->GetOutput();
 
-  // Iterator for walking the output
-  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
-
   // Report progress on a per scanline basis
   const SizeValueType ln = outputRegionForThread.GetSize(0);
   if (ln == 0)
@@ -123,7 +120,7 @@ ExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   }
 
   // Walk the output region, and interpolate the input image
-  while (!outIt.IsAtEnd())
+  for (ImageScanlineIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); outIt.NextLine())
   {
     const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();
 
@@ -154,8 +151,6 @@ ExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       // scanline.
       inputIndex[0] += lineDelta;
     }
-
-    outIt.NextLine();
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -169,8 +169,7 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
     }
   }
 
-  // Setup output region iterator
-  ImageScanlineIterator      outputIt(outputPtr, outputRegionForThread);
+  // Setup region iterator
   ImageScanlineConstIterator inputIter(inputPtr, inputReginForThread);
 
   IndexValueType offset[ImageDimension];
@@ -188,7 +187,7 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  while (!outputIt.IsAtEnd())
+  for (ImageScanlineIterator outputIt(outputPtr, outputRegionForThread); !outputIt.IsAtEnd(); outputIt.NextLine())
   {
     // Determine the index of the output line
     const typename TImage::IndexType outputIndex = outputIt.GetIndex();
@@ -231,7 +230,6 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
       }
     }
 
-    outputIt.NextLine();
     progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -213,15 +213,13 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::DynamicThreadedGenera
     {
       SourceImagePixelType sourceValue = this->GetConstant();
 
-      ImageScanlineIterator outputIt(outputPtr, destinationRegion);
-      while (!outputIt.IsAtEnd())
+      for (ImageScanlineIterator outputIt(outputPtr, destinationRegion); !outputIt.IsAtEnd(); outputIt.NextLine())
       {
         while (!outputIt.IsAtEndOfLine())
         {
           outputIt.Set(sourceValue);
           ++outputIt;
         }
-        outputIt.NextLine();
         progress.Completed(outputRegionForThread.GetSize()[0]);
       }
     }
@@ -258,15 +256,13 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::DynamicThreadedGenera
     {
       SourceImagePixelType sourceValue = this->GetConstant();
 
-      ImageScanlineIterator outputIt(outputPtr, destinationRegion);
-      while (!outputIt.IsAtEnd())
+      for (ImageScanlineIterator outputIt(outputPtr, destinationRegion); !outputIt.IsAtEnd(); outputIt.NextLine())
       {
         while (!outputIt.IsAtEndOfLine())
         {
           outputIt.Set(sourceValue);
           ++outputIt;
         }
-        outputIt.NextLine();
         progress.Completed(outputRegionForThread.GetSize()[0]);
       }
     }

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -434,9 +434,6 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   const InputImageType * inputPtr = this->GetInput();
   const TransformType *  transformPtr = this->GetTransform();
 
-  // Create an iterator that will walk the output region for this thread.
-  ImageScanlineIterator outIt(outputPtr, outputRegionForThread);
-
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   const OutputImageRegionType & largestPossibleRegion = outputPtr->GetLargestPossibleRegion();
@@ -465,7 +462,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
       transformPtr->TransformPoint(outputPtr->template TransformIndexToPhysicalPoint<double>(index)));
   };
 
-  while (!outIt.IsAtEnd())
+  // Create an iterator that will walk the output region for this thread.
+  for (ImageScanlineIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); outIt.NextLine())
   {
     // Determine the continuous index of the first and end pixel of output
     // scan line when mapped to the input coordinate frame.
@@ -513,7 +511,6 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
       ++outIt;
       ++scanlineIndex;
     }
-    outIt.NextLine();
     progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
@@ -71,15 +71,14 @@ NaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGen
 
   NaryArrayType naryInputArray(numberOfValidInputImages);
 
-  OutputImagePointer    outputPtr = this->GetOutput(0);
-  ImageScanlineIterator outputIt(outputPtr, outputRegionForThread);
+  OutputImagePointer outputPtr = this->GetOutput(0);
 
   typename std::vector<ImageScanlineConstIteratorType *>::iterator             regionIterators;
   const typename std::vector<ImageScanlineConstIteratorType *>::const_iterator regionItEnd = inputItrVector.end();
 
   typename NaryArrayType::iterator arrayIt;
 
-  while (!outputIt.IsAtEnd())
+  for (ImageScanlineIterator outputIt(outputPtr, outputRegionForThread); !outputIt.IsAtEnd(); outputIt.NextLine())
   {
     while (!outputIt.IsAtEndOfLine())
     {
@@ -101,7 +100,6 @@ NaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGen
       (*regionIterators)->NextLine();
       ++regionIterators;
     }
-    outputIt.NextLine();
   }
 
   // Free memory

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -195,11 +195,9 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(const
 {
   OutputImagePointer output = this->GetOutput();
 
-  ImageScanlineIterator outLineIt(output, outputRegionForThread);
-
   OffsetValueType linecount = m_ForegroundLineMap.size();
 
-  for (outLineIt.GoToBegin(); !outLineIt.IsAtEnd(); outLineIt.NextLine())
+  for (ImageScanlineIterator outLineIt(output, outputRegionForThread); !outLineIt.IsAtEnd(); outLineIt.NextLine())
   {
     SizeValueType thisIdx = this->IndexToLinearIndex(outLineIt.GetIndex());
     if (!m_ForegroundLineMap[thisIdx].empty())

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -156,14 +156,12 @@ LabelContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(
 {
   OutputImageType * output = this->GetOutput();
 
-  ImageScanlineIterator outLineIt(output, outputRegionForThread);
-
   SizeValueType   pixelcount = output->GetRequestedRegion().GetNumberOfPixels();
   SizeValueType   xsize = output->GetRequestedRegion().GetSize()[0];
   OffsetValueType linecount = pixelcount / xsize;
   itkAssertInDebugAndIgnoreInReleaseMacro(SizeValueType(linecount) == m_LineMap.size());
 
-  for (outLineIt.GoToBegin(); !outLineIt.IsAtEnd(); outLineIt.NextLine())
+  for (ImageScanlineIterator outLineIt(output, outputRegionForThread); !outLineIt.IsAtEnd(); outLineIt.NextLine())
   {
     SizeValueType thisIdx = this->IndexToLinearIndex(outLineIt.GetIndex());
     if (!m_LineMap[thisIdx].empty())

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -154,13 +154,11 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
 {
   const TInputImage * input = this->GetInput();
 
-  ImageScanlineConstIterator inLineIt(input, outputRegionForThread);
-
   WorkUnitData  workUnitData = this->CreateWorkUnitData(outputRegionForThread);
   SizeValueType lineId = workUnitData.firstLine;
 
   SizeValueType nbOfLabels = 0;
-  for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine())
+  for (ImageScanlineConstIterator inLineIt(input, outputRegionForThread); !inLineIt.IsAtEnd(); inLineIt.NextLine())
   {
     LineEncodingType thisLine;
     while (!inLineIt.IsAtEndOfLine())

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -166,13 +166,11 @@ void
 ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThreadedGenerateData(
   const RegionType & outputRegionForThread)
 {
-  ImageScanlineConstIterator inLineIt(m_Input, outputRegionForThread);
-
   WorkUnitData  workUnitData = this->CreateWorkUnitData(outputRegionForThread);
   SizeValueType lineId = workUnitData.firstLine;
 
   SizeValueType nbOfLabels = 0;
-  for (inLineIt.GoToBegin(); !inLineIt.IsAtEnd(); inLineIt.NextLine())
+  for (ImageScanlineConstIterator inLineIt(m_Input, outputRegionForThread); !inLineIt.IsAtEnd(); inLineIt.NextLine())
   {
     LineEncodingType thisLine;
     while (!inLineIt.IsAtEndOfLine())


### PR DESCRIPTION
Looked for iterations of the following form:

    ImageScanlineIterator outIt(output, outputRegionForThread);

    while (!outIt.IsAtEnd())
    {
      ...
      outIt.NextLine();
    }

And replaced them with the corresponding `for` loops.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3957 commit 31c713eb105eff4ba87a457a24a23ef4a6eb3071 "STYLE: Replace `while (!outIt.IsAtEnd())` with `for` loops, in Filtering"