### PR TITLE
ENH: Increase `Optimizers` classes coverage: get cost function derivate

### DIFF
--- a/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
@@ -74,6 +74,10 @@ itkCumulativeGaussianOptimizerTest(int, char *[])
   // Set the data array.
   costFunction->SetOriginalDataArray(cumGaussianArray);
 
+  // Not used; empty method body; called for coverage purposes
+  CostFunctionType::DerivativeType derivative;
+  costFunction->GetDerivative(parameters, derivative);
+
   // Set the cost function.
   optimizer->SetCostFunction(costFunction);
 

--- a/Modules/Numerics/Optimizers/test/itkOptimizersHierarchyTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOptimizersHierarchyTest.cxx
@@ -147,6 +147,12 @@ itkOptimizersHierarchyTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(cumGaussCostFunc, CumulativeGaussianCostFunction, MultipleValuedCostFunction);
 
 
+  // Not used; empty method body; called for coverage purposes
+  CumulativeGaussianCostFunctionType::ParametersType parameters{};
+  CumulativeGaussianCostFunctionType::DerivativeType derivative;
+  cumGaussCostFunc->GetDerivative(parameters, derivative);
+
+
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Increase coverage for classes in the `Optimizers` module: call the cost function derivative getter method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)