### PR TITLE
ENH: Use `itkPrintSelfObjectMacro` to print smart pointers

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -753,18 +753,10 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os,
   os << indent << "ClusterSize: " << m_ClusterSize << std::endl;
   os << indent << "ObjectLabel: " << m_ObjectLabel << std::endl;
   os << indent << "StartPoint: " << m_StartPoint << std::endl;
-  if (m_TrainingImage)
-  {
-    os << indent << "TraingImage: " << m_TrainingImage;
-  }
-  if (m_LabelledImage)
-  {
-    os << indent << "TrainingImage: " << m_TrainingImage;
-  }
-  if (m_ClassifierPtr)
-  {
-    os << indent << "ClassifierPtr: " << m_ClassifierPtr;
-  }
+
+  itkPrintSelfObjectMacro(TrainingImage);
+  itkPrintSelfObjectMacro(LabelledImage);
+  itkPrintSelfObjectMacro(ClassifierPtr);
 }
 } /* end namespace itk. */
 


### PR DESCRIPTION
Use the `itkPrintSelfObjectMacro` macro to print smart pointers: the macro deals with the situation where such objects can be null. Using the macro also saves typing and avoids boilerplate code.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)