### PR TITLE
COMP: Remove clang unsupported compiler flag from default

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -112,7 +112,6 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
     -Wshadow
     -Wunused
     -Wwrite-strings
-    -funit-at-a-time
     -Wno-strict-overflow
   )
 


### PR DESCRIPTION
This reverts commit b50647bf5e73517fd9645803d756bd1dd045629a.

Originally this flag was added to sppress inline warnings on gcc compilers from 2011 (which are no longer supported).

The `-funit-at-a-time` flag is a default flag for all optimization levels -O1 and above on gcc compilers that support it.

New versions of clang compiler do not support this flag: "clang: warning: optimization flag '-funit-at-a-time' is not supported"

The removal of this flag returns all the default compiler flags to flags related to warnings only.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

