### PR TITLE
COMP: Add missing semicolon to macro statement end in tests

### DIFF
--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -249,7 +249,7 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
 
   std::cout << "Number of pixels different: " << numPixelsDifferent << std::endl;
 
-  ITK_TEST_EXPECT_TRUE(numPixelsDifferent <= 10)
+  ITK_TEST_EXPECT_TRUE(numPixelsDifferent <= 10);
 
   std::cout << "Test running registrator without initial deformation field.";
   std::cout << std::endl;
@@ -276,7 +276,7 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   std::cout << "Test nullptr moving image interpolator. " << std::endl;
 
   fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
-  ITK_TEST_EXPECT_TRUE(fptr)
+  ITK_TEST_EXPECT_TRUE(fptr);
 
   fptr->SetMovingImageInterpolator(nullptr);
   registrator->SetInput(initField);

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -715,7 +715,7 @@ itkTemporalProcessObjectTest(int, char *[])
   correctCallStack.emplace_back(3, RecordType::RecordTypeEnum::END_CALL, RecordType::MethodTypeEnum::GENERATE_DATA);
 
   // Check that correct number of calls made
-  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size());
 
   // Check that call lists match
   std::cout << std::endl;
@@ -751,7 +751,7 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo3->Update();
 
   // Check that correct number of calls made
-  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size());
 
   // Check that call lists match
   std::cout << std::endl;
@@ -786,7 +786,7 @@ itkTemporalProcessObjectTest(int, char *[])
   correctCallStack.emplace_back(3, RecordType::RecordTypeEnum::END_CALL, RecordType::MethodTypeEnum::GENERATE_DATA);
 
   // Check that correct number of calls made
-  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
+  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size());
 
   // Check that call lists match
   std::cout << std::endl;
@@ -819,12 +819,12 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo1->UpdateOutputInformation();
 
   // Make sure the requested temporal region of tpo1's output is empty
-  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(), emptyRegion)
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(), emptyRegion);
 
   tpo1->PropagateRequestedRegion(tpo1->GetOutput());
   ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(),
-                        tpo1->GetOutput()->GetLargestPossibleTemporalRegion())
-  ITK_TEST_EXPECT_TRUE(!(tpo1->GetOutput()->GetRequestedTemporalRegion() == emptyRegion))
+                        tpo1->GetOutput()->GetLargestPossibleTemporalRegion());
+  ITK_TEST_EXPECT_TRUE(!(tpo1->GetOutput()->GetRequestedTemporalRegion() == emptyRegion));
 
   // Test that if largest possible temporal region has infinte duration,
   // request gets set to duration 1
@@ -837,8 +837,8 @@ itkTemporalProcessObjectTest(int, char *[])
   tpo1->PropagateRequestedRegion(tpo1->GetOutput());
 
   ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetLargestPossibleTemporalRegion().GetFrameDuration(),
-                        ITK_INFINITE_FRAME_DURATION)
-  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration(), 1)
+                        ITK_INFINITE_FRAME_DURATION);
+  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration(), 1);
 
   // Test streaming enumeration for CallRecordEnums::RecordType elements
   const std::set<itk::TemporalProcessObjectTest::CallRecordEnums::RecordType> allRecordType{


### PR DESCRIPTION
Add missing semicolon to macro statement end in tests.

Fixes:
```
Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx:252:49:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_TRUE(numPixelsDifferent <= 10)
                                                ^
                                                ;
Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx:279:29:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_TRUE(fptr)
                            ^
                            ;
2 errors generated.
```

and
```
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:718:101:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
                                                                                                    ^
                                                                                                    ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:754:101:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
                                                                                                    ^
                                                                                                    ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:789:101:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_EQUAL(itk::TemporalProcessObjectTest::m_CallStack.size(), correctCallStack.size())
                                                                                                    ^
                                                                                                    ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:822:86:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion(), emptyRegion)
                                                                                     ^
                                                                                     ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:826:79:
error: expected ';' after static_assert
                        tpo1->GetOutput()->GetLargestPossibleTemporalRegion())
                                                                              ^
                                                                              ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:827:90:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_TRUE(!(tpo1->GetOutput()->GetRequestedTemporalRegion() == emptyRegion))
                                                                                         ^
                                                                                         ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:840:53:
error: expected ';' after static_assert
                        ITK_INFINITE_FRAME_DURATION)
                                                    ^
                                                    ;
Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx:841:95:
error: expected ';' after static_assert
  ITK_TEST_EXPECT_EQUAL(tpo1->GetOutput()->GetRequestedTemporalRegion().GetFrameDuration(), 1)
                                                                                              ^
                                                                                              ;
8 errors generated.
```

raised for example in:
https://open.cdash.org/viewBuildError.php?onlydeltap&buildid=8966062

Introduced inadvertently in commit c313059.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)