### PR TITLE
BUG: Return exit failure when insufficient test arguments are provided

### DIFF
--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -113,6 +113,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << argv[0];
     std::cerr << " fixedImageFile warpedOutputImageFile" << std::endl;
+    return EXIT_FAILURE;
   }
 
   //   using PixelType = unsigned char;


### PR DESCRIPTION
Return from test with an exit failure in case the test argument check detects that an insufficient number of arguments is provided.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)