### PR TITLE
ENH: Increase `RegistrationParameterScalesFromPhysicalShift` coverage

### DIFF
--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -126,6 +126,10 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
     std::cout << "Testing RegistrationParameterScalesFromPhysicalShift" << std::endl;
     auto shiftScalesEstimator = ShiftScalesEstimatorType::New();
 
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(
+      shiftScalesEstimator, RegistrationParameterScalesFromPhysicalShift, RegistrationParameterScalesFromShiftBase)
+
+
     shiftScalesEstimator->SetMetric(metric);
     ITK_TEST_SET_GET_VALUE(metric, shiftScalesEstimator->GetMetric());
 
@@ -135,6 +139,14 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
     itk::IndexValueType centralRegionRadius = 5;
     shiftScalesEstimator->SetCentralRegionRadius(centralRegionRadius);
     ITK_TEST_SET_GET_VALUE(centralRegionRadius, shiftScalesEstimator->GetCentralRegionRadius());
+
+    typename ShiftScalesEstimatorType::VirtualPointSetType::ConstPointer virtualDomainPointSet{};
+    shiftScalesEstimator->SetVirtualDomainPointSet(virtualDomainPointSet);
+    ITK_TEST_SET_GET_VALUE(virtualDomainPointSet, shiftScalesEstimator->GetVirtualDomainPointSet());
+
+    typename ShiftScalesEstimatorType::ParametersValueType smallParameterVariation = 0.01;
+    shiftScalesEstimator->SetSmallParameterVariation(smallParameterVariation);
+    ITK_TEST_SET_GET_VALUE(smallParameterVariation, shiftScalesEstimator->GetSmallParameterVariation());
 
     scalesEstimator = shiftScalesEstimator;
   }


### PR DESCRIPTION
Increase coverage for
`itk::RegistrationParameterScalesFromPhysicalShift`:
- Exercise basic object methods using the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro. Remove redundant calls to print the filter: rely on the basic method exercising macro call.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)