### PR TITLE
STYLE: Replace std::unique_lock with std::lock_guard in Filter.hxx files

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -257,28 +257,23 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::ThreadedStreamedGenerateDa
   // local copy, this thread may do multiple merges.
   while (true)
   {
-
+    MapType tomerge{};
     {
-      std::unique_lock<std::mutex> lock(m_Mutex);
+      const std::lock_guard<std::mutex> lockGuard(m_Mutex);
 
       if (m_LabelStatistics.empty())
       {
         swap(m_LabelStatistics, localStatistics);
         break;
       }
-      else
-      {
-        // copy the output map to thread local storage
-        MapType tomerge;
-        swap(m_LabelStatistics, tomerge);
 
-        // allow other threads to merge data
-        lock.unlock();
+      // Move the data of the output map to the local `tomerge` and clear the output map.
+      swap(m_LabelStatistics, tomerge);
 
-        // Merge tomerge into localStatistics, locally
-        MergeMap(localStatistics, tomerge);
-      }
-    } // release lock
+    } // release lock, allow other threads to merge data
+
+    // Merge tomerge into localStatistics, locally
+    MergeMap(localStatistics, tomerge);
   }
 }
 


### PR DESCRIPTION
Removed explicit `unlock()` calls. Instead, just made sure that the `lock_guard` variables go out of scope as soon as other threads are allowed to merge data.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4168 commit 1094cdde9ae725ad257d5d77308fffaa3dd6e0fe
"STYLE: Replace `std::unique_lock` with `std::lock_guard` in ThreadPool"

----

When reviewing, you might want to suppress whitespace changes: https://github.com/InsightSoftwareConsortium/ITK/pull/4172/files?w=1