### PR TITLE
STYLE: Use exception checking macros in tests

### DIFF
--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -81,15 +81,8 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   writer->SetFileName(outputImageFileName);
   writer->SetInput(inverseFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & error)
-  {
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
@@ -77,15 +77,8 @@ itkPhilipsRECImageIOOrientationTest(int argc, char * argv[])
   writer->SetInput(subtract->GetOutput());
   writer->UseCompressionOn();
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -43,15 +43,8 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   }
   imageIO->SetFileName(argv[1]);
 
-  try
-  {
-    imageIO->ReadImageInformation();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(imageIO->ReadImageInformation());
+
 
   // Print all of the PAR parameters.
   // Return EXIT_FAILURE if the value cannot be read.

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
@@ -47,15 +47,8 @@ itkPhilipsRECImageIOTest(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -46,34 +46,17 @@ itkBioRadImageIOTest(int argc, char * argv[])
   reader->SetImageIO(bioradImageIO);
   bioradImageIO->DebugOn();
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-  //
+
   using WriterType = itk::ImageFileWriter<InputImageType>;
   auto writer = WriterType::New();
   writer->SetImageIO(bioradImageIO);
   writer->SetFileName(outfilename);
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file writer " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   bioradImageIO->Print(std::cout);
 

--- a/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
@@ -87,15 +87,8 @@ itkImageToHistogramFilterTest4Templated(int argc, char * argv[])
   writer->SetInput(rescale->GetOutput());
   writer->SetFileName(argv[3]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   // print the image produced by HistogramToLogProbabilityImageFilter for visual inspection
   imageFilter->GetOutput()->Print(std::cout);

--- a/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
@@ -25,6 +25,7 @@
 #include "itkComposeImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMaskedImageToHistogramFilterTest1(int argc, char * argv[])
@@ -88,15 +89,8 @@ itkMaskedImageToHistogramFilterTest1(int argc, char * argv[])
   //   histogramFilter->SetHistogramSize( size );
 
   // TODO: this Update() shouldn't be needed - remove it.
-  try
-  {
-    histogramFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
+
 
   // use a 3D image to check the behavior of HistogramToImageFilter when the image
   // is of greater dimension than the histogram
@@ -114,15 +108,8 @@ itkMaskedImageToHistogramFilterTest1(int argc, char * argv[])
   writer->SetInput(rescale->GetOutput());
   writer->SetFileName(argv[5]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   // print the image produced by HistogramToLogProbabilityImageFilter for visual inspection
   imageFilter->GetOutput()->Print(std::cout);

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -20,6 +20,7 @@
 #include "itkFEMSpatialObjectReader.h"
 #include "itkFEMLinearSystemWrapperDenseVNL.h"
 #include "itkFEMLinearSystemWrapperItpack.h"
+#include "itkTestingMacros.h"
 
 
 using FEMSolverType = itk::fem::SolverHyperbolic<2>;
@@ -176,16 +177,9 @@ itkFEMSolverHyperbolicTest(int argc, char * argv[])
   using FEMSpatialObjectReaderPointer = FEMSpatialObjectReaderType::Pointer;
   FEMSpatialObjectReaderPointer SpatialReader = FEMSpatialObjectReaderType::New();
   SpatialReader->SetFileName(argv[1]);
-  try
-  {
-    SpatialReader->Update();
-  }
-  catch (itk::fem::FEMException & e)
-  {
-    std::cout << "Error reading FEM problem: " << argv[1] << "!\n";
-    e.Print(std::cout);
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(SpatialReader->Update());
+
 
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
   FEMObjectSpatialObjectType::ChildrenListType * children = SpatialReader->GetGroup()->GetChildren();
@@ -237,15 +231,8 @@ itkFEMSolverHyperbolicTest(int argc, char * argv[])
       break;
   }
 
-  try
-  {
-    SH->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ITK exception detected: " << err;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(SH->Update());
+
 
   PrintK(SH);
   PrintF(SH);

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -278,78 +278,38 @@ itkDemonsRegistrationFilterTest(int, char *[])
   std::cout << "Test running registrator without initial deformation field.";
   std::cout << std::endl;
 
-  bool passed = true;
-  try
-  {
-    registrator->SetInput(nullptr);
-    registrator->SetNumberOfIterations(2);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Unexpected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = false;
-  }
+  registrator->SetInput(nullptr);
+  registrator->SetNumberOfIterations(2);
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(registrator->Update());
+
 
   //--------------------------------------------------------------
   std::cout << "Test exception handling." << std::endl;
 
   std::cout << "Test nullptr moving image. " << std::endl;
-  passed = false;
-  try
-  {
-    registrator->SetInput(caster->GetOutput());
-    registrator->SetMovingImage(nullptr);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  registrator->SetInput(caster->GetOutput());
+  registrator->SetMovingImage(nullptr);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
+
   registrator->SetMovingImage(moving);
   registrator->ResetPipeline();
 
   std::cout << "Test nullptr moving image interpolator. " << std::endl;
-  passed = false;
-  try
+  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  if (fptr == nullptr)
   {
-    fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
-    if (fptr == nullptr)
-    {
-      std::cerr << "dynamic_cast failed" << std::endl;
-      return EXIT_FAILURE;
-    }
-    fptr->SetMovingImageInterpolator(nullptr);
-    registrator->SetInput(initField);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
-
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
+    std::cerr << "dynamic_cast failed" << std::endl;
     return EXIT_FAILURE;
   }
+  fptr->SetMovingImageInterpolator(nullptr);
+  registrator->SetInput(initField);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
 
   std::cout << "Test passed" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -275,73 +275,34 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   std::cout << "Test running registrator without initial deformation field.";
   std::cout << std::endl;
 
-  bool passed = true;
-  try
-  {
-    registrator->SetInput(nullptr);
-    registrator->SetNumberOfIterations(2);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Unexpected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = false;
-  }
+  registrator->SetInput(nullptr);
+  registrator->SetNumberOfIterations(2);
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(registrator->Update());
+
 
   //--------------------------------------------------------------
   std::cout << "Test exception handling." << std::endl;
 
   std::cout << "Test nullptr moving image. " << std::endl;
-  passed = false;
-  try
-  {
-    registrator->SetInput(caster->GetOutput());
-    registrator->SetMovingImage(nullptr);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  registrator->SetInput(caster->GetOutput());
+  registrator->SetMovingImage(nullptr);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
+
   registrator->SetMovingImage(moving);
   registrator->ResetPipeline();
 
   std::cout << "Test nullptr moving image interpolator. " << std::endl;
-  passed = false;
-  try
-  {
-    fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
-    fptr->SetMovingImageInterpolator(nullptr);
-    registrator->SetInput(initField);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  fptr->SetMovingImageInterpolator(nullptr);
+  registrator->SetInput(initField);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
 
   std::cout << "Test passed" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -160,15 +160,9 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
   //
   auto reader = ReaderType::New();
   reader->SetFileName(argv1);
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << e.what() << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTIION(reader->Update());
+
 
   typename ImageType::Pointer baselineImage = reader->GetOutput();
 


### PR DESCRIPTION
Use exception checking macros in tests:
- Use `ITK_TRY_EXPECT_NO_EXCEPTION` and `ITK_TRY_EXPECT_EXCEPTION` macros when updating filters in lieu of `try/catch` blocks for the sake of readability and compactness, and to save typing/avoid boilerplate code.
- Only place the code that might raise exceptions within the macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)