### PR TITLE
COMP: gcc-13 compatability

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include "ITKMathematicalMorphologyExport.h"
+#include <cstdint>
 
 
 namespace itk
@@ -38,7 +39,7 @@ public:
    * \brief Algorithm or implementation used in the dilation/erosion operations.
    * \ingroup ITKMathematicalMorphology
    */
-  enum class Algorithm : uint8_t
+  enum class Algorithm : std::uint8_t
   {
     BASIC = 0,
     HISTO = 1,


### PR DESCRIPTION
Using gcc-13 ITK does not compile as discussed in this form entry: (https://discourse.itk.org/t/building-itk-error-with-algorithim-module/5927/9). Was able to be fixed thanks to @dzenanz with the inclusion of  <cstdint> to itkMathematicalMorphologyEnums.h and specifying std::uint8_t on line 41.


