### PR TITLE
STYLE: GetGlobalDefaultSplitter replace call_once call with local static

### DIFF
--- a/Modules/Core/Common/src/itkImageSourceCommon.cxx
+++ b/Modules/Core/Common/src/itkImageSourceCommon.cxx
@@ -18,23 +18,16 @@
 
 #include "itkImageRegionSplitterSlowDimension.h"
 #include "itkImageSourceCommon.h"
-#include <mutex>
 
 namespace itk
 {
 
-namespace
-{
-std::once_flag                   globalDefaultSplitterOnceFlag;
-ImageRegionSplitterBase::Pointer globalDefaultSplitter;
-} // namespace
-
 const ImageRegionSplitterBase *
 ImageSourceCommon::GetGlobalDefaultSplitter()
 {
-  std::call_once(globalDefaultSplitterOnceFlag,
-                 []() { globalDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer(); });
-
+  // Note that the initialization of a local static variable is thread-safe ("magic statics").
+  static const ImageRegionSplitterBase::ConstPointer globalDefaultSplitter =
+    ImageRegionSplitterSlowDimension::New().GetPointer();
   return globalDefaultSplitter;
 }
 


### PR DESCRIPTION
Replaced a `call_once` call and two global variables with a single local static variable, to simplify the code, while still being thread-safe.