### PR TITLE
ENH: Print `itk::SparseFieldLevelSetImageFilter` superclass

### DIFF
--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -77,7 +77,7 @@ SparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os, In
 {
   using namespace print_helper;
 
-  os << "SparseFieldCityBlockNeighborList: " << std::endl;
+  Suprclass::PrintSelf(os, indent);
 
   os << indent << "Size: " << m_Size << std::endl;
   os << indent << "Radius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_Radius) << std::endl;


### PR DESCRIPTION
Print the superclass in
`itk::SparseFieldLevelSetImageFilter::PrintSelf`.

Remove unnecessary outputstream message.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)