### PR TITLE
COMP: Fix method parameter bound mismatch warning in `itk::VertexCell`

### DIFF
--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -169,7 +169,7 @@ bool
 VertexCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
                                              PointsContainer *         points,
                                              CoordRepType *            closestPoint,
-                                             CoordRepType              pcoord[2],
+                                             CoordRepType              pcoord[],
                                              double *                  minDist2,
                                              InterpolationWeightType * weights)
 {


### PR DESCRIPTION
Fix method parameter bound mismatch warning in `itk::VertexCell`: do not specify the dimensionality of the array in the implementation file so that it matches the method declaration, and they match the `itk::CellInterface` superclass method declaration.

Fixes:
```
[CTest: warning matched]
Core/Common/include/itkVertexCell.hxx:172:72:
warning: argument 'pcoord' of type 'CoordRepType[2]' with mismatched bound [-Warray-parameter]
                                             CoordRepType              pcoord[2],
                                                                       ^
[CTest: warning matched]
Core/Common/include/itkVertexCell.h:111:32:
note: previously declared as 'CoordRepType[]' here
                   CoordRepType[],
                               ^
```

raised, for example, in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8832331

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)