### PR TITLE
STYLE: Replace `std::unique_lock` with `std::lock_guard` in ThreadPool

### DIFF
--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -93,7 +93,7 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
 
     std::future<return_type> res = task->get_future();
     {
-      std::unique_lock<std::mutex> lock(this->GetMutex());
+      const std::lock_guard<std::mutex> lockGuard(this->GetMutex());
       m_WorkQueue.emplace_back([task]() { (*task)(); });
     }
     m_Condition.notify_one();
@@ -107,7 +107,7 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
   ThreadIdType
   GetMaximumNumberOfThreads() const
   {
-    std::unique_lock<std::mutex> lock(this->GetMutex());
+    const std::lock_guard<std::mutex> lockGuard(this->GetMutex());
     return static_cast<ThreadIdType>(m_Threads.size());
   }
 

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -122,7 +122,7 @@ ThreadPool::ThreadPool()
 void
 ThreadPool::AddThreads(ThreadIdType count)
 {
-  std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_Mutex);
   m_Threads.reserve(m_Threads.size() + count);
   for (ThreadIdType i = 0; i < count; ++i)
   {
@@ -139,7 +139,7 @@ ThreadPool::GetMutex() const
 int
 ThreadPool::GetNumberOfCurrentlyIdleThreads() const
 {
-  std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_Mutex);
   return static_cast<int>(m_Threads.size()) - static_cast<int>(m_WorkQueue.size()); // lousy approximation
 }
 
@@ -148,7 +148,7 @@ ThreadPool::CleanUp()
 {
   bool shouldNotify;
   {
-    std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
+    const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_Mutex);
 
     this->m_Stopping = true;
 


### PR DESCRIPTION
A `std::lock_guard` is more lightweight than a `std::unique_lock`, so for simple use cases, `std::lock_guard` appears preferable.

----

Note that `std::lock_guard` is already used extensively in within ITK (I counted 79 times), so this proposed change would be consistent with the existing code  😃 