### PR TITLE
Avoid CMake warning caused by feature test

### DIFF
--- a/CMake/itkTargetLinkLibrariesWithDynamicLookup.cmake
+++ b/CMake/itkTargetLinkLibrariesWithDynamicLookup.cmake
@@ -48,6 +48,7 @@ function(_itkCheckUndefinedSymbolsAllowed)
 
     file(WRITE "${test_project_dir}/CMakeLists.txt"
 "
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 project(undefined C)
 add_library(foo SHARED \"foo.c\")
 ")


### PR DESCRIPTION
From https://open.cdash.org/build/8807486/configure
```log
...
-- Check the value of the 22nd bit of a 32-bit quiet-NaN - 1 CMake Warning (dev) at /home/vsts/work/1/s-build/Wrapping/CMakeTmp/ITK_UNDEFINED_SYMBOLS_ALLOWED/CMakeLists.txt:2 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Performing Test ITK_UNDEFINED_SYMBOLS_ALLOWED - Success ...
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

