### PR TITLE
BUG: Add semicolon after `ITK_EXERCISE_BASIC_OBJECT_METHODS` call

### DIFF
--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -127,7 +127,7 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
     auto shiftScalesEstimator = ShiftScalesEstimatorType::New();
 
     ITK_EXERCISE_BASIC_OBJECT_METHODS(
-      shiftScalesEstimator, RegistrationParameterScalesFromPhysicalShift, RegistrationParameterScalesFromShiftBase)
+      shiftScalesEstimator, RegistrationParameterScalesFromPhysicalShift, RegistrationParameterScalesFromShiftBase);
 
 
     shiftScalesEstimator->SetMetric(metric);


### PR DESCRIPTION
Add missing semicolon after `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro call in test.

Fixes:
```
itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx:130:116: error: expected ';' after 'static_assert'
      shiftScalesEstimator, RegistrationParameterScalesFromPhysicalShift, RegistrationParameterScalesFromShiftBase)
                                                                                                                   ^
                                                                                                                   ;
```

Reported in:
https://open.cdash.org/viewBuildError.php?buildid=8785957

Oversight introduced in commit 165fb5b6fed0f7f9f0669570472905b9931e64b4.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)