### PR TITLE
STYLE: Use macros in tests

### DIFF
--- a/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
@@ -17,6 +17,8 @@
  *=========================================================================*/
 
 #include "itkBSplineDerivativeKernelFunction.h"
+#include "itkTestingMacros.h"
+
 
 /*
  * This test exercises the BSpline kernel function
@@ -192,24 +194,7 @@ itkBSplineKernelFunctionTest(int, char *[])
     using FunctionType = itk::BSplineKernelFunction<7>;
     auto function = FunctionType::New();
 
-    bool pass = false;
-    try
-    {
-      function->Evaluate(0.0);
-    }
-    catch (const itk::ExceptionObject & err)
-    {
-      std::cout << "Caught expected exception" << std::endl;
-      std::cout << err << std::endl;
-      pass = true;
-    }
-
-    if (!pass)
-    {
-      std::cout << "Did not catch expected exception" << std::endl;
-      std::cout << "Test failed" << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_EXCEPTION(function->Evaluate(0.0));
   }
 
   // Testing case of unimplemented spline order
@@ -218,24 +203,7 @@ itkBSplineKernelFunctionTest(int, char *[])
     using FunctionType = itk::BSplineDerivativeKernelFunction<5>;
     auto function = FunctionType::New();
 
-    bool pass = false;
-    try
-    {
-      function->Evaluate(0.0);
-    }
-    catch (const itk::ExceptionObject & err)
-    {
-      std::cout << "Caught expected exception" << std::endl;
-      std::cout << err << std::endl;
-      pass = true;
-    }
-
-    if (!pass)
-    {
-      std::cout << "Did not catch expected exception" << std::endl;
-      std::cout << "Test failed" << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_EXCEPTION(function->Evaluate(0.0));
   }
 
 

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -94,28 +94,15 @@ itkImageSpatialObjectTest(int, char *[])
   q.Fill(15);
 
   std::cout << "Bounding Box = " << imageSO->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
-  std::cout << "IsInside()...";
-  if (imageSO->IsInsideInWorldSpace(r) || !imageSO->IsInsideInWorldSpace(q))
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  ITK_TEST_EXPECT_TRUE(!imageSO->IsInsideInWorldSpace(r));
+  ITK_TEST_EXPECT_TRUE(imageSO->IsInsideInWorldSpace(q));
 
   q.Fill(15.1);
   expectedValue = 555;
 
-  try
-  {
-    imageSO->ValueAtInWorldSpace(q, returnedValue);
-  }
-  catch (const itk::ExceptionObject &)
-  {
-    throw;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(imageSO->ValueAtInWorldSpace(q, returnedValue));
+
 
   std::cout << "ValueAt()...";
   if (itk::Math::NotAlmostEquals(returnedValue, expectedValue))
@@ -140,16 +127,9 @@ itkImageSpatialObjectTest(int, char *[])
   expectedDerivative[1] = expectedPixel;
   expectedPixel = 100;
   expectedDerivative[2] = expectedPixel;
-  std::cout << "DerivativeAt()...";
-  if (derivative != expectedDerivative)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  ITK_TEST_EXPECT_EQUAL(derivative, expectedDerivative);
+
 
   // Now testing the ValueAt() with an interpolator
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType>;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -256,31 +256,10 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   DisplacementFieldType::DirectionType direction = field->GetDirection();
   DisplacementFieldType::SpacingType   spacing = field->GetSpacing();
 
-  if (size != size2)
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Incorrect size from fixed parameters." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (origin != origin2)
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Incorrect origin from fixed parameters." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (spacing != spacing2)
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Incorrect spacing from fixed parameters." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (direction != direction2)
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Incorrect direction from fixed parameters." << std::endl;
-    return EXIT_FAILURE;
-  }
-
+  ITK_TEST_EXPECT_EQUAL(size, size2);
+  ITK_TEST_EXPECT_EQUAL(origin, origin2);
+  ITK_TEST_EXPECT_EQUAL(spacing, spacing2);
+  ITK_TEST_EXPECT_EQUAL(direction, direction2);
 
   // Initialize Affine transform and use it to create the displacement field
   using AffineTransformType = itk::CenteredAffineTransform<ParametersValueType, Dimensions>;

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 // class to produce a linear image pattern
 template <int VDimension>
@@ -80,7 +81,7 @@ itkExpandImageFilterTest(int, char *[])
   };
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  bool testPassed = true;
+  int testPassed = EXIT_SUCCESS;
 
 
   //=============================================================
@@ -171,7 +172,7 @@ itkExpandImageFilterTest(int, char *[])
 
       if (itk::Math::abs(trueValue - value) > 1e-4)
       {
-        testPassed = false;
+        testPassed = EXIT_FAILURE;
         std::cout << "Error at Index: " << index << ' ';
         std::cout << "Expected: " << trueValue << ' ';
         std::cout << "Actual: " << value << std::endl;
@@ -181,7 +182,7 @@ itkExpandImageFilterTest(int, char *[])
     {
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
-        testPassed = false;
+        testPassed = EXIT_FAILURE;
         std::cout << "Error at Index: " << index << ' ';
         std::cout << "Expected: " << padValue << ' ';
         std::cout << "Actual: " << value << std::endl;
@@ -226,64 +227,33 @@ itkExpandImageFilterTest(int, char *[])
   {
     if (itk::Math::NotExactlyEquals(outIter.Get(), streamIter.Get()))
     {
-      testPassed = false;
+      testPassed = EXIT_FAILURE;
     }
     ++outIter;
     ++streamIter;
   }
 
-
-  if (!testPassed)
-  {
-    std::cout << "Test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
-
   // Test error handling
 
-  try
-  {
-    testPassed = false;
-    std::cout << "Setting Input to nullptr" << std::endl;
-    expander->SetInput(nullptr);
-    expander->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << err << std::endl;
-    expander->ResetPipeline();
-    expander->SetInput(input);
-    testPassed = true;
-  }
+  std::cout << "Setting Input to nullptr" << std::endl;
+  expander->SetInput(nullptr);
 
-  if (!testPassed)
-  {
-    std::cout << "Test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_EXCEPTION(expander->Update());
 
 
-  try
-  {
-    testPassed = false;
-    std::cout << "Setting Interpolator to nullptr" << std::endl;
-    expander->SetInterpolator(nullptr);
-    expander->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << err << std::endl;
-    expander->ResetPipeline();
-    expander->SetInterpolator(interpolator);
-    testPassed = true;
-  }
+  expander->ResetPipeline();
+  expander->SetInput(input);
 
-  if (!testPassed)
-  {
-    std::cout << "Test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "Setting Interpolator to nullptr" << std::endl;
+  expander->SetInterpolator(nullptr);
+
+  ITK_TRY_EXPECT_EXCEPTION(expander->Update());
+
+
+  expander->ResetPipeline();
+  expander->SetInterpolator(interpolator);
+
 
   std::cout << "Test passed." << std::endl;
-  return EXIT_SUCCESS;
+  return testPassed;
 }

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
@@ -24,6 +24,7 @@
 #include "itkVectorImage.h"
 #include "itkVariableLengthVector.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkTestingMacros.h"
 
 using PixelType = double;
 using VectorImage1D = itk::VectorImage<PixelType, 1>;
@@ -216,11 +217,8 @@ itkExpandImageFilterTest2(int, char *[])
   std::cout << PrintTestImage1D<VectorImage1D>(output1D) << '\n';
 
   auto s1 = output1D->GetLargestPossibleRegion().GetSize()[0];
-  if (s1 != 10)
-  {
-    std::cout << "Expected 1D image size 10, actual: " << s1;
-    statusValue = EXIT_FAILURE;
-  }
+
+  ITK_TEST_EXPECT_EQUAL(s1, 10);
 
   double                   slice1[10] = { 6, 6, 7, 7, 8, 8, 9, 9, 10, 10 };
   double                   sliceOut1[10] = {};

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -104,7 +104,7 @@ itkWarpImageFilterTest(int, char *[])
   using VectorType = itk::Vector<float, ImageDimension>;
   using FieldType = itk::Image<VectorType, ImageDimension>;
 
-  bool testPassed = true;
+  int testPassed = EXIT_SUCCESS;
 
 
   //=============================================================
@@ -309,7 +309,7 @@ itkWarpImageFilterTest(int, char *[])
 
       if (itk::Math::abs(trueValue - value) > 1e-4)
       {
-        testPassed = false;
+        testPassed = EXIT_FAILURE;
         std::cout << "Error at Index: " << index << ' ';
         std::cout << "Expected: " << trueValue << ' ';
         std::cout << "Actual: " << value << std::endl;
@@ -320,7 +320,7 @@ itkWarpImageFilterTest(int, char *[])
 
       if (itk::Math::NotExactlyEquals(value, padValue))
       {
-        testPassed = false;
+        testPassed = EXIT_FAILURE;
         std::cout << "Error at Index: " << index << ' ';
         std::cout << "Expected: " << padValue << ' ';
         std::cout << "Actual: " << value << std::endl;
@@ -366,45 +366,27 @@ itkWarpImageFilterTest(int, char *[])
       std::cout << "Error C at Index: " << outIter.GetIndex() << ' ';
       std::cout << "Expected: " << outIter.Get() << ' ';
       std::cout << "Actual: " << streamIter.Get() << std::endl;
-      testPassed = false;
+      testPassed = EXIT_FAILURE;
     }
     ++outIter;
     ++streamIter;
   }
 
-
-  if (!testPassed)
-  {
-    std::cout << "Test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
-
   // Exercise error handling
-
 
   using InterpolatorType = WarperType::InterpolatorType;
   InterpolatorType::Pointer interp = warper->GetModifiableInterpolator();
-  try
-  {
-    std::cout << "Setting interpolator to nullptr" << std::endl;
-    testPassed = false;
-    warper->SetInterpolator(nullptr);
-    warper->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << err << std::endl;
-    testPassed = true;
-    warper->ResetPipeline();
-    warper->SetInterpolator(interp);
-  }
 
-  if (!testPassed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "Setting interpolator to nullptr" << std::endl;
+  warper->SetInterpolator(nullptr);
+
+  ITK_TRY_EXPECT_EXCEPTION(warper->Update());
+
+
+  warper->ResetPipeline();
+  warper->SetInterpolator(interp);
+
 
   std::cout << "Test passed." << std::endl;
-  return EXIT_SUCCESS;
+  return testPassed;
 }

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -21,6 +21,7 @@
 
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 using ImageType = itk::Image<float, 3>;
 using DisplacementFieldType = itk::Image<itk::Vector<double, 3>, 3>;
@@ -134,11 +135,9 @@ itkWarpImageFilterTest2(int, char *[])
       return EXIT_FAILURE;
     }
   }
-  if (it1.IsAtEnd() != it2.IsAtEnd())
-  {
-    std::cout << "Iterators don't agree on end of image" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TEST_EXPECT_EQUAL(it1.IsAtEnd(), it2.IsAtEnd());
+
   //
   // try streaming
   auto monitor1 = MonitorFilter::New();
@@ -167,20 +166,14 @@ itkWarpImageFilterTest2(int, char *[])
       return EXIT_FAILURE;
     }
   }
-  if (streamIt.IsAtEnd() != it2.IsAtEnd())
-  {
-    std::cout << "Iterators don't agree on end of image" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TEST_EXPECT_EQUAL(streamIt.IsAtEnd(), it2.IsAtEnd());
+
 
   // this verifies that the pipeline was executed as expected along
   // with correct region propagation and output information
-  if (!monitor2->VerifyAllInputCanStream(4))
-  {
-    std::cout << "Filter failed to execute as expected!" << std::endl;
-    std::cout << monitor2;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_TRUE(monitor2->VerifyAllInputCanStream(4));
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -353,27 +353,16 @@ itkWarpVectorImageFilterTest(int, char *[])
   using InterpolatorType = WarperType::InterpolatorType;
   InterpolatorType::Pointer interp = warper->GetModifiableInterpolator();
 
-  try
-  {
-    std::cout << "Setting interpolator to nullptr" << std::endl;
-    testPassed = false;
-    warper->SetInterpolator(nullptr);
-    warper->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << err << std::endl;
-    testPassed = true;
-    warper->ResetPipeline();
-    warper->SetInterpolator(interp);
-    ITK_TEST_SET_GET_VALUE(interp, warper->GetInterpolator());
-  }
+  std::cout << "Setting interpolator to nullptr" << std::endl;
+  warper->SetInterpolator(nullptr);
 
-  if (!testPassed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_EXCEPTION(warper->Update());
+
+  warper->ResetPipeline();
+  warper->SetInterpolator(interp);
+
+  ITK_TEST_SET_GET_VALUE(interp, warper->GetInterpolator());
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -249,86 +249,40 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
 
   std::cout << "Number of pixels different: " << numPixelsDifferent << std::endl;
 
-  if (numPixelsDifferent > 10)
-  {
-    std::cout << "Test failed - too many pixels different." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_TRUE(numPixelsDifferent <= 10)
 
   std::cout << "Test running registrator without initial deformation field.";
   std::cout << std::endl;
 
-  bool passed = true;
-  try
-  {
-    registrator->SetInput(nullptr);
-    registrator->SetNumberOfIterations(2);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Unexpected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = false;
-  }
+  registrator->SetInput(nullptr);
+  registrator->SetNumberOfIterations(2);
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(registrator->Update());
+
 
   std::cout << "Test exception handling." << std::endl;
 
   std::cout << "Test nullptr moving image. " << std::endl;
-  passed = false;
-  try
-  {
-    registrator->SetInput(initField);
-    registrator->SetMovingImage(nullptr);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  registrator->SetInput(initField);
+  registrator->SetMovingImage(nullptr);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
+
   registrator->SetMovingImage(moving);
   registrator->ResetPipeline();
 
   std::cout << "Test nullptr moving image interpolator. " << std::endl;
-  passed = false;
-  try
-  {
-    fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
-    if (fptr == nullptr)
-    {
-      std::cerr << "dynamic_cast of registrator difference function failed";
-      return EXIT_FAILURE;
-    }
-    fptr->SetMovingImageInterpolator(nullptr);
-    registrator->SetInput(initField);
-    registrator->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected error." << std::endl;
-    std::cout << err << std::endl;
-    passed = true;
-  }
 
-  if (!passed)
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  ITK_TEST_EXPECT_TRUE(fptr)
+
+  fptr->SetMovingImageInterpolator(nullptr);
+  registrator->SetInput(initField);
+
+  ITK_TRY_EXPECT_EXCEPTION(registrator->Update());
+
 
   std::cout << "Test passed" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -19,6 +19,7 @@
 
 #include "itkTemporalProcessObject.h"
 #include "itkTemporalDataObject.h"
+#include "itkTestingMacros.h"
 
 /** Set up dummy implementations of TemporalProcessObject and
  * TemporalDataObject for testing
@@ -595,43 +596,21 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo3->UpdateOutputInformation();
 
   // Check largest possible temporal region after propagation
-  if (tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration() != 18)
-  {
-    std::cerr << "tpo1 largest possible region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameStart() != 1)
-  {
-    std::cerr << "tpo1 largest possible region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo2->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration() != 48)
-  {
-    std::cerr << "tpo2 largest possible region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo2->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameStart() != 1)
-  {
-    std::cerr << "tpo2 largest possible region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  itk::TemporalRegion endLargestPossibleRegion = tpo3->GetOutput()->GetLargestPossibleTemporalRegion();
-  if (endLargestPossibleRegion.GetFrameDuration() != 24)
-  {
-    std::cerr << "tpo3 largest possible region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (endLargestPossibleRegion.GetFrameStart() != 2)
-  {
-    std::cerr << "tpo3 largest possible region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration(), 18);
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameStart(), 1);
+
+  ITK_TEST_EXPECT_EQUAL(tpo2->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration(), 48);
+  ITK_TEST_EXPECT_EQUAL(tpo2->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameStart(), 1);
+
+  ITK_TEST_EXPECT_EQUAL(tpo3->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration(), 24);
+  ITK_TEST_EXPECT_EQUAL(tpo3->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameStart(), 2);
 
   //////
   // Test results of requested region propagation
   //////
 
   // Set up requested region for the end of the pipeline
+  itk::TemporalRegion endLargestPossibleRegion = tpo3->GetOutput()->GetLargestPossibleTemporalRegion();
   itk::TemporalRegion finalRequest;
   finalRequest.SetFrameStart(endLargestPossibleRegion.GetFrameStart());
   finalRequest.SetFrameDuration(1);
@@ -645,46 +624,18 @@ itkTemporalProcessObjectTest(int, char *[])
 
   // for tpo3, the requested input region should be size 3 because tpo2 can
   // only output in groups of 3
-  if (tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameDuration() != 3)
-  {
-    std::cout << tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameDuration() << std::endl;
-    std::cerr << "tpo3 requested region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameStart() != 3)
-  {
-    std::cerr << tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameStart() << std::endl;
-    std::cerr << "tpo3 requested region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameDuration(), 3);
+  ITK_TEST_EXPECT_EQUAL(tpo3->GetInput()->GetRequestedTemporalRegion().GetFrameStart(), 3);
 
   // tpo2 is 3->3, so an initial request of 2 gets enlarged to 3 which results
   // in propagating a request for 3 to tpo1
-  if (tpo2->GetInput()->GetRequestedTemporalRegion().GetFrameDuration() != 3)
-  {
-    std::cerr << "tpo2 requested region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo2->GetInput()->GetRequestedTemporalRegion().GetFrameStart() != 3)
-  {
-    std::cerr << tpo2->GetInput()->GetRequestedTemporalRegion().GetFrameStart() << std::endl;
-    std::cerr << "tpo2 requested region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo2->GetInput()->GetRequestedTemporalRegion().GetFrameDuration(), 3);
+  ITK_TEST_EXPECT_EQUAL(tpo2->GetInput()->GetRequestedTemporalRegion().GetFrameStart(), 3);
 
   // tpo1 is 3->1 and skips 1 frame for each output, so a request for 3
   // requires 5 as input
-  if (tpo1->GetInput()->GetRequestedTemporalRegion().GetFrameDuration() != 5)
-  {
-    std::cerr << "tpo1 requested region duration not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (tpo1->GetInput()->GetRequestedTemporalRegion().GetFrameStart() != 2)
-  {
-    std::cerr << tpo1->GetInput()->GetRequestedTemporalRegion().GetFrameStart() << std::endl;
-    std::cerr << "tpo1 requested region start not correct" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetInput()->GetRequestedTemporalRegion().GetFrameDuration(), 5);
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetInput()->GetRequestedTemporalRegion().GetFrameStart(), 2);
 
   //////
   // Test Generation of data
@@ -764,11 +715,7 @@ itkTemporalProcessObjectTest(int, char *[])
   correctCallStack.emplace_back(3, RecordType::RecordTypeEnum::END_CALL, RecordType::MethodTypeEnum::GENERATE_DATA);
 
   // Check that correct number of calls made
-  if (itk::TemporalProcessObjectTest::m_CallStack.size() != correctCallStack.size())
-  {
-    std::cerr << "Incorrect number of items in call stack" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
 
   // Check that call lists match
   std::cout << std::endl;
@@ -804,12 +751,7 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo3->Update();
 
   // Check that correct number of calls made
-  if (itk::TemporalProcessObjectTest::m_CallStack.size() != correctCallStack.size())
-  {
-    std::cerr << "Incorrect number of items in call stack. Got: " << itk::TemporalProcessObjectTest::m_CallStack.size()
-              << " Expected: " << correctCallStack.size() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
 
   // Check that call lists match
   std::cout << std::endl;
@@ -844,12 +786,7 @@ itkTemporalProcessObjectTest(int, char *[])
   correctCallStack.emplace_back(3, RecordType::RecordTypeEnum::END_CALL, RecordType::MethodTypeEnum::GENERATE_DATA);
 
   // Check that correct number of calls made
-  if (itk::TemporalProcessObjectTest::m_CallStack.size() != correctCallStack.size())
-  {
-    std::cerr << "Incorrect number of items in call stack. Got: " << itk::TemporalProcessObjectTest::m_CallStack.size()
-              << " Expected: " << correctCallStack.size() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
 
   // Check that call lists match
   std::cout << std::endl;
@@ -882,19 +819,12 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo1->UpdateOutputInformation();
 
   // Make sure the requested temporal region of tpo1's output is empty
-  if (tpo1->GetOutput()->GetRequestedTemporalRegion() != emptyRegion)
-  {
-    std::cerr << "tpo1's output's requested temporal region not empty before propagate" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(), emptyRegion)
 
   tpo1->PropagateRequestedRegion(tpo1->GetOutput());
-  if (tpo1->GetOutput()->GetRequestedTemporalRegion() != tpo1->GetOutput()->GetLargestPossibleTemporalRegion() ||
-      tpo1->GetOutput()->GetRequestedTemporalRegion() == emptyRegion)
-  {
-    std::cerr << "tpo1's output's requested temporal region not set correctly after propagate" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(),
+                        tpo1->GetOutput()->GetLargestPossibleTemporalRegion())
+  ITK_TEST_EXPECT_TRUE(!(tpo1->GetOutput()->GetRequestedTemporalRegion() == emptyRegion))
 
   // Test that if largest possible temporal region has infinte duration,
   // request gets set to duration 1
@@ -905,14 +835,10 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo1->SetInput(tdo);
   tpo1->UpdateOutputInformation();
   tpo1->PropagateRequestedRegion(tpo1->GetOutput());
-  if (tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration() != ITK_INFINITE_FRAME_DURATION ||
-      tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration() != 1)
-  {
-    std::cerr << "tpo1's output's temporal regions not properly set for infinite input" << std::endl;
-    std::cerr << "Requested region duration: " << tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration()
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration(),
+                        ITK_INFINITE_FRAME_DURATION)
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration(), 1)
 
   // Test streaming enumeration for CallRecordEnums::RecordType elements
   const std::set<itk::TemporalProcessObjectTest::CallRecordEnums::RecordType> allRecordType{


### PR DESCRIPTION
Use macros in tests:
- Use `ITK_TRY_EXPECT_NO_EXCEPTION` and `ITK_TRY_EXPECT_EXCEPTION` macros in lieu of `try/catch` blocks for the sake of readability and compactness, and to save typing/avoid boilerplate code.
- Use other testing macros as necessary to check for expected values for the sake of readability and compactness, and to save typing/avoid boilerplate code.
- Only place with the macro the code that might raise exceptions.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)