### PR TITLE
STYLE: Use macros in tests

### DIFF
--- a/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkCurvatureAnisotropicDiffusionImageFilter.h"
 #include "itkNullImageToImageFilterDriver.hxx"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 /**
  * Test the class instance by driving it with a null input and output.
@@ -28,32 +29,27 @@
 int
 itkCurvatureAnisotropicDiffusionImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  try
-  {
-    using ImageType = itk::Image<float, 2>;
+  using ImageType = itk::Image<float, 2>;
 
-    // Set up filter
-    itk::CurvatureAnisotropicDiffusionImageFilter<ImageType, ImageType>::Pointer filter =
-      itk::CurvatureAnisotropicDiffusionImageFilter<ImageType, ImageType>::New();
-    itk::SimpleFilterWatcher watcher(filter);
+  // Set up filter
+  itk::CurvatureAnisotropicDiffusionImageFilter<ImageType, ImageType>::Pointer filter =
+    itk::CurvatureAnisotropicDiffusionImageFilter<ImageType, ImageType>::New();
+  itk::SimpleFilterWatcher watcher(filter);
 
-    filter->SetNumberOfIterations(1);
-    filter->SetConductanceParameter(3.0f);
-    filter->SetTimeStep(0.125f);
+  filter->SetNumberOfIterations(1);
+  filter->SetConductanceParameter(3.0f);
+  filter->SetTimeStep(0.125f);
 
-    // Run Test
-    itk::Size<2> sz;
-    sz[0] = 250;
-    sz[1] = 250;
-    itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    err.Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+  // Run Test
+  itk::Size<2> sz;
+  sz[0] = 250;
+  sz[1] = 250;
+  itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
+  test1.SetImageSize(sz);
+  test1.SetFilter(filter);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkNullImageToImageFilterDriver.hxx"
+#include "itkTestingMacros.h"
 
 /**
  * Test the class instance by driving it with a null input and output.
@@ -27,37 +28,45 @@
 int
 itkGradientAnisotropicDiffusionImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  try
-  {
-    using ImageType = itk::Image<float, 2>;
+  using ImageType = itk::Image<float, 2>;
 
-    // Set up filter
-    itk::GradientAnisotropicDiffusionImageFilter<ImageType, ImageType>::Pointer filter =
-      itk::GradientAnisotropicDiffusionImageFilter<ImageType, ImageType>::New();
-    filter->SetNumberOfIterations(1);
-    filter->SetConductanceParameter(3.0f);
-    filter->SetTimeStep(0.125f);
+  using FilterType = itk::GradientAnisotropicDiffusionImageFilter<ImageType, ImageType>;
 
-    // The following lines are only for increased code coverage in testing.
-    filter->GetTimeStep();
-    filter->GetNumberOfIterations();
-    filter->GetConductanceParameter();
-    filter->SetConductanceScalingParameter(filter->GetConductanceScalingParameter());
-    filter->GetFixedAverageGradientMagnitude();
+  // Set up filter
+  itk::GradientAnisotropicDiffusionImageFilter<ImageType, ImageType>::Pointer filter =
+    itk::GradientAnisotropicDiffusionImageFilter<ImageType, ImageType>::New();
 
-    // Run Test
-    itk::Size<2> sz;
-    sz[0] = 250;
-    sz[1] = 250;
-    itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    err.Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+
+  itk::IdentifierType numberOfIterations = 1;
+  filter->SetNumberOfIterations(numberOfIterations);
+  ITK_TEST_SET_GET_VALUE(numberOfIterations, filter->GetNumberOfIterations());
+
+  FilterType::TimeStepType timeStep = 0.125;
+  filter->SetTimeStep(timeStep);
+  ITK_TEST_SET_GET_VALUE(timeStep, filter->GetTimeStep());
+
+  auto conductanceParameter = 3.0;
+  filter->SetConductanceParameter(conductanceParameter);
+  ITK_TEST_SET_GET_VALUE(conductanceParameter, filter->GetConductanceParameter());
+
+  auto conductanceScalingParameter = 1.0;
+  filter->SetConductanceScalingParameter(conductanceScalingParameter);
+  ITK_TEST_SET_GET_VALUE(conductanceScalingParameter, filter->GetConductanceScalingParameter());
+
+  auto fixedAverageGradientMagnitude = 1.0;
+  filter->SetFixedAverageGradientMagnitude(fixedAverageGradientMagnitude);
+  ITK_TEST_SET_GET_VALUE(fixedAverageGradientMagnitude, filter->GetFixedAverageGradientMagnitude());
+
+  // Run Test
+  itk::Size<2> sz;
+  sz[0] = 250;
+  sz[1] = 250;
+  itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
+  test1.SetImageSize(sz);
+  test1.SetFilter(filter);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
@@ -91,23 +91,17 @@ itkGradientAnisotropicDiffusionImageFilterTest2(int argc, char * argv[])
     itk::CastImageFilter<myFloatImage, myUCharImage>::New();
   caster->SetInput(filter->GetOutput());
 
-  try
-  {
-    caster->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(caster->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<myUCharImage>::Pointer writer;
   writer = itk::ImageFileWriter<myUCharImage>::New();
   writer->SetInput(caster->GetOutput());
-  std::cout << "Writing " << argv[2] << std::endl;
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   myFloatImage::Pointer normalImage = filter->GetOutput();
   normalImage->DisconnectPipeline();
@@ -130,15 +124,8 @@ itkGradientAnisotropicDiffusionImageFilterTest2(int argc, char * argv[])
   // to the same operation
   filter->SetTimeStep(100.0 * filter->GetTimeStep());
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // the results with spacing should be about the same as without
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest2.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest2.cxx
@@ -138,41 +138,31 @@ itkBinaryDilateImageFilterTest2(int, char *[])
   filter->SetInput(inputImage);
   filter->SetKernel(cross);
   filter->SetDilateValue(fgValue);
+  ITK_TEST_SET_GET_VALUE(fgValue, filter->GetDilateValue());
 
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
 
-
-  // Test the itkGetMacro
-  unsigned short value = filter->GetDilateValue();
-  std::cout << "filter->GetDilateValue(): " << value << std::endl;
-
   // Execute the filter
-  try
-  {
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-    //  Print the content of the result image
-    std::cout << "Result with cross radius 1 (default)" << std::endl;
-    i = 0;
-    it2.GoToBegin();
-    while (!it2.IsAtEnd())
+
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result with cross radius 1 (default)" << std::endl;
+  i = 0;
+  it2.GoToBegin();
+  while (!it2.IsAtEnd())
+  {
+    std::cout << it2.Get() << "  ";
+    ++it2;
+
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   // Now try dilation with a cross of higher radius.
@@ -183,31 +173,25 @@ itkBinaryDilateImageFilterTest2(int, char *[])
   filter->Modified();
 
   // Execute the filter
-  try
-  {
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-    //  Print the content of the result image
-    std::cout << "Result with cross radius 2" << std::endl;
-    i = 0;
-    it2.GoToBegin();
-    while (!it2.IsAtEnd())
+
+  // Set the iterator for going through the image output
+  it2.SetRegion(outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result with cross radius 2" << std::endl;
+  i = 0;
+  it2.GoToBegin();
+  while (!it2.IsAtEnd())
+  {
+    std::cout << it2.Get() << "  ";
+    ++it2;
+
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   // All objects should be automatically destroyed at this point

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -140,23 +140,14 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   filter->SetInput(inputImage);
   filter->SetKernel(ball);
   filter->SetErodeValue(fgValue);
-  filter->SetBackgroundValue(5);
+  ITK_TEST_SET_GET_VALUE(fgValue, filter->GetErodeValue());
 
-  // Exercise Set/Get methods for Background Value
-  const unsigned short backGround = filter->GetBackgroundValue();
-  if (backGround != 5)
-  {
-    std::cerr << "Set/Get Background value problem." << std::endl;
-    return EXIT_FAILURE;
-  }
+  unsigned short backgroundValue = 5;
+  filter->SetBackgroundValue(backgroundValue);
+  ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
-
-
-  // Test the itkGetMacro
-  unsigned short value = filter->GetErodeValue();
-  std::cout << "filter->GetErodeValue(): " << value << std::endl;
 
   // Execute the filter
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
@@ -28,66 +28,61 @@
 int
 itkBilateralImageFilterTest(int, char *[])
 {
-  try
-  {
-    constexpr unsigned int Dimension = 2;
+  constexpr unsigned int Dimension = 2;
 
-    using ImageType = itk::Image<float, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
-    // Set up filter
-    using FilterType = itk::BilateralImageFilter<ImageType, ImageType>;
-    itk::BilateralImageFilter<ImageType, ImageType>::Pointer filter =
-      itk::BilateralImageFilter<ImageType, ImageType>::New();
+  // Set up filter
+  using FilterType = itk::BilateralImageFilter<ImageType, ImageType>;
+  itk::BilateralImageFilter<ImageType, ImageType>::Pointer filter =
+    itk::BilateralImageFilter<ImageType, ImageType>::New();
 
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BilateralImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BilateralImageFilter, ImageToImageFilter);
 
 
-    double                         domainSigmaVal = 2.0;
-    typename FilterType::ArrayType domainSigma = FilterType::ArrayType::Filled(domainSigmaVal);
-    filter->SetDomainSigma(domainSigmaVal);
-    ITK_TEST_SET_GET_VALUE(domainSigma, filter->GetDomainSigma());
+  double                         domainSigmaVal = 2.0;
+  typename FilterType::ArrayType domainSigma = FilterType::ArrayType::Filled(domainSigmaVal);
+  filter->SetDomainSigma(domainSigmaVal);
+  ITK_TEST_SET_GET_VALUE(domainSigma, filter->GetDomainSigma());
 
-    domainSigmaVal = 2.5;
-    domainSigma.Fill(domainSigmaVal);
-    filter->SetDomainSigma(domainSigma);
-    ITK_TEST_SET_GET_VALUE(domainSigma, filter->GetDomainSigma());
+  domainSigmaVal = 2.5;
+  domainSigma.Fill(domainSigmaVal);
+  filter->SetDomainSigma(domainSigma);
+  ITK_TEST_SET_GET_VALUE(domainSigma, filter->GetDomainSigma());
 
-    double domainMu = 2.5;
-    filter->SetDomainMu(domainMu);
-    ITK_TEST_SET_GET_VALUE(domainMu, filter->GetDomainMu());
+  double domainMu = 2.5;
+  filter->SetDomainMu(domainMu);
+  ITK_TEST_SET_GET_VALUE(domainMu, filter->GetDomainMu());
 
-    double rangeSigma = 35.0f;
-    filter->SetRangeSigma(rangeSigma);
-    ITK_TEST_SET_GET_VALUE(rangeSigma, filter->GetRangeSigma());
+  double rangeSigma = 35.0f;
+  filter->SetRangeSigma(rangeSigma);
+  ITK_TEST_SET_GET_VALUE(rangeSigma, filter->GetRangeSigma());
 
-    filter->SetFilterDimensionality(Dimension);
-    ITK_TEST_SET_GET_VALUE(Dimension, filter->GetFilterDimensionality());
+  filter->SetFilterDimensionality(Dimension);
+  ITK_TEST_SET_GET_VALUE(Dimension, filter->GetFilterDimensionality());
 
-    bool automaticKernelSize = true;
-    ITK_TEST_SET_GET_BOOLEAN(filter, AutomaticKernelSize, automaticKernelSize);
+  bool automaticKernelSize = true;
+  ITK_TEST_SET_GET_BOOLEAN(filter, AutomaticKernelSize, automaticKernelSize);
 
-    typename FilterType::SizeType::SizeValueType radiusVal = 2;
-    typename FilterType::SizeType                radius = FilterType::SizeType::Filled(radiusVal);
-    filter->SetRadius(radius);
-    ITK_TEST_SET_GET_VALUE(radius, filter->GetRadius());
+  typename FilterType::SizeType::SizeValueType radiusVal = 2;
+  typename FilterType::SizeType                radius = FilterType::SizeType::Filled(radiusVal);
+  filter->SetRadius(radius);
+  ITK_TEST_SET_GET_VALUE(radius, filter->GetRadius());
 
-    unsigned long numberOfRangeGaussianSamples = 150;
-    filter->SetNumberOfRangeGaussianSamples(numberOfRangeGaussianSamples);
-    ITK_TEST_SET_GET_VALUE(numberOfRangeGaussianSamples, filter->GetNumberOfRangeGaussianSamples());
+  unsigned long numberOfRangeGaussianSamples = 150;
+  filter->SetNumberOfRangeGaussianSamples(numberOfRangeGaussianSamples);
+  ITK_TEST_SET_GET_VALUE(numberOfRangeGaussianSamples, filter->GetNumberOfRangeGaussianSamples());
 
-    // Run Test
-    itk::Size<2> sz;
-    sz[0] = 250;
-    sz[1] = 250;
-    itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    err.Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+  // Run Test
+  itk::Size<2> sz;
+  sz[0] = 250;
+  sz[1] = 250;
+  itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
+  test1.SetImageSize(sz);
+  test1.SetFilter(filter);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
@@ -48,59 +48,58 @@ itkBilateralImageFilterTest2(int argc, char * argv[])
 
   // these settings reduce the amount of noise by a factor of 10
   // when the original signal to noise level is 5
-  filter->SetDomainSigma(4.0);
-  filter->SetRangeSigma(50.0);
-  filter->SetDomainMu(2.5);
-
-  // Test itkSetVectorMacro
-  double domainSigma[dimension];
-  for (double & i : domainSigma)
+  auto domainSigmaValue = 4.0;
+  filter->SetDomainSigma(domainSigmaValue);
+  auto domainSigma = filter->GetDomainSigma();
+  for (auto & value : domainSigma)
   {
-    i = 4.0;
+    auto index = &value - &*(domainSigma.begin());
+    ITK_TEST_SET_GET_VALUE(domainSigmaValue, filter->GetDomainSigma()[index]);
   }
-  filter->SetDomainSigma(domainSigma);
 
-  // Test itkGetVectorMacro
-  std::cout << "filter->GetDomainSigma(): " << filter->GetDomainSigma() << std::endl;
+  double domainSigmaArr[dimension];
+  for (double & i : domainSigmaArr)
+  {
+    i = domainSigmaValue;
+  }
+  filter->SetDomainSigma(domainSigmaArr);
+  for (auto & value : domainSigmaArr)
+  {
+    auto index = &value - &domainSigmaArr[0];
+    ITK_TEST_SET_GET_VALUE(value, filter->GetDomainSigma()[index]);
+  }
 
-  // Test itkSetMacro
-  unsigned int  filterDimensionality = dimension;
-  unsigned long numberOfRangeGaussianSamples = 100;
+  auto rangeSigma = 50.0;
+  filter->SetRangeSigma(rangeSigma);
+  ITK_TEST_SET_GET_VALUE(rangeSigma, filter->GetRangeSigma());
+
+  auto domainMu = 2.5;
+  filter->SetDomainMu(domainMu);
+  ITK_TEST_SET_GET_VALUE(domainMu, filter->GetDomainMu());
+
+  unsigned int filterDimensionality = dimension;
   filter->SetFilterDimensionality(filterDimensionality);
+  ITK_TEST_SET_GET_VALUE(filterDimensionality, filter->GetFilterDimensionality());
+
+  unsigned long numberOfRangeGaussianSamples = 100;
   filter->SetNumberOfRangeGaussianSamples(numberOfRangeGaussianSamples);
+  ITK_TEST_SET_GET_VALUE(numberOfRangeGaussianSamples, filter->GetNumberOfRangeGaussianSamples());
 
-  // Test itkGetMacro
-  double rangeSigma2 = filter->GetRangeSigma();
-  std::cout << "filter->GetRangeSigma(): " << rangeSigma2 << std::endl;
-  unsigned int filterDimensionality2 = filter->GetFilterDimensionality();
-  std::cout << "filter->GetFilterDimensionality(): " << filterDimensionality2 << std::endl;
-  unsigned long numberOfRangeGaussianSamples2 = filter->GetNumberOfRangeGaussianSamples();
-  std::cout << "filter->GetNumberOfRangeGaussianSamples(): " << numberOfRangeGaussianSamples2 << std::endl;
-  double domainMu = filter->GetDomainMu();
-  std::cout << "filter->GetDomainMu(): " << domainMu << std::endl;
 
-  try
-  {
-    input->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
-  catch (...)
-  {
-    std::cerr << "Some other exception occurred" << std::endl;
-    return -2;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
+
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
@@ -58,33 +58,35 @@ itkBilateralImageFilterTest3(int argc, char * argv[])
   // the noise reduction in using a single stage with parameters
   // (4.0, 50.0).  The difference is that with 3 less aggressive stages
   // the edges are preserved better.
-  filter1->SetDomainSigma(4.0);
-  filter1->SetRangeSigma(20.0);
-  filter1->SetDomainMu(2.5);
-  filter2->SetDomainSigma(4.0);
-  filter2->SetRangeSigma(20.0);
-  filter2->SetDomainMu(2.5);
-  filter3->SetDomainSigma(4.0);
-  filter3->SetRangeSigma(20.0);
-  filter3->SetDomainMu(2.5);
+  auto domainSigma = 4.0;
+  filter1->SetDomainSigma(domainSigma);
+  auto rangeSigma = 20.0;
+  filter1->SetRangeSigma(rangeSigma);
+  auto domainMu = 2.5;
+  filter1->SetDomainMu(domainMu);
 
-  try
-  {
-    input->Update();
-    filter3->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  filter2->SetDomainSigma(domainSigma);
+  filter2->SetRangeSigma(rangeSigma);
+  filter2->SetDomainMu(domainMu);
+
+  filter3->SetDomainSigma(domainSigma);
+  filter3->SetRangeSigma(rangeSigma);
+  filter3->SetDomainMu(domainMu);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
+
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter3->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter3->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -58,61 +58,50 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int argc, char * argv[])
   // test default values
   RadiusType r1;
   r1.Fill(1);
-  if (filter->GetRadius() != r1)
-  {
-    std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 
-  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
-  {
-    std::cerr << "Wrong default algorithm." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(FilterType::AlgorithmEnum::HISTO, filter->GetAlgorithm());
 
-  if (filter->GetSafeBorder() != true)
-  {
-    std::cerr << "Wrong default safe border." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(true, filter->GetSafeBorder());
 
-  try
-  {
-    filter->SetRadius(20);
-    filter->SetSafeBorder(std::stoi(argv[6]));
+  filter->SetRadius(20);
 
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    auto writer = WriterType::New();
-    writer->SetInput(filter->GetOutput());
+  auto safeBorder = static_cast<bool>(std::stoi(argv[6]));
+  ITK_TEST_SET_GET_BOOLEAN(filter, SafeBorder, safeBorder);
 
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(argv[2]);
-    writer->Update();
-
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(argv[3]);
-    writer->Update();
-
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(argv[4]);
-    writer->Update();
-
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(argv[5]);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
-
-  // Generate test image
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
+  writer->SetFileName(argv[3]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
+  writer->SetFileName(argv[4]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
+  writer->SetFileName(argv[5]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  // Generate test image
+  writer->SetInput(filter->GetOutput());
+  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
@@ -58,61 +58,52 @@ itkGrayscaleMorphologicalOpeningImageFilterTest2(int argc, char * argv[])
   // test default values
   RadiusType r1;
   r1.Fill(1);
-  if (filter->GetRadius() != r1)
-  {
-    std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;
-    return EXIT_FAILURE;
-  }
 
-  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
-  {
-    std::cerr << "Wrong default algorithm." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 
-  if (filter->GetSafeBorder() != true)
-  {
-    std::cerr << "Wrong default safe border." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(FilterType::AlgorithmEnum::HISTO, filter->GetAlgorithm());
 
-  try
-  {
-    filter->SetRadius(20);
-    filter->SetSafeBorder(std::stoi(argv[6]));
+  ITK_TEST_SET_GET_VALUE(true, filter->GetSafeBorder());
 
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    auto writer = WriterType::New();
-    writer->SetInput(filter->GetOutput());
+  filter->SetRadius(20);
 
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(argv[2]);
-    writer->Update();
+  auto safeBorder = static_cast<bool>(std::stoi(argv[6]));
+  ITK_TEST_SET_GET_BOOLEAN(filter, SafeBorder, safeBorder);
 
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(argv[3]);
-    writer->Update();
-
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(argv[4]);
-    writer->Update();
-
-    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(argv[5]);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
-
-  // Generate test image
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
+  writer->SetFileName(argv[3]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
+  writer->SetFileName(argv[4]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
+  writer->SetFileName(argv[5]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  // Generate test image
+  writer->SetInput(filter->GetOutput());
+  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
@@ -146,48 +146,41 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   double  elapsedTime;
 
   // Execute the filter
-  try
-  {
-    std::cout << "Object Dilate..." << std::endl;
-    start = clock();
-    dilateFilter->Update();
-    end = clock();
+  std::cout << "Object Dilate..." << std::endl;
 
-    elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+  start = clock();
 
-    //  Print the content of the result image
-    std::cout << "  Success: " << std::endl;
-    std::cout << "    Time = " << elapsedTime << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during dilate filter Update\n" << e;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(dilateFilter->Update());
+
+
+  end = clock();
+
+  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+
+  //  Print the content of the result image
+  std::cout << "  Success: " << std::endl;
+  std::cout << "    Time = " << elapsedTime << std::endl;
 
   binDilateFilter->SetInput(inputImage);
   binDilateFilter->SetKernel(ball);
   binDilateFilter->SetDilateValue(fgValue);
   myImageType::Pointer outputBinImage = binDilateFilter->GetOutput();
-  try
-  {
-    std::cout << "Binary Dilate..." << std::endl;
 
-    start = clock();
-    binDilateFilter->Update();
-    end = clock();
+  // Execute the filter
+  std::cout << "Binary Dilate..." << std::endl;
 
-    elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+  start = clock();
 
-    //  Print the content of the result image
-    std::cout << "  Success: " << std::endl;
-    std::cout << "    Time = " << elapsedTime << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during dilate filter Update\n" << e;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(binDilateFilter->Update());
+
+
+  end = clock();
+
+  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+
+  //  Print the content of the result image
+  std::cout << "  Success: " << std::endl;
+  std::cout << "    Time = " << elapsedTime << std::endl;
 
   // Create an iterator for going through the image output
   myIteratorType itObj(outputImage, outputImage->GetBufferedRegion());
@@ -241,24 +234,20 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   myImageType::Pointer output2Image = erodeFilter->GetOutput();
 
   // Execute the filter
-  try
-  {
-    std::cout << "Object Erode..." << std::endl;
-    start = clock();
-    erodeFilter->Update();
-    end = clock();
+  std::cout << "Object Erode..." << std::endl;
 
-    elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+  start = clock();
 
-    //  Print the content of the result image
-    std::cout << "  Success: " << std::endl;
-    std::cout << "    Time = " << elapsedTime << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during erode filter Update\n" << e;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(erodeFilter->Update());
+
+
+  end = clock();
+
+  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+
+  //  Print the content of the result image
+  std::cout << "  Success: " << std::endl;
+  std::cout << "    Time = " << elapsedTime << std::endl;
 
   binErodeFilter->SetInput(outputImage);
   binErodeFilter->SetKernel(ball);
@@ -266,24 +255,20 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   myImageType::Pointer outputBin2Image = binErodeFilter->GetOutput();
 
   // Execute the filter
-  try
-  {
-    std::cout << "Binary Erode..." << std::endl;
-    start = clock();
-    binErodeFilter->Update();
-    end = clock();
+  std::cout << "Binary Erode..." << std::endl;
 
-    elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+  start = clock();
 
-    //  Print the content of the result image
-    std::cout << "  Success: " << std::endl;
-    std::cout << "    Time = " << elapsedTime << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during erode filter Update\n" << e;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(binErodeFilter->Update());
+
+
+  end = clock();
+
+  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+
+  //  Print the content of the result image
+  std::cout << "  Success: " << std::endl;
+  std::cout << "    Time = " << elapsedTime << std::endl;
 
   // Create an iterator for going through the image output
   myIteratorType it2Obj(output2Image, output2Image->GetBufferedRegion());
@@ -324,5 +309,7 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   std::cout << "    Time = " << elapsedTime << std::endl;
 
   // All objects should be automatically destroyed at this point
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -57,25 +57,21 @@ itkNoiseImageFilterTest(int argc, char * argv[])
   rescale->SetOutputMaximum(255);
   rescale->SetInput(filter->GetOutput());
 
-  try
-  {
-    radius.Fill(5);
-    filter->SetInput(input->GetOutput());
-    filter->SetRadius(radius);
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  radius.Fill(5);
+  filter->SetInput(input->GetOutput());
+  filter->SetRadius(radius);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<myImageChar>::Pointer writer;
   writer = itk::ImageFileWriter<myImageChar>::New();
   writer->SetInput(rescale->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkFastApproximateRankImageFilterTest(int argc, char * argv[])
@@ -51,62 +52,43 @@ itkFastApproximateRankImageFilterTest(int argc, char * argv[])
   // test default values
   RadiusType r1;
   r1.Fill(1);
-  if (filter->GetRadius() != r1)
-  {
-    std::cerr << "Wrong default Radius." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (filter->GetRank() != 0.5)
-  {
-    std::cerr << "Wrong default Rank." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
+
+  auto rank = 0.5;
+  ITK_TEST_SET_GET_VALUE(rank, filter->GetRank());
 
   // set radius with a radius type
   RadiusType r5;
   r5.Fill(5);
   filter->SetRadius(r5);
-  if (filter->GetRadius() != r5)
-  {
-    std::cerr << "Radius value is not the expected one: r5." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(r5, filter->GetRadius());
 
   // set radius with an integer
-  filter->SetRadius(1);
-  if (filter->GetRadius() != r1)
-  {
-    std::cerr << "Radius value is not the expected one: r1." << std::endl;
-    return EXIT_FAILURE;
-  }
+  auto radius = 1;
+  filter->SetRadius(radius);
+  ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 
-  filter->SetRank(0.25);
-  if (filter->GetRank() != 0.25)
-  {
-    std::cerr << "Rank value is not the expected one: " << filter->GetRank() << std::endl;
-    return EXIT_FAILURE;
-  }
+  rank = 0.25;
+  filter->SetRank(rank);
+  ITK_TEST_SET_GET_VALUE(rank, filter->GetRank());
 
-  try
-  {
-    int r = std::stoi(argv[3]);
-    filter->SetInput(input->GetOutput());
-    filter->SetRadius(r);
-    filter->SetRank(0.5);
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
+  int r = std::stoi(argv[3]);
+  filter->SetInput(input->GetOutput());
+  filter->SetRadius(r);
+  rank = 0.5;
+  filter->SetRank(rank);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Generate test image
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
+++ b/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
@@ -18,12 +18,12 @@ itk_add_test(NAME itkIsolatedConnectedImageFilterTest
       COMMAND ITKRegionGrowingTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/IsolatedConnectedImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest.png
-    itkIsolatedConnectedImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest.png true 115 85 107 110)
+    itkIsolatedConnectedImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest.png 1 115 85 107 110)
 itk_add_test(NAME itkIsolatedConnectedImageFilterTest2
       COMMAND ITKRegionGrowingTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/IsolatedConnectedImageFilterTest2.png}
               ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest2.png
-    itkIsolatedConnectedImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest2.png false 175 125 100 170 176 125 101 170)
+    itkIsolatedConnectedImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest2.png 0 175 125 100 170 176 125 101 170)
 itk_add_test(NAME itkConfidenceConnectedImageFilterTest
       COMMAND ITKRegionGrowingTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/ConfidenceConnectedImageFilterTest.png}

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
   if (argc < 8)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " InputImage OutputImage FindUpper(true,false) seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
+              << " InputImage OutputImage FindUpper seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
                  "seed2_x2 seed2_y2]*\n";
     return EXIT_FAILURE;
   }
@@ -74,56 +74,35 @@ itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
   }
 
   // The min and max values for a .png image
-  filter->SetLower(0);
+  FilterType::InputImagePixelType lower = 0;
+  filter->SetLower(lower);
+  ITK_TEST_SET_GET_VALUE(lower, filter->GetLower());
+
 #if !defined(ITK_LEGACY_REMOVE)
-  filter->SetUpperValueLimit(255); // deprecated method
+  FilterType::InputImagePixelType upperValueLimit = 255;
+  filter->SetUpperValueLimit(upperValueLimit);
+  ITK_TEST_SET_GET_VALUE(upperValueLimit, filter->GetUpperValueLimit());
 #endif
-  filter->SetUpper(255);
-  filter->SetReplaceValue(255);
+  FilterType::InputImagePixelType upper = 255;
+  filter->SetUpper(upper);
+  ITK_TEST_SET_GET_VALUE(upper, filter->GetUpper());
 
-  // Test SetMacro
-  filter->SetIsolatedValueTolerance(1);
+  FilterType::OutputImagePixelType replaceValue = 255;
+  filter->SetReplaceValue(replaceValue);
+  ITK_TEST_SET_GET_VALUE(replaceValue, filter->GetReplaceValue());
 
-  // Test SetMacro
-  std::string findUpper = argv[3];
-  if (findUpper == "true")
-  {
-    filter->FindUpperThresholdOn();
-  }
-  else
-  {
-    filter->FindUpperThresholdOff();
-  }
+  FilterType::InputImagePixelType isolatedValueTolerance = 1;
+  filter->SetIsolatedValueTolerance(isolatedValueTolerance);
+  ITK_TEST_SET_GET_VALUE(isolatedValueTolerance, filter->GetIsolatedValueTolerance());
 
-  // Test GetMacros
-  PixelType lower = filter->GetLower();
-  std::cout << "filter->GetLower(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(lower) << std::endl;
-  PixelType isolatedValueTolerance = filter->GetIsolatedValueTolerance();
-  std::cout << "filter->GetIsolatedValueTolerance(): "
-            << static_cast<itk::NumericTraits<PixelType>::PrintType>(isolatedValueTolerance) << std::endl;
-#if !defined(ITK_LEGACY_REMOVE)
-  PixelType upperValueLimit = filter->GetUpperValueLimit();
-  std::cout << "filter->GetUpperValueLimit(): "
-            << static_cast<itk::NumericTraits<PixelType>::PrintType>(upperValueLimit) << std::endl;
-#endif
-  PixelType upper = filter->GetUpper();
-  std::cout << "filter->GetUpper(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(upper) << std::endl;
-  PixelType replaceValue = filter->GetReplaceValue();
-  std::cout << "filter->GetReplaceValue(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(replaceValue)
-            << std::endl;
-  bool findUpperThreshold = filter->GetFindUpperThreshold();
-  std::cout << "filter->GetFindUpperThreshold(): " << findUpperThreshold << std::endl;
+  auto findUpperThreshold = static_cast<bool>(std::stoi(argv[3]));
+  ITK_TEST_SET_GET_BOOLEAN(filter, FindUpperThreshold, findUpperThreshold);
 
-  try
-  {
-    input->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
+
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   bool thresholdingFailed = filter->GetThresholdingFailed();
 
@@ -141,28 +120,15 @@ itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   // Now flip the mode to test whether it fails
-  if (findUpper == "true")
-  {
-    filter->FindUpperThresholdOff();
-  }
-  else
-  {
-    filter->FindUpperThresholdOn();
-  }
+  ITK_TEST_SET_GET_BOOLEAN(filter, FindUpperThreshold, !findUpperThreshold);
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   thresholdingFailed = filter->GetThresholdingFailed();
 


### PR DESCRIPTION
Use macros in tests:
- Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro when updating filters in lieu of `try/catch` blocks for the sake of readability and compactness, and to save typing/avoid boilerplate code.
- Only place with the macro the code that might raise exceptions.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro: make them quantitative instead of just calling the getter methods, or printing the returned values.

Take advantage of the commit to remove unnecessary/uninformative comments and messages where the code has been modified.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)