### PR TITLE
COMP: Disable KWStyle check "error: namespace is wrong" on *.cxx files

### DIFF
--- a/Utilities/KWStyle/ITKOverwrite.txt
+++ b/Utilities/KWStyle/ITKOverwrite.txt
@@ -1,3 +1,2 @@
-test/.*\.cxx Namespace Disable
-Examples/.*\.cxx Namespace Disable
+.*\.cxx Namespace Disable
 QuickView.h Namespace Disable


### PR DESCRIPTION
*.cxx files may have an unnamed namespace, instead of `namespace itk`, as their first namespace. For example Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx This would cause undeserved failures of the `Namespace` check of KWStyle.

----
Aims to supersede (i.e. replace) pull request #4047:
- #4047

Based on a comment from @thewtex at https://github.com/InsightSoftwareConsortium/ITK/pull/4047#issuecomment-1552084915