### PR TITLE
ENH: Increase coverage for `itk::ConstantVelocityFieldTransform`

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
+++ b/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
@@ -172,7 +172,10 @@ itk_add_test(NAME itkExponentialImageRegistrationTest
               ${TEMP}/itkExponentialImageRegistrationTestNew.nii.gz
               100 # number of affine iterations
               10 # number of deformable iterations
-              )
+              1
+              0.0
+              1.0
+              10)
 set_property(TEST itkExponentialImageRegistrationTest APPEND PROPERTY LABELS RUNS_LONG)
 
 itk_add_test(NAME itkBSplineExponentialImageRegistrationTest


### PR DESCRIPTION
Increase coverage for `itk::ConstantVelocityFieldTransform`:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Exercise other getter method by printing the output to the std output.

Add the values for the ivars of the filter as arguments to the test.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)