### PR TITLE
BUG: Fix `itk::QuadEdgeMeshPolygonCell` test valgrind defect

### DIFF
--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -98,8 +98,8 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
 
   PolygonCellType::PointIdConstIterator constPointId = quadEdgeMeshPolygonCell.PointIdsBegin();
   PolygonCellType::PointIdConstIterator constEndId = quadEdgeMeshPolygonCell.PointIdsEnd();
-  ITK_TEST_EXPECT_TRUE(pointId);
-  ITK_TEST_EXPECT_TRUE(endId);
+  ITK_TEST_EXPECT_TRUE(constPointId);
+  ITK_TEST_EXPECT_TRUE(constEndId);
 
   /**
    * Create the test cell. Note that testCell is a generic auto

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -89,15 +89,15 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
 
 
   // Test point container iterators
-  auto * quadEdgeMeshPolygonCell = new PolygonCellType();
+  PolygonCellType quadEdgeMeshPolygonCell{};
 
-  PolygonCellType::PointIdIterator pointId = quadEdgeMeshPolygonCell->PointIdsBegin();
-  PolygonCellType::PointIdIterator endId = quadEdgeMeshPolygonCell->PointIdsEnd();
+  PolygonCellType::PointIdIterator pointId = quadEdgeMeshPolygonCell.PointIdsBegin();
+  PolygonCellType::PointIdIterator endId = quadEdgeMeshPolygonCell.PointIdsEnd();
   ITK_TEST_EXPECT_TRUE(pointId);
   ITK_TEST_EXPECT_TRUE(endId);
 
-  PolygonCellType::PointIdConstIterator constPointId = quadEdgeMeshPolygonCell->PointIdsBegin();
-  PolygonCellType::PointIdConstIterator constEndId = quadEdgeMeshPolygonCell->PointIdsEnd();
+  PolygonCellType::PointIdConstIterator constPointId = quadEdgeMeshPolygonCell.PointIdsBegin();
+  PolygonCellType::PointIdConstIterator constEndId = quadEdgeMeshPolygonCell.PointIdsEnd();
   ITK_TEST_EXPECT_TRUE(pointId);
   ITK_TEST_EXPECT_TRUE(endId);
 


### PR DESCRIPTION
- BUG: Fix dynamically allocated memory management
- ENH: Test the const point iterators in `itk::QuadEdgeMeshPolygonCell`

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)