### PR TITLE
Rename instances of `std::mutex` from "Lock" to "Mutex"

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -324,7 +324,7 @@ private:
   CreateInstance();
 
   // Local lock to enable concurrent access to singleton
-  std::mutex m_InstanceLock{};
+  std::mutex m_InstanceMutex{};
 
   // Static/Global Variable need to be thread-safely accessed
 
@@ -337,7 +337,7 @@ private:
 inline void
 MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
 {
-  const std::lock_guard<std::mutex> mutexHolder(m_InstanceLock);
+  const std::lock_guard<std::mutex> mutexHolder(m_InstanceMutex);
   this->m_Seed = seed;
   // Initialize generator state with seed
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.

--- a/Modules/Core/Common/include/itkPlatformMultiThreader.h
+++ b/Modules/Core/Common/include/itkPlatformMultiThreader.h
@@ -162,7 +162,7 @@ private:
   /** Storage of MutexFunctions and ints used to control spawned
    *  threads and the spawned thread ids. */
   int                         m_SpawnedThreadActiveFlag[ITK_MAX_THREADS]{};
-  std::shared_ptr<std::mutex> m_SpawnedThreadActiveFlagLock[ITK_MAX_THREADS]{};
+  std::shared_ptr<std::mutex> m_SpawnedThreadActiveFlagMutex[ITK_MAX_THREADS]{};
   ThreadProcessIdType         m_SpawnedThreadProcessID[ITK_MAX_THREADS]{};
   WorkUnitInfo                m_SpawnedThreadInfoArray[ITK_MAX_THREADS]{};
 

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -67,7 +67,7 @@ struct MultiThreaderBaseGlobals
   // API is ever used by the developer, the developers choice is
   // respected over the environmental variable.
   bool       GlobalDefaultThreaderTypeIsInitialized{ false };
-  std::mutex globalDefaultInitializerLock;
+  std::mutex globalDefaultInitializerMutex;
 
   // Global value to control which threader to be used by default. First it is initialized with the default preprocessor
   // definition from CMake configuration value, for compile time control of default. This initial value can be
@@ -114,7 +114,7 @@ MultiThreaderBase::GetGlobalDefaultUseThreadPool()
 void
 MultiThreaderBase::SetGlobalDefaultThreaderPrivate(ThreaderEnum threaderType)
 {
-  // m_PimplGlobals->globalDefaultInitializerLock must be already held here!
+  // m_PimplGlobals->globalDefaultInitializerMutex must be already held here!
 
   m_PimplGlobals->m_GlobalDefaultThreader = threaderType;
   m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized = true;
@@ -126,7 +126,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
 
   MultiThreaderBase::SetGlobalDefaultThreaderPrivate(threaderType);
 }
@@ -134,7 +134,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
 MultiThreaderBase::ThreaderEnum
 MultiThreaderBase::GetGlobalDefaultThreaderPrivate()
 {
-  // m_PimplGlobals->globalDefaultInitializerLock must be already held here!
+  // m_PimplGlobals->globalDefaultInitializerMutex must be already held here!
 
   if (!m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized)
   {
@@ -182,7 +182,7 @@ MultiThreaderBase::GetGlobalDefaultThreader()
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
 
   return MultiThreaderBase::GetGlobalDefaultThreaderPrivate();
 }
@@ -233,7 +233,7 @@ MultiThreaderBase::SetGlobalDefaultNumberOfThreads(ThreadIdType val)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
 
   m_PimplGlobals->m_GlobalDefaultNumberOfThreads =
     std::clamp<ThreadIdType>(val, 1, m_PimplGlobals->m_GlobalMaximumNumberOfThreads);
@@ -263,7 +263,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerLock);
+  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
 
   if (m_PimplGlobals->m_GlobalDefaultNumberOfThreads == 0) // need to initialize
   {

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -57,7 +57,7 @@ PlatformMultiThreader::PlatformMultiThreader()
 #endif
 
     m_SpawnedThreadActiveFlag[i] = 0;
-    m_SpawnedThreadActiveFlagLock[i] = nullptr;
+    m_SpawnedThreadActiveFlagMutex[i] = nullptr;
     m_SpawnedThreadInfoArray[i].WorkUnitID = i;
   }
 }

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -109,11 +109,11 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
 
   for (; id < ITK_MAX_THREADS; ++id)
   {
-    if (!m_SpawnedThreadActiveFlagLock[id])
+    if (!m_SpawnedThreadActiveFlagMutex[id])
     {
-      m_SpawnedThreadActiveFlagLock[id] = std::make_shared<std::mutex>();
+      m_SpawnedThreadActiveFlagMutex[id] = std::make_shared<std::mutex>();
     }
-    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagLock[id]);
+    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagMutex[id]);
 
     if (m_SpawnedThreadActiveFlag[id] == 0)
     {
@@ -131,7 +131,7 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
   m_SpawnedThreadInfoArray[id].UserData = UserData;
   m_SpawnedThreadInfoArray[id].NumberOfWorkUnits = 1;
   m_SpawnedThreadInfoArray[id].ActiveFlag = &m_SpawnedThreadActiveFlag[id];
-  m_SpawnedThreadInfoArray[id].ActiveFlagLock = m_SpawnedThreadActiveFlagLock[id];
+  m_SpawnedThreadInfoArray[id].ActiveFlagLock = m_SpawnedThreadActiveFlagMutex[id];
 
   pthread_attr_t attr;
 
@@ -161,13 +161,13 @@ PlatformMultiThreader::TerminateThread(ThreadIdType WorkUnitID)
   }
 
   {
-    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagLock[WorkUnitID]);
+    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagMutex[WorkUnitID]);
     m_SpawnedThreadActiveFlag[WorkUnitID] = 0;
   }
 
   pthread_join(m_SpawnedThreadProcessID[WorkUnitID], nullptr);
 
-  m_SpawnedThreadActiveFlagLock[WorkUnitID] = nullptr;
+  m_SpawnedThreadActiveFlagMutex[WorkUnitID] = nullptr;
 }
 #endif
 

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -104,11 +104,11 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
 
   for (; id < ITK_MAX_THREADS; ++id)
   {
-    if (!m_SpawnedThreadActiveFlagLock[id])
+    if (!m_SpawnedThreadActiveFlagMutex[id])
     {
-      m_SpawnedThreadActiveFlagLock[id] = std::make_shared<std::mutex>();
+      m_SpawnedThreadActiveFlagMutex[id] = std::make_shared<std::mutex>();
     }
-    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagLock[id]);
+    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagMutex[id]);
 
     if (m_SpawnedThreadActiveFlag[id] == 0)
     {
@@ -126,7 +126,7 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
   m_SpawnedThreadInfoArray[id].UserData = UserData;
   m_SpawnedThreadInfoArray[id].NumberOfWorkUnits = 1;
   m_SpawnedThreadInfoArray[id].ActiveFlag = &m_SpawnedThreadActiveFlag[id];
-  m_SpawnedThreadInfoArray[id].ActiveFlagLock = m_SpawnedThreadActiveFlagLock[id];
+  m_SpawnedThreadInfoArray[id].ActiveFlagLock = m_SpawnedThreadActiveFlagMutex[id];
 
   // Using _beginthreadex on a PC
   //
@@ -148,13 +148,13 @@ PlatformMultiThreader::TerminateThread(ThreadIdType WorkUnitID)
   }
 
   {
-    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagLock[WorkUnitID]);
+    const std::lock_guard<std::mutex> lockGuard(*m_SpawnedThreadActiveFlagMutex[WorkUnitID]);
     m_SpawnedThreadActiveFlag[WorkUnitID] = 0;
   }
 
   WaitForSingleObject(m_SpawnedThreadProcessID[WorkUnitID], INFINITE);
   CloseHandle(m_SpawnedThreadProcessID[WorkUnitID]);
-  m_SpawnedThreadActiveFlagLock[WorkUnitID] = nullptr;
+  m_SpawnedThreadActiveFlagMutex[WorkUnitID] = nullptr;
 }
 #endif
 

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -367,7 +367,7 @@ private:
 
   static FFTWGlobalConfigurationGlobals * m_PimplGlobals;
 
-  std::mutex  m_Lock;
+  std::mutex  m_Mutex;
   bool        m_NewWisdomAvailable{ false };
   int         m_PlanRigor{ 0 };
   bool        m_WriteWisdomCache{ false };

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -48,7 +48,7 @@ struct FFTWGlobalConfigurationGlobals
     : m_Instance(nullptr){};
 
   FFTWGlobalConfiguration::Pointer m_Instance;
-  std::mutex                       m_CreationLock;
+  std::mutex                       m_CreationMutex;
 };
 
 WisdomFilenameGeneratorBase::WisdomFilenameGeneratorBase() = default;
@@ -148,7 +148,7 @@ FFTWGlobalConfiguration::GetInstance()
   itkInitGlobalsMacro(PimplGlobals);
   if (!m_PimplGlobals->m_Instance)
   {
-    const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_CreationLock);
+    const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_CreationMutex);
     // Need to make sure that during gaining access
     // to the lock that some other thread did not
     // initialize the singleton.
@@ -734,7 +734,7 @@ FFTWGlobalConfiguration::ExportWisdomFileDouble(const std::string &
 std::mutex &
 FFTWGlobalConfiguration::GetLockMutex()
 {
-  return GetInstance()->m_Lock;
+  return GetInstance()->m_Mutex;
 }
 
 void

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -937,7 +937,7 @@ ImageIOBase::ReadBufferAsASCII(std::istream & is, void * buffer, IOComponentEnum
 
 namespace
 {
-std::mutex                       ioDefaultSplitterLock;
+std::mutex                       ioDefaultSplitterMutex;
 ImageRegionSplitterBase::Pointer ioDefaultSplitter;
 
 } // namespace
@@ -949,7 +949,7 @@ ImageIOBase::GetImageRegionSplitter() const
   {
     // thread safe lazy initialization,  prevent race condition on
     // setting, with an atomic set if null.
-    const std::lock_guard<std::mutex> lock(ioDefaultSplitterLock);
+    const std::lock_guard<std::mutex> lock(ioDefaultSplitterMutex);
     if (ioDefaultSplitter.IsNull())
     {
       ioDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer();

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -26,7 +26,7 @@ namespace itk
 
 namespace
 {
-std::mutex createImageIOLock;
+std::mutex createImageIOMutex;
 }
 
 ImageIOBase::Pointer
@@ -34,7 +34,7 @@ ImageIOFactory::CreateImageIO(const char * path, IOFileModeEnum mode)
 {
   std::list<ImageIOBase::Pointer> possibleImageIO;
 
-  const std::lock_guard<std::mutex> mutexHolder(createImageIOLock);
+  const std::lock_guard<std::mutex> mutexHolder(createImageIOMutex);
 
   for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
   {

--- a/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
@@ -75,7 +75,7 @@ public:
   {
     if (m_Factory == nullptr)
     {
-      const std::lock_guard<std::mutex> lockGuard(m_CreationLock);
+      const std::lock_guard<std::mutex> lockGuard(m_CreationMutex);
       // Need to make sure that during gaining access
       // to the lock that some other thread did not
       // initialize the singleton.
@@ -110,7 +110,7 @@ protected:
   ~FEMFactoryBase() override;
 
 private:
-  static std::mutex       m_CreationLock;
+  static std::mutex       m_CreationMutex;
   static FEMFactoryBase * m_Factory;
 };
 } // end namespace itk

--- a/Modules/Numerics/FEM/src/itkFEMFactoryBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMFactoryBase.cxx
@@ -42,7 +42,7 @@
 namespace itk
 {
 FEMFactoryBase * FEMFactoryBase::m_Factory = nullptr;
-std::mutex       FEMFactoryBase::m_CreationLock;
+std::mutex       FEMFactoryBase::m_CreationMutex;
 
 FEMFactoryBase::FEMFactoryBase() = default;
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -292,7 +292,7 @@ private:
   mutable GPUReduction<float>::Pointer m_GPUSquaredDifference{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -376,7 +376,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Re
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -279,9 +279,9 @@ protected:
    *
    * Thread safety note:
    * A separate object is used locally per each thread. Only the members
-   * m_ParentJointPDFDerivativesLockPtr and m_ParentJointPDFDerivatives
+   * m_ParentJointPDFDerivativesMutexPtr and m_ParentJointPDFDerivatives
    * are shared between threads and access to m_ParentJointPDFDerivatives
-   * is controlled with the m_ParentJointPDFDerivativesLockPtr mutex lock.
+   * is controlled with the m_ParentJointPDFDerivativesMutexPtr mutex lock.
    * \ingroup ITKMetricsv4
    */
   class DerivativeBufferManager
@@ -294,7 +294,7 @@ protected:
     void
     Initialize(size_t                                    maxBufferLength,
                const size_t                              cachedNumberOfLocalParameters,
-               std::mutex *                              parentDerivativeLockPtr,
+               std::mutex *                              parentDerivativeMutexPtr,
                typename JointPDFDerivativesType::Pointer parentJointPDFDerivatives);
 
     void
@@ -354,7 +354,7 @@ protected:
     size_t                       m_CachedNumberOfLocalParameters;
     size_t                       m_MaxBufferSize;
     // Pointer handle to parent version
-    std::mutex * m_ParentJointPDFDerivativesLockPtr;
+    std::mutex * m_ParentJointPDFDerivativesMutexPtr;
     // Smart pointer handle to parent version
     typename JointPDFDerivativesType::Pointer m_ParentJointPDFDerivatives;
   };

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -555,7 +555,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                             TMetricTraits>::DerivativeBufferManager ::
   Initialize(size_t                                    maxBufferLength,
              const size_t                              cachedNumberOfLocalParameters,
-             std::mutex *                              parentDerivativeLockPtr,
+             std::mutex *                              parentDerivativeMutexPtr,
              typename JointPDFDerivativesType::Pointer parentJointPDFDerivatives)
 {
   m_CurrentFillSize = 0;
@@ -564,7 +564,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
   m_BufferOffsetContainer.resize(maxBufferLength, 0);
   m_CachedNumberOfLocalParameters = cachedNumberOfLocalParameters;
   m_MaxBufferSize = maxBufferLength;
-  m_ParentJointPDFDerivativesLockPtr = parentDerivativeLockPtr;
+  m_ParentJointPDFDerivativesMutexPtr = parentDerivativeMutexPtr;
   m_ParentJointPDFDerivatives = parentJointPDFDerivatives;
   // Allocate and initialize to zero (note the () at the end of the new
   // operator)
@@ -614,7 +614,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
   if (m_CurrentFillSize == m_MaxBufferSize)
   {
     // Attempt to acquire the lock once
-    std::unique_lock<std::mutex> FirstTryLockHolder(*this->m_ParentJointPDFDerivativesLockPtr, std::try_to_lock);
+    std::unique_lock<std::mutex> FirstTryLockHolder(*this->m_ParentJointPDFDerivativesMutexPtr, std::try_to_lock);
     if (FirstTryLockHolder.owns_lock())
     {
       ReduceBuffer();
@@ -623,7 +623,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
     {
       DoubleBufferSize();
       // Attempt to acquire the lock a second time
-      std::unique_lock<std::mutex> SecondTryLockHolder(*this->m_ParentJointPDFDerivativesLockPtr, std::try_to_lock);
+      std::unique_lock<std::mutex> SecondTryLockHolder(*this->m_ParentJointPDFDerivativesMutexPtr, std::try_to_lock);
       if (SecondTryLockHolder.owns_lock())
       {
         ReduceBuffer();
@@ -652,7 +652,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
 {
   if (m_CurrentFillSize > 0)
   {
-    const std::lock_guard<std::mutex> LockHolder(*this->m_ParentJointPDFDerivativesLockPtr);
+    const std::lock_guard<std::mutex> LockHolder(*this->m_ParentJointPDFDerivativesMutexPtr);
     ReduceBuffer();
   }
 }

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -258,7 +258,7 @@ private:
   mutable double        m_SumOfSquaredChange{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -237,7 +237,7 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Relea
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -323,7 +323,7 @@ private:
   mutable double        m_SumOfSquaredChange{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -409,7 +409,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Re
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -242,7 +242,7 @@ private:
   mutable double        m_SumOfSquaredChange{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -262,7 +262,7 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -282,7 +282,7 @@ private:
   mutable double        m_SumOfSquaredChange{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 
   bool m_UseImageSpacing{};
 };

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -377,7 +377,7 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -243,7 +243,7 @@ private:
   mutable double        m_SumOfSquaredChange{};
 
   /** Mutex lock to protect modification to metric. */
-  mutable std::mutex m_MetricCalculationLock{};
+  mutable std::mutex m_MetricCalculationMutex{};
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -288,7 +288,7 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
 {
   const std::unique_ptr<const GlobalDataStruct> globalData(static_cast<GlobalDataStruct *>(gd));
 
-  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationLock);
+  const std::lock_guard<std::mutex> lockGuard(m_MetricCalculationMutex);
   m_SumOfSquaredDifference += globalData->m_SumOfSquaredDifference;
   m_NumberOfPixelsProcessed += globalData->m_NumberOfPixelsProcessed;
   m_SumOfSquaredChange += globalData->m_SumOfSquaredChange;


### PR DESCRIPTION
Follow-up to commit d0a853468fac32a87159bd30466695f155db50ec "ENH: using standard library's mutex primitives", Dženan Zukić (@dzenanz), October 31, 2018.