### PR TITLE
STYLE: Increase consistency in test argument check message

### DIFF
--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
@@ -69,8 +69,9 @@ itkGradientAnisotropicDiffusionImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage\n";
-    return -1;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
+    return EXIT_FAILURE;
   }
 
 

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
@@ -28,8 +28,9 @@ itkBilateralImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage\n";
-    return -1;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   using PixelType = unsigned char;

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
@@ -28,8 +28,9 @@ itkBilateralImageFilterTest3(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage\n";
-    return -1;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   using PixelType = unsigned char;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -33,9 +33,10 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int argc, char * argv[])
 
   if (argc < 7)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
@@ -33,9 +33,10 @@ itkGrayscaleMorphologicalOpeningImageFilterTest2(int argc, char * argv[])
 
   if (argc < 7)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -33,7 +33,8 @@ itkNoiseImageFilterTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -32,8 +32,9 @@ itkFastApproximateRankImageFilterTest(int argc, char * argv[])
 
   if (argc < 4)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << argv[0] << " InputImage BaselineImage radius" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -28,9 +28,11 @@ itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
 {
   if (argc < 8)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " InputImage OutputImage FindUpper seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
-                 "seed2_x2 seed2_y2]*\n";
+              << " InputImage OutputImage FindUpper seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2"
+                 " seed2_x2 seed2_y2]"
+              << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Increase consistency in the missing argument check message, following the ITK SW guide coding guidelines. Specifically:
- Return `EXIT_FAILURE` instead of `-1`.
- State explicitly that arguments are missing.
- Use `std::endl` instead of `\n` to introduce new lines.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)