### PR TITLE
BUG: Use `lock_guard<mutex>` in FEMFactoryBase to deal with exception

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
@@ -75,7 +75,7 @@ public:
   {
     if (m_Factory == nullptr)
     {
-      m_CreationLock.lock();
+      const std::lock_guard<std::mutex> lockGuard(m_CreationLock);
       // Need to make sure that during gaining access
       // to the lock that some other thread did not
       // initialize the singleton.
@@ -85,17 +85,11 @@ public:
         auto p = FEMFactoryBase::New();
         if (p.IsNull())
         {
-          std::ostringstream message;
-          message << "itk::ERROR: "
-                  << "FEMFactoryBase"
-                  << " instance not created";
-          itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
-          throw e_; /* Explicit naming to work around for Intel compiler bug. */
+          itkGenericExceptionMacro("FEMFactoryBase instance not created");
         }
         ObjectFactoryBase::RegisterFactory(p);
         m_Factory = p.GetPointer();
       }
-      m_CreationLock.unlock();
       m_Factory->RegisterDefaultTypes(); // Not initialize all default types.
     }
     return m_Factory;


### PR DESCRIPTION
When calling `lock()` and `unlock()` explicitly, throwing an exception between between those two calls would leave the mutex locked, which appears undesirable. Used `std::lock_guard` to solve this problem.

Also replaced manual creation of an exception with an `itkGenericExceptionMacro` call.

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4181 commit a00eb3914d0ab4e4973180f295db56b736aa1ef4
"BUG: Use `lock_guard<mutex>` in FFT configuration to deal with exception"