### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/Core/Common/test/itkTimeProbeTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbeTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include <iostream>
+#include "itkIndent.h"
 #include "itkTimeProbe.h"
 #include "itkMath.h"
 
@@ -89,6 +90,10 @@ itkTimeProbeTest(int, char *[])
   std::cout << "sec  " << timeStamp.GetTimeInSeconds() << std::endl;
   std::cout << "msec " << timeStamp.GetTimeInMilliSeconds() << std::endl;
   std::cout << "usec " << timeStamp.GetTimeInMicroSeconds() << std::endl;
+
+  // Exercise the Print method
+  itk::Indent indent{};
+  localTimer.Print(std::cout, indent);
 
   std::cout << "[PASSED]" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -154,6 +154,9 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(integral, 1276.));
 
+  ITK_TEST_EXPECT_TRUE(interp->IsInsideBuffer(query));
+  ITK_TEST_EXPECT_TRUE(interp->IsInsideBuffer(index));
+
 
   std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
@@ -259,6 +259,10 @@ itkFrequencyBandImageFilterTest(int argc, char * argv[])
   auto testFilter = UnaryFilterType::New();
   ITK_EXERCISE_BASIC_OBJECT_METHODS(testFilter, UnaryFrequencyDomainFilter, InPlaceImageFilter);
 
+
+  auto actualXDimensionIsOdd = false;
+  ITK_TEST_SET_GET_BOOLEAN(testFilter, ActualXDimensionIsOdd, actualXDimensionIsOdd);
+
   struct TestStruct
   {
     static double

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -140,6 +140,10 @@ itkVectorExpandImageFilterTest(int, char *[])
   using InterpolatorType = itk::VectorNearestNeighborInterpolateImageFunction<ImageType, double>;
   auto interpolator = InterpolatorType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    interpolator, VectorNearestNeighborInterpolateImageFunction, VectorInterpolateImageFunction);
+
+
   expander->SetInterpolator(interpolator);
   ITK_TEST_SET_GET_VALUE(interpolator, expander->GetInterpolator());
 

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -28,6 +28,7 @@
 #include "itkIOTestHelper.h"
 #include "itkMINCTransformAdapter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 
 static constexpr double tolerance = 1e-5;
@@ -230,6 +231,73 @@ itkMINCTransformAdapterTest(int argc, char * argv[])
   {
     itksys::SystemTools::ChangeDirectory(argv[1]);
   }
+
+
+  constexpr unsigned int InputDimension = 3;
+  constexpr unsigned int OutputDimension = 3;
+
+  using ParametersValueType = double;
+
+  using TransformAdapterType = itk::MINCTransformAdapter<ParametersValueType, InputDimension, OutputDimension>;
+
+  TransformAdapterType::Pointer xfm = TransformAdapterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(xfm, MINCTransformAdapter, Transform);
+
+  // Test exceptions
+  TransformAdapterType::InputVectorType vector{};
+  TransformAdapterType::InputPointType  point{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->TransformVector(vector, point));
+
+  TransformAdapterType::InputVnlVectorType vnlVector{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->TransformVector(vnlVector, point));
+
+  TransformAdapterType::InputVectorPixelType vectorPixel{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->TransformVector(vectorPixel, point));
+
+  TransformAdapterType::InputCovariantVectorType covariantVector{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->TransformCovariantVector(covariantVector, point));
+
+  ITK_TRY_EXPECT_EXCEPTION(xfm->TransformCovariantVector(vectorPixel, point));
+
+  TransformAdapterType::FixedParametersType fixedParams{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->SetFixedParameters(fixedParams));
+
+  TransformAdapterType::JacobianType jacobian{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->ComputeJacobianWithRespectToParameters(point, jacobian));
+
+  ITK_TRY_EXPECT_EXCEPTION(xfm->GetNumberOfParameters());
+
+  TransformAdapterType::ParametersType params{};
+  ITK_TRY_EXPECT_EXCEPTION(xfm->SetParameters(params));
+
+  ITK_TRY_EXPECT_EXCEPTION(xfm->GetParameters());
+
+  constexpr unsigned int InputDimensionExcp1 = 1;
+  constexpr unsigned int OutputDimensionExcp1 = 1;
+
+  using TransformAdapterTypeExcp11 =
+    itk::MINCTransformAdapter<ParametersValueType, InputDimensionExcp1, OutputDimensionExcp1>;
+
+  ITK_TRY_EXPECT_EXCEPTION(TransformAdapterTypeExcp11::New());
+
+  constexpr unsigned int InputDimensionExcp2 = 2;
+  constexpr unsigned int OutputDimensionExcp2 = 2;
+
+  using TransformAdapterTypeExcp22 =
+    itk::MINCTransformAdapter<ParametersValueType, InputDimensionExcp2, OutputDimensionExcp2>;
+
+  ITK_TRY_EXPECT_EXCEPTION(TransformAdapterTypeExcp22::New());
+
+  constexpr unsigned int InputDimensionExcp4 = 4;
+  constexpr unsigned int OutputDimensionExcp4 = 4;
+
+  using TransformAdapterTypeExcp44 =
+    itk::MINCTransformAdapter<ParametersValueType, InputDimensionExcp4, OutputDimensionExcp4>;
+
+  ITK_TRY_EXPECT_EXCEPTION(TransformAdapterTypeExcp44::New());
+
+
   itk::TransformFactory<itk::DisplacementFieldTransform<double, 3>>::RegisterTransform();
   itk::ObjectFactoryBase::RegisterFactory(itk::MINCTransformIOFactory::New());
 

--- a/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
@@ -218,6 +218,8 @@ itkLBFGSBOptimizerTest(int, char *[])
   itkOptimizer->SetMaximumNumberOfCorrections(maximumNumberOfCorrections);
   ITK_TEST_SET_GET_VALUE(maximumNumberOfCorrections, itkOptimizer->GetMaximumNumberOfCorrections());
 
+  ITK_TEST_EXPECT_TRUE(!itkOptimizer->CanUseScales());
+
   constexpr unsigned int        SpaceDimension = 2;
   OptimizerType::ParametersType initialValue(SpaceDimension);
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -238,10 +238,16 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   using MetricTypePointer = MetricType::Pointer;
   MetricTypePointer metric = MetricType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(metric, ANTSNeighborhoodCorrelationImageToImageMetricv4, ImageToImageMetricv4);
+
+
   const itk::Size<ImageDimension> neighborhoodRadius0{ { 1 } };
 
   metric->SetRadius(neighborhoodRadius0);
   ITK_TEST_SET_GET_VALUE(neighborhoodRadius0, metric->GetRadius());
+
+  const MetricType::RadiusType constRadius = metric->GetRadius();
+  ITK_TEST_EXPECT_EQUAL(neighborhoodRadius0, constRadius);
 
   itk::Size<ImageDimension> neighborhoodRadius;
   neighborhoodRadius.Fill(1);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -310,7 +310,13 @@ PerformSimpleImageRegistration(int argc, char * argv[])
   displacementFieldSimple->SetNumberOfLevels(numberOfLevels);
   ITK_TEST_SET_GET_VALUE(numberOfLevels, displacementFieldSimple->GetNumberOfLevels());
 
-  displacementFieldSimple->SetMovingInitialTransformInput(affineSimple->GetTransformOutput());
+  typename AffineRegistrationType::DecoratedOutputTransformType * transformOutputNonConst =
+    affineSimple->GetTransformOutput();
+  const typename AffineRegistrationType::DecoratedOutputTransformType * transformOutputConst =
+    affineSimple->GetTransformOutput();
+  ITK_TEST_EXPECT_EQUAL(transformOutputNonConst, transformOutputConst);
+
+  displacementFieldSimple->SetMovingInitialTransformInput(transformOutputNonConst);
   displacementFieldSimple->SetMetric(correlationMetric);
   displacementFieldSimple->SetOptimizer(optimizer);
 

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
@@ -145,6 +145,10 @@ itkDeformableSimplexMesh3DGradientConstraintForceFilterTest(int, char *[])
 
   std::cout << "[TEST DONE]" << std::endl;
 
+  // Print the filter after its update so that its StartVoxel, Positive and Negative ivars's ImageVoxel class stream
+  // insertion operator overload gets exercised.
+  deformFilter->Print(std::cout);
+
   // Test streaming enumeration for DeformableSimplexMesh3DGradientConstraintForceFilterEnums::SIDE elements
   const std::set<itk::DeformableSimplexMesh3DGradientConstraintForceFilterEnums::SIDE> allSIDE{
     itk::DeformableSimplexMesh3DGradientConstraintForceFilterEnums::SIDE::NORMAL,


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Exercise basic object methods using the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Use other testing macros as necessary to check for expected values.
- Test the exceptions using the `ITK_TRY_EXPECT_EXCEPTION`.
- Explicitly call the `Print` method when some ivars (e.g. containers of some kind) need to have some data so that the corresponding serialization statements in the `PrintSelf` method can be called. Call these methods once the instance data has been set and the filter has been updated.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)