### PR TITLE
ENH: Add macros to `itk::RegistrationParameterScalesEstimator` ivars

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -150,6 +150,7 @@ public:
    *  with the images when appropriate.
    */
   itkSetObjectMacro(Metric, MetricType);
+  itkGetConstObjectMacro(Metric, MetricType);
 
   /** m_TransformForward specifies which transform scales to be estimated.
    * m_TransformForward = true (default) for the moving transform parameters.
@@ -157,6 +158,7 @@ public:
    */
   itkSetMacro(TransformForward, bool);
   itkGetConstMacro(TransformForward, bool);
+  itkBooleanMacro(TransformForward);
 
   /** Get/Set a point set for virtual domain sampling. */
   itkSetObjectMacro(VirtualDomainPointSet, VirtualPointSetType);
@@ -165,6 +167,7 @@ public:
 
   /** the radius of the central region for sampling. */
   itkSetMacro(CentralRegionRadius, IndexValueType);
+  itkGetConstMacro(CentralRegionRadius, IndexValueType);
 
   /** Estimate parameter scales */
   void

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkGradientDescentOptimizerv4.h"
+#include "itkIntTypes.h"
 #include "itkMeanSquaresImageToImageMetricv4.h"
 #include "itkRegistrationParameterScalesFromPhysicalShift.h"
 #include "itkRegistrationParameterScalesFromJacobian.h"
@@ -124,8 +125,17 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
   {
     std::cout << "Testing RegistrationParameterScalesFromPhysicalShift" << std::endl;
     auto shiftScalesEstimator = ShiftScalesEstimatorType::New();
+
     shiftScalesEstimator->SetMetric(metric);
-    shiftScalesEstimator->SetTransformForward(true); // default
+    ITK_TEST_SET_GET_VALUE(metric, shiftScalesEstimator->GetMetric());
+
+    auto transformForward = true;
+    ITK_TEST_SET_GET_BOOLEAN(shiftScalesEstimator, TransformForward, transformForward);
+
+    itk::IndexValueType centralRegionRadius = 5;
+    shiftScalesEstimator->SetCentralRegionRadius(centralRegionRadius);
+    ITK_TEST_SET_GET_VALUE(centralRegionRadius, shiftScalesEstimator->GetCentralRegionRadius());
+
     scalesEstimator = shiftScalesEstimator;
   }
   else


### PR DESCRIPTION
Add getter and boolean macros to
`itk::RegistrationParameterScalesEstimator` ivars.

Check the expected values in the test using the appropriate itk testing macros.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)