### PR TITLE
PERF: Use `std::move` inside `itkSetMacro`, declare parameter non-const

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -966,17 +966,17 @@ compilers.
   itkSetDecoratedObjectInputMacro(name, type);         \
   itkGetDecoratedObjectInputMacro(name, type)
 
-/** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility()); */
+/** Set built-in type or regular C++ type.  Creates member Set"name"() (e.g., SetVisibility()); */
 // clang-format off
 #define itkSetMacro(name, type)                     \
-  virtual void Set##name(const type _arg)           \
+  virtual void Set##name(type _arg)           \
   {                                                 \
     itkDebugMacro("setting " #name " to " << _arg); \
     CLANG_PRAGMA_PUSH                               \
     CLANG_SUPPRESS_Wfloat_equal                     \
     if (this->m_##name != _arg)                     \
     {                                               \
-      this->m_##name = _arg;                        \
+      this->m_##name = std::move(_arg);                        \
       this->Modified();                             \
     }                                               \
     CLANG_PRAGMA_POP                                \

--- a/Modules/IO/XML/include/itkDOMNode.h
+++ b/Modules/IO/XML/include/itkDOMNode.h
@@ -93,11 +93,11 @@ public:
   GetParent() const;
 
   /** Retrieve the tag name of this node. */
-  itkSetMacro(Name, std::string &);
+  itkSetMacro(Name, const std::string &);
   itkGetConstReferenceMacro(Name, std::string);
 
   /** Retrieve the special attribute "id" of this node. */
-  itkSetMacro(ID, std::string &);
+  itkSetMacro(ID, const std::string &);
   itkGetConstReferenceMacro(ID, std::string);
 
   /** Retrieve an attribute by key (return an empty string if not found). */

--- a/Modules/IO/XML/include/itkDOMTextNode.h
+++ b/Modules/IO/XML/include/itkDOMTextNode.h
@@ -55,7 +55,7 @@ public:
   itkTypeMacro(DOMTextNode, DOMNode);
 
   /** Functions to set/get the enclosed text of this node. */
-  itkSetMacro(Text, std::string &);
+  itkSetMacro(Text, const std::string &);
   itkGetConstReferenceMacro(Text, std::string);
 
 protected:


### PR DESCRIPTION
Avoids an unnecessary copy (possibly involving memory allocation) of the argument of a Set member function.

Note that `itkSetMacro` calls that define a Set member function which passes the argument by const-reference must explicitly specify the `const` keyword now.