### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/Core/Common/test/itkDecoratorTest.cxx
+++ b/Modules/Core/Common/test/itkDecoratorTest.cxx
@@ -134,6 +134,11 @@ itkDecoratorTest(int, char *[])
     vop->Set(vp);
 
     std::cout << vop;
+
+    VectorType *       vec = vop->Get();
+    const VectorType * constVec = vop->Get();
+    std::cout << "AutoPointerDataObjectDecorator::Get: " << vec << std::endl;
+    std::cout << "AutoPointerDataObjectDecorator::Get const: " << constVec << std::endl;
   }
 
   std::cout << "----------------------------------------------------" << std::endl;

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -887,6 +887,10 @@ itkNumericTraitsTest(int, char *[])
   rgbaPixelSize = itk::NumericTraits<RGBAPixelType>::GetLength(rgbaPixel) - 1;
   ITK_TRY_EXPECT_EXCEPTION(itk::NumericTraits<RGBAPixelType>::SetLength(rgbaPixel, rgbaPixelSize));
 
+  const auto constRgbaPixel = RGBAPixelType();
+  rgbaPixelSize = itk::NumericTraits<RGBAPixelType>::GetLength(constRgbaPixel);
+  ITK_TEST_EXPECT_EQUAL(rgbaPixelSize, 4);
+
   // itk::SymmetricSecondRankTensor<char, 1>()
   CheckFixedArrayTraits(itk::SymmetricSecondRankTensor<char, 1>());
   CheckFixedArrayTraits(itk::SymmetricSecondRankTensor<signed char, 1>());

--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -20,6 +20,7 @@
 #include "itkNeighborhoodOperatorImageFunction.h"
 
 #include "itkGaussianOperator.h"
+#include "itkTestingMacros.h"
 
 int
 itkNeighborhoodOperatorImageFunctionTest(int, char *[])
@@ -54,6 +55,10 @@ itkNeighborhoodOperatorImageFunctionTest(int, char *[])
 
 
   auto function = FunctionType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(function, NeighborhoodOperatorImageFunction, ImageFunction);
+
+
   function->SetInputImage(image);
 
   auto * oper = new NeighborhoodOperatorType;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkQuadEdgeMesh.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 
@@ -86,6 +87,20 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
    */
   mesh->SetCellsAllocationMethod(itk::MeshEnums::MeshClassCellsAllocationMethod::CellsAllocatedDynamicallyCellByCell);
 
+
+  // Test point container iterators
+  auto * quadEdgeMeshPolygonCell = new PolygonCellType();
+
+  PolygonCellType::PointIdIterator pointId = quadEdgeMeshPolygonCell->PointIdsBegin();
+  PolygonCellType::PointIdIterator endId = quadEdgeMeshPolygonCell->PointIdsEnd();
+  ITK_TEST_EXPECT_TRUE(pointId);
+  ITK_TEST_EXPECT_TRUE(endId);
+
+  PolygonCellType::PointIdConstIterator constPointId = quadEdgeMeshPolygonCell->PointIdsBegin();
+  PolygonCellType::PointIdConstIterator constEndId = quadEdgeMeshPolygonCell->PointIdsEnd();
+  ITK_TEST_EXPECT_TRUE(pointId);
+  ITK_TEST_EXPECT_TRUE(endId);
+
   /**
    * Create the test cell. Note that testCell is a generic auto
    * pointer to a cell; in this example it ends up pointing to
@@ -109,6 +124,27 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
     std::cerr << "Get Point should have failed !" << std::endl;
     return EXIT_FAILURE;
   }
+
+  // Test iterators
+  std::cout << "Iterator: ";
+  pointId = newcell->PointIdsBegin();
+  endId = newcell->PointIdsEnd();
+  while (pointId != endId)
+  {
+    std::cout << *pointId << ", ";
+    pointId++;
+  }
+  std::cout << std::endl;
+
+  std::cout << "Iterator const: ";
+  constPointId = newcell->PointIdsBegin();
+  constEndId = newcell->PointIdsEnd();
+  while (constPointId != constEndId)
+  {
+    std::cout << *constPointId << ", ";
+    constPointId++;
+  }
+  std::cout << std::endl;
 
   std::cout << "Test MakeCopy" << std::endl;
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -37,8 +37,19 @@ itkSpatialObjectDuplicatorTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(duplicator, SpatialObjectDuplicator, Object);
 
 
+  ITK_TEST_SET_GET_NULL_VALUE(duplicator->GetOutput());
+#if !defined(ITK_LEGACY_REMOVE)
+  ITK_TEST_SET_GET_NULL_VALUE(duplicator->GetModifiedOutput());
+#endif
+
   duplicator->SetInput(ellipse);
   duplicator->Update();
+
+
+  std::cout << "Output: " << duplicator->GetOutput() << std::endl;
+#if !defined(ITK_LEGACY_REMOVE)
+  std::cout << "ModifiedOutput: " << duplicator->GetModifiedOutput() << std::endl;
+#endif
 
   EllipseType::Pointer ellipse_copy = duplicator->GetOutput();
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -119,7 +119,11 @@ itkBinaryDilateImageFilterTest(int, char *[])
   using myFilterType = itk::BinaryDilateImageFilter<myImageType, myImageType, myKernelType>;
 
   // Create the filter
-  auto                     filter = myFilterType::New();
+  auto filter = myFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BinaryDilateImageFilter, BinaryMorphologyImageFilter);
+
+
   itk::SimpleFilterWatcher filterWatcher(filter);
 
   // Create the structuring element
@@ -133,15 +137,13 @@ itkBinaryDilateImageFilterTest(int, char *[])
   // Connect the input image
   filter->SetInput(inputImage);
   filter->SetKernel(ball);
+
   filter->SetDilateValue(fgValue);
+  ITK_TEST_SET_GET_VALUE(fgValue, filter->GetDilateValue());
+
 
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
-
-
-  // Test the itkGetMacro
-  unsigned short value = filter->GetDilateValue();
-  std::cout << "filter->GetDilateValue(): " << value << std::endl;
 
   // Execute the filter
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -119,7 +119,11 @@ itkBinaryErodeImageFilterTest(int, char *[])
   using myFilterType = itk::BinaryErodeImageFilter<myImageType, myImageType, myKernelType>;
 
   // Create the filter
-  auto                     filter = myFilterType::New();
+  auto filter = myFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BinaryErodeImageFilter, BinaryMorphologyImageFilter);
+
+
   itk::SimpleFilterWatcher watcher(filter, "filter");
 
   // Create the structuring element
@@ -133,15 +137,13 @@ itkBinaryErodeImageFilterTest(int, char *[])
   // Connect the input image
   filter->SetInput(inputImage);
   filter->SetKernel(ball);
+
   filter->SetErodeValue(fgValue);
+  ITK_TEST_SET_GET_VALUE(fgValue, filter->GetErodeValue());
 
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
 
-
-  // Test the itkGetMacro
-  unsigned short value = filter->GetErodeValue();
-  std::cout << "filter->GetErodeValue(): " << value << std::endl;
 
   // Execute the filter
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
@@ -47,12 +47,23 @@ doDenoising(const std::string & inputFileName, const std::string & outputFileNam
   auto filter = FilterType::New();
   filter->SetInput(reader->GetOutput());
 
+  ITK_TEST_SET_GET_BOOLEAN(filter, UseSmoothDiscPatchWeights, true);
+  auto kernelBandwidthSigma = typename FilterType::RealArrayType{};
+  ITK_TEST_SET_GET_VALUE(kernelBandwidthSigma, filter->GetKernelBandwidthSigma());
+  ITK_TEST_SET_GET_VALUE(0.20, filter->GetKernelBandwidthFractionPixelsForEstimation());
+  ITK_TEST_SET_GET_BOOLEAN(filter, ComputeConditionalDerivatives, false);
+  ITK_TEST_SET_GET_BOOLEAN(filter, UseFastTensorComputations, true);
+  ITK_TEST_SET_GET_VALUE(1.0, filter->GetKernelBandwidthMultiplicationFactor());
+  ITK_TEST_SET_GET_VALUE(0, filter->GetNoiseSigma());
+
   // Use 2 threads for consistency
   filter->SetNumberOfWorkUnits(2);
 
   // Denoise the image
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
+
+  std::cout << "NumIndependentComponents: " << filter->GetNumIndependentComponents() << std::endl;
 
   // Write the denoised image to file
   auto writer = WriterType::New();

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -218,6 +218,8 @@ doDenoising(const std::string & inputFileName,
 
     ITK_TRY_EXPECT_EXCEPTION(filter->Update());
 
+    std::cout << "NumIndependentComponents: " << filter->GetNumIndependentComponents() << std::endl;
+
     // Restore the original pixel value
     inputImage->SetPixel(pixelIndex, originalPixelValue);
   }

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -180,7 +180,11 @@ TEST_F(PasteFixture, ConstantPaste3_2)
   filter->SetDestinationImage(inputImage);
 
   filter->SetDestinationIndex({ { 11, 13, 17 } });
-  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
+
+  SkipType destinationSkipAxes{ { { true, false, false } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("dfdbfe702adeccece580c5e0795d8f0a", MD5Hash(filter->GetOutput()));
@@ -189,20 +193,32 @@ TEST_F(PasteFixture, ConstantPaste3_2)
 
 
   filter->SetDestinationIndex({ { 11, 13, 17 } });
-  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
+
+  destinationSkipAxes = SkipType{ { { false, false, true } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("7bca1328ead4ab2c6b89e1cdd1e3fdad", MD5Hash(filter->GetOutput()));
 
   filter->SetDestinationIndex({ { 11, 13, 17 } });
-  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
+
+  destinationSkipAxes = SkipType{ { { false, false, true } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("7bca1328ead4ab2c6b89e1cdd1e3fdad", MD5Hash(filter->GetOutput()));
 
 
   filter->SetDestinationIndex({ { 11, 13, 17 } });
-  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
+
+  destinationSkipAxes = SkipType{ { { true, false, false } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->SetSourceRegion(Utils::SourceSizeType{ { 1, 1 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("2e40b486120da8d8a225d9ab505bc580", MD5Hash(filter->GetOutput()));
@@ -210,15 +226,23 @@ TEST_F(PasteFixture, ConstantPaste3_2)
 
   filter->SetDestinationIndex({ { 11, 13, 17 } });
   filter->SetSourceRegion(Utils::SourceSizeType{ { 1, 1 } });
-  filter->SetDestinationSkipAxes(SkipType{ { { true, true, true } } });
+
+  destinationSkipAxes = SkipType{ { { true, true, true } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 
+  destinationSkipAxes = SkipType{ { { false, true, true } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
 
-  filter->SetDestinationSkipAxes(SkipType{ { { false, true, true } } });
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 
+  destinationSkipAxes = SkipType{ { { true, true, false } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
 
-  filter->SetDestinationSkipAxes(SkipType{ { { true, true, false } } });
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 }
 TEST_F(PasteFixture, InPlace)
@@ -296,18 +320,27 @@ TEST_F(PasteFixture, Paste3_2)
   filter->SetDestinationIndex({ { 11, 13, 17 } });
   filter->SetSourceRegion(sourceImage->GetLargestPossibleRegion());
 
-  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
+  SkipType destinationSkipAxes{ { { true, false, false } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("753e433a43ab8fcf3d2ef0f8c78aef35", MD5Hash(filter->GetOutput()));
   EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 12, 13, 17 } }));
 
-  filter->SetDestinationSkipAxes(SkipType{ { { false, true, false } } });
+  destinationSkipAxes = SkipType{ { { false, true, false } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 11, 14, 17 } }));
   EXPECT_EQ("44bd0a10b89c58fd306beee6148fdb4d", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
+  destinationSkipAxes = SkipType{ { { false, false, true } } };
+  filter->SetDestinationSkipAxes(destinationSkipAxes);
+  EXPECT_EQ(destinationSkipAxes, filter->GetDestinationSkipAxes());
+
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("ce630d54304b6eba8cd73ec9617d2cf4", MD5Hash(filter->GetOutput()));
   EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 11, 13, 18 } }));

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -120,7 +120,11 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   using myFilterType = itk::GrayscaleFunctionDilateImageFilter<myImageType, myImageType, myKernelType>;
 
   // Create the filter
-  auto                     filter = myFilterType::New();
+  auto filter = myFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, GrayscaleFunctionDilateImageFilter, MorphologyImageFilter);
+
+
   itk::SimpleFilterWatcher filterWatcher(filter);
 
   // Create the structuring element
@@ -141,6 +145,8 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   // Execute the filter
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
+
+  std::cout << "BoundaryCondition: " << filter->GetBoundaryCondition() << std::endl;
 
   // Create an iterator for going through the image output
   myIteratorType it2(outputImage, outputImage->GetBufferedRegion());

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -120,7 +120,11 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   using myFilterType = itk::GrayscaleFunctionErodeImageFilter<myImageType, myImageType, myKernelType>;
 
   // Create the filter
-  auto                     filter = myFilterType::New();
+  auto filter = myFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, GrayscaleFunctionErodeImageFilter, MorphologyImageFilter);
+
+
   itk::SimpleFilterWatcher watcher(filter, "filter");
 
   // Create the structuring element
@@ -141,6 +145,8 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   // Execute the filter
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
+
+  std::cout << "BoundaryCondition: " << filter->GetBoundaryCondition() << std::endl;
 
   // Create an iterator for going through the image output
   myIteratorType it2(outputImage, outputImage->GetBufferedRegion());

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -199,9 +199,28 @@ itkFEMSolverHyperbolicTest(int argc, char * argv[])
    */
 
   auto SH = FEMSolverType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(SH, SolverHyperbolic, Solver);
+
+
   SH->SetInput(femSO->GetFEMObject());
-  SH->SetTimeStep(.5);
+  ITK_TEST_SET_GET_VALUE(femSO->GetFEMObject(), SH->GetInput());
+
+  FEMSolverType::Float gamma = 0.5;
+  SH->SetGamma(gamma);
+  ITK_TEST_SET_GET_VALUE(gamma, SH->GetGamma());
+
+  FEMSolverType::Float beta = 0.25;
+  SH->SetBeta(beta);
+  ITK_TEST_SET_GET_VALUE(beta, SH->GetBeta());
+
   SH->SetNumberOfIterations(niter);
+  ITK_TEST_SET_GET_VALUE(niter, SH->GetNumberOfIterations());
+
+  FEMSolverType::Float timeStep = 0.5;
+  SH->SetTimeStep(timeStep);
+  ITK_TEST_SET_GET_VALUE(timeStep, SH->GetTimeStep());
+
 
   itk::fem::LinearSystemWrapperDenseVNL lsw_dvnl;
   itk::fem::LinearSystemWrapperItpack   lsw_itpack;

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
@@ -175,6 +175,7 @@ itkDeformableSimplexMesh3DFilterTest(int, char *[])
     simplexMesh->DisconnectPipeline();
     deformFilter->SetInput(simplexMesh);
     deformFilter->SetGradient(gradientFilter->GetOutput());
+    ITK_TEST_SET_GET_VALUE(gradientFilter->GetOutput(), deformFilter->GetGradient());
 
     deformFilter->SetAlpha(alpha);
     ITK_TEST_SET_GET_VALUE(alpha, deformFilter->GetAlpha());
@@ -197,6 +198,9 @@ itkDeformableSimplexMesh3DFilterTest(int, char *[])
     deformFilter->Update();
   }
 
+  std::cout << "ImageWidth: " << deformFilter->GetImageWidth() << std::endl;
+  std::cout << "ImageHeight: " << deformFilter->GetImageHeight() << std::endl;
+  std::cout << "ImageDepth: " << deformFilter->GetImageDepth() << std::endl;
   std::cout << "Deform filter Step: " << deformFilter->GetStep() << std::endl;
 
   SimplexMeshType::Pointer deformResult = deformFilter->GetOutput();


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Exercise basic object methods using the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Use other testing macros as necessary to check for expected values.
- Call other Get methods for ivars that have no Set methods/ivars having an informative purpose.
- Remove statements that serialize the values obtained through the Get macro and call the Get methods in the context of the quantitative testing macros.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)