### PR TITLE
ENH: Drop support for MSVC toolset v141 aka Visual Studio 2017

### DIFF
--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -18,8 +18,8 @@ endif ()
 
 # Minimum compiler version check: Microsoft C/C++
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.14)
-  message(FATAL_ERROR "Microsoft Visual Studio 2017 15.7 (MSVC 19.14) or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.20)
+  message(FATAL_ERROR "Microsoft Visual Studio 2019 16.0 (MSVC 19.20) or later is required.")
 endif ()
 
 # Minimum compiler version check: Intel C++ (ICC)

--- a/Documentation/SupportedCompilers.md
+++ b/Documentation/SupportedCompilers.md
@@ -1,8 +1,7 @@
 ITK requires a compiler with C++17 support.
 
 # Visual Studio
-* VS2015 and earlier: **NOT supported**
-* MSVC toolset v141 (first shipped with VS2017): supported from VS2017 version 15.7
+* VS2017 and earlier: **NOT supported**
 * MSVC toolset v142 (first shipped with VS2019): supported
 * MSVC toolset v143 (first shipped with VS2022): supported
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -151,14 +151,11 @@ namespace itk
 #endif
 
 /*
- * ITK only supports MSVC++ 14.14 and greater
- * MSVC++ 14.14 _MSC_VER == 1914 (Visual Studio 2017 version 15.7)
- * MSVC++ 14.15 _MSC_VER == 1915 (Visual Studio 2017 version 15.8)
- * MSVC++ 14.16 _MSC_VER == 1916 (Visual Studio 2017 version 15.9)
+ * ITK only supports MSVC++ 14.2 and greater
  * MSVC++ 14.2 _MSC_VER == 1920 (Visual Studio 2019 Version 16.0)
  */
-#if defined(_MSC_VER) && (_MSC_VER < 1914)
-#  error "MSVC version before Visual Studio 2017 version 15.7 is not supported under ITKv5.4"
+#if defined(_MSC_VER) && (_MSC_VER < 1920)
+#  error "MSVC versions before Visual Studio 2019 are not supported under ITKv5.4"
 #endif
 #if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5140)
 #  error "SUNPro C++ < 5.14.0 is not supported under ITKv5 and above"


### PR DESCRIPTION
Enabling C++17 broke VS2017 due to its numerous bugs. See discussion: https://discourse.itk.org/t/c-17-breaks-visual-studio-2017-drop-support/5884

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

