### PR TITLE
COMP: Use conjunction_v to check argument types of MakePoint, MakeVector

### DIFF
--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -365,11 +365,11 @@ template <typename TValue, typename... TVariadic>
 auto
 MakePoint(const TValue firstValue, const TVariadic... otherValues)
 {
-  constexpr unsigned int dimension{ 1 + sizeof...(TVariadic) };
+  static_assert(std::conjunction_v<std::is_same<TVariadic, TValue>...>,
+                "The other values should have the same type as the first value.");
 
-  // Note that the class template argument deduction guide of std::array ensures that all values have the same type.
-  const std::array stdArray{ firstValue, otherValues... };
-
+  constexpr unsigned int              dimension{ 1 + sizeof...(TVariadic) };
+  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
   return Point<TValue, dimension>{ stdArray };
 }
 

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -331,11 +331,11 @@ template <typename TValue, typename... TVariadic>
 auto
 MakeVector(const TValue firstValue, const TVariadic... otherValues)
 {
-  constexpr unsigned int dimension{ 1 + sizeof...(TVariadic) };
+  static_assert(std::conjunction_v<std::is_same<TVariadic, TValue>...>,
+                "The other values should have the same type as the first value.");
 
-  // Note that the class template argument deduction guide of std::array ensures that all values have the same type.
-  const std::array stdArray{ firstValue, otherValues... };
-
+  constexpr unsigned int              dimension{ 1 + sizeof...(TVariadic) };
+  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
   return Vector<TValue, dimension>{ stdArray };
 }
 


### PR DESCRIPTION
The previous approach, using the class template argument deduction guide of std::array appeared to trigger compile errors from  AppleClang 10.0.0.10001044, as Mihail Isakov (@issakomi) remarked at https://github.com/InsightSoftwareConsortium/ITK/pull/4154#discussion_r1292840598, like:

> Modules/Core/Common/include/itkPoint.h:371:20: error: no viable constructor or deduction guide for deduction of template arguments of 'array'
>   const std::array stdArray{ firstValue, otherValues... };
>                   ^
> [CTest: warning matched] Modules/Core/Common/test/itkPointGTest.cxx:63:46: note: in instantiation of function template specialization 'itk::MakePoint<int>' requested here
>   static_assert(std::is_same_v<decltype(itk::MakePoint(0))::ValueType, int> &&

---

The proposed approach is very much inspired by the `std::conjunction` example at https://en.cppreference.com/w/cpp/types/conjunction#Example specifically:

```
template<typename T, typename... Ts>
constexpr bool all_types_are_same = std::conjunction_v<std::is_same<T, Ts>...>;
 
static_assert(all_types_are_same<int, int, int>);

```




