### PR TITLE
STYLE: Improve `itkIOTransformMINCTest.cxx` style

### DIFF
--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -106,12 +106,8 @@ check_linear(const char * linear_transform)
 
 
   TransformFileReader::TransformListType list = *reader->GetTransformList();
+  ITK_TEST_EXPECT_EQUAL("AffineTransform_double_3_3", list.front()->GetTransformTypeAsString());
 
-  if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
-  {
-    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
-    return EXIT_FAILURE;
-  }
   AffineTransformType::Pointer affine2 = static_cast<AffineTransformType *>(list.front().GetPointer());
 
   std::cout << "Read transform : " << std::endl;
@@ -224,11 +220,8 @@ check_nonlinear_double(const char * nonlinear_transform)
   TransformFileReader::TransformListType list = *nlreader->GetTransformList();
   std::cout << "Read :" << list.size() << " transformations" << std::endl;
 
-  if (list.front()->GetTransformTypeAsString() != "DisplacementFieldTransform_double_3_3")
-  {
-    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL("DisplacementFieldTransform_double_3_3", list.front()->GetTransformTypeAsString());
+
   DisplacementFieldTransform::Pointer disp2 = static_cast<DisplacementFieldTransform *>(list.front().GetPointer());
   DisplacementFieldType::ConstPointer field2 = disp2->GetDisplacementField();
 
@@ -347,11 +340,8 @@ check_nonlinear_float(const char * nonlinear_transform)
   TransformFileReaderFloat::TransformListType list = *nlreader->GetTransformList();
   std::cout << "Read :" << list.size() << " transformations" << std::endl;
 
-  if (list.front()->GetTransformTypeAsString() != "DisplacementFieldTransform_float_3_3")
-  {
-    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL("DisplacementFieldTransform_float_3_3", list.front()->GetTransformTypeAsString());
+
   DisplacementFieldTransform::Pointer disp2 = static_cast<DisplacementFieldTransform *>(list.front().GetPointer());
   DisplacementFieldType::ConstPointer field2 = disp2->GetDisplacementField();
 
@@ -474,11 +464,8 @@ check_composite(const char * transform_file)
   TransformFileReader::TransformListType list = *reader->GetTransformList();
 
   // MINC XFM internally collapeses two concatenated linear transforms into one
-  if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
-  {
-    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL("AffineTransform_double_3_3", list.front()->GetTransformTypeAsString());
+
   AffineTransformType::Pointer affine_xfm = static_cast<AffineTransformType *>(list.front().GetPointer());
 
   std::cout << "Read transform : " << std::endl;
@@ -585,14 +572,8 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
 
 
   const TransformFileReader::TransformListType * list = reader->GetTransformList();
+  ITK_TEST_EXPECT_EQUAL(2, list->size());
 
-  if (list->size() != 2)
-  {
-    std::cerr << "Unexpected number of transforms:" << list->size() << std::endl;
-    std::cerr << "Expected:2" << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
   std::cout << "Reading back transforms : " << list->size() << std::endl << std::endl;
 
   using CompositeTransformType = itk::CompositeTransform<double, 3>;

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -29,6 +29,7 @@
 #include "itkCompositeTransform.h"
 #include "itkIOTestHelper.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 static constexpr int point_counter = 1000;
 using TransformFileReader = itk::TransformFileReaderTemplate<double>;
@@ -95,66 +96,50 @@ check_linear(const char * linear_transform)
 
   // Testing writing std::cout << "Testing write : ";
   affine->Print(std::cout);
-  try
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Testing read : " << std::endl;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
+  TransformFileReader::TransformListType list = *reader->GetTransformList();
+
+  if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
   {
-    writer->Update();
-    std::cout << std::endl;
-    std::cout << "Testing read : " << std::endl;
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while saving the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
+    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
     return EXIT_FAILURE;
   }
+  AffineTransformType::Pointer affine2 = static_cast<AffineTransformType *>(list.front().GetPointer());
 
-  try
+  std::cout << "Read transform : " << std::endl;
+  affine2->Print(std::cout);
+
+  vnl_random randgen(12345678);
+
+  AffineTransformType::InputPointType pnt, pnt2;
+
+  std::cout << "Testing that transformations are the same ..." << std::endl;
+  for (int i = 0; i < point_counter; ++i)
   {
-    TransformFileReader::TransformListType list = *reader->GetTransformList();
+    AffineTransformType::OutputPointType v1;
+    AffineTransformType::OutputPointType v2;
 
-    if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
+    RandomPoint<double>(randgen, pnt, 100);
+    pnt2 = pnt;
+    v1 = affine->TransformPoint(pnt);
+    v2 = affine2->TransformPoint(pnt2);
+
+    if ((v1 - v2).GetSquaredNorm() > tolerance)
     {
-      std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
+      std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
+                << " in " << linear_transform << " at " << pnt << std::endl;
       return EXIT_FAILURE;
     }
-    AffineTransformType::Pointer affine2 = static_cast<AffineTransformType *>(list.front().GetPointer());
-
-    std::cout << "Read transform : " << std::endl;
-    affine2->Print(std::cout);
-
-    vnl_random randgen(12345678);
-
-    AffineTransformType::InputPointType pnt, pnt2;
-
-    std::cout << "Testing that transformations are the same ..." << std::endl;
-    for (int i = 0; i < point_counter; ++i)
-    {
-      AffineTransformType::OutputPointType v1;
-      AffineTransformType::OutputPointType v2;
-
-      RandomPoint<double>(randgen, pnt, 100);
-      pnt2 = pnt;
-      v1 = affine->TransformPoint(pnt);
-      v2 = affine2->TransformPoint(pnt2);
-
-      if ((v1 - v2).GetSquaredNorm() > tolerance)
-      {
-        std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
-                  << " in " << linear_transform << " at " << pnt << std::endl;
-        return EXIT_FAILURE;
-      }
-    }
-    std::cout << " Done !" << std::endl;
   }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while reading the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << " Done !" << std::endl;
 
   return EXIT_SUCCESS;
 }
@@ -224,31 +209,15 @@ check_nonlinear_double(const char * nonlinear_transform)
   // Testing writing
   std::cout << "Testing write of non linear transform (double) : " << std::endl;
 
-  try
-  {
-    nlwriter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while saving the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(nlwriter->Update());
+
 
   // Testing writing
   std::cout << "Testing read of non linear transform (double): " << std::endl;
-  try
-  {
-    nlreader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while reading the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(nlreader->Update());
+
+
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Comparing of non linear transform (double) : " << std::endl;
@@ -363,31 +332,15 @@ check_nonlinear_float(const char * nonlinear_transform)
   // Testing writing
   std::cout << "Testing write of non linear transform (float): " << std::endl;
 
-  try
-  {
-    nlwriter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while saving the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(nlwriter->Update());
+
 
   // Testing writing
   std::cout << "Testing read of non linear transform (float) : " << std::endl;
-  try
-  {
-    nlreader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while reading the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(nlreader->Update());
+
+
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Comparing of non linear transform : " << std::endl;
@@ -509,67 +462,51 @@ check_composite(const char * transform_file)
   reader->SetFileName(transform_file);
 
   compositeTransform->Print(std::cout);
-  try
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Testing read : " << std::endl;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
+  TransformFileReader::TransformListType list = *reader->GetTransformList();
+
+  // MINC XFM internally collapeses two concatenated linear transforms into one
+  if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
   {
-    writer->Update();
-    std::cout << std::endl;
-    std::cout << "Testing read : " << std::endl;
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while saving the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
+    std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
     return EXIT_FAILURE;
   }
+  AffineTransformType::Pointer affine_xfm = static_cast<AffineTransformType *>(list.front().GetPointer());
 
-  try
+  std::cout << "Read transform : " << std::endl;
+  affine_xfm->Print(std::cout);
+
+  vnl_random randgen(12345678);
+
+  AffineTransformType::InputPointType pnt, pnt2;
+
+  std::cout << "Testing that transformations are the same ..." << std::endl;
+  for (int i = 0; i < point_counter; ++i)
   {
-    TransformFileReader::TransformListType list = *reader->GetTransformList();
+    AffineTransformType::OutputPointType v1;
+    AffineTransformType::OutputPointType v2;
 
-    // MINC XFM internally collapeses two concatenated linear transforms into one
-    if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
+    RandomPoint<double>(randgen, pnt, 100);
+    pnt2 = pnt;
+    v1 = compositeTransform->TransformPoint(pnt);
+    v2 = affine_xfm->TransformPoint(pnt2);
+
+    if ((v1 - v2).GetSquaredNorm() > tolerance)
     {
-      std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
+      std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
+                << " in " << compositeTransform << " at " << pnt << std::endl;
       return EXIT_FAILURE;
     }
-    AffineTransformType::Pointer affine_xfm = static_cast<AffineTransformType *>(list.front().GetPointer());
-
-    std::cout << "Read transform : " << std::endl;
-    affine_xfm->Print(std::cout);
-
-    vnl_random randgen(12345678);
-
-    AffineTransformType::InputPointType pnt, pnt2;
-
-    std::cout << "Testing that transformations are the same ..." << std::endl;
-    for (int i = 0; i < point_counter; ++i)
-    {
-      AffineTransformType::OutputPointType v1;
-      AffineTransformType::OutputPointType v2;
-
-      RandomPoint<double>(randgen, pnt, 100);
-      pnt2 = pnt;
-      v1 = compositeTransform->TransformPoint(pnt);
-      v2 = affine_xfm->TransformPoint(pnt2);
-
-      if ((v1 - v2).GetSquaredNorm() > tolerance)
-      {
-        std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
-                  << " in " << compositeTransform << " at " << pnt << std::endl;
-        return EXIT_FAILURE;
-      }
-    }
-    std::cout << " Done !" << std::endl;
   }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while reading the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << " Done !" << std::endl;
 
   return EXIT_SUCCESS;
 }
@@ -599,121 +536,104 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
 
   fb.close();
 
-  try
+  // generate field
+  using DisplacementFieldTransform = itk::DisplacementFieldTransform<double, 3>;
+  using DisplacementFieldType = DisplacementFieldTransform::DisplacementFieldType;
+
+  auto field = DisplacementFieldType::New();
+
+  // create zero displacement field
+  DisplacementFieldType::SizeType  imageSize3D = { { 10, 10, 10 } };
+  DisplacementFieldType::IndexType startIndex3D = { { 0, 0, 0 } };
+
+  double                            spacing[] = { 2.0, 2.0, 2.0 };
+  double                            origin[] = { -10.0, -10.0, -10.0 };
+  DisplacementFieldType::RegionType region;
+
+  region.SetSize(imageSize3D);
+  region.SetIndex(startIndex3D);
+
+  field->SetRegions(region);
+
+  field->SetSpacing(spacing);
+  field->SetOrigin(origin);
+  field->Allocate();
+
+  DisplacementFieldType::PixelType displacement;
+  displacement.Fill(0.0);
+  displacement[0] = 1.0;
+  field->FillBuffer(displacement);
+
+  using MincWriterType = itk::ImageFileWriter<DisplacementFieldType>;
+
+  auto writer = MincWriterType::New();
+  // expecting .mnc here
+  writer->SetFileName(transform_grid_file);
+
+  writer->SetInput(field);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  TransformFileReader::Pointer reader;
+  using CompositeTransformType = itk::CompositeTransform<double, 3>;
+
+  reader = TransformFileReader::New();
+  reader->SetFileName(transform_file);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
+  const TransformFileReader::TransformListType * list = reader->GetTransformList();
+
+  if (list->size() != 2)
   {
-    // generate field
-    using DisplacementFieldTransform = itk::DisplacementFieldTransform<double, 3>;
-    using DisplacementFieldType = DisplacementFieldTransform::DisplacementFieldType;
-
-    auto field = DisplacementFieldType::New();
-
-    // create zero displacement field
-    DisplacementFieldType::SizeType  imageSize3D = { { 10, 10, 10 } };
-    DisplacementFieldType::IndexType startIndex3D = { { 0, 0, 0 } };
-
-    double                            spacing[] = { 2.0, 2.0, 2.0 };
-    double                            origin[] = { -10.0, -10.0, -10.0 };
-    DisplacementFieldType::RegionType region;
-
-    region.SetSize(imageSize3D);
-    region.SetIndex(startIndex3D);
-
-    field->SetRegions(region);
-
-    field->SetSpacing(spacing);
-    field->SetOrigin(origin);
-    field->Allocate();
-
-    DisplacementFieldType::PixelType displacement;
-    displacement.Fill(0.0);
-    displacement[0] = 1.0;
-    field->FillBuffer(displacement);
-
-    using MincWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-
-    auto writer = MincWriterType::New();
-    // expecting .mnc here
-    writer->SetFileName(transform_grid_file);
-
-    writer->SetInput(field);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while writing the deformation field" << std::endl;
-    std::cerr << excp << std::endl;
+    std::cerr << "Unexpected number of transforms:" << list->size() << std::endl;
+    std::cerr << "Expected:2" << std::endl;
     std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "Reading back transforms : " << list->size() << std::endl << std::endl;
+
+  using CompositeTransformType = itk::CompositeTransform<double, 3>;
+  using TransformType = itk::Transform<double, 3>;
+
+  auto _xfm = CompositeTransformType::New();
+  for (const auto & it : *list)
+  {
+    it->Print(std::cout);
+    std::cout << std::endl;
+    _xfm->AddTransform(static_cast<TransformType *>(it.GetPointer()));
+  }
+  std::cout << std::endl;
+  std::cout << std::endl;
+  std::cout << std::endl;
+
+  _xfm->Print(std::cout);
+
+  std::cout << "Testing that transformations is expected ..." << std::endl;
+
+  CompositeTransformType::InputPointType  pnt;
+  CompositeTransformType::OutputPointType v, v2;
+
+  pnt[0] = 1.0;
+  pnt[1] = pnt[2] = 0.0;
+  // expected transform: shift by 1 , rotate by 45 deg
+  v2[0] = v[1] = sqrt(2);
+  v2[2] = 0.0;
+
+  v = _xfm->TransformPoint(pnt);
+
+  std::cout << "In:" << pnt << " Out:" << v << std::endl;
+  if ((v - v2).GetSquaredNorm() > tolerance)
+  {
+    std::cerr << "Expected coordinates (" << v << ") doesn't match read-in coordinates (" << v2 << " ) "
+              << " in " << _xfm << " at " << pnt << std::endl;
     return EXIT_FAILURE;
   }
 
 
-  try
-  {
-    TransformFileReader::Pointer reader;
-    using CompositeTransformType = itk::CompositeTransform<double, 3>;
-
-    reader = TransformFileReader::New();
-    reader->SetFileName(transform_file);
-    reader->Update();
-
-    const TransformFileReader::TransformListType * list = reader->GetTransformList();
-
-    if (list->size() != 2)
-    {
-      std::cerr << "Unexpected number of transforms:" << list->size() << std::endl;
-      std::cerr << "Expected:2" << std::endl;
-      std::cout << "[FAILED]" << std::endl;
-      return EXIT_FAILURE;
-    }
-    std::cout << "Reading back transforms : " << list->size() << std::endl << std::endl;
-
-    using CompositeTransformType = itk::CompositeTransform<double, 3>;
-    using TransformType = itk::Transform<double, 3>;
-
-    auto _xfm = CompositeTransformType::New();
-    for (const auto & it : *list)
-    {
-      it->Print(std::cout);
-      std::cout << std::endl;
-      _xfm->AddTransform(static_cast<TransformType *>(it.GetPointer()));
-    }
-    std::cout << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-
-    _xfm->Print(std::cout);
-
-    std::cout << "Testing that transformations is expected ..." << std::endl;
-
-    CompositeTransformType::InputPointType  pnt;
-    CompositeTransformType::OutputPointType v, v2;
-
-    pnt[0] = 1.0;
-    pnt[1] = pnt[2] = 0.0;
-    // expected transform: shift by 1 , rotate by 45 deg
-    v2[0] = v[1] = sqrt(2);
-    v2[2] = 0.0;
-
-    v = _xfm->TransformPoint(pnt);
-
-    std::cout << "In:" << pnt << " Out:" << v << std::endl;
-    if ((v - v2).GetSquaredNorm() > tolerance)
-    {
-      std::cerr << "Expected coordinates (" << v << ") doesn't match read-in coordinates (" << v2 << " ) "
-                << " in " << _xfm << " at " << pnt << std::endl;
-      return EXIT_FAILURE;
-    }
-
-
-    std::cout << " Done !" << std::endl;
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while reading the transforms" << std::endl;
-    std::cerr << excp << std::endl;
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << " Done !" << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -225,6 +225,7 @@ check_nonlinear_double(const char * nonlinear_transform)
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Comparing of non linear transform (double) : " << std::endl;
+
   TransformFileReader::TransformListType list = *nlreader->GetTransformList();
   std::cout << "Read :" << list.size() << " transformations" << std::endl;
 
@@ -351,6 +352,7 @@ check_nonlinear_float(const char * nonlinear_transform)
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Comparing of non linear transform : " << std::endl;
+
   TransformFileReaderFloat::TransformListType list = *nlreader->GetTransformList();
   std::cout << "Read :" << list.size() << " transformations" << std::endl;
 

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -59,6 +59,8 @@ RandomPoint(vnl_random & randgen, itk::Point<T, 3> & pix, double _max = itk::Num
 static int
 check_linear(const char * linear_transform)
 {
+  int testStatus = EXIT_SUCCESS;
+
   using AffineTransformType = itk::AffineTransform<double, 3>;
   const double tolerance = 1e-5;
 
@@ -128,21 +130,27 @@ check_linear(const char * linear_transform)
     v1 = affine->TransformPoint(pnt);
     v2 = affine2->TransformPoint(pnt2);
 
-    if ((v1 - v2).GetSquaredNorm() > tolerance)
+    double expectedDiff = 0.0;
+    if (!itk::Math::FloatAlmostEqual(expectedDiff, (v1 - v2).GetSquaredNorm(), 10, tolerance))
     {
-      std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
-                << " in " << linear_transform << " at " << pnt << std::endl;
-      return EXIT_FAILURE;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in pixel value at point ( " << pnt << ")" << std::endl;
+      std::cerr << "Expected value " << v1;
+      std::cerr << " differs from " << v2;
+      std::cerr << " by more than " << tolerance << std::endl;
+      testStatus = EXIT_FAILURE;
     }
   }
   std::cout << " Done !" << std::endl;
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 static int
 check_nonlinear_double(const char * nonlinear_transform)
 {
+  int testStatus = EXIT_SUCCESS;
+
   const double tolerance = 1e-5;
 
   using DisplacementFieldTransform = itk::DisplacementFieldTransform<double, 3>;
@@ -232,10 +240,11 @@ check_nonlinear_double(const char * nonlinear_transform)
     {
       if (it.Value() != it2.Value())
       {
-        std::cout << "Original Pixel (" << it.Value() << ") doesn't match read-in Pixel (" << it2.Value() << " ) "
-                  << std::endl
-                  << " in " << nonlinear_transform << std::endl;
-        return EXIT_FAILURE;
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in pixel value" << std::endl;
+        std::cerr << "Expected value " << it.Value();
+        std::cerr << " differs from " << it2.Value() << std::endl;
+        testStatus = EXIT_FAILURE;
       }
     }
   }
@@ -243,23 +252,28 @@ check_nonlinear_double(const char * nonlinear_transform)
   { // account for rounding errors
     for (it.GoToBegin(), it2.GoToBegin(); !it.IsAtEnd() && !it2.IsAtEnd(); ++it, ++it2)
     {
-      if ((it.Value() - it2.Value()).GetSquaredNorm() > tolerance)
+      double expectedDiff = 0.0;
+      if (!itk::Math::FloatAlmostEqual(expectedDiff, (it.Value() - it2.Value()).GetSquaredNorm(), 10, tolerance))
       {
-        std::cout << "Original Pixel (" << it.Value() << ") doesn't match read-in Pixel (" << it2.Value() << " ) "
-                  << " in " << nonlinear_transform << std::endl;
-        return EXIT_FAILURE;
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in pixel value" << std::endl;
+        std::cerr << "Expected value " << it.Value();
+        std::cerr << " differs from " << it2.Value();
+        std::cerr << " by more than " << tolerance << std::endl;
+        testStatus = EXIT_FAILURE;
       }
     }
   }
 
-
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 
 static int
 check_nonlinear_float(const char * nonlinear_transform)
 {
+  int testStatus = EXIT_SUCCESS;
+
   double tolerance = 1e-5;
 
   using TransformFileWriterFloat = itk::TransformFileWriterTemplate<float>;
@@ -352,10 +366,11 @@ check_nonlinear_float(const char * nonlinear_transform)
     {
       if (it.Value() != it2.Value())
       {
-        std::cout << "Original Pixel (" << it.Value() << ") doesn't match read-in Pixel (" << it2.Value() << " ) "
-                  << std::endl
-                  << " in " << nonlinear_transform << std::endl;
-        return EXIT_FAILURE;
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in pixel value" << std::endl;
+        std::cerr << "Expected value " << it.Value();
+        std::cerr << " differs from " << it2.Value() << std::endl;
+        testStatus = EXIT_FAILURE;
       }
     }
   }
@@ -363,17 +378,20 @@ check_nonlinear_float(const char * nonlinear_transform)
   { // account for rounding errors
     for (it.GoToBegin(), it2.GoToBegin(); !it.IsAtEnd() && !it2.IsAtEnd(); ++it, ++it2)
     {
-      if ((it.Value() - it2.Value()).GetSquaredNorm() > tolerance)
+      double expectedDiff = 0.0;
+      if (!itk::Math::FloatAlmostEqual(expectedDiff, (it.Value() - it2.Value()).GetSquaredNorm(), 10, tolerance))
       {
-        std::cout << "Original Pixel (" << it.Value() << ") doesn't match read-in Pixel (" << it2.Value() << " ) "
-                  << " in " << nonlinear_transform << std::endl;
-        return EXIT_FAILURE;
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in pixel value" << std::endl;
+        std::cerr << "Expected value " << it.Value();
+        std::cerr << " differs from " << it2.Value();
+        std::cerr << " by more than " << tolerance << std::endl;
+        testStatus = EXIT_FAILURE;
       }
     }
   }
 
-
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 static int
@@ -410,6 +428,8 @@ secondTest()
 static int
 check_composite(const char * transform_file)
 {
+  int testStatus = EXIT_SUCCESS;
+
   using AffineTransformType = itk::AffineTransform<double, 3>;
   using CompositeTransformType = itk::CompositeTransform<double, 3>;
 
@@ -486,21 +506,27 @@ check_composite(const char * transform_file)
     v1 = compositeTransform->TransformPoint(pnt);
     v2 = affine_xfm->TransformPoint(pnt2);
 
-    if ((v1 - v2).GetSquaredNorm() > tolerance)
+    double expectedDiff = 0.0;
+    if (!itk::Math::FloatAlmostEqual(expectedDiff, (v1 - v2).GetSquaredNorm(), 10, tolerance))
     {
-      std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
-                << " in " << compositeTransform << " at " << pnt << std::endl;
-      return EXIT_FAILURE;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in pixel value at point ( " << pnt << ")" << std::endl;
+      std::cerr << "Expected value " << v1;
+      std::cerr << " differs from " << v2;
+      std::cerr << " by more than " << tolerance << std::endl;
+      testStatus = EXIT_FAILURE;
     }
   }
   std::cout << " Done !" << std::endl;
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 static int
 check_composite2(const char * transform_file, const char * transform_grid_file)
 {
+  int testStatus = EXIT_SUCCESS;
+
   const double tolerance = 1e-5;
 
   std::filebuf fb;
@@ -606,17 +632,21 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
   v = _xfm->TransformPoint(pnt);
 
   std::cout << "In:" << pnt << " Out:" << v << std::endl;
-  if ((v - v2).GetSquaredNorm() > tolerance)
-  {
-    std::cerr << "Expected coordinates (" << v << ") doesn't match read-in coordinates (" << v2 << " ) "
-              << " in " << _xfm << " at " << pnt << std::endl;
-    return EXIT_FAILURE;
-  }
 
+  double expectedDiff = 0.0;
+  if (!itk::Math::FloatAlmostEqual(expectedDiff, (v - v2).GetSquaredNorm(), 10, tolerance))
+  {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in pixel value at point ( " << pnt << ")" << std::endl;
+    std::cerr << "Expected value " << v2;
+    std::cerr << " differs from " << v;
+    std::cerr << " by more than " << tolerance << std::endl;
+    testStatus = EXIT_FAILURE;
+  }
 
   std::cout << " Done !" << std::endl;
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 


### PR DESCRIPTION
- STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in `IOTransformMINC` test
- STYLE: Prefer using `ITK_TEST_EXPECT_EQUAL` lh and rh comparison macro
- STYLE: Prefer using `itk::Math::FloatAlmostEqual` in comparisons
- STYLE: Add vertical space for readability in `itkIOTransformMINCTest`

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)