### PR TITLE
STYLE: Use an unsigned integer to store the number of poles

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
@@ -116,7 +116,7 @@ public:
   itkGetConstMacro(SplinePoles, SplinePolesVectorType);
 
   /** Get the number of poles. */
-  itkGetConstMacro(NumberOfPoles, int);
+  itkGetConstMacro(NumberOfPoles, unsigned int);
 
 
 #ifdef ITK_USE_CONCEPT_CHECKING
@@ -198,7 +198,7 @@ private:
 
   SplinePolesVectorType m_SplinePoles{};
 
-  int m_NumberOfPoles{};
+  unsigned int m_NumberOfPoles{};
 
   /** Tolerance used for determining initial causal coefficient. Default is 1e-10.*/
   double m_Tolerance{ 1e-10 };

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -81,7 +81,7 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoefficients1D
   }
 
   // Compute over all gain
-  for (int k = 0; k < m_NumberOfPoles; ++k)
+  for (unsigned int k = 0; k < m_NumberOfPoles; ++k)
   {
     // Note for cubic splines lambda = 6
     c0 = c0 * (1.0 - m_SplinePoles[k]) * (1.0 - 1.0 / m_SplinePoles[k]);
@@ -94,7 +94,7 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::DataToCoefficients1D
   }
 
   // Loop over all poles
-  for (int k = 0; k < m_NumberOfPoles; ++k)
+  for (unsigned int k = 0; k < m_NumberOfPoles; ++k)
   {
     // Causal initialization
     this->SetInitialCausalCoefficient(m_SplinePoles[k]);

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -110,16 +110,7 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
 
   FilterType::SplinePolesVectorType expectedSplinePoles = ParseSplinePoles<FilterType>(argv[2]);
 
-  int expectedNumberOfPoles = expectedSplinePoles.size();
-  int resultNumberOfPoles = filter->GetNumberOfPoles();
-  if (!itk::Math::ExactlyEquals(expectedNumberOfPoles, resultNumberOfPoles))
-  {
-    std::cout << "Test failed!" << std::endl;
-    std::cout << "Error in GetNumberOfPoles()" << std::endl;
-    std::cout << "Expected: " << expectedNumberOfPoles << std::endl;
-    std::cout << " , but got: " << resultNumberOfPoles << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL(filter->GetNumberOfPoles(), expectedSplinePoles.size());
 
   FilterType::SplinePolesVectorType resultSplinePoles = filter->GetSplinePoles();
   double                            tolerance1 = 1e-10;


### PR DESCRIPTION
Use an unsigned integer instead of a signed to store the number of poles
in `itk::BSplineDecompositionImageFilter`: the number of poles cannot be
negative.

Take advantage of the commit to use `ITK_TEST_EXPECT_EQUAL` in the
corresponding check as an exact comparisons can be performed, ensures
that the lh and rh arguments have the exact same types at compile time,
and since it improves readability, and avoids boilerplate code.

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)