### PR TITLE
Remove initial `<<` insertion of the form `Macro(<< "`...`)` from itk macro calls

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
@@ -79,7 +79,7 @@ PostOrderTreeIterator<TTreeType>::PostOrderTreeIterator(TTreeType * tree)
     const auto * root = dynamic_cast<const TreeNodeType *>(tree->GetRoot());
     if (root == nullptr)
     {
-      itkGenericExceptionMacro(<< "Can't downcast root node to TreeNodeType *");
+      itkGenericExceptionMacro("Can't downcast root node to TreeNodeType *");
     }
     this->m_Position = const_cast<TreeNodeType *>(root);
     this->m_Position = const_cast<TreeNodeType *>(FindMostRightLeaf(this->m_Position));
@@ -138,7 +138,7 @@ PostOrderTreeIterator<TTreeType>::FindNextNode() const
   auto * rval = dynamic_cast<TreeNodeType *>(this->m_Position->GetParent());
   if (rval == nullptr)
   {
-    itkGenericExceptionMacro(<< "Can't downcast to TreeNodeType *");
+    itkGenericExceptionMacro("Can't downcast to TreeNodeType *");
   }
   return rval;
 }
@@ -156,7 +156,7 @@ PostOrderTreeIterator<TTreeType>::FindSister(TreeNodeType * node) const
   auto * parent = dynamic_cast<TreeNodeType *>(node->GetParent());
   if (parent == nullptr)
   {
-    itkGenericExceptionMacro(<< "Can't downcast to TreeNodeType *");
+    itkGenericExceptionMacro("Can't downcast to TreeNodeType *");
   }
 
   int childPosition = parent->ChildPosition(node);
@@ -173,7 +173,7 @@ PostOrderTreeIterator<TTreeType>::FindSister(TreeNodeType * node) const
       auto * sister = dynamic_cast<TreeNodeType *>(parent->GetChild(childPosition + 1));
       if (sister == nullptr)
       {
-        itkGenericExceptionMacro(<< "Can't downcast to TreeNodeType *");
+        itkGenericExceptionMacro("Can't downcast to TreeNodeType *");
       }
       return sister;
     }
@@ -203,7 +203,7 @@ PostOrderTreeIterator<TTreeType>::FindMostRightLeaf(TreeNodeType * node) const
         helpNode = dynamic_cast<TreeNodeType *>(node->GetChild(i));
         if (helpNode == nullptr)
         {
-          itkGenericExceptionMacro(<< "Can't downcast to TreeNodeType *");
+          itkGenericExceptionMacro("Can't downcast to TreeNodeType *");
         }
       }
       ++i;

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -92,7 +92,7 @@ ByteSwapper<T>::SwapFromSystemToBigEndian(T * p)
       Self::Swap8(p);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 
@@ -129,7 +129,7 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
       Self::Swap8Range(p, num);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 
@@ -163,7 +163,7 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStrea
       Self::SwapWrite8Range(p, num, fp);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 
@@ -190,7 +190,7 @@ ByteSwapper<T>::SwapFromSystemToLittleEndian(T * p)
       Self::Swap8(p);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 
@@ -220,7 +220,7 @@ ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T * p, BufferSizeType num)
       Self::Swap8Range(p, num);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 
@@ -250,7 +250,7 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OSt
       Self::SwapWrite8Range(p, num, fp);
       return;
     default:
-      itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
+      itkGenericExceptionMacro("Cannot swap number of bytes requested");
   }
 }
 

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -119,8 +119,9 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::CreateActiveListFro
 {
   if (this->GetRadius() != neighborhood.GetRadius())
   {
-    itkGenericExceptionMacro(<< "Radius of shaped iterator(" << this->GetRadius()
-                             << ") does not equal radius of neighborhood(" << neighborhood.GetRadius() << ')');
+    itkGenericExceptionMacro("Radius of shaped iterator(" << this->GetRadius()
+                                                          << ") does not equal radius of neighborhood("
+                                                          << neighborhood.GetRadius() << ')');
   }
   typename NeighborhoodType::ConstIterator nit;
   NeighborIndexType                        idx = 0;

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -295,7 +295,7 @@ void
 ExtractImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput();

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -52,8 +52,8 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coef
     }
     if (coeff.size() > m_MaximumKernelWidth)
     {
-      itkDebugMacro(<< "Kernel size has exceeded the specified maximum width of " << m_MaximumKernelWidth
-                    << " and has been truncated to " << coeff.size()
+      itkDebugMacro("Kernel size has exceeded the specified maximum width of "
+                    << m_MaximumKernelWidth << " and has been truncated to " << coeff.size()
                     << " elements.  You can raise the maximum width using the SetMaximumKernelWidth method.");
       break;
     }

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -195,8 +195,8 @@ public:
   {
     if (direction >= TImage::ImageDimension)
     {
-      itkGenericExceptionMacro(<< "In image of dimension " << TImage::ImageDimension << " Direction " << direction
-                               << " was selected");
+      itkGenericExceptionMacro("In image of dimension " << TImage::ImageDimension << " Direction " << direction
+                                                        << " was selected");
     }
     m_Direction = direction;
     m_Jump = this->m_OffsetTable[m_Direction];

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -249,8 +249,8 @@ ImageRegion<VImageDimension>::Slice(const unsigned int dim) const -> SliceRegion
 {
   if (dim >= VImageDimension)
   {
-    itkGenericExceptionMacro(<< "The dimension to remove: " << dim
-                             << " is greater than the dimension of the image: " << VImageDimension);
+    itkGenericExceptionMacro(
+      "The dimension to remove: " << dim << " is greater than the dimension of the image: " << VImageDimension);
   }
 
   Index<SliceDimension> sliceIndex;

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -61,7 +61,7 @@ ImageSink<TInputImage>::GetInput(unsigned int idx) const -> const InputImageType
 
   if (in == nullptr && this->ProcessObject::GetInput(idx) != nullptr)
   {
-    itkWarningMacro(<< "Unable to convert input number " << idx << " to type " << typeid(InputImageType).name());
+    itkWarningMacro("Unable to convert input number " << idx << " to type " << typeid(InputImageType).name());
   }
   return in;
 }
@@ -75,7 +75,7 @@ ImageSink<TInputImage>::GetInput(const DataObjectIdentifierType & key) const -> 
 
   if (in == nullptr && this->ProcessObject::GetInput(key) != nullptr)
   {
-    itkWarningMacro(<< "Unable to convert input \"" << key << "\" to type " << typeid(InputImageType).name());
+    itkWarningMacro("Unable to convert input \"" << key << "\" to type " << typeid(InputImageType).name());
   }
   return in;
 }

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
@@ -184,8 +184,8 @@ ImageSliceConstIteratorWithIndex<TImage>::SetFirstDirection(unsigned int directi
 {
   if (direction >= TImage::ImageDimension)
   {
-    itkGenericExceptionMacro(<< "In image of dimension " << TImage::ImageDimension << " Direction " << direction
-                             << " sas selected");
+    itkGenericExceptionMacro("In image of dimension " << TImage::ImageDimension << " Direction " << direction
+                                                      << " sas selected");
   }
   m_Direction_A = direction;
   m_PixelJump = this->m_OffsetTable[m_Direction_A];
@@ -200,8 +200,8 @@ ImageSliceConstIteratorWithIndex<TImage>::SetSecondDirection(unsigned int direct
 {
   if (direction >= TImage::ImageDimension)
   {
-    itkGenericExceptionMacro(<< "In image of dimension " << TImage::ImageDimension << " Direction " << direction
-                             << " sas selected");
+    itkGenericExceptionMacro("In image of dimension " << TImage::ImageDimension << " Direction " << direction
+                                                      << " sas selected");
   }
   m_Direction_B = direction;
   m_LineJump = this->m_OffsetTable[m_Direction_B];

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -94,7 +94,7 @@ ImageSource<TOutputImage>::GetOutput(unsigned int idx) -> OutputImageType *
 
   if (out == nullptr && this->ProcessObject::GetOutput(idx) != nullptr)
   {
-    itkWarningMacro(<< "Unable to convert output number " << idx << " to type " << typeid(OutputImageType).name());
+    itkWarningMacro("Unable to convert output number " << idx << " to type " << typeid(OutputImageType).name());
   }
   return out;
 }

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -78,7 +78,7 @@ ImageToImageFilter<TInputImage, TOutputImage>::GetInput(unsigned int idx) const 
 
   if (in == nullptr && this->ProcessObject::GetInput(idx) != nullptr)
   {
-    itkWarningMacro(<< "Unable to convert input number " << idx << " to type " << typeid(InputImageType).name());
+    itkWarningMacro("Unable to convert input number " << idx << " to type " << typeid(InputImageType).name());
   }
   return in;
 }

--- a/Modules/Core/Common/include/itkLineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkLineConstIterator.hxx
@@ -146,7 +146,7 @@ LineConstIterator<TImage>::operator++()
     // The new index is outside the acceptable region.  We can iterate no
     // farther, call this the end.  NOTE THAT INPUT IS STILL INCREMENTED.
     m_IsAtEnd = true;
-    itkWarningMacro(<< "Line left region; unable to finish tracing it");
+    itkWarningMacro("Line left region; unable to finish tracing it");
   }
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1374,8 +1374,8 @@ itkDynamicCastInDebugMode(TSource x)
   TTarget rval = dynamic_cast<TTarget>(x);
   if (rval == nullptr)
   {
-    itkGenericExceptionMacro(<< "Failed dynamic cast to " << typeid(TTarget).name()
-                             << " object type = " << x->GetNameOfClass());
+    itkGenericExceptionMacro("Failed dynamic cast to " << typeid(TTarget).name()
+                                                       << " object type = " << x->GetNameOfClass());
   }
   return rval;
 #else

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -470,7 +470,7 @@ OutputWindowDisplayDebugText(const char *);
 /** This macro is used to print debug (or other information). They are
  * also used to catch errors, etc. Requires that the caller implements
  * the GetDebug() method (see itk::Object). Example usage looks like:
- * itkDebugMacro(<< "this is debug info" << this->SomeVariable); */
+ * itkDebugMacro("this is debug info" << this->SomeVariable); */
 #if defined(NDEBUG)
 #  define itkDebugMacro(x) ITK_NOOP_STATEMENT
 #  define itkDebugStatement(x) ITK_NOOP_STATEMENT

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -494,7 +494,7 @@ OutputWindowDisplayDebugText(const char *);
 
 /** This macro is used to print warning information (i.e., unusual circumstance
  * but not necessarily fatal.) Example usage looks like:
- * itkWarningMacro(<< "this is warning info" << this->SomeVariable); */
+ * itkWarningMacro("this is warning info" << this->SomeVariable); */
 #define itkWarningMacro(x)                                                   \
   do                                                                         \
   {                                                                          \

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -278,7 +278,7 @@ public:
   {
     if (vnl_determinant(m_Matrix) == NumericTraits<T>::ZeroValue())
     {
-      itkGenericExceptionMacro(<< "Singular matrix. Determinant is 0.");
+      itkGenericExceptionMacro("Singular matrix. Determinant is 0.");
     }
     vnl_matrix_inverse<T> inverse(m_Matrix.as_ref());
     return vnl_matrix_fixed<T, VColumns, VRows>{ inverse.as_matrix() };

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -187,7 +187,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -366,7 +366,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -472,7 +472,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -594,7 +594,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -698,7 +698,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -800,7 +800,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -903,7 +903,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1005,7 +1005,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1127,7 +1127,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1230,7 +1230,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1333,7 +1333,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1437,7 +1437,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1540,7 +1540,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1651,7 +1651,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1755,7 +1755,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1850,7 +1850,7 @@ public:
   {
     if (s != 1)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a scalar to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }
@@ -1976,7 +1976,7 @@ public:
   {
     if (s != 2)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a complex to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a complex to " << s);
     }
     m = NumericTraits<ValueType>::ZeroValue();
   }

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -155,7 +155,7 @@ public:
   {
     if (s != D)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a CovariantVector of length " << D << " to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a CovariantVector of length " << D << " to " << s);
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -157,8 +157,8 @@ public:
   {
     if (s != 6)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a DiffusionTensor3D "
-                                  "to anything other than 6.");
+      itkGenericExceptionMacro("Cannot set the size of a DiffusionTensor3D "
+                               "to anything other than 6.");
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -151,7 +151,7 @@ public:
   {
     if (s != D)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a FixedArray of length " << D << " to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a FixedArray of length " << D << " to " << s);
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -142,7 +142,7 @@ public:
   {
     if (s != D)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a Point of length " << D << " to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a Point of length " << D << " to " << s);
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -182,8 +182,8 @@ public:
   {
     if (s != 4)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a RGBAPixel to anything other "
-                                  "than 4.");
+      itkGenericExceptionMacro("Cannot set the size of a RGBAPixel to anything other "
+                               "than 4.");
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -182,8 +182,8 @@ public:
   {
     if (s != 3)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a RGBPixel to anything other "
-                                  "than 3.");
+      itkGenericExceptionMacro("Cannot set the size of a RGBPixel to anything other "
+                               "than 3.");
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -156,8 +156,8 @@ public:
   {
     if (s != D * (D + 1) / 2)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a SymmetricSecondRankTensor "
-                                  "of dimension "
+      itkGenericExceptionMacro("Cannot set the size of a SymmetricSecondRankTensor "
+                               "of dimension "
                                << D << " ( = size of " << D * (D + 1) / 2 << ") to " << s);
     }
     m.Fill(NumericTraits<T>::ZeroValue());

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -197,7 +197,7 @@ public:
   {
     if (s != D)
     {
-      itkGenericExceptionMacro(<< "Cannot set the size of a Vector of length " << D << " to " << s);
+      itkGenericExceptionMacro("Cannot set the size of a Vector of length " << D << " to " << s);
     }
     m.Fill(NumericTraits<T>::ZeroValue());
   }

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -109,7 +109,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
 {
   unsigned int i;
 
-  itkDebugMacro(<< "PointSetToImageFilter::Update() called");
+  itkDebugMacro("PointSetToImageFilter::Update() called");
 
   // Get the input and output pointers
   const InputPointSetType * InputPointSet = this->GetInput();
@@ -220,7 +220,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
     ++pointItr;
   }
 
-  itkDebugMacro(<< "PointSetToImageFilter::Update() finished");
+  itkDebugMacro("PointSetToImageFilter::Update() finished");
 } // end update function
 
 template <typename TInputPointSet, typename TOutputImage>

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -296,7 +296,7 @@ const typename PriorityQueueContainer<TElementWrapper, TElementWrapperInterface,
 {
   if (Empty())
   {
-    itkGenericExceptionMacro(<< "Empty PriorityQueueContainer");
+    itkGenericExceptionMacro("Empty PriorityQueueContainer");
   }
   return (GetElementAtLocation(0));
 }
@@ -343,7 +343,7 @@ PriorityQueueContainer<TElementWrapper, TElementWrapperInterface, TElementPriori
   {
     if (location >= this->Size())
     {
-      itkGenericExceptionMacro(<< " ElementWrapperType location is out of range");
+      itkGenericExceptionMacro(" ElementWrapperType location is out of range");
     }
     UpdateDownTree(location);
     UpdateUpTree(location);
@@ -373,7 +373,7 @@ PriorityQueueContainer<TElementWrapper, TElementWrapperInterface, TElementPriori
 
     if (location >= tsize)
     {
-      itkGenericExceptionMacro(<< " ElementWrapperType location is out of range");
+      itkGenericExceptionMacro(" ElementWrapperType location is out of range");
     }
     else
     {

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
@@ -272,7 +272,7 @@ QuadraticTriangleCell<TCellInterface>::EvaluateShapeFunctions(const ParametricCo
 {
   if (parametricCoordinates.size() != 3)
   {
-    itkGenericExceptionMacro(<< "QuadraticTriangleCell expect three coordinates");
+    itkGenericExceptionMacro("QuadraticTriangleCell expect three coordinates");
   }
 
   const double L1 = parametricCoordinates[0];

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
@@ -42,7 +42,7 @@ ResourceProbesCollectorBase<TProbe>::Stop(const char * id)
   auto pos = this->m_Probes.find(tid);
   if (pos == this->m_Probes.end())
   {
-    itkGenericExceptionMacro(<< "The probe \"" << id << "\" does not exist. It can not be stopped.");
+    itkGenericExceptionMacro("The probe \"" << id << "\" does not exist. It can not be stopped.");
   }
   pos->second.Stop();
 }
@@ -57,7 +57,7 @@ ResourceProbesCollectorBase<TProbe>::GetProbe(const char * id) const
   auto pos = this->m_Probes.find(tid);
   if (pos == this->m_Probes.end())
   {
-    itkGenericExceptionMacro(<< "The probe \"" << id << "\" does not exist.");
+    itkGenericExceptionMacro("The probe \"" << id << "\" does not exist.");
   }
   return pos->second;
 }

--- a/Modules/Core/Common/include/itkSmapsFileParser.hxx
+++ b/Modules/Core/Common/include/itkSmapsFileParser.hxx
@@ -102,7 +102,7 @@ SmapsFileParser<TSmapsDataType>::ReadFile(const std::string & mapFileLocation)
   if (filename.str().empty())
   {
 #if defined(WIN32) || defined(_WIN32)
-    itkGenericExceptionMacro(<< "smaps files don't exist on Windows");
+    itkGenericExceptionMacro("smaps files don't exist on Windows");
 #else
     int pid = getpid();
     filename << "/proc/" << pid << "/smaps";
@@ -127,8 +127,7 @@ SmapsFileParser<TSmapsDataType>::ReadFile(const std::string & mapFileLocation)
   catch (const ExceptionObject & excp)
   {
     // propagate the exception
-    itkGenericExceptionMacro(<< "The smaps file " << filename.str()
-                             << " is an invalid file or contains errors: " << excp);
+    itkGenericExceptionMacro("The smaps file " << filename.str() << " is an invalid file or contains errors: " << excp);
   }
   this->m_MapFilePath = filename.str();
 }
@@ -147,7 +146,7 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
       // can't find or open the VMap file
       if (inputFile.is_open() == false)
       {
-        itkGenericExceptionMacro(<< "The VMap file " << mapFileLocation << " could not be open");
+        itkGenericExceptionMacro("The VMap file " << mapFileLocation << " could not be open");
       }
       // load the file
       inputFile >> this->m_MapData;
@@ -156,7 +155,7 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
     else
     {
 #if defined(WIN32) || defined(_WIN32)
-      itkGenericExceptionMacro(<< "VMMap files don't exist on Windows");
+      itkGenericExceptionMacro("VMMap files don't exist on Windows");
 #else
       std::stringstream vmmapCommand;
       vmmapCommand << "vmmap " << getpid();
@@ -164,7 +163,7 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
       FILE * vmmapCommandOutput = nullptr;
       if ((vmmapCommandOutput = popen(vmmapCommand.str().c_str(), "r")) == nullptr)
       {
-        itkGenericExceptionMacro(<< "Error using pmap. Can execute pmap command");
+        itkGenericExceptionMacro("Error using pmap. Can execute pmap command");
       }
 
       // Not optimal solution: copy the output into an std::istream object.
@@ -186,7 +185,7 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
   catch (const ExceptionObject & excp)
   {
     // propagate the exception
-    itkGenericExceptionMacro(<< "The vmmap file is an invalid file or contains errors:\n" << excp);
+    itkGenericExceptionMacro("The vmmap file is an invalid file or contains errors:\n" << excp);
   }
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -153,7 +153,7 @@ Int2EigenValueOrderEnum(const uint8_t value)
     default:
       break;
   }
-  itkGenericExceptionMacro(<< "Error: Invalid value for conversion.");
+  itkGenericExceptionMacro("Error: Invalid value for conversion.");
 }
 
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -208,7 +208,7 @@ VariableLengthVector<TValue>::AllocateElements(ElementIdentifier size) const
   {
     // Intercept std::bad_alloc and any exception thrown from TValue
     // default constructor.
-    itkGenericExceptionMacro(<< "Failed to allocate memory of length " << size << " for VariableLengthVector.");
+    itkGenericExceptionMacro("Failed to allocate memory of length " << size << " for VariableLengthVector.");
   }
 }
 

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -38,8 +38,8 @@ Array<T> VariableSizeMatrix<T>::operator*(const Array<T> & vect) const
 
   if (vect.Size() != cols)
   {
-    itkGenericExceptionMacro(<< "Matrix with " << this->Cols() << " columns cannot be "
-                             << "multiplied with array of length: " << vect.Size());
+    itkGenericExceptionMacro("Matrix with " << this->Cols() << " columns cannot be "
+                                            << "multiplied with array of length: " << vect.Size());
   }
 
   Array<T> result(rows);
@@ -63,9 +63,9 @@ VariableSizeMatrix<T> VariableSizeMatrix<T>::operator*(const Self & matrix) cons
 {
   if (this->Cols() != matrix.Rows())
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << this->Rows() << ',' << this->Cols()
-                             << ") cannot be multiplied by matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
-                             << ')');
+    itkGenericExceptionMacro("Matrix with size (" << this->Rows() << ',' << this->Cols()
+                                                  << ") cannot be multiplied by matrix with size (" << matrix.Rows()
+                                                  << ',' << matrix.Cols() << ')');
   }
   Self result;
   result = m_Matrix * matrix.m_Matrix;
@@ -81,9 +81,9 @@ VariableSizeMatrix<T>::operator+(const Self & matrix) const
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
-                             << ") cannot be added to a matrix with size (" << this->Rows() << ',' << this->Cols()
-                             << ')');
+    itkGenericExceptionMacro("Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                                                  << ") cannot be added to a matrix with size (" << this->Rows() << ','
+                                                  << this->Cols() << ')');
   }
 
   Self result(this->Rows(), this->Cols());
@@ -106,9 +106,9 @@ VariableSizeMatrix<T>::operator+=(const Self & matrix)
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
-                             << ") cannot be added to a matrix with size (" << this->Rows() << ',' << this->Cols()
-                             << ')');
+    itkGenericExceptionMacro("Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                                                  << ") cannot be added to a matrix with size (" << this->Rows() << ','
+                                                  << this->Cols() << ')');
   }
 
   for (unsigned int r = 0; r < this->Rows(); ++r)
@@ -130,9 +130,9 @@ VariableSizeMatrix<T>::operator-(const Self & matrix) const
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
-                             << ") cannot be subtracted from matrix with size (" << this->Rows() << ',' << this->Cols()
-                             << ')');
+    itkGenericExceptionMacro("Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                                                  << ") cannot be subtracted from matrix with size (" << this->Rows()
+                                                  << ',' << this->Cols() << ')');
   }
 
   Self result(this->Rows(), this->Cols());
@@ -155,9 +155,9 @@ VariableSizeMatrix<T>::operator-=(const Self & matrix)
 {
   if ((matrix.Rows() != this->Rows()) || (matrix.Cols() != this->Cols()))
   {
-    itkGenericExceptionMacro(<< "Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
-                             << ") cannot be subtracted from matrix with size (" << this->Rows() << ',' << this->Cols()
-                             << ')');
+    itkGenericExceptionMacro("Matrix with size (" << matrix.Rows() << ',' << matrix.Cols()
+                                                  << ") cannot be subtracted from matrix with size (" << this->Rows()
+                                                  << ',' << this->Cols() << ')');
   }
 
   for (unsigned int r = 0; r < this->Rows(); ++r)

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -347,8 +347,8 @@ Versor<T>::Set(const MatrixType & mat)
       itk::Math::abs(I[1][1] - itk::NumericTraits<T>::OneValue()) > epsilonDiff ||
       itk::Math::abs(I[2][2] - itk::NumericTraits<T>::OneValue()) > epsilonDiff || vnl_det(I) < 0)
   {
-    itkGenericExceptionMacro(<< "The following matrix does not represent rotation to within an epsion of " << epsilon
-                             << '.' << std::endl
+    itkGenericExceptionMacro("The following matrix does not represent rotation to within an epsion of "
+                             << epsilon << '.' << std::endl
                              << m << std::endl
                              << "det(m * m transpose) is: " << vnl_det(I) << std::endl
                              << "m * m transpose is:" << std::endl

--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -211,13 +211,13 @@ WindowsMemoryUsageObserver::GetMemoryUsage()
 
   if (!m_hNTLib)
   {
-    itkGenericExceptionMacro(<< "Can't find ntdll.dll. "
+    itkGenericExceptionMacro("Can't find ntdll.dll. "
                              << "You should probably disable SUPPORT_TOOLHELP32");
   }
   // the ntdll.dll library could not have been opened (file not found?)
   if (!ZwQuerySystemInformation)
   {
-    itkGenericExceptionMacro(<< "The file ntdll.dll is not supported. "
+    itkGenericExceptionMacro("The file ntdll.dll is not supported. "
                              << "You should probably disable SUPPORT_TOOLHELP32");
   }
 
@@ -365,7 +365,7 @@ SunSolarisMemoryUsageObserver::GetMemoryUsage()
 
   if ((fp = popen(command.str().c_str(), "r")) == nullptr)
   {
-    itkGenericExceptionMacro(<< "Error using pmap. Can execute pmap command");
+    itkGenericExceptionMacro("Error using pmap. Can execute pmap command");
   }
   char remaining[256];
   int  pmappid = -1;
@@ -373,7 +373,7 @@ SunSolarisMemoryUsageObserver::GetMemoryUsage()
   // the first word shall be the process ID
   if (pmappid != pid)
   {
-    itkGenericExceptionMacro(<< "Error using pmap. 1st line output shall be PID: name");
+    itkGenericExceptionMacro("Error using pmap. 1st line output shall be PID: name");
   }
   bool        heapNotFound = true;
   char        address[64], perms[32];
@@ -404,13 +404,13 @@ SunSolarisMemoryUsageObserver::GetMemoryUsage()
     {
       if (ferror(fp))
       {
-        itkGenericExceptionMacro(<< "Error using pmap. Corrupted pmap output");
+        itkGenericExceptionMacro("Error using pmap. Corrupted pmap output");
       }
     }
   }
   if (pclose(fp) == -1)
   {
-    itkGenericExceptionMacro(<< "Error using pmap. Can't close pmap output file.");
+    itkGenericExceptionMacro("Error using pmap. Can't close pmap output file.");
   }
   return mem;
 }

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -74,7 +74,7 @@ MetaDataDictionary::Get(const std::string & key) const
 {
   if (!this->HasKey(key))
   {
-    itkGenericExceptionMacro(<< "Key '" << key << "' does not exist ");
+    itkGenericExceptionMacro("Key '" << key << "' does not exist ");
   }
   MetaDataObjectBase::Pointer entry = (*m_Dictionary)[key];
   const MetaDataObjectBase *  constentry = entry.GetPointer();

--- a/Modules/Core/Common/src/itkNumberToString.cxx
+++ b/Modules/Core/Common/src/itkNumberToString.cxx
@@ -54,7 +54,7 @@ FloatingPointNumberToString(const TValue val)
 
   if (!ConvertToShortest(double_conversion::DoubleToStringConverter::EcmaScriptConverter(), val, builder))
   {
-    itkGenericExceptionMacro(<< "Conversion failed for " << val);
+    itkGenericExceptionMacro("Conversion failed for " << val);
   }
   return std::string(builder.Finalize());
 }

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -361,7 +361,7 @@ Object::Modified() const
 void
 Object::Register() const
 {
-  itkDebugMacro(<< "Registered, "
+  itkDebugMacro("Registered, "
                 << "ReferenceCount = " << (m_ReferenceCount + 1));
 
   // call the parent
@@ -375,7 +375,7 @@ void
 Object::UnRegister() const noexcept
 {
   // call the parent
-  itkDebugMacro(<< "UnRegistered, "
+  itkDebugMacro("UnRegistered, "
                 << "ReferenceCount = " << (m_ReferenceCount - 1));
 
   if ((m_ReferenceCount - 1) <= 0)
@@ -415,7 +415,7 @@ Object::UnRegister() const noexcept
 void
 Object::SetReferenceCount(int ref)
 {
-  itkDebugMacro(<< "Reference Count set to " << ref);
+  itkDebugMacro("Reference Count set to " << ref);
 
   // ReferenceCount in now unlocked.  We may have a race condition to
   // to delete the object.
@@ -561,7 +561,7 @@ Object::Object()
 
 Object::~Object()
 {
-  itkDebugMacro(<< "Destructing!");
+  itkDebugMacro("Destructing!");
 }
 
 /**

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -567,7 +567,7 @@ ObjectFactoryBase::RegisterFactory(ObjectFactoryBase * factory, InsertionPositio
     }
     else
     {
-      itkGenericOutputMacro(<< "Possible incompatible factory load:"
+      itkGenericOutputMacro("Possible incompatible factory load:"
                             << "\nRunning itk version :\n"
                             << Version::GetITKSourceVersion() << "\nLoaded factory version:\n"
                             << factory->GetITKSourceVersion() << "\nLoading factory:\n"

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -559,7 +559,7 @@ ObjectFactoryBase::RegisterFactory(ObjectFactoryBase * factory, InsertionPositio
   {
     if (m_PimplGlobals->m_StrictVersionChecking)
     {
-      itkGenericExceptionMacro(<< "Incompatible factory version load attempt:"
+      itkGenericExceptionMacro("Incompatible factory version load attempt:"
                                << "\nRunning itk version :\n"
                                << Version::GetITKSourceVersion() << "\nAttempted loading factory version:\n"
                                << factory->GetITKSourceVersion() << "\nAttempted factory:\n"

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -849,7 +849,7 @@ ProcessObject::AddRequiredInputName(const DataObjectIdentifierType & name, DataO
 
   if (!m_RequiredInputNames.insert(name).second)
   {
-    itkWarningMacro(<< "Input already \"" << name << "\" already required!");
+    itkWarningMacro("Input already \"" << name << "\" already required!");
     // Input already required, but it is not added as indexed input?
     return false;
   }

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -61,22 +61,22 @@ ITKCommon_EXPORT std::istream &
     stream >> address;
     if (!stream.good())
     {
-      itkGenericExceptionMacro(<< "bad address: " << address);
+      itkGenericExceptionMacro("bad address: " << address);
     }
     stream >> perms;
     if (!stream.good())
     {
-      itkGenericExceptionMacro(<< "bad perms: " << perms);
+      itkGenericExceptionMacro("bad perms: " << perms);
     }
     stream >> offset;
     if (!stream.good())
     {
-      itkGenericExceptionMacro(<< "bad offset: " << offset);
+      itkGenericExceptionMacro("bad offset: " << offset);
     }
     stream >> device;
     if (!stream.good())
     {
-      itkGenericExceptionMacro(<< "bad device: " << device);
+      itkGenericExceptionMacro("bad device: " << device);
     }
     stream >> inode;
     // name can be empty
@@ -102,7 +102,7 @@ ITKCommon_EXPORT std::istream &
       std::getline(in, token);
       if (token != " kB" || !in.good())
       {
-        itkGenericExceptionMacro(<< "bad size: " << record.m_Tokens[token]);
+        itkGenericExceptionMacro("bad size: " << record.m_Tokens[token]);
       }
       lastPos = in.tellg();
     }
@@ -111,7 +111,7 @@ ITKCommon_EXPORT std::istream &
   {
     record.Reset();
     // propagate the exception
-    itkGenericExceptionMacro(<< "The smaps header is corrupted" << excp);
+    itkGenericExceptionMacro("The smaps header is corrupted" << excp);
   }
   return in;
 }
@@ -133,7 +133,7 @@ ITKCommon_EXPORT std::istream &
 
     if (!in.good())
     {
-      itkGenericExceptionMacro(<< "Bad record name: " << record.m_RecordName);
+      itkGenericExceptionMacro("Bad record name: " << record.m_RecordName);
     }
 
     std::string bracket;
@@ -145,28 +145,28 @@ ITKCommon_EXPORT std::istream &
 
     if (!in.good() || bracket.find("[", 0) == std::string::npos)
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad left bracket: " << bracket);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad left bracket: " << bracket);
     }
 
     in >> record.m_Tokens["Size"];
 
     if (!in.good())
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad size: " << record.m_Tokens["Size"]);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad size: " << record.m_Tokens["Size"]);
     }
 
     in >> bracket;
 
     if (!in.good())
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad right bracket: " << bracket);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad right bracket: " << bracket);
     }
   }
   catch (const ExceptionObject & excp)
   {
     record.Reset();
     // propagate the exception
-    itkGenericExceptionMacro(<< "The smaps header is corrupted" << excp);
+    itkGenericExceptionMacro("The smaps header is corrupted" << excp);
   }
   return in;
 }
@@ -209,7 +209,7 @@ ITKCommon_EXPORT std::istream &
 
       if (!in.good())
       {
-        itkGenericExceptionMacro(<< "Bad record name: " << record.m_RecordName);
+        itkGenericExceptionMacro("Bad record name: " << record.m_RecordName);
       }
 
       // skip Submap entries
@@ -232,7 +232,7 @@ ITKCommon_EXPORT std::istream &
 
         if (!in.good())
         {
-          itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad address: " << address);
+          itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad address: " << address);
         }
         // If address is "[" then recordName was the address and there is name
         // for
@@ -262,7 +262,7 @@ ITKCommon_EXPORT std::istream &
     }
     if (!in.good() || bracket.find("[", 0) == std::string::npos)
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad left bracket: " << bracket);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad left bracket: " << bracket);
     }
     if (bracket.length() > 1)
     { // bracket contains the size, ie "[1024K]"
@@ -275,19 +275,19 @@ ITKCommon_EXPORT std::istream &
     }
     if (!in.good())
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad size: " << record.m_Tokens["Size"]);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad size: " << record.m_Tokens["Size"]);
     }
     in.getline(line, 256);
     if (!in.good())
     {
-      itkGenericExceptionMacro(<< "For record: " << record.m_RecordName << ", bad end of line: " << line);
+      itkGenericExceptionMacro("For record: " << record.m_RecordName << ", bad end of line: " << line);
     }
   }
   catch (const ExceptionObject & excp)
   {
     record.Reset();
     // propagate the exception
-    itkGenericExceptionMacro(<< "The smaps header is corrupted" << excp);
+    itkGenericExceptionMacro("The smaps header is corrupted" << excp);
   }
   return in;
 }
@@ -410,7 +410,7 @@ operator>>(std::istream & smapsStream, SmapsData_2_6 & data)
     // in case of error, erase the records.
     data.Reset();
     // propagate the exception
-    itkGenericExceptionMacro(<< "The Smaps stream contains errors, can't read the memory records." << excp);
+    itkGenericExceptionMacro("The Smaps stream contains errors, can't read the memory records." << excp);
   }
   delete record;
   return smapsStream;
@@ -487,7 +487,7 @@ operator>>(std::istream & stream, VMMapData_10_2 & data)
       }
       if (stream.fail())
       {
-        itkGenericExceptionMacro(<< "Can't find the \"Writable regions\" section, can't read the memory records.");
+        itkGenericExceptionMacro("Can't find the \"Writable regions\" section, can't read the memory records.");
       }
       data.m_UsingSummary = false;
     }
@@ -529,7 +529,7 @@ operator>>(std::istream & stream, VMMapData_10_2 & data)
     // in case of error, erase the records.
     data.Reset();
     // propagate the exception
-    itkGenericExceptionMacro(<< "The VMMap stream contains errors, can't read the memory records." << excp);
+    itkGenericExceptionMacro("The VMMap stream contains errors, can't read the memory records." << excp);
   }
   // last record failed, it hasn't be added into data, delete it.
   delete record;

--- a/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
@@ -66,7 +66,7 @@ protected:
     if (outputRegionForThread.GetIndex(0) == m_ExceptionIndex)
     {
       std::cout << "Exception launched" << std::endl;
-      itkGenericExceptionMacro(<< "Error");
+      itkGenericExceptionMacro("Error");
     }
   }
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -194,7 +194,7 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::ResolveTimeStep(const st
   if (!flag)
   {
     // no values!
-    itkGenericExceptionMacro(<< "there is no satisfying value");
+    itkGenericExceptionMacro("there is no satisfying value");
   }
 
   t_it = timeStepList.begin();

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -78,7 +78,7 @@ GPUImageDataManager<ImageType>::MakeCPUBufferUpToDate()
     if ((m_IsCPUBufferDirty || (gpu_time > cpu_time)) && m_GPUBuffer != nullptr && m_CPUBuffer != nullptr)
     {
       cl_int errid;
-      itkDebugMacro(<< "GPU->CPU data copy");
+      itkDebugMacro("GPU->CPU data copy");
       errid = clEnqueueReadBuffer(m_ContextManager->GetCommandQueue(m_CommandQueueId),
                                   m_GPUBuffer,
                                   CL_TRUE,
@@ -120,7 +120,7 @@ GPUImageDataManager<ImageType>::MakeGPUBufferUpToDate()
     if ((m_IsGPUBufferDirty || (gpu_time < cpu_time)) && m_CPUBuffer != nullptr && m_GPUBuffer != nullptr)
     {
       cl_int errid;
-      itkDebugMacro(<< "CPU->GPU data copy");
+      itkDebugMacro("CPU->GPU data copy");
       errid = clEnqueueWriteBuffer(m_ContextManager->GetCommandQueue(m_CommandQueueId),
                                    m_GPUBuffer,
                                    CL_TRUE,

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -282,7 +282,7 @@ GPUKernelManager::GetKernelWorkGroupInfo(int kernelIdx, cl_kernel_work_group_inf
       valueSize = sizeof(cl_ulong);
       break;
     default:
-      itkGenericExceptionMacro(<< "Unknown type of work goup information");
+      itkGenericExceptionMacro("Unknown type of work goup information");
   }
 
   cl_int errid = clGetKernelWorkGroupInfo(
@@ -304,7 +304,7 @@ GPUKernelManager::GetDeviceInfo(cl_kernel_work_group_info paramName, size_t argS
       errid = clGetDeviceInfo(m_Manager->GetDeviceId(0), CL_DEVICE_MAX_WORK_ITEM_SIZES, argSize, argValue, nullptr);
       break;
     default:
-      itkGenericExceptionMacro(<< "Unknown type of device info");
+      itkGenericExceptionMacro("Unknown type of device info");
   }
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -145,14 +145,14 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   InputMeshCellsContainerConstPointer    inCells = input->GetCells();
   InputMeshCellDataContainerConstPointer inCellData = input->GetCellData();
 
-  itkDebugMacro(<< "Executing connectivity");
+  itkDebugMacro("Executing connectivity");
 
   //  Check input/allocate storage
   IdentifierType numCells = input->GetNumberOfCells();
   IdentifierType numPts = input->GetNumberOfPoints();
   if (numPts < 1 || numCells < 1)
   {
-    itkDebugMacro(<< "No data to connect!");
+    itkDebugMacro("No data to connect!");
     return;
   }
 
@@ -273,7 +273,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   delete m_Wave2;
   m_Wave = m_Wave2 = nullptr;
 
-  itkDebugMacro(<< "Extracted " << m_RegionNumber << " region(s)");
+  itkDebugMacro("Extracted " << m_RegionNumber << " region(s)");
 
   // Pass the point and point data through
   this->CopyInputMeshToOutputMeshPoints();
@@ -392,8 +392,8 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     {
       count += regionSize;
     }
-    itkDebugMacro(<< "Total #of cells accounted for: " << count);
-    itkDebugMacro(<< "Extracted " << output->GetNumberOfCells() << " cells");
+    itkDebugMacro("Total #of cells accounted for: " << count);
+    itkDebugMacro("Extracted " << output->GetNumberOfCells() << " cells");
   }
 #endif
 

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -1018,7 +1018,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::ReleaseCellsMemory()
       {
         // The user forgot to tell the mesh about how he allocated
         // the cells. No responsible guess can be made here. Call for help.
-        itkGenericExceptionMacro(<< "Cells Allocation Method was not specified. See SetCellsAllocationMethod()");
+        itkGenericExceptionMacro("Cells Allocation Method was not specified. See SetCellsAllocationMethod()");
         break;
       }
       case MeshEnums::MeshClassCellsAllocationMethod::CellsAllocatedAsStaticArray:

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -1050,7 +1050,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::ReleaseCellsMemory()
         while (cell != end)
         {
           const CellType * cellToBeDeleted = cell->Value();
-          itkDebugMacro(<< "Mesh destructor deleting cell = " << cellToBeDeleted);
+          itkDebugMacro("Mesh destructor deleting cell = " << cellToBeDeleted);
           delete cellToBeDeleted;
           ++cell;
         }

--- a/Modules/Core/Mesh/include/itkMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkMeshSource.hxx
@@ -60,8 +60,8 @@ template <typename TOutputMesh>
 void
 MeshSource<TOutputMesh>::SetOutput(OutputMeshType * output)
 {
-  itkWarningMacro(<< "SetOutput(): This method is slated to be removed from ITK.  Please use GraftOutput() in possible "
-                     "combination with DisconnectPipeline() instead.");
+  itkWarningMacro("SetOutput(): This method is slated to be removed from ITK.  Please use GraftOutput() in possible "
+                  "combination with DisconnectPipeline() instead.");
   this->ProcessObject::SetNthOutput(0, output);
 }
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -170,7 +170,7 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
   }
   else
   {
-    itkWarningMacro(<< "Unpredicted situation...!"
+    itkWarningMacro("Unpredicted situation...!"
                     << "absu: " << absu[0] << ", " << absu[1] << ", " << absu[2]);
     return;
   }

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -135,7 +135,7 @@ template <typename TInputMesh, typename TOutputImage>
 void
 TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "TriangleMeshToBinaryImageFilter::Update() called");
+  itkDebugMacro("TriangleMeshToBinaryImageFilter::Update() called");
 
   // Get the input and output pointers
   OutputImagePointer OutputImage = this->GetOutput();
@@ -155,7 +155,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
   }
   else
   {
-    itkDebugMacro(<< "Using info image");
+    itkDebugMacro("Using info image");
     m_InfoImage->Update();
     OutputImage->CopyInformation(m_InfoImage);
     OutputImage->SetRegions(m_InfoImage->GetLargestPossibleRegion());
@@ -170,7 +170,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
 
   RasterizeTriangles();
 
-  itkDebugMacro(<< "TriangleMeshToBinaryImageFilter::Update() finished");
+  itkDebugMacro("TriangleMeshToBinaryImageFilter::Update() finished");
 }
 
 template <typename TInputMesh, typename TOutputImage>

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -201,7 +201,7 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateSpatialObjectScene
 
       if (converterIt == this->m_ConverterMap.end())
       {
-        itkGenericExceptionMacro(<< "Unable to find MetaObject -> SpatialObject converter for " << objectTypeName);
+        itkGenericExceptionMacro("Unable to find MetaObject -> SpatialObject converter for " << objectTypeName);
       }
       currentSO = converterIt->second->MetaObjectToSpatialObject(*it);
     }
@@ -340,8 +340,7 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
       auto converterIt = this->m_ConverterMap.find(spatialObjectTypeName);
       if (converterIt == this->m_ConverterMap.end())
       {
-        itkGenericExceptionMacro(<< "Unable to find MetaObject -> SpatialObject converter for "
-                                 << spatialObjectTypeName);
+        itkGenericExceptionMacro("Unable to find MetaObject -> SpatialObject converter for " << spatialObjectTypeName);
       }
       currentMeta = converterIt->second->SpatialObjectToMetaObject(*it);
     }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -265,7 +265,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
 {
   unsigned int i;
 
-  itkDebugMacro(<< "SpatialObjectToImageFilter::Update() called");
+  itkDebugMacro("SpatialObjectToImageFilter::Update() called");
 
   // Get the input and output pointers
   const InputSpatialObjectType * InputObject = this->GetInput();
@@ -363,7 +363,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
     progress.CompletedPixel();
   }
 
-  itkDebugMacro(<< "SpatialObjectToImageFilter::Update() finished");
+  itkDebugMacro("SpatialObjectToImageFilter::Update() finished");
 } // end update function
 
 template <typename TInputSpatialObject, typename TOutputImage>

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -135,7 +135,7 @@ itkMetaArrowConverterTest(int argc, char * argv[])
   auto * newMetaArrow = dynamic_cast<MetaArrow *>(converter->SpatialObjectToMetaObject(itkArrow));
   if (newMetaArrow == nullptr)
   {
-    itkGenericExceptionMacro(<< "Failed to downcast from MetaObject to MetaArrow");
+    itkGenericExceptionMacro("Failed to downcast from MetaObject to MetaArrow");
   }
 
   // check length

--- a/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
@@ -108,7 +108,7 @@ itkMetaGaussianConverterTest(int argc, char * argv[])
   auto * newMetaGaussian = dynamic_cast<MetaGaussian *>(converter->SpatialObjectToMetaObject(GaussianSpatialObj));
   if (newMetaGaussian == nullptr)
   {
-    itkGenericExceptionMacro(<< "Failed to downcast from GaussianSpatialObject to MetaGaussian");
+    itkGenericExceptionMacro("Failed to downcast from GaussianSpatialObject to MetaGaussian");
   }
 
   // Check maximum

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -41,7 +41,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyDownStreamFilterExecutedPropagatio
   if (m_OutputRequestedRegions.size() != this->GetNumberOfUpdates() ||
       m_InputRequestedRegions.size() != this->GetNumberOfUpdates())
   {
-    itkWarningMacro(<< "Down stream filter didn't execute PropagateRequestedRegion well");
+    itkWarningMacro("Down stream filter didn't execute PropagateRequestedRegion well");
     ret = false;
   }
   return ret;
@@ -64,8 +64,9 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterExecutedStreaming(int e
   {
     return true;
   }
-  itkWarningMacro(<< "Streamed pipeline was executed " << this->GetNumberOfUpdates()
-                  << " times which was not the expected number " << expectedNumber << " of times.");
+  itkWarningMacro("Streamed pipeline was executed " << this->GetNumberOfUpdates()
+                                                    << " times which was not the expected number " << expectedNumber
+                                                    << " of times.");
   return false;
 }
 
@@ -77,30 +78,30 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterMatchedUpdateOutputInfo
   InputImageConstPointer input = this->GetInput();
   if (input->GetSpacing() != m_UpdatedOutputSpacing)
   {
-    itkWarningMacro(<< "The input filter's Spacing does not match UpdateOutputInformation");
+    itkWarningMacro("The input filter's Spacing does not match UpdateOutputInformation");
     return false;
   }
   if (input->GetOrigin() != m_UpdatedOutputOrigin)
   {
-    itkWarningMacro(<< "The input filter's Origin does not match UpdateOutputInformation");
+    itkWarningMacro("The input filter's Origin does not match UpdateOutputInformation");
     return false;
   }
   if (input->GetDirection() != m_UpdatedOutputDirection)
   {
-    itkWarningMacro(<< "The input filter's Direction does not match UpdateOutputInformation");
+    itkWarningMacro("The input filter's Direction does not match UpdateOutputInformation");
     return false;
   }
   if (input->GetLargestPossibleRegion() != m_UpdatedOutputLargestPossibleRegion)
   {
-    itkWarningMacro(<< "The input filter's LargestPossibleRegion does not match UpdateOutputInformation");
-    itkWarningMacro(<< "input: " << input->GetLargestPossibleRegion()
-                    << "updated: " << m_UpdatedOutputLargestPossibleRegion);
+    itkWarningMacro("The input filter's LargestPossibleRegion does not match UpdateOutputInformation");
+    itkWarningMacro("input: " << input->GetLargestPossibleRegion()
+                              << "updated: " << m_UpdatedOutputLargestPossibleRegion);
     return false;
   }
   if (!m_UpdatedBufferedRegions.empty() &&
       !m_UpdatedOutputLargestPossibleRegion.IsInside(m_UpdatedBufferedRegions.back()))
   {
-    itkWarningMacro(<< "The input filter's BufferedRegion is not contained by LargestPossibleRegion");
+    itkWarningMacro("The input filter's BufferedRegion is not contained by LargestPossibleRegion");
     return false;
   }
   return true;
@@ -119,7 +120,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterBufferedRequestedRegion
   {
     if (m_UpdatedBufferedRegions[i] != m_UpdatedRequestedRegions[i])
     {
-      itkWarningMacro(<< "The input filter's updated buffered region was not the requested region");
+      itkWarningMacro("The input filter's updated buffered region was not the requested region");
       ret = false;
     }
   }
@@ -143,7 +144,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterMatchedRequestedRegions
   {
     if (m_UpdatedBufferedRegions[--i] != m_InputRequestedRegions[--j])
     {
-      itkWarningMacro(<< "The input filter's updated buffer region was not the region we requested");
+      itkWarningMacro("The input filter's updated buffer region was not the region we requested");
       ret = false;
     }
   }
@@ -158,7 +159,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterRequestedLargestRegion(
 {
   if (m_InputRequestedRegions.back() != m_UpdatedOutputLargestPossibleRegion)
   {
-    itkWarningMacro(<< "The input filter didn't set its output request to the largest region");
+    itkWarningMacro("The input filter didn't set its output request to the largest region");
     return false;
   }
   return true;

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -213,7 +213,7 @@ template <typename TOutputImage>
 void
 RandomImageSource<TOutputImage>::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  itkDebugMacro(<< "Generating a random image of scalars");
+  itkDebugMacro("Generating a random image of scalars");
 
 
   using scalarType = typename TOutputImage::PixelType;

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -246,7 +246,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
 
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   // Get the input and output pointers
   const TInputImage * inputPtr = this->GetInput();

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
@@ -53,7 +53,7 @@ template <typename TParametersValueType>
 void
 CenteredEuler3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters
   if (&parameters != &(this->m_Parameters))
@@ -84,7 +84,7 @@ CenteredEuler3DTransform<TParametersValueType>::SetParameters(const ParametersTy
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
@@ -39,7 +39,7 @@ template <typename TParametersValueType>
 void
 CenteredRigid2DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
   // Parameters are ordered as:
   //
   // p[0]   = angle
@@ -81,7 +81,7 @@ CenteredRigid2DTransform<TParametersValueType>::SetParameters(const ParametersTy
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -89,7 +89,7 @@ template <typename TParametersValueType>
 auto
 CenteredRigid2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
   // Parameters are ordered as:
   //
   // p[0]   = angle
@@ -110,7 +110,7 @@ CenteredRigid2DTransform<TParametersValueType>::GetParameters() const -> const P
     this->m_Parameters[j + 1 + SpaceDimension] = this->GetTranslation()[j];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
@@ -39,7 +39,7 @@ template <typename TParametersValueType>
 void
 CenteredSimilarity2DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -78,7 +78,7 @@ CenteredSimilarity2DTransform<TParametersValueType>::SetParameters(const Paramet
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -86,7 +86,7 @@ template <typename TParametersValueType>
 auto
 CenteredSimilarity2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetScale();
   this->m_Parameters[1] = this->GetAngle();
@@ -103,7 +103,7 @@ CenteredSimilarity2DTransform<TParametersValueType>::GetParameters() const -> co
     this->m_Parameters[i + 4] = translation[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -78,7 +78,7 @@ template <typename TParametersValueType>
 void
 ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -110,7 +110,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Par
   newVersor.Set(axis);
   this->SetVarVersor(newVersor);
 
-  itkDebugMacro(<< "Versor is now " << newVersor);
+  itkDebugMacro("Versor is now " << newVersor);
 
   // Matrix must be defined before translation so that offset can be computed
   // from translation
@@ -136,7 +136,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Par
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //
@@ -154,7 +154,7 @@ template <typename TParametersValueType>
 auto
 ComposeScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -172,7 +172,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -
   this->m_Parameters[10] = this->GetSkew()[1];
   this->m_Parameters[11] = this->GetSkew()[2];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -70,7 +70,7 @@ template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -96,7 +96,7 @@ Euler3DTransform<TParametersValueType>::SetParameters(const ParametersType & par
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 template <typename TParametersValueType>

--- a/Modules/Core/Transform/include/itkRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.h
@@ -299,8 +299,8 @@ template <typename TParametersValueType>
 inline auto
 Rigid2DTransform<TParametersValueType>::BackTransform(const OutputPointType & point) const -> InputPointType
 {
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
+  itkWarningMacro("BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
+                  "to generate an inverse transform and then perform the transform using that inverted transform.");
   return this->GetInverseMatrix() * (point - this->GetOffset());
 }
 
@@ -309,8 +309,8 @@ template <typename TParametersValueType>
 inline auto
 Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVectorType & vect) const -> InputVectorType
 {
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
+  itkWarningMacro("BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
+                  "to generate an inverse transform and then perform the transform using that inverted transform.");
   return this->GetInverseMatrix() * vect;
 }
 
@@ -319,8 +319,8 @@ template <typename TParametersValueType>
 inline auto
 Rigid2DTransform<TParametersValueType>::BackTransform(const OutputVnlVectorType & vect) const -> InputVnlVectorType
 {
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
+  itkWarningMacro("BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
+                  "to generate an inverse transform and then perform the transform using that inverted transform.");
   return this->GetInverseMatrix() * vect;
 }
 
@@ -330,8 +330,8 @@ inline auto
 Rigid2DTransform<TParametersValueType>::BackTransform(const OutputCovariantVectorType & vect) const
   -> InputCovariantVectorType
 {
-  itkWarningMacro(<< "BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
-                     "to generate an inverse transform and then perform the transform using that inverted transform.");
+  itkWarningMacro("BackTransform(): This method is slated to be removed from ITK.  Instead, please use GetInverse() "
+                  "to generate an inverse transform and then perform the transform using that inverted transform.");
   return this->GetMatrix() * vect;
 }
 

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -223,7 +223,7 @@ template <typename TParametersValueType>
 void
 Rigid2DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -251,7 +251,7 @@ Rigid2DTransform<TParametersValueType>::SetParameters(const ParametersType & par
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -259,7 +259,7 @@ template <typename TParametersValueType>
 auto
 Rigid2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   // Get the angle
   this->m_Parameters[0] = this->GetAngle();
@@ -269,7 +269,7 @@ Rigid2DTransform<TParametersValueType>::GetParameters() const -> const Parameter
     this->m_Parameters[i + 1] = this->GetTranslation()[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
@@ -57,7 +57,7 @@ template <typename TParametersValueType>
 void
 Rigid3DPerspectiveTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -88,7 +88,7 @@ Rigid3DPerspectiveTransform<TParametersValueType>::SetParameters(const Parameter
 
   m_Versor.Set(axis);
 
-  itkDebugMacro(<< "Versor is now " << this->GetRotation());
+  itkDebugMacro("Versor is now " << this->GetRotation());
 
   // Transfer the translation part
   OffsetType offset;
@@ -111,7 +111,7 @@ template <typename TParametersValueType>
 auto
 Rigid3DPerspectiveTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetRotation().GetX();
   this->m_Parameters[1] = this->GetRotation().GetY();
@@ -122,7 +122,7 @@ Rigid3DPerspectiveTransform<TParametersValueType>::GetParameters() const -> cons
   this->m_Parameters[4] = this->GetOffset()[1];
   this->m_Parameters[5] = this->GetOffset()[2];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -49,7 +49,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 ScaleLogarithmicTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   const ScaleType & scales = this->GetScale();
   // Transfer the translation part
@@ -58,7 +58,7 @@ ScaleLogarithmicTransform<TParametersValueType, VDimension>::GetParameters() con
     this->m_Parameters[i] = std::log(scales[i]);
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
@@ -74,7 +74,7 @@ template <typename TParametersValueType>
 void
 ScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -106,7 +106,7 @@ ScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Parameters
   newVersor.Set(axis);
   this->SetVarVersor(newVersor);
 
-  itkDebugMacro(<< "Versor is now " << newVersor);
+  itkDebugMacro("Versor is now " << newVersor);
 
   // Matrix must be defined before translation so that offset can be computed
   // from translation
@@ -135,7 +135,7 @@ ScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Parameters
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //
@@ -153,7 +153,7 @@ template <typename TParametersValueType>
 auto
 ScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -174,7 +174,7 @@ ScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -> const
   this->m_Parameters[13] = this->GetSkew()[4];
   this->m_Parameters[14] = this->GetSkew()[5];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -57,14 +57,14 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 ScaleTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
   // Transfer the translation part
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     this->m_Parameters[i] = m_Scale[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
@@ -71,7 +71,7 @@ template <typename TParametersValueType>
 void
 ScaleVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -103,7 +103,7 @@ ScaleVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType
   newVersor.Set(axis);
   this->SetVarVersor(newVersor);
 
-  itkDebugMacro(<< "Versor is now " << newVersor);
+  itkDebugMacro("Versor is now " << newVersor);
 
   // Matrix must be defined before translation so that offset can be computed
   // from translation
@@ -124,7 +124,7 @@ ScaleVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //
@@ -141,7 +141,7 @@ template <typename TParametersValueType>
 auto
 ScaleVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -155,7 +155,7 @@ ScaleVersor3DTransform<TParametersValueType>::GetParameters() const -> const Par
   this->m_Parameters[7] = this->GetScale()[1];
   this->m_Parameters[8] = this->GetScale()[2];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -51,7 +51,7 @@ template <typename TParametersValueType>
 void
 Similarity2DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -82,7 +82,7 @@ Similarity2DTransform<TParametersValueType>::SetParameters(const ParametersType 
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 
@@ -90,7 +90,7 @@ template <typename TParametersValueType>
 auto
 Similarity2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetScale();
   this->m_Parameters[1] = this->GetAngle();
@@ -102,7 +102,7 @@ Similarity2DTransform<TParametersValueType>::GetParameters() const -> const Para
     this->m_Parameters[i + 2] = translation[i];
   }
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -122,7 +122,7 @@ template <typename TParametersValueType>
 void
 Similarity3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -156,7 +156,7 @@ Similarity3DTransform<TParametersValueType>::SetParameters(const ParametersType 
   m_Scale = parameters[6]; // must be set before calling ComputeMatrix();
   this->ComputeMatrix();
 
-  itkDebugMacro(<< "Versor is now " << this->GetVersor());
+  itkDebugMacro("Versor is now " << this->GetVersor());
 
   // Transfer the translation part
   TranslationType newTranslation;
@@ -170,7 +170,7 @@ Similarity3DTransform<TParametersValueType>::SetParameters(const ParametersType 
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //
@@ -187,7 +187,7 @@ template <typename TParametersValueType>
 auto
 Similarity3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -200,7 +200,7 @@ Similarity3DTransform<TParametersValueType>::GetParameters() const -> const Para
 
   this->m_Parameters[6] = this->GetScale();
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -466,8 +466,8 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::ApplyToImage
 
   if (!this->IsLinear())
   {
-    itkWarningMacro(<< "ApplyToImageMetadata was invoked with non-linear transform of type: " << this->GetNameOfClass()
-                    << ". This might produce unexpected results.");
+    itkWarningMacro("ApplyToImageMetadata was invoked with non-linear transform of type: "
+                    << this->GetNameOfClass() << ". This might produce unexpected results.");
   }
 
   typename Self::Pointer inverse = this->GetInverseTransform();

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
@@ -45,7 +45,7 @@ template <typename TParametersValueType>
 void
 VersorRigid3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -73,7 +73,7 @@ VersorRigid3DTransform<TParametersValueType>::SetParameters(const ParametersType
   this->SetVarVersor(newVersor);
   this->ComputeMatrix();
 
-  itkDebugMacro(<< "Versor is now " << this->GetVersor());
+  itkDebugMacro("Versor is now " << this->GetVersor());
 
   // Transfer the translation part
   TranslationType newTranslation;
@@ -87,7 +87,7 @@ VersorRigid3DTransform<TParametersValueType>::SetParameters(const ParametersType
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 //
@@ -103,7 +103,7 @@ template <typename TParametersValueType>
 auto
 VersorRigid3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
-  itkDebugMacro(<< "Getting parameters ");
+  itkDebugMacro("Getting parameters ");
 
   this->m_Parameters[0] = this->GetVersor().GetX();
   this->m_Parameters[1] = this->GetVersor().GetY();
@@ -114,7 +114,7 @@ VersorRigid3DTransform<TParametersValueType>::GetParameters() const -> const Par
   this->m_Parameters[4] = this->GetTranslation()[1];
   this->m_Parameters[5] = this->GetTranslation()[2];
 
-  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+  itkDebugMacro("After getting parameters " << this->m_Parameters);
 
   return this->m_Parameters;
 }

--- a/Modules/Core/Transform/include/itkVersorTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorTransform.hxx
@@ -48,7 +48,7 @@ template <typename TParametersValueType>
 void
 VersorTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
 {
-  itkDebugMacro(<< "Setting parameters " << parameters);
+  itkDebugMacro("Setting parameters " << parameters);
 
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
@@ -66,7 +66,7 @@ VersorTransform<TParametersValueType>::SetParameters(const ParametersType & para
   // The versor will compute the scalar part.
   m_Versor.Set(rightPart);
 
-  itkDebugMacro(<< "Versor is now " << m_Versor);
+  itkDebugMacro("Versor is now " << m_Versor);
 
   this->ComputeMatrix();
   this->ComputeOffset();
@@ -75,7 +75,7 @@ VersorTransform<TParametersValueType>::SetParameters(const ParametersType & para
   // parameters and cannot know if the parameters have changed.
   this->Modified();
 
-  itkDebugMacro(<< "After setting parameters ");
+  itkDebugMacro("After setting parameters ");
 }
 
 template <typename TParametersValueType>

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -68,7 +68,8 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration(
   {
     //    f->SetTimeStep(1.0 / std::pow(2.0,
     // static_cast<double>(ImageDimension)));
-    itkWarningMacro(<< "Anisotropic diffusion unstable time step: " << m_TimeStep << std::endl
+    itkWarningMacro("Anisotropic diffusion unstable time step: "
+                    << m_TimeStep << std::endl
                     << "Stable time step for this image must be smaller than "
                     << minSpacing / std::pow(2.0, static_cast<double>(ImageDimension + 1)));
   }

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -293,7 +293,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::SetSchedule
 {
   if (schedule.rows() != m_NumberOfLevels || schedule.columns() != ImageDimension)
   {
-    itkDebugMacro(<< "Schedule has wrong dimensions");
+    itkDebugMacro("Schedule has wrong dimensions");
     return;
   }
 
@@ -441,7 +441,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::EstimateBia
                                                                                        int maximumIteration)
   -> BiasFieldType
 {
-  itkDebugMacro(<< "Estimating bias field ");
+  itkDebugMacro("Estimating bias field ");
 
   bool                          cleanCoeffs = false;
   BiasFieldType::DomainSizeType biasSize;
@@ -547,7 +547,7 @@ void
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImage(BiasFieldType &      bias,
                                                                                   InputImageRegionType region)
 {
-  itkDebugMacro(<< "Correcting the image ");
+  itkDebugMacro("Correcting the image ");
   using Pixel = InternalImagePixelType;
   ImageRegionIterator<InternalImageType> iIter(m_InternalInput, region);
   BiasFieldType::SimpleForwardIterator   bIter(&bias);
@@ -558,7 +558,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImag
   bIter.Begin();
   if (m_OutputMask.IsNotNull())
   {
-    itkDebugMacro(<< "Output mask is being used");
+    itkDebugMacro("Output mask is being used");
     ImageRegionIterator<ImageMaskType> mIter(m_OutputMask, region);
     mIter.GoToBegin();
     while (!bIter.IsAtEnd())
@@ -580,7 +580,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImag
   }
   else
   {
-    itkDebugMacro(<< "Output mask is not being used");
+    itkDebugMacro("Output mask is not being used");
     while (!bIter.IsAtEnd())
     {
       double diff = iIter.Get() - bIter.Get();
@@ -626,13 +626,13 @@ template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateData()
 {
-  itkDebugMacro(<< "Initializing filter...");
+  itkDebugMacro("Initializing filter...");
   this->Initialize();
-  itkDebugMacro(<< "Filter initialized.");
+  itkDebugMacro("Filter initialized.");
 
   if (m_UsingSlabIdentification)
   {
-    itkDebugMacro(<< "Searching slabs...");
+    itkDebugMacro("Searching slabs...");
 
     typename MRASlabIdentifier<InputImageType>::Pointer identifier = MRASlabIdentifier<InputImageType>::New();
     // Find slabs
@@ -654,7 +654,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
   }
 
   this->AdjustSlabRegions(m_Slabs, this->GetOutput()->GetRequestedRegion());
-  itkDebugMacro(<< "After adjustment, there are " << static_cast<SizeValueType>(m_Slabs.size()) << " slabs.");
+  itkDebugMacro("After adjustment, there are " << static_cast<SizeValueType>(m_Slabs.size()) << " slabs.");
 
   auto iter = m_Slabs.begin();
 
@@ -677,15 +677,15 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
 
     if (m_UsingInterSliceIntensityCorrection)
     {
-      itkDebugMacro(<< "  Correcting inter-slice intensity...");
+      itkDebugMacro("  Correcting inter-slice intensity...");
       this->CorrectInterSliceIntensityInhomogeneity(*iter);
-      itkDebugMacro(<< "  Inter-slice intensity corrected.");
+      itkDebugMacro("  Inter-slice intensity corrected.");
     }
 
     // Correct 3D bias
     if (m_UsingBiasFieldCorrection)
     {
-      itkDebugMacro(<< "  Correcting bias...");
+      itkDebugMacro("  Correcting bias...");
 
       m_BiasFieldCoefficients.clear();
       for (int i = 0; i < nCoef; ++i)
@@ -709,7 +709,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
       }
 
       this->CorrectImage(bias, *iter);
-      itkDebugMacro(<< "  Bias corrected.");
+      itkDebugMacro("  Bias corrected.");
     }
     ++iter;
   }
@@ -730,7 +730,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
 
   if (m_GeneratingOutput)
   {
-    itkDebugMacro(<< "Generating the output image...");
+    itkDebugMacro("Generating the output image...");
 
     if (this->GetBiasFieldMultiplicative())
     {
@@ -742,7 +742,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
     output->Allocate();
     CopyAndConvertImage(m_InternalInput.GetPointer(), output, output->GetRequestedRegion());
 
-    itkDebugMacro(<< "The output image generated.");
+    itkDebugMacro("The output image generated.");
   }
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -55,7 +55,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
 {
-  itkDebugMacro(<< "PrepareData Start");
+  itkDebugMacro("PrepareData Start");
   OutputImagePointer pruneImage = GetPruning();
 
   InputImagePointer inputImage = dynamic_cast<const TInputImage *>(ProcessObject::GetInput(0));
@@ -68,7 +68,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
   ImageRegionIterator<TOutputImage>     ot(pruneImage, region);
 
-  itkDebugMacro(<< "PrepareData: Copy input to output");
+  itkDebugMacro("PrepareData: Copy input to output");
 
   while (!ot.IsAtEnd())
   {
@@ -76,7 +76,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
     ++it;
     ++ot;
   }
-  itkDebugMacro(<< "PrepareData End");
+  itkDebugMacro("PrepareData End");
 }
 
 /**
@@ -86,7 +86,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinaryPruningImageFilter<TInputImage, TOutputImage>::ComputePruneImage()
 {
-  itkDebugMacro(<< "ComputeThinImage Start");
+  itkDebugMacro("ComputeThinImage Start");
   OutputImagePointer pruneImage = GetPruning();
 
   typename OutputImageType::RegionType region = pruneImage->GetRequestedRegion();
@@ -128,7 +128,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::ComputePruneImage()
     }
     ++count;
   }
-  itkDebugMacro(<< "ComputeThinImage End");
+  itkDebugMacro("ComputeThinImage End");
 }
 
 /**
@@ -140,7 +140,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   this->PrepareData();
 
-  itkDebugMacro(<< "GenerateData: Computing Thinning Image");
+  itkDebugMacro("GenerateData: Computing Thinning Image");
   this->ComputePruneImage();
 } // end GenerateData()
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -56,7 +56,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
 {
-  itkDebugMacro(<< "PrepareData Start");
+  itkDebugMacro("PrepareData Start");
   OutputImagePointer thinImage = GetThinning();
 
   InputImagePointer inputImage = dynamic_cast<const TInputImage *>(ProcessObject::GetInput(0));
@@ -69,7 +69,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
   ImageRegionIterator<TOutputImage>     ot(thinImage, region);
 
-  itkDebugMacro(<< "PrepareData: Copy input to output");
+  itkDebugMacro("PrepareData: Copy input to output");
 
   // Copy the input to the output, changing all foreground pixels to
   // have value 1 in the process.
@@ -86,7 +86,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
     ++it;
     ++ot;
   }
-  itkDebugMacro(<< "PrepareData End");
+  itkDebugMacro("PrepareData End");
 }
 
 /**
@@ -96,7 +96,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinaryThinningImageFilter<TInputImage, TOutputImage>::ComputeThinImage()
 {
-  itkDebugMacro(<< "ComputeThinImage Start");
+  itkDebugMacro("ComputeThinImage Start");
   OutputImagePointer thinImage = GetThinning();
 
   typename OutputImageType::RegionType region = thinImage->GetRequestedRegion();
@@ -275,7 +275,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::ComputeThinImage()
     } // end step loop
   }   // end noChange while loop
 
-  itkDebugMacro(<< "ComputeThinImage End");
+  itkDebugMacro("ComputeThinImage End");
 }
 
 /**
@@ -287,7 +287,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   this->PrepareData();
 
-  itkDebugMacro(<< "GenerateData: Computing Thinning Image");
+  itkDebugMacro("GenerateData: Computing Thinning Image");
   this->ComputeThinImage();
 } // end GenerateData()
 } // end namespace itk

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -100,7 +100,7 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Find the optimal kernel bandwidth parameter.
       this->ComputeKernelBandwidthUpdate();
     }
-    itkDebugMacro(<< "Computing Image Update iteration " << m_ElapsedIterations + 1 << " of " << m_NumberOfIterations);
+    itkDebugMacro("Computing Image Update iteration " << m_ElapsedIterations + 1 << " of " << m_NumberOfIterations);
 
     // Update the image intensities to denoise the image.
     this->ComputeImageUpdate();

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -417,7 +417,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::EnforceConstraints()
   {
     if (this->GetNoiseModelFidelityWeight() > 0)
     {
-      itkWarningMacro(<< "Noise model is undefined for RIEMANNIAN case, "
+      itkWarningMacro("Noise model is undefined for RIEMANNIAN case, "
                       << "disabling noise model by setting fidelity weight "
                       << "to zero.");
       this->SetNoiseModelFidelityWeight(0.0);
@@ -689,7 +689,7 @@ typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataSt
 
   if (m_NumIndependentComponents != 1)
   {
-    itkWarningMacro(<< "ThreadedRiemannianMinMax calculation assumes that "
+    itkWarningMacro("ThreadedRiemannianMinMax calculation assumes that "
                     << "there is exactly 1 independent component, but "
                     << "num independent components = " << m_NumIndependentComponents << " instead.\n");
   }

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -171,14 +171,15 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GenerateInputRequeste
   // Pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(voxelNeighborhoodSize);
 
-  itkDebugMacro(<< "Padding inputRequestedRegion by " << voxelNeighborhoodSize << '\n'
+  itkDebugMacro("Padding inputRequestedRegion by "
+                << voxelNeighborhoodSize << '\n'
                 << "inputRequestedRegion: " << inputRequestedRegion << '\n'
                 << "largestPossibleRegion: " << inputPtr->GetLargestPossibleRegion());
 
   // Crop the input requested region at the input's largest possible region
   if (inputRequestedRegion.Crop(inputPtr->GetLargestPossibleRegion()))
   {
-    itkDebugMacro(<< "Cropped inputRequestedRegion to: " << inputRequestedRegion);
+    itkDebugMacro("Cropped inputRequestedRegion to: " << inputRequestedRegion);
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
@@ -245,9 +246,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
   // For automatic sigma estimation, can't use more than 100% of pixels.
   m_SigmaUpdateDecimationFactor = std::max(m_SigmaUpdateDecimationFactor, 1u);
 
-  itkDebugMacro(<< "m_KernelBandwidthFractionPixelsForEstimation: " << m_KernelBandwidthFractionPixelsForEstimation
-                << ", "
-                << "m_SigmaUpdateDecimationFactor: " << m_SigmaUpdateDecimationFactor);
+  itkDebugMacro("m_KernelBandwidthFractionPixelsForEstimation: " << m_KernelBandwidthFractionPixelsForEstimation << ", "
+                                                                 << "m_SigmaUpdateDecimationFactor: "
+                                                                 << m_SigmaUpdateDecimationFactor);
 
   // Get the number of components per pixel in the input image.
   m_NumPixelComponents = this->GetInput()->GetNumberOfComponentsPerPixel();
@@ -342,7 +343,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
     }
   }
 
-  itkDebugMacro(<< "Image Intensity range: [" << m_ImageMin << ',' << m_ImageMax << "], "
+  itkDebugMacro("Image Intensity range: ["
+                << m_ImageMin << ',' << m_ImageMax << "], "
                 << "IntensityRescaleInvFactor: " << m_IntensityRescaleInvFactor << " , "
                 << "KernelBandwidthMultiplicationFactor: " << m_KernelBandwidthMultiplicationFactor << " , "
                 << "KernelBandwidthSigma initialized to: " << m_KernelBandwidthSigma);
@@ -752,11 +754,11 @@ typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataSt
     threadData.minNorm[0] = std::sqrt(minNorm[0]);
     threadData.maxNorm[0] = std::sqrt(maxNorm[0]);
 
-    itkDebugMacro(<< "threadData minNorm: " << minNorm[0] << ", maxNorm: " << maxNorm[0]);
+    itkDebugMacro("threadData minNorm: " << minNorm[0] << ", maxNorm: " << maxNorm[0]);
   }
   else
   {
-    itkDebugMacro(<< "no pixels in this region");
+    itkDebugMacro("no pixels in this region");
   }
   return threadData;
 }
@@ -791,7 +793,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveRiemannianMinM
     }
   }
 
-  itkDebugMacro(<< "image min resolved to: " << m_ImageMin << ", image max resolved to: " << m_ImageMax);
+  itkDebugMacro("image min resolved to: " << m_ImageMin << ", image max resolved to: " << m_ImageMax);
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -1649,7 +1651,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeSigmaU
     else
     {
       InputImagePatchIterator queryIt = sampler->GetSample()->GetMeasurementVector(currentPatchId)[0];
-      itkDebugMacro(<< "unexpected index for current patch, search results are empty."
+      itkDebugMacro("unexpected index for current patch, search results are empty."
                     << "\ncurrent patch id: " << currentPatchId << "\ncurrent patch index: " << nIndex
                     << "\nindex calculated by searcher: " << queryIt.GetIndex(queryIt.GetCenterNeighborhoodIndex())
                     << "\npatch accessed by searcher: ");
@@ -1831,7 +1833,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate() 
       continue;
     }
 
-    itkDebugMacro(<< "Resolving sigma update for pixel component " << ic);
+    itkDebugMacro("Resolving sigma update for pixel component " << ic);
 
     // Accumulate the first and second derivatives from all the threads
     const RealValueType kernelSigma = m_KernelBandwidthSigma[ic];
@@ -1849,15 +1851,15 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate() 
     firstDerivative /= static_cast<RealValueType>(m_TotalNumberPixels);
     secondDerivative /= static_cast<RealValueType>(m_TotalNumberPixels);
 
-    itkDebugMacro(<< "first deriv: " << firstDerivative << ", second deriv: " << secondDerivative
-                  << ", old sigma: " << kernelSigma);
+    itkDebugMacro("first deriv: " << firstDerivative << ", second deriv: " << secondDerivative
+                                  << ", old sigma: " << kernelSigma);
 
     // If second derivative is zero or negative, compute update using gradient
     // descent
     if ((Math::ExactlyEquals(itk::Math::abs(secondDerivative), NumericTraits<RealValueType>::ZeroValue())) ||
         (secondDerivative < 0))
     {
-      itkDebugMacro(<< "** Second derivative NOT POSITIVE");
+      itkDebugMacro("** Second derivative NOT POSITIVE");
       sigmaUpdate[ic] = -itk::Math::sgn(firstDerivative) * kernelSigma * 0.3;
     }
     else
@@ -1866,30 +1868,30 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate() 
       sigmaUpdate[ic] = -firstDerivative / secondDerivative;
     }
 
-    itkDebugMacro(<< "update: " << sigmaUpdate[ic]);
+    itkDebugMacro("update: " << sigmaUpdate[ic]);
 
     // Avoid very large updates to prevent instabilities in Newton-Raphson
     if (itk::Math::abs(sigmaUpdate[ic]) > kernelSigma * 0.3)
     {
-      itkDebugMacro(<< "** Restricting large updates \n");
+      itkDebugMacro("** Restricting large updates \n");
       sigmaUpdate[ic] = itk::Math::sgn(sigmaUpdate[ic]) * kernelSigma * 0.3;
 
-      itkDebugMacro(<< "update: " << sigmaUpdate[ic]);
+      itkDebugMacro("update: " << sigmaUpdate[ic]);
     }
 
     // keep the updated sigma from being too close to zero
     if (kernelSigma + sigmaUpdate[ic] < m_MinSigma)
     {
-      itkDebugMacro(<< "** TOO SMALL SIGMA: adjusting sigma");
+      itkDebugMacro("** TOO SMALL SIGMA: adjusting sigma");
       m_KernelBandwidthSigma[ic] = (kernelSigma + m_MinSigma) / 2.0;
 
-      itkDebugMacro(<< "new sigma: " << m_KernelBandwidthSigma[ic]);
+      itkDebugMacro("new sigma: " << m_KernelBandwidthSigma[ic]);
     }
     else
     {
       m_KernelBandwidthSigma[ic] = kernelSigma + sigmaUpdate[ic];
 
-      itkDebugMacro(<< "new sigma: " << m_KernelBandwidthSigma[ic]);
+      itkDebugMacro("new sigma: " << m_KernelBandwidthSigma[ic]);
     }
   } // end for each independent pixel component
 

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -139,17 +139,17 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   // they don't.
   if (refOrigin != maskOrigin)
   {
-    itkWarningMacro(<< "Mask origin doesn't match Reference origin "
+    itkWarningMacro("Mask origin doesn't match Reference origin "
                     << "Mask Origin " << maskOrigin << " Ref Origin " << refOrigin);
   }
   if (refSpacing != maskSpacing)
   {
-    itkWarningMacro(<< "Mask spacing doesn't match Reference spacing "
+    itkWarningMacro("Mask spacing doesn't match Reference spacing "
                     << "Mask Spacing " << maskSpacing << " Ref Spacing " << refSpacing);
   }
   if (refDirection != maskDirection)
   {
-    itkWarningMacro(<< "Mask direction doesn't match Reference direction "
+    itkWarningMacro("Mask direction doesn't match Reference direction "
                     << "Mask Direction " << maskDirection << " Ref Direction " << refDirection);
   }
 }

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
@@ -66,7 +66,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 ExponentialDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   InputImageConstPointer inputPtr = this->GetInput();
 

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -182,16 +182,16 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
     ++ot;
   }
 
-  itkDebugMacro(<< "Number of Landmarks created = " << numberOfLandmarks);
+  itkDebugMacro("Number of Landmarks created = " << numberOfLandmarks);
 
   m_KernelTransform->GetModifiableTargetLandmarks()->SetPoints(target);
   m_KernelTransform->GetModifiableSourceLandmarks()->SetPoints(source);
 
-  itkDebugMacro(<< "Before ComputeWMatrix() ");
+  itkDebugMacro("Before ComputeWMatrix() ");
 
   m_KernelTransform->ComputeWMatrix();
 
-  itkDebugMacro(<< "After ComputeWMatrix() ");
+  itkDebugMacro("After ComputeWMatrix() ");
 }
 
 /**
@@ -205,7 +205,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
   // the KernelBased spline.
   this->PrepareKernelBaseSpline();
 
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   // Get the output pointers
   OutputImageType * outputPtr = this->GetOutput();

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -89,11 +89,11 @@ LandmarkDisplacementFieldSource<TOutputImage>::PrepareKernelBaseSpline()
   m_KernelTransform->GetModifiableTargetLandmarks()->SetPoints(targets);
   m_KernelTransform->GetModifiableSourceLandmarks()->SetPoints(sources);
 
-  itkDebugMacro(<< "Before ComputeWMatrix() ");
+  itkDebugMacro("Before ComputeWMatrix() ");
 
   m_KernelTransform->ComputeWMatrix();
 
-  itkDebugMacro(<< "After ComputeWMatrix() ");
+  itkDebugMacro("After ComputeWMatrix() ");
 }
 
 /**
@@ -107,7 +107,7 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
   // the KernelBased spline.
   this->PrepareKernelBaseSpline();
 
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   // Get the output pointers
   OutputImageType * outputPtr = this->GetOutput();

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -89,7 +89,7 @@ template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::PrepareData()
 {
-  itkDebugMacro(<< "PrepareData Start");
+  itkDebugMacro("PrepareData Start");
   VoronoiImagePointer voronoiMap = this->GetVoronoiMap();
 
   InputImagePointer inputImage = dynamic_cast<const InputImageType *>(ProcessObject::GetInput(0));
@@ -129,7 +129,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
   ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, region);
   ImageRegionIteratorWithIndex<VoronoiImageType>    ot(voronoiMap, region);
 
-  itkDebugMacro(<< "PrepareData: Copy input to output");
+  itkDebugMacro("PrepareData: Copy input to output");
   if (m_InputIsBinary)
   {
     VoronoiPixelType npt = 1;
@@ -178,7 +178,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
     minValue[j] = 0;
   }
 
-  itkDebugMacro(<< "PrepareData: Copy output to ct");
+  itkDebugMacro("PrepareData: Copy output to ct");
 
   // Iterate over the input image and distanceComponents image.
   // Wherever the input image is non-zero, initialize the distanceComponents image to the minValue.
@@ -197,14 +197,14 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
     ++it;
     ++ct;
   }
-  itkDebugMacro(<< "PrepareData End");
+  itkDebugMacro("PrepareData End");
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::ComputeVoronoiMap()
 {
-  itkDebugMacro(<< "ComputeVoronoiMap Start");
+  itkDebugMacro("ComputeVoronoiMap Start");
   VoronoiImagePointer voronoiMap = this->GetVoronoiMap();
   OutputImagePointer  distanceMap = this->GetDistanceMap();
   VectorImagePointer  distanceComponents = this->GetVectorDistanceMap();
@@ -215,7 +215,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Comp
   ImageRegionIteratorWithIndex<VectorImageType>  ct(distanceComponents, region);
   ImageRegionIteratorWithIndex<OutputImageType>  dt(distanceMap, region);
 
-  itkDebugMacro(<< "ComputeVoronoiMap Region: " << region);
+  itkDebugMacro("ComputeVoronoiMap Region: " << region);
   while (!ot.IsAtEnd())
   {
     IndexType index = ct.GetIndex() + ct.Get();
@@ -254,7 +254,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Comp
     ++ct;
     ++dt;
   }
-  itkDebugMacro(<< "ComputeVoronoiMap End");
+  itkDebugMacro("ComputeVoronoiMap End");
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
@@ -307,7 +307,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Gene
 
   RegionType region = voronoiMap->GetRequestedRegion();
 
-  itkDebugMacro(<< "Region to process: " << region);
+  itkDebugMacro("Region to process: " << region);
 
   // Instantiate reflective iterator
 
@@ -359,7 +359,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Gene
 
   SizeValueType i = 0;
 
-  itkDebugMacro(<< "GenerateData: Computing distance transform");
+  itkDebugMacro("GenerateData: Computing distance transform");
   while (!it.IsAtEnd())
   {
     if (!(i % updateVisits))
@@ -399,7 +399,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Gene
     ++inputIt;
   }
 
-  itkDebugMacro(<< "GenerateData: ComputeVoronoiMap");
+  itkDebugMacro("GenerateData: ComputeVoronoiMap");
 
   this->ComputeVoronoiMap();
 }

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -141,7 +141,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::AfterThreadedG
   }
   else
   {
-    itkGenericExceptionMacro(<< "pixelcount is equal to 0");
+    itkGenericExceptionMacro("pixelcount is equal to 0");
   }
 
   m_DirectedHausdorffDistance = m_MaxDistance;

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -44,7 +44,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::FastChamferDistanceIm
       m_Weights[--dim] = 0.92644;
       break;
     default:
-      itkWarningMacro(<< "Dimension " << ImageDimension << " with Default weights ");
+      itkWarningMacro("Dimension " << ImageDimension << " with Default weights ");
       for (unsigned int i = 1; i <= ImageDimension; ++i)
       {
         m_Weights[i - 1] = std::sqrt(static_cast<float>(i));

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -83,7 +83,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequested
   else
   {
     // pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::IsoContourDistanceImageFilter"
+    itkWarningMacro("itk::IsoContourDistanceImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(TOutputImage *).name());
   }

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -341,7 +341,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ComputeValue(const Inp
       }
       if (diff < NumericTraits<PixelRealType>::min())
       {
-        itkGenericExceptionMacro(<< "diff " << diff << " < NumericTraits< PixelRealType >::min()");
+        itkGenericExceptionMacro("diff " << diff << " < NumericTraits< PixelRealType >::min()");
         continue;
       }
 

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -106,7 +106,7 @@ FFTWGlobalConfiguration::GetPlanRigorValue(const std::string & name)
   {
     return FFTW_EXHAUSTIVE;
   }
-  itkGenericExceptionMacro(<< "Unknown plan rigor: " << name);
+  itkGenericExceptionMacro("Unknown plan rigor: " << name);
 }
 
 std::string
@@ -123,7 +123,7 @@ FFTWGlobalConfiguration::GetPlanRigorName(const int value)
     case FFTW_EXHAUSTIVE:
       return "FFTW_EXHAUSTIVE";
     default:
-      itkGenericExceptionMacro(<< "Unknown plan rigor: " << value);
+      itkGenericExceptionMacro("Unknown plan rigor: " << value);
   }
 }
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -111,7 +111,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::EnlargeOutputRequestedRegion(Da
   else
   {
     // Pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::FastMarchingImageFilter"
+    itkWarningMacro("itk::FastMarchingImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(TLevelSet *).name());
   }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -100,7 +100,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::EnlargeOutputRequestedRegion(DataO
   else
   {
     // Pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::FastMarchingImageFilter"
+    itkWarningMacro("itk::FastMarchingImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(OutputImageType *).name());
   }
@@ -416,7 +416,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::CheckTopology(OutputImageType * oI
     }
     else
     {
-      itkWarningMacro(<< "CheckTopology has not be implemented for Dimension != 2 and != 3."
+      itkWarningMacro("CheckTopology has not be implemented for Dimension != 2 and != 3."
                       << "m_TopologyCheck should be set to Nothing.");
     }
   }
@@ -585,7 +585,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
       }
       else
       {
-        itkWarningMacro(<< "Topology checking is only valid for level set dimensions of 2 and 3");
+        itkWarningMacro("Topology checking is only valid for level set dimensions of 2 and 3");
       }
     }
   }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -113,7 +113,7 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GenerateDa
 
   if (!is_ok)
   {
-    itkWarningMacro(<< "no input image provided");
+    itkWarningMacro("no input image provided");
   }
 }
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -112,14 +112,14 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UpdateNeighbors(OutputMeshT
       }
       else
       {
-        itkGenericExceptionMacro(<< "qe_it is nullptr");
+        itkGenericExceptionMacro("qe_it is nullptr");
       }
       qe_it = qe_it->GetOnext();
     } while (qe_it != qe);
   }
   else
   {
-    itkGenericExceptionMacro(<< "qe is nullptr");
+    itkGenericExceptionMacro("qe is nullptr");
   }
 }
 
@@ -135,7 +135,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UpdateValue(OutputMeshType 
 
   if (F < 0.)
   {
-    itkGenericExceptionMacro(<< "F < 0.");
+    itkGenericExceptionMacro("F < 0.");
   }
 
   OutputQEType * qe = p.GetEdge();
@@ -195,7 +195,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UpdateValue(OutputMeshType 
       else
       {
         // throw one exception here
-        itkGenericExceptionMacro(<< "qe_it2 is nullptr");
+        itkGenericExceptionMacro("qe_it2 is nullptr");
       }
     } while (qe_it != qe);
 
@@ -211,7 +211,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UpdateValue(OutputMeshType 
   else
   {
     // throw one exception
-    itkGenericExceptionMacro(<< "qe_it is nullptr");
+    itkGenericExceptionMacro("qe_it is nullptr");
   }
 }
 
@@ -595,7 +595,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::InitializeOutput(OutputMesh
 
       if (cell->GetNumberOfPoints() != 3)
       {
-        itkGenericExceptionMacro(<< "Input mesh has non triangular faces");
+        itkGenericExceptionMacro("Input mesh has non triangular faces");
       }
       ++c_it;
     }

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -58,7 +58,8 @@ GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter
   {
     //    f->SetTimeStep(1.0 / std::pow(2.0,
     // static_cast<double>(ImageDimension)));
-    itkWarningMacro(<< "Anisotropic diffusion unstable time step: " << this->GetTimeStep() << std::endl
+    itkWarningMacro("Anisotropic diffusion unstable time step: "
+                    << this->GetTimeStep() << std::endl
                     << "Stable time step for this image must be smaller than "
                     << minSpacing / std::pow(2.0, static_cast<double>(ImageDimension + 1)));
   }

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.hxx
@@ -53,9 +53,9 @@ template <typename TInputImage, typename TOutputImage>
 void
 GPUCastImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 {
-  itkDebugMacro(<< "Calling GPUCastImageFilter::GPUGenerateData()");
+  itkDebugMacro("Calling GPUCastImageFilter::GPUGenerateData()");
   GPUSuperclass::GPUGenerateData();
-  itkDebugMacro(<< "GPUCastImageFilter::GPUGenerateData() finished");
+  itkDebugMacro("GPUCastImageFilter::GPUGenerateData() finished");
 }
 
 

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -39,7 +39,7 @@ template <typename TPixel>
 void
 Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
 {
-  itkDebugMacro(<< "Hessian3DToVesselnessMeasureImageFilter generating data ");
+  itkDebugMacro("Hessian3DToVesselnessMeasureImageFilter generating data ");
 
   m_SymmetricEigenValueFilter->SetInput(this->GetInput());
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -147,7 +147,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "HessianRecursiveGaussianImageFilter generating data ");
+  itkDebugMacro("HessianRecursiveGaussianImageFilter generating data ");
 
   // Create a process accumulator for tracking the progress of this
   // minipipeline

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -112,7 +112,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "LaplacianRecursiveGaussianImageFilter generating data ");
+  itkDebugMacro("LaplacianRecursiveGaussianImageFilter generating data ");
 
   // Set the number of threads on all the filters
   for (unsigned int i = 0; i < ImageDimension - 1; ++i)

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -182,7 +182,7 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   {
     const double sigma = this->ComputeSigmaValue(scaleLevel);
 
-    itkDebugMacro(<< "Computing measure for scale with sigma = " << sigma);
+    itkDebugMacro("Computing measure for scale with sigma = " << sigma);
 
     m_HessianFilter->SetSigma(sigma);
 

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
@@ -242,7 +242,7 @@ BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::D
   }
   else
   {
-    itkGenericExceptionMacro(<< "At most one of the inputs can be a constant.");
+    itkGenericExceptionMacro("At most one of the inputs can be a constant.");
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
@@ -250,7 +250,7 @@ BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::DynamicThr
   }
   else
   {
-    itkGenericExceptionMacro(<< "At most one of the inputs can be a constant.");
+    itkGenericExceptionMacro("At most one of the inputs can be a constant.");
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <typename TInputImage, typename TDataType>
 DifferenceOfGaussiansGradientImageFilter<TInputImage, TDataType>::DifferenceOfGaussiansGradientImageFilter()
 {
-  itkDebugMacro(<< "DifferenceOfGaussiansGradientImageFilter::DifferenceOfGaussiansGradientImageFilter() called");
+  itkDebugMacro("DifferenceOfGaussiansGradientImageFilter::DifferenceOfGaussiansGradientImageFilter() called");
 
   m_Width = 2;
 }
@@ -36,7 +36,7 @@ template <typename TInputImage, typename TDataType>
 void
 DifferenceOfGaussiansGradientImageFilter<TInputImage, TDataType>::GenerateData()
 {
-  itkDebugMacro(<< "DifferenceOfGaussiansGradientImageFilter::GenerateData() called");
+  itkDebugMacro("DifferenceOfGaussiansGradientImageFilter::GenerateData() called");
 
   // Get the input and output pointers
   typename Superclass::InputImagePointer  inputPtr = const_cast<TInputImage *>(this->GetInput(0));
@@ -128,7 +128,7 @@ DifferenceOfGaussiansGradientImageFilter<TInputImage, TDataType>::GenerateData()
     progress.CompletedPixel();
   }
 
-  itkDebugMacro(<< "DifferenceOfGaussiansGradientImageFilter::GenerateData() finished");
+  itkDebugMacro("DifferenceOfGaussiansGradientImageFilter::GenerateData() finished");
 }
 
 template <typename TInputImage, typename TDataType>

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -174,7 +174,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "GradientMagnitudeRecursiveGaussianImageFilter generating data ");
+  itkDebugMacro("GradientMagnitudeRecursiveGaussianImageFilter generating data ");
 
   const typename TInputImage::ConstPointer inputImage(this->GetInput());
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -163,7 +163,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeO
   else
   {
     // pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::BSplineDownsampleImageFilter"
+    itkWarningMacro("itk::BSplineDownsampleImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(TOutputImage *).name());
   }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -34,7 +34,7 @@ template <typename TInputImage, typename TOutputImage, typename ResamplerType>
 void
 BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateData()
 {
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   // Get the input and output pointers
   InputImagePointer  inputPtr = const_cast<TInputImage *>(this->GetInput());

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -170,7 +170,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeOut
   else
   {
     // pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::BSplineUpsampleImageFilter"
+    itkWarningMacro("itk::BSplineUpsampleImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(TOutputImage *).name());
   }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -45,7 +45,7 @@ template <typename TInputImage, typename TOutputImage, typename ResamplerType>
 void
 BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateData()
 {
-  itkDebugMacro(<< "Actually executing");
+  itkDebugMacro("Actually executing");
 
   // Get the input and output pointers
   InputImagePointer  inputPtr = const_cast<TInputImage *>(this->GetInput());

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -98,7 +98,7 @@ void
 BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  itkDebugMacro(<< "BinShrinkImageFilter executing on region:" << outputRegionForThread);
+  itkDebugMacro("BinShrinkImageFilter executing on region:" << outputRegionForThread);
 
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput();

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -632,7 +632,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   int          goodInput, goodOutput;
 
   // Are the regions non-empty?
-  itkDebugMacro(<< "MirrorPadImageFilter::DynamicThreadedGenerateData");
+  itkDebugMacro("MirrorPadImageFilter::DynamicThreadedGenerateData");
 
   // Get the input and output pointers
   const InputImageType * inputPtr = this->GetInput();

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -543,7 +543,7 @@ OrientImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
   else
   {
-    itkDebugMacro(<< "No need to flip");
+    itkDebugMacro("No need to flip");
   }
 
   //

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -107,7 +107,7 @@ protected:
     if (input != nullptr &&
         itk::Math::AlmostEquals(input->Get(), itk::NumericTraits<typename TInputImage2::PixelType>::ZeroValue()))
     {
-      itkGenericExceptionMacro(<< "The constant value used as denominator should not be set to zero");
+      itkGenericExceptionMacro("The constant value used as denominator should not be set to zero");
     }
   }
 };

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -127,7 +127,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   ImageLineIteratorType imit(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
   imit.SetDirection(0);
 
-  itkDebugMacro(<< "Generating the mask defined by the polyline.....");
+  itkDebugMacro("Generating the mask defined by the polyline.....");
 
   while (piter != container->End())
   {

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -88,15 +88,15 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   nViewVector = m_ViewVector;
   nViewVector.Normalize();
 
-  itkDebugMacro(<< "Normalized Up vector" << nUpVector);
-  itkDebugMacro(<< "Normalized View vector" << nViewVector);
+  itkDebugMacro("Normalized Up vector" << nUpVector);
+  itkDebugMacro("Normalized View vector" << nViewVector);
 
   // Orthogonalize nUpVector and nViewVector
   TVector nOrthogonalVector;
 
   nOrthogonalVector = nUpVector - (nViewVector * (nUpVector * nViewVector));
 
-  itkDebugMacro(<< "Up vector component orthogonal to View vector " << nOrthogonalVector);
+  itkDebugMacro("Up vector component orthogonal to View vector " << nOrthogonalVector);
 
   // Perform the cross product and determine a third coordinate axis
   // orthogonal to both nOrthogonalVector and nViewVector.
@@ -104,7 +104,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   TVector nThirdAxis;
   nThirdAxis = itk::CrossProduct(nOrthogonalVector, nViewVector);
 
-  itkDebugMacro(<< "Third basis vector" << nThirdAxis);
+  itkDebugMacro("Third basis vector" << nThirdAxis);
 
   // Populate the rotation matrix using the unit vectors of the
   // camera reference coordinate system.
@@ -292,7 +292,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   }
 
   const BoundingBoxType::BoundsArrayType & bounds = boundingBox->GetBounds();
-  itkDebugMacro(<< "Projection image bounding box=" << bounds);
+  itkDebugMacro("Projection image bounding box=" << bounds);
 
   ProjectionImageIndexType projectionStart;
   projectionStart[0] = 0;
@@ -323,9 +323,9 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
 
   projectionImagePtr->SetSpacing(spacing);
 
-  itkDebugMacro(<< "Projection image size:" << projectionSize);
-  itkDebugMacro(<< "Projection image start index:" << projectionStart);
-  itkDebugMacro(<< "Projection image origin:" << origin);
+  itkDebugMacro("Projection image size:" << projectionSize);
+  itkDebugMacro("Projection image start index:" << projectionStart);
+  itkDebugMacro("Projection image origin:" << origin);
 
   projectionImagePtr->SetRegions(projectionRegion);
   projectionImagePtr->Allocate(true); // initialize buffer to zero
@@ -333,7 +333,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   using ProjectionImageIteratorType = ImageRegionIterator<ProjectionImageType>;
   ProjectionImageIteratorType projectionIt(projectionImagePtr, projectionImagePtr->GetLargestPossibleRegion());
 
-  itkDebugMacro(<< "Rotation matrix" << m_RotationMatrix);
+  itkDebugMacro("Rotation matrix" << m_RotationMatrix);
 
   const VertexListType * container = polylinePtr->GetVertexList();
 
@@ -386,7 +386,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
       pflag = true;
     }
 
-    itkDebugMacro(<< "Polyline:" << startImageIndex << ',' << endImageIndex);
+    itkDebugMacro("Polyline:" << startImageIndex << ',' << endImageIndex);
     LineIteratorType it(projectionImagePtr, startImageIndex, endImageIndex);
     it.GoToBegin();
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -37,7 +37,7 @@ template <typename TInputImage, typename TBasisImage>
 void
 ImagePCADecompositionCalculator<TInputImage, TBasisImage>::SetBasisImages(const BasisImagePointerVector & v)
 {
-  itkDebugMacro(<< "setting BasisImages");
+  itkDebugMacro("setting BasisImages");
   this->m_BasisMatrixCalculated = false;
   // We need this modified setter function so that the calculator
   // can cache the basis set between calculations. Note that computing the

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -135,7 +135,7 @@ itkImageMomentsTest(int argc, char * argv[])
       dynamic_cast<itk::SpatialObject<MaskImageType::ImageDimension> *>(mask.GetPointer());
     if (test.IsNull())
     {
-      itkGenericExceptionMacro(<< "Failed conversion to SpatialObject base class.");
+      itkGenericExceptionMacro("Failed conversion to SpatialObject base class.");
     }
     moments->SetSpatialObjectMask(test.GetPointer());
   }

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -40,7 +40,7 @@ LabelObject<TLabel, VImageDimension>::GetAttributeFromName(const std::string & s
     return LABEL;
   }
   // can't recognize the name
-  itkGenericExceptionMacro(<< "Unknown attribute: " << s);
+  itkGenericExceptionMacro("Unknown attribute: " << s);
 }
 
 template <typename TLabel, unsigned int VImageDimension>
@@ -53,7 +53,7 @@ LabelObject<TLabel, VImageDimension>::GetNameFromAttribute(const AttributeType &
       return "Label";
   }
   // can't recognize the namespace
-  itkGenericExceptionMacro(<< "Unknown attribute: " << a);
+  itkGenericExceptionMacro("Unknown attribute: " << a);
 }
 
 /**
@@ -254,7 +254,7 @@ LabelObject<TLabel, VImageDimension>::GetIndex(SizeValueType offset) const -> In
 
     ++it;
   }
-  itkGenericExceptionMacro(<< "Invalid offset: " << offset);
+  itkGenericExceptionMacro("Invalid offset: " << offset);
 }
 
 /** Copy the lines from another node. */

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
@@ -144,7 +144,7 @@ MergeLabelMapFilter<TImage>::MergeWithStrict()
       }
       else
       {
-        itkGenericExceptionMacro(<< "Label "
+        itkGenericExceptionMacro("Label "
                                  << static_cast<typename itk::NumericTraits<PixelType>::PrintType>(newLo->GetLabel())
                                  << " from input " << i << " is output background value.");
       }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -87,8 +87,8 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   if (maxValue == seedValue)
   {
-    itkWarningMacro(<< "GrayscaleConnectedClosingImageFilter: pixel value at seed point matches maximum value in "
-                       "image.  Resulting image will have a constant value.");
+    itkWarningMacro("GrayscaleConnectedClosingImageFilter: pixel value at seed point matches maximum value in "
+                    "image.  Resulting image will have a constant value.");
     outputImage->FillBuffer(maxValue);
     this->UpdateProgress(1.0);
     return;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -87,8 +87,8 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   if (minValue == seedValue)
   {
-    itkWarningMacro(<< "GrayscaleConnectedClosingImageFilter: pixel value at seed point matches minimum value in "
-                       "image.  Resulting image will have a constant value.");
+    itkWarningMacro("GrayscaleConnectedClosingImageFilter: pixel value at seed point matches minimum value in "
+                    "image.  Resulting image will have a constant value.");
     outputImage->FillBuffer(minValue);
     return;
   }

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -477,8 +477,7 @@ ContourExtractor2DImageFilter<TInputImage>::AddSegment(VertexType from, VertexTy
         // There should be exactly one entry in the hash for that endpoint
         if (erased != 1)
         {
-          itkWarningMacro(<< "There should be exactly one entry in the hash for that endpoint, but there are "
-                          << erased);
+          itkWarningMacro("There should be exactly one entry in the hash for that endpoint, but there are " << erased);
         }
         contourData.m_Contours.erase(tail); // remove from the master list
 
@@ -500,8 +499,7 @@ ContourExtractor2DImageFilter<TInputImage>::AddSegment(VertexType from, VertexTy
           head->front()) };
         if (erased != 1)
         {
-          itkWarningMacro(<< "There should be exactly one entry in the hash for that endpoint, but there are "
-                          << erased);
+          itkWarningMacro("There should be exactly one entry in the hash for that endpoint, but there are " << erased);
         }
         contourData.m_Contours.erase(head); // remove from the master list
 

--- a/Modules/Filtering/Path/include/itkPathConstIterator.hxx
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.hxx
@@ -97,7 +97,7 @@ PathConstIterator<TImage, TPath>::operator++()
     // The new index is outside the acceptable region.  We can iterate no
     // farther, call this the end.  NOTE THAT INPUT IS STILL INCREMENTED.
     m_IsAtEnd = true;
-    itkWarningMacro(<< "Path left region; unable to finish tracing it");
+    itkWarningMacro("Path left region; unable to finish tracing it");
   }
   else
   {

--- a/Modules/Filtering/Path/include/itkPathSource.hxx
+++ b/Modules/Filtering/Path/include/itkPathSource.hxx
@@ -81,7 +81,7 @@ PathSource<TOutputPath>::GraftNthOutput(unsigned int idx, TOutputPath * graft)
     if (output && graft)
     {
       // Paths do not have a generic pointer to their bulk data
-      itkWarningMacro(<< "Warning:  GraftNthOutput() is broken");
+      itkWarningMacro("Warning:  GraftNthOutput() is broken");
 
       // possible VERY WRONG KLUDGE that should enable mini-pipelining:
       // Completely copy the path to graft over the current output path,

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -186,7 +186,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
 {
   unsigned int i;
 
-  itkDebugMacro(<< "PathToImageFilter::GenerateData() called");
+  itkDebugMacro("PathToImageFilter::GenerateData() called");
 
   // Get the input and output pointers
   const InputPathType * InputPath = this->GetInput();
@@ -275,7 +275,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
     pathIt.Set(m_PathValue);
   }
 
-  itkDebugMacro(<< "PathToImageFilter::GenerateData() finished");
+  itkDebugMacro("PathToImageFilter::GenerateData() finished");
 }
 
 template <typename TInputPath, typename TOutputImage>

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -104,7 +104,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder() -> Inp
 
   if (!list || list->empty())
   {
-    itkGenericExceptionMacro(<< "This filter requires at least one boundary");
+    itkGenericExceptionMacro("This filter requires at least one boundary");
   }
 
   InputCoordRepType max_length(0.0), length(0.0);
@@ -154,7 +154,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLargestBorder() -> Inp
 
   if (!list || list->empty())
   {
-    itkGenericExceptionMacro(<< "This filter requires at least one boundary");
+    itkGenericExceptionMacro("This filter requires at least one boundary");
   }
 
   SizeValueType max_id = 0L;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -62,7 +62,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeBoundary()
       bdryEdge = ComputeLargestBorder();
       break;
     default:
-      itkWarningMacro(<< "Unknown Border to be picked...");
+      itkWarningMacro("Unknown Border to be picked...");
       break;
   }
 

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 BinomialBlurImageFilter<TInputImage, TOutputImage>::BinomialBlurImageFilter()
 {
-  itkDebugMacro(<< "BinomialBlurImageFilter::BinomialBlurImageFilter() called");
+  itkDebugMacro("BinomialBlurImageFilter::BinomialBlurImageFilter() called");
 
   // The default is to just do one repetition
   m_Repetitions = 1;
@@ -39,7 +39,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
-  itkDebugMacro(<< "BinomialBlurImageFilter::GenerateInputRequestedRegion() called");
+  itkDebugMacro("BinomialBlurImageFilter::GenerateInputRequestedRegion() called");
 
   Superclass::GenerateInputRequestedRegion();
 
@@ -95,7 +95,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "BinomialBlurImageFilter::GenerateData() called");
+  itkDebugMacro("BinomialBlurImageFilter::GenerateData() called");
 
   // Get the input and output pointers
   InputImageConstPointer inputPtr = this->GetInput(0);
@@ -151,7 +151,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   // walk the output image forwards and compute blur
   for (unsigned int rep = 0; rep < m_Repetitions; ++rep)
   {
-    itkDebugMacro(<< "Repetition #" << rep);
+    itkDebugMacro("Repetition #" << rep);
 
     // blur each dimension
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
@@ -192,7 +192,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
         ++tempItDir;
       } // end walk the image forwards
 
-      itkDebugMacro(<< "End processing forward dimension " << dim);
+      itkDebugMacro("End processing forward dimension " << dim);
 
       //----------------------Reverse pass----------------------
       TempReverseIterator tempReverseIt(tempPtr, tempPtr->GetRequestedRegion());

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -200,7 +200,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "SmoothingRecursiveGaussianImageFilter generating data ");
+  itkDebugMacro("SmoothingRecursiveGaussianImageFilter generating data ");
 
   const typename TInputImage::ConstPointer inputImage(this->GetInput());
 

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
@@ -25,7 +25,7 @@ namespace itk
 template <typename TSpatialFunction, typename TInputImage, typename TOutputImage>
 SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>::SpatialFunctionImageEvaluatorFilter()
 {
-  itkDebugMacro(<< "SpatialFunctionImageEvaluatorFilter::SpatialFunctionImageEvaluatorFilter() called");
+  itkDebugMacro("SpatialFunctionImageEvaluatorFilter::SpatialFunctionImageEvaluatorFilter() called");
 
   // Set the internal function to null
   this->m_PixelFunction = nullptr;
@@ -35,7 +35,7 @@ template <typename TSpatialFunction, typename TInputImage, typename TOutputImage
 void
 SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "SpatialFunctionImageEvaluatorFilter::GenerateData() called");
+  itkDebugMacro("SpatialFunctionImageEvaluatorFilter::GenerateData() called");
 
   // Allocate the output image
   typename TOutputImage::Pointer outputPtr = this->GetOutput();
@@ -66,7 +66,7 @@ SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>
     outIt.Set((PixelType)value);
   }
 
-  itkDebugMacro(<< "SpatialFunctionImageEvaluatorFilter::GenerateData() finished");
+  itkDebugMacro("SpatialFunctionImageEvaluatorFilter::GenerateData() finished");
 }
 
 template <typename TSpatialFunction, typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -53,7 +53,7 @@ HuangThresholdCalculator<THistogram, TOutput>::GenerateData()
   }
   if (m_FirstBin == m_Size)
   {
-    itkWarningMacro(<< "No data in histogram");
+    itkWarningMacro("No data in histogram");
     return;
   }
   m_LastBin = m_Size - 1;

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -93,7 +93,7 @@ IntermodesThresholdCalculator<THistogram, TOutput>::GenerateData()
 
     if (smIter > m_MaximumSmoothingIterations)
     {
-      itkGenericExceptionMacro(<< "Exceeded maximum iterations for histogram smoothing.");
+      itkGenericExceptionMacro("Exceeded maximum iterations for histogram smoothing.");
     }
   }
 

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
@@ -121,7 +121,7 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   if (itk::Math::abs(As1) < itk::Math::eps)
   {
-    itkGenericExceptionMacro(<< "As1 = 0.");
+    itkGenericExceptionMacro("As1 = 0.");
   }
 
   while (threshold != Tprev)
@@ -133,7 +133,7 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
 
     if (itk::Math::abs(At) < itk::Math::eps)
     {
-      itkGenericExceptionMacro(<< "At = 0.");
+      itkGenericExceptionMacro("At = 0.");
     }
     double mu = Bt / At;
 
@@ -152,17 +152,17 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
 
     if (sigma2 < itk::Math::eps)
     {
-      itkGenericExceptionMacro(<< "sigma2 <= 0");
+      itkGenericExceptionMacro("sigma2 <= 0");
     }
 
     if (itk::Math::abs(tau2) < itk::Math::eps)
     {
-      itkGenericExceptionMacro(<< "tau2 = 0");
+      itkGenericExceptionMacro("tau2 = 0");
     }
 
     if (itk::Math::abs(p) < itk::Math::eps)
     {
-      itkGenericExceptionMacro(<< "p = 0");
+      itkGenericExceptionMacro("p = 0");
     }
 
     // The terms of the quadratic equation to be solved.

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
@@ -139,7 +139,7 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
 
     if (itk::Math::abs(As1 - At) < itk::Math::eps)
     {
-      itkWarningMacro(<< "KittlerIllingworthThresholdCalculator: not converging: As1 = At = " << At);
+      itkWarningMacro("KittlerIllingworthThresholdCalculator: not converging: As1 = At = " << At);
       break;
     }
 
@@ -174,7 +174,7 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
     double sqterm = w1 * w1 - w0 * w2;
     if (sqterm < itk::Math::eps)
     {
-      itkWarningMacro(<< "KittlerIllingworthThresholdCalculator: not converging.");
+      itkWarningMacro("KittlerIllingworthThresholdCalculator: not converging.");
       break;
     }
 
@@ -205,7 +205,7 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
       // Not sure if this condition is really useful
       if (itk::Math::isnan(temp))
       {
-        itkWarningMacro(<< "KittlerIllingworthThresholdCalculator: NaN, not converging.");
+        itkWarningMacro("KittlerIllingworthThresholdCalculator: NaN, not converging.");
         threshold = Tprev;
         break;
       }

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -60,7 +60,7 @@ BMPImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
   }
 
 
@@ -68,7 +68,7 @@ BMPImageIO::CanReadFile(const char * filename)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
   }
 
   // Now check the content
@@ -153,14 +153,14 @@ BMPImageIO::CanWriteFile(const char * name)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
   }
 
   bool extensionFound = this->HasSupportedWriteExtension(name, false);
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -137,7 +137,7 @@ BioRadImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -146,7 +146,7 @@ BioRadImageIO::CanReadFile(const char * filename)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 
@@ -165,7 +165,7 @@ BioRadImageIO::CanReadFile(const char * filename)
   file.read((char *)(&file_id), 2);
   ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&file_id);
 
-  itkDebugMacro(<< "Magic number: " << file_id);
+  itkDebugMacro("Magic number: " << file_id);
 
   file.close();
   return file_id == BIORAD_MAGIC_NUMBER;
@@ -379,7 +379,7 @@ BioRadImageIO::CanWriteFile(const char * name)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -387,7 +387,7 @@ BioRadImageIO::CanWriteFile(const char * name)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -262,7 +262,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
     const auto          hsize = static_cast<SizeValueType>(h.nx * h.ny * h.npic);
     if (gcount == hsize)
     {
-      itkWarningMacro(<< "File is declared as two bytes but really is only one byte");
+      itkWarningMacro("File is declared as two bytes but really is only one byte");
       SetComponentType(IOComponentEnum::UCHAR);
     }
     else if (gcount == hsize * 2)

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
@@ -108,7 +108,7 @@ CSVNumericObjectFileWriter<TValue, VRows, VColumns>::PrepareForWriting()
   // object are not the same
   if (!this->m_RowHeaders.empty() && (this->m_RowHeaders.size() != this->m_Rows))
   {
-    itkWarningMacro(<< "Warning: The number of row headers and the number of rows in"
+    itkWarningMacro("Warning: The number of row headers and the number of rows in"
                     << " the input object is not consistent.");
   }
 
@@ -118,12 +118,12 @@ CSVNumericObjectFileWriter<TValue, VRows, VColumns>::PrepareForWriting()
   {
     if (!this->m_RowHeaders.empty() && this->m_ColumnHeaders.size() != (this->m_Columns + 1))
     {
-      itkWarningMacro(<< "Warning: The number of column headers and the number of"
+      itkWarningMacro("Warning: The number of column headers and the number of"
                       << " columns in the input object is not consistent.");
     }
     if (this->m_RowHeaders.empty() && this->m_ColumnHeaders.size() != this->m_Columns)
     {
-      itkWarningMacro(<< "Warning: The number of column headers and the number of"
+      itkWarningMacro("Warning: The number of column headers and the number of"
                       << " columns in the input object is not consistent.");
     }
   }

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -203,7 +203,7 @@ CSVFileReaderBase::GetNextField(std::string & str)
 
   std::string empty;
   // Check that we are not at the end of the file
-  itkDebugMacro(<< "m_Line: " << m_Line);
+  itkDebugMacro("m_Line: " << m_Line);
   if (!this->m_InputStream.eof())
   {
     bool OnANewLine = false;

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -58,7 +58,7 @@ CSVFileReaderBase::PrepareForParsing()
 
   if (this->m_UseStringDelimiterCharacter && !(this->m_HasRowHeaders || this->m_HasColumnHeaders))
   {
-    itkWarningMacro(<< " Use string delimiter has been set to on but row and/or column headers indicators are off!");
+    itkWarningMacro(" Use string delimiter has been set to on but row and/or column headers indicators are off!");
   }
 
   if (this->m_UseStringDelimiterCharacter && this->m_FieldDelimiterCharacter == this->m_StringDelimiterCharacter)
@@ -177,7 +177,7 @@ CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
   // warning to the user.
   if (!isSame)
   {
-    itkWarningMacro(<< "Warning: Data appears to contain missing data! "
+    itkWarningMacro("Warning: Data appears to contain missing data! "
                     << "These will be set to NaN.");
   }
 

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -373,7 +373,7 @@ DCMTKFileReader::LoadFile()
 {
   if (this->m_FileName.empty())
   {
-    itkGenericExceptionMacro(<< "No filename given");
+    itkGenericExceptionMacro("No filename given");
   }
   delete this->m_DFile;
   this->m_DFile = new DcmFileFormat();

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -214,7 +214,7 @@ DCMTKImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
   }
 
 #if !defined(__EMSCRIPTEN__)

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -54,8 +54,8 @@ DCMTKSeriesFileNames::SetInputDirectory(std::string const & name)
 {
   if (name.empty())
   {
-    itkWarningMacro(<< "You need to specify a directory where "
-                       "the DICOM files are located");
+    itkWarningMacro("You need to specify a directory where "
+                    "the DICOM files are located");
     return;
   }
   if (m_InputDirectory == name)

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -813,7 +813,7 @@ GDCMImageIO::CanWriteFile(const char * name)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -1001,7 +1001,7 @@ GDCMImageIO::Write(const void * buffer)
       }
       else
       {
-        itkDebugMacro(<< "GDCMImageIO: non-DICOM and non-ITK standard key = " << key);
+        itkDebugMacro("GDCMImageIO: non-DICOM and non-ITK standard key = " << key);
       }
     }
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -356,8 +356,8 @@ GDCMImageIO::Read(void * pointer)
     {
       itkExceptionMacro("Failed to change to Photometric Interpretation");
     }
-    itkWarningMacro(<< "Converting from MONOCHROME1 to MONOCHROME2 may impact the meaning of DICOM attributes related "
-                       "to pixel values.");
+    itkWarningMacro("Converting from MONOCHROME1 to MONOCHROME2 may impact the meaning of DICOM attributes related "
+                    "to pixel values.");
     image = icpi.GetOutput();
   }
 

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -55,8 +55,8 @@ GDCMSeriesFileNames::SetInputDirectory(std::string const & name)
 {
   if (name.empty())
   {
-    itkWarningMacro(<< "You need to specify a directory where "
-                       "the DICOM files are located");
+    itkWarningMacro("You need to specify a directory where "
+                    "the DICOM files are located");
     return;
   }
   if (m_InputDirectory == name)
@@ -98,7 +98,7 @@ GDCMSeriesFileNames::GetSeriesUIDs()
   }
   if (m_SeriesUIDs.empty())
   {
-    itkWarningMacro(<< "No Series were found");
+    itkWarningMacro("No Series were found");
   }
   return m_SeriesUIDs;
 }
@@ -111,7 +111,7 @@ GDCMSeriesFileNames::GetFileNames(const std::string serie)
   gdcm::FileList * flist = m_SerieHelper->GetFirstSingleSerieUIDFileSet();
   if (!flist)
   {
-    itkWarningMacro(<< "No Series can be found, make sure your restrictions are not too strong");
+    itkWarningMacro("No Series can be found, make sure your restrictions are not too strong");
     return m_InputFileNames;
   }
   if (!serie.empty()) // user did not specify any sub selection based on UID
@@ -134,7 +134,7 @@ GDCMSeriesFileNames::GetFileNames(const std::string serie)
     }
     if (!found)
     {
-      itkWarningMacro(<< "No Series were found");
+      itkWarningMacro("No Series were found");
       return m_InputFileNames;
     }
   }
@@ -150,13 +150,13 @@ GDCMSeriesFileNames::GetFileNames(const std::string serie)
       gdcm::File * header = *it;
       if (!header)
       {
-        itkWarningMacro(<< "GDCMSeriesFileNames got nullptr header, "
-                           "this is a serious bug");
+        itkWarningMacro("GDCMSeriesFileNames got nullptr header, "
+                        "this is a serious bug");
         continue;
       }
       if (!header->IsReadable())
       {
-        itkWarningMacro(<< "GDCMSeriesFileNames got a non DICOM file:" << header->GetFileName());
+        itkWarningMacro("GDCMSeriesFileNames got a non DICOM file:" << header->GetFileName());
         continue;
       }
       m_InputFileNames.push_back(header->GetFileName());

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -170,7 +170,7 @@ GDCMSeriesFileNames::GetFileNames(const std::string serie)
   }
   else
   {
-    itkDebugMacro(<< "No files were found");
+    itkDebugMacro("No files were found");
   }
 
   return m_InputFileNames;
@@ -197,7 +197,7 @@ GDCMSeriesFileNames::GetOutputFileNames()
 
   if (m_OutputDirectory.empty())
   {
-    itkDebugMacro(<< "No output directory was specified");
+    itkDebugMacro("No output directory was specified");
     return m_OutputFileNames;
   }
 
@@ -256,7 +256,7 @@ GDCMSeriesFileNames::GetOutputFileNames()
   }
   else
   {
-    itkDebugMacro(<< "No files were found.");
+    itkDebugMacro("No files were found.");
   }
 
   return m_OutputFileNames;

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -105,7 +105,7 @@ GiplImageIO::CanReadFile(const char * filename)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 
@@ -183,14 +183,14 @@ GiplImageIO::CanWriteFile(const char * name)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
   }
 
   bool extensionFound = CheckExtension(name);
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 
@@ -1108,7 +1108,7 @@ GiplImageIO::CheckExtension(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -76,7 +76,7 @@ template <typename TScalar>
 H5::PredType
 GetType()
 {
-  itkGenericExceptionMacro(<< "Type not handled "
+  itkGenericExceptionMacro("Type not handled "
                            << "in HDF5 File: " << typeid(TScalar).name());
 }
 #define GetH5TypeSpecialize(CXXType, H5Type) \
@@ -159,7 +159,7 @@ GetH5TypeSpecialize(float, H5::PredType::NATIVE_FLOAT) GetH5TypeSpecialize(doubl
   {
     return IOComponentEnum::DOUBLE;
   }
-  itkGenericExceptionMacro(<< "unsupported HDF5 data type with id " << type.getId());
+  itkGenericExceptionMacro("unsupported HDF5 data type with id " << type.getId());
 }
 
 H5::PredType
@@ -193,10 +193,10 @@ ComponentToPredType(IOComponentEnum cType)
       return H5::PredType::NATIVE_DOUBLE;
     case IOComponentEnum::LDOUBLE:
     case IOComponentEnum::UNKNOWNCOMPONENTTYPE:
-      itkGenericExceptionMacro(<< "unsupported IOComponentEnum" << static_cast<char>(cType));
+      itkGenericExceptionMacro("unsupported IOComponentEnum" << static_cast<char>(cType));
   }
 
-  itkGenericExceptionMacro(<< "unsupported IOComponentEnum" << static_cast<char>(cType));
+  itkGenericExceptionMacro("unsupported IOComponentEnum" << static_cast<char>(cType));
 }
 
 std::string
@@ -242,7 +242,7 @@ ComponentToString(IOComponentEnum cType)
       rval = "DOUBLE";
       break;
     default:
-      itkGenericExceptionMacro(<< "unsupported IOComponentEnum" << static_cast<char>(cType));
+      itkGenericExceptionMacro("unsupported IOComponentEnum" << static_cast<char>(cType));
   }
   return rval;
 }

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -125,12 +125,12 @@ public:
       }
       catch (...)
       {
-        itkGenericExceptionMacro(<< "IO library exception not converted to an itk::ExceptionObject.");
+        itkGenericExceptionMacro("IO library exception not converted to an itk::ExceptionObject.");
       }
       if (!exception_correctly_caught)
       {
-        itkGenericExceptionMacro(<< "Invalid file writing path did not throw an exception: " << bad_filename << " with "
-                                 << imageio->GetNameOfClass());
+        itkGenericExceptionMacro("Invalid file writing path did not throw an exception: " << bad_filename << " with "
+                                                                                          << imageio->GetNameOfClass());
       }
     }
   }

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -74,7 +74,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
 {
   typename TOutputImage::Pointer output = this->GetOutput();
 
-  itkDebugMacro(<< "Reading file for GenerateOutputInformation()" << this->GetFileName());
+  itkDebugMacro("Reading file for GenerateOutputInformation()" << this->GetFileName());
 
   // Check to see if we can read the file given the name or prefix
   //
@@ -291,7 +291,7 @@ template <typename TOutputImage, typename ConvertPixelTraits>
 void
 ImageFileReader<TOutputImage, ConvertPixelTraits>::EnlargeOutputRequestedRegion(DataObject * output)
 {
-  itkDebugMacro(<< "Starting EnlargeOutputRequestedRegion() ");
+  itkDebugMacro("Starting EnlargeOutputRequestedRegion() ");
   typename TOutputImage::Pointer    out = dynamic_cast<TOutputImage *>(output);
   typename TOutputImage::RegionType largestRegion = out->GetLargestPossibleRegion();
   ImageRegionType                   streamableRegion;
@@ -341,8 +341,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::EnlargeOutputRequestedRegion(
     throw e;
   }
 
-  itkDebugMacro(<< "RequestedRegion is set to:" << streamableRegion
-                << " while the m_ActualIORegion is: " << m_ActualIORegion);
+  itkDebugMacro("RequestedRegion is set to:" << streamableRegion
+                                             << " while the m_ActualIORegion is: " << m_ActualIORegion);
 
   out->SetRequestedRegion(streamableRegion);
 }
@@ -355,7 +355,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
 
   typename TOutputImage::Pointer output = this->GetOutput();
 
-  itkDebugMacro(<< "ImageFileReader::GenerateData() \n"
+  itkDebugMacro("ImageFileReader::GenerateData() \n"
                 << "Allocating the buffer with the EnlargedRequestedRegion \n"
                 << output->GetRequestedRegion() << '\n');
 
@@ -381,7 +381,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
   // Tell the ImageIO to read the file
   m_ImageIO->SetFileName(this->GetFileName().c_str());
 
-  itkDebugMacro(<< "Setting imageIO IORegion to: " << m_ActualIORegion);
+  itkDebugMacro("Setting imageIO IORegion to: " << m_ActualIORegion);
   m_ImageIO->SetIORegion(m_ActualIORegion);
 
   // the size of the buffer is computed based on the actual number of
@@ -396,7 +396,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
   {
     // the pixel types don't match so a type conversion needs to be
     // performed
-    itkDebugMacro(<< "Buffer conversion required from: "
+    itkDebugMacro("Buffer conversion required from: "
                   << m_ImageIO->GetComponentTypeAsString(m_ImageIO->GetComponentType())
                   << " to: " << m_ImageIO->GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
                   << ConvertPixelTraits::GetNumberOfComponents() << " m_ImageIO->NumComponents "
@@ -416,7 +416,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
     // requested to not match, the dimensions of the two regions may
     // be different, therefore we buffer and copy the pixels
 
-    itkDebugMacro(<< "Buffer required because file dimension is greater then image dimension");
+    itkDebugMacro("Buffer required because file dimension is greater then image dimension");
 
     OutputImagePixelType * outputBuffer = output->GetPixelContainer()->GetBufferPointer();
 
@@ -431,7 +431,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
   }
   else
   {
-    itkDebugMacro(<< "No buffer conversion required.");
+    itkDebugMacro("No buffer conversion required.");
 
     OutputImagePixelType * outputBuffer = output->GetPixelContainer()->GetBufferPointer();
     m_ImageIO->Read(outputBuffer);

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -81,7 +81,7 @@ ImageFileWriter<TInputImage>::Write()
 {
   const InputImageType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing an image file");
+  itkDebugMacro("Writing an image file");
 
   // Make sure input is available
   if (input == nullptr)
@@ -101,12 +101,12 @@ ImageFileWriter<TInputImage>::Write()
     // try creating via factory
     if (m_ImageIO.IsNull())
     {
-      itkDebugMacro(<< "Attempting factory creation of ImageIO for file: " << m_FileName);
+      itkDebugMacro("Attempting factory creation of ImageIO for file: " << m_FileName);
     }
     else // ( m_FactorySpecifiedImageIO && !m_ImageIO->CanWriteFile( m_FileName.c_str() )
     {
-      itkDebugMacro(<< "ImageIO exists but doesn't know how to write file:" << m_FileName);
-      itkDebugMacro(<< "Attempting creation of ImageIO with a factory for file:" << m_FileName);
+      itkDebugMacro("ImageIO exists but doesn't know how to write file:" << m_FileName);
+      itkDebugMacro("Attempting creation of ImageIO with a factory for file:" << m_FileName);
     }
     m_ImageIO = ImageIOFactory::CreateImageIO(m_FileName.c_str(), ImageIOFactory::IOFileModeEnum::WriteMode);
     m_FactorySpecifiedImageIO = true;
@@ -332,7 +332,7 @@ ImageFileWriter<TInputImage>::GenerateData()
   InputImageRegionType   largestRegion = input->GetLargestPossibleRegion();
   InputImagePointer      cacheImage;
 
-  itkDebugMacro(<< "Writing file: " << m_FileName);
+  itkDebugMacro("Writing file: " << m_FileName);
 
   // now extract the data as a raw buffer pointer
   const void * dataPtr = input->GetBufferPointer();

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -475,8 +475,7 @@ ImageSeriesReader<TOutputImage>::GenerateData()
   if (TOutputImage::ImageDimension != this->m_NumberOfDimensionsInImage &&
       maxSpacingDeviation > m_SpacingWarningRelThreshold * outputSpacing[this->m_NumberOfDimensionsInImage])
   {
-    itkWarningMacro(<< "Non uniform sampling or missing slices detected,  maximum nonuniformity:"
-                    << maxSpacingDeviation);
+    itkWarningMacro("Non uniform sampling or missing slices detected,  maximum nonuniformity:" << maxSpacingDeviation);
   }
   if (maxSpacingDeviation > 0.0)
   {

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -71,7 +71,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::Write()
 {
   const InputImageType * inputImage = this->GetInput();
 
-  itkDebugMacro(<< "Writing an image file");
+  itkDebugMacro("Writing an image file");
 
   // Make sure input is available
   if (inputImage == nullptr)
@@ -151,7 +151,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 ImageSeriesWriter<TInputImage, TOutputImage>::GenerateData()
 {
-  itkDebugMacro(<< "Writing a series of files");
+  itkDebugMacro("Writing a series of files");
   if (m_FileNames.empty())
   {
     // this method will be deprecated. It is here only to maintain the old API
@@ -245,7 +245,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
                                                            << " were expected ");
   }
 
-  itkDebugMacro(<< "Number of files to write = " << m_FileNames.size());
+  itkDebugMacro("Number of files to write = " << m_FileNames.size());
 
   ProgressReporter progress(this, 0, expectedNumberOfFiles, expectedNumberOfFiles);
 

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -628,7 +628,7 @@ ImageIOBase::OpenFileForReading(std::ifstream & inputStream, const std::string &
   }
 
   // Open the new file for reading
-  itkDebugMacro(<< "Opening file for reading: " << filename);
+  itkDebugMacro("Opening file for reading: " << filename);
 
   std::ios::openmode mode = std::ios::in;
   if (!ascii)
@@ -666,7 +666,7 @@ ImageIOBase::OpenFileForWriting(std::ofstream & outputStream, const std::string 
   }
 
   // Open the new file for writing
-  itkDebugMacro(<< "Opening file for writing: " << filename);
+  itkDebugMacro("Opening file for writing: " << filename);
 
   std::ios::openmode mode = std::ios::out;
   if (truncate)

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -35,7 +35,7 @@ StreamingImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
 bool
 StreamingImageIOBase::StreamReadBufferAsBinary(std::istream & file, void * _buffer)
 {
-  itkDebugMacro(<< "StreamingReadBufferAsBinary called");
+  itkDebugMacro("StreamingReadBufferAsBinary called");
 
   auto * buffer = static_cast<char *>(_buffer);
   // Offset into file
@@ -68,8 +68,8 @@ StreamingImageIOBase::StreamReadBufferAsBinary(std::istream & file, void * _buff
       subDimensionQuantity *= this->GetDimensions(i);
     }
 
-    itkDebugMacro(<< "Reading " << sizeOfChunk << " of " << sizeOfRegion << " bytes for " << m_FileName << " at "
-                  << dataPos + seekPos << " position in file");
+    itkDebugMacro("Reading " << sizeOfChunk << " of " << sizeOfRegion << " bytes for " << m_FileName << " at "
+                             << dataPos + seekPos << " position in file");
 
     file.seekg(dataPos + seekPos, std::ios::beg);
 
@@ -120,7 +120,7 @@ StreamingImageIOBase::ReadBufferAsBinary(std::istream & is, void * buffer, Strea
   {
     std::streamsize bytesToRead = bytesRemaining > maxChunk ? maxChunk : bytesRemaining;
 
-    itkDebugMacro(<< "Reading " << bytesToRead << " of " << bytesRemaining << " bytes for " << m_FileName);
+    itkDebugMacro("Reading " << bytesToRead << " of " << bytesRemaining << " bytes for " << m_FileName);
 
     is.read(static_cast<char *>(buffer), bytesToRead);
 
@@ -147,7 +147,7 @@ StreamingImageIOBase::WriteBufferAsBinary(std::ostream & os, const void * buffer
   {
     SizeType bytesToWrite = bytesRemaining > maxChunk ? maxChunk : bytesRemaining;
 
-    itkDebugMacro(<< "Writing " << bytesToWrite << " of " << bytesRemaining << " bytes for " << m_FileName);
+    itkDebugMacro("Writing " << bytesToWrite << " of " << bytesRemaining << " bytes for " << m_FileName);
 
     os.write(static_cast<const char *>(buffer), bytesToWrite);
     if (os.fail())
@@ -165,7 +165,7 @@ StreamingImageIOBase::WriteBufferAsBinary(std::ostream & os, const void * buffer
 bool
 StreamingImageIOBase::StreamWriteBufferAsBinary(std::ostream & file, const void * _buffer)
 {
-  itkDebugMacro(<< "StreamingWriteBufferAsBinary called");
+  itkDebugMacro("StreamingWriteBufferAsBinary called");
 
   const auto * buffer = static_cast<const char *>(_buffer);
   // Offset into file
@@ -203,8 +203,8 @@ StreamingImageIOBase::StreamWriteBufferAsBinary(std::ostream & file, const void 
     // increment the buffer pointer
     buffer += sizeOfChunk;
 
-    itkDebugMacro(<< "Writing " << sizeOfChunk << " of "
-                  << " ?? bytes for " << m_FileName << " at " << dataPos + seekPos << " position in file");
+    itkDebugMacro("Writing " << sizeOfChunk << " of "
+                             << " ?? bytes for " << m_FileName << " at " << dataPos + seekPos << " position in file");
 
     if (file.fail())
     {

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -27,7 +27,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
 
   if (argc < 2)
   {
-    itkGenericOutputMacro(<< "Need a file to process");
+    itkGenericOutputMacro("Need a file to process");
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -232,7 +232,7 @@ JPEGImageIO::Read(void * buffer)
         jpeg_destroy_decompress(&cinfo);
         delete[] row_pointers;
         delete[] buf0;
-        itkWarningMacro(<< "JPEG error in the file " << this->GetFileName());
+        itkWarningMacro("JPEG error in the file " << this->GetFileName());
         return;
       }
 
@@ -270,7 +270,7 @@ JPEGImageIO::Read(void * buffer)
       {
         jpeg_destroy_decompress(&cinfo);
         delete[] row_pointers;
-        itkWarningMacro(<< "JPEG error in the file " << this->GetFileName());
+        itkWarningMacro("JPEG error in the file " << this->GetFileName());
         return;
       }
 

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -97,7 +97,7 @@ JPEGImageIO::CanReadFile(const char * file)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -105,7 +105,7 @@ JPEGImageIO::CanReadFile(const char * file)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -109,7 +109,7 @@ JPEG2000ImageIO::PrintSelf(std::ostream & os, Indent indent) const
 bool
 JPEG2000ImageIO::CanReadFile(const char * filename)
 {
-  itkDebugMacro(<< "JPEG2000ImageIO::CanReadFile()");
+  itkDebugMacro("JPEG2000ImageIO::CanReadFile()");
 
   //
   // If the file exists, and have extension .j2k or jp2 or jpt, then we are good
@@ -117,7 +117,7 @@ JPEG2000ImageIO::CanReadFile(const char * filename)
   //
   if (!itksys::SystemTools::FileExists(filename))
   {
-    itkDebugMacro(<< "File doesn't exist");
+    itkDebugMacro("File doesn't exist");
     return false;
   }
 
@@ -137,7 +137,7 @@ JPEG2000ImageIO::SetTileSize(int x, int y)
 void
 JPEG2000ImageIO::ReadImageInformation()
 {
-  itkDebugMacro(<< "ReadImageInformation()");
+  itkDebugMacro("ReadImageInformation()");
 
   FILE * l_file = fopen(this->m_FileName.c_str(), "rb");
 
@@ -257,7 +257,7 @@ JPEG2000ImageIO::ReadImageInformation()
   OPJ_UINT32 l_nb_tiles_x;
   OPJ_UINT32 l_nb_tiles_y;
 
-  itkDebugMacro(<< "Trying to read header now...");
+  itkDebugMacro("Trying to read header now...");
 
   bResult = opj_read_header(this->m_Internal->m_Dinfo,
                             &l_image,
@@ -293,7 +293,7 @@ JPEG2000ImageIO::ReadImageInformation()
   this->m_Internal->m_NumberOfTilesInY = l_nb_tiles_y;
 
 
-  itkDebugMacro(<< "Number of Components = " << l_image->numcomps);
+  itkDebugMacro("Number of Components = " << l_image->numcomps);
   this->SetNumberOfComponents(l_image->numcomps);
 
   if (l_image->comps[0].prec == 8)
@@ -329,17 +329,17 @@ JPEG2000ImageIO::ReadImageInformation()
       this->SetPixelType(IOPixelEnum::VECTOR);
   }
 
-  itkDebugMacro(<< "bits per pixel = " << l_image->comps[0].prec);
-  itkDebugMacro(<< "Color space = " << l_image->color_space);
-  itkDebugMacro(<< "Tile Start X = " << this->m_Internal->m_TileStartX);
-  itkDebugMacro(<< "Tile Start Y = " << this->m_Internal->m_TileStartY);
-  itkDebugMacro(<< "Tile Width = " << this->m_Internal->m_TileWidth);
-  itkDebugMacro(<< "Tile Height = " << this->m_Internal->m_TileHeight);
-  itkDebugMacro(<< "Number of Tiles X = " << this->m_Internal->m_NumberOfTilesInX);
-  itkDebugMacro(<< "Number of Tiles Y = " << this->m_Internal->m_NumberOfTilesInY);
+  itkDebugMacro("bits per pixel = " << l_image->comps[0].prec);
+  itkDebugMacro("Color space = " << l_image->color_space);
+  itkDebugMacro("Tile Start X = " << this->m_Internal->m_TileStartX);
+  itkDebugMacro("Tile Start Y = " << this->m_Internal->m_TileStartY);
+  itkDebugMacro("Tile Width = " << this->m_Internal->m_TileWidth);
+  itkDebugMacro("Tile Height = " << this->m_Internal->m_TileHeight);
+  itkDebugMacro("Number of Tiles X = " << this->m_Internal->m_NumberOfTilesInX);
+  itkDebugMacro("Number of Tiles Y = " << this->m_Internal->m_NumberOfTilesInY);
 
-  itkDebugMacro(<< "image->x1 = " << l_image->x1);
-  itkDebugMacro(<< "image->y1 = " << l_image->y1);
+  itkDebugMacro("image->x1 = " << l_image->x1);
+  itkDebugMacro("image->y1 = " << l_image->y1);
 
   this->SetDimensions(0, l_image->x1);
   this->SetDimensions(1, l_image->y1);
@@ -366,7 +366,7 @@ JPEG2000ImageIO::ReadImageInformation()
 void
 JPEG2000ImageIO::Read(void * buffer)
 {
-  itkDebugMacro(<< "JPEG2000ImageIO::Read() Begin");
+  itkDebugMacro("JPEG2000ImageIO::Read() Begin");
 
   FILE * l_file = fopen(this->m_FileName.c_str(), "rb");
 
@@ -493,15 +493,15 @@ JPEG2000ImageIO::Read(void * buffer)
   auto p_end_x = static_cast<OPJ_INT32>(startx + sizex);
   auto p_end_y = static_cast<OPJ_INT32>(starty + sizey);
 
-  itkDebugMacro(<< "opj_set_decode_area() before");
-  itkDebugMacro(<< "p_start_x = " << p_start_x);
-  itkDebugMacro(<< "p_start_y = " << p_start_y);
-  itkDebugMacro(<< "p_end_x = " << p_end_x);
-  itkDebugMacro(<< "p_end_y = " << p_end_y);
+  itkDebugMacro("opj_set_decode_area() before");
+  itkDebugMacro("p_start_x = " << p_start_x);
+  itkDebugMacro("p_start_y = " << p_start_y);
+  itkDebugMacro("p_end_x = " << p_end_x);
+  itkDebugMacro("p_end_y = " << p_end_y);
 
   bResult = opj_set_decode_area(this->m_Internal->m_Dinfo, p_start_x, p_start_y, p_end_x, p_end_y);
 
-  itkDebugMacro(<< "opj_set_decode_area() after");
+  itkDebugMacro("opj_set_decode_area() after");
 
   if (!bResult)
   {
@@ -553,14 +553,14 @@ JPEG2000ImageIO::Read(void * buffer)
                                                                 << "Reason: opj_read_tile_header returns false");
     }
 
-    itkDebugMacro(<< "l_tile_index " << l_tile_index);
-    itkDebugMacro(<< "l_data_size " << l_data_size);
-    itkDebugMacro(<< "l_current_tile_x0 " << l_current_tile_x0);
-    itkDebugMacro(<< "l_current_tile_y0 " << l_current_tile_y0);
-    itkDebugMacro(<< "l_current_tile_x1 " << l_current_tile_x1);
-    itkDebugMacro(<< "l_current_tile_y1 " << l_current_tile_y1);
-    itkDebugMacro(<< "l_nb_comps " << l_nb_comps);
-    itkDebugMacro(<< "l_go_on " << l_go_on);
+    itkDebugMacro("l_tile_index " << l_tile_index);
+    itkDebugMacro("l_data_size " << l_data_size);
+    itkDebugMacro("l_current_tile_x0 " << l_current_tile_x0);
+    itkDebugMacro("l_current_tile_y0 " << l_current_tile_y0);
+    itkDebugMacro("l_current_tile_x1 " << l_current_tile_x1);
+    itkDebugMacro("l_current_tile_y1 " << l_current_tile_y1);
+    itkDebugMacro("l_nb_comps " << l_nb_comps);
+    itkDebugMacro("l_go_on " << l_go_on);
 
     if (l_go_on)
     {
@@ -578,7 +578,7 @@ JPEG2000ImageIO::Read(void * buffer)
                                                                     << "Reason: Error reallocating memory");
         }
 
-        itkDebugMacro(<< "reallocated for " << l_data_size);
+        itkDebugMacro("reallocated for " << l_data_size);
 
         l_max_data_size = l_data_size;
       }
@@ -606,8 +606,8 @@ JPEG2000ImageIO::Read(void * buffer)
       const SizeValueType sizePerComponentInBytes = l_data_size / (numberOfPixels * numberOfComponents);
       const SizeValueType sizePerChannelInBytes = l_data_size / (numberOfComponents);
 
-      itkDebugMacro(<< "sizePerComponentInBytes: " << sizePerComponentInBytes);
-      itkDebugMacro(<< "sizePerChannelInBytes:   " << sizePerChannelInBytes);
+      itkDebugMacro("sizePerComponentInBytes: " << sizePerComponentInBytes);
+      itkDebugMacro("sizePerChannelInBytes:   " << sizePerChannelInBytes);
 
       const SizeValueType sizePerStrideXInBytes = sizePerChannelInBytes / tsizey;
       const SizeValueType initialStrideInBytes =
@@ -617,11 +617,11 @@ JPEG2000ImageIO::Read(void * buffer)
       const SizeValueType postStrideInBytes =
         (p_end_x - l_current_tile_x1) * sizePerComponentInBytes * numberOfComponents;
 
-      itkDebugMacro(<< "sizePerStrideYInBytes:   " << sizePerChannelInBytes / tsizex);
-      itkDebugMacro(<< "sizePerStrideXInBytes:   " << sizePerStrideXInBytes);
-      itkDebugMacro(<< "initialStrideInBytes:    " << initialStrideInBytes);
-      itkDebugMacro(<< "priorStrideInBytes:      " << priorStrideInBytes);
-      itkDebugMacro(<< "postStrideInBytes:       " << postStrideInBytes);
+      itkDebugMacro("sizePerStrideYInBytes:   " << sizePerChannelInBytes / tsizex);
+      itkDebugMacro("sizePerStrideXInBytes:   " << sizePerStrideXInBytes);
+      itkDebugMacro("initialStrideInBytes:    " << initialStrideInBytes);
+      itkDebugMacro("priorStrideInBytes:      " << priorStrideInBytes);
+      itkDebugMacro("postStrideInBytes:       " << postStrideInBytes);
 
 
       // TODO: Read the void buffer within the tile ROI. How do we specify the
@@ -691,7 +691,7 @@ JPEG2000ImageIO::Read(void * buffer)
     free(l_data);
   }
 
-  itkDebugMacro(<< "JPEG2000ImageIO::Read() End");
+  itkDebugMacro("JPEG2000ImageIO::Read() End");
 }
 
 bool
@@ -703,7 +703,7 @@ JPEG2000ImageIO::CanWriteFile(const char * filename)
 void
 JPEG2000ImageIO::WriteImageInformation()
 {
-  itkDebugMacro(<< "WriteImageInformation()");
+  itkDebugMacro("WriteImageInformation()");
 
   // the IORegion is not required to be set so we must use GetNumberOfDimensions
   if (this->GetNumberOfDimensions() != 2)
@@ -737,7 +737,7 @@ JPEG2000ImageIO::WriteImageInformation()
 void
 JPEG2000ImageIO::Write(const void * buffer)
 {
-  itkDebugMacro(<< "Write() " << this->GetNumberOfComponents());
+  itkDebugMacro("Write() " << this->GetNumberOfComponents());
 
   bool bSuccess;
 
@@ -910,7 +910,7 @@ JPEG2000ImageIO::Write(const void * buffer)
   // HERE, copy the buffer
   SizeValueType index = 0;
   SizeValueType numberOfPixels = SizeValueType(w) * SizeValueType(h);
-  itkDebugMacro(<< " START COPY BUFFER");
+  itkDebugMacro(" START COPY BUFFER");
   if (this->GetComponentType() == IOComponentEnum::UCHAR)
   {
     const auto * charBuffer = (const unsigned char *)buffer;
@@ -936,7 +936,7 @@ JPEG2000ImageIO::Write(const void * buffer)
       ++index;
     }
   }
-  itkDebugMacro(<< " END COPY BUFFER");
+  itkDebugMacro(" END COPY BUFFER");
   //--------------------------------------------------------------------
 
   opj_codec_t * cinfo = nullptr;
@@ -1066,8 +1066,8 @@ RequestedRegion */
 ImageIORegion
 JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const
 {
-  itkDebugMacro(<< "JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion()");
-  itkDebugMacro(<< "Requested region = " << requestedRegion);
+  itkDebugMacro("JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion()");
+  itkDebugMacro("Requested region = " << requestedRegion);
 
   ImageIORegion streamableRegion(this->m_NumberOfDimensions);
 
@@ -1084,7 +1084,7 @@ JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORe
     this->ComputeRegionInTileBoundaries(1, this->m_Internal->m_TileHeight, streamableRegion);
   }
 
-  itkDebugMacro(<< "Streamable region = " << streamableRegion);
+  itkDebugMacro("Streamable region = " << streamableRegion);
 
   return streamableRegion;
 }

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -321,7 +321,7 @@ JPEG2000ImageIO::ReadImageInformation()
     case 3:
       if (l_image->color_space != CLRSPC_SRGB)
       {
-        itkWarningMacro(<< "file does not specify color space, assuming sRGB");
+        itkWarningMacro("file does not specify color space, assuming sRGB");
       }
       this->SetPixelType(IOPixelEnum::RGB);
       break;

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -123,14 +123,14 @@ LSMImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
 
   if (!this->HasSupportedReadExtension(filename))
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 
@@ -269,7 +269,7 @@ LSMImageIO::Write(const void * buffer)
   TIFF * tif = TIFFOpen(m_FileName.c_str(), "w");
   if (!tif)
   {
-    itkDebugMacro(<< "Returning");
+    itkDebugMacro("Returning");
     return;
   }
 
@@ -354,7 +354,7 @@ LSMImageIO::Write(const void * buffer)
     {
       predictor = 2;
       TIFFSetField(tif, TIFFTAG_PREDICTOR, predictor);
-      itkDebugMacro(<< "LZW compression is patented outside US so it is disabled");
+      itkDebugMacro("LZW compression is patented outside US so it is disabled");
     }
     else if (compression == COMPRESSION_DEFLATE)
     {

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -91,7 +91,7 @@ MINCImageIO::CanReadFile(const char * name)
 {
   if (*name == 0)
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -160,7 +160,7 @@ MINCImageIO::Read(void * buffer)
       volume_data_type = MI_TYPE_DOUBLE;
       break;
     default:
-      itkDebugMacro(<< "Could read datatype " << this->GetComponentType());
+      itkDebugMacro("Could read datatype " << this->GetComponentType());
       return;
   }
 
@@ -893,7 +893,7 @@ MINCImageIO::CanWriteFile(const char * name)
 {
   if (name[0] == '\0')
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -1117,7 +1117,7 @@ MINCImageIO::WriteImageInformation()
           case 'V':
             if (nComp <= 1)
             {
-              itkDebugMacro(<< "Dimension order is incorrect " << dimension_order.c_str());
+              itkDebugMacro("Dimension order is incorrect " << dimension_order.c_str());
               dimorder_good = false;
             }
             else
@@ -1129,7 +1129,7 @@ MINCImageIO::WriteImageInformation()
           case 'T':
             if (nComp <= 1)
             {
-              itkDebugMacro(<< "Dimension order is incorrect " << dimension_order.c_str());
+              itkDebugMacro("Dimension order is incorrect " << dimension_order.c_str());
               dimorder_good = false;
             }
             else
@@ -1150,7 +1150,7 @@ MINCImageIO::WriteImageInformation()
             j = this->m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0) + 2);
             break;
           default:
-            itkDebugMacro(<< "Dimension order is incorrect " << dimension_order.c_str());
+            itkDebugMacro("Dimension order is incorrect " << dimension_order.c_str());
             dimorder_good = false;
             j = 0;
             break;
@@ -1184,7 +1184,7 @@ MINCImageIO::WriteImageInformation()
     }
     else
     {
-      itkDebugMacro(<< "Dimension order is incorrect " << dimension_order.c_str());
+      itkDebugMacro("Dimension order is incorrect " << dimension_order.c_str());
     }
   }
 
@@ -1329,7 +1329,7 @@ MINCImageIO::WriteImageInformation()
       }
       else
       {
-        itkDebugMacro(<< "Unsupported metadata type:" << tname);
+        itkDebugMacro("Unsupported metadata type:" << tname);
       }
     }
     else if (it->first == "history")

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -69,7 +69,7 @@ MRCHeaderObject::SetHeader(const Header * buffer)
   // the cmap field must should either be the magic field or 0
   if (strncmp(_header->cmap, magicMAP, 4) != 0 && memcmp(_header->cmap, "\0\0\0\0", 4) != 0)
   {
-    itkWarningMacro(<< "The header's cmap field does not have expected values");
+    itkWarningMacro("The header's cmap field does not have expected values");
     return false;
   }
 
@@ -100,7 +100,7 @@ MRCHeaderObject::SetHeader(const Header * buffer)
   else
   {
     // the stamp is not expected
-    itkWarningMacro(<< "The header's stamp field does not have expected values");
+    itkWarningMacro("The header's stamp field does not have expected values");
     return false;
   }
 
@@ -121,13 +121,13 @@ MRCHeaderObject::SetHeader(const Header * buffer)
       this->m_Header.nxstart >= this->m_Header.nx || this->m_Header.nystart >= this->m_Header.ny ||
       this->m_Header.nzstart >= this->m_Header.nz)
   {
-    itkWarningMacro(<< "Some header data does not have sensable values");
+    itkWarningMacro("Some header data does not have sensable values");
     return false;
   }
 
   if (this->m_Header.nxstart != 0 || this->m_Header.nystart != 0 || this->m_Header.nzstart != 0)
   {
-    itkWarningMacro(<< "The header's nxstart, nystart and nzstart fields are not supported correctly");
+    itkWarningMacro("The header's nxstart, nystart and nzstart fields are not supported correctly");
   }
 
   return true;

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -79,7 +79,7 @@ MRCImageIO::CanReadFile(const char * filename)
     return false;
   }
 
-  itkDebugMacro(<< "Reading Magic numbers " << filename);
+  itkDebugMacro("Reading Magic numbers " << filename);
   char map[4];
   char stamp[4];
 
@@ -233,7 +233,7 @@ MRCImageIO::InternalReadImageInformation(std::ifstream & file)
 
   m_MRCHeader = MRCHeaderObject::New();
 
-  itkDebugMacro(<< "Reading Information ");
+  itkDebugMacro("Reading Information ");
 
   this->OpenFileForReading(file, m_FileName);
 

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -355,7 +355,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
   {
     // the point pixel types don't match a type conversion needs to be
     // performed
-    itkDebugMacro(<< "Buffer conversion required from: "
+    itkDebugMacro("Buffer conversion required from: "
                   << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetPointPixelComponentType()) << " to: "
                   << m_MeshIO->GetComponentTypeAsString(
                        MeshIOBase::MapComponentType<typename ConvertPointPixelTraits::ComponentType>::CType)
@@ -372,7 +372,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
   }
   else
   {
-    itkDebugMacro(<< "No buffer conversion required.");
+    itkDebugMacro("No buffer conversion required.");
     m_MeshIO->ReadPointData(static_cast<void *>(outputPointDataBuffer.get()));
   }
 
@@ -396,7 +396,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
   {
     // the cell pixel types don't match a type conversion needs to be
     // performed
-    itkDebugMacro(<< "Buffer conversion required from: "
+    itkDebugMacro("Buffer conversion required from: "
                   << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetCellPixelComponentType()) << " to: "
                   << m_MeshIO->GetComponentTypeAsString(
                        MeshIOBase::MapComponentType<typename ConvertCellPixelTraits::ComponentType>::CType)
@@ -413,7 +413,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
   }
   else
   {
-    itkDebugMacro(<< "No buffer conversion required.");
+    itkDebugMacro("No buffer conversion required.");
     m_MeshIO->ReadCellData(static_cast<void *>(outputCellDataBuffer.get()));
   }
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -72,7 +72,7 @@ MeshFileWriter<TInputMesh>::Write()
 {
   const InputMeshType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing an mesh file");
+  itkDebugMacro("Writing an mesh file");
 
   // Make sure input is available
   if (input == nullptr)
@@ -91,7 +91,7 @@ MeshFileWriter<TInputMesh>::Write()
     // Try creating via factory
     if (m_MeshIO.IsNull())
     {
-      itkDebugMacro(<< "Attempting factory creation of MeshIO for file: " << m_FileName);
+      itkDebugMacro("Attempting factory creation of MeshIO for file: " << m_FileName);
       m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::IOFileModeEnum::WriteMode);
       m_FactorySpecifiedMeshIO = true;
     }
@@ -99,8 +99,8 @@ MeshFileWriter<TInputMesh>::Write()
     {
       if (m_FactorySpecifiedMeshIO && !m_MeshIO->CanWriteFile(m_FileName.c_str()))
       {
-        itkDebugMacro(<< "MeshIO exists but doesn't know how to write file:" << m_FileName);
-        itkDebugMacro(<< "Attempting creation of MeshIO with a factory for file:" << m_FileName);
+        itkDebugMacro("MeshIO exists but doesn't know how to write file:" << m_FileName);
+        itkDebugMacro("Attempting creation of MeshIO with a factory for file:" << m_FileName);
         m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::IOFileModeEnum::WriteMode);
         m_FactorySpecifiedMeshIO = true;
       }
@@ -248,7 +248,7 @@ MeshFileWriter<TInputMesh>::WritePoints()
 {
   const InputMeshType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing points: " << m_FileName);
+  itkDebugMacro("Writing points: " << m_FileName);
   SizeValueType pointsBufferSize = input->GetNumberOfPoints() * TInputMesh::PointDimension;
   using ValueType = typename TInputMesh::PointType::ValueType;
   const auto buffer = make_unique_for_overwrite<ValueType[]>(pointsBufferSize);
@@ -260,7 +260,7 @@ template <typename TInputMesh>
 void
 MeshFileWriter<TInputMesh>::WriteCells()
 {
-  itkDebugMacro(<< "Writing cells: " << m_FileName);
+  itkDebugMacro("Writing cells: " << m_FileName);
 
   SizeValueType cellsBufferSize = m_MeshIO->GetCellBufferSize();
   using PointIdentifierType = typename TInputMesh::PointIdentifier;
@@ -275,7 +275,7 @@ MeshFileWriter<TInputMesh>::WritePointData()
 {
   const InputMeshType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing point data: " << m_FileName);
+  itkDebugMacro("Writing point data: " << m_FileName);
 
   if (input->GetPointData()->Size())
   {
@@ -296,7 +296,7 @@ MeshFileWriter<TInputMesh>::WriteCellData()
 {
   const InputMeshType * input = this->GetInput();
 
-  itkDebugMacro(<< "Writing cell data: " << m_FileName);
+  itkDebugMacro("Writing cell data: " << m_FileName);
 
   if (input->GetCellData()->Size())
   {

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -86,7 +86,7 @@ MetaImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
@@ -92,7 +92,7 @@ SlopeInterceptTest()
   nifti_image_free(niftiImage); // Must free before throwing exception.
   if (nifti_write_status)
   {
-    itkGenericExceptionMacro(<< "ERROR: nifti library failed to write image" << filename);
+    itkGenericExceptionMacro("ERROR: nifti library failed to write image" << filename);
   }
 
   //

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -215,7 +215,7 @@ NrrdImageIO::CanReadFile(const char * filename)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -68,7 +68,7 @@ PNGImageIO::CanReadFile(const char * file)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -140,7 +140,7 @@ RawImageIO<TPixel, VImageDimension>::Read(void * buffer)
 
   const auto numberOfBytesToBeRead = static_cast<SizeValueType>(this->GetImageSizeInBytes());
 
-  itkDebugMacro(<< "Reading " << numberOfBytesToBeRead << " bytes");
+  itkDebugMacro("Reading " << numberOfBytesToBeRead << " bytes");
 
   const auto componentType = this->GetComponentType();
   if (m_FileType == IOFileEnum::Binary)
@@ -156,7 +156,7 @@ RawImageIO<TPixel, VImageDimension>::Read(void * buffer)
     this->ReadBufferAsASCII(file, buffer, this->GetComponentType(), this->GetImageSizeInComponents());
   }
 
-  itkDebugMacro(<< "Reading Done");
+  itkDebugMacro("Reading Done");
   const SizeValueType numberOfComponents = this->GetImageSizeInComponents();
   ReadRawBytesAfterSwapping(componentType, buffer, m_ByteOrder, numberOfComponents);
 }

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -64,7 +64,7 @@ StimulateImageIO::CanReadFile(const char * filename)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -72,7 +72,7 @@ StimulateImageIO::CanReadFile(const char * filename)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 
@@ -271,7 +271,7 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
     else if (text.find("extent") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "Extent was specified");
+      itkDebugMacro("Extent was specified");
     }
     else if (text.find("fov") < text.length())
     {
@@ -367,7 +367,7 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
       char * pch;
       pch = strchr(line, ':');
       sscanf(++pch, "%s", m_FidName); // delete any white space left
-      itkDebugMacro(<< "fidName was specified");
+      itkDebugMacro("fidName was specified");
     }
     else if (text.find("sdtOrient") < text.length())
     {
@@ -379,12 +379,12 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
       char * pch;
       pch = strchr(line, ':');
       sscanf(++pch, "%s", m_SdtOrient); // delete any white space left
-      itkDebugMacro(<< "Orientation was specified");
+      itkDebugMacro("Orientation was specified");
     }
     else if (text.find("dsplyThres") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "Display threshold was specified");
+      itkDebugMacro("Display threshold was specified");
     }
     else if (text.find("endian") < text.length())
     {
@@ -397,12 +397,12 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
     else if (text.find("mapParmFileName") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "mapParmFileName was specified");
+      itkDebugMacro("mapParmFileName was specified");
     }
     else if (text.find("mapTypeName") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "mapTypeName was specified");
+      itkDebugMacro("mapTypeName was specified");
     }
     else if (text.find("stimFileName:") < text.length())
     {
@@ -432,12 +432,12 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
     else if (text.find("mapConf") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "mapConf was specified");
+      itkDebugMacro("mapConf was specified");
     }
     else if (text.find("periodStr") < text.length())
     {
       // not documented
-      itkDebugMacro(<< "periodStr was specified");
+      itkDebugMacro("periodStr was specified");
     }
   }
 
@@ -473,7 +473,7 @@ StimulateImageIO::CanWriteFile(const char * name)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -482,7 +482,7 @@ StimulateImageIO::CanWriteFile(const char * name)
 
   if (!extensionFound)
   {
-    itkDebugMacro(<< "The filename extension is not recognized");
+    itkDebugMacro("The filename extension is not recognized");
     return false;
   }
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -518,7 +518,7 @@ TIFFImageIO::ReadImageInformation()
     else
     {
       itkDebugMacro("Using TIFFReadRGBAImageOriented");
-      itkWarningMacro(<< "Could not read this palette image as scalar+Palette because of its TIFF format");
+      itkWarningMacro("Could not read this palette image as scalar+Palette because of its TIFF format");
       // can't read as scalar+palette so reset type to RGB
       m_IsReadAsScalarPlusPalette = false;
       this->SetNumberOfComponents(3);
@@ -732,7 +732,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
     {
       if (this->GetWritePalette())
       {
-        itkWarningMacro(<< "Could not write this image as palette because pixel is not scalar");
+        itkWarningMacro("Could not write this image as palette because pixel is not scalar");
       }
       TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
     }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -35,7 +35,7 @@ TIFFImageIO::CanReadFile(const char * file)
 
   if (filename.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 
@@ -506,7 +506,7 @@ TIFFImageIO::ReadImageInformation()
 
     if (!m_IsReadAsScalarPlusPalette)
     {
-      itkDebugMacro(<< "Using TIFFReadRGBAImageOriented");
+      itkDebugMacro("Using TIFFReadRGBAImageOriented");
       if (m_InternalImage->m_BitsPerSample > 8)
       {
         itkWarningMacro("Falling back to suboptimal 8-bit RGBA reader. Data loss will occur with reduced bit depth.");
@@ -517,7 +517,7 @@ TIFFImageIO::ReadImageInformation()
     }
     else
     {
-      itkDebugMacro(<< "Using TIFFReadRGBAImageOriented");
+      itkDebugMacro("Using TIFFReadRGBAImageOriented");
       itkWarningMacro(<< "Could not read this palette image as scalar+Palette because of its TIFF format");
       // can't read as scalar+palette so reset type to RGB
       m_IsReadAsScalarPlusPalette = false;
@@ -1188,8 +1188,8 @@ TIFFImageIO::ReadTIFFTags()
       continue;
     }
 
-    itkDebugMacro(<< "TiffInfo tag " << field_name << '(' << tag << "): " << itkTIFFFieldDataType(field) << ' '
-                  << value_count << ' ' << raw_data);
+    itkDebugMacro("TiffInfo tag " << field_name << '(' << tag << "): " << itkTIFFFieldDataType(field) << ' '
+                                  << value_count << ' ' << raw_data);
 
 
 #define itkEncapsulate(T1, T2)                                                         \

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -129,7 +129,7 @@ TIFFReaderInternal::Initialize()
       if (!TIFFGetField(this->m_Image, TIFFTAG_TILEWIDTH, &this->m_TileWidth) ||
           !TIFFGetField(this->m_Image, TIFFTAG_TILELENGTH, &this->m_TileHeight))
       {
-        itkGenericExceptionMacro(<< "Cannot read tile width and tile length from file");
+        itkGenericExceptionMacro("Cannot read tile width and tile length from file");
       }
       else
       {

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -145,7 +145,7 @@ public:
   static inline void
   CorrectTransformPrecisionType(std::string & itkNotUsed(inputTransformName))
   {
-    itkGenericExceptionMacro(<< "Unknown ScalarType" << typeid(ScalarType).name());
+    itkGenericExceptionMacro("Unknown ScalarType" << typeid(ScalarType).name());
   }
 
 protected:
@@ -165,7 +165,7 @@ protected:
   static inline const std::string
   GetTypeNameString()
   {
-    itkGenericExceptionMacro(<< "Unknown ScalarType" << typeid(ScalarType).name());
+    itkGenericExceptionMacro("Unknown ScalarType" << typeid(ScalarType).name());
   }
 
 private:

--- a/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
+++ b/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
@@ -116,7 +116,7 @@ CompositeTransformIOHelperTemplate<TParametersValueType>::GetTransformList(const
       this->BuildTransformList<6>(transform) == 0 && this->BuildTransformList<7>(transform) == 0 &&
       this->BuildTransformList<8>(transform) == 0 && this->BuildTransformList<9>(transform) == 0)
   {
-    itkGenericExceptionMacro(<< "Unsupported Composite Transform Type " << transform->GetTransformTypeAsString());
+    itkGenericExceptionMacro("Unsupported Composite Transform Type " << transform->GetTransformTypeAsString());
   }
   return m_TransformList;
 }
@@ -137,7 +137,7 @@ CompositeTransformIOHelperTemplate<TParametersValueType>::SetTransformList(Trans
       this->InternalSetTransformList<8>(transform, transformList) == 0 &&
       this->InternalSetTransformList<9>(transform, transformList) == 0)
   {
-    itkGenericExceptionMacro(<< "Unsupported Composite Transform Type " << transform->GetTransformTypeAsString());
+    itkGenericExceptionMacro("Unsupported Composite Transform Type " << transform->GetTransformTypeAsString());
   }
 }
 

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -158,9 +158,9 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
     if (KernelTransformHelper<TParametersValueType, ITK_TRANSFORM_FACTORY_MAX_DIM>::InitializeWMatrix(
           ioTransformList.front().GetPointer()))
     {
-      itkDebugMacro(<< "KernelTransform with dimension " << ioTransformList.front()->GetInputSpaceDimension()
-                    << " is not automatically initialized. \"ComputeWMatrix()\""
-                       " method has to be called.");
+      itkDebugMacro("KernelTransform with dimension " << ioTransformList.front()->GetInputSpaceDimension()
+                                                      << " is not automatically initialized. \"ComputeWMatrix()\""
+                                                         " method has to be called.");
     }
   }
 

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -206,7 +206,7 @@ struct TransformIOHelper
     OutputTransformPointer convertedTransform = dynamic_cast<TOutputTransformType *>(i.GetPointer());
     if (convertedTransform.IsNull())
     {
-      itkGenericExceptionMacro(<< "Could not create an instance of " << transformName);
+      itkGenericExceptionMacro("Could not create an instance of " << transformName);
     }
     convertedTransform->UnRegister();
     return convertedTransform;

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -402,7 +402,7 @@ VoxBoCUBImageIO::CanReadFile(const char * filename)
 
   if (reader == nullptr)
   {
-    itkDebugMacro(<< "The file is not a valid CUB file");
+    itkDebugMacro("The file is not a valid CUB file");
     return false;
   }
 
@@ -761,7 +761,7 @@ VoxBoCUBImageIO::CheckExtension(const char * filename, bool & isCompressed)
 
   if (fname.empty())
   {
-    itkDebugMacro(<< "No filename specified.");
+    itkDebugMacro("No filename specified.");
     return false;
   }
 

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -547,7 +547,7 @@ Solver<VDimension>::RunSolver()
     throw FEMExceptionSolution(__FILE__, __LINE__, "FEMObject::Solve()", "Master force vector was not initialized!");
   }
   timer.Stop();
-  itkDebugMacro(<< "Assemble Matrix took " << timer.GetMean() << " seconds.\n");
+  itkDebugMacro("Assemble Matrix took " << timer.GetMean() << " seconds.\n");
 
   itk::TimeProbe timer1;
   timer1.Start();
@@ -559,7 +559,7 @@ Solver<VDimension>::RunSolver()
   this->GetOutput()->DeepCopy(this->GetInput());
   this->UpdateDisplacements();
   timer1.Stop();
-  itkDebugMacro(<< "FE Solution took " << timer1.GetMean() << " seconds.\n");
+  itkDebugMacro("FE Solution took " << timer1.GetMean() << " seconds.\n");
 }
 
 template <unsigned int VDimension>

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -146,7 +146,7 @@ Solver<VDimension>::GetOutput(unsigned int idx) -> FEMObjectType *
 
   if (out == nullptr)
   {
-    itkWarningMacro(<< "dynamic_cast to output type failed");
+    itkWarningMacro("dynamic_cast to output type failed");
   }
   return out;
 }

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -101,7 +101,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput(unsigned int idx) -> F
 
   if (out == nullptr)
   {
-    itkWarningMacro(<< "dynamic_cast to output type failed");
+    itkWarningMacro("dynamic_cast to output type failed");
   }
   return out;
 }
@@ -113,7 +113,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GenerateData()
 
   if (this->GetNumberOfInputs() < 1)
   {
-    itkWarningMacro(<< "GenerateData() found no input objects");
+    itkWarningMacro("GenerateData() found no input objects");
   }
 
   if (NDimensions == 2)

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
@@ -34,7 +34,7 @@ LinearSystemWrapperVNL::InitializeMatrix(unsigned int matrixIndex)
     m_Matrices = new MatrixHolder(m_NumberOfMatrices);
     if (m_Matrices == nullptr)
     {
-      itkGenericExceptionMacro(<< "LinearSystemWrapperVNL::InitializeMatrix(): m_Matrices allocation failed.");
+      itkGenericExceptionMacro("LinearSystemWrapperVNL::InitializeMatrix(): m_Matrices allocation failed.");
     }
   }
 
@@ -44,8 +44,8 @@ LinearSystemWrapperVNL::InitializeMatrix(unsigned int matrixIndex)
   (*m_Matrices)[matrixIndex] = new MatrixRepresentation(this->GetSystemOrder(), this->GetSystemOrder());
   if ((*m_Matrices)[matrixIndex] == nullptr)
   {
-    itkGenericExceptionMacro(<< "LinearSystemWrapperVNL::InitializeMatrix(): allocation of (*m_Matrices)["
-                             << matrixIndex << "] failed.");
+    itkGenericExceptionMacro("LinearSystemWrapperVNL::InitializeMatrix(): allocation of (*m_Matrices)[" << matrixIndex
+                                                                                                        << "] failed.");
   }
 }
 
@@ -83,7 +83,7 @@ LinearSystemWrapperVNL::InitializeVector(unsigned int vectorIndex)
     m_Vectors = new std::vector<vnl_vector<Float> *>(m_NumberOfVectors);
     if (m_Vectors == nullptr)
     {
-      itkGenericExceptionMacro(<< "InitializeVector(): m_Vectors memory allocation failed.");
+      itkGenericExceptionMacro("InitializeVector(): m_Vectors memory allocation failed.");
     }
   }
 
@@ -93,7 +93,7 @@ LinearSystemWrapperVNL::InitializeVector(unsigned int vectorIndex)
   (*m_Vectors)[vectorIndex] = new vnl_vector<Float>(this->GetSystemOrder());
   if ((*m_Vectors)[vectorIndex] == nullptr)
   {
-    itkGenericExceptionMacro(<< "InitializeVector(): allocation of (*m_Vectors)[" << vectorIndex << "] failed.");
+    itkGenericExceptionMacro("InitializeVector(): allocation of (*m_Vectors)[" << vectorIndex << "] failed.");
   }
   (*m_Vectors)[vectorIndex]->fill(0.0);
 }
@@ -132,7 +132,7 @@ LinearSystemWrapperVNL::InitializeSolution(unsigned int solutionIndex)
     m_Solutions = new std::vector<vnl_vector<Float> *>(m_NumberOfSolutions);
     if (m_Solutions == nullptr)
     {
-      itkGenericExceptionMacro(<< "InitializeSolution(): m_Solutions memory allocation failed.");
+      itkGenericExceptionMacro("InitializeSolution(): m_Solutions memory allocation failed.");
     }
   }
 
@@ -142,7 +142,7 @@ LinearSystemWrapperVNL::InitializeSolution(unsigned int solutionIndex)
   (*m_Solutions)[solutionIndex] = new vnl_vector<Float>(this->GetSystemOrder());
   if ((*m_Solutions)[solutionIndex] == nullptr)
   {
-    itkGenericExceptionMacro(<< "InitializeSolution(): allocation of (*m_olutions)[" << solutionIndex << "] failed.");
+    itkGenericExceptionMacro("InitializeSolution(): allocation of (*m_olutions)[" << solutionIndex << "] failed.");
   }
   (*m_Solutions)[solutionIndex]->fill(0.0);
 }

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -142,7 +142,7 @@ ExhaustiveOptimizer::AdvanceOneStep()
   ParametersType newPosition(spaceDimension);
   IncrementIndex(newPosition);
 
-  itkDebugMacro(<< "new position = " << newPosition);
+  itkDebugMacro("new position = " << newPosition);
 
   this->SetCurrentPosition(newPosition);
 }

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -120,8 +120,8 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
     }
   }
 
-  itkDebugMacro(<< ": initial position: " << parentPosition);
-  itkDebugMacro(<< ": initial fitness: " << pvalue);
+  itkDebugMacro(": initial position: " << parentPosition);
+  itkDebugMacro(": initial fitness: " << pvalue);
 
   this->SetCurrentPosition(parentPosition);
   const Optimizer::ScalesType & scales = this->GetScales();
@@ -187,20 +187,20 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
       }
     }
 
-    itkDebugMacro(<< "iter: " << iter << ": parent position: " << parentPosition);
-    itkDebugMacro(<< "iter: " << iter << ": parent fitness: " << pvalue);
-    itkDebugMacro(<< "iter: " << iter << ": random vector: " << f_norm);
-    itkDebugMacro(<< "iter: " << iter << ": A: " << std::endl << A);
-    itkDebugMacro(<< "iter: " << iter << ": delta: " << delta);
-    itkDebugMacro(<< "iter: " << iter << ": child position: " << childPosition);
-    itkDebugMacro(<< "iter: " << iter << ": child fitness: " << cvalue);
+    itkDebugMacro("iter: " << iter << ": parent position: " << parentPosition);
+    itkDebugMacro("iter: " << iter << ": parent fitness: " << pvalue);
+    itkDebugMacro("iter: " << iter << ": random vector: " << f_norm);
+    itkDebugMacro("iter: " << iter << ": A: " << std::endl << A);
+    itkDebugMacro("iter: " << iter << ": delta: " << delta);
+    itkDebugMacro("iter: " << iter << ": child position: " << childPosition);
+    itkDebugMacro("iter: " << iter << ": child fitness: " << cvalue);
 
     double adjust = m_ShrinkFactor;
     if (m_Maximize)
     {
       if (cvalue > pvalue)
       {
-        itkDebugMacro(<< "iter: " << iter << ": increasing search radius");
+        itkDebugMacro("iter: " << iter << ": increasing search radius");
         pvalue = cvalue;
         parent.swap(child);
         adjust = m_GrowthFactor;
@@ -212,14 +212,14 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
       }
       else
       {
-        itkDebugMacro(<< "iter: " << iter << ": decreasing search radius");
+        itkDebugMacro("iter: " << iter << ": decreasing search radius");
       }
     }
     else
     {
       if (cvalue < pvalue)
       {
-        itkDebugMacro(<< "iter: " << iter << ": increasing search radius");
+        itkDebugMacro("iter: " << iter << ": increasing search radius");
         pvalue = cvalue;
         parent.swap(child);
         adjust = m_GrowthFactor;
@@ -231,7 +231,7 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
       }
       else
       {
-        itkDebugMacro(<< "iter: " << iter << ": decreasing search radius");
+        itkDebugMacro("iter: " << iter << ": decreasing search radius");
       }
     }
 
@@ -240,10 +240,10 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
     // Compute double precision sum of absolute values of
     // a single precision vector
     m_FrobeniusNorm = A.fro_norm();
-    itkDebugMacro(<< "A f-norm:" << m_FrobeniusNorm);
+    itkDebugMacro("A f-norm:" << m_FrobeniusNorm);
     if (m_FrobeniusNorm <= m_Epsilon)
     {
-      itkDebugMacro(<< "converges at iteration = " << iter);
+      itkDebugMacro("converges at iteration = " << iter);
       m_StopConditionDescription.str("");
       m_StopConditionDescription << this->GetNameOfClass() << ": "
                                  << "Fnorm (" << m_FrobeniusNorm << ") is less than Epsilon (" << m_Epsilon
@@ -275,7 +275,7 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
     }
 
     this->InvokeEvent(IterationEvent());
-    itkDebugMacro(<< "Current position: " << this->GetCurrentPosition());
+    itkDebugMacro("Current position: " << this->GetCurrentPosition());
   }
   m_StopConditionDescription.str("");
   m_StopConditionDescription << this->GetNameOfClass() << ": "

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -74,7 +74,7 @@ PowellOptimizer::GetLineValue(double x, ParametersType & tempCoord) const
   {
     tempCoord[i] = this->m_LineOrigin[i] + x * this->m_LineDirection[i];
   }
-  itkDebugMacro(<< "x = " << x);
+  itkDebugMacro("x = " << x);
   double val;
   try
   {
@@ -95,7 +95,7 @@ PowellOptimizer::GetLineValue(double x, ParametersType & tempCoord) const
   {
     val = -val;
   }
-  itkDebugMacro(<< "val = " << val);
+  itkDebugMacro("val = " << val);
   return val;
 }
 
@@ -207,7 +207,7 @@ PowellOptimizer::LineBracket(double *         x1,
     *f3 = this->GetLineValue(*x3, tempCoord);
   }
 
-  itkDebugMacro(<< "Initial: " << *x1 << ", " << *x2 << ", " << *x3);
+  itkDebugMacro("Initial: " << *x1 << ", " << *x2 << ", " << *x3);
   //
   // Report the central point as the minimum
   //
@@ -282,9 +282,9 @@ PowellOptimizer::BracketedLineOptimize(double           ax,
       *extX = x;
       *extVal = functionValueOfX;
       this->SetCurrentLinePoint(x, functionValueOfX);
-      itkDebugMacro(<< "x = " << *extX);
-      itkDebugMacro(<< "val = " << *extVal);
-      itkDebugMacro(<< "return 1");
+      itkDebugMacro("x = " << *extX);
+      itkDebugMacro("val = " << *extVal);
+      itkDebugMacro("return 1");
       return; /* Acceptable approx. is found  */
     }
 
@@ -395,9 +395,9 @@ PowellOptimizer::BracketedLineOptimize(double           ax,
 
   *extX = x;
   *extVal = functionValueOfX;
-  itkDebugMacro(<< "x = " << *extX);
-  itkDebugMacro(<< "val = " << *extVal);
-  itkDebugMacro(<< "return 2");
+  itkDebugMacro("x = " << *extX);
+  itkDebugMacro("val = " << *extVal);
+  itkDebugMacro("return 2");
 
   this->SetCurrentLinePoint(x, functionValueOfX);
 }

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
 void
 RegularStepGradientDescentOptimizer::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
 {
-  itkDebugMacro(<< "factor = " << factor << "  transformedGradient= " << transformedGradient);
+  itkDebugMacro("factor = " << factor << "  transformedGradient= " << transformedGradient);
 
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();
 
@@ -39,7 +39,7 @@ RegularStepGradientDescentOptimizer::StepAlongGradient(double factor, const Deri
     newPosition[j] = currentPosition[j] + transformedGradient[j] * factor;
   }
 
-  itkDebugMacro(<< "new position = " << newPosition);
+  itkDebugMacro("new position = " << newPosition);
 
   this->SetCurrentPosition(newPosition);
 }

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -159,7 +159,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::AdvanceOneStep()
   ParametersType newPosition(spaceDimension);
   this->IncrementIndex(newPosition);
 
-  itkDebugMacro(<< "new position = " << newPosition);
+  itkDebugMacro("new position = " << newPosition);
 
   this->m_Metric->SetParameters(newPosition);
 }

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -134,7 +134,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
       }
       catch (const std::exception & e)
       {
-        itkWarningMacro(<< "GetConvergenceValue() failed with exception: " << e.what() << std::endl);
+        itkWarningMacro("GetConvergenceValue() failed with exception: " << e.what() << std::endl);
       }
     }
 

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -127,8 +127,8 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
     }
   }
 
-  itkDebugMacro(<< ": initial position: " << parentPosition);
-  itkDebugMacro(<< ": initial fitness: " << pvalue);
+  itkDebugMacro(": initial position: " << parentPosition);
+  itkDebugMacro(": initial fitness: " << pvalue);
 
   this->m_Metric->SetParameters(parentPosition);
   const ScalesType & scales = this->GetScales();
@@ -196,19 +196,19 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
       }
     }
 
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": parent position: " << parentPosition);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": parent fitness: " << pvalue);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": random vector: " << f_norm);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": A: " << std::endl << A);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": delta: " << delta);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": child position: " << childPosition);
-    itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": child fitness: " << cvalue);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": parent position: " << parentPosition);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": parent fitness: " << pvalue);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": random vector: " << f_norm);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": A: " << std::endl << A);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": delta: " << delta);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": child position: " << childPosition);
+    itkDebugMacro("iter: " << this->m_CurrentIteration << ": child fitness: " << cvalue);
 
     double adjust = m_ShrinkFactor;
 
     if (cvalue < pvalue)
     {
-      itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": increasing search radius");
+      itkDebugMacro("iter: " << this->m_CurrentIteration << ": increasing search radius");
       pvalue = cvalue;
       parent.swap(child);
       adjust = m_GrowthFactor;
@@ -220,7 +220,7 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
     }
     else
     {
-      itkDebugMacro(<< "iter: " << this->m_CurrentIteration << ": decreasing search radius");
+      itkDebugMacro("iter: " << this->m_CurrentIteration << ": decreasing search radius");
     }
 
     m_CurrentCost = pvalue;
@@ -228,10 +228,10 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
     // Compute double precision sum of absolute values of
     // a single precision vector
     m_FrobeniusNorm = A.fro_norm();
-    itkDebugMacro(<< "A f-norm:" << m_FrobeniusNorm);
+    itkDebugMacro("A f-norm:" << m_FrobeniusNorm);
     if (m_FrobeniusNorm <= m_Epsilon)
     {
-      itkDebugMacro(<< "converges at iteration = " << this->m_CurrentIteration);
+      itkDebugMacro("converges at iteration = " << this->m_CurrentIteration);
       m_StopConditionDescription.str("");
       m_StopConditionDescription << this->GetNameOfClass() << ": "
                                  << "Fnorm (" << m_FrobeniusNorm << ") is less than Epsilon (" << m_Epsilon
@@ -263,7 +263,7 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
     }
 
     this->InvokeEvent(IterationEvent());
-    itkDebugMacro(<< "Current position: " << this->GetCurrentPosition());
+    itkDebugMacro("Current position: " << this->GetCurrentPosition());
   }
   if (this->m_CurrentIteration >= m_MaximumIteration)
   {

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -67,7 +67,7 @@ PowellOptimizerv4<TInternalComputationValueType>::GetLineValue(double x, Paramet
     tempCoord[i] = this->m_LineOrigin[i] + x * this->m_LineDirection[i];
   }
   this->m_Metric->SetParameters(tempCoord);
-  itkDebugMacro(<< "x = " << x);
+  itkDebugMacro("x = " << x);
   double val;
   try
   {
@@ -84,7 +84,7 @@ PowellOptimizerv4<TInternalComputationValueType>::GetLineValue(double x, Paramet
       throw;
     }
   }
-  itkDebugMacro(<< "val = " << val);
+  itkDebugMacro("val = " << val);
   return val;
 }
 
@@ -200,7 +200,7 @@ PowellOptimizerv4<TInternalComputationValueType>::LineBracket(double *         x
     *f3 = this->GetLineValue(*x3, tempCoord);
   }
 
-  itkDebugMacro(<< "Initial: " << *x1 << ", " << *x2 << ", " << *x3);
+  itkDebugMacro("Initial: " << *x1 << ", " << *x2 << ", " << *x3);
   //
   // Report the central point as the minimum
   //
@@ -277,9 +277,9 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
       *extX = x;
       *extVal = functionValueOfX;
       this->SetCurrentLinePoint(x, functionValueOfX);
-      itkDebugMacro(<< "x = " << *extX);
-      itkDebugMacro(<< "val = " << *extVal);
-      itkDebugMacro(<< "return 1");
+      itkDebugMacro("x = " << *extX);
+      itkDebugMacro("val = " << *extVal);
+      itkDebugMacro("return 1");
       return; /* Acceptable approx. is found  */
     }
 
@@ -390,9 +390,9 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
 
   *extX = x;
   *extVal = functionValueOfX;
-  itkDebugMacro(<< "x = " << *extX);
-  itkDebugMacro(<< "val = " << *extVal);
-  itkDebugMacro(<< "return 2");
+  itkDebugMacro("x = " << *extX);
+  itkDebugMacro("val = " << *extVal);
+  itkDebugMacro("return 2");
 
   this->SetCurrentLinePoint(x, functionValueOfX);
 }

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -87,8 +87,8 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateScales(ScalesType & p
 
   if (Math::ExactlyEquals(minNonZeroShift, NumericTraits<FloatType>::max()))
   {
-    itkWarningMacro(<< "Variation in any parameter won't change a voxel position. The default scales (1.0) are used to "
-                       "avoid division-by-zero.");
+    itkWarningMacro("Variation in any parameter won't change a voxel position. The default scales (1.0) are used to "
+                    "avoid division-by-zero.");
     parameterScales.Fill(NumericTraits<typename ScalesType::ValueType>::OneValue());
   }
   else

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -95,7 +95,7 @@ LBFGSBOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 void
 LBFGSBOptimizerv4::SetScales(const ScalesType &)
 {
-  itkWarningMacro(<< "LBFGSB optimizer does not support scaling. All scales are set to one.");
+  itkWarningMacro("LBFGSB optimizer does not support scaling. All scales are set to one.");
   m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
   m_Scales.Fill(NumericTraits<ScalesType::ValueType>::OneValue());
   this->m_ScalesAreIdentity = true;

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -40,7 +40,7 @@ SingleValuedVnlCostFunctionAdaptorv4::f(const InternalParametersType & inparamet
 {
   if (!m_ObjectMetric)
   {
-    itkGenericExceptionMacro(<< "Attempt to use a SingleValuedVnlCostFunctionAdaptorv4 without any Metric plugge d in");
+    itkGenericExceptionMacro("Attempt to use a SingleValuedVnlCostFunctionAdaptorv4 without any Metric plugge d in");
   }
 
   // Use scales if they are provided

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -26,7 +26,7 @@ MultivariateLegendrePolynomial::MultivariateLegendrePolynomial(unsigned int     
 {
   if (dimension > 3 || dimension < 2)
   {
-    itkGenericExceptionMacro(<< "MultivariateLegendrePolynomial only supports 2D and 3D");
+    itkGenericExceptionMacro("MultivariateLegendrePolynomial only supports 2D and 3D");
   }
 
   m_Dimension = dimension;

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -114,7 +114,7 @@ template <typename THistogram, typename TImage, typename TFunction>
 void
 HistogramToImageFilter<THistogram, TImage, TFunction>::GenerateData()
 {
-  itkDebugMacro(<< "HistogramToImageFilter::Update() called");
+  itkDebugMacro("HistogramToImageFilter::Update() called");
 
   this->AllocateOutputs();
 

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -252,7 +252,7 @@ FindSampleBound(const TSample *                           sample,
   const MeasurementVectorSizeType measurementSize = sample->GetMeasurementVectorSize();
   if (measurementSize == 0)
   {
-    itkGenericExceptionMacro(<< "Length of a sample's measurement vector hasn't been set.");
+    itkGenericExceptionMacro("Length of a sample's measurement vector hasn't been set.");
   }
   // Sanity check
   MeasurementVectorTraits::Assert(max, measurementSize, "Length mismatch StatisticsAlgorithm::FindSampleBound");
@@ -260,7 +260,7 @@ FindSampleBound(const TSample *                           sample,
 
   if (sample->Size() == 0)
   {
-    itkGenericExceptionMacro(<< "Attempting to compute bounds of a sample list containing no measurement vectors");
+    itkGenericExceptionMacro("Attempting to compute bounds of a sample list containing no measurement vectors");
   }
 
   min = begin.GetMeasurementVector();
@@ -303,7 +303,7 @@ FindSampleBoundAndMean(const TSubsample *                           sample,
   const MeasurementVectorSizeType Dimension = sample->GetMeasurementVectorSize();
   if (Dimension == 0)
   {
-    itkGenericExceptionMacro(<< "Length of a sample's measurement vector hasn't been set.");
+    itkGenericExceptionMacro("Length of a sample's measurement vector hasn't been set.");
   }
 
   Array<double> sum(Dimension);

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -95,8 +95,8 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Initi
   // Validate initial transform parameters
   if (m_InitialTransformParameters.Size() != m_Metric->GetNumberOfParameters())
   {
-    itkWarningMacro(<< " WARNING : Size mismatch between initial parameter and transform");
-    itkWarningMacro(<< "Resizing m_InitialTransformParameters to  " << m_Transform->GetNumberOfParameters());
+    itkWarningMacro(" WARNING : Size mismatch between initial parameter and transform");
+    itkWarningMacro("Resizing m_InitialTransformParameters to  " << m_Transform->GetNumberOfParameters());
     m_InitialTransformParameters.set_size(m_Transform->GetNumberOfParameters());
     m_InitialTransformParameters.Fill(0.0f);
   }

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -732,7 +732,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   }
   else
   {
-    itkWarningMacro(<< "Less than 2 landmarks available. Rotation is not computed");
+    itkWarningMacro("Less than 2 landmarks available. Rotation is not computed");
   }
 
   auto t = Rigid2DTransformType::New();

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -376,8 +376,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
   PointType3D movingCentroid = ComputeCentroid(this->m_MovingLandmarks);
 
-  itkDebugMacro(<< "fixed centroid  = " << fixedCentroid);
-  itkDebugMacro(<< "moving centroid  = " << movingCentroid);
+  itkDebugMacro("fixed centroid  = " << fixedCentroid);
+  itkDebugMacro("moving centroid  = " << movingCentroid);
 
   using VersorType = typename VersorRigid3DTransformType::VersorType;
 
@@ -418,8 +418,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
       }
 
       itkDebugStatement(++ii);
-      itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
-      itkDebugMacro(<< "m_" << ii << " = " << movingCentered);
+      itkDebugMacro("f_" << ii << " = " << fixedCentered);
+      itkDebugMacro("m_" << ii << " = " << movingCentered);
 
       ++movingItr;
       ++fixedItr;
@@ -431,9 +431,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
     CreateMatrix(N, M);
 
-    itkDebugMacro(<< "For Closed form solution: ");
-    itkDebugMacro(<< "M matrix " << M);
-    itkDebugMacro(<< "N matrix " << N);
+    itkDebugMacro("For Closed form solution: ");
+    itkDebugMacro("M matrix " << M);
+    itkDebugMacro("N matrix " << N);
 
     vnl_matrix<ParametersValueType> eigenVectors(4, 4);
     vnl_vector<ParametersValueType> eigenValues(4);
@@ -446,8 +446,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
     symmetricEigenSystem.ComputeEigenValuesAndVectors(N, eigenValues, eigenVectors);
 
-    itkDebugMacro(<< "EigenVectors " << eigenVectors);
-    itkDebugMacro(<< "EigenValues " << eigenValues);
+    itkDebugMacro("EigenVectors " << eigenVectors);
+    itkDebugMacro("EigenValues " << eigenValues);
 
     // By default eigen values are sorted in ascending order therefore the
     // maximum eigen value is the one in the fourth place = index 3. We need the
@@ -455,7 +455,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     // eigenvector from the last row, index=3.
 
     versor.Set(eigenVectors[3][1], eigenVectors[3][2], eigenVectors[3][3], eigenVectors[3][0]);
-    itkDebugMacro(<< "Resulting versor" << versor);
+    itkDebugMacro("Resulting versor" << versor);
   }
 
 
@@ -508,8 +508,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
   PointType3D movingCentroid = ComputeCentroid(this->m_MovingLandmarks);
 
-  itkDebugMacro(<< "fixed centroid  = " << fixedCentroid);
-  itkDebugMacro(<< "moving centroid  = " << movingCentroid);
+  itkDebugMacro("fixed centroid  = " << fixedCentroid);
+  itkDebugMacro("moving centroid  = " << movingCentroid);
 
   using VersorType = typename VersorRigid3DTransformType::VersorType;
 
@@ -559,8 +559,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
       }
 
       itkDebugStatement(++ii);
-      itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
-      itkDebugMacro(<< "m_" << ii << " = " << movingCentered);
+      itkDebugMacro("f_" << ii << " = " << fixedCentered);
+      itkDebugMacro("m_" << ii << " = " << movingCentered);
 
       ++movingItr;
       ++fixedItr;
@@ -571,9 +571,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     itk::Matrix<ParametersValueType, 4, 4> N;
 
     CreateMatrix(N, M);
-    itkDebugMacro(<< "For Closed form solution: ");
-    itkDebugMacro(<< "M matrix " << M);
-    itkDebugMacro(<< "N matrix " << N);
+    itkDebugMacro("For Closed form solution: ");
+    itkDebugMacro("M matrix " << M);
+    itkDebugMacro("N matrix " << N);
 
     vnl_matrix<ParametersValueType> eigenVectors(4, 4);
     vnl_vector<ParametersValueType> eigenValues(4);
@@ -586,8 +586,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
     symmetricEigenSystem.ComputeEigenValuesAndVectors(N, eigenValues, eigenVectors);
 
-    itkDebugMacro(<< "EigenVectors " << eigenVectors);
-    itkDebugMacro(<< "EigenValues " << eigenValues);
+    itkDebugMacro("EigenVectors " << eigenVectors);
+    itkDebugMacro("EigenValues " << eigenValues);
 
     // By default eigen values are sorted in ascending order therefore the
     // maximum eigen value is the one  in the fourth place = index 3. We need the
@@ -595,7 +595,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     // eigenvector from the last row, index=3.
 
     versor.Set(eigenVectors[3][1], eigenVectors[3][2], eigenVectors[3][3], eigenVectors[3][0]);
-    itkDebugMacro(<< "Resulting versor" << versor);
+    itkDebugMacro("Resulting versor" << versor);
   }
 
   transform->SetCenter(fixedCentroid);
@@ -671,8 +671,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   movingCentroid[0] /= this->m_MovingLandmarks.size();
   movingCentroid[1] /= this->m_MovingLandmarks.size();
 
-  itkDebugMacro(<< "fixed centroid  = " << fixedCentroid);
-  itkDebugMacro(<< "moving centroid  = " << movingCentroid);
+  itkDebugMacro("fixed centroid  = " << fixedCentroid);
+  itkDebugMacro("moving centroid  = " << movingCentroid);
 
   double rotationAngle = 0.0;
 
@@ -713,14 +713,14 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
       s_cross += (movingCentered[1] * fixedCentered[0]) - (movingCentered[0] * fixedCentered[1]);
 
       itkDebugStatement(++ii);
-      itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
-      itkDebugMacro(<< "m_" << ii << " = " << movingCentered);
+      itkDebugMacro("f_" << ii << " = " << fixedCentered);
+      itkDebugMacro("m_" << ii << " = " << movingCentered);
 
       ++movingItr;
       ++fixedItr;
     }
 
-    itkDebugMacro(<< "Dot Product of landmarks: " << s_dot << " Cross Product: " << s_cross);
+    itkDebugMacro("Dot Product of landmarks: " << s_dot << " Cross Product: " << s_cross);
     if (itk::Math::abs(s_dot) > 0.00005)
     {
       rotationAngle = std::atan2(s_cross, s_dot);
@@ -743,9 +743,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   transform->SetAngle(rotationAngle);
 
   VectorType translation = transform->GetTranslation();
-  itkDebugMacro(<< "Initial transform translation: " << translation);
+  itkDebugMacro("Initial transform translation: " << translation);
   translation = movingCentroid - fixedCentroid;
-  itkDebugMacro(<< "translation computed as difference of centroids: " << translation);
+  itkDebugMacro("translation computed as difference of centroids: " << translation);
   transform->SetTranslation(translation);
 }
 

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -101,7 +101,7 @@ public:
   void
   GetDerivative(const TransformParametersType &, DerivativeType & derivative) const override
   {
-    itkWarningMacro(<< "This metric does not provide metric derivatives.");
+    itkWarningMacro("This metric does not provide metric derivatives.");
     derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
   }
 

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -222,10 +222,10 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PreparePyrami
   using IndexType = typename FixedImageRegionType::IndexType;
 
   ScheduleType schedule = m_FixedImagePyramid->GetSchedule();
-  itkDebugMacro(<< "FixedImage schedule: " << schedule);
+  itkDebugMacro("FixedImage schedule: " << schedule);
 
   ScheduleType movingschedule = m_MovingImagePyramid->GetSchedule();
-  itkDebugMacro(<< "MovingImage schedule: " << movingschedule);
+  itkDebugMacro("MovingImage schedule: " << movingschedule);
 
   SizeType  inputSize = m_FixedImageRegion.GetSize();
   IndexType inputStart = m_FixedImageRegion.GetIndex();

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -143,7 +143,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetSchedule(const 
 {
   if (schedule.rows() != m_NumberOfLevels || schedule.columns() != ImageDimension)
   {
-    itkDebugMacro(<< "Schedule has wrong dimensions");
+    itkDebugMacro("Schedule has wrong dimensions");
     return;
   }
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -273,7 +273,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::CreateMesh(unsigne
   {
     m_Material->SetYoungsModulus(this->GetElasticity(m_CurrentLevel));
 
-    itkDebugMacro(<< " Generating regular Quad mesh " << std::endl);
+    itkDebugMacro(" Generating regular Quad mesh " << std::endl);
     auto meshFilter = ImageToMeshType::New();
     meshFilter->SetInput(m_MovingImage);
     meshFilter->SetPixelsPerElement(pixPerElement);
@@ -282,13 +282,13 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::CreateMesh(unsigne
     meshFilter->Update();
     m_FEMObject = meshFilter->GetOutput();
     m_FEMObject->FinalizeMesh();
-    itkDebugMacro(<< " Generating regular mesh done " << std::endl);
+    itkDebugMacro(" Generating regular mesh done " << std::endl);
   }
   else if (ImageDimension == 3 && dynamic_cast<Element3DC0LinearHexahedron *>(&*m_Element) != nullptr)
   {
     m_Material->SetYoungsModulus(this->GetElasticity(m_CurrentLevel));
 
-    itkDebugMacro(<< " Generating regular Hex mesh " << std::endl);
+    itkDebugMacro(" Generating regular Hex mesh " << std::endl);
     auto meshFilter = ImageToMeshType::New();
     meshFilter->SetInput(m_MovingImage);
     meshFilter->SetPixelsPerElement(pixPerElement);
@@ -297,7 +297,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::CreateMesh(unsigne
     meshFilter->Update();
     m_FEMObject = meshFilter->GetOutput();
     m_FEMObject->FinalizeMesh();
-    itkDebugMacro(<< " Generating regular mesh done " << std::endl);
+    itkDebugMacro(" Generating regular mesh done " << std::endl);
   }
   else
   {
@@ -366,7 +366,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
   // Apply the boundary conditions. We pin the image corners.
   // First compute which elements these will be.
   //
-  itkDebugMacro(<< " Applying loads ");
+  itkDebugMacro(" Applying loads ");
 
   vnl_vector<Float> pd;
   pd.set_size(ImageDimension);
@@ -384,11 +384,11 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
     {
       m_LandmarkArray[lmind]->GetElementArray()[0] = nullptr;
 
-      itkDebugMacro(<< " Prescale Pt: " << m_LandmarkArray[lmind]->GetTarget());
+      itkDebugMacro(" Prescale Pt: " << m_LandmarkArray[lmind]->GetTarget());
       if (scaling)
       {
         m_LandmarkArray[lmind]->ScalePointAndForce(scaling, m_EnergyReductionFactor);
-        itkDebugMacro(<< " Postscale Pt: " << m_LandmarkArray[lmind]->GetTarget() << "; scale: " << scaling[0]);
+        itkDebugMacro(" Postscale Pt: " << m_LandmarkArray[lmind]->GetTarget() << "; scale: " << scaling[0]);
       }
 
       pu = m_LandmarkArray[lmind]->GetSource();
@@ -408,7 +408,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
       LoadLandmark::Pointer l5 = dynamic_cast<LoadLandmark *>(&*m_LandmarkArray[lmind]->CreateAnother());
       m_FEMObject->AddNextLoad(l5);
     }
-    itkDebugMacro(<< " Landmarks done");
+    itkDebugMacro(" Landmarks done");
   }
 
   // Now apply the BC loads
@@ -494,7 +494,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
       } // end elt loop
     }
     ++nodect;
-    itkDebugMacro(<< " Node: " << nodect);
+    itkDebugMacro(" Node: " << nodect);
   }
 }
 
@@ -543,18 +543,18 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::IterativeSolve(Sol
 
     if (DLS == 2 && deltE < 0.0)
     {
-      itkDebugMacro(<< " Line search ");
+      itkDebugMacro(" Line search ");
       constexpr float tol = 1.0; // ((0.01  < LastE) ? 0.01 : LastE/10.);
       LastE = this->GoldenSection(solver, tol, m_LineSearchMaximumIterations);
       deltE = (m_MinE - LastE);
-      itkDebugMacro(<< " Line search done " << std::endl);
+      itkDebugMacro(" Line search done " << std::endl);
     }
 
     ++iters;
 
     if (deltE == 0.0)
     {
-      itkDebugMacro(<< " No change in energy " << std::endl);
+      itkDebugMacro(" No change in energy " << std::endl);
       Done = true;
     }
     if ((DLS == 0) && (iters >= m_Maxiters[m_CurrentLevel]))
@@ -592,7 +592,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::IterativeSolve(Sol
         this->EnforceDiffeomorphism(1.0, solver, true);
       }
     }
-    itkDebugMacro(<< " min E: " << m_MinE << "; delt E: " << deltE << "; iters: " << iters << std::endl);
+    itkDebugMacro(" min E: " << m_MinE << "; delt E: " << deltE << "; iters: " << iters << std::endl);
     ++m_TotalIterations;
   }
 }
@@ -637,7 +637,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::InterpolateVectorF
   }
   m_FieldSize = field->GetLargestPossibleRegion().GetSize();
 
-  itkDebugMacro(<< " Interpolating vector field of size " << m_FieldSize);
+  itkDebugMacro(" Interpolating vector field of size " << m_FieldSize);
 
   Float rstep, sstep, tstep;
 
@@ -769,7 +769,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::InterpolateVectorF
   }
 
   // Ensure that the values are exact at the nodes. They won't necessarily be unless we use this code.
-  itkDebugMacro(<< " Interpolation done " << std::endl);
+  itkDebugMacro(" Interpolation done " << std::endl);
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
@@ -791,7 +791,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ComputeJacobian()
 
   m_MinJacobian = statisticsFilter->GetMinimum();
 
-  itkDebugMacro(<< " Min Jacobian: " << m_MinJacobian << std::endl);
+  itkDebugMacro(" Min Jacobian: " << m_MinJacobian << std::endl);
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
@@ -800,7 +800,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
                                                                                     SolverType * solver,
                                                                                     bool         onlywriteimages)
 {
-  itkDebugMacro(<< " Checking Jacobian using threshold " << thresh);
+  itkDebugMacro(" Checking Jacobian using threshold " << thresh);
 
   this->ComputeJacobian();
 
@@ -818,36 +818,36 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
   // If using landmarks, warp them
   if (m_UseLandmarks)
   {
-    itkDebugMacro(<< " Warping landmarks: " << m_LandmarkArray.size());
+    itkDebugMacro(" Warping landmarks: " << m_LandmarkArray.size());
 
     if (!m_LandmarkArray.empty())
     {
       for (unsigned int lmind = 0; lmind < m_LandmarkArray.size(); ++lmind)
       {
-        itkDebugMacro(<< " Old source: " << m_LandmarkArray[lmind]->GetSource());
-        itkDebugMacro(<< " Target: " << m_LandmarkArray[lmind]->GetTarget());
+        itkDebugMacro(" Old source: " << m_LandmarkArray[lmind]->GetSource());
+        itkDebugMacro(" Target: " << m_LandmarkArray[lmind]->GetTarget());
 
         // Convert the source to warped coords.
         m_LandmarkArray[lmind]->GetSource() =
           m_LandmarkArray[lmind]->GetSource() +
           (dynamic_cast<LoadLandmark *>(&*solver->GetOutput()->GetLoadWithGlobalNumber(lmind))->GetForce());
-        itkDebugMacro(<< " New source: " << m_LandmarkArray[lmind]->GetSource());
-        itkDebugMacro(<< " Target: " << m_LandmarkArray[lmind]->GetTarget());
+        itkDebugMacro(" New source: " << m_LandmarkArray[lmind]->GetSource());
+        itkDebugMacro(" Target: " << m_LandmarkArray[lmind]->GetTarget());
         LoadLandmark::Pointer l5 = dynamic_cast<LoadLandmark *>(&*m_LandmarkArray[lmind]->CreateAnother());
         solver->GetOutput()->AddNextLoad(l5);
       }
-      itkDebugMacro(<< " Warping landmarks done ");
+      itkDebugMacro(" Warping landmarks done ");
     }
     else
     {
-      itkDebugMacro(<< " Landmark array empty ");
+      itkDebugMacro(" Landmark array empty ");
     }
   }
 
   // Store the total deformation by composing with the full field
   if (!m_TotalField && !onlywriteimages)
   {
-    itkDebugMacro(<< " Allocating total deformation field ");
+    itkDebugMacro(" Allocating total deformation field ");
 
     m_TotalField = FieldType::New();
 
@@ -923,7 +923,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
       ++totalFieldIter;
     }
 
-    itkDebugMacro(<< " Incremental path length: " << pathsteplength);
+    itkDebugMacro(" Incremental path length: " << pathsteplength);
 
     // Set the field to zero
     FieldIterator fieldIter(m_Field, m_Field->GetLargestPossibleRegion());
@@ -968,7 +968,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
 
     m_Load->SetMovingImage(this->GetMovingImage());
   }
-  itkDebugMacro(<< " Enforcing diffeomorphism done ");
+  itkDebugMacro(" Enforcing diffeomorphism done ");
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
@@ -1005,8 +1005,8 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ExpandVectorField(
     field = m_Field;
   }
 
-  itkDebugMacro(<< " Input field size: " << m_Field->GetLargestPossibleRegion().GetSize());
-  itkDebugMacro(<< " Expand factors: ");
+  itkDebugMacro(" Input field size: " << m_Field->GetLargestPossibleRegion().GetSize());
+  itkDebugMacro(" Expand factors: ");
   VectorType pad;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -1083,7 +1083,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintVectorField(u
     VectorType disp = fieldIter.Get();
     if ((ct % modnum) == 0)
     {
-      itkDebugMacro(<< " Field pix: " << fieldIter.Get() << std::endl);
+      itkDebugMacro(" Field pix: " << fieldIter.Get() << std::endl);
     }
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -1096,7 +1096,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintVectorField(u
     ++ct;
   }
 
-  itkDebugMacro(<< " Max vec: " << max << std::endl);
+  itkDebugMacro(" Max vec: " << max << std::endl);
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
@@ -1105,7 +1105,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::MultiResSolve()
 {
   for (m_CurrentLevel = 0; m_CurrentLevel < m_MaxLevel; ++m_CurrentLevel)
   {
-    itkDebugMacro(<< " Beginning level " << m_CurrentLevel << std::endl);
+    itkDebugMacro(" Beginning level " << m_CurrentLevel << std::endl);
 
     auto solver = SolverType::New();
 
@@ -1156,14 +1156,14 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::MultiResSolve()
 
     // Now expand the field for the next level, if necessary.
 
-    itkDebugMacro(<< " End level: " << m_CurrentLevel);
+    itkDebugMacro(" End level: " << m_CurrentLevel);
 
   } // end image resolution loop
 
   if (m_TotalField)
   {
-    itkDebugMacro(<< " Copy field: " << m_TotalField->GetLargestPossibleRegion().GetSize());
-    itkDebugMacro(<< " To: " << m_Field->GetLargestPossibleRegion().GetSize() << std::endl);
+    itkDebugMacro(" Copy field: " << m_TotalField->GetLargestPossibleRegion().GetSize());
+    itkDebugMacro(" To: " << m_Field->GetLargestPossibleRegion().GetSize() << std::endl);
     FieldIterator fieldIter(m_TotalField, m_TotalField->GetLargestPossibleRegion());
     fieldIter.GoToBegin();
     for (; !fieldIter.IsAtEnd(); ++fieldIter)

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -56,10 +56,10 @@ public:
   ShowProgress()
   {
     // std::cout
-    itkDebugMacro(<< "Progress: " << m_Process->GetProgress() << "  "
-                  << "Iter: " << m_Process->GetElapsedIterations() << "  "
-                  << "Metric: " << m_Process->GetMetric() << "  "
-                  << "RMSChange: " << m_Process->GetRMSChange() << "  ");
+    itkDebugMacro("Progress: " << m_Process->GetProgress() << "  "
+                               << "Iter: " << m_Process->GetElapsedIterations() << "  "
+                               << "Metric: " << m_Process->GetMetric() << "  "
+                               << "RMSChange: " << m_Process->GetRMSChange() << "  ");
     //               << std::endl;
 
     if (m_Process->GetElapsedIterations() == 10000)

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -136,7 +136,7 @@ void
 BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisionType, TPriorsPrecisionType>::
   ComputeBayesRule()
 {
-  itkDebugMacro(<< "Computing Bayes Rule");
+  itkDebugMacro("Computing Bayes Rule");
   const InputImageType * membershipImage = this->GetInput();
 
   ImageRegionType imageRegion = membershipImage->GetBufferedRegion();
@@ -166,7 +166,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
 
     const unsigned int numberOfClasses = membershipImage->GetVectorLength();
 
-    itkDebugMacro(<< "Computing Bayes Rule nclasses in membershipImage: " << numberOfClasses);
+    itkDebugMacro("Computing Bayes Rule nclasses in membershipImage: " << numberOfClasses);
 
     while (!itrMembershipImage.IsAtEnd())
     {

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -159,7 +159,7 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
 
   // calculate the class covariances using the sumsOfSquares, sums, and
   // classCount information
-  itkDebugMacro(<< "Estimated parameters after Kmeans filter");
+  itkDebugMacro("Estimated parameters after Kmeans filter");
   for (unsigned int i = 0; i < m_NumberOfClasses; ++i)
   {
     estimatedCovariances[i] =
@@ -169,9 +169,9 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
     {
       estimatedCovariances[i] = 0.0000001;
     }
-    itkDebugMacro(<< "cluster[" << i << "]-- ");
-    itkDebugMacro(<< " estimated mean : " << estimatedMeans[i]);
-    itkDebugMacro(<< " estimated covariance : " << estimatedCovariances[i]);
+    itkDebugMacro("cluster[" << i << "]-- ");
+    itkDebugMacro(" estimated mean : " << estimatedMeans[i]);
+    itkDebugMacro(" estimated covariance : " << estimatedCovariances[i]);
   }
 
   // Create gaussian membership functions.

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -74,25 +74,25 @@ template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::PrintKmeansAlgorithmResults()
 {
-  itkDebugMacro(<< "                                    ");
-  itkDebugMacro(<< "Results of the clustering algorithms");
-  itkDebugMacro(<< "====================================");
+  itkDebugMacro("                                    ");
+  itkDebugMacro("Results of the clustering algorithms");
+  itkDebugMacro("====================================");
 
-  itkDebugMacro(<< "                                    ");
-  itkDebugMacro(<< "Means of the clustered vector       ");
-  itkDebugMacro(<< "++++++++++++++++++++++++++++++++++++");
+  itkDebugMacro("                                    ");
+  itkDebugMacro("Means of the clustered vector       ");
+  itkDebugMacro("++++++++++++++++++++++++++++++++++++");
 
   itkDebugMacro(<< m_Centroid);
 
-  itkDebugMacro(<< "                                    ");
-  itkDebugMacro(<< "Distortion measures                 ");
-  itkDebugMacro(<< "+++++++++++++++++++++++++++++++++++ ");
+  itkDebugMacro("                                    ");
+  itkDebugMacro("Distortion measures                 ");
+  itkDebugMacro("+++++++++++++++++++++++++++++++++++ ");
 
   itkDebugMacro(<< m_CodewordDistortion);
 
-  itkDebugMacro(<< "                                    ");
-  itkDebugMacro(<< "Histogram of the vector             ");
-  itkDebugMacro(<< "+++++++++++++++++++++++++++++++++++ ");
+  itkDebugMacro("                                    ");
+  itkDebugMacro("Histogram of the vector             ");
+  itkDebugMacro("+++++++++++++++++++++++++++++++++++ ");
 
   itkDebugMacro(<< m_CodewordHistogram);
 }
@@ -349,7 +349,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
       }
 
       // Try getting new codewords, send a warning to user
-      itkDebugMacro(<< "Attempting to fill empty cells in the codebook");
+      itkDebugMacro("Attempting to fill empty cells in the codebook");
 
       // Consolidate the highest distortion codewords into the beginning
       // of the array.  Take care to protect zero distortion codewords
@@ -650,7 +650,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithoutCodebookUseL
   const SizeValueType codebookSize = m_Codebook.rows();
   if (m_NumberOfCodewords != codebookSize)
   {
-    itkDebugMacro(<< "Returning fewer codewords than requested");
+    itkDebugMacro("Returning fewer codewords than requested");
   }
 
   // itkDebugMacro(<<"Done with local function LBG ()");

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -342,7 +342,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
       // If there have been too many attempts to fill cells, stop iterations
       if (pass == m_MaxSplitAttempts)
       {
-        itkWarningMacro(<< "Unable to fill all empty cells");
+        itkWarningMacro("Unable to fill all empty cells");
         m_OutputNumberOfEmptyCells = emptycells;
         m_OutputDistortion = distortion;
         return GLA_CONVERGED;

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -188,7 +188,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
         // create a new entry label
         if (maxLabel == maxPossibleLabel)
         {
-          itkWarningMacro(<< "ConnectedComponentFunctorImageFilter::GenerateData: Number of labels "
+          itkWarningMacro("ConnectedComponentFunctorImageFilter::GenerateData: Number of labels "
                           << static_cast<long>(maxLabel) << " exceeds number of available labels "
                           << static_cast<long>(maxPossibleLabel) << " for the output type.");
         }

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -309,7 +309,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
 
   if (m_InitialNumberOfRegions < this->GetMaximumNumberOfRegions())
   {
-    itkWarningMacro(<< "Number of initial image regions is less than requested: reduce granularity of the grid");
+    itkWarningMacro("Number of initial image regions is less than requested: reduce granularity of the grid");
   }
 
   // Set current number of regions

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -508,7 +508,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
   }
   else
   {
-    itkDebugMacro(<< "Passed initialization");
+    itkDebugMacro("Passed initialization");
   }
 
   // Allocate memory to store the array of pointers that point to the
@@ -587,8 +587,8 @@ template <typename TInputImage, typename TOutputImage>
 void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
 {
-  itkDebugMacro(<< "--------------------");
-  itkDebugMacro(<< "   Merging Regions  ");
+  itkDebugMacro("--------------------");
+  itkDebugMacro("   Merging Regions  ");
 
   // Subtract border length before removing it
   m_TotalBorderLength -= m_BorderCandidate->m_Pointer->GetBorderLength();
@@ -646,9 +646,9 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
   // For DEBUG purposes
   if (this->GetDebug())
   {
-    itkDebugMacro(<< "First Region ");
+    itkDebugMacro("First Region ");
     pRegion1->PrintRegionInfo();
-    itkDebugMacro(<< "Second Region ");
+    itkDebugMacro("Second Region ");
     pRegion2->PrintRegionInfo();
   }
 

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -89,16 +89,16 @@ KLMSegmentationBorder::EvaluateLambda()
 void
 KLMSegmentationBorder::PrintBorderInfo()
 {
-  itkDebugMacro(<< "------------------------------");
-  itkDebugMacro(<< "Location      : " << this);
-  itkDebugMacro(<< "Lambda        : " << m_Lambda);
-  itkDebugMacro(<< "Region1       : " << this->GetRegion1());
-  itkDebugMacro(<< "Region 1 Label: " << (this->GetRegion1()->GetRegionLabel()));
-  itkDebugMacro(<< "Region2       : " << this->GetRegion2());
-  itkDebugMacro(<< "Region 2 Label: " << (this->GetRegion2()->GetRegionLabel()));
-  itkDebugMacro(<< "++++++++++++++++++++++++++++++");
-  itkDebugMacro(<< "------------------------------");
-  itkDebugMacro(<< "------------------------------");
+  itkDebugMacro("------------------------------");
+  itkDebugMacro("Location      : " << this);
+  itkDebugMacro("Lambda        : " << m_Lambda);
+  itkDebugMacro("Region1       : " << this->GetRegion1());
+  itkDebugMacro("Region 1 Label: " << (this->GetRegion1()->GetRegionLabel()));
+  itkDebugMacro("Region2       : " << this->GetRegion2());
+  itkDebugMacro("Region 2 Label: " << (this->GetRegion2()->GetRegionLabel()));
+  itkDebugMacro("++++++++++++++++++++++++++++++");
+  itkDebugMacro("------------------------------");
+  itkDebugMacro("------------------------------");
 
   std::cout << "Location      : " << this << std::endl << "Lambda        : " << m_Lambda << std::endl;
 }

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -119,8 +119,8 @@ LevelSetNeighborhoodExtractor<TLevelSet>::GenerateData()
     this->GenerateDataFull();
   }
 
-  itkDebugMacro(<< "No. inside points: " << m_InsidePoints->Size());
-  itkDebugMacro(<< "No. outside points: " << m_OutsidePoints->Size());
+  itkDebugMacro("No. inside points: " << m_InsidePoints->Size());
+  itkDebugMacro("No. outside points: " << m_OutsidePoints->Size());
 }
 
 /*

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -233,7 +233,7 @@ public:
   void
   SetUseNegativeFeatures(bool u)
   {
-    itkWarningMacro(<< "SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
+    itkWarningMacro("SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
     if (u == true)
     {
       this->SetReverseExpansionDirection(false);

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -93,7 +93,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::EnlargeOutputRequestedRegion(DataObj
   else
   {
     // pointer could not be cast to TLevelSet *
-    itkWarningMacro(<< "itk::ReinitializeLevelSetImageFilter"
+    itkWarningMacro("itk::ReinitializeLevelSetImageFilter"
                     << "::EnlargeOutputRequestedRegion cannot cast " << typeid(output).name() << " to "
                     << typeid(TLevelSet *).name());
   }

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -280,7 +280,7 @@ public:
   void
   SetUseNegativeFeatures(bool u)
   {
-    itkWarningMacro(<< "SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
+    itkWarningMacro("SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
     if (u == true)
     {
       this->SetReverseExpansionDirection(false);

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -72,7 +72,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
 {
   if (this->m_InputImage.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputImage is nullptr");
+    itkGenericExceptionMacro("m_InputImage is nullptr");
   }
 
   this->m_LabelMap = LevelSetLabelMapType::New();
@@ -349,7 +349,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDi
 {
   if (this->m_InputImage.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputImage is nullptr");
+    itkGenericExceptionMacro("m_InputImage is nullptr");
   }
 
   this->m_LabelMap = LevelSetLabelMapType::New();
@@ -492,7 +492,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
 {
   if (this->m_InputImage.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputImage is nullptr");
+    itkGenericExceptionMacro("m_InputImage is nullptr");
   }
 
   this->m_LabelMap = LevelSetLabelMapType::New();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
@@ -76,7 +76,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Initialize(
   }
   else
   {
-    itkWarningMacro(<< "m_Heaviside is nullptr");
+    itkWarningMacro("m_Heaviside is nullptr");
   }
 }
 
@@ -134,7 +134,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const
   }
   else
   {
-    itkWarningMacro(<< "m_Heaviside is nullptr");
+    itkWarningMacro("m_Heaviside is nullptr");
   }
   return NumericTraits<LevelSetOutputPixelType>::ZeroValue();
 }
@@ -164,7 +164,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const
   }
   else
   {
-    itkWarningMacro(<< "m_Heaviside is nullptr");
+    itkWarningMacro("m_Heaviside is nullptr");
   }
   return NumericTraits<LevelSetOutputPixelType>::ZeroValue();
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
@@ -38,7 +38,7 @@ LevelSetEquationContainer<TTermContainer>::AddEquation(const LevelSetIdentifierT
     {
       if (!iEquation->GetLevelSetContainer())
       {
-        itkGenericExceptionMacro(<< "m_LevelSetContainer and iEquation->GetLevelSetContainer() are nullptr");
+        itkGenericExceptionMacro("m_LevelSetContainer and iEquation->GetLevelSetContainer() are nullptr");
       }
     }
     this->m_Container[iId] = iEquation;
@@ -50,7 +50,7 @@ LevelSetEquationContainer<TTermContainer>::AddEquation(const LevelSetIdentifierT
   }
   else
   {
-    itkGenericExceptionMacro(<< "Term supplied is null");
+    itkGenericExceptionMacro("Term supplied is null");
   }
 }
 
@@ -60,13 +60,13 @@ LevelSetEquationContainer<TTermContainer>::GetEquation(const LevelSetIdentifierT
 {
   if (this->m_Container.empty())
   {
-    itkGenericExceptionMacro(<< "m_Container is empty");
+    itkGenericExceptionMacro("m_Container is empty");
   }
 
   auto it = this->m_Container.find(iId);
   if (it == this->m_Container.end())
   {
-    itkGenericExceptionMacro(<< "this equation " << iId << " does not exist");
+    itkGenericExceptionMacro("this equation " << iId << " does not exist");
   }
   return it->second;
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -73,7 +73,7 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Init
   {
     if (m_CurvatureImage.IsNull())
     {
-      itkGenericExceptionMacro(<< "m_UseCurvatureImage is true and m_CurvatureImage is null");
+      itkGenericExceptionMacro("m_UseCurvatureImage is true and m_CurvatureImage is null");
     }
   }
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -112,13 +112,13 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::SetUp()
 
     if (this->m_CurrentLevelSetPointer.IsNull())
     {
-      itkWarningMacro(<< "m_CurrentLevelSetId does not exist in the level set container");
+      itkWarningMacro("m_CurrentLevelSetId does not exist in the level set container");
     }
   }
 
   if (!this->m_Heaviside.IsNotNull())
   {
-    itkWarningMacro(<< "m_Heaviside is nullptr");
+    itkWarningMacro("m_Heaviside is nullptr");
   }
 }
 // ----------------------------------------------------------------------------

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -56,7 +56,7 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::SetLevelSetContainer(
   }
   else
   {
-    itkGenericExceptionMacro(<< "iContainer is nullptr");
+    itkGenericExceptionMacro("iContainer is nullptr");
   }
 }
 
@@ -106,7 +106,7 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::SetUp()
   {
     if (this->m_LevelSetContainer.IsNull())
     {
-      itkGenericExceptionMacro(<< "m_LevelSetContainer is nullptr");
+      itkGenericExceptionMacro("m_LevelSetContainer is nullptr");
     }
     this->m_CurrentLevelSetPointer = this->m_LevelSetContainer->GetLevelSet(this->m_CurrentLevelSetId);
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -78,7 +78,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::AddTerm(const Te
       }
       else
       {
-        itkGenericExceptionMacro(<< "m_Input and iTerm->GetInput are nullptr");
+        itkGenericExceptionMacro("m_Input and iTerm->GetInput are nullptr");
       }
     }
     iTerm->SetCurrentLevelSetId(this->m_CurrentLevelSetId);
@@ -91,7 +91,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::AddTerm(const Te
     {
       if (!iTerm->GetLevelSetContainer())
       {
-        itkGenericExceptionMacro(<< "m_LevelSetContainer and iTerm->GetLevelSetContainer() are nullptr");
+        itkGenericExceptionMacro("m_LevelSetContainer and iTerm->GetLevelSetContainer() are nullptr");
       }
     }
 
@@ -114,7 +114,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::AddTerm(const Te
   }
   else
   {
-    itkGenericExceptionMacro(<< "Term supplied is null");
+    itkGenericExceptionMacro("Term supplied is null");
   }
 }
 
@@ -133,7 +133,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::PushTerm(TermTyp
       }
       else
       {
-        itkGenericExceptionMacro(<< "m_Input and iTerm->GetInput are nullptr");
+        itkGenericExceptionMacro("m_Input and iTerm->GetInput are nullptr");
       }
     }
 
@@ -147,7 +147,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::PushTerm(TermTyp
     {
       if (!iTerm->GetLevelSetContainer())
       {
-        itkGenericExceptionMacro(<< "m_LevelSetContainer and iTerm->GetLevelSetContainer() are nullptr");
+        itkGenericExceptionMacro("m_LevelSetContainer and iTerm->GetLevelSetContainer() are nullptr");
       }
     }
 
@@ -173,7 +173,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::PushTerm(TermTyp
   }
   else
   {
-    itkGenericExceptionMacro(<< "Term supplied is null");
+    itkGenericExceptionMacro("Term supplied is null");
   }
 }
 
@@ -186,7 +186,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const st
 
   if (it == m_Container.end())
   {
-    itkGenericExceptionMacro(<< "the term " << iName.c_str() << " is not present in the container");
+    itkGenericExceptionMacro("the term " << iName.c_str() << " is not present in the container");
   }
 
   return it->second;
@@ -201,7 +201,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const Te
 
   if (it == m_Container.end())
   {
-    itkGenericExceptionMacro(<< "the term " << iId << " is not present in the container");
+    itkGenericExceptionMacro("the term " << iId << " is not present in the container");
   }
 
   return it->second;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
@@ -128,17 +128,17 @@ LevelSetEvolution<TEquationContainer, LevelSetDenseImage<TImage>>::ComputeTimeSt
       {
         if (Math::ExactlyEquals(contribution, NumericTraits<LevelSetOutputRealType>::max()))
         {
-          itkGenericExceptionMacro(<< "contribution is " << contribution);
+          itkGenericExceptionMacro("contribution is " << contribution);
         }
         else
         {
-          itkGenericExceptionMacro(<< "contribution is too low");
+          itkGenericExceptionMacro("contribution is too low");
         }
       }
     }
     else
     {
-      itkGenericExceptionMacro(<< "m_Alpha should be in ]0,1[");
+      itkGenericExceptionMacro("m_Alpha should be in ]0,1[");
     }
   }
 }
@@ -304,17 +304,17 @@ LevelSetEvolution<TEquationContainer,
       {
         if (Math::ExactlyEquals(contribution, NumericTraits<LevelSetOutputRealType>::max()))
         {
-          itkGenericExceptionMacro(<< "contribution is " << contribution);
+          itkGenericExceptionMacro("contribution is " << contribution);
         }
         else
         {
-          itkGenericExceptionMacro(<< "contribution is too low " << contribution);
+          itkGenericExceptionMacro("contribution is too low " << contribution);
         }
       }
     }
     else
     {
-      itkGenericExceptionMacro(<< "m_Alpha should be in ]0,1[");
+      itkGenericExceptionMacro("m_Alpha should be in ]0,1[");
     }
   }
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -45,7 +45,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::SetTimeStep(const LevelSet
   }
   else
   {
-    itkGenericExceptionMacro(<< "iDt should be > epsilon");
+    itkGenericExceptionMacro("iDt should be > epsilon");
   }
 }
 
@@ -66,28 +66,28 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::CheckSetUp()
 {
   if (this->m_LevelSetContainer.IsNull())
   {
-    itkGenericExceptionMacro(<< "this->m_LevelSetContainer is nullptr");
+    itkGenericExceptionMacro("this->m_LevelSetContainer is nullptr");
   }
 
   if (this->m_EquationContainer.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_EquationContainer is nullptr");
+    itkGenericExceptionMacro("m_EquationContainer is nullptr");
   }
 
   typename EquationContainerType::Iterator eqIt = this->m_EquationContainer->Begin();
 
   if (eqIt == this->m_EquationContainer->End())
   {
-    itkGenericExceptionMacro(<< "this->m_EquationContainer is empty");
+    itkGenericExceptionMacro("this->m_EquationContainer is empty");
   }
   if (!eqIt->GetEquation())
   {
-    itkGenericExceptionMacro(<< "m_EquationContainer->GetEquation( 0 ) is nullptr");
+    itkGenericExceptionMacro("m_EquationContainer->GetEquation( 0 ) is nullptr");
   }
 
   if (this->m_LevelSetContainer != this->m_EquationContainer->GetLevelSetContainer())
   {
-    itkGenericExceptionMacro(<< "this->m_LevelSetContainer != this->m_EquationContainer->GetLevelSetContainer()"
+    itkGenericExceptionMacro("this->m_LevelSetContainer != this->m_EquationContainer->GetLevelSetContainer()"
                              << std::endl
                              << this->m_LevelSetContainer.GetPointer()
                              << " != " << this->m_EquationContainer->GetLevelSetContainer() << std::endl);
@@ -98,7 +98,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::CheckSetUp()
 
   if (inputImage.IsNull())
   {
-    itkGenericExceptionMacro(<< "input Image is nullptr");
+    itkGenericExceptionMacro("input Image is nullptr");
   }
 
   // Get the LevelSetContainer from the EquationContainer
@@ -107,24 +107,24 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::CheckSetUp()
 
   if (termIt == termContainer->End())
   {
-    itkGenericExceptionMacro(<< "TermContainer is empty");
+    itkGenericExceptionMacro("TermContainer is empty");
   }
 
   if (this->m_LevelSetContainer != termContainer->GetLevelSetContainer())
   {
-    itkGenericExceptionMacro(<< "this->m_LevelSetContainer != termContainer->GetLevelSetContainer()");
+    itkGenericExceptionMacro("this->m_LevelSetContainer != termContainer->GetLevelSetContainer()");
   }
 
   TermPointer term = termIt->GetTerm();
 
   if (this->m_LevelSetContainer != term->GetLevelSetContainer())
   {
-    itkGenericExceptionMacro(<< "this->m_LevelSetContainer != term->GetLevelSetContainer()");
+    itkGenericExceptionMacro("this->m_LevelSetContainer != term->GetLevelSetContainer()");
   }
 
   if (this->m_StoppingCriterion.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_StoppingCriterion is nullptr");
+    itkGenericExceptionMacro("m_StoppingCriterion is nullptr");
   }
 
   this->m_NumberOfIterations = 0;
@@ -162,7 +162,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::InitializeIteration()
 
         if (idList->empty())
         {
-          itkGenericExceptionMacro(<< "No level set exists at voxel");
+          itkGenericExceptionMacro("No level set exists at voxel");
         }
 
         auto idListIt = idList->begin();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
@@ -35,7 +35,7 @@ template <typename TMesh>
 auto
 LevelSetQuadEdgeMesh<TMesh>::EvaluateGradient(const InputType & itkNotUsed(iP)) const -> GradientType
 {
-  itkWarningMacro(<< "to be implemented");
+  itkWarningMacro("to be implemented");
   return Self::GradientType(); // Create a new object with default initializer
 }
 
@@ -43,7 +43,7 @@ template <typename TMesh>
 auto
 LevelSetQuadEdgeMesh<TMesh>::EvaluateHessian(const InputType & itkNotUsed(iP)) const -> HessianType
 {
-  itkWarningMacro(<< "to be implemented");
+  itkWarningMacro("to be implemented");
   return Self::HessianType(); // Create a new object with default initializer
 }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
@@ -94,7 +94,7 @@ LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) const -> c
   auto it = m_Layers.find(value);
   if (it == m_Layers.end())
   {
-    itkGenericExceptionMacro(<< "This layer does not exist");
+    itkGenericExceptionMacro("This layer does not exist");
   }
   return it->second;
 }
@@ -107,7 +107,7 @@ LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) -> LayerTy
   auto it = m_Layers.find(value);
   if (it == m_Layers.end())
   {
-    itkGenericExceptionMacro(<< "This layer does not exist");
+    itkGenericExceptionMacro("This layer does not exist");
   }
   return it->second;
 }
@@ -168,7 +168,7 @@ LevelSetSparseImage<TOutput, VDimension>::GetAsLabelObject()
 
   if (this->m_InternalLabelList.empty())
   {
-    itkGenericExceptionMacro(<< "this->m_InternalLabelList empty");
+    itkGenericExceptionMacro("this->m_InternalLabelList empty");
   }
 
   auto lIt = this->m_InternalLabelList.begin();

--- a/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
@@ -62,7 +62,7 @@ MalcolmSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputPixel) c
     }
     else
     {
-      itkGenericExceptionMacro(<< "status " << static_cast<int>(status) << " should be 1 or -1");
+      itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 1 or -1");
     }
   }
 }
@@ -73,7 +73,7 @@ auto
 MalcolmSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & inputPixel) const -> HessianType
 {
   (void)inputPixel;
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Malcolm's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"
@@ -87,7 +87,7 @@ auto
 MalcolmSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & inputPixel) const -> OutputRealType
 {
   (void)inputPixel;
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Malcolm's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"
@@ -101,7 +101,7 @@ auto
 MalcolmSparseLevelSetImage<VDimension>::EvaluateMeanCurvature(const InputType & inputPixel) const -> OutputRealType
 {
   (void)inputPixel;
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Malcolm's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"

--- a/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
@@ -62,7 +62,7 @@ ShiSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputIndex) const
     }
     else
     {
-      itkGenericExceptionMacro(<< "status " << static_cast<int>(status) << " should be 3 or -3");
+      itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 3 or -3");
     }
   }
 }
@@ -72,7 +72,7 @@ template <unsigned int VDimension>
 auto
 ShiSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & itkNotUsed(inputIndex)) const -> HessianType
 {
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"
@@ -84,7 +84,7 @@ template <unsigned int VDimension>
 auto
 ShiSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & itkNotUsed(inputIndex)) const -> OutputRealType
 {
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"
@@ -97,7 +97,7 @@ auto
 ShiSparseLevelSetImage<VDimension>::EvaluateMeanCurvature(const InputType & itkNotUsed(inputIndex)) const
   -> OutputRealType
 {
-  itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
+  itkGenericExceptionMacro("The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."
                            << " If it was required for regularization purpose, "
                            << " you better check recommended regularization methods"

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -42,7 +42,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::Update()
 {
   if (this->m_InputLevelSet.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputLevelSet is nullptr");
+    itkGenericExceptionMacro("m_InputLevelSet is nullptr");
   }
 
   this->m_Offset = this->m_InputLevelSet->GetDomainOffset();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
@@ -39,7 +39,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Update()
 {
   if (this->m_InputLevelSet.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputLevelSet is nullptr");
+    itkGenericExceptionMacro("m_InputLevelSet is nullptr");
   }
 
   this->m_Offset = this->m_InputLevelSet->GetDomainOffset();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -50,11 +50,11 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   if (this->m_InputLevelSet.IsNull())
   {
-    itkGenericExceptionMacro(<< "m_InputLevelSet is nullptr");
+    itkGenericExceptionMacro("m_InputLevelSet is nullptr");
   }
   if (this->m_Update.empty())
   {
-    itkGenericExceptionMacro(<< "m_Update is empty");
+    itkGenericExceptionMacro("m_Update is empty");
   }
 
   this->m_Offset = this->m_InputLevelSet->GetDomainOffset();

--- a/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
@@ -68,13 +68,13 @@ WhitakerSparseLevelSetImage<TOutput, VDimension>::Evaluate(const InputType & inp
         }
         else
         {
-          itkGenericExceptionMacro(<< "status " << static_cast<int>(status) << " should be 3 or -3");
+          itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 3 or -3");
         }
       }
     }
     else
     {
-      itkGenericExceptionMacro(<< "Note: m_LabelMap is nullptr");
+      itkGenericExceptionMacro("Note: m_LabelMap is nullptr");
     }
   }
   return rval;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -377,7 +377,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::ApplyMRFImageFilter()
   m_NumberOfIterations = 0;
   do
   {
-    itkDebugMacro(<< "Iteration No." << m_NumberOfIterations);
+    itkDebugMacro("Iteration No." << m_NumberOfIterations);
 
     MinimizeFunctional();
     m_NumberOfIterations += 1;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -279,8 +279,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   function->ThresholdBetween(static_cast<InputImagePixelType>(lower), static_cast<InputImagePixelType>(upper));
 
-  itkDebugMacro(<< "\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
-                << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
+  itkDebugMacro("\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
+                                       << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
 
   // Segment the image, the iterator walks the output image (so Set()
   // writes into the output image), starting at the seed point.  As
@@ -332,10 +332,11 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     // if the variance is zero, there is no point in continuing
     if (Math::AlmostEquals(m_Variance, 0.0))
     {
-      itkDebugMacro(<< "\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
-                    << ", variance = " << m_Variance << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
-      itkDebugMacro(<< "\nsum = " << sum << ", sumOfSquares = " << sumOfSquares
-                    << "\nnumberOfSamples = " << numberOfSamples);
+      itkDebugMacro("\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
+                                           << ", variance = " << m_Variance
+                                           << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
+      itkDebugMacro("\nsum = " << sum << ", sumOfSquares = " << sumOfSquares
+                               << "\nnumberOfSamples = " << numberOfSamples);
       break;
     }
     lower = m_Mean - m_Multiplier * std::sqrt(m_Variance);
@@ -365,9 +366,10 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     function->ThresholdBetween(static_cast<InputImagePixelType>(lower), static_cast<InputImagePixelType>(upper));
 
-    itkDebugMacro(<< "\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
-                  << ", variance = " << m_Variance << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
-    itkDebugMacro(<< "\nsum = " << sum << ", sumOfSquares = " << sumOfSquares << "\nnum = " << numberOfSamples);
+    itkDebugMacro("\nLower intensity = " << lower << ", Upper intensity = " << upper << "\nmean = " << m_Mean
+                                         << ", variance = " << m_Variance
+                                         << " , std::sqrt(variance) = " << std::sqrt(m_Variance));
+    itkDebugMacro("\nsum = " << sum << ", sumOfSquares = " << sumOfSquares << "\nnum = " << numberOfSamples);
 
     // Rerun the segmentation, the iterator walks the output image,
     // starting at the seed point.  As the iterator walks, if the

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -204,7 +204,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   m_ThresholdFunction->SetThreshold(m_Multiplier);
 
-  itkDebugMacro(<< "\nMultiplier originally = " << m_Multiplier);
+  itkDebugMacro("\nMultiplier originally = " << m_Multiplier);
 
   // Make sure that the multiplier is large enough to include the seed points
   // themselves.
@@ -232,7 +232,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // threshold itself.
   m_ThresholdFunction->SetThreshold(m_Multiplier);
 
-  itkDebugMacro(<< "\nMultiplier after verifying seeds inclusion = " << m_Multiplier);
+  itkDebugMacro("\nMultiplier after verifying seeds inclusion = " << m_Multiplier);
 
   // Segment the image, the iterator walks the output image (so Set()
   // writes into the output image), starting at the seed point.  As

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
@@ -168,14 +168,14 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Evaluate(con
   // transform the point into the shape model space
   PointType mappedPoint = m_Transform->TransformPoint(point);
 
-  itkDebugMacro(<< "mappedPoint:" << mappedPoint);
+  itkDebugMacro("mappedPoint:" << mappedPoint);
 
   using RealType = typename NumericTraits<OutputType>::RealType;
   RealType output;
 
   if (!m_Interpolators[0]->IsInsideBuffer(mappedPoint))
   {
-    itkDebugMacro(<< "use extrapolator");
+    itkDebugMacro("use extrapolator");
     output = m_Extrapolators[0]->Evaluate(mappedPoint);
 
     for (unsigned int i = 0; i < m_NumberOfPrincipalComponents; ++i)
@@ -186,7 +186,7 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Evaluate(con
   }
   else
   {
-    itkDebugMacro(<< "use interpolator");
+    itkDebugMacro("use interpolator");
     output = m_Interpolators[0]->Evaluate(mappedPoint);
 
     for (unsigned int i = 0; i < m_NumberOfPrincipalComponents; ++i)

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -399,7 +399,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
         }
         else
         {
-          itkDebugMacro(<< "Numerical problem 1" << curr[0] << ' ' << curr1[1]);
+          itkDebugMacro("Numerical problem 1" << curr[0] << ' ' << curr1[1]);
         }
       }
     }

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -96,7 +96,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
       // This is the first pixel we've visited
       Visited.clear();
       Visited.push_back(CurrentPositionIndex);
-      itkDebugMacro(<< "Found unlabeled pixel at: " << CurrentPositionIndex << " Value: " << MinimumNeighborValue);
+      itkDebugMacro("Found unlabeled pixel at: " << CurrentPositionIndex << " Value: " << MinimumNeighborValue);
       // Search along a steepest descent path to a local minimum
       do
       {
@@ -149,8 +149,8 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
         }
         // Get the true class of this pixel
         MinimumNeighborClass = outputImage->GetPixel(MinimumNeighborIndex);
-        itkDebugMacro(<< "\tFound Neighbor at: " << MinimumNeighborIndex << " Value: " << MinimumNeighborValue
-                      << " Class: " << MinimumNeighborClass);
+        itkDebugMacro("\tFound Neighbor at: " << MinimumNeighborIndex << " Value: " << MinimumNeighborValue
+                                              << " Class: " << MinimumNeighborClass);
         // we've slid into a different class
         if (MinimumNeighborClass > 1)
         {
@@ -172,15 +172,15 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
         std::vector<IndexType> OpenList;
         OpenList.clear();
         OpenList.push_back(CurrentPositionIndex);
-        itkDebugMacro(<< "\tFinished slide at: " << CurrentPositionIndex << " Value: " << MinimumNeighborValue
-                      << " Class: " << MinimumNeighborClass);
+        itkDebugMacro("\tFinished slide at: " << CurrentPositionIndex << " Value: " << MinimumNeighborValue
+                                              << " Class: " << MinimumNeighborClass);
         while (!OpenList.empty())
         {
           // Pop the last one off
           IndexType SeedIndex = OpenList.back();
           OpenList.pop_back();
           Visited.push_back(SeedIndex);
-          itkDebugMacro(<< "Flood fill, looking at " << SeedIndex);
+          itkDebugMacro("Flood fill, looking at " << SeedIndex);
           // Look at the neighbors
           InputImagePixelType SeedValue;
           SeedValue = inputImage->GetPixel(SeedIndex);
@@ -230,7 +230,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
         LabelForRegion = MinimumNeighborClass;
         CurrentPositionIndex = MinimumNeighborIndex;
       }
-      itkDebugMacro(<< "Filling in: " << static_cast<unsigned int>(Visited.size()) << " with: " << LabelForRegion);
+      itkDebugMacro("Filling in: " << static_cast<unsigned int>(Visited.size()) << " with: " << LabelForRegion);
       // Loop over all the visited positions, setting their label
       for (i = 0; i < Visited.size(); ++i)
       {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -168,7 +168,7 @@ SegmentTreeGenerator<TScalar>::CompileMergeList(SegmentTableTypePointer segments
     if (segment_ptr->second.edge_list.empty())
     {
       // This is to defend against the referencing below.  This was causing an assert error.
-      itkGenericExceptionMacro(<< "CompileMergeList:: An unexpected and fatal error has occurred.");
+      itkGenericExceptionMacro("CompileMergeList:: An unexpected and fatal error has occurred.");
     }
     labelTO = m_MergedSegmentsTable->RecursiveLookup(segment_ptr->second.edge_list.front().label);
     while (labelTO == labelFROM) // Pop off any bogus merges with ourself
@@ -307,7 +307,7 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
 
   if (from_seg == 0 || to_seg == 0)
   {
-    itkGenericExceptionMacro(<< "PruneMergeSegments:: An unexpected and fatal error has occurred.");
+    itkGenericExceptionMacro("PruneMergeSegments:: An unexpected and fatal error has occurred.");
   }
 
   // Compare the minimum values.
@@ -444,8 +444,8 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
 
   if (from_seg == nullptr || to_seg == nullptr)
   {
-    itkGenericExceptionMacro(<< "itk::watershed::SegmentTreeGenerator::MergeSegments:: An unexpected and fatal error "
-                                "has occurred. This is probably the result of overthresholding of the input image.");
+    itkGenericExceptionMacro("itk::watershed::SegmentTreeGenerator::MergeSegments:: An unexpected and fatal error "
+                             "has occurred. This is probably the result of overthresholding of the input image.");
   }
 
   // Compare the minimum values.

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1017,7 +1017,7 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
     segment_ptr = segments->Lookup(edge_table_entry_ptr->first);
     if (segment_ptr == nullptr)
     {
-      itkGenericExceptionMacro(<< "UpdateSegmentTable:: An unexpected and fatal error has occurred.");
+      itkGenericExceptionMacro("UpdateSegmentTable:: An unexpected and fatal error has occurred.");
     }
 
     // Copy into the segment list
@@ -1135,7 +1135,7 @@ Segmenter<TInputImage>::MergeFlatRegions(flat_region_table_t & regions, Equivale
   {
     if (((a = regions.find(it->first)) == regions.end()) || ((b = regions.find(it->second)) == regions.end()))
     {
-      itkGenericExceptionMacro(<< "MergeFlatRegions:: An unexpected and fatal error has occurred.");
+      itkGenericExceptionMacro("MergeFlatRegions:: An unexpected and fatal error has occurred.");
     }
 
     if (a->second.bounds_min < b->second.bounds_min)

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -240,7 +240,7 @@ OpenCVVideoIO::ReadImageInformation()
       // If the I-Frame spacing is not 1, warn the user
       if (this->m_IFrameInterval != 1)
       {
-        itkWarningMacro(<< "OpenCV can only seek to I-Frames. I-Frame spacing for this video is "
+        itkWarningMacro("OpenCV can only seek to I-Frames. I-Frame spacing for this video is "
                         << this->m_IFrameInterval << ". Last I-Frame is " << this->m_LastIFrame);
       }
     }
@@ -389,7 +389,7 @@ OpenCVVideoIO::CanWriteFile(const char * filename)
   // Make sure reader is closed
   if (this->m_ReaderOpen)
   {
-    itkWarningMacro(<< "Can't write anything if reader is open");
+    itkWarningMacro("Can't write anything if reader is open");
     return false;
   }
 
@@ -397,7 +397,7 @@ OpenCVVideoIO::CanWriteFile(const char * filename)
   std::string fname = filename;
   if (fname == "")
   {
-    itkWarningMacro(<< "No Filename specified");
+    itkWarningMacro("No Filename specified");
     return false;
   }
 
@@ -419,7 +419,7 @@ OpenCVVideoIO::CanWriteFile(const char * filename)
   }
   if (!extensionFound)
   {
-    itkWarningMacro(<< "Unrecognized file extension " << fname);
+    itkWarningMacro("Unrecognized file extension " << fname);
     return false;
   }
 

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -137,7 +137,7 @@ OpenCVVideoIO::CanReadFile(const char * filename)
   std::string fname = filename;
   if (fname == "")
   {
-    itkDebugMacro(<< "NoFilename specified");
+    itkDebugMacro("NoFilename specified");
     return false;
   }
 
@@ -159,7 +159,7 @@ OpenCVVideoIO::CanReadFile(const char * filename)
   }
   if (!extensionFound)
   {
-    itkDebugMacro(<< "Unrecognized file extension");
+    itkDebugMacro("Unrecognized file extension");
     return false;
   }
 
@@ -367,7 +367,7 @@ OpenCVVideoIO::SetNextFrameToRead(OpenCVVideoIO::FrameOffsetType frameNumber)
   // Make sure we're not setting past the end
   if (frameNumber > this->m_LastIFrame)
   {
-    itkDebugMacro(<< "Warning: Trying to seek past end of video (past last I-Frame)");
+    itkDebugMacro("Warning: Trying to seek past end of video (past last I-Frame)");
     return false;
   }
 

--- a/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
+++ b/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
@@ -250,7 +250,7 @@ VXLVideoIO::CanReadFile(const char * filename)
 bool
 VXLVideoIO::CanReadCamera(CameraIDType cameraID) const
 {
-  itkWarningMacro(<< "For now, camera reading is not supported with VXL:" << cameraID);
+  itkWarningMacro("For now, camera reading is not supported with VXL:" << cameraID);
   return false;
 }
 
@@ -321,8 +321,8 @@ VXLVideoIO::ReadImageInformation()
       // If the I-Frame spacing is not 1, warn the user
       if (this->m_IFrameInterval != 1)
       {
-        itkWarningMacro(<< "VXL can only seek to I-Frames. I-Frame spacing for this video is " << this->m_IFrameInterval
-                        << ". Last I-Frame is " << this->m_LastIFrame);
+        itkWarningMacro("VXL can only seek to I-Frames. I-Frame spacing for this video is "
+                        << this->m_IFrameInterval << ". Last I-Frame is " << this->m_LastIFrame);
       }
     }
   }
@@ -443,7 +443,7 @@ VXLVideoIO::CanWriteFile(const char * filename)
   // Make sure reader is closed
   if (this->m_ReaderOpen)
   {
-    itkWarningMacro(<< "Can't write anything if reader is open");
+    itkWarningMacro("Can't write anything if reader is open");
     return false;
   }
 
@@ -451,7 +451,7 @@ VXLVideoIO::CanWriteFile(const char * filename)
   std::string fname = filename;
   if (fname == "")
   {
-    itkWarningMacro(<< "No Filename specified");
+    itkWarningMacro("No Filename specified");
     return false;
   }
 
@@ -473,7 +473,7 @@ VXLVideoIO::CanWriteFile(const char * filename)
   }
   if (!extensionFound)
   {
-    itkWarningMacro(<< "Unrecognized file extension " << fname);
+    itkWarningMacro("Unrecognized file extension " << fname);
     return false;
   }
 
@@ -665,7 +665,7 @@ VXLVideoIO::FourCCtoEncoderType(const char * fourCC)
   }
   else
   {
-    itkWarningMacro(<< "Unknown FourCC: " << fourCC);
+    itkWarningMacro("Unknown FourCC: " << fourCC);
     return vidl_ffmpeg_ostream_params::DEFAULT;
   }
 }
@@ -716,7 +716,7 @@ VXLVideoIO::OpenReader()
   // Read from camera
   else if (this->m_ReadType == ReadFromCamera)
   {
-    itkWarningMacro(<< "VXL camera not currently implemented");
+    itkWarningMacro("VXL camera not currently implemented");
   }
 }
 

--- a/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
+++ b/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
@@ -206,7 +206,7 @@ VXLVideoIO::CanReadFile(const char * filename)
   std::string fname = filename;
   if (fname == "")
   {
-    itkDebugMacro(<< "NoFilename specified");
+    itkDebugMacro("NoFilename specified");
     return false;
   }
 
@@ -228,7 +228,7 @@ VXLVideoIO::CanReadFile(const char * filename)
   }
   if (!extensionFound)
   {
-    itkDebugMacro(<< "Unrecognized file extension");
+    itkDebugMacro("Unrecognized file extension");
     return false;
   }
 
@@ -356,7 +356,7 @@ VXLVideoIO::Read(void * buffer)
   // Advance to the next frame if possible
   if (!this->m_Reader->advance())
   {
-    itkDebugMacro(<< "Could not advance to the next frame");
+    itkDebugMacro("Could not advance to the next frame");
   }
 
   // Read the current frame
@@ -413,7 +413,7 @@ VXLVideoIO::SetNextFrameToRead(FrameOffsetType frameNumber)
   // Make sure we're not setting past the end
   if (frameNumber > this->m_LastIFrame)
   {
-    itkDebugMacro(<< "Warning: Trying to seek past end of video (past last I-Frame)");
+    itkDebugMacro("Warning: Trying to seek past end of video (past last I-Frame)");
     return false;
   }
 

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -157,7 +157,7 @@ TemporalDataObject::GetUnbufferedRequestedTemporalRegion()
   // Handle case with unbuffered frames at beginning and end
   if (reqStart < bufStart && reqEnd > bufEnd)
   {
-    itkDebugMacro(<< "Unbuffered frames at beginning and end. Returning entire "
+    itkDebugMacro("Unbuffered frames at beginning and end. Returning entire "
                   << "requested region as unbuffered");
     return this->m_RequestedTemporalRegion;
   }

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -194,7 +194,7 @@ VideoFileReader<TOutputVideoStream>::InitializeVideoIO()
   {
     // the pixel types don't match so a type conversion needs to be
     // performed
-    itkDebugMacro(<< "Buffer conversion required from: "
+    itkDebugMacro("Buffer conversion required from: "
                   << m_VideoIO->GetComponentTypeAsString(m_VideoIO->GetComponentType())
                   << " to: " << m_VideoIO->GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
                   << ConvertPixelTraits::GetNumberOfComponents() << " m_VideoIO->NumComponents "


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4057 commit 89beb0447fc9d40dcfdd6ced49f81e1b1a1bc97e
"STYLE: Remove initial `<<` insertion from `itkExceptionMacro(<< "` calls"