### PR TITLE
COMP: Rule of Zero, SFINAE for ImageBufferRange, ImageRegionRange iterators, update ShapedImageNeighborhoodRange documentation

### DIFF
--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -25,7 +25,7 @@
 #include <iterator>    // For bidirectional_iterator_tag.
 #include <functional>  // For multiplies.
 #include <numeric>     // For accumulate.
-#include <type_traits> // For conditional and is_const.
+#include <type_traits> // For conditional, enable_if, and is_const.
 
 #include "itkImageHelper.h"
 #include "itkImageRegion.h"
@@ -205,12 +205,15 @@ private:
      * the guarantee added to the C++14 Standard: "value-initialized iterators
      * may be compared and shall compare equal to other value-initialized
      * iterators of the same type."
+     *
+     * \note The other five "special member functions" are defaulted implicitly,
+     * following the C++ "Rule of Zero".
      */
     QualifiedIterator() = default;
 
-    /** Constructor that allows implicit conversion from non-const to const
-     * iterator. Also serves as copy-constructor of a non-const iterator.  */
-    QualifiedIterator(const QualifiedIterator<false> & arg) noexcept
+    /** Constructor for implicit conversion from non-const to const iterator.  */
+    template <bool VIsArgumentConst, typename = std::enable_if_t<VIsConst && !VIsArgumentConst>>
+    QualifiedIterator(const QualifiedIterator<VIsArgumentConst> & arg) noexcept
       : m_BufferIterator(arg.m_BufferIterator)
       ,
       // Note: Use parentheses instead of curly braces to initialize data members,
@@ -281,15 +284,6 @@ private:
       // Implemented just like the corresponding std::rel_ops operator.
       return !(lhs == rhs);
     }
-
-
-    /** Explicitly-defaulted assignment operator. */
-    QualifiedIterator &
-    operator=(const QualifiedIterator &) noexcept = default;
-
-
-    /** Explicitly-defaulted destructor. */
-    ~QualifiedIterator() = default;
   };
 
   // Inspired by, and originally copied from ImageBase::FastComputeOffset(ind)).

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -380,11 +380,9 @@ private:
      * the guarantee added to the C++14 Standard: "value-initialized iterators
      * may be compared and shall compare equal to other value-initialized
      * iterators of the same type."
-     * \note `QualifiedIterator<VIsConst>` follows the C++ "Rule of Zero" when
-     * VIsConst is true: The other five "special member functions" of the class
-     * are then implicitly defaulted. When VIsConst is false, its
-     * copy-constructor is provided explicitly, but it still behaves the same as
-     * a default implementation.
+     *
+     * \note The other five "special member functions" are defaulted implicitly,
+     * following the C++ "Rule of Zero".
      */
     QualifiedIterator() = default;
 


### PR DESCRIPTION
Used SFINAE (`enable_if`) to implement non-const to const conversion for the iterator types of `ImageBufferRange` and `ImageRegionRange`. Followed the Rule of Zero for those types.

Prevents potential clang warnings, as reported before (pull request #4049) by Bradley Lowekamp (@blowekamp):

> definition of implicit copy constructor for 'QualifiedIterator<true>'
> is deprecated because it has a user-declared copy assignment operator

Documented that the iterator types of `ShapedImageNeighborhoodRange` now unconditionally follow the Rule of Zero, and did the same for the iterator types of `ImageBufferRange` and `ImageRegionRange`.

Follow-up to pull request #4049 commit df6aa66e40c6e4ce91c05df95f5364f3558ab43a "COMP: QualifiedIterator follow rule of zero", merged on 19 May, 2023
