### PR TITLE
ENH: Print the superclass object in `itk::MRFImageFilter::PrintSelf`

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -46,6 +46,8 @@ MRFImageFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Inde
 {
   using namespace print_helper;
 
+  Superclass::PrintSelf(os, indent);
+
   os << indent << "InputImageNeighborhoodRadius: "
      << static_cast<typename NumericTraits<InputImageNeighborhoodRadiusType>::PrintType>(m_InputImageNeighborhoodRadius)
      << std::endl;


### PR DESCRIPTION
Print the superclass object in `itk::MRFImageFilter::PrintSelf` method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)