### PR TITLE
ENH: Remove ivar memberless `PrintSelf` implementation

### DIFF
--- a/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
@@ -110,11 +110,6 @@ public:
 protected:
   ExtrapolateImageFunction() = default;
   ~ExtrapolateImageFunction() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override
-  {
-    Superclass::PrintSelf(os, indent);
-  }
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -137,11 +137,6 @@ public:
 protected:
   VectorInterpolateImageFunction() = default;
   ~VectorInterpolateImageFunction() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override
-  {
-    Superclass::PrintSelf(os, indent);
-  }
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
@@ -99,11 +99,6 @@ public:
 protected:
   VectorNearestNeighborInterpolateImageFunction() = default;
   ~VectorNearestNeighborInterpolateImageFunction() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override
-  {
-    Superclass::PrintSelf(os, indent);
-  }
 };
 } // end namespace itk
 


### PR DESCRIPTION
Remove `PrintSelf` re-implementations across miscellaneous interpolation/extrapolation image function classes that do not contain instance variable members as their parent class re-implementation prints the necessary information.

Follow-up to d2ff311.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)