### PR TITLE
ENH: Add getter methods to `itk::RGBGibbsPriorFilter` ivars

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -103,8 +103,9 @@ public:
   using InputImageVecType = typename TInputImage::PixelType;
   using IndexType = typename TInputImage::IndexType;
 
-  /** Set the image required for training type classifiers. */
+  /** Set/Get the image required for training type classifiers. */
   itkSetMacro(TrainingImage, TrainingImageType);
+  itkGetConstMacro(TrainingImage, TrainingImageType);
 
   /** Set the labelled image. */
   void
@@ -161,20 +162,25 @@ public:
     return this->m_MaximumNumberOfIterations;
   }
 
-  /** Set the threshold for the object size. */
+  /** Set/Get the threshold for the object size. */
   itkSetMacro(ClusterSize, unsigned int);
+  itkGetConstMacro(ClusterSize, unsigned int);
 
-  /** Set the label for the object region. */
+  /** Set/Get the label for the object region. */
   itkSetMacro(ObjectLabel, LabelType);
+  itkGetConstMacro(ObjectLabel, LabelType);
 
   /** Extract the input image dimension. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   itkSetMacro(StartPoint, IndexType);
+  itkGetConstMacro(StartPoint, IndexType);
 
   itkSetMacro(BoundaryGradient, unsigned int);
+  itkGetConstMacro(BoundaryGradient, unsigned int);
 
   itkSetMacro(ObjectThreshold, double);
+  itkGetConstMacro(ObjectThreshold, double);
 
   /** set and get the value for Clique weights */
   itkSetMacro(CliqueWeight_1, double);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -268,11 +268,25 @@ itkRGBGibbsPriorFilterTest(int, char *[])
   applyGibbsImageFilter->SetNumberOfClasses(NumClasses);
   applyGibbsImageFilter->SetMaximumNumberOfIterations(MaxNumIter);
 
-  //  applyGibbsImageFilter->SetErrorTollerance(0.00);
-  applyGibbsImageFilter->SetClusterSize(10);
-  applyGibbsImageFilter->SetBoundaryGradient(6);
-  applyGibbsImageFilter->SetObjectLabel(1);
-  //  applyGibbsImageFilter->SetRecursiveNumber(1);
+  //  applyGibbsImageFilter->SetErrorTolerance(0.00);
+
+  unsigned int clusterSize = 10;
+  applyGibbsImageFilter->SetClusterSize(clusterSize);
+  ITK_TEST_SET_GET_VALUE(clusterSize, applyGibbsImageFilter->GetClusterSize());
+
+  unsigned int boundaryGradient = 6;
+  applyGibbsImageFilter->SetBoundaryGradient(boundaryGradient);
+  ITK_TEST_SET_GET_VALUE(boundaryGradient, applyGibbsImageFilter->GetBoundaryGradient());
+
+  unsigned int objectLabel = 1;
+  applyGibbsImageFilter->SetObjectLabel(objectLabel);
+  ITK_TEST_SET_GET_VALUE(objectLabel, applyGibbsImageFilter->GetObjectLabel());
+
+  GibbsPriorFilterType::IndexType startPoint{};
+  applyGibbsImageFilter->SetStartPoint(startPoint);
+  ITK_TEST_SET_GET_VALUE(startPoint, applyGibbsImageFilter->GetStartPoint());
+
+  // applyGibbsImageFilter->SetRecursiveNumber(1);
 
   double cliqueWeight1 = 5.0;
   applyGibbsImageFilter->SetCliqueWeight_1(cliqueWeight1);
@@ -301,10 +315,13 @@ itkRGBGibbsPriorFilterTest(int, char *[])
   applyGibbsImageFilter->SetInput(vecImage);
   applyGibbsImageFilter->SetClassifier(myClassifier);
 
-  applyGibbsImageFilter->SetObjectThreshold(5.0);
+  auto objectThreshold = 5.0;
+  applyGibbsImageFilter->SetObjectThreshold(objectThreshold);
+  ITK_TEST_SET_GET_VALUE(objectThreshold, applyGibbsImageFilter->GetObjectThreshold());
 
   // Since a suvervised classifier is used, it requires a training image
   applyGibbsImageFilter->SetTrainingImage(classImage);
+  ITK_TEST_SET_GET_VALUE(classImage, applyGibbsImageFilter->GetTrainingImage());
 
   // Kick off the Gibbs labeller function
   applyGibbsImageFilter->Update();


### PR DESCRIPTION
Add getter methods to `itk::RGBGibbsPriorFilter` ivars. Change the documentation to mention the getter methods. Add the corresponding checks in the filter`s test file.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)