### PR TITLE
STYLE: Do not use superclass template parameters in `itk::fem` RTTI

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(SolverCrankNicolson, Solver<TDimension>);
+  itkTypeMacro(SolverCrankNicolson, Solver);
 
   using Float = Element::Float;
 

--- a/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SolverHyperbolic, Solver<TDimension>);
+  itkTypeMacro(SolverHyperbolic, Solver);
 
   using Float = Element::Float;
 


### PR DESCRIPTION
Do not use the superclass template parameters in `itk::fem` classes RTTI macros.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)