### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkTimeVaryingVelocityFieldIntegrationImageFilter.h"
 #include "itkImportImageFilter.h"
 #include "itkTestingMacros.h"
+#include "itkVectorLinearInterpolateImageFunction.h"
 
 int
 itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
@@ -71,6 +72,21 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(integrator, TimeVaryingVelocityFieldIntegrationImageFilter, ImageToImageFilter);
 
+
+  auto velocityFieldInterpolator =
+    itk::VectorLinearInterpolateImageFunction<IntegratorType::TimeVaryingVelocityFieldType,
+                                              IntegratorType::ScalarType>::New();
+  integrator->SetVelocityFieldInterpolator(velocityFieldInterpolator);
+  ITK_TEST_SET_GET_VALUE(velocityFieldInterpolator, integrator->GetVelocityFieldInterpolator());
+
+  auto displacementFieldInterpolator =
+    itk::VectorLinearInterpolateImageFunction<IntegratorType::DisplacementFieldType, IntegratorType::ScalarType>::New();
+  integrator->SetDisplacementFieldInterpolator(displacementFieldInterpolator);
+  ITK_TEST_SET_GET_VALUE(displacementFieldInterpolator, integrator->GetDisplacementFieldInterpolator());
+
+  auto initialDiffeomorphism = IntegratorType::DisplacementFieldType::New();
+  integrator->SetInitialDiffeomorphism(initialDiffeomorphism);
+  ITK_TEST_SET_GET_VALUE(initialDiffeomorphism, integrator->GetInitialDiffeomorphism());
 
   auto lowerTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[1]));
   integrator->SetLowerTimeBound(lowerTimeBound);

--- a/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
@@ -106,5 +106,13 @@ itkMatchCardinalityImageToImageMetricTest(int argc, char * argv[])
     }
   }
 
+
+  MetricType::ParametersType parameters = transform->GetParameters();
+  MetricType::DerivativeType derivative;
+  metric->GetDerivative(parameters, derivative);
+
+  MetricType::DerivativeType derivative1{};
+  ITK_TEST_EXPECT_EQUAL(derivative, derivative1);
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -196,7 +196,18 @@ itkThresholdSegmentationLevelSetImageFilterTest(int, char *[])
 
 
   filter->SetInput(seedImage);
+  ITK_TEST_SET_GET_VALUE(seedImage, filter->GetInitialImage());
+
+  filter->SetInitialImage(seedImage);
+  ITK_TEST_SET_GET_VALUE(seedImage, filter->GetInput());
+  ITK_TEST_SET_GET_VALUE(seedImage, filter->GetInitialImage());
+
   filter->SetFeatureImage(inputImage);
+  ITK_TEST_SET_GET_VALUE(inputImage, filter->GetFeatureImage());
+
+  auto advectionImage = FilterType::SegmentationFunctionType::VectorImageType::New();
+  filter->SetAdvectionImage(advectionImage);
+  ITK_TEST_SET_GET_VALUE(advectionImage, filter->GetAdvectionImage());
 
   typename FilterType::ValueType upperThreshold = 63;
   filter->SetUpperThreshold(upperThreshold);
@@ -224,9 +235,20 @@ itkThresholdSegmentationLevelSetImageFilterTest(int, char *[])
 
   filter->SetMaximumRMSError(0.04);
   filter->SetNumberOfIterations(10);
+
+  auto reverseExpansionDirection = true;
+
+  filter->SetUseNegativeFeaturesOff();
   filter->SetUseNegativeFeaturesOn(); // Change the default behavior of the speed
                                       // function so that negative values result in
                                       // surface growth.
+  filter->SetUseNegativeFeatures(reverseExpansionDirection);
+  ITK_TEST_SET_GET_VALUE(reverseExpansionDirection, filter->GetUseNegativeFeatures());
+
+  ITK_TEST_SET_GET_BOOLEAN(filter, ReverseExpansionDirection, reverseExpansionDirection);
+
+  auto autoGenerateSpeedAdvection = true;
+  ITK_TEST_SET_GET_BOOLEAN(filter, AutoGenerateSpeedAdvection, autoGenerateSpeedAdvection);
 
   itk::RMSCommand::Pointer c = itk::RMSCommand::New();
   filter->AddObserver(itk::IterationEvent(), c);


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Use other testing macros as necessary to check for expected values.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)