### PR TITLE
BUG: Get image geometry from GDCM Secondary Capture

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
@@ -729,7 +729,7 @@ std::vector<double> ImageHelper::GetDirectionCosinesValue(File const & f)
     }
 
   dircos.resize( 6 );
-  if( ms == MediaStorage::SecondaryCaptureImageStorage || !GetDirectionCosinesFromDataSet(ds, dircos) )
+  if( !GetDirectionCosinesFromDataSet(ds, dircos) )
     {
     dircos[0] = 1;
     dircos[1] = 0;
@@ -1269,7 +1269,8 @@ Tag ImageHelper::GetSpacingTagFromMediaStorage(MediaStorage const &ms)
   case MediaStorage::MultiframeTrueColorSecondaryCaptureImageStorage:
     // See PS 3.3-2008. Table C.8-25 SC IMAGE MODULE ATTRIBUTES
     // and Table C.8-25b SC MULTI-FRAME IMAGE MODULE ATTRIBUTES
-    t = Tag(0x0018,0x2010);
+    //t = Tag(0x0018,0x2010); Clarified in CP-586 2006-01-25 that PixelSpacing is correct
+    t = Tag(0x0028,0x0030);
     break;
   case MediaStorage::HardcopyGrayscaleImageStorage:
   case MediaStorage::HardcopyColorImageStorage:


### PR DESCRIPTION
Secondary capture images can have pixel spacing and image orientation, but the GDCM code explicitly ignored these values (whereas DCMTK code read them).

Per David Clunie (@dclunie) the editor of the standard, it was clarified in CP-586 that PixelSpacing is the correct place to store the best known value (e.g. one that has been corrected for distortion) while other fields like the NominalScannedPixelSpacing, which GDCM used before this commit, if stored at all should have the uncorrected values.

For these reasons this commit makes the default behavior of GDCM for SC match what it would do if SC images were MR or CT in terms of handling the image geometry, which is a better default than the previos behavior.

https://dicom.nema.org/medical/dicom/Final/cp586_ft.pdf

Fixes #4109