### PR TITLE
COMP: Workaround itkPyCommand KWStyle check "error: namespace is wrong"

### DIFF
--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
@@ -18,6 +18,9 @@
 
 #include "itkPyCommand.h"
 
+namespace itk
+{
+
 namespace
 {
 // Wrapper to automatics obtain and release GIL
@@ -32,9 +35,6 @@ private:
   PyGILState_STATE m_GIL;
 };
 } // end anonymous namespace
-
-namespace itk
-{
 
 PyCommand::PyCommand()
 {


### PR DESCRIPTION
Worked around the KWStyle check failure ("error: namespace is wrong"), by moving the unnamed namespace of itkPyCommand.cxx inside the `itk` namespace. Apparently, KWStyle expects the first opened namespace in an ITK source file to be named `itk`.

----
Note: From a C++ point of view I think it's entirely correct to have an unnamed namespace at the begin of an ITK cxx file (even before opening the `itk` namespace). So I think the KWStyle check failure is undeserved. But well, that's why it's just a workaround 😺 The KWStyle check appears implemented at https://github.com/Kitware/KWStyle/blob/1173206c0e7f4bc70dc3af641daf6e33f4042772/kwsCheckNamespace.cxx  