### PR TITLE
DOC: Improve MINC transform adapter exception message

### DIFF
--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -293,7 +293,7 @@ protected:
   {
     if (VInputDimension != 3 || VOutputDimension != 3)
     {
-      itkExceptionMacro("Sorry, only 3D to 3d minc xfm transform is currently implemented");
+      itkExceptionMacro("MINC transform is currently implemented only for 3D to 3D.");
     }
   }
 


### PR DESCRIPTION
Improve MINC transform adapter exception message:
- Make it more neutral.
- Respect the MINC library case: use uppercases.
- Use "D" (uppercase) instead of "d" (lowercase) to mean "-dimension".
- Do not use "xfm" to refer to "transform" for the sake of clearliness.
- 
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)