### PR TITLE
ENH: Improve warning messages (label numbers as ints instead of chars)

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
@@ -196,12 +196,15 @@ public:
 protected:
   LabelOverlapMeasuresImageFilter();
   ~LabelOverlapMeasuresImageFilter() override = default;
+
+  /** Type to use for printing label values (e.g. in warnings). */
+  using PrintType = typename NumericTraits<LabelType>::PrintType;
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
   BeforeStreamedGenerateData() override;
-
 
   void
   ThreadedStreamedGenerateData(const RegionType &) override;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -174,7 +174,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetTargetOverlap(LabelType label) 
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
 
@@ -225,7 +225,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap(LabelType label) c
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
 
@@ -292,7 +292,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity(LabelType labe
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
   RealType value = 2.0 *
@@ -335,7 +335,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError(LabelType la
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
 
@@ -391,7 +391,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType la
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
 
@@ -446,7 +446,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseDiscoveryRate(LabelType la
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
   {
-    itkWarningMacro("Label " << label << " not found.");
+    itkWarningMacro("Label " << static_cast<PrintType>(label) << " not found.");
     return 0.0;
   }
 


### PR DESCRIPTION
This filter is typically instantiated with unsigned char pixel type, which leads to output which needs deciphering, such as:
```log
WARNING: In C:\P\IPP\ITK-source\ITK\Modules\Filtering\ImageStatistics\include\itkLabelOverlapMeasuresImageFilter.hxx, line 233
LabelOverlapMeasuresImageFilter (000001FF7CF72F80): Label  not found.

WARNING: In C:\P\IPP\ITK-source\ITK\Modules\Filtering\ImageStatistics\include\itkLabelOverlapMeasuresImageFilter.hxx, line 233
LabelOverlapMeasuresImageFilter (000001FF7CF72F80): Label  not found.

WARNING: In C:\P\IPP\ITK-source\ITK\Modules\Filtering\ImageStatistics\include\itkLabelOverlapMeasuresImageFilter.hxx, line 233
LabelOverlapMeasuresImageFilter (000001FF7CF72F80): Label  not found.

WARNING: In C:\P\IPP\ITK-source\ITK\Modules\Filtering\ImageStatistics\include\itkLabelOverlapMeasuresImageFilter.hxx, line 233
LabelOverlapMeasuresImageFilter (000001FF7CF72F80): Label not found.
```
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

