### PR TITLE
DOC: Change the Insight Journal handle links to insight-journal links

### DIFF
--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -31,7 +31,6 @@
  *
  * "Grayscale morphological attribute operations"
  * by Beare R.
- * https://hdl.handle.net/1926/1316
  * https://www.insight-journal.org/browse/publication/203
  *
  */

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -23,14 +23,6 @@
 
 #include <cfloat> // for DBL_MIN
 
-/*
- * This code was contributed in the Insight Journal paper:
- * "Conformal Flattening ITK Filter"
- * by Gao Y., Melonakos J., Tannenbaum A.
- * https://hdl.handle.net/1926/225
- * https://www.insight-journal.org/browse/publication/112
- *
- */
 
 namespace itk
 {

--- a/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
@@ -20,15 +20,6 @@
 
 #include "itkProgressAccumulator.h"
 
-/*
- *
- * This code was contributed in the Insight Journal paper:
- * "Efficient implementation of kernel filtering"
- * by Beare R., Lehmann G
- * https://hdl.handle.net/1926/555
- * https://www.insight-journal.org/browse/publication/160
- *
- */
 
 namespace itk
 {

--- a/Modules/Remote/Ultrasound.remote.cmake
+++ b/Modules/Remote/Ultrasound.remote.cmake
@@ -47,7 +47,7 @@ itk_fetch_module(Ultrasound
 
 McCormick, M.
 An Open Source, Fast Ultrasound B-Mode Implementation for Commodity Hardware.
-Insight Journal. 2010 January-June. URL: https://hdl.handle.net/10380/3159
+Insight Journal. 2010 January-June. URL: https://www.insight-journal.org/browse/publication/722
 
 McCormick, M, Rubert, N and Varghese, T.
 Bayesian Regularization Applied to Ultrasound Strain Imaging.


### PR DESCRIPTION
Change the Insight Journal handle links to insight-journal links or remove handle links where insight-journal links were already present: handle links are no longer valid.

Remove completely the documentation blocks containing the handle links from implementation files as the corresponding blocks containing the insight-journal links are already present in the header files.

Left behind in commit e936cabc7aaef3764de27880fd1fe7846d0ba768.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)