### PR TITLE
Use trailing return type instead of `typename` in "*.h" files and multi-line member function declarations

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
@@ -75,8 +75,8 @@ InOrderTreeIterator<TTreeType>::InOrderTreeIterator(TTreeType * tree, TreeNodeTy
 
 /** Get the type of the iterator */
 template <typename TTreeType>
-typename InOrderTreeIterator<TTreeType>::NodeType
-InOrderTreeIterator<TTreeType>::GetType() const
+auto
+InOrderTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::INORDER;
 }

--- a/Modules/Compatibility/Deprecated/include/itkLeafTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkLeafTreeIterator.h
@@ -106,8 +106,8 @@ LeafTreeIterator<TTreeType>::~LeafTreeIterator() = default;
 
 /** Return the type of iterator */
 template <typename TTreeType>
-typename LeafTreeIterator<TTreeType>::NodeType
-LeafTreeIterator<TTreeType>::GetType() const
+auto
+LeafTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::LEAF;
 }

--- a/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
@@ -89,8 +89,8 @@ PostOrderTreeIterator<TTreeType>::PostOrderTreeIterator(TTreeType * tree)
 
 /** Return the type of the iterator */
 template <typename TTreeType>
-typename PostOrderTreeIterator<TTreeType>::NodeType
-PostOrderTreeIterator<TTreeType>::GetType() const
+auto
+PostOrderTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::POSTORDER;
 }

--- a/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
@@ -75,8 +75,8 @@ PreOrderTreeIterator<TTreeType>::PreOrderTreeIterator(const TTreeType * tree, co
 
 /** Return the type of the iterator */
 template <typename TTreeType>
-typename PreOrderTreeIterator<TTreeType>::NodeType
-PreOrderTreeIterator<TTreeType>::GetType() const
+auto
+PreOrderTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::PREORDER;
 }

--- a/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
@@ -74,8 +74,8 @@ RootTreeIterator<TTreeType>::RootTreeIterator(TTreeType * tree, const TreeNodeTy
 
 /** Return the type of the iterator */
 template <typename TTreeType>
-typename RootTreeIterator<TTreeType>::NodeType
-RootTreeIterator<TTreeType>::GetType() const
+auto
+RootTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::ROOT;
 }

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -27,9 +27,9 @@ namespace itk
 {
 /** Compute weights for interpolation at continuous index position */
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType
+auto
 BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> WeightsType
 {
   WeightsType weights;
   IndexType   startIndex;

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -23,20 +23,21 @@ namespace itk
 {
 
 template <typename TInputImage, typename TOutputImage>
-typename ConstantBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ConstantBoundaryCondition<TInputImage, TOutputImage>::operator()(const OffsetType &,
                                                                  const OffsetType &,
-                                                                 const NeighborhoodType *) const
+                                                                 const NeighborhoodType *) const -> OutputPixelType
 {
   return m_Constant;
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConstantBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ConstantBoundaryCondition<TInputImage, TOutputImage>::operator()(const OffsetType &,
                                                                  const OffsetType &,
                                                                  const NeighborhoodType *,
                                                                  const NeighborhoodAccessorFunctorType &) const
+  -> OutputPixelType
 {
   return m_Constant;
 }
@@ -56,10 +57,10 @@ ConstantBoundaryCondition<TInputImage, TOutputImage>::GetConstant() const -> con
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConstantBoundaryCondition<TInputImage, TOutputImage>::RegionType
+auto
 ConstantBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
   const RegionType & inputLargestPossibleRegion,
-  const RegionType & outputRequestedRegion) const
+  const RegionType & outputRequestedRegion) const -> RegionType
 {
   RegionType inputRequestedRegion(inputLargestPossibleRegion);
   bool       cropped = inputRequestedRegion.Crop(outputRequestedRegion);

--- a/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
@@ -23,11 +23,11 @@
 namespace itk
 {
 template <typename TImage, typename TOperator, typename TComputation>
-typename NeighborhoodInnerProduct<TImage, TOperator, TComputation>::OutputPixelType
+auto
 NeighborhoodInnerProduct<TImage, TOperator, TComputation>::Compute(const ConstNeighborhoodIterator<TImage> & it,
                                                                    const OperatorType &                      op,
                                                                    const unsigned int                        start,
-                                                                   const unsigned int                        stride)
+                                                                   const unsigned int stride) -> OutputPixelType
 {
   using InputPixelType = typename TImage::PixelType;
   using InputPixelRealType = typename NumericTraits<InputPixelType>::RealType;
@@ -49,13 +49,13 @@ NeighborhoodInnerProduct<TImage, TOperator, TComputation>::Compute(const ConstNe
 }
 
 template <typename TImage, typename TOperator, typename TComputation>
-typename NeighborhoodInnerProduct<TImage, TOperator, TComputation>::OutputPixelType
+auto
 NeighborhoodInnerProduct<TImage, TOperator, TComputation>::Compute(
   /*           const ImageBoundaryCondition<TImage> *,*/
   const NeighborhoodType & N,
   const OperatorType &     op,
   const unsigned int       start,
-  const unsigned int       stride)
+  const unsigned int       stride) -> OutputPixelType
 {
   typename OperatorType::ConstIterator o_it;
 

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -23,10 +23,10 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-typename PeriodicBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 PeriodicBoundaryCondition<TInputImage, TOutputImage>::operator()(const OffsetType &       point_index,
                                                                  const OffsetType &       boundary_offset,
-                                                                 const NeighborhoodType * data) const
+                                                                 const NeighborhoodType * data) const -> OutputPixelType
 {
   // This is guaranteed to be called with an object that is using
   // PeriodicBoundaryCondition
@@ -77,12 +77,12 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::operator()(const OffsetTyp
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PeriodicBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 PeriodicBoundaryCondition<TInputImage, TOutputImage>::operator()(
   const OffsetType &                      point_index,
   const OffsetType &                      boundary_offset,
   const NeighborhoodType *                data,
-  const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const
+  const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const -> OutputPixelType
 {
   // This is guaranteed to be called with an object that is using
   // PeriodicBoundaryCondition
@@ -133,10 +133,10 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::operator()(
 
 
 template <typename TInputImage, typename TOutputImage>
-typename PeriodicBoundaryCondition<TInputImage, TOutputImage>::RegionType
+auto
 PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
   const RegionType & inputLargestPossibleRegion,
-  const RegionType & outputRequestedRegion) const
+  const RegionType & outputRequestedRegion) const -> RegionType
 {
   IndexType imageIndex = inputLargestPossibleRegion.GetIndex();
   SizeType  imageSize = inputLargestPossibleRegion.GetSize();

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -219,9 +219,9 @@ Point<T, TPointDimension>::SetToBarycentricCombination(const Self * P, const dou
  * Set the point to the barycentric combination of N points in a Container
  */
 template <typename TPointContainer, typename TWeightContainer>
-typename BarycentricCombination<TPointContainer, TWeightContainer>::PointType
+auto
 BarycentricCombination<TPointContainer, TWeightContainer>::Evaluate(const PointContainerPointer & points,
-                                                                    const WeightContainerType &   weights)
+                                                                    const WeightContainerType &   weights) -> PointType
 {
   using ValueType = typename PointType::ValueType;
   PointType barycentre;

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -35,9 +35,9 @@ const typename ElementWrapperInterface<TElement, TElementIdentifier>::ElementIde
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 template <typename TElementWrapperPointer, typename TElementIdentifier>
-typename ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::ElementIdentifierType
+auto
 ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::GetLocation(
-  const ElementWrapperPointerType & element) const
+  const ElementWrapperPointerType & element) const -> ElementIdentifierType
 {
   return (element->GetLocation(*element));
 }
@@ -130,9 +130,9 @@ MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::
 
 // -----------------------------------------------------------------------------
 template <typename TElement, typename TElementPriority, typename TElementIdentifier>
-typename MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::ElementIdentifierType
+auto
 MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::GetLocation(
-  const MinPriorityQueueElementWrapper & element) const
+  const MinPriorityQueueElementWrapper & element) const -> ElementIdentifierType
 {
   return element.m_Location;
 }

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -98,13 +98,13 @@ TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, co
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::PointType
+auto
 TriangleHelper<TPoint>::ComputeBarycenter(const CoordRepType & iA1,
                                           const PointType &    iP1,
                                           const CoordRepType & iA2,
                                           const PointType &    iP2,
                                           const CoordRepType & iA3,
-                                          const PointType &    iP3)
+                                          const PointType &    iP3) -> PointType
 {
   PointType oPt;
 
@@ -187,10 +187,10 @@ TriangleHelper<TPoint>::ComputeCircumCenter(const PointType & iP1, const PointTy
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::PointType
+auto
 TriangleHelper<TPoint>::ComputeConstrainedCircumCenter(const PointType & iP1,
                                                        const PointType & iP2,
-                                                       const PointType & iP3)
+                                                       const PointType & iP3) -> PointType
 {
   const CoordRepType a = iP2.SquaredEuclideanDistanceTo(iP3);
   const CoordRepType b = iP1.SquaredEuclideanDistanceTo(iP3);

--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
@@ -21,10 +21,10 @@
 namespace itk
 {
 template <typename TImage>
-typename VectorNeighborhoodInnerProduct<TImage>::PixelType
+auto
 VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &                        s,
                                                    const ConstNeighborhoodIterator<TImage> & it,
-                                                   const OperatorType &                      op) const
+                                                   const OperatorType &                      op) const -> PixelType
 {
   PixelType sum{};
 
@@ -47,10 +47,10 @@ VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &           
 }
 
 template <typename TImage>
-typename VectorNeighborhoodInnerProduct<TImage>::PixelType
+auto
 VectorNeighborhoodInnerProduct<TImage>::operator()(const std::slice &       s,
                                                    const NeighborhoodType & it,
-                                                   const OperatorType &     op) const
+                                                   const OperatorType &     op) const -> PixelType
 {
   PixelType sum{};
 

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -22,10 +22,11 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-typename ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::operator()(const OffsetType &       point_index,
                                                                         const OffsetType &       boundary_offset,
                                                                         const NeighborhoodType * data) const
+  -> OutputPixelType
 {
   int linear_index = 0;
 
@@ -60,12 +61,12 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::operator()(const Of
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::operator()(
   const OffsetType &                      point_index,
   const OffsetType &                      boundary_offset,
   const NeighborhoodType *                data,
-  const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const
+  const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const -> OutputPixelType
 {
   int linear_index = 0;
 
@@ -80,10 +81,10 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::operator()(
 
 
 template <typename TInputImage, typename TOutputImage>
-typename ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::RegionType
+auto
 ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
   const RegionType & inputLargestPossibleRegion,
-  const RegionType & outputRequestedRegion) const
+  const RegionType & outputRequestedRegion) const -> RegionType
 {
   IndexType inputIndex = inputLargestPossibleRegion.GetIndex();
   SizeType  inputSize = inputLargestPossibleRegion.GetSize();
@@ -150,9 +151,10 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRe
 
 
 template <typename TInputImage, typename TOutputImage>
-typename ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType &   index,
                                                                       const TInputImage * image) const
+  -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
   IndexType  imageIndex = imageRegion.GetIndex();

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -206,10 +206,10 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedApplyUpdate
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::TimeStepType
+auto
 DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedCalculateChange(
   const ThreadRegionType & regionToProcess,
-  ThreadIdType)
+  ThreadIdType) -> TimeStepType
 {
   using SizeType = typename OutputImageType::SizeType;
   using NeighborhoodIteratorType = typename FiniteDifferenceFunctionType::NeighborhoodType;

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -165,9 +165,10 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRe
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename FiniteDifferenceImageFilter<TInputImage, TOutputImage>::TimeStepType
+auto
 FiniteDifferenceImageFilter<TInputImage, TOutputImage>::ResolveTimeStep(const std::vector<TimeStepType> & timeStepList,
                                                                         const BooleanStdVectorType &      valid) const
+  -> TimeStepType
 {
   TimeStepType oMin{};
   bool         flag = false;

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -242,10 +242,10 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Prec
 }
 
 template <typename TInputImageType, typename TSparseOutputImageType>
-typename FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::TimeStepType
+auto
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::ThreadedCalculateChange(
   const ThreadRegionType & regionToProcess,
-  ThreadIdType)
+  ThreadIdType) -> TimeStepType
 {
   using NeighborhoodIteratorType = typename FiniteDifferenceFunctionType::NeighborhoodType;
 

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -180,10 +180,10 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::G
 }
 
 template <typename TInputImage, typename TOutputImage, typename TParentImageFilter>
-typename GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::TimeStepType
+auto
 GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::ResolveTimeStep(
   const std::vector<TimeStepType> & timeStepList,
-  const BooleanStdVectorType &      valid) const
+  const BooleanStdVectorType &      valid) const -> TimeStepType
 {
   TimeStepType oMin{};
   bool         flag = false;

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -496,11 +496,11 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::ApplyM
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-typename BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::OutputType
+auto
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndexInternal(
   const ContinuousIndexType & x,
   vnl_matrix<long> &          evaluateIndex,
-  vnl_matrix<double> &        weights) const
+  vnl_matrix<double> &        weights) const -> OutputType
 {
   // compute the interpolation indexes
   this->DetermineRegionOfSupport((evaluateIndex), x, m_SplineOrder);
@@ -608,12 +608,12 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-typename BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::CovariantVectorType
+auto
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateDerivativeAtContinuousIndexInternal(
   const ContinuousIndexType & x,
   vnl_matrix<long> &          evaluateIndex,
   vnl_matrix<double> &        weights,
-  vnl_matrix<double> &        weightsDerivative) const
+  vnl_matrix<double> &        weightsDerivative) const -> CovariantVectorType
 {
   this->DetermineRegionOfSupport((evaluateIndex), x, m_SplineOrder);
 

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -432,9 +432,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
 }
 
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
-typename CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::OutputType
+auto
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> OutputType
 {
   OutputType derivative;
   // When ScalarDerivativeType is the same as OutputType, this calls

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -236,9 +236,9 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const PointType 
 }
 
 template <typename TInputImage, typename TOutput>
-typename GaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
+auto
 GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> OutputType
 {
   IndexType index;
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -72,9 +72,9 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeBoundingBox()
 
 
 template <typename TInputImage, typename TCoordRep>
-typename GaussianInterpolateImageFunction<TInputImage, TCoordRep>::RegionType
+auto
 GaussianInterpolateImageFunction<TInputImage, TCoordRep>::ComputeInterpolationRegion(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> RegionType
 {
   RegionType region = this->GetInputImage()->GetBufferedRegion();
   for (unsigned int d = 0; d < ImageDimension; ++d)
@@ -91,9 +91,10 @@ GaussianInterpolateImageFunction<TInputImage, TCoordRep>::ComputeInterpolationRe
 }
 
 template <typename TImageType, typename TCoordRep>
-typename GaussianInterpolateImageFunction<TImageType, TCoordRep>::OutputType
+auto
 GaussianInterpolateImageFunction<TImageType, TCoordRep>::EvaluateAtContinuousIndex(const ContinuousIndexType & cindex,
                                                                                    OutputType * grad) const
+  -> OutputType
 {
   vnl_vector<RealType> erfArray[ImageDimension];
   vnl_vector<RealType> gerfArray[ImageDimension];

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -34,10 +34,10 @@ namespace itk
 {
 
 template <typename TInputImage, typename TCoordRep, typename TPixelCompare>
-typename LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordRep, TPixelCompare>::OutputType
+auto
 LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordRep, TPixelCompare>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & cindex,
-  OutputType *                itkNotUsed(grad)) const
+  OutputType *                itkNotUsed(grad)) const -> OutputType
 {
   vnl_vector<RealType> erfArray[ImageDimension];
   vnl_vector<RealType> gerfArray[ImageDimension];

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1430,9 +1430,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTyp
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename RayCastInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 RayCastInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> OutputType
 {
   OutputPointType point;
 

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -30,9 +30,9 @@ const unsigned long VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>
 
 
 template <typename TInputImage, typename TCoordRep>
-typename VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> OutputType
 {
   //
   // Compute base index = closet index below point

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
@@ -31,9 +31,9 @@ const unsigned int VectorLinearInterpolateNearestNeighborExtrapolateImageFunctio
   1 << TInputImage::ImageDimension;
 
 template <typename TInputImage, typename TCoordRep>
-typename VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & index) const
+  const ContinuousIndexType & index) const -> OutputType
 {
   unsigned int dim; // index over dimension
 
@@ -126,9 +126,9 @@ VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoo
  * Evaluate at image index position
  */
 template <typename TInputImage, typename TCoordRep>
-typename VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(
-  const IndexType & index) const
+  const IndexType & index) const -> OutputType
 {
   // Find the index that is closest to the requested one
   // but that lies within the image

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
@@ -74,13 +74,13 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const CoordinateType * p0) ->
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(CoordinateType x0,
                                                    CoordinateType x1,
                                                    CoordinateType x2,
                                                    CoordinateType x3,
                                                    CoordinateType x4,
-                                                   CoordinateType x5)
+                                                   CoordinateType x5) -> IdentifierType
 {
   CoordinateType p0[] = { x0, x1, x2, x3, x4, x5 };
   PointType      newPoint;
@@ -484,10 +484,10 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddLine(IdentifierType pointId0, Ident
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(IdentifierType pointId0,
                                                       IdentifierType pointId1,
-                                                      IdentifierType pointId2)
+                                                      IdentifierType pointId2) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(3);
   pointIDs[0] = pointId0;
@@ -497,11 +497,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(IdentifierType pointId0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(IdentifierType pointId0,
                                                            IdentifierType pointId1,
                                                            IdentifierType pointId2,
-                                                           IdentifierType pointId3)
+                                                           IdentifierType pointId3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = pointId0;
@@ -512,11 +512,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(IdentifierType pointI
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(IdentifierType pointId0,
                                                          IdentifierType pointId1,
                                                          IdentifierType pointId2,
-                                                         IdentifierType pointId3)
+                                                         IdentifierType pointId3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = pointId0;
@@ -527,7 +527,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(IdentifierType pointId0
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(IdentifierType pointId0,
                                                         IdentifierType pointId1,
                                                         IdentifierType pointId2,
@@ -535,7 +535,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(IdentifierType pointId0,
                                                         IdentifierType pointId4,
                                                         IdentifierType pointId5,
                                                         IdentifierType pointId6,
-                                                        IdentifierType pointId7)
+                                                        IdentifierType pointId7) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(8);
   pointIDs[0] = pointId0;
@@ -581,11 +581,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const PointType & p0, cons
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const PointType & p0,
                                                            const PointType & p1,
                                                            const PointType & p2,
-                                                           const PointType & p3)
+                                                           const PointType & p3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = AddPoint(p0);
@@ -596,11 +596,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const PointType & p0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const PointType & p0,
                                                          const PointType & p1,
                                                          const PointType & p2,
-                                                         const PointType & p3)
+                                                         const PointType & p3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = AddPoint(p0);
@@ -611,7 +611,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const PointType & p0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const PointType & p0,
                                                         const PointType & p1,
                                                         const PointType & p2,
@@ -619,7 +619,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const PointType & p0,
                                                         const PointType & p4,
                                                         const PointType & p5,
                                                         const PointType & p6,
-                                                        const PointType & p7)
+                                                        const PointType & p7) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(8);
   pointIDs[0] = AddPoint(p0);
@@ -654,10 +654,10 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const CoordinateType * p0, con
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const CoordinateType * p0,
                                                       const CoordinateType * p1,
-                                                      const CoordinateType * p2)
+                                                      const CoordinateType * p2) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(3);
   pointIDs[0] = AddPoint(p0);
@@ -667,11 +667,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const CoordinateType * p0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const CoordinateType * p0,
                                                            const CoordinateType * p1,
                                                            const CoordinateType * p2,
-                                                           const CoordinateType * p3)
+                                                           const CoordinateType * p3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = AddPoint(p0);
@@ -682,11 +682,11 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const CoordinateType 
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const CoordinateType * p0,
                                                          const CoordinateType * p1,
                                                          const CoordinateType * p2,
-                                                         const CoordinateType * p3)
+                                                         const CoordinateType * p3) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(4);
   pointIDs[0] = AddPoint(p0);
@@ -697,7 +697,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const CoordinateType * 
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const CoordinateType * p0,
                                                         const CoordinateType * p1,
                                                         const CoordinateType * p2,
@@ -705,7 +705,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const CoordinateType * p
                                                         const CoordinateType * p4,
                                                         const CoordinateType * p5,
                                                         const CoordinateType * p6,
-                                                        const CoordinateType * p7)
+                                                        const CoordinateType * p7) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(8);
   pointIDs[0] = AddPoint(p0);

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -605,11 +605,12 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetCellBoundaryFeature(int           
  * though, and we are not sure how wide-spread this support is.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
+auto
 Mesh<TPixelType, VDimension, TMeshTraits>::GetCellBoundaryFeatureNeighbors(int                        dimension,
                                                                            CellIdentifier             cellId,
                                                                            CellFeatureIdentifier      featureId,
                                                                            std::set<CellIdentifier> * cellSet)
+  -> CellIdentifier
 {
   /**
    * Sanity check on mesh status.

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -199,9 +199,9 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddFace(CellAutoPointer & cell
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
+auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::ReplaceFace(CellIdentifier    replaceIndex,
-                                                              CellAutoPointer & cellPointer)
+                                                              CellAutoPointer & cellPointer) -> CellIdentifier
 {
   // Release previous cell, if any.
   // See documentation of Mesh::SetCell().
@@ -248,10 +248,10 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier i
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::NeighborListType *
+auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier    idx,
                                                                unsigned int       radius,
-                                                               NeighborListType * list) const
+                                                               NeighborListType * list) const -> NeighborListType *
 {
   if (list == nullptr)
   {

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -83,10 +83,10 @@ SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::CreateTriangles()
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::CellIdentifier
+auto
 SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::FindCellId(CellIdentifier id1,
                                                                      CellIdentifier id2,
-                                                                     CellIdentifier id3)
+                                                                     CellIdentifier id3) -> CellIdentifier
 {
   std::set<CellIdentifier> cells1 = this->GetInput(0)->GetCellLinks()->GetElement(id1);
   std::set<CellIdentifier> cells2 = this->GetInput(0)->GetCellLinks()->GetElement(id2);

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -398,9 +398,10 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::InputPointType
+auto
 TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::ComputeFaceCenter(CellIdentifier        faceId,
                                                                             const InputMeshType * inputMesh)
+  -> InputPointType
 {
   InputPointType v1, v2, v3;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -674,9 +674,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddEdge(const PointIdentifier & orgPi
 }
 
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::AddEdgeWithSecurePointList(const PointIdentifier & orgPid,
-                                                                      const PointIdentifier & destPid)
+                                                                      const PointIdentifier & destPid) -> QEPrimal *
 {
   PointsContainerPointer points = this->GetPoints();
 
@@ -1140,9 +1140,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::EdgeCellType *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdgeCell(const PointIdentifier & pid0,
-                                                        const PointIdentifier & pid1) const
+                                                        const PointIdentifier & pid1) const -> EdgeCellType *
 {
   auto *     result = (EdgeCellType *)nullptr;
   QEPrimal * EdgeGeom = FindEdge(pid0, pid1);
@@ -1340,10 +1340,10 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(QEPrimal * entry)
  * @param cPid \ref PointIdentifier of third point
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceTriangle(const PointIdentifier & aPid,
                                                            const PointIdentifier & bPid,
-                                                           const PointIdentifier & cPid)
+                                                           const PointIdentifier & cPid) -> QEPrimal *
 {
   PointIdList points(3);
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -313,9 +313,10 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QETy
 }
 
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::EdgeStatusType
+auto
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CheckStatus(QEType *                e,
                                                                          std::stack<TQEType *> & oToBeDeleted)
+  -> EdgeStatusType
 {
 #ifndef NDEBUG
   if (!e)

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -129,36 +129,36 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputPointType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformPoint(
-  const InputPointType & point) const
+  const InputPointType & point) const -> OutputPointType
 {
   return m_Matrix * point + m_Offset;
 }
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
-  const InputVectorType & vect) const
+  const InputVectorType & vect) const -> OutputVectorType
 {
   return m_Matrix * vect;
 }
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVnlVectorType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
-  const InputVnlVectorType & vect) const
+  const InputVnlVectorType & vect) const -> OutputVnlVectorType
 {
   return m_Matrix.GetVnlMatrix() * vect;
 }
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
-  const InputVectorPixelType & vect) const
+  const InputVectorPixelType & vect) const -> OutputVectorPixelType
 {
   const unsigned int vectorDim = vect.Size();
 
@@ -193,9 +193,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputCovariantVectorType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
-  const InputCovariantVectorType & vec) const
+  const InputCovariantVectorType & vec) const -> OutputCovariantVectorType
 {
   OutputCovariantVectorType result; // Converted vector
 
@@ -213,9 +213,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
-  const InputVectorPixelType & vect) const
+  const InputVectorPixelType & vect) const -> OutputVectorPixelType
 {
 
   const unsigned int vectorDim = vect.Size();
@@ -251,9 +251,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputDiffusionTensor3DType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
-  const InputDiffusionTensor3DType & tensor) const
+  const InputDiffusionTensor3DType & tensor) const -> OutputDiffusionTensor3DType
 {
 
   JacobianType jacobian;
@@ -274,9 +274,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
-  const InputVectorPixelType & tensor) const
+  const InputVectorPixelType & tensor) const -> OutputVectorPixelType
 {
   OutputVectorPixelType result(InputDiffusionTensor3DType::InternalDimension); // Converted tensor
 
@@ -346,9 +346,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
-  const InputVectorPixelType & inputTensor) const
+  const InputVectorPixelType & inputTensor) const -> OutputVectorPixelType
 {
   JacobianType jacobian;
   jacobian.SetSize(VOutputDimension, VInputDimension);

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -120,9 +120,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::UpdateTransf
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVectorType & vector,
                                                                                     const InputPointType &  point) const
+  -> OutputVectorType
 {
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
@@ -141,9 +142,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVnlVectorType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVnlVectorType & vector,
                                                                                     const InputPointType & point) const
+  -> OutputVnlVectorType
 {
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
@@ -162,9 +164,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVectorPixelType & vector,
                                                                                     const InputPointType & point) const
+  -> OutputVectorPixelType
 {
 
   if (vector.GetSize() != VInputDimension)
@@ -192,10 +195,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputCovariantVectorType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputCovariantVectorType & vector,
-  const InputPointType &           point) const
+  const InputPointType &           point) const -> OutputCovariantVectorType
 {
   InverseJacobianPositionType jacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, jacobian);
@@ -214,10 +217,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCov
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputVectorPixelType & vector,
-  const InputPointType &       point) const
+  const InputPointType &       point) const -> OutputVectorPixelType
 {
 
   if (vector.GetSize() != VInputDimension)
@@ -245,10 +248,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCov
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputDiffusionTensor3DType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
   const InputDiffusionTensor3DType & inputTensor,
-  const InputPointType &             point) const
+  const InputPointType &             point) const -> OutputDiffusionTensor3DType
 {
   InverseJacobianPositionType invJacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, invJacobian);
@@ -261,10 +264,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDif
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & inputTensor,
-  const InputPointType &       point) const
+  const InputPointType &       point) const -> OutputVectorPixelType
 {
   if (inputTensor.GetSize() != 6)
   {
@@ -375,10 +378,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputSymmetricSecondRankTensorType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
   const InputSymmetricSecondRankTensorType & inputTensor,
-  const InputPointType &                     point) const
+  const InputPointType &                     point) const -> OutputSymmetricSecondRankTensorType
 {
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
@@ -411,10 +414,10 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSym
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+auto
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
   const InputVectorPixelType & inputTensor,
-  const InputPointType &       point) const
+  const InputPointType &       point) const -> OutputVectorPixelType
 {
 
   if (inputTensor.GetSize() != (VInputDimension * VInputDimension))

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -257,32 +257,36 @@ private:
 
 // Back transform a point
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename TranslationTransform<TParametersValueType, VDimension>::InputPointType
+inline auto
 TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputPointType & point) const
+  -> InputPointType
 {
   return point - m_Offset;
 }
 
 // Back transform a vector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename TranslationTransform<TParametersValueType, VDimension>::InputVectorType
+inline auto
 TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputVectorType & vect) const
+  -> InputVectorType
 {
   return vect;
 }
 
 // Back transform a vnl_vector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename TranslationTransform<TParametersValueType, VDimension>::InputVnlVectorType
+inline auto
 TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputVnlVectorType & vect) const
+  -> InputVnlVectorType
 {
   return vect;
 }
 
 // Back Transform a CovariantVector
 template <typename TParametersValueType, unsigned int VDimension>
-inline typename TranslationTransform<TParametersValueType, VDimension>::InputCovariantVectorType
+inline auto
 TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputCovariantVectorType & vect) const
+  -> InputCovariantVectorType
 {
   return vect;
 }

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -144,9 +144,9 @@ TranslationTransform<TParametersValueType, VDimension>::TransformVector(const In
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename TranslationTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+auto
 TranslationTransform<TParametersValueType, VDimension>::TransformCovariantVector(
-  const InputCovariantVectorType & vect) const
+  const InputCovariantVectorType & vect) const -> OutputCovariantVectorType
 {
   return vect;
 }

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -70,10 +70,10 @@ CurvatureNDAnisotropicDiffusionFunction<TImage>::CurvatureNDAnisotropicDiffusion
 }
 
 template <typename TImage>
-typename CurvatureNDAnisotropicDiffusionFunction<TImage>::PixelType
+auto
 CurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                                void *                   itkNotUsed(globalData),
-                                                               const FloatOffsetType &  itkNotUsed(offset))
+                                                               const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   unsigned int i, j;
   double       speed, dx_forward_Cn, dx_backward_Cn, propagation_gradient;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -74,10 +74,10 @@ GradientNDAnisotropicDiffusionFunction<TImage>::GradientNDAnisotropicDiffusionFu
 }
 
 template <typename TImage>
-typename GradientNDAnisotropicDiffusionFunction<TImage>::PixelType
+auto
 GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                               void *,
-                                                              const FloatOffsetType &)
+                                                              const FloatOffsetType &) -> PixelType
 {
   unsigned int i, j;
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -73,10 +73,10 @@ VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::VectorCurvatureNDAnisotro
 }
 
 template <typename TImage>
-typename VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::PixelType
+auto
 VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                                      void *,
-                                                                     const FloatOffsetType &)
+                                                                     const FloatOffsetType &) -> PixelType
 {
   unsigned int i, j, k;
   double       speed;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
@@ -73,10 +73,10 @@ VectorGradientNDAnisotropicDiffusionFunction<TImage>::VectorGradientNDAnisotropi
 }
 
 template <typename TImage>
-typename VectorGradientNDAnisotropicDiffusionFunction<TImage>::PixelType
+auto
 VectorGradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                                     void *,
-                                                                    const FloatOffsetType &)
+                                                                    const FloatOffsetType &) -> PixelType
 {
   unsigned int i, j, k;
   PixelType    delta;

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -55,11 +55,11 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::AntiAliasBinaryImageFilte
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::ValueType
+auto
 AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::CalculateUpdateValue(const IndexType &    idx,
                                                                             const TimeStepType & dt,
                                                                             const ValueType &    value,
-                                                                            const ValueType &    change)
+                                                                            const ValueType &    change) -> ValueType
 {
   // This method introduces the constraint on the flow of the surface.
 

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -435,10 +435,11 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::Initialize(
 }
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
-typename MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::BiasFieldType
+auto
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::EstimateBiasField(InputImageRegionType region,
                                                                                        unsigned int         degree,
                                                                                        int maximumIteration)
+  -> BiasFieldType
 {
   itkDebugMacro(<< "Estimating bias field ");
 

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
@@ -31,10 +31,10 @@ BinaryMinMaxCurvatureFlowFunction<TImage>::BinaryMinMaxCurvatureFlowFunction()
 }
 
 template <typename TImage>
-typename BinaryMinMaxCurvatureFlowFunction<TImage>::PixelType
+auto
 BinaryMinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                          void *                   globalData,
-                                                         const FloatOffsetType &  offset)
+                                                         const FloatOffsetType &  offset) -> PixelType
 {
   using CurvatureFlowFunctionType = CurvatureFlowFunction<TImage>;
   PixelType update = this->CurvatureFlowFunctionType::ComputeUpdate(it, globalData, offset);

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -47,10 +47,10 @@ CurvatureFlowFunction<TImage>::ComputeGlobalTimeStep(void * itkNotUsed(gd)) cons
 }
 
 template <typename TImage>
-typename CurvatureFlowFunction<TImage>::PixelType
+auto
 CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                              void *                   itkNotUsed(gd),
-                                             const FloatOffsetType &  itkNotUsed(offset))
+                                             const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   PixelRealType  firstderiv[ImageDimension];
   PixelRealType  secderiv[ImageDimension];

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -392,10 +392,10 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
 }
 
 template <typename TImage>
-typename MinMaxCurvatureFlowFunction<TImage>::PixelType
+auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                                    void *                   globalData,
-                                                   const FloatOffsetType &  offset)
+                                                   const FloatOffsetType &  offset) -> PixelType
 {
   PixelType update = this->Superclass::ComputeUpdate(it, globalData, offset);
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -1156,10 +1156,10 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::AddEuclideanUpdate(co
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::RealType
+auto
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::AddExponentialMapUpdate(
   const DiffusionTensor3D<RealValueType> & spdMatrix,
-  const DiffusionTensor3D<RealValueType> & symMatrix)
+  const DiffusionTensor3D<RealValueType> & symMatrix) -> RealType
 {
   using RealEigenValuesArrayType = typename RealType::EigenValuesArrayType;
   using RealEigenVectorsMatrixType = typename RealType::EigenVectorsMatrixType;
@@ -1505,11 +1505,11 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeSigmaUpdateThr
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataStruct
+auto
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeSigmaUpdate(
   const InputImageRegionType & regionToProcess,
   const int                    itkNotUsed(threadId),
-  ThreadDataStruct             threadData)
+  ThreadDataStruct             threadData) -> ThreadDataStruct
 {
   // Create two images to list adaptors, one for the iteration over the region
   // the other for querying to find the patches set the region of interest for
@@ -1941,11 +1941,11 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeImageUpdateThr
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataStruct
+auto
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeImageUpdate(
   const InputImageRegionType & regionToProcess,
   const int                    threadId,
-  ThreadDataStruct             threadData)
+  ThreadDataStruct             threadData) -> ThreadDataStruct
 {
   // Create two images to list adaptors, one for the iteration over the region
   // the other for querying to find the patches set the region of interest for
@@ -2121,12 +2121,12 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeImageU
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::RealType
+auto
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeGradientJointEntropy(
   InstanceIdentifier                  id,
   typename ListAdaptorType::Pointer & inList,
   BaseSamplerPointer &                sampler,
-  ThreadDataStruct &                  threadData)
+  ThreadDataStruct &                  threadData) -> RealType
 {
   using IndexType = typename OutputImageType::IndexType;
 

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -164,10 +164,10 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Upda
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::ConstantVelocityFieldPointer
+auto
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSplineSmoothConstantVelocityField(
   const ConstantVelocityFieldType * field,
-  const ArrayType &                 numberOfControlPoints)
+  const ArrayType &                 numberOfControlPoints) -> ConstantVelocityFieldPointer
 {
   auto bspliner = BSplineFilterType::New();
   bspliner->SetUseInputFieldToDefineTheBSplineDomain(true);

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -161,10 +161,10 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldPointer
+auto
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::BSplineSmoothDisplacementField(
   const DisplacementFieldType * field,
-  const ArrayType &             numberOfControlPoints)
+  const ArrayType &             numberOfControlPoints) -> DisplacementFieldPointer
 {
   auto bspliner = BSplineFilterType::New();
   bspliner->SetUseInputFieldToDefineTheBSplineDomain(true);

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -307,9 +307,9 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::IntegrateVeloc
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename ConstantVelocityFieldTransform<TParametersValueType, VDimension>::DisplacementFieldType::Pointer
+auto
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
-  const DisplacementFieldType * toCopy) const
+  const DisplacementFieldType * toCopy) const -> typename DisplacementFieldType::Pointer
 {
   auto rval = DisplacementFieldType::New();
   rval->SetOrigin(toCopy->GetOrigin());

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -133,10 +133,10 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Upd
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::ConstantVelocityFieldPointer
+auto
 GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::GaussianSmoothConstantVelocityField(
   ConstantVelocityFieldType * field,
-  ScalarType                  variance)
+  ScalarType                  variance) -> ConstantVelocityFieldPointer
 {
   if (variance <= 0.0)
   {

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -126,10 +126,10 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldPointer
+auto
 GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::GaussianSmoothDisplacementField(
   DisplacementFieldType * field,
-  ScalarType              variance)
+  ScalarType              variance) -> DisplacementFieldPointer
 {
   if (variance <= 0.0)
   {

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -155,10 +155,10 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 }
 
 template <typename TTimeVaryingVelocityField, typename TDisplacementField>
-typename TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>::VectorType
+auto
 TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>::IntegrateVelocityAtPoint(
   const PointType &                    initialSpatialPoint,
-  const TimeVaryingVelocityFieldType * inputField)
+  const TimeVaryingVelocityFieldType * inputField) -> VectorType
 {
   // Solve the initial value problem using fourth-order Runge-Kutta
   //    y' = f(t, y), y(t_0) = y_0

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -235,9 +235,9 @@ VelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParametersFrom
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename VelocityFieldTransform<TParametersValueType, VDimension>::DisplacementFieldType::Pointer
+auto
 VelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
-  const DisplacementFieldType * toCopy) const
+  const DisplacementFieldType * toCopy) const -> typename DisplacementFieldType::Pointer
 {
   auto rval = DisplacementFieldType::New();
   rval->SetOrigin(toCopy->GetOrigin());

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -46,9 +46,9 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Dani
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::DataObjectPointer
+auto
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::MakeOutput(
-  DataObjectPointerArraySizeType idx)
+  DataObjectPointerArraySizeType idx) -> DataObjectPointer
 {
   if (idx == 1)
   {

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -52,9 +52,9 @@ SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>
 
 /** This is overloaded to create the VectorDistanceMap output image */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::DataObjectPointer
+auto
 SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::MakeOutput(
-  DataObjectPointerArraySizeType idx)
+  DataObjectPointerArraySizeType idx) -> DataObjectPointer
 {
   if (idx == 1)
   {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
@@ -52,9 +52,9 @@ FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>:
 
 
 template <typename TInput, typename TOutput, typename TAuxValue, unsigned int VAuxDimension>
-typename FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>::AuxImageType *
+auto
 FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>::GetAuxiliaryImage(
-  const unsigned int idx)
+  const unsigned int idx) -> AuxImageType *
 {
   if (idx >= AuxDimension || this->GetNumberOfIndexedOutputs() < idx + 2)
   {

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -135,9 +135,10 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::OutputImagePixelType
+auto
 CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ComputeCannyEdge(const NeighborhoodType & it,
                                                                            void * itkNotUsed(globalData))
+  -> OutputImagePixelType
 {
 
   NeighborhoodInnerProduct<OutputImageType> innerProduct;

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -74,9 +74,9 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
 
 
 template <typename TInputImage, typename THessianImage, typename TOutputImage>
-typename MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::DataObjectPointer
+auto
 MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::MakeOutput(
-  DataObjectPointerArraySizeType idx)
+  DataObjectPointerArraySizeType idx) -> DataObjectPointer
 {
   if (idx == 1)
   {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -146,9 +146,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const 
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & idx) const
+  const ContinuousIndexType & idx) const -> OutputType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -266,9 +266,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTy
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::GradientType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtParametricPoint(
-  const PointType & point) const
+  const PointType & point) const -> GradientType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -294,9 +294,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtInde
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::GradientType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtContinuousIndex(
-  const ContinuousIndexType & idx) const
+  const ContinuousIndexType & idx) const -> GradientType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -430,10 +430,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradient(const
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::HessianComponentType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtParametricPoint(
   const PointType &  point,
-  const unsigned int component) const
+  const unsigned int component) const -> HessianComponentType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -445,9 +445,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtParam
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::HessianComponentType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtIndex(const IndexType &  idx,
                                                                                  const unsigned int component) const
+  -> HessianComponentType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -459,10 +460,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtIndex
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::HessianComponentType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtContinuousIndex(
   const ContinuousIndexType & idx,
-  const unsigned int          component) const
+  const unsigned int          component) const -> HessianComponentType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -474,9 +475,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtConti
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::HessianComponentType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessian(const PointType &  params,
                                                                           const unsigned int component) const
+  -> HessianComponentType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -1091,9 +1091,9 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetPhiL
 }
 
 template <typename TInputPointSet, typename TOutputImage>
-typename BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::IndexType
+auto
 BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::NumberToIndex(const unsigned int number,
-                                                                                       const SizeType     size)
+                                                                                       const SizeType size) -> IndexType
 {
   IndexType k;
   k[0] = 1;

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -64,11 +64,11 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GenerateBSplineSha
 }
 
 template <unsigned int VSplineOrder, typename TRealValueType>
-typename CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PolynomialType
+auto
 CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::CoxDeBoor(const unsigned short order,
                                                                         const VectorType     knots,
                                                                         const unsigned int   whichBasisFunction,
-                                                                        const unsigned int   whichPiece)
+                                                                        const unsigned int whichPiece) -> PolynomialType
 {
   VectorType           tmp(2);
   PolynomialType       poly1(TRealValueType{ 0.0 });

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
@@ -89,8 +89,8 @@ private:
 
 
 template <typename TInput, typename TOutput>
-inline typename Clamp<TInput, TOutput>::OutputType
-Clamp<TInput, TOutput>::operator()(const InputType & A) const
+inline auto
+Clamp<TInput, TOutput>::operator()(const InputType & A) const -> OutputType
 {
   const auto dA = static_cast<double>(A);
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
@@ -29,10 +29,10 @@ BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::BasicDilateImageFilt
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-typename BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::PixelType
+auto
 BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const NeighborhoodIteratorType & nit,
                                                                      const KernelIteratorType         kernelBegin,
-                                                                     const KernelIteratorType         kernelEnd)
+                                                                     const KernelIteratorType kernelEnd) -> PixelType
 {
   unsigned int i;
   PixelType    max = NumericTraits<PixelType>::NonpositiveMin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
@@ -29,10 +29,10 @@ BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::BasicErodeImageFilter
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-typename BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::PixelType
+auto
 BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const NeighborhoodIteratorType & nit,
                                                                     const KernelIteratorType         kernelBegin,
-                                                                    const KernelIteratorType         kernelEnd)
+                                                                    const KernelIteratorType kernelEnd) -> PixelType
 {
   unsigned int i;
   PixelType    min = NumericTraits<PixelType>::max();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
@@ -29,10 +29,11 @@ GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::Grayscal
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-typename GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::PixelType
+auto
 GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const NeighborhoodIteratorType & nit,
                                                                                  const KernelIteratorType kernelBegin,
                                                                                  const KernelIteratorType kernelEnd)
+  -> PixelType
 {
   unsigned int i;
   PixelType    max = NumericTraits<PixelType>::NonpositiveMin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
@@ -29,10 +29,11 @@ GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::Grayscale
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-typename GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::PixelType
+auto
 GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const NeighborhoodIteratorType & nit,
                                                                                 const KernelIteratorType kernelBegin,
                                                                                 const KernelIteratorType kernelEnd)
+  -> PixelType
 {
   unsigned int i;
   PixelType    min = NumericTraits<PixelType>::max();

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -394,11 +394,11 @@ ContourExtractor2DImageFilter<TInputImage>::GenerateDataForLabels()
 
 
 template <typename TInputImage>
-inline typename ContourExtractor2DImageFilter<TInputImage>::VertexType
+inline auto
 ContourExtractor2DImageFilter<TInputImage>::InterpolateContourPosition(InputPixelType  fromValue,
                                                                        InputPixelType  toValue,
                                                                        InputIndexType  fromIndex,
-                                                                       InputOffsetType toOffset)
+                                                                       InputOffsetType toOffset) -> VertexType
 {
   // Now calculate the fraction of the way from 'from' to 'to' that the contour
   // crosses. Interpolate linearly: y = v0 + (v1 - v0) * x, and solve for the

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -100,31 +100,31 @@ HilbertPath<TIndexValue, VDimension>::TransformMultiDimensionalIndexToPathIndex(
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetTransform(const PathIndexType entry,
                                                    const PathIndexType direction,
                                                    const PathIndexType width,
-                                                   const PathIndexType x)
+                                                   const PathIndexType x) -> PathIndexType
 {
   return (this->GetRightBitRotation(x ^ entry, direction + 1, width));
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetInverseTransform(const PathIndexType entry,
                                                           const PathIndexType direction,
                                                           const PathIndexType width,
-                                                          const PathIndexType x)
+                                                          const PathIndexType x) -> PathIndexType
 {
   return (this->GetLeftBitRotation(x, direction + 1, width) ^ entry);
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetBitRange(const PathIndexType x,
                                                   const PathIndexType width,
                                                   const PathIndexType start,
-                                                  const PathIndexType end)
+                                                  const PathIndexType end) -> PathIndexType
 {
   return (x >> (width - end) & ((1 << (end - start)) - 1));
 }
@@ -146,11 +146,11 @@ HilbertPath<TIndexValue, VDimension>::GetRightBitRotation(PathIndexType x, PathI
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::SetBit(const PathIndexType x,
                                              const PathIndexType width,
                                              const PathIndexType i,
-                                             const PathIndexType b)
+                                             const PathIndexType b) -> PathIndexType
 {
   if (b != 0)
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -41,9 +41,9 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
 }
 
 template <typename TInputMesh, typename TOutputMesh, typename TSolverTraits>
-typename LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::OutputCoordRepType
+auto
 LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::ComputeMixedAreaForGivenVertex(
-  OutputPointIdentifier iId)
+  OutputPointIdentifier iId) -> OutputCoordRepType
 {
   OutputMeshType * output = this->GetOutput();
   OutputQEPrimal * qe = output->FindEdge(iId);
@@ -64,9 +64,10 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
 }
 
 template <typename TInputMesh, typename TOutputMesh, typename TSolverTraits>
-typename LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::OutputCoordRepType
+auto
 LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::ComputeMixedArea(OutputQEPrimal * iQE1,
                                                                                                  OutputQEPrimal * iQE2)
+  -> OutputCoordRepType
 {
   if (iQE1->IsLeftSet())
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -89,9 +89,10 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeAllVertexNormals()
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::OutputVertexNormalType
+auto
 NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeVertexNormal(const OutputPointIdentifier & iId,
                                                                        OutputMeshType *              outputMesh)
+  -> OutputVertexNormalType
 {
 
   OutputQEType *       edge = outputMesh->FindEdge(iId);
@@ -117,10 +118,11 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeVertexNormal(const Out
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::OutputVertexNormalComponentType
+auto
 NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdentifier & iPId,
                                                           const OutputCellIdentifier &  iCId,
                                                           OutputMeshType *              outputMesh)
+  -> OutputVertexNormalComponentType
 {
   if (m_Weight == WeightEnum::GOURAUD)
   {

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
@@ -167,11 +167,12 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::GenerateData()
 }
 
 template <typename THistogram, typename TOutput>
-typename RenyiEntropyThresholdCalculator<THistogram, TOutput>::InstanceIdentifier
+auto
 RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding(const HistogramType *       histogram,
                                                                              const std::vector<double> & normHisto,
                                                                              const std::vector<double> & P1,
                                                                              const std::vector<double> & P2)
+  -> InstanceIdentifier
 {
 
   // Calculate the total entropy each gray-level and fin the threshold that
@@ -220,12 +221,12 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding(con
 }
 
 template <typename THistogram, typename TOutput>
-typename RenyiEntropyThresholdCalculator<THistogram, TOutput>::InstanceIdentifier
+auto
 RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding2(
   const HistogramType *       itkNotUsed(histogram),
   const std::vector<double> & normHisto,
   const std::vector<double> & P1,
-  const std::vector<double> & P2)
+  const std::vector<double> & P2) -> InstanceIdentifier
 {
 
   InstanceIdentifier threshold =
@@ -270,12 +271,12 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding2(
 }
 
 template <typename THistogram, typename TOutput>
-typename RenyiEntropyThresholdCalculator<THistogram, TOutput>::InstanceIdentifier
+auto
 RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding3(
   const HistogramType *       itkNotUsed(histogram),
   const std::vector<double> & normHisto,
   const std::vector<double> & P1,
-  const std::vector<double> & P2)
+  const std::vector<double> & P2) -> InstanceIdentifier
 {
   InstanceIdentifier threshold =
     0; // was MIN_INT in original code, but if an empty image is processed it gives an error later on.

--- a/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
+++ b/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
@@ -103,8 +103,9 @@ ITK_GCC_PRAGMA_DIAG_POP()
 } // namespace
 
 template <typename TParametersValueType>
-typename CompositeTransformIOHelperTemplate<TParametersValueType>::ConstTransformListType &
+auto
 CompositeTransformIOHelperTemplate<TParametersValueType>::GetTransformList(const TransformType * transform)
+  -> ConstTransformListType &
 {
   this->m_TransformList.clear();
 

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -160,8 +160,8 @@ HDF5TransformIOTemplate<TParametersValueType>::WriteFixedParameters(const std::s
 
 /** read a parameter array from the location specified by name */
 template <typename TParametersValueType>
-typename HDF5TransformIOTemplate<TParametersValueType>::ParametersType
-HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string & DataSetName) const
+auto
+HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string & DataSetName) const -> ParametersType
 {
 
   H5::DataSet       paramSet = this->m_H5File->openDataSet(DataSetName);
@@ -206,8 +206,9 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string 
 
 /** read a parameter array from the location specified by name */
 template <typename TParametersValueType>
-typename HDF5TransformIOTemplate<TParametersValueType>::FixedParametersType
+auto
 HDF5TransformIOTemplate<TParametersValueType>::ReadFixedParameters(const std::string & DataSetName) const
+  -> FixedParametersType
 {
 
   H5::DataSet paramSet = this->m_H5File->openDataSet(DataSetName);

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
@@ -78,9 +78,9 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-typename ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::OutputType
+auto
 ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & x) const
+  const ContinuousIndexType & x) const -> OutputType
 {
   typename InterpolatorType::OutputType realPart = m_RealInterpolator->EvaluateAtContinuousIndex(x);
   typename InterpolatorType::OutputType imagPart = m_ImaginaryInterpolator->EvaluateAtContinuousIndex(x);

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -191,9 +191,9 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const Po
 
 /** Evaluate the function at specified ContinuousIndex position.*/
 template <typename TInputImage, typename TOutput>
-typename DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -225,9 +225,9 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::Evaluate(c
 
 /** Evaluate the function at specified ContinuousIndex position.*/
 template <typename TInputImage, typename TOutput>
-typename DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -222,9 +222,9 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::Evaluate(const Point
 
 /** Evaluate the function at specified ContinuousIndex position.*/
 template <typename TInputImage, typename TOutput>
-typename DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & cindex) const
+  const ContinuousIndexType & cindex) const -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -164,10 +164,10 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeGlobalTimeSte
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ScalarValueType
+auto
 RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeCurvature(const NeighborhoodType & itkNotUsed(it),
                                                                              const FloatOffsetType & itkNotUsed(offset),
-                                                                             GlobalDataStruct *      gd)
+                                                                             GlobalDataStruct * gd) -> ScalarValueType
 {
   // Calculate the mean curvature
   ScalarValueType curvature{};
@@ -240,10 +240,10 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeHessian(const
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::PixelType
+auto
 RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const NeighborhoodType & it,
                                                                           void *                   globalData,
-                                                                          const FloatOffsetType &  offset)
+                                                                          const FloatOffsetType &  offset) -> PixelType
 {
   // Access the neighborhood center pixel of phi
   const ScalarValueType inputValue = it.GetCenterPixel();
@@ -354,10 +354,10 @@ of Heaviside and dirac delta for each part of the fidelity term.
 - the final dH is the dirac delta term corresponding to the current
 level set we are updating. */
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ScalarValueType
+auto
 RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeGlobalTerm(
   const ScalarValueType & itkNotUsed(inputPixel),
-  const InputIndexType &  inputIndex)
+  const InputIndexType &  inputIndex) -> ScalarValueType
 {
   // computes if it belongs to background
   ScalarValueType product = 1;

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
@@ -144,10 +144,10 @@ ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Comp
 }
 
 template <typename TInputImage, typename TFeatureImage, typename TSharedData>
-typename ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ScalarValueType
+auto
 ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ComputeInternalTerm(
   const FeaturePixelType & iValue,
-  const FeatureIndexType & itkNotUsed(iIdx))
+  const FeatureIndexType & itkNotUsed(iIdx)) -> ScalarValueType
 {
   const unsigned int    fId = this->m_FunctionId;
   const ScalarValueType cVals = this->m_SharedData->m_LevelSetDataPointerVector[fId]->m_ForegroundConstantValues;
@@ -157,10 +157,10 @@ ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Comp
 }
 
 template <typename TInputImage, typename TFeatureImage, typename TSharedData>
-typename ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ScalarValueType
+auto
 ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ComputeExternalTerm(
   const FeaturePixelType & iValue,
-  const FeatureIndexType & itkNotUsed(iIdx))
+  const FeatureIndexType & itkNotUsed(iIdx)) -> ScalarValueType
 {
   const unsigned int    fId = this->m_FunctionId;
   const ScalarValueType cBgrnd =

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
@@ -23,10 +23,10 @@ namespace itk
 {
 
 template <typename TInputImage, typename TFeatureImage, typename TSharedData>
-typename ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ScalarValueType
+auto
 ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::ComputeOverlapParameters(
   const FeatureIndexType & globalIndex,
-  ScalarValueType &        product)
+  ScalarValueType &        product) -> ScalarValueType
 {
   // This conditional statement computes the amount of overlap s
   // and the presence of background pr

--- a/Modules/Numerics/FEM/include/itkFEMPArray.h
+++ b/Modules/Numerics/FEM/include/itkFEMPArray.h
@@ -104,8 +104,8 @@ public:
  * Find function for for non-const objects
  */
 template <typename T>
-typename FEMPArray<T>::ClassTypePointer
-FEMPArray<T>::Find(int gn)
+auto
+FEMPArray<T>::Find(int gn) -> ClassTypePointer
 {
   auto it = this->begin();
   auto iend = this->end();
@@ -136,8 +136,8 @@ FEMPArray<T>::Find(int gn)
  * Find function for for const objects
  */
 template <typename T>
-typename FEMPArray<T>::ClassTypeConstPointer
-FEMPArray<T>::Find(int gn) const
+auto
+FEMPArray<T>::Find(int gn) const -> ClassTypeConstPointer
 {
   using ConstIterator = typename Superclass::const_iterator;
 

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
@@ -122,24 +122,24 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::ResumeOptimization()
 
 // LBFGS method
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
+auto
 LBFGS2Optimizerv4Template<TInternalComputationValueType>::EvaluateCostCallback(
   void *                                                                          instance,
   const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType * x,
   LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType *       g,
   const int                                                                       n,
-  const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType   step)
+  const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType   step) -> PrecisionType
 {
   auto * optimizer = static_cast<LBFGS2Optimizerv4Template *>(instance);
   return optimizer->EvaluateCost(x, g, n, step);
 }
 template <typename TInternalComputationValueType>
-typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType
+auto
 LBFGS2Optimizerv4Template<TInternalComputationValueType>::EvaluateCost(
   const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType * x,
   LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType *       g,
   const int                                                                       n,
-  const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType)
+  const LBFGS2Optimizerv4Template<TInternalComputationValueType>::PrecisionType) -> PrecisionType
 {
   ParametersType xItk(n);
   // TODO: potentially not thread safe since x is modified by lbfgs

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -46,10 +46,10 @@ GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::InternalClone() const
 }
 
 template <typename TSample, typename TRegion>
-typename GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::RandomIntType
+auto
 GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::GetIntegerVariate(RandomIntType lowerBound,
                                                                              RandomIntType upperBound,
-                                                                             RandomIntType mean)
+                                                                             RandomIntType mean) -> RandomIntType
 {
   if (upperBound < lowerBound)
   {

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
@@ -56,8 +56,7 @@ ImageToListSampleAdaptor<TImage>::Size() const -> InstanceIdentifier
 }
 
 template <typename TImage>
-inline typename ImageToListSampleAdaptor<TImage>::AbsoluteFrequencyType ImageToListSampleAdaptor<TImage>::GetFrequency(
-  InstanceIdentifier) const
+inline auto ImageToListSampleAdaptor<TImage>::GetFrequency(InstanceIdentifier) const -> AbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
@@ -45,8 +45,7 @@ JointDomainImageToListSampleAdaptor<TImage>::Size() const -> InstanceIdentifier
 }
 
 template <typename TImage>
-inline typename JointDomainImageToListSampleAdaptor<TImage>::AbsoluteFrequencyType
-  JointDomainImageToListSampleAdaptor<TImage>::GetFrequency(InstanceIdentifier) const
+inline auto JointDomainImageToListSampleAdaptor<TImage>::GetFrequency(InstanceIdentifier) const -> AbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
@@ -113,12 +113,12 @@ KdTreeGenerator<TSample>::GenerateData()
 }
 
 template <typename TSample>
-inline typename KdTreeGenerator<TSample>::KdTreeNodeType *
+inline auto
 KdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginIndex,
                                                   unsigned int            endIndex,
                                                   MeasurementVectorType & lowerBound,
                                                   MeasurementVectorType & upperBound,
-                                                  unsigned int            level)
+                                                  unsigned int            level) -> KdTreeNodeType *
 {
   using NodeType = typename KdTreeType::KdTreeNodeType;
   MeasurementType dimensionLowerBound;
@@ -184,12 +184,12 @@ KdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginI
 }
 
 template <typename TSample>
-inline typename KdTreeGenerator<TSample>::KdTreeNodeType *
+inline auto
 KdTreeGenerator<TSample>::GenerateTreeLoop(unsigned int            beginIndex,
                                            unsigned int            endIndex,
                                            MeasurementVectorType & lowerBound,
                                            MeasurementVectorType & upperBound,
-                                           unsigned int            level)
+                                           unsigned int            level) -> KdTreeNodeType *
 {
   if (endIndex - beginIndex <= m_BucketSize)
   {

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
@@ -96,8 +96,7 @@ PointSetToListSampleAdaptor<TPointSet>::GetMeasurementVector(InstanceIdentifier 
 }
 
 template <typename TPointSet>
-inline typename PointSetToListSampleAdaptor<TPointSet>::AbsoluteFrequencyType
-  PointSetToListSampleAdaptor<TPointSet>::GetFrequency(InstanceIdentifier) const
+inline auto PointSetToListSampleAdaptor<TPointSet>::GetFrequency(InstanceIdentifier) const -> AbsoluteFrequencyType
 {
   if (m_PointSet.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -85,9 +85,9 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Scal
 }
 
 template <typename TImage, typename THistogramFrequencyContainer>
-typename ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::DataObjectPointer
+auto
 ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::MakeOutput(
-  DataObjectPointerArraySizeType itkNotUsed(idx))
+  DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return FeatureValueVectorDataObjectType::New().GetPointer();
 }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -112,9 +112,9 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
 }
 
 template <typename TImageType, typename THistogramFrequencyContainer>
-typename ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::DataObjectPointer
+auto
 ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::MakeOutput(
-  DataObjectPointerArraySizeType itkNotUsed(idx))
+  DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return HistogramType::New().GetPointer();
 }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -85,9 +85,9 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
 }
 
 template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
-typename ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::DataObjectPointer
+auto
 ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::MakeOutput(
-  DataObjectPointerArraySizeType itkNotUsed(idx))
+  DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return FeatureValueVectorDataObjectType::New().GetPointer();
 }

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -173,10 +173,11 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
 } // end Search method
 
 template <typename TSample, typename TRegion>
-typename UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::RandomIntType
+auto
 UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::GetIntegerVariate(RandomIntType lowerBound,
                                                                             RandomIntType upperBound,
                                                                             RandomIntType itkNotUsed(mean))
+  -> RandomIntType
 {
   RandomIntType sizeRange = upperBound - lowerBound;
   // mean ignored since we are uniformly sampling

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -63,8 +63,8 @@ VectorContainerToListSampleAdaptor<TVectorContainer>::GetMeasurementVector(Insta
 }
 
 template <typename TVectorContainer>
-inline typename VectorContainerToListSampleAdaptor<TVectorContainer>::AbsoluteFrequencyType
-  VectorContainerToListSampleAdaptor<TVectorContainer>::GetFrequency(InstanceIdentifier) const
+inline auto VectorContainerToListSampleAdaptor<TVectorContainer>::GetFrequency(InstanceIdentifier) const
+  -> AbsoluteFrequencyType
 {
   if (this->m_VectorContainer.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
@@ -32,12 +32,12 @@ WeightedCentroidKdTreeGenerator<TSample>::PrintSelf(std::ostream & os, Indent in
 }
 
 template <typename TSample>
-inline typename WeightedCentroidKdTreeGenerator<TSample>::KdTreeNodeType *
+inline auto
 WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginIndex,
                                                                   unsigned int            endIndex,
                                                                   MeasurementVectorType & lowerBound,
                                                                   MeasurementVectorType & upperBound,
-                                                                  unsigned int            level)
+                                                                  unsigned int            level) -> KdTreeNodeType *
 {
   MeasurementType dimensionLowerBound;
   MeasurementType dimensionUpperBound;

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
@@ -22,9 +22,9 @@
 namespace itk
 {
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
-  HistogramType & histogram) const
+  HistogramType & histogram) const -> MeasureType
 {
   const MeasureType varianceX = this->VarianceX(histogram);
   const MeasureType varianceY = this->VarianceY(histogram);
@@ -104,9 +104,9 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Va
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Covariance(
-  HistogramType & histogram) const
+  HistogramType & histogram) const -> MeasureType
 {
   MeasureType var{};
   MeasureType meanX = MeanX(histogram);

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -43,9 +43,9 @@ EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::Get
 }
 
 template <typename TFixedPointSet, typename TMovingPointSet, typename TDistanceMap>
-typename EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::MeasureType
+auto
 EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
 

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -287,10 +287,10 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   const TransformParametersType & parameters,
-  const double *                  subtractionFactor) const
+  const double *                  subtractionFactor) const -> MeasureType
 {
   unsigned int iDimension;
 
@@ -347,9 +347,9 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   unsigned int iFilter; // Index of Sobel filters for
                         // each dimension

--- a/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
@@ -41,9 +41,9 @@ KullbackLeiblerCompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::In
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename KullbackLeiblerCompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 KullbackLeiblerCompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
-  HistogramType & histogram) const
+  HistogramType & histogram) const -> MeasureType
 {
   // Two terms.
   // First the term that measures the entropy of the term

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -767,9 +767,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initia
 }
 
 template <typename TTransform, typename TFixedImage, typename TMovingImage>
-typename LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::PointType3D
+auto
 LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::ComputeCentroid(
-  const LandmarkPointContainer inputLandmarks)
+  const LandmarkPointContainer inputLandmarks) -> PointType3D
 {
   // Compute the centroids.
   PointType3D centroid;

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -32,17 +32,17 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MatchCardinalityI
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   return const_cast<Self *>(this)->GetNonconstValue(parameters);
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
-  const TransformParametersType & parameters)
+  const TransformParametersType & parameters) -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -43,9 +43,9 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Pri
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedImageConstPointer fixedImage = this->m_FixedImage;
 

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -31,9 +31,9 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet,
 }
 
 template <typename TFixedPointSet, typename TMovingImage>
-typename MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::MeasureType
+auto
 MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
 

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
@@ -91,11 +91,11 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::I
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   itkNotUsed(globalData),
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   // Get fixed image related information
   // Note: no need to check the index is within

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -26,9 +26,9 @@ namespace itk
  * Get the match Measure
  */
 template <typename TFixedPointSet, typename TMovingImage>
-typename MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::MeasureType
+auto
 MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
 

--- a/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
@@ -23,9 +23,9 @@
 namespace itk
 {
 template <typename TFixedImage, typename TMovingImage>
-typename MutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
-  HistogramType & histogram) const
+  HistogramType & histogram) const -> MeasureType
 {
   MeasureType entropyX{};
   MeasureType entropyY{};

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -30,9 +30,9 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::NormalizedCo
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedImageConstPointer fixedImage = this->m_FixedImage;
 

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -30,9 +30,9 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::Normal
 }
 
 template <typename TFixedPointSet, typename TMovingImage>
-typename NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::MeasureType
+auto
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
-  const TransformParametersType & parameters) const
+  const TransformParametersType & parameters) const -> MeasureType
 {
   FixedPointSetConstPointer fixedPointSet = this->GetFixedPointSet();
 

--- a/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
@@ -23,9 +23,9 @@
 namespace itk
 {
 template <typename TFixedImage, typename TMovingImage>
-typename NormalizedMutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 NormalizedMutualInformationHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(
-  HistogramType & histogram) const
+  HistogramType & histogram) const -> MeasureType
 {
   MeasureType entropyX{};
   MeasureType entropyY{};

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -995,9 +995,9 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::SmoothDisplacement
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
-typename FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::FieldPointer
+auto
 FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ExpandVectorField(ExpandFactorsType * expandFactors,
-                                                                                FieldType *         field)
+                                                                                FieldType * field) -> FieldPointer
 {
   // Re-size the vector field
   if (!field)

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -82,11 +82,11 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Initializ
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   itkNotUsed(globalData),
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   // We compute the derivative of MI w.r.t. the infinitesimal
   // displacement, following Viola and Wells.

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
@@ -75,11 +75,11 @@ NCCRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Initiali
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename NCCRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 NCCRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   itkNotUsed(globalData),
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   const IndexType oindex = it.GetIndex();
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -282,11 +282,11 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   // Get fixed image related information
   // Note: no need to check the index is within

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -141,11 +141,11 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Initi
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   // Get fixed image related information
   // Note: no need to check the index is within

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -165,11 +165,11 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::In
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   auto *    globalData = (GlobalDataStruct *)gd;
   PixelType update;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -145,11 +145,11 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   auto *          globalData = (GlobalDataStruct *)gd;
   const IndexType FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -199,11 +199,11 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   const IndexType index = it.GetIndex();
 
@@ -354,9 +354,9 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::TimeStepType
+auto
 LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeGlobalTimeStep(
-  void * GlobalData) const
+  void * GlobalData) const -> TimeStepType
 {
   TimeStepType dt = 1.0;
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -133,11 +133,11 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
+auto
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUpdate(
   const NeighborhoodType & it,
   void *                   gd,
-  const FloatOffsetType &  itkNotUsed(offset))
+  const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   auto *          globalData = (GlobalDataStruct *)gd;
   const IndexType FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -553,9 +553,10 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::L_Func(const double r,
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::PointType
+auto
 DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeBarycentricCoordinates(PointType             p,
                                                                                       SimplexMeshGeometry * data)
+  -> PointType
 {
   const PointType a = data->neighbors[0];
   const PointType b = data->neighbors[1];

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -23,10 +23,10 @@
 namespace itk
 {
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::ScalarValueType
+auto
 LevelSetFunction<TImageType>::ComputeCurvatureTerm(const NeighborhoodType & neighborhood,
                                                    const FloatOffsetType &  offset,
-                                                   GlobalDataStruct *       gd)
+                                                   GlobalDataStruct *       gd) -> ScalarValueType
 {
   if (m_UseMinimalCurvature == false)
   {
@@ -50,10 +50,10 @@ LevelSetFunction<TImageType>::ComputeCurvatureTerm(const NeighborhoodType & neig
 }
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::ScalarValueType
+auto
 LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & itkNotUsed(neighborhood),
                                                       const FloatOffsetType &  itkNotUsed(offset),
-                                                      GlobalDataStruct *       gd)
+                                                      GlobalDataStruct *       gd) -> ScalarValueType
 {
   unsigned int          i, j, n;
   ScalarValueType       gradMag = std::sqrt(gd->m_GradMagSqr);
@@ -119,10 +119,10 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
 }
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::ScalarValueType
+auto
 LevelSetFunction<TImageType>::Compute3DMinimalCurvature(const NeighborhoodType & neighborhood,
                                                         const FloatOffsetType &  offset,
-                                                        GlobalDataStruct *       gd)
+                                                        GlobalDataStruct *       gd) -> ScalarValueType
 {
   ScalarValueType mean_curve = this->ComputeMeanCurvature(neighborhood, offset, gd);
 
@@ -148,10 +148,10 @@ LevelSetFunction<TImageType>::Compute3DMinimalCurvature(const NeighborhoodType &
 }
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::ScalarValueType
+auto
 LevelSetFunction<TImageType>::ComputeMeanCurvature(const NeighborhoodType & itkNotUsed(neighborhood),
                                                    const FloatOffsetType &  itkNotUsed(offset),
-                                                   GlobalDataStruct *       gd)
+                                                   GlobalDataStruct *       gd) -> ScalarValueType
 {
   // Calculate the mean curvature
   ScalarValueType curvature_term{};
@@ -280,10 +280,10 @@ LevelSetFunction<TImageType>::Initialize(const RadiusType & r)
 }
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::PixelType
+auto
 LevelSetFunction<TImageType>::ComputeUpdate(const NeighborhoodType & it,
                                             void *                   globalData,
-                                            const FloatOffsetType &  offset)
+                                            const FloatOffsetType &  offset) -> PixelType
 {
   unsigned int          i, j;
   const ScalarValueType ZERO{};

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -67,9 +67,9 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeGlobalTimeSt
 }
 
 template <typename TImageType, typename TSparseImageType>
-typename LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ScalarValueType
+auto
 LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
-  const NeighborhoodType & neighborhood) const
+  const NeighborhoodType & neighborhood) const -> ScalarValueType
 {
   unsigned int              j, k;
   unsigned int              counterN, counterP;
@@ -147,10 +147,11 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
 }
 
 template <typename TImageType, typename TSparseImageType>
-typename LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ScalarValueType
+auto
 LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::PropagationSpeed(const NeighborhoodType & neighborhood,
                                                                               const FloatOffsetType &  offset,
                                                                               GlobalDataStruct *       globaldata) const
+  -> ScalarValueType
 {
   IndexType       idx = neighborhood.GetIndex();
   NodeType *      targetnode = m_SparseTargetImage->GetPixel(idx);

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -171,10 +171,10 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
 }
 
 template <typename TSparseImageType>
-typename NormalVectorDiffusionFunction<TSparseImageType>::NormalVectorType
+auto
 NormalVectorDiffusionFunction<TSparseImageType>::ComputeSparseUpdate(NeighborhoodType & it,
                                                                      void *,
-                                                                     const FloatOffsetType &) const
+                                                                     const FloatOffsetType &) const -> NormalVectorType
 {
   unsigned int           i;
   NormalVectorType       change;

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
@@ -75,10 +75,11 @@ SegmentationLevelSetFunction<TImageType, TFeatureImageType>::AllocateAdvectionIm
 }
 
 template <typename TImageType, typename TFeatureImageType>
-typename SegmentationLevelSetFunction<TImageType, TFeatureImageType>::ScalarValueType
+auto
 SegmentationLevelSetFunction<TImageType, TFeatureImageType>::PropagationSpeed(const NeighborhoodType & neighborhood,
                                                                               const FloatOffsetType &  offset,
                                                                               GlobalDataStruct *) const
+  -> ScalarValueType
 {
   IndexType idx = neighborhood.GetIndex();
 
@@ -100,10 +101,10 @@ SegmentationLevelSetFunction<TImageType, TFeatureImageType>::PropagationSpeed(co
 }
 
 template <typename TImageType, typename TFeatureImageType>
-typename SegmentationLevelSetFunction<TImageType, TFeatureImageType>::VectorType
+auto
 SegmentationLevelSetFunction<TImageType, TFeatureImageType>::AdvectionField(const NeighborhoodType & neighborhood,
                                                                             const FloatOffsetType &  offset,
-                                                                            GlobalDataStruct *) const
+                                                                            GlobalDataStruct *) const -> VectorType
 {
   IndexType           idx = neighborhood.GetIndex();
   ContinuousIndexType cdx;

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
@@ -88,9 +88,9 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogInsideTerm(con
 }
 
 template <typename TFeatureImage, typename TOutputPixel>
-typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
+auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogShapePriorTerm(
-  const ParametersType & parameters) const
+  const ParametersType & parameters) const -> MeasureType
 {
   // assume the shape parameters is from an independent gaussian distributions
   MeasureType measure = 0.0;
@@ -137,9 +137,9 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogGradientTerm(c
 }
 
 template <typename TFeatureImage, typename TOutputPixel>
-typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
+auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogPosePriorTerm(
-  const ParametersType & itkNotUsed(parameters)) const
+  const ParametersType & itkNotUsed(parameters)) const -> MeasureType
 {
   return 0.0;
 }

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -44,11 +44,11 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PrintSelf
 }
 
 template <typename TImageType, typename TFeatureImageType>
-typename ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PixelType
+auto
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeUpdate(
   const NeighborhoodType & neighborhood,
   void *                   gd,
-  const FloatOffsetType &  offset)
+  const FloatOffsetType &  offset) -> PixelType
 {
   // Compute the generic level set update using superclass
   PixelType value = this->Superclass::ComputeUpdate(neighborhood, gd, offset);

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -80,9 +80,9 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::SetLevelSe
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ValueType
+auto
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCurvatureFromSparseImageNeighborhood(
-  SparseImageIteratorType & it) const
+  SparseImageIteratorType & it) const -> ValueType
 {
   unsigned int            counter;
   SizeValueType           position, stride[ImageDimension], indicator[ImageDimension];

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
@@ -39,9 +39,9 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GetDomainMap() const ->
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::InputImageRegionType
+auto
 LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::ComputeConsistentRegion(
-  const InputImageRegionType & inputRegion) const
+  const InputImageRegionType & inputRegion) const -> InputImageRegionType
 {
   bool regionWasModified = false;
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -173,9 +173,10 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & iP,
                                                                  const LevelSetDataType &       iData)
+  -> LevelSetOutputRealType
 {
   VectorType             advectionField = this->AdvectionSpeed(iP);
   LevelSetOutputRealType oValue{};

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -76,9 +76,10 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSet
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index,
                                                                   const LevelSetDataType &       itkNotUsed(data))
+  -> LevelSetOutputRealType
 {
   const InputPixelType   pixel = this->m_Mask->GetPixel(index);
   LevelSetOutputRealType value;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
@@ -140,9 +140,10 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & inputIndex,
                                                                            const LevelSetDataType &       data)
+  -> LevelSetOutputRealType
 {
   if (this->m_Heaviside.IsNotNull())
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -45,9 +45,10 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::SetC
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
-typename LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::LevelSetOutputRealType
+auto
 LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Value(const LevelSetInputIndexType & iP,
                                                                                   const LevelSetDataType &       iData)
+  -> LevelSetOutputRealType
 {
   // MeanCurvature has should be computed by this point.
   itkAssertInDebugAndIgnoreInReleaseMacro(iData.MeanCurvature.m_Computed == true);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -55,9 +55,9 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::UpdatePixel(
 {}
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LaplacianSpeed(
-  const LevelSetInputIndexType & itkNotUsed(iP)) const
+  const LevelSetInputIndexType & itkNotUsed(iP)) const -> LevelSetOutputRealType
 {
   return NumericTraits<LevelSetOutputRealType>::OneValue();
 }
@@ -75,9 +75,10 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & iP,
                                                                  const LevelSetDataType &       iData)
+  -> LevelSetOutputRealType
 {
   // Laplacian should be computed by this point.
   itkAssertInDebugAndIgnoreInReleaseMacro(iData.Laplacian.m_Computed == true);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -70,9 +70,10 @@ LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Value(const Leve
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index,
                                                                       const LevelSetDataType &       itkNotUsed(data))
+  -> LevelSetOutputRealType
 {
   LevelSetOutputRealType value{};
   this->ComputeSumTerm(index, value);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -68,9 +68,9 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
 {}
 
 template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-typename LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::LevelSetOutputRealType
+auto
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::PropagationSpeed(
-  const LevelSetInputIndexType & iP) const
+  const LevelSetInputIndexType & iP) const -> LevelSetOutputRealType
 {
   return (static_cast<LevelSetOutputRealType>(this->m_PropagationImage->GetPixel(iP)));
 }
@@ -106,9 +106,10 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-typename LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::LevelSetOutputRealType
+auto
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::Value(const LevelSetInputIndexType & iP,
                                                                                       const LevelSetDataType & iData)
+  -> LevelSetOutputRealType
 {
   const LevelSetOutputRealType zero{};
   LevelSetOutputRealType       propagation_gradient = zero;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -79,9 +79,10 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelS
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelSetInputIndexType & iP,
                                                                     const LevelSetDataType &       iData)
+  -> LevelSetOutputRealType
 {
   if (itk::Math::abs(this->m_Coefficient) > NumericTraits<LevelSetOutputRealType>::epsilon())
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -290,9 +290,10 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Evaluate(const L
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Evaluate(const LevelSetInputIndexType & iP,
                                                                          const LevelSetDataType &       iData)
+  -> LevelSetOutputRealType
 {
   auto term_it = m_Container.begin();
   auto term_end = m_Container.end();

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -708,9 +708,9 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::AfterThreadedGenerat
 
 
 template <typename TInputImage, typename TOutputImage, typename TDistancePixel>
-typename SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::DistanceType
+auto
 SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::Distance(const ClusterType & cluster1,
-                                                                     const ClusterType & cluster2)
+                                                                     const ClusterType & cluster2) -> DistanceType
 {
   const unsigned int s = cluster1.size();
   DistanceType       d1 = 0.0;
@@ -732,10 +732,10 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::Distance(const Clust
 }
 
 template <typename TInputImage, typename TOutputImage, typename TDistancePixel>
-typename SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::DistanceType
+auto
 SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::Distance(const ClusterType &    cluster,
                                                                      const InputPixelType & _v,
-                                                                     const PointType &      pt)
+                                                                     const PointType &      pt) -> DistanceType
 {
   const unsigned int                                                    s = cluster.size();
   DistanceType                                                          d1 = 0.0;


### PR DESCRIPTION
In accordance with ITKSoftwareGuide:
- https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/pull/162

Follow-up to:
- https://github.com/InsightSoftwareConsortium/ITK/pull/4026
- https://github.com/InsightSoftwareConsortium/ITK/pull/2780

----
Interesting... less code, but more _lines of code_ 😸 
