### PR TITLE
STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests

### DIFF
--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterRGBTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterRGBTest.cxx
@@ -20,6 +20,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkRGBPixel.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageToVTKImageFilterRGBTest(int argc, char * argv[])
@@ -27,7 +28,7 @@ itkImageToVTKImageFilterRGBTest(int argc, char * argv[])
   if (argc != 2)
   {
     std::cerr << "Usage: ";
-    std::cerr << argv[0];
+    std::cerr << itkNameOfTestExecutableMacro(argv);
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
 

--- a/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
@@ -37,13 +37,14 @@
 #include <sstream>
 #include <map>
 #include "QuickView.h"
+#include "itkTestingMacros.h"
 
 int
 itkVtkConnectedComponentImageFilterTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cout << "Usage: " << argv[0];
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cout << " inputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
@@ -25,6 +25,7 @@
 #include <sstream>
 
 #include "QuickView.h"
+#include "itkTestingMacros.h"
 
 int
 itkVtkMedianFilterTest(int argc, char * argv[])
@@ -33,7 +34,7 @@ itkVtkMedianFilterTest(int argc, char * argv[])
   if (argc < 2)
   {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " InputImageFile [radius]" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " InputImageFile [radius]" << std::endl;
     return EXIT_FAILURE;
   }
   std::string inputFilename = argv[1];

--- a/Modules/Core/Common/test/itkDownCastTest.cxx
+++ b/Modules/Core/Common/test/itkDownCastTest.cxx
@@ -24,6 +24,7 @@
 
 
 #include "itkDynamicLoader.h"
+#include "itkTestingMacros.h"
 
 using PRODUCER_FUNCTION = itk::Object * (*)();
 using DYNAMIC_DOWNCAST_FUNCTION = int (*)(const char * type, const char * instanceSource, itk::Object const * base);
@@ -33,7 +34,7 @@ itkDownCastTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " <LibraryBFilePath>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <LibraryBFilePath>" << std::endl;
     return EXIT_SUCCESS;
   }
 

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -41,6 +41,7 @@
 #include "itkFFTWComplexToComplexFFTImageFilter.h"
 #include "itkFFTWForwardFFTImageFilter.h"
 #include "itkFFTWInverseFFTImageFilter.h"
+#include "itkTestingMacros.h"
 
 template <typename TPixel, unsigned int VDimension>
 int
@@ -99,7 +100,8 @@ itkFFTWComplexToComplexFFTImageFilterTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Usage: " << argv[0] << " <InputImage> <OutputImage> <float|double>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <InputImage> <OutputImage> <float|double>"
+              << std::endl;
     return EXIT_FAILURE;
   }
   const char *      inputImageFileName = argv[1];

--- a/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
@@ -74,7 +74,7 @@ itkForward1DFFTImageFilterTest(int argc, char * argv[])
   if (argc < 3)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage outputImagePrefix [backend]" << std::endl;
     std::cerr << "backend implementation options:" << std::endl;
     std::cerr << "  0 default" << std::endl;

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
@@ -25,6 +25,7 @@
 #include "itkSubtractImageFilter.h"
 
 #include "itkPhilipsRECImageIO.h"
+#include "itkTestingMacros.h"
 
 int
 itkPhilipsRECImageIOOrientationTest(int argc, char * argv[])
@@ -32,7 +33,7 @@ itkPhilipsRECImageIOOrientationTest(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Usage: " << argv[0] << " ReferenceImage TargetImage ";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " ReferenceImage TargetImage ";
     std::cerr << "OutputImage" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -21,6 +21,7 @@
 
 #include <vxl_version.h>
 #include "vnl/vnl_vector_fixed.h"
+#include "itkTestingMacros.h"
 
 int
 itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
@@ -28,7 +29,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
 
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkPhilipsRECImageIOFactory.h"
+#include "itkTestingMacros.h"
 
 int
 itkPhilipsRECImageIOTest(int argc, char * argv[])
@@ -27,7 +28,7 @@ itkPhilipsRECImageIOTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkBioRadImageIO.h"
 #include "itkImage.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkBioRadImageIOTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " BioRad.pic OutputImage.pic\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " BioRad.pic OutputImage.pic\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
@@ -29,6 +29,7 @@
 #include "itkComposeImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 template <typename TVectorImage>
 int
@@ -38,7 +39,8 @@ itkImageToHistogramFilterTest4Templated(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputImageFileName inputImageFileName outputHistogramFile" << std::endl;
+    std::cerr << "Usage :  " << itkNameOfTestExecutableMacro(argv)
+              << " inputImageFileName inputImageFileName outputHistogramFile" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
@@ -25,6 +25,7 @@
 #include "itkComposeImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMaskedImageToHistogramFilterTest1(int argc, char * argv[])
@@ -33,7 +34,7 @@ itkMaskedImageToHistogramFilterTest1(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0]
+    std::cerr << "Usage :  " << itkNameOfTestExecutableMacro(argv)
               << " inputImageFileName inputImageFileName maskImage maskValue outputHistogramFile" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkFastApproximateRankImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -20,6 +20,7 @@
 #include "itkFEMSpatialObjectReader.h"
 #include "itkFEMLinearSystemWrapperDenseVNL.h"
 #include "itkFEMLinearSystemWrapperItpack.h"
+#include "itkTestingMacros.h"
 
 
 using FEMSolverType = itk::fem::SolverHyperbolic<2>;
@@ -152,7 +153,7 @@ itkFEMSolverHyperbolicTest(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cout << "Usage: " << argv[0];
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cout << " input-file iterations lsw (0=VNL, 1=Dense VNL, 2=Itpack)";
     std::cout << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -353,7 +353,7 @@ itkFEMFiniteDifferenceFunctionLoadTest(int argc, char * argv[])
   if (argc != 2)
   {
     std::cerr << "Missing Parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " outputFilenamePrefix" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputFilenamePrefix" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
+++ b/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
@@ -36,7 +36,7 @@ itkPhysicsBasedNonRigidRegistrationMethodTest(int argc, char * argv[])
   if (argc != 12)
   {
     std::cerr << "Missing Parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " fixedImageFile"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " fixedImageFile"
               << " movingImageFile"
               << " maskImageFile"
               << " meshFile"

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -41,6 +41,7 @@
 #include "itkGPUContextManager.h"
 #include "itkGPUDemonsRegistrationFilter.h"
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 namespace
 {
@@ -112,7 +113,7 @@ itkGPUDemonsRegistrationFilterTest(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " imageDimension numOfIterations ";
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile " << std::endl;

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -24,6 +24,7 @@
 #include "itkCommand.h"
 #include "itkCastImageFilter.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 namespace
@@ -111,7 +112,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   if (argc < 3)
   {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile warpedOutputImageFile" << std::endl;
   }
 

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -24,6 +24,7 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
 #include "itkOpenCVTestHelper.h"
+#include "itkTestingMacros.h"
 
 #if defined(CV_VERSION_EPOCH) // OpenCV 2.4.x
 #  include "highgui.h"
@@ -244,7 +245,8 @@ itkOpenCVImageBridgeGrayScaleTest(int argc, char * argv[])
   //
   if (argc != 4)
   {
-    std::cerr << "Usage: " << argv[0] << "scalar_image1 scalar_image2 scalar_image3" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "scalar_image1 scalar_image2 scalar_image3"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
 #include "itkOpenCVTestHelper.h"
+#include "itkTestingMacros.h"
 
 #if defined(CV_VERSION_EPOCH) // OpenCV 2.4.x
 #  include "highgui.h"
@@ -285,7 +286,8 @@ itkOpenCVImageBridgeRGBTest(int argc, char * argv[])
   //
   if (argc != 4)
   {
-    std::cerr << "Usage: " << argv[0] << "rgb_jpg_image rgb_mha_image rgb_image2" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "rgb_jpg_image rgb_mha_image rgb_image2"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
@@ -21,6 +21,7 @@
 #include "itkOpenCVVideoCapture.h"
 #include "itkVideoFileReader.h"
 #include "itkOpenCVVideoIOFactory.h"
+#include "itkTestingMacros.h"
 
 #include "opencv2/core/version.hpp"
 #if !defined(CV_VERSION_EPOCH)
@@ -50,7 +51,7 @@ itkOpenCVVideoCaptureTest(int argc, char * argv[])
   //
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0] << " input_video scalar_output_video RGB_output_video "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input_video scalar_output_video RGB_output_video "
               << "width height" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
+++ b/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
@@ -20,6 +20,7 @@
 #include "vidl_itk_istream.hxx"
 #include "itkVideoFileReader.h"
 #include "itkVXLVideoIOFactory.h"
+#include "itkTestingMacros.h"
 #include "vidl/vidl_ffmpeg_ostream.h"
 
 
@@ -134,7 +135,7 @@ vidl_itk_istreamTest(int argc, char * argv[])
   //
   if (argc < 5)
   {
-    std::cerr << "Usage: " << argv[0] << " input_file output_file width height" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input_file output_file width height" << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Use the `itkNameOfTestExecutableMacro` macro to get the test name instead of hard-coding the test name.

Left behind in 1fa53fec51eee61f8d602505959640d50497838b and in successive related commits.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)