### PR TITLE
BUG: ImageRandomIteratorWithIndex should not assign data in constructor

### DIFF
--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -26,12 +26,8 @@ template <typename TImage>
 ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex(const ImageType *  ptr,
                                                                              const RegionType & region)
   : ImageConstIteratorWithIndex<TImage>(ptr, region)
-{
-  m_NumberOfPixelsInRegion = region.GetNumberOfPixels();
-  m_NumberOfSamplesRequested = 0L;
-  m_NumberOfSamplesDone = 0L;
-  m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
-}
+  , m_NumberOfPixelsInRegion{ region.GetNumberOfPixels() }
+{}
 
 template <typename TImage>
 void

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -26,12 +26,8 @@ template <typename TImage>
 ImageRandomConstIteratorWithOnlyIndex<TImage>::ImageRandomConstIteratorWithOnlyIndex(const ImageType *  ptr,
                                                                                      const RegionType & region)
   : ImageConstIteratorWithOnlyIndex<TImage>(ptr, region)
-{
-  m_NumberOfPixelsInRegion = region.GetNumberOfPixels();
-  m_NumberOfSamplesRequested = 0L;
-  m_NumberOfSamplesDone = 0L;
-  m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
-}
+  , m_NumberOfPixelsInRegion{ region.GetNumberOfPixels() }
+{}
 
 template <typename TImage>
 void


### PR DESCRIPTION
The constructors of `ImageRandomConstIteratorWithIndex` and `ImageRandomConstIteratorWithOnlyIndex` that support two arguments (image and region) accidentally still assigned their data members, while they were already initialized by in-class default member initialization. This in-class default member initialization was added as part of pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3929 commit 4e46cb6ef56658353c14bd58e6b28b63c410f1c8 "STYLE: Default default-constructor of ImageRandom ConstIterator classes", merged on February 24, 2023 and included with tag ITK v5.4rc01.

This caused extra `MersenneTwisterRandomVariateGenerator::New()` calls, which changed the seeds of random number generation. These changes can possibly cause regression failures in unit tests of client applications, including elastix.

This commit removes all data member assignments from the bodies of these constructors.

----

The bug was my fault, actually :anguished:, introduced with commit 4e46cb6ef56658353c14bd58e6b28b63c410f1c8

Some background information: Each `MersenneTwisterRandomVariateGenerator::New()` call changes the random seed. Now it would not be a problem to have the very same `MersenneTwisterRandomVariateGenerator::New()` call both inside the class definition (in-class default member initialization) and in the constructor member initializer list:

```
ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex(const ImageType *  ptr,
                                                                             const RegionType & region)
  : ImageConstIteratorWithIndex<TImage>(ptr, region),
  m_Generator(MersenneTwisterRandomVariateGenerator::New()) // member initializer list
{
}

``` 
An initialization in the constructor member initializer list would overrule (supersede) the in-class default member initialization of the same member variable.

However, an assignment to a member variable in the constructor body does not supersede the in-class default member initialization.

```
{
  // Constructor body. Produces an extra MersenneTwisterRandomVariateGenerator::New() call.
  m_Generator = Statistics::MersenneTwisterRandomVariateGenerator::New();
}
```

So that's why `MersenneTwisterRandomVariateGenerator::New()` was called twice, instead of once, when the in-class default member initialization was added.