### PR TITLE
DOC: Clean up method Doxygen documentation

### DIFF
--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- *
- */
+
 template <typename TInputImage, typename TOutputImage>
 ExtractImageFilter<TInputImage, TOutputImage>::ExtractImageFilter()
 {
@@ -34,9 +32,6 @@ ExtractImageFilter<TInputImage, TOutputImage>::ExtractImageFilter()
   this->DynamicMultiThreadingOn();
 }
 
-/**
- *
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ExtractImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -101,15 +96,6 @@ ExtractImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputImageReg
   this->Modified();
 }
 
-/**
- * ExtractImageFilter can produce an image which is a different resolution
- * than its input image.  As such, ExtractImageFilter needs to provide an
- * implementation for GenerateOutputInformation() in order to inform
- * the pipeline execution model.  The original documentation of this
- * method is below.
- *
- * \sa ProcessObject::GenerateOutputInformaton()
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
@@ -278,18 +264,6 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateData()
   this->Superclass::GenerateData();
 }
 
-/**
- * ExtractImageFilter can be implemented as a multithreaded filter.
- * Therefore, this implementation provides a DynamicThreadedGenerateData()
- * routine which is called for each processing thread. The output
- * image data is allocated automatically by the superclass prior to
- * calling DynamicThreadedGenerateData().  DynamicThreadedGenerateData can only
- * write to the portion of the output image specified by the
- * parameter "outputRegionForThread"
- *
- * \sa ImageToImageFilter::ThreadedGenerateData(),
- *     ImageToImageFilter::GenerateData()
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ExtractImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -505,8 +505,8 @@ public:
 
   /**
    * Delete the element defined by the index identifier.  In practice, it
-   * doesn't make sense to delete a vector index.  Instead, this method just
-   * overwrite the index with the default element.
+   * doesn't make sense to delete a vector index; overwrite the index with
+   * the default element instead.
    */
   void DeleteIndex(ElementIdentifier);
 
@@ -541,6 +541,8 @@ public:
   Size() const;
 
   /**
+   * Allocate memory for at the requested number of elements.
+   *
    * Tell the container to allocate enough memory to allow at least as many
    * elements as the size given to be stored.  In the generic case of ITK
    * containers this is NOT guaranteed to actually allocate any memory, but it
@@ -552,6 +554,8 @@ public:
   void Reserve(ElementIdentifier);
 
   /**
+   * Try to compact the internal representation of the memory.
+   *
    * Tell the container to try to minimize its memory usage for storage of the
    * current number of elements.  This is NOT guaranteed to decrease memory
    * usage. This method is included here mainly for providing a unified API

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -22,14 +22,7 @@
 
 namespace itk
 {
-/**
- * Get a reference to the element at the given index.
- * It is assumed that the index exists, and it will not automatically
- * be created.
- *
- * It is assumed that the value of the element is modified through the
- * reference.
- */
+
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) -> reference
@@ -38,12 +31,6 @@ VectorContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) -
   return this->VectorType::operator[](id);
 }
 
-/**
- * Get a reference to the element at the given index.
- * It is assumed that the index exists, and it will not automatically
- * be created.
- *
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) const -> const_reference
@@ -51,14 +38,6 @@ VectorContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) c
   return this->VectorType::operator[](id);
 }
 
-/**
- * Get a reference to the element at the given index.
- * If the element location does not exist, it will be created with a
- * default element value.
- *
- * It is assumed that the value of the element is modified through the
- * reference.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id) -> reference
@@ -71,10 +50,6 @@ VectorContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier
   return this->VectorType::operator[](id);
 }
 
-/**
- * Read the element from the given index.
- * It is assumed that the index exists.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const -> Element
@@ -82,10 +57,6 @@ VectorContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) 
   return this->VectorType::operator[](id);
 }
 
-/**
- * Set the element value at the given index.
- * It is assumed that the index exists.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::SetElement(ElementIdentifier id, Element element)
@@ -94,11 +65,6 @@ VectorContainer<TElementIdentifier, TElement>::SetElement(ElementIdentifier id, 
   this->Modified();
 }
 
-/**
- * Set the element value at the given index.
- * If the element location does not exist, it will be created with a
- * default element value.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::InsertElement(ElementIdentifier id, Element element)
@@ -112,10 +78,6 @@ VectorContainer<TElementIdentifier, TElement>::InsertElement(ElementIdentifier i
   this->Modified();
 }
 
-/**
- * Check if the index range of the STL vector is large enough to allow the
- * given index without expansion.
- */
 template <typename TElementIdentifier, typename TElement>
 bool
 VectorContainer<TElementIdentifier, TElement>::IndexExists(ElementIdentifier identifier) const
@@ -124,11 +86,6 @@ VectorContainer<TElementIdentifier, TElement>::IndexExists(ElementIdentifier ide
           (identifier < static_cast<ElementIdentifier>(this->VectorType::size())));
 }
 
-/**
- * Check if the given index is in range of the STL vector.  If it is not,
- * return false.  Otherwise, set the element through the pointer (if it isn't
- * nullptr), and return true.
- */
 template <typename TElementIdentifier, typename TElement>
 bool
 VectorContainer<TElementIdentifier, TElement>::GetElementIfIndexExists(ElementIdentifier identifier,
@@ -146,11 +103,6 @@ VectorContainer<TElementIdentifier, TElement>::GetElementIfIndexExists(ElementId
   return false;
 }
 
-/**
- * Make sure that the index range of the STL vector is large enough to allow
- * the given index, expanding it if necessary.  The index will contain
- * the default element regardless of whether expansion occurred.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::CreateIndex(ElementIdentifier id)
@@ -176,10 +128,6 @@ VectorContainer<TElementIdentifier, TElement>::CreateIndex(ElementIdentifier id)
   }
 }
 
-/**
- * It doesn't make sense to delete a vector index.
- * Instead, just overwrite the index with the default element.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::DeleteIndex(ElementIdentifier id)
@@ -188,9 +136,6 @@ VectorContainer<TElementIdentifier, TElement>::DeleteIndex(ElementIdentifier id)
   this->Modified();
 }
 
-/**
- * Get a begin const iterator for the vector.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::Begin() const -> ConstIterator
@@ -198,9 +143,6 @@ VectorContainer<TElementIdentifier, TElement>::Begin() const -> ConstIterator
   return ConstIterator(0, this->VectorType::begin());
 }
 
-/**
- * Get an end const iterator for the vector.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::End() const -> ConstIterator
@@ -208,9 +150,6 @@ VectorContainer<TElementIdentifier, TElement>::End() const -> ConstIterator
   return ConstIterator(this->VectorType::size() - 1, this->VectorType::end());
 }
 
-/**
- * Get a begin iterator for the vector.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::Begin() -> Iterator
@@ -218,9 +157,6 @@ VectorContainer<TElementIdentifier, TElement>::Begin() -> Iterator
   return Iterator(0, this->VectorType::begin());
 }
 
-/**
- * Get an end iterator for the vector.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::End() -> Iterator
@@ -228,9 +164,6 @@ VectorContainer<TElementIdentifier, TElement>::End() -> Iterator
   return Iterator(this->VectorType::size() - 1, this->VectorType::end());
 }
 
-/**
- * Get the number of elements currently stored in the vector.
- */
 template <typename TElementIdentifier, typename TElement>
 auto
 VectorContainer<TElementIdentifier, TElement>::Size() const -> ElementIdentifier
@@ -238,9 +171,6 @@ VectorContainer<TElementIdentifier, TElement>::Size() const -> ElementIdentifier
   return static_cast<ElementIdentifier>(this->VectorType::size());
 }
 
-/**
- * Clear the elements. The final size will be zero.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::Initialize()
@@ -248,9 +178,6 @@ VectorContainer<TElementIdentifier, TElement>::Initialize()
   this->VectorType::clear();
 }
 
-/**
- *    Allocate memory for at the requested number of elements.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier sz)
@@ -258,9 +185,6 @@ VectorContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier sz)
   this->CreateIndex(sz - 1);
 }
 
-/**
- *   Try to compact the internal representation of the memory.
- */
 template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::Squeeze()

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
@@ -103,8 +103,11 @@ public:
   itkSetObjectMacro(Interpolator, InterpolatorType);
   itkGetModifiableObjectMacro(Interpolator, InterpolatorType);
 
-  /** This method is used to set the state of the filter before
-   * multi-threading. */
+  /**
+   * Set up the state of the filter before multi-threading.
+   * InterpolatorType::SetInputImage is not thread-safe and hence
+   * has to be setup before ThreadedGenerateData.
+   */
   void
   BeforeThreadedGenerateData() override;
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -72,11 +72,6 @@ InterpolateImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, 
   os << indent << "Distance: " << m_Distance << std::endl;
 }
 
-/**
- * Setup state of filter before multi-threading.
- * InterpolatorType::SetInputImage is not thread-safe and hence
- * has to be setup before ThreadedGenerateData
- */
 template <typename TInputImage, typename TOutputImage>
 void
 InterpolateImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -22,9 +22,7 @@
 
 namespace itk
 {
-/**
- * Initialize member variables with meaningful values.
- */
+
 template <typename TInputImage, typename TOutputImage>
 DirectFourierReconstructionImageToImageFilter<TInputImage,
                                               TOutputImage>::DirectFourierReconstructionImageToImageFilter()
@@ -46,9 +44,6 @@ DirectFourierReconstructionImageToImageFilter<TInputImage,
   m_PI = 4 * std::atan(RADIANS);
 }
 
-/**
- * Print out class state (member variables)
- */
 template <typename TInputImage, typename TOutputImage>
 void
 DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
@@ -68,9 +63,6 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::PrintS
   os << indent << "Input Requested Region: " << m_InputRequestedRegion << std::endl;
 }
 
-/**
- * Calculate image boundaries and define output regions, spacing, origin etc.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
@@ -123,9 +115,6 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
   outputImage->SetSpacing(outputSpacing);
 }
 
-/**
- * Calculate necessary input image boundaries
- */
 template <typename TInputImage, typename TOutputImage>
 void
 DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
@@ -156,9 +145,6 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
   inputImage->SetRequestedRegion(m_InputRequestedRegion);
 }
 
-/**
- * Actual computation
- */
 template <typename TInputImage, typename TOutputImage>
 void
 DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/**
- *
- */
+
 template <typename TLevelSet>
 LevelSetNeighborhoodExtractor<TLevelSet>::LevelSetNeighborhoodExtractor()
   : m_InsidePoints(nullptr)
@@ -41,9 +39,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::LevelSetNeighborhoodExtractor()
   m_NodesUsed.resize(SetDimension);
 }
 
-/*
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent indent) const
@@ -58,9 +53,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent in
   os << m_InputNarrowBand.GetPointer() << std::endl;
 }
 
-/*
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::SetInputNarrowBand(NodeContainer * ptr)
@@ -72,9 +64,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::SetInputNarrowBand(NodeContainer * ptr
   }
 }
 
-/**
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::Locate()
@@ -82,9 +71,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::Locate()
   this->GenerateData();
 }
 
-/**
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::Initialize()
@@ -96,9 +82,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::Initialize()
   m_ImageRegion = this->m_InputLevelSet->GetBufferedRegion();
 }
 
-/*
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::GenerateData()
@@ -123,9 +106,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::GenerateData()
   itkDebugMacro("No. outside points: " << m_OutsidePoints->Size());
 }
 
-/*
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::GenerateDataFull()
@@ -157,9 +137,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::GenerateDataFull()
   }
 }
 
-/**
- *
- */
 template <typename TLevelSet>
 void
 LevelSetNeighborhoodExtractor<TLevelSet>::GenerateDataNarrowBand()
@@ -201,9 +178,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::GenerateDataNarrowBand()
   }
 }
 
-/**
- *
- */
 template <typename TLevelSet>
 double
 LevelSetNeighborhoodExtractor<TLevelSet>::CalculateDistance(IndexType & index)


### PR DESCRIPTION
Clean up method Doxygen documentation:
- Consolidate documentation so that methods are documented in the header files.
- Remove the documentation of trivial methods: constructors, destructors, `PrintSelf` methods, etc.
- Remove empty method documentation blocks from implementation file.

Follow-up to d58bf56.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)