### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/IO/TransformBase/test/itkTransformFileReaderTemplateTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileReaderTemplateTest.cxx
@@ -18,6 +18,7 @@
 
 
 #include "itkTransformFileReader.h"
+#include "itkTestingMacros.h"
 
 int
 itkTransformFileReaderTemplateTest(int argc, char * argv[])
@@ -33,14 +34,17 @@ itkTransformFileReaderTemplateTest(int argc, char * argv[])
 
   auto transformReader = TransformReaderType::New();
 
-  std::cout << "Reader class = " << transformReader->GetNameOfClass() << "Reader base = "
-            << dynamic_cast<TransformReaderType::Superclass *>(transformReader.GetPointer())->GetNameOfClass()
-            << std::endl;
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(transformReader, TransformFileReaderTemplate, LightProcessObject);
+
 
   // trigger empty read exception
   ITK_TRY_EXPECT_EXCEPTION(transformReader->Update());
 
-  transformReader->SetFileName("transform.garbage");
+
+  const char * fileName = "transform.garbage";
+  transformReader->SetFileName(fileName);
+  ITK_TEST_SET_GET_VALUE(fileName, transformReader->GetFileName());
+
   // trigger exception for transformio not found
   ITK_TRY_EXPECT_EXCEPTION(transformReader->Update());
 

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
@@ -18,6 +18,7 @@
 
 
 #include "itkTransformFileWriter.h"
+#include "itkTestingMacros.h"
 
 int
 itkTransformFileWriterTemplateTest(int argc, char * argv[])
@@ -30,18 +31,21 @@ itkTransformFileWriterTemplateTest(int argc, char * argv[])
   }
 
   using TransformWriterType = itk::TransformFileWriterTemplate<double>;
-
-
   auto transformWriter = TransformWriterType::New();
 
-  std::cout << "Writer class = " << transformWriter->GetNameOfClass() << "Writer base = "
-            << dynamic_cast<TransformWriterType::Superclass *>(transformWriter.GetPointer())->GetNameOfClass()
-            << std::endl;
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(transformWriter, TransformFileWriterTemplate, LightProcessObject);
+
+
+  auto useCompression = false;
+  ITK_SET_GET_BOOLEAN(transformWriter, UseCompression, useCompression);
 
   // trigger empty write exception
   ITK_TRY_EXPECT_EXCEPTION(transformWriter->Update());
 
-  transformWriter->SetFileName("transform.garbage");
+  const char * fileName = "transform.garbage";
+  transformWriter->SetFileName(fileName);
+  ITK_TEST_SET_GET_VALUE(fileName, transformWriter->GetFileName());
+
   // trigger exception for transformio not found
   ITK_TRY_EXPECT_EXCEPTION(transformWriter->Update());
 

--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkBioRadImageIO.h"
 #include "itkImage.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -43,6 +44,10 @@ itkBioRadImageIOTest(int argc, char * argv[])
   reader->SetFileName(filename);
 
   auto bioradImageIO = ImageIOType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(bioradImageIO, BioRadImageIO, ImageIOBase);
+
+
   reader->SetImageIO(bioradImageIO);
   bioradImageIO->DebugOn();
 
@@ -75,7 +80,6 @@ itkBioRadImageIOTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  bioradImageIO->Print(std::cout);
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -45,7 +45,11 @@ itkFastApproximateRankImageFilterTest(int argc, char * argv[])
 
   // Create a filter
   using FilterType = itk::FastApproximateRankImageFilter<ImageType, ImageType>;
-  auto                     filter = FilterType::New();
+  auto filter = FilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, FastApproximateRankImageFilter, MiniPipelineSeparableImageFilter);
+
+
   itk::SimpleFilterWatcher filterWatch(filter);
 
   using RadiusType = FilterType::RadiusType;

--- a/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkPointSet.h"
 #include "itkFEMScatteredDataPointSetToImageFilter.h"
+#include "itkTestingMacros.h"
+
 /**
  * In this test, we create a simple 2D mesh and feature points to do evaluation.
  *
@@ -66,6 +68,9 @@ itkFEMScatteredDataPointSetToImageFilterTest(int, char *[])
   using ConstIteratorType = itk::ImageRegionConstIterator<DeformationFieldType>;
 
   auto filter = FilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, FEMScatteredDataPointSetToImageFilter, PointSetToImageFilter);
+
 
   // Construct a feature point set
   auto      featurePoints = FeaturePointSetType::New();
@@ -119,6 +124,7 @@ itkFEMScatteredDataPointSetToImageFilterTest(int, char *[])
   elementSpacing[0] = 2.0;
   elementSpacing[1] = 2.0;
   filter->SetElementSpacing(elementSpacing);
+  ITK_TEST_SET_GET_VALUE(elementSpacing, filter->GetSpacingPerElement());
 
   // Set the output
   DeformationFieldType::SizeType size;
@@ -137,6 +143,9 @@ itkFEMScatteredDataPointSetToImageFilterTest(int, char *[])
   filter->SetOrigin(origin);
 
   filter->Update();
+
+  std::cout << "NumberOfElements: " << filter->GetNumberOfElements() << std::endl;
+
 
   DeformationFieldType::Pointer DF = filter->GetOutput();
 

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -182,17 +182,59 @@ itkDemonsRegistrationFilterTest(int, char *[])
   using RegistrationType = itk::DemonsRegistrationFilter<ImageType, ImageType, FieldType>;
   auto registrator = RegistrationType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(registrator, DemonsRegistrationFilter, PDEDeformableRegistrationFilter);
+
+
   registrator->SetInitialDisplacementField(caster->GetOutput());
+  ITK_TEST_SET_GET_VALUE(caster->GetOutput(), registrator->GetInitialDisplacementField());
+
   registrator->SetMovingImage(moving);
+  ITK_TEST_SET_GET_VALUE(moving, registrator->GetMovingImage());
+
   registrator->SetFixedImage(fixed);
-  registrator->SetNumberOfIterations(200);
-  registrator->SetStandardDeviations(1.0);
-  registrator->SetMaximumError(0.08);
-  registrator->SetMaximumKernelWidth(10);
-  registrator->SetIntensityDifferenceThreshold(0.001);
+  ITK_TEST_SET_GET_VALUE(fixed, registrator->GetFixedImage());
+
+  auto numberOfIterations = static_cast<itk::IdentifierType>(200);
+  registrator->SetNumberOfIterations(numberOfIterations);
+  ITK_TEST_SET_GET_VALUE(numberOfIterations, registrator->GetNumberOfIterations());
+
+  double                                   standardDeviationsVal = 1.0;
+  RegistrationType::StandardDeviationsType standardDeviations{ standardDeviationsVal };
+  registrator->SetStandardDeviations(standardDeviationsVal);
+  ITK_TEST_SET_GET_VALUE(standardDeviations, registrator->GetStandardDeviations());
+
+  registrator->SetStandardDeviations(standardDeviations);
+  ITK_TEST_SET_GET_VALUE(standardDeviations, registrator->GetStandardDeviations());
+
+  auto maximumError = 0.08;
+  registrator->SetMaximumError(maximumError);
+  ITK_TEST_SET_GET_VALUE(maximumError, registrator->GetMaximumError());
+
+  unsigned int maximumKernelWidth = 10;
+  registrator->SetMaximumKernelWidth(maximumKernelWidth);
+  ITK_TEST_SET_GET_VALUE(maximumKernelWidth, registrator->GetMaximumKernelWidth());
+
+  auto intensityDifferenceThreshold = 0.001;
+  registrator->SetIntensityDifferenceThreshold(intensityDifferenceThreshold);
+  ITK_TEST_SET_GET_VALUE(intensityDifferenceThreshold, registrator->GetIntensityDifferenceThreshold());
+
+  auto smoothDisplacementField = true;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, SmoothDisplacementField, smoothDisplacementField);
+
+  auto smoothUpdateField = false;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, SmoothUpdateField, smoothUpdateField);
+
+  double                                   updateFieldStandardDeviationsVal = 1.0;
+  RegistrationType::StandardDeviationsType updateFieldStandardDeviations{ updateFieldStandardDeviationsVal };
+  registrator->SetUpdateFieldStandardDeviations(updateFieldStandardDeviationsVal);
+  ITK_TEST_SET_GET_VALUE(updateFieldStandardDeviations, registrator->GetUpdateFieldStandardDeviations());
+
+  registrator->SetUpdateFieldStandardDeviations(updateFieldStandardDeviations);
+  ITK_TEST_SET_GET_VALUE(updateFieldStandardDeviations, registrator->GetUpdateFieldStandardDeviations());
 
   // turn on inplace execution
-  registrator->InPlaceOn();
+  auto inPlace = true;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, InPlace, inPlace);
 
   // turn on/off use moving image gradient
   auto useMovingImageGradient = false;
@@ -204,18 +246,6 @@ itkDemonsRegistrationFilterTest(int, char *[])
   {
     fptr->Print(std::cout);
   }
-
-  // exercise other member variables
-  std::cout << "No. Iterations: " << registrator->GetNumberOfIterations() << std::endl;
-  std::cout << "Max. kernel error: " << registrator->GetMaximumError() << std::endl;
-  std::cout << "Max. kernel width: " << registrator->GetMaximumKernelWidth() << std::endl;
-
-  double v[ImageDimension];
-  for (unsigned int j = 0; j < ImageDimension; ++j)
-  {
-    v[j] = registrator->GetStandardDeviations()[j];
-  }
-  registrator->SetStandardDeviations(v);
 
   using ProgressType = ShowProgressObject<RegistrationType>;
   ProgressType                                    progressWatch(registrator);
@@ -271,6 +301,8 @@ itkDemonsRegistrationFilterTest(int, char *[])
     std::cout << "Test failed - too many pixels different." << std::endl;
     return EXIT_FAILURE;
   }
+
+  std::cout << "IntensityDifferenceThreshold: " << registrator->GetIntensityDifferenceThreshold() << std::endl;
 
   registrator->Print(std::cout);
 

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -186,33 +186,60 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
 
 
   registrator->SetInitialDisplacementField(caster->GetOutput());
+  ITK_TEST_SET_GET_VALUE(caster->GetOutput(), registrator->GetInitialDisplacementField());
+
   registrator->SetMovingImage(moving);
+  ITK_TEST_SET_GET_VALUE(moving, registrator->GetMovingImage());
+
   registrator->SetFixedImage(fixed);
-  registrator->SetNumberOfIterations(200);
-  registrator->SetStandardDeviations(1.0);
-  registrator->SetMaximumError(0.08);
-  registrator->SetMaximumKernelWidth(10);
-  registrator->SetIntensityDifferenceThreshold(0.001);
+  ITK_TEST_SET_GET_VALUE(fixed, registrator->GetFixedImage());
+
+  auto numberOfIterations = static_cast<itk::IdentifierType>(200);
+  registrator->SetNumberOfIterations(numberOfIterations);
+  ITK_TEST_SET_GET_VALUE(numberOfIterations, registrator->GetNumberOfIterations());
+
+  double                                   standardDeviationsVal = 1.0;
+  RegistrationType::StandardDeviationsType standardDeviations{ standardDeviationsVal };
+  registrator->SetStandardDeviations(standardDeviationsVal);
+  ITK_TEST_SET_GET_VALUE(standardDeviations, registrator->GetStandardDeviations());
+
+  registrator->SetStandardDeviations(standardDeviations);
+  ITK_TEST_SET_GET_VALUE(standardDeviations, registrator->GetStandardDeviations());
+
+  auto maximumError = 0.08;
+  registrator->SetMaximumError(maximumError);
+  ITK_TEST_SET_GET_VALUE(maximumError, registrator->GetMaximumError());
+
+  unsigned int maximumKernelWidth = 10;
+  registrator->SetMaximumKernelWidth(maximumKernelWidth);
+  ITK_TEST_SET_GET_VALUE(maximumKernelWidth, registrator->GetMaximumKernelWidth());
+
+  auto intensityDifferenceThreshold = 0.001;
+  registrator->SetIntensityDifferenceThreshold(intensityDifferenceThreshold);
+  ITK_TEST_SET_GET_VALUE(intensityDifferenceThreshold, registrator->GetIntensityDifferenceThreshold());
+
+  auto smoothDisplacementField = true;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, SmoothDisplacementField, smoothDisplacementField);
+
+  auto smoothUpdateField = false;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, SmoothUpdateField, smoothUpdateField);
+
+  double                                   updateFieldStandardDeviationsVal = 1.0;
+  RegistrationType::StandardDeviationsType updateFieldStandardDeviations{ updateFieldStandardDeviationsVal };
+  registrator->SetUpdateFieldStandardDeviations(updateFieldStandardDeviationsVal);
+  ITK_TEST_SET_GET_VALUE(updateFieldStandardDeviations, registrator->GetUpdateFieldStandardDeviations());
+
+  registrator->SetUpdateFieldStandardDeviations(updateFieldStandardDeviations);
+  ITK_TEST_SET_GET_VALUE(updateFieldStandardDeviations, registrator->GetUpdateFieldStandardDeviations());
 
   // turn on inplace execution
-  registrator->InPlaceOn();
+  auto inPlace = true;
+  ITK_TEST_SET_GET_BOOLEAN(registrator, InPlace, inPlace);
 
   using FunctionType = RegistrationType::DemonsRegistrationFunctionType;
   FunctionType * fptr;
   fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
-
-  // exercise other member variables
-  std::cout << "No. Iterations: " << registrator->GetNumberOfIterations() << std::endl;
-  std::cout << "Max. kernel error: " << registrator->GetMaximumError() << std::endl;
-  std::cout << "Max. kernel width: " << registrator->GetMaximumKernelWidth() << std::endl;
-
-  double v[ImageDimension];
-  for (unsigned int j = 0; j < ImageDimension; ++j)
-  {
-    v[j] = registrator->GetStandardDeviations()[j];
-  }
-  registrator->SetStandardDeviations(v);
 
   using ProgressType = ShowProgressObject<RegistrationType>;
   ProgressType                                    progressWatch(registrator);


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Exercise basic object methods using the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro. Remove redundant calls to print the filter: rely on the basic method exercising macro call.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Call other Get methods for ivars that have no Set methods/ivars having an informative purpose.
- Remove statements that serialize the values obtained through the Get macro and call the Get methods in the context of the quantitative testing macros.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)