### PR TITLE
DOC: Avoid documenting ivar default values in SpatialFunction class

### DIFF
--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
@@ -115,7 +115,7 @@ public:
 
   /** Set/Get direction along the gradient to search.
    * Set to true to use the direction that the gradient is pointing;
-   * set to false for the opposite direction. Default is Off. */
+   * set to false for the opposite direction. */
   itkGetConstMacro(Polarity, bool);
   itkSetMacro(Polarity, bool);
   itkBooleanMacro(Polarity);


### PR DESCRIPTION
Avoid documenting ivar default values in
`itk::ConicShellInteriorExteriorSpatialFunction` since:
- All ivar values should be initialized to some default value.
- When default values are changed, it is easy to forget about updating the documentation and making it inconsistent with the actual value in the code.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)