### PR TITLE
BUG: GetGlobalDefaultSplitter to a global singleton

### DIFF
--- a/Modules/Core/Common/include/itkImageSourceCommon.h
+++ b/Modules/Core/Common/include/itkImageSourceCommon.h
@@ -20,9 +20,12 @@
 
 #include "ITKCommonExport.h"
 #include "itkImageRegionSplitterBase.h"
+#include "itkSingletonMacro.h"
 
 namespace itk
 {
+
+struct ImageSourceCommonGlobals;
 
 /** \class ImageSourceCommon
  * \brief Secondary base class of ImageSource common between templates
@@ -43,6 +46,10 @@ struct ITKCommon_EXPORT ImageSourceCommon
    */
   static const ImageRegionSplitterBase *
   GetGlobalDefaultSplitter();
+
+private:
+  itkGetGlobalDeclarationMacro(ImageSourceCommonGlobals, PimplGlobals);
+  static ImageSourceCommonGlobals * m_PimplGlobals;
 };
 
 } // end namespace itk

--- a/Modules/Core/Common/src/itkImageSourceCommon.cxx
+++ b/Modules/Core/Common/src/itkImageSourceCommon.cxx
@@ -15,27 +15,29 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-
 #include "itkImageRegionSplitterSlowDimension.h"
 #include "itkImageSourceCommon.h"
+#include "itkSingleton.h"
 #include <mutex>
 
 namespace itk
 {
 
-namespace
+struct ImageSourceCommonGlobals
 {
-std::once_flag                   globalDefaultSplitterOnceFlag;
-ImageRegionSplitterBase::Pointer globalDefaultSplitter;
-} // namespace
+  ImageSourceCommonGlobals() { m_GlobalDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer(); };
+
+  ImageRegionSplitterBase::Pointer m_GlobalDefaultSplitter;
+};
+
+itkGetGlobalSimpleMacro(ImageSourceCommon, ImageSourceCommonGlobals, PimplGlobals);
+ImageSourceCommonGlobals * ImageSourceCommon::m_PimplGlobals;
 
 const ImageRegionSplitterBase *
 ImageSourceCommon::GetGlobalDefaultSplitter()
 {
-  std::call_once(globalDefaultSplitterOnceFlag,
-                 []() { globalDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer(); });
-
-  return globalDefaultSplitter;
+  itkInitGlobalsMacro(PimplGlobals);
+  return m_PimplGlobals->m_GlobalDefaultSplitter;
 }
 
 


### PR DESCRIPTION
Ensure a shared instance across binaries via itk::Singleton.