### PR TITLE
COMP: Fix method parameter bound mismatch warning in misc cell classes

### DIFF
--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -82,7 +82,7 @@ bool
 TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
                                                   PointsContainer *         points,
                                                   CoordRepType *            closestPoint,
-                                                  CoordRepType              pcoord[3],
+                                                  CoordRepType              pcoord[],
                                                   double *                  minDist2,
                                                   InterpolationWeightType * weights)
 {

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -449,7 +449,7 @@ bool
 TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
                                                PointsContainer *         points,
                                                CoordRepType *            closestPoint,
-                                               CoordRepType              pcoord[3],
+                                               CoordRepType              pcoord[],
                                                double *                  minDist2,
                                                InterpolationWeightType * weights)
 {


### PR DESCRIPTION
Fix method parameter bound mismatch warning in `itk::TriangleCell` and `itk::TetrahedronCell`: do not specify the dimensionality of the array in the implementation file so that it matches the method declaration, and they match the `itk::CellInterface` superclass method declaration.

Fixes:
```
[CTest: warning matched]
Modules/Core/Common/include/itkTriangleCell.hxx:452:74:
warning: argument 'pcoord' of type 'CoordRepType[3]' with mismatched bound [-Warray-parameter]
                                               CoordRepType              pcoord[3],
                                                                         ^
[CTest: warning matched]
Modules/Core/Common/include/itkTriangleCell.h:130:32:
note: previously declared as 'CoordRepType[]' here
                   CoordRepType[],
                               ^
```

and
```
[CTest: warning matched]
Modules/Core/Common/include/itkTetrahedronCell.hxx:85:77:
warning: argument 'pcoord' of type 'CoordRepType[3]' with mismatched bound [-Warray-parameter]
                                                  CoordRepType              pcoord[3],
                                                                            ^
[CTest: warning matched]
Modules/Core/Common/include/itkTetrahedronCell.h:137:32:
note: previously declared as 'CoordRepType[]' here
                   CoordRepType[],
                               ^
```

raised, for example, in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8839489

Related to commit 2338bdc.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)