### PR TITLE
DOC: Document miscellaneous cell class methods in header files

### DIFF
--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -44,7 +44,7 @@ class ITK_TEMPLATE_EXPORT TetrahedronCell
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TetrahedronCell);
 
-  /** Standard class type aliasa. */
+  /** Standard class type alias. */
   itkCellCommonTypedefs(TetrahedronCell);
   itkCellInheritedTypedefs(TCellInterface);
 
@@ -70,6 +70,8 @@ public:
   static constexpr unsigned int NumberOfFaces = 4;
   static constexpr unsigned int CellDimension = 3;
 
+  // Standard CellInterface
+
   /** Implement the standard CellInterface. */
   CellGeometryEnum
   GetType() const override
@@ -79,51 +81,86 @@ public:
   void
   MakeCopy(CellAutoPointer &) const override;
 
+  /** Get the topological dimension of this cell. */
   unsigned int
   GetDimension() const override;
 
+  /** Get the number of points required to define the cell. */
   unsigned int
   GetNumberOfPoints() const override;
 
+  /** Get the number of boundary features of the given dimension. */
   CellFeatureCount
   GetNumberOfBoundaryFeatures(int dimension) const override;
 
+  /** Get the boundary feature of the given dimension specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfBoundaryFeatures(dimension)-1.
+   */
   bool
   GetBoundaryFeature(int dimension, CellFeatureIdentifier, CellAutoPointer &) override;
+
+  /** Set the point id list used by the cell. It is assumed that the given iterator can be incremented and safely
+   * de-referenced enough times to get all the point ids needed by the cell.
+   */
   void
   SetPointIds(PointIdConstIterator first) override;
 
+  /** Set the point id list used by the cell.  It is assumed that the range of iterators [first, last) contains the
+   * correct number of points needed to define the cell.  The position *last is NOT referenced, so it can safely be
+   * one beyond the end of an array or other container.
+   */
   void
   SetPointIds(PointIdConstIterator first, PointIdConstIterator last) override;
 
+  /** Set an individual point identifier in the cell. */
   void
   SetPointId(int localId, PointIdentifier) override;
+
+  /** Get a begin iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsBegin() override;
 
+  /** Get a const begin iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsBegin() const override;
 
+  /** Get an end iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsEnd() override;
 
+  /** Get a const end iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsEnd() const override;
 
-  /** Tetrahedron-specific interface. */
+  // Tetrahedron-specific interface
+
+  /** Get the number of vertices defining the tetrahedron. */
   virtual CellFeatureCount
   GetNumberOfVertices() const;
 
+  /** Get the number of edges defined for the tetrahedron. */
   virtual CellFeatureCount
   GetNumberOfEdges() const;
 
+  /** Get the number of faces defined for the tetrahedron. */
   virtual CellFeatureCount
   GetNumberOfFaces() const;
 
+  /** Get the vertex specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfVertices()-1.
+   */
   virtual bool
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
+
+  /** Get the edge specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfEdges()-1.
+   */
   virtual bool
   GetEdge(CellFeatureIdentifier, EdgeAutoPointer &);
+
+  /** Get the face specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfFaces()-1.
+   */
   virtual bool
   GetFace(CellFeatureIdentifier, FaceAutoPointer &);
 

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Standard CellInterface:
- */
+
 template <typename TCellInterface>
 void
 TetrahedronCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
@@ -34,10 +32,6 @@ TetrahedronCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
   cellPointer->SetPointIds(this->GetPointIds());
 }
 
-/**
- * Standard CellInterface:
- * Get the topological dimension of this cell.
- */
 template <typename TCellInterface>
 unsigned int
 TetrahedronCell<TCellInterface>::GetDimension() const
@@ -45,10 +39,6 @@ TetrahedronCell<TCellInterface>::GetDimension() const
   return Self::CellDimension;
 }
 
-/**
- * Standard CellInterface:
- * Get the number of points required to define the cell.
- */
 template <typename TCellInterface>
 unsigned int
 TetrahedronCell<TCellInterface>::GetNumberOfPoints() const
@@ -56,10 +46,6 @@ TetrahedronCell<TCellInterface>::GetNumberOfPoints() const
   return Self::NumberOfPoints;
 }
 
-/**
- * Standard CellInterface:
- * Get the number of boundary features of the given dimension.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
@@ -220,12 +206,6 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   return false;
 }
 
-/**
- * Standard CellInterface:
- * Get the boundary feature of the given dimension specified by the given
- * cell feature Id.
- * The Id can range from 0 to GetNumberOfBoundaryFeatures(dimension)-1.
- */
 template <typename TCellInterface>
 bool
 TetrahedronCell<TCellInterface>::GetBoundaryFeature(int                   dimension,
@@ -271,12 +251,6 @@ TetrahedronCell<TCellInterface>::GetBoundaryFeature(int                   dimens
   return false;
 }
 
-/**
- * Standard CellInterface:
- * Set the point id list used by the cell.  It is assumed that the given
- * iterator can be incremented and safely de-referenced enough times to
- * get all the point ids needed by the cell.
- */
 template <typename TCellInterface>
 void
 TetrahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
@@ -284,13 +258,6 @@ TetrahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
   std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
-/**
- * Standard CellInterface:
- * Set the point id list used by the cell.  It is assumed that the range
- * of iterators [first, last) contains the correct number of points needed to
- * define the cell.  The position *last is NOT referenced, so it can safely
- * be one beyond the end of an array or other container.
- */
 template <typename TCellInterface>
 void
 TetrahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConstIterator last)
@@ -304,10 +271,6 @@ TetrahedronCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointId
   }
 }
 
-/**
- * Standard CellInterface:
- * Set an individual point identifier in the cell.
- */
 template <typename TCellInterface>
 void
 TetrahedronCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
@@ -315,10 +278,6 @@ TetrahedronCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
   m_PointIds[localId] = ptId;
 }
 
-/**
- * Standard CellInterface:
- * Get a begin iterator to the list of point identifiers used by the cell.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
@@ -326,11 +285,6 @@ TetrahedronCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
   return &m_PointIds[0];
 }
 
-/**
- * Standard CellInterface:
- * Get a const begin iterator to the list of point identifiers used
- * by the cell.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
@@ -338,10 +292,6 @@ TetrahedronCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
   return &m_PointIds[0];
 }
 
-/**
- * Standard CellInterface:
- * Get an end iterator to the list of point identifiers used by the cell.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
@@ -349,11 +299,6 @@ TetrahedronCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/**
- * Standard CellInterface:
- * Get a const end iterator to the list of point identifiers used
- * by the cell.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
@@ -361,10 +306,6 @@ TetrahedronCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the number of vertices defining the tetrahedron.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
@@ -372,10 +313,6 @@ TetrahedronCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
   return Self::NumberOfVertices;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the number of edges defined for the tetrahedron.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
@@ -383,10 +320,6 @@ TetrahedronCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
   return Self::NumberOfEdges;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the number of faces defined for the tetrahedron.
- */
 template <typename TCellInterface>
 auto
 TetrahedronCell<TCellInterface>::GetNumberOfFaces() const -> CellFeatureCount
@@ -394,11 +327,6 @@ TetrahedronCell<TCellInterface>::GetNumberOfFaces() const -> CellFeatureCount
   return Self::NumberOfFaces;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the vertex specified by the given cell feature Id.
- * The Id can range from 0 to GetNumberOfVertices()-1.
- */
 template <typename TCellInterface>
 bool
 TetrahedronCell<TCellInterface>::GetVertex(CellFeatureIdentifier vertexId, VertexAutoPointer & vertexPointer)
@@ -410,11 +338,6 @@ TetrahedronCell<TCellInterface>::GetVertex(CellFeatureIdentifier vertexId, Verte
   return true;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the edge specified by the given cell feature Id.
- * The Id can range from 0 to GetNumberOfEdges()-1.
- */
 template <typename TCellInterface>
 bool
 TetrahedronCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAutoPointer & edgePointer)
@@ -429,11 +352,6 @@ TetrahedronCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAutoP
   return true;
 }
 
-/**
- * Tetrahedron-specific:
- * Get the face specified by the given cell feature Id.
- * The Id can range from 0 to GetNumberOfFaces()-1.
- */
 template <typename TCellInterface>
 bool
 TetrahedronCell<TCellInterface>::GetFace(CellFeatureIdentifier faceId, FaceAutoPointer & facePointer)

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -71,6 +71,8 @@ public:
   static constexpr unsigned int NumberOfEdges = 3;
   static constexpr unsigned int CellDimension = 2;
 
+  // Standard CellInterface
+
   /** Implement the standard CellInterface. */
   CellGeometryEnum
   GetType() const override
@@ -80,49 +82,80 @@ public:
   void
   MakeCopy(CellAutoPointer &) const override;
 
+  /** Get the topological dimension of this cell. */
   unsigned int
   GetDimension() const override;
 
+  /** Get the number of points required to define the cell. */
   unsigned int
   GetNumberOfPoints() const override;
 
+  /** Get the number of boundary features of the given dimension. */
   CellFeatureCount
   GetNumberOfBoundaryFeatures(int dimension) const override;
 
+  /** Get the boundary feature of the given dimension specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfBoundaryFeatures(dimension)-1.
+   */
   bool
   GetBoundaryFeature(int dimension, CellFeatureIdentifier, CellAutoPointer &) override;
+
+  /** Set the point id list used by the cell.  It is assumed that the given iterator can be incremented and safely
+   * de-referenced enough times to get all the point ids needed by the cell.
+   */
   void
   SetPointIds(PointIdConstIterator first) override;
 
+  /** Set the point id list used by the cell.  It is assumed that the range of iterators [first, last) contains the
+   * correct number of points needed to define the cell.  The position *last is NOT referenced, so it can safely be
+   * one beyond the end of an array or other container.
+   */
   void
   SetPointIds(PointIdConstIterator first, PointIdConstIterator last) override;
 
+  /** Set an individual point identifier in the cell. */
   void
   SetPointId(int localId, PointIdentifier) override;
+
+  /** Get a begin iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsBegin() override;
 
+  /** Get a const begin iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsBegin() const override;
 
+  /** Get an end iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsEnd() override;
 
+  /** Get a const end iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsEnd() const override;
 
-  /** Triangle-specific interface. */
+  // Triangle-specific interface
+
+  /** Get the number of vertices defining the triangle. */
   virtual CellFeatureCount
   GetNumberOfVertices() const;
 
+  /** Get the number of edges defined for the triangle. */
   virtual CellFeatureCount
   GetNumberOfEdges() const;
 
+  /** Get the vertex specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfVertices()-1.
+   */
   virtual bool
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
+
+  /** Get the edge specified by the given cell feature Id.
+   * The Id can range from 0 to GetNumberOfEdges()-1.
+   */
   virtual bool
   GetEdge(CellFeatureIdentifier, EdgeAutoPointer &);
 
+  /** Evaluate the position of a given point inside the cell */
   bool
   EvaluatePosition(CoordRepType *,
                    PointsContainer *,
@@ -134,7 +167,7 @@ public:
   /** Cell visitor interface. */
   itkCellVisitMacro(CellGeometryEnum::TRIANGLE_CELL);
 
-  /** \brief Compute Area to a TriangleCell given a PointsContainer.  */
+  /** Compute Area to a TriangleCell given a PointsContainer. */
   CoordRepType
   ComputeArea(PointsContainer *);
 
@@ -166,8 +199,8 @@ protected:
     NumericTraits<PointIdentifier>::max()) };
 
 private:
-  /** Computes the SQUARED distance between a point and a line segment defined
-   * by two other points */
+  /** Compute the squared distance between a point and a line segment defined by two other points. Returns the
+   * parametric coordinate t and point location on line. */
   double
   DistanceToLine(PointType x, PointType p1, PointType p2, double & t, CoordRepType * closestPoint);
 

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -23,9 +23,7 @@
 
 namespace itk
 {
-/**
- * Standard CellInterface:
- */
+
 template <typename TCellInterface>
 void
 TriangleCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
@@ -34,10 +32,6 @@ TriangleCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
   cellPointer->SetPointIds(this->GetPointIds());
 }
 
-/**
- * Standard CellInterface:
- * Get the topological dimension of this cell.
- */
 template <typename TCellInterface>
 unsigned int
 TriangleCell<TCellInterface>::GetDimension() const
@@ -45,10 +39,6 @@ TriangleCell<TCellInterface>::GetDimension() const
   return Self::CellDimension;
 }
 
-/**
- * Standard CellInterface:
- * Get the number of points required to define the cell.
- */
 template <typename TCellInterface>
 unsigned int
 TriangleCell<TCellInterface>::GetNumberOfPoints() const
@@ -56,10 +46,6 @@ TriangleCell<TCellInterface>::GetNumberOfPoints() const
   return Self::NumberOfPoints;
 }
 
-/**
- * Standard CellInterface:
- * Get the number of boundary features of the given dimension.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
@@ -75,12 +61,6 @@ TriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -
   }
 }
 
-/**
- * Standard CellInterface:
- * Get the boundary feature of the given dimension specified by the given
- * cell feature Id.
- * The Id can range from 0 to GetNumberOfBoundaryFeatures(dimension)-1.
- */
 template <typename TCellInterface>
 bool
 TriangleCell<TCellInterface>::GetBoundaryFeature(int                   dimension,
@@ -116,12 +96,6 @@ TriangleCell<TCellInterface>::GetBoundaryFeature(int                   dimension
   return false;
 }
 
-/**
- * Standard CellInterface:
- * Set the point id list used by the cell.  It is assumed that the given
- * iterator can be incremented and safely de-referenced enough times to
- * get all the point ids needed by the cell.
- */
 template <typename TCellInterface>
 void
 TriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
@@ -129,13 +103,6 @@ TriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
   std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
-/**
- * Standard CellInterface:
- * Set the point id list used by the cell.  It is assumed that the range
- * of iterators [first, last) contains the correct number of points needed to
- * define the cell.  The position *last is NOT referenced, so it can safely
- * be one beyond the end of an array or other container.
- */
 template <typename TCellInterface>
 void
 TriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConstIterator last)
@@ -149,10 +116,6 @@ TriangleCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdCon
   }
 }
 
-/**
- * Standard CellInterface:
- * Set an individual point identifier in the cell.
- */
 template <typename TCellInterface>
 void
 TriangleCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
@@ -160,10 +123,6 @@ TriangleCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
   m_PointIds[localId] = ptId;
 }
 
-/**
- * Standard CellInterface:
- * Get a begin iterator to the list of point identifiers used by the cell.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
@@ -171,11 +130,6 @@ TriangleCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
   return &m_PointIds[0];
 }
 
-/**
- * Standard CellInterface:
- * Get a const begin iterator to the list of point identifiers used
- * by the cell.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
@@ -183,10 +137,6 @@ TriangleCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
   return &m_PointIds[0];
 }
 
-/**
- * Standard CellInterface:
- * Get an end iterator to the list of point identifiers used by the cell.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
@@ -194,11 +144,6 @@ TriangleCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/**
- * Standard CellInterface:
- * Get a const end iterator to the list of point identifiers used
- * by the cell.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
@@ -206,10 +151,6 @@ TriangleCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/**
- * Triangle-specific:
- * Get the number of vertices defining the triangle.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
@@ -217,10 +158,6 @@ TriangleCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
   return Self::NumberOfVertices;
 }
 
-/**
- * Triangle-specific:
- * Get the number of edges defined for the triangle.
- */
 template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
@@ -228,11 +165,6 @@ TriangleCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
   return Self::NumberOfEdges;
 }
 
-/**
- * Triangle-specific:
- * Get the vertex specified by the given cell feature Id.
- * The Id can range from 0 to GetNumberOfVertices()-1.
- */
 template <typename TCellInterface>
 bool
 TriangleCell<TCellInterface>::GetVertex(CellFeatureIdentifier vertexId, VertexAutoPointer & vertexPointer)
@@ -244,11 +176,6 @@ TriangleCell<TCellInterface>::GetVertex(CellFeatureIdentifier vertexId, VertexAu
   return true;
 }
 
-/**
- * Triangle-specific:
- * Get the edge specified by the given cell feature Id.
- * The Id can range from 0 to GetNumberOfEdges()-1.
- */
 template <typename TCellInterface>
 bool
 TriangleCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAutoPointer & edgePointer)
@@ -263,8 +190,6 @@ TriangleCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAutoPoin
   return true;
 }
 
-/** Compute distance to finite line. Returns parametric coordinate t
- *  and point location on line. */
 template <typename TCellInterface>
 double
 TriangleCell<TCellInterface>::DistanceToLine(PointType      x,
@@ -443,7 +368,6 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> 
   }
 }
 
-/** Evaluate the position of a given point inside the cell */
 template <typename TCellInterface>
 bool
 TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -55,6 +55,8 @@ public:
   static constexpr unsigned int NumberOfPoints = 1;
   static constexpr unsigned int CellDimension = 0;
 
+  // Standard CellInterface
+
   /** Implement the standard CellInterface. */
   CellGeometryEnum
   GetType() const override
@@ -64,39 +66,61 @@ public:
   void
   MakeCopy(CellAutoPointer &) const override;
 
+  /** Get the topological dimension of this cell. */
   unsigned int
   GetDimension() const override;
 
+  /** Get the number of points required to define the cell. */
   unsigned int
   GetNumberOfPoints() const override;
 
+  /** A vertex has no boundary entities of any dimension. */
   CellFeatureCount
   GetNumberOfBoundaryFeatures(int dimension) const override;
 
+  /** A vertex has no boundary entities.  Just return null. */
   bool
   GetBoundaryFeature(int dimension, CellFeatureIdentifier, CellAutoPointer &) override;
+
+  /** Set the point id list used by the cell.  It is assumed that the given
+   *  iterator can be incremented and safely de-referenced enough times to
+   *  get all the point ids needed by the cell. */
   void
   SetPointIds(PointIdConstIterator first) override;
 
+  /** Set the point id list used by the cell.  It is assumed that the range
+   *  of iterators [first, last) contains the correct number of points needed to
+   *  define the cell.  The position *last is NOT referenced, so it can safely
+   *  be one beyond the end of an array or other container. */
   void
   SetPointIds(PointIdConstIterator first, PointIdConstIterator last) override;
 
+  // Vertex-specific interface
+
+  /** Set an individual point identifier in the cell. */
   void
   SetPointId(int localId, PointIdentifier) override;
+
+  /** Get a begin iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsBegin() override;
 
+  /** Get a const begin iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsBegin() const override;
 
+  /** Get an end iterator to the list of point identifiers used by the cell. */
   PointIdIterator
   PointIdsEnd() override;
 
+  /** Get a const end iterator to the list of point identifiers used by the cell. */
   PointIdConstIterator
   PointIdsEnd() const override;
 
-  /** Vertex-specific interface. */
+  /** Set the identifier of the point defining the vertex. */
   virtual void SetPointId(PointIdentifier);
+
+  /** Get the identifier of the point defining the vertex. */
   virtual PointIdentifier
   GetPointId();
 

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-/** Standard CellInterface: */
+
 template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
@@ -31,8 +31,6 @@ VertexCell<TCellInterface>::MakeCopy(CellAutoPointer & cellPointer) const
   cellPointer->SetPointIds(this->GetPointIds());
 }
 
-/** Standard CellInterface:
- *  Get the topological dimension of this cell. */
 template <typename TCellInterface>
 unsigned int
 VertexCell<TCellInterface>::GetDimension() const
@@ -40,8 +38,6 @@ VertexCell<TCellInterface>::GetDimension() const
   return Self::CellDimension;
 }
 
-/** Standard CellInterface:
- *  Get the number of points required to define the cell. */
 template <typename TCellInterface>
 unsigned int
 VertexCell<TCellInterface>::GetNumberOfPoints() const
@@ -49,8 +45,6 @@ VertexCell<TCellInterface>::GetNumberOfPoints() const
   return Self::NumberOfPoints;
 }
 
-/** Standard CellInterface:
- *  A vertex has no boundary entities of any dimension. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::GetNumberOfBoundaryFeatures(int) const -> CellFeatureCount
@@ -58,8 +52,6 @@ VertexCell<TCellInterface>::GetNumberOfBoundaryFeatures(int) const -> CellFeatur
   return 0;
 }
 
-/** Standard CellInterface:
- *  A vertex has no boundary entities.  Just return null. */
 template <typename TCellInterface>
 bool
 VertexCell<TCellInterface>::GetBoundaryFeature(int, CellFeatureIdentifier, CellAutoPointer & cellAPtr)
@@ -68,10 +60,6 @@ VertexCell<TCellInterface>::GetBoundaryFeature(int, CellFeatureIdentifier, CellA
   return false;
 }
 
-/** Standard CellInterface:
- *  Set the point id list used by the cell.  It is assumed that the given
- *  iterator can be incremented and safely de-referenced enough times to
- *  get all the point ids needed by the cell. */
 template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
@@ -79,11 +67,6 @@ VertexCell<TCellInterface>::SetPointIds(PointIdConstIterator first)
   std::copy_n(first, Self::NumberOfPoints, m_PointIds.begin());
 }
 
-/** Standard CellInterface:
- *  Set the point id list used by the cell.  It is assumed that the range
- *  of iterators [first, last) contains the correct number of points needed to
- *  define the cell.  The position *last is NOT referenced, so it can safely
- *  be one beyond the end of an array or other container. */
 template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConstIterator last)
@@ -97,8 +80,6 @@ VertexCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConst
   }
 }
 
-/** Standard CellInterface:
- *  Set an individual point identifier in the cell. */
 template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
@@ -106,9 +87,6 @@ VertexCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
   m_PointIds[localId] = ptId;
 }
 
-/** Standard CellInterface:
- *  Get a begin iterator to the list of point identifiers used by the
- *  cell. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
@@ -116,9 +94,6 @@ VertexCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
   return &m_PointIds[0];
 }
 
-/** Standard CellInterface:
- *  Get a const begin iterator to the list of point identifiers used
- *  by the cell. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
@@ -126,8 +101,6 @@ VertexCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
   return &m_PointIds[0];
 }
 
-/** Standard CellInterface:
- *  Get an end iterator to the list of point identifiers used by the cell. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
@@ -135,9 +108,6 @@ VertexCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/** Standard CellInterface:
- *  Get a const end iterator to the list of point identifiers used
- *  by the cell. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
@@ -145,8 +115,6 @@ VertexCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
 
-/** Vertex-specific:
- *  Set the identifier of the point defining the vertex. */
 template <typename TCellInterface>
 void
 VertexCell<TCellInterface>::SetPointId(PointIdentifier ptId)
@@ -154,8 +122,6 @@ VertexCell<TCellInterface>::SetPointId(PointIdentifier ptId)
   m_PointIds[0] = ptId;
 }
 
-/** Vertex-specific:
- *  Get the identifier of the point defining the vertex. */
 template <typename TCellInterface>
 auto
 VertexCell<TCellInterface>::GetPointId() -> PointIdentifier
@@ -163,7 +129,6 @@ VertexCell<TCellInterface>::GetPointId() -> PointIdentifier
   return m_PointIds[0];
 }
 
-/** Evaluate the position of a given point */
 template <typename TCellInterface>
 bool
 VertexCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,


### PR DESCRIPTION
Document miscellaneous cell class methods in header files: Doxygen picks the method documentation from the header files, and leaves the method documentation empty if it does not find it there.

Increase consistency in the characters used for documentation blocks and follow the ITK SW Guideline: prefer using single-line comments for separation of logical blocks.

Take advantage of the commit to fix typos in the method documentation.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)