### PR TITLE
ENH: Ensure 3D multi-components conversion in image_from_vtk_image is tested

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -586,7 +586,7 @@ try:
 
     for components in [2, 3, 4, 5, 10]:
         for size in [(12, 8, components), (4, 6, 8, components)]:  # 2D and 3D
-            numpy_image = np.random.rand(12, 8, components).astype(np.float32)
+            numpy_image = np.random.rand(*size).astype(np.float32)
             input_image = itk.image_from_array(numpy_image, is_vector=True)
             # test itk -> vtk -> itk round trip
             vtk_image = itk.vtk_image_from_image(input_image)


### PR DESCRIPTION
Follow-up of 336be62d3d (ENH: Better support for multi-component images in image_from_vtk_image) integrated through:
* https://github.com/InsightSoftwareConsortium/ITK/pull/4142

cc: @dzenanz @thewtex 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
<!--
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.
-->