### PR TITLE
STYLE: Increase `itk::LabelStatisticsImageFilter::PrintSelf` consistency

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -22,6 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkHistogram.h"
+#include "itkPrintHelper.h"
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -219,6 +220,39 @@ public:
         m_Histogram = l.m_Histogram;
       }
       return *this;
+    }
+
+    friend std::ostream &
+    operator<<(std::ostream & os, const LabelStatistics & labelStatistics)
+    {
+      using namespace print_helper;
+
+      os << "Count: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(labelStatistics.m_Count)
+         << std::endl;
+      os << "Minimum: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Minimum)
+         << std::endl;
+      os << "Maximum: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Maximum)
+         << std::endl;
+      os << "Mean: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Mean) << std::endl;
+      os << "Sum: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Sum) << std::endl;
+      os << "SumOfSquares: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_SumOfSquares)
+         << std::endl;
+      os << "Sigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Sigma) << std::endl;
+      os << "Variance: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Variance)
+         << std::endl;
+      os << "BoundingBox: " << labelStatistics.m_BoundingBox << std::endl;
+
+      os << "Histogram: ";
+      if (labelStatistics.m_Histogram)
+      {
+        labelStatistics.m_Histogram->Print(os);
+      }
+      else
+      {
+        os << "nullptr" << std::endl;
+      }
+
+      return os;
     }
 
     IdentifierType                  m_Count;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -520,12 +520,21 @@ template <typename TImage, typename TLabelImage>
 void
 LabelStatisticsImageFilter<TImage, TLabelImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Number of labels: " << m_LabelStatistics.size() << std::endl;
-  os << indent << "Use Histograms: " << m_UseHistograms << std::endl;
-  os << indent << "Histogram Lower Bound: " << m_LowerBound << std::endl;
-  os << indent << "Histogram Upper Bound: " << m_UpperBound << std::endl;
+  os << indent << "LabelStatistics: " << std::endl;
+  for (auto const & pair : m_LabelStatistics)
+  {
+    os << indent.GetNextIndent() << "{" << pair.first << ": " << pair.second << "}" << std::endl;
+  }
+
+  os << indent << "ValidLabelValues: " << m_ValidLabelValues << std::endl;
+  os << indent << "UseHistograms: " << (m_UseHistograms ? "On" : "Off") << std::endl;
+  os << indent << "NumBins: " << m_NumBins << std::endl;
+  os << indent << "LowerBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LowerBound) << std::endl;
+  os << indent << "UpperBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_UpperBound) << std::endl;
 }
 } // end namespace itk
 #endif


### PR DESCRIPTION
Make `itk::LabelStatisticsImageFilter::PrintSelf` implementation style consistent following the ITK SWG coding style guideline and the available ITK macros:
- Print only the class instance variables.
- Use the `os << indent << "{ivarName}: " << m_ivarName << std::endl` recipe: do not print the leading `m_` of the ivar; use a colon after printing its name; leave a whitespace between the colon and the printed value of the ivar.
- For boolean ivars print `On`/`Off` according to their values using the ternary operator.
- Take advantage of the output stream `<<` insertion operator overload for `std::vector` types in the `itk::print_helper` namespace defined in `itkPrintHelper.h` to print such types consistently.
- Cast custom types to their numerical values using `itk::NumericTraits::PrinType` so that they are printed as expected.

Overload the stream insertion operator `<<` for the `itk::LabelStatistics` class so that the `itk::LabelStatisticsImageFilter` class instance can print the corresponding ivar.

Follow-up to commit c47ed1c1b3e26051de655f7ad03e975fae93b73b.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)