### PR TITLE
STYLE: Make non-macro comparison conditional blocks consistent in tests

### DIFF
--- a/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
@@ -63,26 +63,30 @@ itkBSplineKernelFunctionTest(int, char *[])
 
 
   // Testing the output of BSplineKernelFunction
-#define TEST_BSPLINE_KERNEL(ORDERNUM)                                                          \
-  {                                                                                            \
-    using FunctionType = itk::BSplineKernelFunction<ORDERNUM>;                                 \
-    auto function = FunctionType::New();                                                       \
-                                                                                               \
-    function->Print(std::cout);                                                                \
-    for (unsigned int j = 0; j < npoints; ++j)                                                 \
-    {                                                                                          \
-      double results = function->Evaluate(x[j]);                                               \
-      /* compare with external results */                                                      \
-      if (itk::Math::abs(results - b##ORDERNUM[j]) > 1e-6)                                     \
-      {                                                                                        \
-        std::cout << "Error with " << ORDERNUM << " order BSplineKernelFunction" << std::endl; \
-        std::cout << "Expected: " << b##ORDERNUM[j] << " but got " << results;                 \
-        std::cout << " at x = " << x[j] << std::endl;                                          \
-        std::cout << "Test failed" << std::endl;                                               \
-        return EXIT_FAILURE;                                                                   \
-      }                                                                                        \
-    }                                                                                          \
-  }                                                                                            \
+#define TEST_BSPLINE_KERNEL(ORDERNUM)                                               \
+  {                                                                                 \
+    using FunctionType = itk::BSplineKernelFunction<ORDERNUM>;                      \
+    auto function = FunctionType::New();                                            \
+                                                                                    \
+    function->Print(std::cout);                                                     \
+    const double epsilon = 1e-6;                                                    \
+    for (unsigned int j = 0; j < npoints; ++j)                                      \
+    {                                                                               \
+      double results = function->Evaluate(x[j]);                                    \
+      /* compare with external results */                                           \
+      if (itk::Math::abs(results - b##ORDERNUM[j]) > epsilon)                       \
+      {                                                                             \
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon)))); \
+        std::cerr << "Test failed!" << std::endl;                                   \
+        std::cerr << "Error with " << ORDERNUM << " order BSplineKernelFunction ";  \
+        std::cerr << "at index [" << j << "] " << std::endl;                        \
+        std::cerr << "Expected value " << b##ORDERNUM[j] << std::endl;              \
+        std::cerr << " differs from " << results;                                   \
+        std::cerr << " by more than " << epsilon << std::endl;                      \
+        return EXIT_FAILURE;                                                        \
+      }                                                                             \
+    }                                                                               \
+  }                                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_BSPLINE_KERNEL(0);
@@ -101,12 +105,15 @@ itkBSplineKernelFunctionTest(int, char *[])
     double expectedValue = 0.0;
     double results = derivFunction->Evaluate(xx);
 
-    if (itk::Math::abs(results - expectedValue) > 1e-6)
+    const double epsilon = 1e-6;
+    if (itk::Math::abs(results - expectedValue) > epsilon)
     {
-      std::cout << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction" << std::endl;
-      std::cout << "Expected: " << expectedValue << " but got " << results;
-      std::cout << " at x = " << xx << std::endl;
-      std::cout << "Test failed" << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction at " << xx << std::endl;
+      std::cerr << "Expected value " << expectedValue << std::endl;
+      std::cerr << " differs from " << results;
+      std::cerr << " by more than " << epsilon << std::endl;
       return EXIT_FAILURE;
     }
   }
@@ -125,12 +132,15 @@ itkBSplineKernelFunctionTest(int, char *[])
       double expectedValue = function->Evaluate(xx + 0.5) - function->Evaluate(xx - 0.5);
       double results = derivFunction->Evaluate(xx);
 
-      if (itk::Math::abs(results - expectedValue) > 1e-6)
+      const double epsilon = 1e-6;
+      if (itk::Math::abs(results - expectedValue) > epsilon)
       {
-        std::cout << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction" << std::endl;
-        std::cout << "Expected: " << expectedValue << " but got " << results;
-        std::cout << " at x = " << xx << std::endl;
-        std::cout << "Test failed" << std::endl;
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction at " << xx << std::endl;
+        std::cerr << "Expected value " << expectedValue << std::endl;
+        std::cerr << " differs from " << results;
+        std::cerr << " by more than " << epsilon << std::endl;
         return EXIT_FAILURE;
       }
     }
@@ -151,12 +161,15 @@ itkBSplineKernelFunctionTest(int, char *[])
       double expectedValue = function->Evaluate(xx + 0.5) - function->Evaluate(xx - 0.5);
       double results = derivFunction->Evaluate(xx);
 
-      if (itk::Math::abs(results - expectedValue) > 1e-6)
+      const double epsilon = 1e-6;
+      if (itk::Math::abs(results - expectedValue) > epsilon)
       {
-        std::cout << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction" << std::endl;
-        std::cout << "Expected: " << expectedValue << " but got " << results;
-        std::cout << " at x = " << xx << std::endl;
-        std::cout << "Test failed" << std::endl;
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction at " << xx << std::endl;
+        std::cerr << "Expected value " << expectedValue << std::endl;
+        std::cerr << " differs from " << results;
+        std::cerr << " by more than " << epsilon << std::endl;
         return EXIT_FAILURE;
       }
     }
@@ -177,12 +190,15 @@ itkBSplineKernelFunctionTest(int, char *[])
       double expectedValue = function->Evaluate(xx + 0.5) - function->Evaluate(xx - 0.5);
       double results = derivFunction->Evaluate(xx);
 
-      if (itk::Math::abs(results - expectedValue) > 1e-6)
+      const double epsilon = 1e-6;
+      if (itk::Math::abs(results - expectedValue) > epsilon)
       {
-        std::cout << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction" << std::endl;
-        std::cout << "Expected: " << expectedValue << " but got " << results;
-        std::cout << " at x = " << xx << std::endl;
-        std::cout << "Test failed" << std::endl;
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error with " << SplineOrder << " order BSplineDerivativeKernelFunction at " << xx << std::endl;
+        std::cerr << "Expected value " << expectedValue << std::endl;
+        std::cerr << " differs from " << results;
+        std::cerr << " by more than " << epsilon << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
@@ -104,9 +104,10 @@ itkGaussianSpatialFunctionTest(int argc, char * argv[])
 
   if (itk::Math::NotAlmostEquals(expectedValueAtMean, computedValueAtMean))
   {
-    std::cout << "Error in point " << point << ": ";
-    std::cout << "expected: " << expectedValueAtMean << ", but got " << computedValueAtMean << std::endl;
-    std::cout << "Test failed" << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Evaluate at point " << point << std::endl;
+    std::cerr << "Expected value " << expectedValueAtMean << std::endl;
+    std::cerr << " differs from " << computedValueAtMean << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -120,12 +120,12 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
     FilterType::SplinePolesVectorType::value_type resultSplinePole = resultSplinePoles[i];
     if (!itk::Math::FloatAlmostEqual(expectedSplinePole, resultSplinePole, 10, tolerance1))
     {
-      std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance1))));
-      std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetSplinePoles() at index: [" << i << ']' << std::endl;
-      std::cout << "Expected: " << expectedSplinePole << std::endl;
-      std::cout << " , but got: " << resultSplinePole << std::endl;
-      std::cout << " Values differ by more than: " << tolerance1 << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance1))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in GetSplinePoles() at index [" << i << ']' << std::endl;
+      std::cerr << "Expected value " << expectedSplinePole << std::endl;
+      std::cerr << " differs from " << resultSplinePole;
+      std::cerr << " by more than " << tolerance1 << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -107,8 +107,10 @@ itkImageSpatialObjectTest(int, char *[])
   std::cout << "ValueAt()...";
   if (itk::Math::NotAlmostEquals(returnedValue, expectedValue))
   {
-    std::cout << "Expected: " << expectedValue << " returned: " << returnedValue << std::endl;
-    std::cout << "[FAILED]: " << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in ValueAt at point " << q << std::endl;
+    std::cerr << "Expected value " << expectedValue << std::endl;
+    std::cerr << " differs from " << returnedValue << std::endl;
     return EXIT_FAILURE;
   }
   else
@@ -143,9 +145,15 @@ itkImageSpatialObjectTest(int, char *[])
 
 
   std::cout << "ValueAt() with interpolator...";
-  if (itk::Math::abs(returnedValue - expectedValue) > 0.001)
+  double epsilon = 0.001;
+  if (itk::Math::abs(returnedValue - expectedValue) > epsilon)
   {
-    std::cout << "Expected: " << expectedValue << " returned: " << returnedValue << std::endl;
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in ValueAt at point " << q << std::endl;
+    std::cerr << "Expected value " << expectedValue << std::endl;
+    std::cerr << " differs from " << returnedValue;
+    std::cerr << " by more than " << epsilon << std::endl;
     return EXIT_FAILURE;
   }
   else
@@ -159,12 +167,17 @@ itkImageSpatialObjectTest(int, char *[])
   expectedDerivative[1] = 10;
   expectedDerivative[2] = 100;
   std::cout << "DerivativeAt() with interpolator ...";
-  if (itk::Math::abs(derivative[0] - expectedDerivative[0]) > 0.00001 ||
-      itk::Math::abs(derivative[1] - expectedDerivative[1]) > 0.00001 ||
-      itk::Math::abs(derivative[2] - expectedDerivative[2]) > 0.00001)
+  epsilon = 0.00001;
+  if (itk::Math::abs(derivative[0] - expectedDerivative[0]) > epsilon ||
+      itk::Math::abs(derivative[1] - expectedDerivative[1]) > epsilon ||
+      itk::Math::abs(derivative[2] - expectedDerivative[2]) > epsilon)
   {
-    std::cout << "Expected: " << derivative << " returned: " << expectedDerivative << std::endl;
-    std::cout << "[FAILED]" << std::endl;
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in ValueAt at point " << q << std::endl;
+    std::cerr << "Expected value " << expectedDerivative << std::endl;
+    std::cerr << " differs from " << derivative;
+    std::cerr << " by more than " << epsilon << std::endl;
     return EXIT_FAILURE;
   }
   else

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -386,9 +386,12 @@ itkEuler2DTransformTest(int, char *[])
     {
       if (itk::Math::abs(parameters3[j] - pdash[j]) > epsilon)
       {
-        std::cout << "Expected: " << parameters3 << std::endl;
-        std::cout << "Got: " << pdash << std::endl;
-        std::cout << " [ FAILED ] " << std::endl;
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in parameters at index [" << j << "]" << std::endl;
+        std::cerr << "Expected value " << parameters3 << std::endl;
+        std::cerr << " differs from " << pdash;
+        std::cerr << " by more than " << epsilon << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -628,9 +628,12 @@ itkSimilarity2DTransformTest(int, char *[])
     {
       if (itk::Math::abs(parameters[j] - pdash[j]) > epsilon)
       {
-        std::cout << "Expected: " << parameters << std::endl;
-        std::cout << "Got: " << pdash << std::endl;
-        std::cout << " [ FAILED ] " << std::endl;
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in parameters at index [" << j << "]" << std::endl;
+        std::cerr << "Expected value " << parameters << std::endl;
+        std::cerr << " differs from " << pdash;
+        std::cerr << " by more than " << epsilon << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -108,8 +108,9 @@ TestDisplacementJacobianDeterminantValue()
   double epsilon = 1e-13;
   if (itk::Math::abs(jacobianDeterminant - expectedJacobianDeterminant) > epsilon)
   {
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in pixel value at index [" << index << ']' << std::endl;
+    std::cerr << "Error in pixel value at index [" << index << "]" << std::endl;
     std::cerr << "Expected value " << jacobianDeterminant << std::endl;
     std::cerr << " differs from " << expectedJacobianDeterminant;
     std::cerr << " by more than " << epsilon << std::endl;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -37,11 +37,14 @@ samePoint(const TPoint & p1, const TPoint & p2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(p1[i], p2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << ']' << std::endl;
-      std::cout << "Expected: "
-                << static_cast<typename itk::NumericTraits<typename TPoint::ValueType>::PrintType>(p1[i])
-                << ", but got: "
-                << static_cast<typename itk::NumericTraits<typename TPoint::ValueType>::PrintType>(p2[i]) << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in point at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value "
+                << static_cast<typename itk::NumericTraits<typename TPoint::ValueType>::PrintType>(p1[i]) << std::endl;
+      std::cerr << " differs from "
+                << static_cast<typename itk::NumericTraits<typename TPoint::ValueType>::PrintType>(p2[i]);
+      std::cerr << " by more than " << epsilon << std::endl;
       pass = false;
     }
   }
@@ -58,11 +61,14 @@ sameVector(const TVector & v1, const TVector & v2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(v1[i], v2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << ']' << std::endl;
-      std::cout << "Expected: "
-                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i])
-                << ", but got: "
-                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v2[i]) << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in vector at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value "
+                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i]) << std::endl;
+      std::cerr << " differs from "
+                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v2[i]);
+      std::cerr << " by more than " << epsilon << std::endl;
       pass = false;
     }
   }
@@ -86,11 +92,14 @@ sameVariableVector(const TVector & v1, const TVector & v2, double epsilon = 1e-8
   {
     if (!itk::Math::FloatAlmostEqual(v1[i], v2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << ']' << std::endl;
-      std::cout << "Expected: "
-                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i])
-                << ", but got: "
-                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v2[i]) << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in variable vector at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value "
+                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v1[i]) << std::endl;
+      std::cerr << " differs from "
+                << static_cast<typename itk::NumericTraits<typename TVector::ValueType>::PrintType>(v2[i]);
+      std::cerr << " by more than " << epsilon << std::endl;
       pass = false;
     }
   }
@@ -107,11 +116,14 @@ sameTensor(const TTensor & t1, const TTensor & t2, double epsilon = 1e-8)
   {
     if (!itk::Math::FloatAlmostEqual(t1[i], t2[i], 10, epsilon))
     {
-      std::cout << "Error at index [" << i << ']' << std::endl;
-      std::cout << "Expected: "
-                << static_cast<typename itk::NumericTraits<typename TTensor::ValueType>::PrintType>(t1[i])
-                << ", but got: "
-                << static_cast<typename itk::NumericTraits<typename TTensor::ValueType>::PrintType>(t2[i]) << std::endl;
+      std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in tensor at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value "
+                << static_cast<typename itk::NumericTraits<typename TTensor::ValueType>::PrintType>(t1[i]) << std::endl;
+      std::cerr << " differs from "
+                << static_cast<typename itk::NumericTraits<typename TTensor::ValueType>::PrintType>(t2[i]);
+      std::cerr << " by more than " << epsilon << std::endl;
       pass = false;
     }
   }
@@ -134,12 +146,16 @@ sameArray2D(const TArray2D & a1, const TArray2D_ARG1 & a2, double epsilon = 1e-8
     {
       if (!itk::Math::FloatAlmostEqual(a1(j, i), a2(j, i), 10, epsilon))
       {
-        std::cout << "Error at index (" << j << ", " << i << ')' << std::endl;
-        std::cout << "Expected: "
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in array at index [" << j << ", " << i << "]" << std::endl;
+        std::cerr << "Expected value "
                   << static_cast<typename itk::NumericTraits<typename TArray2D::element_type>::PrintType>(a1(j, i))
-                  << ", but got: "
-                  << static_cast<typename itk::NumericTraits<typename TArray2D_ARG1::element_type>::PrintType>(a2(j, i))
                   << std::endl;
+        std::cerr << " differs from "
+                  << static_cast<typename itk::NumericTraits<typename TArray2D_ARG1::element_type>::PrintType>(
+                       a2(j, i));
+        std::cerr << " by more than " << epsilon << std::endl;
         pass = false;
       }
     }
@@ -558,15 +574,18 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   {
     if (itk::Math::NotExactlyEquals(params[i], updateTruth[i]))
     {
-      std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in UpdateTransformParameters(...) at index [" << i << ']' << std::endl;
-      std::cout << "Expected: "
-                << static_cast<itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
-                     updateTruth[i])
-                << ", but got: "
-                << static_cast<itk::NumericTraits<DisplacementTransformType::ParametersType::ValueType>::PrintType>(
-                     params[i])
-                << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in UpdateTransformParameters at index [" << i << "]" << std::endl;
+      std::cerr
+        << "Expected value "
+        << static_cast<typename itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
+             updateTruth[i])
+        << std::endl;
+      std::cerr
+        << " differs from "
+        << static_cast<typename itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
+             params[i])
+        << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -170,22 +170,27 @@ itkExpandImageFilterTest(int, char *[])
       ImageType::IndexType inputIndex = input->TransformPhysicalPointToIndex(point);
       double               trueValue = pattern.Evaluate(inputIndex);
 
-      if (itk::Math::abs(trueValue - value) > 1e-4)
+      double epsilon = 1e-4;
+      if (itk::Math::abs(trueValue - value) > epsilon)
       {
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value " << trueValue << std::endl;
+        std::cerr << " differs from " << value << std::endl;
+        std::cerr << " by more than " << epsilon << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << ' ';
-        std::cout << "Expected: " << trueValue << ' ';
-        std::cout << "Actual: " << value << std::endl;
       }
     }
     else
     {
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value " << padValue << std::endl;
+        std::cerr << " differs from " << value << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << ' ';
-        std::cout << "Expected: " << padValue << ' ';
-        std::cout << "Actual: " << value << std::endl;
       }
     }
     ++outIter;
@@ -227,6 +232,10 @@ itkExpandImageFilterTest(int, char *[])
   {
     if (itk::Math::NotExactlyEquals(outIter.Get(), streamIter.Get()))
     {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in streamed output at index [" << outIter.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << outIter.Get() << std::endl;
+      std::cerr << " differs from " << streamIter.Get() << std::endl;
       testPassed = EXIT_FAILURE;
     }
     ++outIter;

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
@@ -232,8 +232,10 @@ itkExpandImageFilterTest2(int, char *[])
   }
   if (!b1)
   {
-    std::cout << "Expected 1D image channel 2: " << DoubleToStringArray(slice1, 10)
-              << "\nActual: " << DoubleToStringArray(sliceOut1, 10) << '\n';
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in 1D image channel 2" << std::endl;
+    std::cerr << "Expected: " << DoubleToStringArray(slice1, 10) << std::endl;
+    std::cerr << " , but got: " << DoubleToStringArray(sliceOut1, 10) << std::endl;
     statusValue = EXIT_FAILURE;
   }
 
@@ -273,8 +275,10 @@ itkExpandImageFilterTest2(int, char *[])
   }
   if (!b2)
   {
-    std::cout << "Expected 3D image size: " << DoubleToStringArray(d3, 3) << '\n'
-              << "Actual:" << DoubleToStringArray(d4, 3) << '\n';
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in 3D image size" << std::endl;
+    std::cerr << "Expected: " << DoubleToStringArray(d3, 3) << std::endl;
+    std::cerr << " , but got: " << DoubleToStringArray(d4, 3) << std::endl;
     statusValue = EXIT_FAILURE;
   }
 
@@ -293,8 +297,10 @@ itkExpandImageFilterTest2(int, char *[])
 
   if (!b3)
   {
-    std::cout << "Expected 3D image (1,0:9,1) Channel 2: " << DoubleToStringArray(slice3, 6)
-              << "\nActual: " << DoubleToStringArray(slice3Out, 6) << '\n';
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in 3D image (1,0:9,1) Channel 2" << std::endl;
+    std::cerr << "Expected: " << DoubleToStringArray(slice3, 6) << std::endl;
+    std::cerr << " , but got: " << DoubleToStringArray(slice3Out, 6) << std::endl;
     statusValue = EXIT_FAILURE;
   }
   return statusValue;

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -307,12 +307,16 @@ itkWarpImageFilterTest(int, char *[])
 
       double trueValue = pattern.Evaluate(outIter.GetIndex(), validSize, clampSize, padValue);
 
-      if (itk::Math::abs(trueValue - value) > 1e-4)
+      double epsilon = 1e-4;
+      if (itk::Math::abs(trueValue - value) > epsilon)
       {
+        std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value " << trueValue << std::endl;
+        std::cerr << " differs from " << value;
+        std::cerr << " by more than " << epsilon << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << ' ';
-        std::cout << "Expected: " << trueValue << ' ';
-        std::cout << "Actual: " << value << std::endl;
       }
     }
     else
@@ -320,10 +324,11 @@ itkWarpImageFilterTest(int, char *[])
 
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value " << padValue << std::endl;
+        std::cerr << " differs from " << value << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << ' ';
-        std::cout << "Expected: " << padValue << ' ';
-        std::cout << "Actual: " << value << std::endl;
       }
     }
     ++outIter;
@@ -363,9 +368,10 @@ itkWarpImageFilterTest(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(outIter.Get(), streamIter.Get()))
     {
-      std::cout << "Error C at Index: " << outIter.GetIndex() << ' ';
-      std::cout << "Expected: " << outIter.Get() << ' ';
-      std::cout << "Actual: " << streamIter.Get() << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in streamed output at index [" << outIter.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << outIter.Get() << std::endl;
+      std::cerr << " differs from " << streamIter.Get() << std::endl;
       testPassed = EXIT_FAILURE;
     }
     ++outIter;

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -131,7 +131,10 @@ itkWarpImageFilterTest2(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(it1.Value(), it2.Value()))
     {
-      std::cout << "Pixels differ " << it1.Value() << ' ' << it2.Value() << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in pixel value at index [" << it1.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << it1.Value() << std::endl;
+      std::cerr << " differs from " << it2.Value();
       return EXIT_FAILURE;
     }
   }
@@ -162,7 +165,10 @@ itkWarpImageFilterTest2(int, char *[])
   {
     if (itk::Math::NotAlmostEquals(streamIt.Value(), it2.Value()))
     {
-      std::cout << "Pixels differ " << streamIt.Value() << ' ' << it2.Value() << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in pixel value at index [" << streamIt.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << it2.Value() << std::endl;
+      std::cerr << " differs from " << streamIt.Value();
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -279,10 +279,11 @@ itkWarpVectorImageFilterTest(int, char *[])
       {
         if (itk::Math::abs(trueValue[k] - value[k]) > 1e-4)
         {
+          std::cerr << "Test failed!" << std::endl;
+          std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+          std::cerr << "Expected value " << trueValue << std::endl;
+          std::cerr << " differs from " << value << std::endl;
           testPassed = false;
-          std::cout << "Error at Index: " << index << ' ';
-          std::cout << "Expected: " << trueValue << ' ';
-          std::cout << "Actual: " << value << std::endl;
           break;
         }
       }
@@ -292,10 +293,11 @@ itkWarpVectorImageFilterTest(int, char *[])
 
       if (value != PixelType(padValue))
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in Evaluate at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value " << padValue << std::endl;
+        std::cerr << " differs from " << value << std::endl;
         testPassed = false;
-        std::cout << "Error at Index: " << index << ' ';
-        std::cout << "Expected: " << padValue << ' ';
-        std::cout << "Actual: " << value << std::endl;
       }
     }
     ++outIter;
@@ -335,6 +337,10 @@ itkWarpVectorImageFilterTest(int, char *[])
   {
     if (outIter.Get() != streamIter.Get())
     {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in streamed output at index [" << outIter.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << outIter.Get() << std::endl;
+      std::cerr << " differs from " << streamIter.Get() << std::endl;
       testPassed = false;
     }
     ++outIter;

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -197,8 +197,11 @@ itkVectorExpandImageFilterTest(int, char *[])
       }
       if (k < VectorDimension)
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in vector dimension at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value less than " << VectorDimension << std::endl;
+        std::cerr << " differs from " << k << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << std::endl;
       }
     }
     else
@@ -213,8 +216,11 @@ itkVectorExpandImageFilterTest(int, char *[])
       }
       if (k < VectorDimension)
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in vector dimension at index [" << index << "]" << std::endl;
+        std::cerr << "Expected value less than " << VectorDimension << std::endl;
+        std::cerr << " differs from " << k << std::endl;
         testPassed = EXIT_FAILURE;
-        std::cout << "Error at Index: " << index << std::endl;
       }
     }
   }
@@ -255,6 +261,10 @@ itkVectorExpandImageFilterTest(int, char *[])
     {
       if (itk::Math::NotExactlyEquals(outIter.Get()[k], streamIter.Get()[k]))
       {
+        std::cerr << "Test failed!" << std::endl;
+        std::cerr << "Error in vector dimension at index [" << k << "]" << std::endl;
+        std::cerr << "Expected value " << outIter.Get()[k] << std::endl;
+        std::cerr << " differs from " << streamIter.Get()[k] << std::endl;
         testPassed = EXIT_FAILURE;
       }
     }

--- a/Modules/Filtering/ImageSources/test/itkGaborKernelFunctionTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborKernelFunctionTest.cxx
@@ -53,11 +53,12 @@ itkGaborKernelFunctionTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   double result = gabor->Evaluate(point);
   if (!itk::Math::FloatAlmostEqual(expectedValue, result, 10, tolerance))
   {
-    std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance))));
-    std::cout << "Error in point " << point << ": ";
-    std::cout << "Expected: " << expectedValue << ", differs from: " << result << std::endl;
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance))));
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Evaluate at point " << point << std::endl;
+    std::cerr << "Expected value " << expectedValue << std::endl;
+    std::cerr << " differs from: " << result;
     std::cerr << " by more than " << tolerance << std::endl;
-    std::cout << "Test failed" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -68,11 +69,12 @@ itkGaborKernelFunctionTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   result = gabor->Evaluate(point);
   if (!itk::Math::FloatAlmostEqual(expectedValue, result, 10, tolerance))
   {
-    std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance))));
-    std::cout << "Error in point " << point << ": ";
-    std::cout << "Expected: " << expectedValue << ", differs from: " << result << std::endl;
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(tolerance))));
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Evaluate at point " << point << std::endl;
+    std::cerr << "Expected value " << expectedValue << std::endl;
+    std::cerr << " differs from " << result << std::endl;
     std::cerr << " by more than " << tolerance << std::endl;
-    std::cout << "Test failed" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -196,9 +196,10 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   {
     if (varReturned[i] != varChanged[i])
     {
-      std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetVariance() at index [" << i << ']' << std::endl;
-      std::cout << "Expected: " << varChanged[i] << ", but got: " << varReturned[i] << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in GetVariance at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value " << varChanged[i] << std::endl;
+      std::cerr << " differs from " << varReturned[i] << std::endl;
       return EXIT_FAILURE;
     }
   }
@@ -215,9 +216,10 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   {
     if (itk::Math::NotAlmostEquals(varReturned[i], itk::Math::pi))
     {
-      std::cout << "Test failed!" << std::endl;
-      std::cout << "Error in GetVariance() at index [" << i << ']' << std::endl;
-      std::cout << "Expected: " << itk::Math::pi << ", but got: " << varReturned[i] << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in GetVariance at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value " << itk::Math::pi << std::endl;
+      std::cerr << " differs from " << varReturned[i] << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
@@ -82,11 +82,12 @@ itkRobustAutomaticThresholdCalculatorTest(int argc, char * argv[])
   CalculatorType::InputPixelType computedOutput = calculator->GetOutput();
   if (itk::Math::NotAlmostEquals(expectedOutput, computedOutput))
   {
-    std::cout << "Test failed!" << std::endl;
-    std::cout << "Error in GetOutput()" << std::endl;
-    std::cout << "Expected: "
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in itk::RobustAutomaticThresholdCalculator::GetOutput" << std::endl;
+    std::cerr << "Expected: "
               << static_cast<itk::NumericTraits<CalculatorType::InputPixelType>::PrintType>(expectedOutput)
-              << ", but got: "
+              << std::endl;
+    std::cerr << ", but got: "
               << static_cast<itk::NumericTraits<CalculatorType::InputPixelType>::PrintType>(computedOutput)
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
@@ -90,11 +90,11 @@ itkRobustAutomaticThresholdImageFilterTest(int argc, char * argv[])
   FilterType::InputPixelType computedThreshold = filter->GetThreshold();
   if (itk::Math::NotAlmostEquals(expectedThreshold, computedThreshold))
   {
-    std::cout << "Test failed!" << std::endl;
-    std::cout << "Error in GetThreshold()" << std::endl;
-    std::cout << "Expected: "
-              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
-              << ", but got: "
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in ik::RobustAutomaticThresholdImageFilter::GetThreshold" << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold) << std::endl;
+    std::cerr << ", but got: "
               << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(computedThreshold) << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -184,11 +184,11 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   if (schedule != pyramid->GetSchedule())
   {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in GetSchedule" << std::endl;
+    std::cerr << "Expected value " << schedule << std::endl;
+    std::cerr << " differs from " << pyramid->GetSchedule() << std::endl;
     pass = false;
-    std::cout << "Schedule should be: " << std::endl;
-    std::cout << schedule << std::endl;
-    std::cout << "instead of: " << std::endl;
-    std::cout << pyramid->GetSchedule();
   }
 
   // set schedule by specifying the starting shrink factors
@@ -216,11 +216,11 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   if (schedule != pyramid->GetSchedule())
   {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in GetSchedule" << std::endl;
+    std::cerr << "Expected value " << schedule << std::endl;
+    std::cerr << " differs from " << pyramid->GetSchedule() << std::endl;
     pass = false;
-    std::cout << "Schedule should be: " << std::endl;
-    std::cout << schedule << std::endl;
-    std::cout << "instead of: " << std::endl;
-    std::cout << pyramid->GetSchedule();
   }
 
   // test start factors
@@ -323,9 +323,10 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   {
     if (!itk::Math::FloatAlmostEqual(iter1.Get(), iter2.Get(), 2))
     {
-      std::cout << "Expected: " << iter1.Get() << " but got: " << iter2.Get() << std::endl;
-      std::cout << "\t@: " << iter1.GetIndex() << std::endl;
-      std::cout << "Streamed output is different!!!" << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in streamed output at index [" << iter1.GetIndex() << "]" << std::endl;
+      std::cerr << "Expected value " << iter1.Get() << std::endl;
+      std::cerr << " differs from " << iter2.Get() << std::endl;
       pass = false;
       // break;
     }

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -721,15 +721,15 @@ itkTemporalProcessObjectTest(int, char *[])
   std::cout << std::endl;
   for (SizeValueType i = 0; i < itk::TemporalProcessObjectTest::m_CallStack.size(); ++i)
   {
-    std::cout << "Got: ";
-    itk::TemporalProcessObjectTest::m_CallStack[i].Print();
-    std::cout << "Expected: ";
-    correctCallStack[i].Print();
-    std::cout << std::endl;
-
     if (itk::TemporalProcessObjectTest::m_CallStack[i] != correctCallStack[i])
     {
-      std::cerr << "Call stacks don't match" << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in call stack at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value ";
+      correctCallStack[i].Print();
+      std::cerr << std::endl;
+      std::cerr << " differs from ";
+      itk::TemporalProcessObjectTest::m_CallStack[i].Print();
       return EXIT_FAILURE;
     }
   }
@@ -757,15 +757,15 @@ itkTemporalProcessObjectTest(int, char *[])
   std::cout << std::endl;
   for (SizeValueType i = 0; i < itk::TemporalProcessObjectTest::m_CallStack.size(); ++i)
   {
-    std::cout << "Got: ";
-    itk::TemporalProcessObjectTest::m_CallStack[i].Print();
-    std::cout << "Expected: ";
-    correctCallStack[i].Print();
-    std::cout << std::endl;
-
     if (itk::TemporalProcessObjectTest::m_CallStack[i] != correctCallStack[i])
     {
-      std::cerr << "Call stacks don't match" << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in call stack at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value ";
+      correctCallStack[i].Print();
+      std::cerr << std::endl;
+      std::cerr << " differs from ";
+      itk::TemporalProcessObjectTest::m_CallStack[i].Print();
       return EXIT_FAILURE;
     }
   }
@@ -792,15 +792,15 @@ itkTemporalProcessObjectTest(int, char *[])
   std::cout << std::endl;
   for (SizeValueType i = 0; i < itk::TemporalProcessObjectTest::m_CallStack.size(); ++i)
   {
-    std::cout << "Got: ";
-    itk::TemporalProcessObjectTest::m_CallStack[i].Print();
-    std::cout << "Expected: ";
-    correctCallStack[i].Print();
-    std::cout << std::endl;
-
     if (itk::TemporalProcessObjectTest::m_CallStack[i] != correctCallStack[i])
     {
-      std::cerr << "Call stacks don't match" << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in call stack at index [" << i << "]" << std::endl;
+      std::cerr << "Expected value ";
+      correctCallStack[i].Print();
+      std::cerr << std::endl;
+      std::cerr << " differs from ";
+      itk::TemporalProcessObjectTest::m_CallStack[i].Print();
       return EXIT_FAILURE;
     }
   }


### PR DESCRIPTION
Make non-macro comparison conditional blocks consistent in tests: adhere to the ITK SWG guidelines:
- Report the messages to `std::cerr`.
- Make the printed messages be consistent.
- Declare and re-use epsilon/tolerance values.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)