### PR TITLE
ENH: Add TransformMINC to default modules

### DIFF
--- a/Modules/IO/TransformMINC/itk-module.cmake
+++ b/Modules/IO/TransformMINC/itk-module.cmake
@@ -19,5 +19,4 @@ itk_module(ITKIOTransformMINC
     TransformIO::MINC
   DESCRIPTION
     "${DOCUMENTATION}"
-  EXCLUDE_FROM_DEFAULT
 )

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -628,7 +628,7 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
   pnt[0] = 1.0;
   pnt[1] = pnt[2] = 0.0;
   // expected transform: shift by 1 , rotate by 45 deg
-  v2[0] = v[1] = sqrt(2);
+  v2[0] = v2[1] = sqrt(2);
   v2[2] = 0.0;
 
   v = _xfm->TransformPoint(pnt);


### PR DESCRIPTION
Add TransformMINC to default modules.

MINC is already enabled by default but it's transforms were not.

Ref: https://github.com/conda-forge/libitk-feedstock/pull/83