### PR TITLE
ENH: Add boolean macro to `TransformFileWriterTemplate::m_AppendMode`

### DIFF
--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.h
@@ -67,18 +67,23 @@ public:
   /** Get the filename */
   itkGetStringMacro(FileName);
 
-  /** Set/Get the write mode (append/overwrite) for the Filter */
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  /** Set/Get the write mode (append/overwrite) for the Filter.
+   * Deprecated. */
   void
   SetAppendOff();
 
   void
   SetAppendOn();
 
-  void
-  SetAppendMode(bool mode);
-
   bool
   GetAppendMode();
+#endif
+
+  /** Set/Get the write mode (append/overwrite) for the filter. */
+  itkSetMacro(AppendMode, bool);
+  itkGetConstMacro(AppendMode, bool);
+  itkBooleanMacro(AppendMode);
 
   /** Set/Get a boolean to use the compression or not. */
   itkSetMacro(UseCompression, bool);

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -37,6 +37,7 @@ TransformFileWriterTemplate<TParametersValueType>::TransformFileWriterTemplate()
 template <typename TParametersValueType>
 TransformFileWriterTemplate<TParametersValueType>::~TransformFileWriterTemplate() = default;
 
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
 /** Set the writer to append to the specified file */
 template <typename TParametersValueType>
 void
@@ -54,14 +55,6 @@ TransformFileWriterTemplate<TParametersValueType>::SetAppendOff()
   this->SetAppendMode(false);
 }
 
-/** Set the writer mode (append/overwrite). */
-template <typename TParametersValueType>
-void
-TransformFileWriterTemplate<TParametersValueType>::SetAppendMode(bool mode)
-{
-  this->m_AppendMode = mode;
-}
-
 /** Get the writer mode. */
 template <typename TParametersValueType>
 bool
@@ -69,6 +62,7 @@ TransformFileWriterTemplate<TParametersValueType>::GetAppendMode()
 {
   return (this->m_AppendMode);
 }
+#endif
 
 template <>
 void

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
@@ -32,6 +32,19 @@ itkTransformFileWriterTemplateTest(int, char *[])
   auto useCompression = false;
   ITK_SET_GET_BOOLEAN(transformWriter, UseCompression, useCompression);
 
+  auto appendMode = false;
+  ITK_SET_GET_BOOLEAN(transformWriter, AppendMode, appendMode);
+
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  transformWriter->SetAppendOn();
+  auto nonConstAppendMode = transformWriter->GetAppendMode();
+  ITK_TEST_EXPECT_TRUE(nonConstAppendMode);
+
+  transformWriter->SetAppendOff();
+  nonConstAppendMode = transformWriter->GetAppendMode();
+  ITK_TEST_EXPECT_TRUE(!nonConstAppendMode);
+#endif
+
   // trigger empty write exception
   ITK_TRY_EXPECT_EXCEPTION(transformWriter->Update());
 


### PR DESCRIPTION
Add the boolean macro to the
`itk::RegistrationParameterScalesEstimator::m_AppendMode` ivar.

Use the setter and getter macros for the ivar.

Deprecate the old API of the ivar.

Check the expected values in the test using the appropriate testing macros.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)