### PR TITLE
COMP: Adjust check that all arguments of MakePoint/Vector have same type

### DIFF
--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -365,17 +365,11 @@ template <typename TValue, typename... TVariadic>
 auto
 MakePoint(const TValue firstValue, const TVariadic... otherValues)
 {
-  // Assert that the other values have the same type as the first value.
-  const auto assertSameType = [](const auto value) {
-    static_assert(std::is_same_v<decltype(value), const TValue>, "Each value must have the same type!");
-    return true;
-  };
-  const bool assertions[] = { true, assertSameType(otherValues)... };
-  (void)assertions;
-  (void)assertSameType;
+  constexpr unsigned int dimension{ 1 + sizeof...(TVariadic) };
 
-  constexpr unsigned int              dimension{ 1 + sizeof...(TVariadic) };
-  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
+  // Note that the class template argument deduction guide of std::array ensures that all values have the same type.
+  const std::array stdArray{ firstValue, otherValues... };
+
   return Point<TValue, dimension>{ stdArray };
 }
 

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -331,17 +331,11 @@ template <typename TValue, typename... TVariadic>
 auto
 MakeVector(const TValue firstValue, const TVariadic... otherValues)
 {
-  // Assert that the other values have the same type as the first value.
-  const auto assertSameType = [](const auto value) {
-    static_assert(std::is_same_v<decltype(value), const TValue>, "Each value must have the same type!");
-    return true;
-  };
-  const bool assertions[] = { true, assertSameType(otherValues)... };
-  (void)assertions;
-  (void)assertSameType;
+  constexpr unsigned int dimension{ 1 + sizeof...(TVariadic) };
 
-  constexpr unsigned int              dimension{ 1 + sizeof...(TVariadic) };
-  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
+  // Note that the class template argument deduction guide of std::array ensures that all values have the same type.
+  const std::array stdArray{ firstValue, otherValues... };
+
   return Vector<TValue, dimension>{ stdArray };
 }
 


### PR DESCRIPTION
The original `assertSameType` lambda's appeared to trigger compile errors from MSVC, as reported by Dženan Zukić at https://github.com/InsightSoftwareConsortium/ITK/issues/4153 "ITK does not compile with VS2022 17.7.0", like:

> Modules\Core\Common\include\itkPoint.h(369,45): error C2187: syntax error: 'attribute specifier' was unexpected here
> Modules\Core\Common\test\itkPointGTest.cxx(63,57): message : see reference to function template instantiation 'auto itk::MakePoint<int,>(const TValue)' being compiled
> Modules\Core\Common\include\itkPoint.h(367,1): error C2938: 'itk::MakePoint::<lambda_706d090a84c31981802e12f4e9361bdf>::<lambda_typedef_cdecl>' : Failed to specialize alias template
> Modules\Core\Common\include\itkPoint.h(367,1): message : see reference to alias template instantiation 'itk::MakePoint::<lambda_706d090a84c31981802e12f4e9361bdf>::<lambda_typedef_cdecl><_T1>' being compiled

This appears to be caused by a compiler bug from MSVC Compiler Version 19.37.32822.

Instead of these `assertSameType` lambda, with this commit, both `MakePoint` and `MakeVector` make use of class template argument deduction (CTAD), as supported by `std::array`. The deduction guide of std::array ensures that all values have the same type.