### PR TITLE
COMP: add missing header with GCC 13.1.1

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
+++ b/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include "itkIntTypes.h"
 #include "itkMathematicalMorphologyEnums.h"
 
 namespace itk


### PR DESCRIPTION
With GCC 13.1.1 `<cstdint>` is no longer implicitly included causing build failure


```
/home/fabio/Dev/AURNEW/insight-toolkit/src/InsightToolkit-5.3.0/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h:23:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   22 | #include "ITKMathematicalMorphologyExport.h"
  +++ |+#include <cstdint>
   23 | 
```