### PR TITLE
STYLE: Fix ITK coding style inconsistency linter error

### DIFF
--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -63,6 +63,5 @@ itkBioRadImageIOTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fix ITK coding style inconsistency linter error.

Fixes:
```
Error: Code is inconsistent with ITK Coding Style.
Add the *action:ApplyClangFormat* PR label to correct.

Changes required:

Files:
Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx

Changes:
diff --git a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
           b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
index 813d8b00..af2ea2b8 100644
--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -63,6 +63,5 @@ itkBioRadImageIOTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());

-
   return EXIT_SUCCESS;
 }
```

raised, for example, at:
https://github.com/InsightSoftwareConsortium/ITK/actions/runs/5802502099/job/15728990457#step:4:6

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)