### PR TITLE
Document and use the fact that `SingletonIndex::SetGlobalInstance` always returns true

### DIFF
--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -59,7 +59,7 @@ public:
   }
 
 
-  // returns true if the globalName has not been registered yet.
+  // Returns true.
   //
   // It is assumed that the global will remain valid until the start
   // of globals being destroyed.

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -120,11 +120,7 @@ Singleton(const char * globalName, std::function<void(void *)> func, std::functi
   if (instance == nullptr)
   {
     instance = new T;
-    if (!SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, func, deleteFunc))
-    {
-      delete instance;
-      instance = nullptr;
-    }
+    SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, func, deleteFunc);
   }
   return instance;
 }

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -70,7 +70,8 @@ public:
                     std::function<void(void *)> func,
                     std::function<void()>       deleteFunc)
   {
-    return this->SetGlobalInstancePrivate(globalName, global, func, deleteFunc);
+    this->SetGlobalInstancePrivate(globalName, global, func, deleteFunc);
+    return true;
   }
 
   /** Set/Get the pointer to GlobalSingleton.
@@ -90,9 +91,9 @@ private:
   // work, and could use some type of Holder<T> class for intrinsic types
   void *
   GetGlobalInstancePrivate(const char * globalName);
-  // If globalName is already registered than false is return,
-  // otherwise global is added to the singleton index under globalName
-  bool
+
+  // global is added or set to the singleton index under globalName
+  void
   SetGlobalInstancePrivate(const char *                globalName,
                            void *                      global,
                            std::function<void(void *)> func,

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -98,14 +98,13 @@ SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
 
 // If globalName is already registered, set its global as specified,
 // otherwise global is added to the singleton index under globalName
-bool
+void
 SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
                                          void *                      global,
                                          std::function<void(void *)> func,
                                          std::function<void()>       deleteFunc)
 {
   m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, func, deleteFunc));
-  return true;
 }
 
 SingletonIndex *

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -96,7 +96,7 @@ SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
   return std::get<0>(it->second);
 }
 
-// If globalName is already registered remove it from map,
+// If globalName is already registered, set its global as specified,
 // otherwise global is added to the singleton index under globalName
 bool
 SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
@@ -104,8 +104,7 @@ SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
                                          std::function<void(void *)> func,
                                          std::function<void()>       deleteFunc)
 {
-  m_GlobalObjects.erase(globalName);
-  m_GlobalObjects.insert(std::make_pair(globalName, std::make_tuple(global, func, deleteFunc)));
+  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, func, deleteFunc));
   return true;
 }
 


### PR DESCRIPTION
Note that `SetGlobalInstance` has always just returned `true`, from the very first commit, pull request #118 commit a66337ec215c88f4900a2caf419b055483c42085 _ENH: Synchronize factories across modules in Python_ by Francois Budin (@fbudin69500) and Hans Johnson (@hjmjohnson), February 2019.

Looking at the initial (2019) version of `SetGlobalInstance` and `SetGlobalInstancePrivate`:

https://github.com/InsightSoftwareConsortium/ITK/blob/a66337ec215c88f4900a2caf419b055483c42085/Modules/Core/Common/include/itkSingleton.h#L62-L64
https://github.com/InsightSoftwareConsortium/ITK/blob/a66337ec215c88f4900a2caf419b055483c42085/Modules/Core/Common/src/itkSingleton.cxx#L97-L104 
