### PR TITLE
ENH: Print the superclass object in miscellaneous classes' `PrintSelf`

### DIFF
--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -77,7 +77,7 @@ SparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os, In
 {
   using namespace print_helper;
 
-  os << "SparseFieldCityBlockNeighborList: " << std::endl;
+  Superclass::PrintSelf(os, indent);
 
   os << indent << "Size: " << m_Size << std::endl;
   os << indent << "Radius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_Radius) << std::endl;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -46,6 +46,8 @@ MRFImageFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Inde
 {
   using namespace print_helper;
 
+  Superclass::PrintSelf(os, indent);
+
   os << indent << "InputImageNeighborhoodRadius: "
      << static_cast<typename NumericTraits<InputImageNeighborhoodRadiusType>::PrintType>(m_InputImageNeighborhoodRadius)
      << std::endl;


### PR DESCRIPTION
Print the superclass object in miscellaneous classes' `PrintSelf` method.

Remove unnecessary outputstream message in
`itk::SparseFieldLevelSetImageFilter::PrintSelf` implementation.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)