### PR TITLE
DOC: Fix typo in `itk::Math` function parameter documentation

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -300,7 +300,7 @@ FloatAddULP(T x, typename Detail::FloatIEEE<T>::IntType ulps)
  * to each other.
  *
  * \param x1                    first floating value to compare
- * \param x2                    second floating values to compare
+ * \param x2                    second floating value to compare
  * \param maxUlps               maximum units in the last place to be considered equal
  * \param maxAbsoluteDifference maximum absolute difference to be considered equal
  */


### PR DESCRIPTION
Fix typo in `itk::Math` function parameter documentation: use the singular form instead of plural to refer to the parameter at issue.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)