### PR TITLE
STYLE: Remove unused parameter from `SetGlobalInstance` and `Singleton`

### DIFF
--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -49,7 +49,7 @@
         m_##VarName = nullptr;                                                                      \
       };                                                                                            \
       auto * old_instance = SingletonIndex::GetInstance()->GetGlobalInstance<Type>(#SingletonName); \
-      m_##VarName = Singleton<Type>(#SingletonName, {}, deleteLambda);                              \
+      m_##VarName = Singleton<Type>(#SingletonName, deleteLambda);                                  \
       if (old_instance == nullptr)                                                                  \
       {                                                                                             \
         Init;                                                                                       \

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -130,8 +130,7 @@ auto
 ObjectFactoryBase::GetPimplGlobalsPointer() -> ObjectFactoryBasePrivate *
 {
   const auto                 deleteLambda = []() { m_PimplGlobals->UnRegister(); };
-  ObjectFactoryBasePrivate * globalInstance =
-    Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", SynchronizeObjectFactoryBase, deleteLambda);
+  ObjectFactoryBasePrivate * globalInstance = Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", deleteLambda);
   if (globalInstance != m_PimplGlobals)
   {
     SynchronizeObjectFactoryBase(globalInstance);


### PR DESCRIPTION
Added overloads of `SetGlobalInstance` and `Singleton` without the unused `func` parameter. Let the new `SetGlobalInstance` overload just return `void`, instead of `bool`. Deprecated the original overloads.

Follow-up to:

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4164 commit 6d1c4c7ab7f688bd0a4563bacbe788212a039769
"STYLE: SingletonIndex does not need to store the unused `func` parameter"

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4162 commit 6ec6328ed2383fb474ace88fbd10c3f1be6bfaba
"STYLE: Let `Singleton` assume that SetGlobalInstance always returns true"