### PR TITLE
STYLE: Code cleanup ImageRandomConstIteratorWith(Only)Index RandomJump()

### DIFF
--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -64,20 +64,15 @@ ImageRandomConstIteratorWithIndex<TImage>::RandomJump()
 {
   using PositionValueType = IndexValueType;
 
-  const PositionValueType randomPosition = static_cast<PositionValueType>(
+  auto position = static_cast<PositionValueType>(
     m_Generator->GetVariateWithOpenRange(static_cast<double>(m_NumberOfPixelsInRegion) - 0.5));
-  /*
-      vnl_sample_uniform(0.0f,
-      static_cast<double>(m_NumberOfPixelsInRegion)-0.5) );
-  */
 
-  PositionValueType position = randomPosition;
-  PositionValueType residual;
+  const SizeType regionSize = this->m_Region.GetSize();
 
   for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
   {
-    const SizeValueType sizeInThisDimension = this->m_Region.GetSize()[dim];
-    residual = position % sizeInThisDimension;
+    const SizeValueType     sizeInThisDimension = regionSize[dim];
+    const PositionValueType residual = position % sizeInThisDimension;
     this->m_PositionIndex[dim] = residual + this->m_BeginIndex[dim];
     position -= residual;
     position /= sizeInThisDimension;

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -63,15 +63,15 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::RandomJump()
 {
   using PositionValueType = IndexValueType;
 
-  const PositionValueType randomPosition = static_cast<PositionValueType>(
+  auto position = static_cast<PositionValueType>(
     m_Generator->GetVariateWithOpenRange(static_cast<double>(m_NumberOfPixelsInRegion) - 0.5));
-  PositionValueType position = randomPosition;
-  PositionValueType residual;
+
+  const SizeType regionSize = this->m_Region.GetSize();
 
   for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
   {
-    const SizeValueType sizeInThisDimension = this->m_Region.GetSize()[dim];
-    residual = position % sizeInThisDimension;
+    const SizeValueType     sizeInThisDimension = regionSize[dim];
+    const PositionValueType residual = position % sizeInThisDimension;
     this->m_PositionIndex[dim] = residual + this->m_BeginIndex[dim];
     position -= residual;
     position /= sizeInThisDimension;


### PR DESCRIPTION
Removed unnecessary local `randomPosition` variables, reduced scope of `residual`, avoided redundant `m_Region.GetSize()` calls, etc.