### PR TITLE
DOC: Clean up `itk::ConformalFlatteningMeshFilter` Doxygen documentation

### DIFF
--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -89,11 +89,11 @@ public:
   using PointIdIterator = typename CellType::PointIdIterator;
   using CellAutoPointer = typename CellType::CellAutoPointer;
 
-  /** Select the cell that will be used as reference for the flattening.
-   * This value must be the identifier of a cell existing in the input Mesh.
-   * A point of this cell will be mapped to infinity on the plane, or it
-   * will be mapped to the north-pole on the sphere. It is recommended to
-   * select a cell whose curvature is relatively flat. */
+  /** Select the cell that will be used to define the boundary/used as reference for the flattening.
+   * This value must be the identifier of a cell existing in the input Mesh. A point of this cell will be mapped to
+   * infinity on the plane, or it will be mapped to the north-pole on the sphere. It is recommended to select a cell
+   * whose curvature is relatively flat.
+   */
   void
   SetPolarCellIdentifier(CellIdentifier cellId);
 

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/**
- *
- */
+
 template <typename TInputMesh, typename TOutputMesh>
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::ConformalFlatteningMeshFilter()
 {
@@ -43,9 +41,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::ConformalFlatteningMeshF
   // same number of vertices.
 }
 
-/**
- * Set the triangle used to define the boundary of the flattened region.
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::SetPolarCellIdentifier(CellIdentifier cellId)
@@ -53,10 +48,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::SetPolarCellIdentifier(C
   this->m_PolarCellIdentifier = cellId;
 }
 
-/**
- * Define the scale of the mapping. The largest coordinates of the
- * furthest point in the plane is m_MapScale.
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::SetScale(double scale)
@@ -64,9 +55,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::SetScale(double scale)
   this->m_MapScale = scale;
 }
 
-/**
- * Define that the input surface will be mapped to a sphere
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::MapToSphere()
@@ -74,9 +62,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::MapToSphere()
   this->m_MapToSphere = true;
 }
 
-/** Define that the input surface will be mapped to a plane.
- *  This skips the steps of the stereographic projection.
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::MapToPlane()
@@ -84,9 +69,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::MapToPlane()
   this->m_MapToSphere = false;
 }
 
-/**
- *
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream & os, Indent indent) const
@@ -94,9 +76,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream &
   Superclass::PrintSelf(os, indent);
 }
 
-/**
- * This method causes the filter to generate its output.
- */
 template <typename TInputMesh, typename TOutputMesh>
 void
 ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()


### PR DESCRIPTION
Clean up method Doxygen documentation for
`itk::ConformalFlatteningMeshFilter`:
- Consolidate documentation so that methods are documented in the header files.
- Remove empty method documentation blocks from implementation file.

Take advantage of the commit to make the modified method documentation
blocks have a consistent line length.

Follow-up to d58bf56fe2320fe3c7a451c96e3d8cd5e7c68358.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)