### PR TITLE
STYLE: Improve ivar printing style

### DIFF
--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -25,14 +25,14 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << "ActiveIndexList: [";
+  os << indent << "ActiveIndexList: [";
   for (auto it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
   {
-    os << *it << ' ';
+    os << indent.GetNextIndent() << *it << ' ';
   }
   os << "] ";
 
-  os << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
+  os << indent << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
 }
 
 template <typename TImage, typename TBoundaryCondition>

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -133,14 +133,14 @@ Neighborhood<TPixel, VDimension, TContainer>::PrintSelf(std::ostream & os, Inden
   os << indent << "StrideTable: [ ";
   for (DimensionValueType i = 0; i < VDimension; ++i)
   {
-    os << m_StrideTable[i] << ' ';
+    os << indent.GetNextIndent() << m_StrideTable[i] << ' ';
   }
   os << ']' << std::endl;
 
   os << indent << "OffsetTable: [ ";
   for (DimensionValueType i = 0; i < m_OffsetTable.size(); ++i)
   {
-    os << m_OffsetTable[i] << ' ';
+    os << indent.GetNextIndent() << m_OffsetTable[i] << ' ';
   }
   os << ']' << std::endl;
 }

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -963,7 +963,7 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
   os << indent << "TransformsToOptimizeFlags: " << std::endl << indent << indent;
   for (auto it = m_TransformsToOptimizeFlags.begin(); it != m_TransformsToOptimizeFlags.end(); ++it)
   {
-    os << *it << ' ';
+    os << indent.GetNextIndent() << *it << ' ';
   }
   os << std::endl;
 
@@ -971,8 +971,8 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
   typename TransformQueueType::const_iterator cit;
   for (cit = m_TransformsToOptimizeQueue.begin(); cit != m_TransformsToOptimizeQueue.end(); ++cit)
   {
-    os << indent << ">>>>>>>>>" << std::endl;
-    (*cit)->Print(os, indent);
+    (*cit)->Print(os, indent.GetNextIndent());
+    os << std::endl;
   }
 
   os << indent << "PreviousTransformsToOptimizeUpdateTime: "

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1168,7 +1168,7 @@ FlatStructuringElement<VDimension>::PrintSelf(std::ostream & os, Indent indent) 
   os << "Lines: " << std::endl;
   for (unsigned int i = 0; i < m_Lines.size(); ++i)
   {
-    os << indent << m_Lines[i] << std::endl;
+    os << indent.GetNextIndent() << m_Lines[i] << std::endl;
   }
 
   os << indent << "RadiusIsParametric: " << (m_RadiusIsParametric ? "On" : "Off") << std::endl;

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -689,7 +689,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
   {
     for (const auto & elem : elemVec)
     {
-      os << indent << "[" << &elem - &*(elemVec.begin())
+      os << indent.GetNextIndent() << "[" << &elem - &*(elemVec.begin())
          << "]: " << static_cast<typename NumericTraits<MeasurementType>::PrintType>(elem) << std::endl;
     }
   }
@@ -699,7 +699,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
   {
     for (const auto & elem : elemVec)
     {
-      os << indent << "[" << &elem - &*(elemVec.begin())
+      os << indent.GetNextIndent() << "[" << &elem - &*(elemVec.begin())
          << "]: " << static_cast<typename NumericTraits<MeasurementType>::PrintType>(elem) << std::endl;
     }
   }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1202,7 +1202,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent << "TransformParametersAdaptorsPerLevel: ";
   for (const auto & val : m_TransformParametersAdaptorsPerLevel)
   {
-    os << val << " ";
+    os << indent.GetNextIndent() << val << " ";
   }
   os << std::endl;
 

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -43,7 +43,7 @@ ClassifierBase<TDataContainer>::PrintSelf(std::ostream & os, Indent indent) cons
   os << indent << "MembershipFunctions: " << std::endl;
   for (unsigned int i = 0; i < m_MembershipFunctions.size(); ++i)
   {
-    os << indent << m_MembershipFunctions[i] << std::endl;
+    os << indent.GetNextIndent() << m_MembershipFunctions[i] << std::endl;
   }
 }
 


### PR DESCRIPTION
Improve ivar printing style. Specifically:
- Use `indent.GetNextIndent()` to get the next indent value when printing the elements of a list or array.
- Add missing calls to indentation.
- Do not print unnecessary characters (e.g. `">>>>>>>>>"`).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)