### PR TITLE
STYLE: SingletonIndex does not need to store the unused `func` parameter

### DIFF
--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -44,16 +44,12 @@
   {                                                                                                 \
     if (m_##VarName == nullptr)                                                                     \
     {                                                                                               \
-      const auto setLambda = [](void * a) {                                                         \
-        delete m_##VarName;                                                                         \
-        m_##VarName = static_cast<Type *>(a);                                                       \
-      };                                                                                            \
       const auto deleteLambda = []() {                                                              \
         delete m_##VarName;                                                                         \
         m_##VarName = nullptr;                                                                      \
       };                                                                                            \
       auto * old_instance = SingletonIndex::GetInstance()->GetGlobalInstance<Type>(#SingletonName); \
-      m_##VarName = Singleton<Type>(#SingletonName, setLambda, deleteLambda);                       \
+      m_##VarName = Singleton<Type>(#SingletonName, {}, deleteLambda);                              \
       if (old_instance == nullptr)                                                                  \
       {                                                                                             \
         Init;                                                                                       \

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -87,8 +87,7 @@ namespace itk
 void *
 SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
 {
-  SingletonData::iterator it;
-  it = m_GlobalObjects.find(globalName);
+  const auto it = m_GlobalObjects.find(globalName);
   if (it == m_GlobalObjects.end())
   {
     return nullptr;
@@ -99,12 +98,9 @@ SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
 // If globalName is already registered, set its global as specified,
 // otherwise global is added to the singleton index under globalName
 void
-SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
-                                         void *                      global,
-                                         std::function<void(void *)> func,
-                                         std::function<void()>       deleteFunc)
+SingletonIndex::SetGlobalInstancePrivate(const char * globalName, void * global, std::function<void()> deleteFunc)
 {
-  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, func, deleteFunc));
+  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, deleteFunc));
 }
 
 SingletonIndex *
@@ -128,7 +124,7 @@ SingletonIndex::~SingletonIndex()
 {
   for (auto & pair : m_GlobalObjects)
   {
-    std::get<2>(pair.second)();
+    std::get<1>(pair.second)();
   }
 }
 


### PR DESCRIPTION
No longer stored the `func` parameter from `SingletonIndex::SetGlobalInstance`, and from `Singleton(globalName, func, deleteFunc)`, as it was never actually retrieved from `m_GlobalObjects` afterwards.


Deprecated the `SingletonIndex::SingletonData` type alias, as it is no longer used internally anymore, and it should not be public either.

----

Note that even with the initial commit a66337ec215c88f4900a2caf419b055483c42085 (pull request #118, Francois Budin (@fbudin69500) and Hans Johnson (@hjmjohnson), February 2019), the value of the `func` parameter was never retrieved from `SingletonIndex::m_GlobalObjects`, looking at:
https://github.com/InsightSoftwareConsortium/ITK/blob/a66337ec215c88f4900a2caf419b055483c42085/Modules/Core/Common/src/itkSingleton.cxx

https://github.com/InsightSoftwareConsortium/ITK/blob/a66337ec215c88f4900a2caf419b055483c42085/Modules/Core/Common/include/itkSingleton.h