### PR TITLE
STYLE: Use macros in `itk::SLICImageFilter` test

### DIFF
--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
@@ -86,18 +86,14 @@ protected:
 } // namespace
 
 
-TEST_F(SLICFixture, SetGetPrint)
+TEST_F(SLICFixture, SetGet)
 {
   using namespace itk::GTest::TypedefsAndConstructors::Dimension3;
   using Utils = FixtureUtilities<3>;
 
   auto filter = Utils::FilterType::New();
-  filter->Print(std::cout);
 
   typename Utils::FilterType::ConstPointer constfilter = (const Utils::FilterType *)(filter.GetPointer());
-
-  EXPECT_STREQ("SLICImageFilter", filter->GetNameOfClass());
-  EXPECT_STREQ("ImageToImageFilter", filter->Superclass::GetNameOfClass());
 
   Utils::FilterType::SuperGridSizeType gridSize3(3);
   EXPECT_NO_THROW(filter->SetSuperGridSize(gridSize3));

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -148,5 +148,6 @@ itkSLICImageFilterTest(int argc, char * argv[])
   }
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -148,5 +148,5 @@ itkSLICImageFilterTest(int argc, char * argv[])
   }
 
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -44,11 +44,11 @@ iterationEventCallback(itk::Object * object, const itk::EventObject & event, voi
 
 
 template <typename TInputImageType>
-void
-itkSLICImageFilter(const std::string & inFileName,
-                   const std::string & outFileName,
-                   const unsigned int  gridSize,
-                   bool                enforceConnectivity)
+int
+itkSLICImageFilterTestHelper(const std::string & inFileName,
+                             const std::string & outFileName,
+                             const unsigned int  gridSize,
+                             bool                enforceConnectivity)
 {
 
   const unsigned int Dimension = TInputImageType::ImageDimension;
@@ -63,6 +63,10 @@ itkSLICImageFilter(const std::string & inFileName,
 
   using FilterType = itk::SLICImageFilter<InputImageType, OutputImageType>;
   auto filter = FilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, SLICImageFilter, ImageToImageFilter);
+
+
   filter->SetInput(reader->GetOutput());
   filter->SetSuperGridSize(gridSize);
   filter->SetEnforceConnectivity(enforceConnectivity);
@@ -80,6 +84,8 @@ itkSLICImageFilter(const std::string & inFileName,
   writer->SetFileName(outFileName);
   writer->SetInput(filter->GetOutput());
   writer->Update();
+
+  return EXIT_SUCCESS;
 }
 } // namespace
 
@@ -117,21 +123,23 @@ itkSLICImageFilterTest(int argc, char * argv[])
     case 2:
       if (numberOfComponents == 1)
       {
-        itkSLICImageFilter<itk::Image<float, 2>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        itkSLICImageFilterTestHelper<itk::Image<float, 2>>(inFileName, outFileName, gridSize, enforceConnectivity);
       }
       else
       {
-        itkSLICImageFilter<itk::VectorImage<float, 2>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        itkSLICImageFilterTestHelper<itk::VectorImage<float, 2>>(
+          inFileName, outFileName, gridSize, enforceConnectivity);
       }
       break;
     case 3:
       if (numberOfComponents == 1)
       {
-        itkSLICImageFilter<itk::Image<float, 3>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        itkSLICImageFilterTestHelper<itk::Image<float, 3>>(inFileName, outFileName, gridSize, enforceConnectivity);
       }
       else
       {
-        itkSLICImageFilter<itk::VectorImage<float, 3>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        itkSLICImageFilterTestHelper<itk::VectorImage<float, 3>>(
+          inFileName, outFileName, gridSize, enforceConnectivity);
       }
       break;
     default:


### PR DESCRIPTION
- STYLE: Prefer using macros for `itk::SLICImageFilter` basic methods
- STYLE: Use standard exit return code in `itk::SLICImagetFilter` test
- STYLE: Conform to ITK SWG style guidelines in test ending message

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)