### PR TITLE
STYLE: Remove `ITK_X_ASSERT`, just use `assert` in `constexpr` functions

### DIFF
--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -27,16 +27,6 @@
 #include <cstdint> // For uintmax_t
 #include <limits>
 
-// C++11 does not guarantee that assert can be used in constexpr
-// functions. This is a work-around for GCC 4.8, 4.9. Originating
-// from Andrzej's C++ blog:
-//  https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
-#if defined NDEBUG
-#  define ITK_X_ASSERT(CHECK) void(0)
-#else
-#  define ITK_X_ASSERT(CHECK) ((CHECK) ? void(0) : [] { assert(!#CHECK); }())
-#endif
-
 namespace itk
 {
 
@@ -185,7 +175,7 @@ private:
   static constexpr uintmax_t
   CalculateSum(const uintmax_t a, const uintmax_t b) noexcept
   {
-    return ((a + b) >= a) && ((a + b) >= b) ? (a + b) : (ITK_X_ASSERT(!"CalculateSum overflow!"), 0);
+    return ((a + b) >= a) && ((a + b) >= b) ? (a + b) : (assert(!"CalculateSum overflow!"), 0);
   }
 
 
@@ -195,7 +185,7 @@ private:
   CalculatePowerOfTwo(const size_t n) noexcept
   {
     return (n < std::numeric_limits<uintmax_t>::digits) ? (uintmax_t{ 1 } << n)
-                                                        : (ITK_X_ASSERT(!"CalculatePowerOfTwo overflow!"), 0);
+                                                        : (assert(!"CalculatePowerOfTwo overflow!"), 0);
   }
 
 
@@ -206,7 +196,7 @@ private:
   static constexpr uintmax_t
   CalculateBinomialCoefficient(const uintmax_t n, const uintmax_t k) noexcept
   {
-    return (k > n) ? (ITK_X_ASSERT(!"Out of range!"), 0)
+    return (k > n) ? (assert(!"Out of range!"), 0)
                    : (k == 0) ? 1 : Math::UnsignedProduct(n, CalculateBinomialCoefficient(n - 1, k - 1)) / k;
   }
 
@@ -232,9 +222,8 @@ private:
   static constexpr size_t
   CalculateSumOfNumberOfHypercubesOnBoundaryOfCube(const size_t i, const size_t m) noexcept
   {
-    return ITK_X_ASSERT(i >= m),
-           CalculateSum(CalculateNumberOfHypercubesOnBoundaryOfCube(i, ImageDimension),
-                        ((i <= m) ? 0 : CalculateSumOfNumberOfHypercubesOnBoundaryOfCube(i - 1, m)));
+    return assert(i >= m), CalculateSum(CalculateNumberOfHypercubesOnBoundaryOfCube(i, ImageDimension),
+                                        ((i <= m) ? 0 : CalculateSumOfNumberOfHypercubesOnBoundaryOfCube(i - 1, m)));
   }
 
 
@@ -272,7 +261,5 @@ GenerateConnectedImageNeighborhoodShapeOffsets() noexcept
 }
 
 } // namespace itk
-
-#undef ITK_X_ASSERT
 
 #endif

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -28,6 +28,7 @@
 #ifndef itkMath_h
 #define itkMath_h
 
+#include <cassert>
 #include <cmath>
 #include "itkMathDetail.h"
 #include "itkConceptChecking.h"
@@ -764,15 +765,6 @@ GreatestPrimeFactor(unsigned long n);
 ITKCommon_EXPORT unsigned long long
 GreatestPrimeFactor(unsigned long long n);
 
-// C++11 does not guarantee that assert can be used in constexpr
-// functions. This is a work-around for GCC 4.8, 4.9. Originating
-// from Andrzej's C++ blog:
-//  https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
-#if defined NDEBUG
-#  define ITK_X_ASSERT(CHECK) void(0)
-#else
-#  define ITK_X_ASSERT(CHECK) ((CHECK) ? void(0) : [] { assert(!#CHECK); }())
-#endif
 
 /**  Returns `a * b`. Numeric overflow triggers a compilation error in
  * "constexpr context" and a debug assert failure at run-time.
@@ -788,7 +780,7 @@ UnsignedProduct(const uintmax_t a, const uintmax_t b) noexcept
   return (a == 0) || (b == 0) ||
              (((static_cast<TReturnType>(a * b) / a) == b) && ((static_cast<TReturnType>(a * b) / b) == a))
            ? static_cast<TReturnType>(a * b)
-           : (ITK_X_ASSERT(!"UnsignedProduct overflow!"), 0);
+           : (assert(!"UnsignedProduct overflow!"), 0);
 }
 
 
@@ -808,13 +800,11 @@ UnsignedPower(const uintmax_t base, const uintmax_t exponent) noexcept
   // Uses recursive function calls because C++11 does not support other ways of
   // iterations for a constexpr function.
   return (exponent == 0)
-           ? (ITK_X_ASSERT(base > 0), 1)
+           ? (assert(base > 0), 1)
            : (exponent == 1) ? base
                              : UnsignedProduct<TReturnType>(UnsignedPower<TReturnType>(base, exponent / 2),
                                                             UnsignedPower<TReturnType>(base, (exponent + 1) / 2));
 }
-
-#undef ITK_X_ASSERT
 
 
 /*==========================================


### PR DESCRIPTION
From C++14, the standard `assert` supports being called directly from inside a `constexpr` function, as was already mentioned in Andrzej's C++ blog entry https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions The `ITK_X_ASSERT` workaround for GCC 4 is no longer needed, as ITK now requires at least GCC 7 (and also at least C++17).

This reverts commit 9ff8f9fcdef345a11a47320253d96438a60d5859 "COMP: Fix C++11 compatibility with assert in constexpr" by Bradley Lowekamp (@blowekamp), June 25, 2018.
