### PR TITLE
DOC: Document `itk::Indent` class methods in header file only

### DIFF
--- a/Modules/Core/Common/src/itkIndent.cxx
+++ b/Modules/Core/Common/src/itkIndent.cxx
@@ -34,19 +34,12 @@ namespace itk
 {
 static constexpr char blanks[ITK_NUMBER_OF_BLANKS + 1] = "                                        ";
 
-/**
- * Instance creation.
- */
 Indent *
 Indent::New()
 {
   return new Self;
 }
 
-/**
- * Determine the next indentation level. Keep indenting by two until the
- * max of forty.
- */
 Indent
 Indent::GetNextIndent() const
 {
@@ -59,9 +52,6 @@ Indent::GetNextIndent() const
   return indent;
 }
 
-/**
- * Print out the indentation. Basically output a bunch of spaces.
- */
 std::ostream &
 operator<<(std::ostream & os, const Indent & ind)
 {


### PR DESCRIPTION
Document `itk::Indent` class methods in header file only: Doxygen picks the method documentation from the header files, and leaves the method documentation empty if it does not find it there. So remove the method documentation from the implementation file.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)