### PR TITLE
ENH: Update ContinuousIntegration Batch test to use VS2022

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       maxParallel: 2
       matrix:
-        v141:
-          CTEST_CMAKE_GENERATOR_TOOLSET: v141
+        v143:
+          CTEST_CMAKE_GENERATOR_TOOLSET: v143
           CTEST_CMAKE_GENERATOR_PLATFORM: x64
           CTEST_CONFIGURATION_TYPE: Release
-          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
-          imageName: 'windows-2019'
+          CTEST_CMAKE_GENERATOR: "Visual Studio 17 2022"
+          imageName: 'windows-2022'
         v142:
           CTEST_CMAKE_GENERATOR_TOOLSET: v142
           CTEST_CMAKE_GENERATOR_PLATFORM: x64


### PR DESCRIPTION
This is a follow-up to 140f3c249fbb20c4f4a1607e563e19ee9a9cbd78. Thanks to @issakomi for pointing out the oversight. As VS2017 has been broken for a month, this CI test not longer gets triggered.
