### PR TITLE
STYLE: Remove redundant checks in `ProcessObject::VerifyPreconditions()`

### DIFF
--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1341,20 +1341,6 @@ ProcessObject::VerifyPreconditions() ITKv5_CONST
   }
 
   /**
-   * Verify the require named inputs.
-   */
-  auto i = m_RequiredInputNames.begin();
-  while (i != m_RequiredInputNames.end())
-  {
-    if (this->GetInput(*i) == nullptr)
-    {
-      itkExceptionMacro("Required Input " << *i << "is not specified!"
-                                          << " The required inputs are expected to be the first inputs.");
-    }
-    ++i;
-  }
-
-  /**
    * Count the number of required indexed inputs which have been assigned
    */
   const DataObjectPointerArraySizeType validIndexedInputs = this->GetNumberOfValidRequiredInputs();


### PR DESCRIPTION
Removed redundant checks of required named inputs, which were performed already in the previous lines of code.

Partially reverts commit bf6f1065a07037fe27d290f72adf81c81ed408ec "BUG: VerifyPreconditions checks required named inputs", April 23, 2013.

----

Please compare the code that is removed by this PR with the code just above it:

https://github.com/InsightSoftwareConsortium/ITK/blob/bc1025b1c00d8cd99d98646c6a59072edf0488f9/Modules/Core/Common/src/itkProcessObject.cxx#L1332-L1341

Isn't it basically just doing the same check? 