### PR TITLE
ENH: Add series_uid arg to imread() for dicom series selection

### DIFF
--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -63,6 +63,10 @@ if(ITK_WRAP_unsigned_char AND WRAP_2)
         ${ITK_TEST_OUTPUT_DIR}/extras-mushroom.vtk
         ${ITK_TEST_OUTPUT_DIR}
         ${ITK_TEST_OUTPUT_DIR}/LinearTransformWritten.h5
+        ${ExternalData_BINARY_ROOT}/Testing/Data/Input/DicomSeries
+      )
+    set_tests_properties( PythonExtrasTest PROPERTIES DEPENDS
+      PythonDICOMSeries
       )
     itk_python_add_test(NAME PythonXarrayTest
       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_xarray.py

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -163,6 +163,15 @@ except Exception as e:
 image = itk.imread(filename, imageio=itk.PNGImageIO.New())
 assert type(image) == itk.Image[itk.RGBPixel[itk.UC], 2]
 
+# imread using a dicom series
+image = itk.imread(sys.argv[8])
+image0 = itk.imread(sys.argv[8], series_uid=0)
+imageS = itk.imread(sys.argv[8], series_uid="1.2.840.113619.2.133.1762890640.1886.1055165015.999.31.625625620030625")
+assert itk.size(image) == itk.size(image0)
+assert itk.size(image) == itk.size(imageS)
+assert image[1,10,10] == image0[1,10,10]
+assert image[1,10,10] == imageS[1,10,10]
+
 # Test serialization with pickle
 array = np.random.randint(0, 256, (8, 12)).astype(np.uint8)
 image = itk.image_from_array(array)


### PR DESCRIPTION
Typical usage:

`img = itk.imread(filename="./my_dicom_dir", series_uid="1.2.3.456.789.101112.1314")`

If filename is a directory of DICOM files, and series_uid is a string, it will read the DICOM series that matches this series_uid name.  If series_uid is an integer, it will read the series_uid'th DICOM series in the directory (using python notation, e.g., -1 is the last DICOM series in the directory). If unspecified, it will read the first series in the directory.

This does represent a change in the default behavior in that it used to raise an exception if a DICOM directory with more than one series was passed to imread, and now it will read the first series in that directory.

Closes #4038 

## PR Checklist
- Extends API of imread() in wrapping/generators/python/itk/support/extras.py to have series_uid as an argument
- No major design changes
- Tests added to wrapping/generators/testing/extras.py
- Updated API documentation
