### PR TITLE
STYLE: Make PrintSelf implementation style consistent

### DIFF
--- a/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
@@ -27,9 +27,15 @@ void
 BinaryThresholdSpatialFunction<TFunction>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << " m_LowerThreshold: " << m_LowerThreshold << std::endl;
-  os << indent << " m_UpperThreshold: " << m_UpperThreshold << std::endl;
-  os << indent << " m_Function: " << m_Function.GetPointer() << std::endl;
+
+  os << indent
+     << "LowerThreshold: " << static_cast<typename NumericTraits<FunctionOutputType>::PrintType>(m_LowerThreshold)
+     << std::endl;
+  os << indent
+     << "UpperThreshold: " << static_cast<typename NumericTraits<FunctionOutputType>::PrintType>(m_UpperThreshold)
+     << std::endl;
+
+  itkPrintSelfObjectMacro(Function);
 }
 
 template <typename TFunction>

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -88,7 +88,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::PrintSelf(s
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Scale: " << m_Scale << std::endl;
-  os << indent << "Normalized?: " << m_Normalized << std::endl;
+  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
   os << indent << "Direction: " << m_Direction << std::endl;
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
@@ -66,7 +66,7 @@ GaussianSpatialFunction<TOutput, VImageDimension, TInput>::PrintSelf(std::ostrea
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Scale: " << m_Scale << std::endl;
-  os << indent << "Normalized?: " << m_Normalized << std::endl;
+  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -69,7 +69,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, In
     os << indent << "Extent[" << i << "] : " << m_Extent[i] << std::endl;
   }
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 
   os << indent << "Internal Image : " << m_InternalImage << std::endl;
 }

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -251,7 +251,7 @@ void
 GaussianDerivativeImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 
   os << indent << "Sigma: " << m_Sigma << std::endl;
   os << indent << "Extent: " << m_Extent << std::endl;

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -240,13 +240,13 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Alpha: " << this->m_Alpha << std::endl;
-  os << indent << "Sigma: " << this->m_Sigma << std::endl;
+  os << indent << "Alpha: " << m_Alpha << std::endl;
+  os << indent << "Sigma: " << m_Sigma << std::endl;
 
-  os << indent << "Bounding box start: " << this->m_BoundingBoxStart << std::endl;
-  os << indent << "Bounding box end: " << this->m_BoundingBoxEnd << std::endl;
-  os << indent << "Scaling factor: " << this->m_ScalingFactor << std::endl;
-  os << indent << "Cut-off distance: " << this->m_CutOffDistance << std::endl;
+  os << indent << "BoundingBoxStart: " << m_BoundingBoxStart << std::endl;
+  os << indent << "BoundingBoxEnd: " << m_BoundingBoxEnd << std::endl;
+  os << indent << "ScalingFactor: " << m_ScalingFactor << std::endl;
+  os << indent << "CutOffDistance: " << m_CutOffDistance << std::endl;
 }
 } // namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -114,7 +114,7 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -97,7 +97,7 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
      << std::endl;
   os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -236,7 +236,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 
   os << indent << "DerivativeWeights: " << m_DerivativeWeights << std::endl;
   os << indent << "HalfDerivativeWeights: " << m_HalfDerivativeWeights << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "RequestedNumberOfThreads: "
      << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
   os << indent << "RealValuedInputImage: " << m_RealValuedInputImage.GetPointer() << std::endl;

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -240,7 +240,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(st
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "ContourDirectedMeanDistance: " << m_ContourDirectedMeanDistance << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -151,7 +151,7 @@ ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std::ostre
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "MeanDistance: " << m_MeanDistance << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -53,10 +53,17 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Narrowbanding: " << m_NarrowBanding << std::endl;
-  os << indent << "LevelSetValue: " << m_LevelSetValue << std::endl;
-  os << indent << "FarValue: " << m_FarValue << std::endl;
-  os << std::endl;
+  os << indent << "LevelSetValue: " << static_cast<typename NumericTraits<PixelRealType>::PrintType>(m_LevelSetValue)
+     << std::endl;
+  os << indent << "FarValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_FarValue) << std::endl;
+  os << indent << "Spacing: " << static_cast<typename NumericTraits<InputSpacingType>::PrintType>(m_Spacing)
+     << std::endl;
+  os << indent << "NarrowBanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+
+  itkPrintSelfObjectMacro(NarrowBand);
+
+  // ToDo
+  // os << indent << "NarrowBandRegion: " << m_NarrowBandRegion << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -147,7 +147,7 @@ DerivativeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, I
 
   os << indent << "Order: " << m_Order << std::endl;
   os << indent << "Direction: " << m_Direction << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -282,7 +282,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::PrintSelf(std:
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "InternalNumberOfStreamDivisions: " << m_InternalNumberOfStreamDivisions << std::endl;
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -293,7 +293,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   os << indent << "Disc Radius Ratio: " << m_DiscRadiusRatio << std::endl;
   os << indent << "Accumulator blur variance: " << m_Variance << std::endl;
   os << indent << "Sweep angle : " << m_SweepAngle << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
 
   itkPrintSelfObjectMacro(RadiusImage);
 

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -52,7 +52,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::PrintS
   os << indent << "DerivativeWeights: " << m_DerivativeWeights << std::endl;
   os << indent << "ComponentWeights: " << m_ComponentWeights << std::endl;
   os << indent << "SqrtComponentWeights: " << m_SqrtComponentWeights << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "UsePrincipleComponents: " << m_UsePrincipleComponents << std::endl;
   os << indent << "RequestedNumberOfThreads: "
      << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -252,12 +252,11 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << this->m_FullyConnected << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
+     << std::endl;
+  os << indent
+     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -120,10 +120,10 @@ GaussianImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) c
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Gaussian mean: " << m_Mean << std::endl;
-  os << indent << "Gaussian sigma: " << m_Sigma << std::endl;
-  os << indent << "Gaussian scale: " << m_Scale << std::endl;
-  os << indent << "Normalized Gaussian?: " << m_Normalized << std::endl;
+  os << indent << "Mean: " << m_Mean << std::endl;
+  os << indent << "Sigma: " << m_Sigma << std::endl;
+  os << indent << "Scale: " << m_Scale << std::endl;
+  os << indent << "Normalized: " << (m_Normalized ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -133,7 +133,7 @@ BinaryFillholeImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent inde
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -110,7 +110,7 @@ BinaryGrindPeakImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent ind
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
@@ -94,7 +94,7 @@ BinaryImageToShapeLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "BackgroundValue: "
      << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
   os << indent << "ForegroundValue: "

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -100,7 +100,7 @@ BinaryImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>:
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "OutputBackgroundValue: "
      << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
   os << indent << "InputForegroundValue: "

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
@@ -116,7 +116,7 @@ BinaryReconstructionByDilationImageFilter<TInputImage>::PrintSelf(std::ostream &
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
@@ -132,7 +132,7 @@ BinaryReconstructionByErosionImageFilter<TInputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -111,7 +111,7 @@ BinaryShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
@@ -115,7 +115,7 @@ BinaryShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -115,7 +115,7 @@ BinaryStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(s
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
@@ -118,7 +118,7 @@ BinaryStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -141,7 +141,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::PrintSel
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Kernel: " << m_Kernel << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "PreserveIntensities: " << m_PreserveIntensities << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -133,8 +133,8 @@ DoubleThresholdImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
      << std::endl;
   os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
      << std::endl;
-  os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -144,7 +144,7 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
 
   os << indent << "Seed point: " << m_Seed << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -143,7 +143,7 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
 
   os << indent << "Seed point: " << m_Seed << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -144,7 +144,7 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -154,7 +154,7 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -105,7 +105,7 @@ HConcaveImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Ind
   os << indent << "Depth of local minima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -106,7 +106,7 @@ HConvexImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Height of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -113,7 +113,7 @@ HMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Height of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -113,7 +113,7 @@ HMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Depth of local maxima (contrast): "
      << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -141,7 +141,7 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::PrintSel
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Kernel: " << m_Kernel << std::endl;
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "PreserveIntensities: " << m_PreserveIntensities << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -342,7 +342,7 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "MarkerValue: " << m_MarkerValue << std::endl;
   os << indent << "UseInternalCopy: " << m_UseInternalCopy << std::endl;
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -130,7 +130,7 @@ RegionalMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "FlatIsMaxima: " << m_FlatIsMaxima << std::endl;
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -134,7 +134,7 @@ RegionalMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "FlatIsMinima: " << m_FlatIsMinima << std::endl;
   os << indent
      << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -214,7 +214,7 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "Flat: " << m_Flat << std::endl;
   os << indent << "MarkerValue: " << m_MarkerValue << std::endl;
 }

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -343,7 +343,7 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
   os << indent << "FilterDimensionality: " << m_FilterDimensionality << std::endl;
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "RealBoundaryCondition: " << m_RealBoundaryCondition << std::endl;
 }
 } // end namespace itk

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -121,7 +121,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+    os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   }
 
 private:

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -123,7 +123,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+    os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   }
 
 private:

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -238,7 +238,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "Lambda: " << static_cast<typename NumericTraits<AttributeType>::PrintType>(m_Lambda) << std::endl;
 }
 } // end namespace itk

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -49,18 +49,18 @@ void
 DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
                                                                                     Indent         indent) const
 {
-  // call the superclass' implementation of this method
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Zero Padding Factor: " << this->GetZeroPadding() << std::endl;
-  os << indent << "Fourier Oversampling Factor: " << this->GetOverSampling() << std::endl;
-  os << indent << "Radial Spline Order: " << this->GetRadialSplineOrder() << std::endl;
-  os << indent << "Fourier Radial Cutoff Frequency: " << this->GetCutoff() << std::endl;
-  os << indent << "Alpha Range: " << this->GetAlphaRange() << std::endl;
-  os << indent << "Z Direction: " << this->GetZDirection() << std::endl;
-  os << indent << "Alpha Direction: " << this->GetAlphaDirection() << std::endl;
-  os << indent << "Radial Direction: " << this->GetRDirection() << std::endl;
-  os << indent << "Input Requested Region: " << m_InputRequestedRegion << std::endl;
+  os << indent << "ZeroPaddingFactor: " << m_ZeroPadding << std::endl;
+  os << indent << "OverSampling: " << m_OverSampling << std::endl;
+  os << indent << "Cutoff: " << m_Cutoff << std::endl;
+  os << indent << "AlphaRange: " << m_AlphaRange << std::endl;
+  os << indent << "ZDirection: " << m_ZDirection << std::endl;
+  os << indent << "AlphaDirection: " << m_AlphaDirection << std::endl;
+  os << indent << "RDirection: " << m_RDirection << std::endl;
+  os << indent << "RadialSplineOrder: " << m_RadialSplineOrder << std::endl;
+  os << indent << "PI: " << m_PI << std::endl;
+  os << indent << "InputRequestedRegion: " << m_InputRequestedRegion << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -38,7 +38,7 @@ void
 DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "Order: " << m_Order << std::endl;

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -36,7 +36,7 @@ void
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -36,7 +36,7 @@ void
 DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
+  os << indent << "UseImageSpacing: " << (m_UseImageSpacing ? "On" : "Off") << std::endl;
   os << indent << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -44,13 +44,21 @@ void
 LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Input level set: " << m_InputLevelSet.GetPointer();
-  os << std::endl;
-  os << indent << "Level set value: " << m_LevelSetValue << std::endl;
-  os << indent << "Narrow bandwidth: " << m_NarrowBandwidth << std::endl;
-  os << indent << "Narrowbanding: " << m_NarrowBanding << std::endl;
-  os << indent << "Input narrow band: ";
-  os << m_InputNarrowBand.GetPointer() << std::endl;
+
+  os << indent << "LevelSetValue: " << m_LevelSetValue << std::endl;
+
+  os << indent << "InsidePoints: " << m_InsidePoints << std::endl;
+  os << indent << "OutsidePoints: " << m_OutsidePoints << std::endl;
+  os << indent << "InputLevelSet: " << m_InputLevelSet << std::endl;
+  os << indent << "NarrowBanding: " << (m_NarrowBanding ? "On" : "Off") << std::endl;
+  os << indent << "NarrowBandwidth: " << m_NarrowBandwidth << std::endl;
+  os << indent << "InputNarrowBand: " << m_InputNarrowBand << std::endl;
+  os << indent << "ImageRegion: " << m_ImageRegion << std::endl;
+  os << indent << "LargeValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_LargeValue)
+     << std::endl;
+  // ToDo
+  // os << indent << "NodesUsed: " << m_NodesUsed << std::endl;
+  os << indent << "LastPointIsInside: " << (m_LastPointIsInside ? "On" : "Off") << std::endl;
 }
 
 template <typename TLevelSet>

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -430,7 +430,7 @@ MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "MarkWatershedLine: " << m_MarkWatershedLine << std::endl;
 }
 

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -143,7 +143,7 @@ MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FullyConnected: " << m_FullyConnected << std::endl;
+  os << indent << "FullyConnected: " << (m_FullyConnected ? "On" : "Off") << std::endl;
   os << indent << "MarkWatershedLine: " << m_MarkWatershedLine << std::endl;
   os << indent << "Level: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Level)
      << std::endl;


### PR DESCRIPTION
Make `PrintSelf`implementation style consistent following the ITK SWG coding style guideline and the available ITK macros:
- Print only the class instance variables.
- Use the `os << indent << "{ivarName}: " << m_ivarName << std::endl` recipe: do not print the leading `m_` of the ivar; use a colon after printing its name; leave a whitespace between the colon and the printed value of the ivar.
- For boolean ivars print `On`/`Off` according to their values using the ternary operator.
- Use `itkPrintSelfObjectMacro` to print objects inheriting from `itk::LightObject` that can be null.
- Take advantage of the output stream `<<` insertion operator overload for `std::vector` types in the `itk::print_helper` namespace defined in `itkPrintHelper.h` to print such types consistently.
- Cast custom types to their numerical values using `itk::NumericTraits::PrinType` so that they are printed as expected.
- Save typing `this->` to point to the instance of the current class.

Follow-up to commit c47ed1c1b3e26051de655f7ad03e975fae93b73b.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)