### PR TITLE
DOC: Consolidate `LaplacianSharpeningImageFilter` `UseImageSpacing` doc

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
@@ -84,13 +84,9 @@ public:
   /** Method for creation through the object factory.  */
   itkNewMacro(Self);
 
-  /** Enable/Disable using the image spacing information in
-   *  calculations. Use this option if you  want derivatives in
-   *  physical space. Default  is UseImageSpacingOn. */
+  /** Set/Get whether or not the filter will use the spacing information of the input image in its calculations. Use
+   * this option if derivatives are required in physical space. */
   itkBooleanMacro(UseImageSpacing);
-
-  /** Set/Get whether or not the filter will use the spacing of the input
-      image in its calculations */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
 


### PR DESCRIPTION
Consolidate `itk::LaplacianSharpeningImageFilter` `UseImageSpacing` ivar documentation: group together the `itkBooleanMacro` macro and the `Set/Get` methods, and document them at a single place.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)