### PR TITLE
COMP: Remove pkg_resources import from base.py

### DIFF
--- a/Wrapping/Generators/Python/itk/support/base.py
+++ b/Wrapping/Generators/Python/itk/support/base.py
@@ -23,8 +23,6 @@ from sys import stderr as system_error_stream
 # Required to work around weird import error with xarray
 from typing import Dict, Any, List, Optional, Sequence, Union
 
-import pkg_resources
-
 import itkConfig
 from itkConfig import DefaultFactoryLoading as _DefaultFactoryLoading
 from itk.support.template_class import itkTemplate


### PR DESCRIPTION
To address:

```
../../../../../../bin/micromamba/envs/itk-wasm/lib/python3.11/site-packages/itk/support/base.py:26
  pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

../../../../../../bin/micromamba/envs/itk-wasm/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
  Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
```

This was brought it by https://github.com/InsightSoftwareConsortium/ITK/commit/b7b6638b7a083fa5220d261753c50dd1dbdaf014 to work around an xarray import issue, but with xarray-2023.8.0, the tests pass.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

