### PR TITLE
STYLE: ImageSourceCommonGlobals default member initializer, Rule of Zero

### DIFF
--- a/Modules/Core/Common/src/itkImageSourceCommon.cxx
+++ b/Modules/Core/Common/src/itkImageSourceCommon.cxx
@@ -25,9 +25,7 @@ namespace itk
 
 struct ImageSourceCommonGlobals
 {
-  ImageSourceCommonGlobals() { m_GlobalDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer(); };
-
-  ImageRegionSplitterBase::Pointer m_GlobalDefaultSplitter;
+  ImageRegionSplitterBase::Pointer m_GlobalDefaultSplitter{ ImageRegionSplitterSlowDimension::New().GetPointer() };
 };
 
 itkGetGlobalSimpleMacro(ImageSourceCommon, ImageSourceCommonGlobals, PimplGlobals);


### PR DESCRIPTION
Added an in-class default member initializer to the data member of `ImageSourceCommonGlobals`. Removed its default-constructor, following the C++ "Rule of Zero".

----

Aims to clarify our discussion at https://github.com/InsightSoftwareConsortium/ITK/pull/4122#discussion_r1272163516 