### PR TITLE
STYLE: Rename local `std::lock_guard` variables "lockGuard"

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -337,7 +337,7 @@ private:
 inline void
 MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
 {
-  const std::lock_guard<std::mutex> mutexHolder(m_InstanceMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_InstanceMutex);
   this->m_Seed = seed;
   // Initialize generator state with seed
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -187,7 +187,7 @@ protected:
   {
     if (m_Process)
     {
-      const std::lock_guard<std::mutex> outputSerializer(m_ProgressOutput);
+      const std::lock_guard<std::mutex> lockGuard(m_ProgressOutput);
       ++m_Steps;
       if (!m_Quiet)
       {

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -70,7 +70,7 @@ MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
 
   if (!m_PimplGlobals->m_StaticInstance)
   {

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -126,7 +126,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->globalDefaultInitializerMutex);
 
   MultiThreaderBase::SetGlobalDefaultThreaderPrivate(threaderType);
 }
@@ -182,7 +182,7 @@ MultiThreaderBase::GetGlobalDefaultThreader()
   itkInitGlobalsMacro(PimplGlobals);
 
   // Acquire mutex then call private method to do the real work.
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->globalDefaultInitializerMutex);
 
   return MultiThreaderBase::GetGlobalDefaultThreaderPrivate();
 }
@@ -233,7 +233,7 @@ MultiThreaderBase::SetGlobalDefaultNumberOfThreads(ThreadIdType val)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->globalDefaultInitializerMutex);
 
   m_PimplGlobals->m_GlobalDefaultNumberOfThreads =
     std::clamp<ThreadIdType>(val, 1, m_PimplGlobals->m_GlobalMaximumNumberOfThreads);
@@ -263,7 +263,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard<std::mutex> lock(m_PimplGlobals->globalDefaultInitializerMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->globalDefaultInitializerMutex);
 
   if (m_PimplGlobals->m_GlobalDefaultNumberOfThreads == 0) // need to initialize
   {

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -96,7 +96,7 @@ OutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 void
 OutputWindow::DisplayText(const char * txt)
 {
-  const std::lock_guard<std::mutex> cerrLock(m_cerrMutex);
+  const std::lock_guard<std::mutex> lockGuard(m_cerrMutex);
   std::cerr << txt;
   if (m_PromptUser)
   {
@@ -117,7 +117,7 @@ OutputWindow::Pointer
 OutputWindow::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
   if (!m_PimplGlobals->m_Instance)
   {
     // Try the factory first
@@ -145,7 +145,7 @@ OutputWindow::SetInstance(OutputWindow * instance)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
-  const std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::recursive_mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
   if (m_PimplGlobals->m_Instance == instance)
   {
     return;

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -234,7 +234,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
       ItE.Set(-displacement);
     }
     {
-      const std::lock_guard<std::mutex> holder(m_Mutex);
+      const std::lock_guard<std::mutex> lockGuard(m_Mutex);
       this->m_MeanErrorNorm += localMean;
       if (this->m_MaxErrorNorm < localMax)
       {

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -183,7 +183,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DynamicThreade
 
     progress.CompletedPixel();
   }
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   m_MaxDistance = std::max(m_MaxDistance, maxDistance);
   m_Sum += sum;
   m_PixelCount += pixelCount;

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -373,7 +373,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ComputeValue(const Inp
 
         PixelRealType                     valNew0 = val0 * val;
         PixelRealType                     valNew1 = val1 * val;
-        const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+        const std::lock_guard<std::mutex> lockGuard(m_Mutex);
         if (itk::Math::abs(static_cast<double>(valNew0)) < itk::Math::abs(static_cast<double>(outNeigIt.GetNext(n, 0))))
         {
           outNeigIt.SetNext(n, 0, static_cast<PixelType>(valNew0));

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -133,7 +133,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -233,7 +233,7 @@ public:
   {
     //
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -335,7 +335,7 @@ public:
            bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -388,7 +388,7 @@ public:
   DestroyPlan(PlanType p)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
 #  endif
     fftwf_destroy_plan(p);
   }
@@ -469,7 +469,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -568,7 +568,7 @@ public:
                bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -670,7 +670,7 @@ public:
            bool          canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -723,7 +723,7 @@ public:
   DestroyPlan(PlanType p)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
 #  endif
     fftw_destroy_plan(p);
   }

--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -65,7 +65,7 @@ public:
   Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -77,7 +77,7 @@ public:
   Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -89,7 +89,7 @@ public:
   Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -101,7 +101,7 @@ public:
   Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -114,7 +114,7 @@ public:
   Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -126,7 +126,7 @@ public:
   Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -138,7 +138,7 @@ public:
   Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -150,7 +150,7 @@ public:
   Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -162,7 +162,7 @@ public:
   Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -201,7 +201,7 @@ public:
   Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -213,7 +213,7 @@ public:
   Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -225,7 +225,7 @@ public:
   Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -237,7 +237,7 @@ public:
   Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -250,7 +250,7 @@ public:
   Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -263,7 +263,7 @@ public:
   Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -276,7 +276,7 @@ public:
   Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -289,7 +289,7 @@ public:
   Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;
@@ -301,7 +301,7 @@ public:
   Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
-    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lock(FFTWGlobalConfiguration::GetLockMutex());
+    const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
 #  else
     (void)threads;

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
@@ -83,7 +83,7 @@ ShiftScaleImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     progress.Completed(outputRegion.GetSize()[0]);
   }
 
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   m_OverflowCount += overflow;
   m_UnderflowCount += underflow;
 }

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -188,7 +188,7 @@ protected:
   void
   LinkLabels(const InternalLabelType label1, const InternalLabelType label2)
   {
-    const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+    const std::lock_guard<std::mutex> lockGuard(m_Mutex);
     InternalLabelType                 E1 = this->LookupSet(label1);
     InternalLabelType                 E2 = this->LookupSet(label2);
 

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
@@ -112,7 +112,7 @@ MinimumMaximumImageFilter<TInputImage>::ThreadedStreamedGenerateData(const Regio
     it.NextLine();
   }
 
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   m_ThreadMin = std::min(localMin, m_ThreadMin);
   m_ThreadMax = std::max(localMax, m_ThreadMax);
 }

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -125,7 +125,7 @@ StatisticsImageFilter<TInputImage>::ThreadedStreamedGenerateData(const RegionTyp
     it.NextLine();
   }
 
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   m_ThreadSum += sum;
   m_SumOfSquares += sumOfSquares;
   m_Count += count;

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -193,7 +193,7 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   }
 
   this->m_NumberOfLabels.fetch_add(nbOfLabels, std::memory_order_relaxed);
-  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(this->m_Mutex);
   this->m_WorkUnitResults.push_back(workUnitData);
 }
 

--- a/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
@@ -136,7 +136,7 @@ ChangeRegionLabelMapFilter<TInputImage>::ThreadedProcessLabelObject(LabelObjectT
   // remove the object if it is empty
   if (labelObject->Empty())
   {
-    const std::lock_guard<std::mutex> mutexHolder(this->m_LabelObjectContainerLock);
+    const std::lock_guard<std::mutex> lockGuard(this->m_LabelObjectContainerLock);
     this->GetOutput()->RemoveLabelObject(labelObject);
   }
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
@@ -89,7 +89,7 @@ LabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const Out
     LabelObjectType * labelObject;
     // begin mutex lock
     {
-      const std::lock_guard<std::mutex> lock(m_LabelObjectContainerLock);
+      const std::lock_guard<std::mutex> lockGuard(m_LabelObjectContainerLock);
 
       if (m_LabelObjectIterator.IsAtEnd())
       {

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -949,7 +949,7 @@ ImageIOBase::GetImageRegionSplitter() const
   {
     // thread safe lazy initialization,  prevent race condition on
     // setting, with an atomic set if null.
-    const std::lock_guard<std::mutex> lock(ioDefaultSplitterMutex);
+    const std::lock_guard<std::mutex> lockGuard(ioDefaultSplitterMutex);
     if (ioDefaultSplitter.IsNull())
     {
       ioDefaultSplitter = ImageRegionSplitterSlowDimension::New().GetPointer();

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -34,7 +34,7 @@ ImageIOFactory::CreateImageIO(const char * path, IOFileModeEnum mode)
 {
   std::list<ImageIOBase::Pointer> possibleImageIO;
 
-  const std::lock_guard<std::mutex> mutexHolder(createImageIOMutex);
+  const std::lock_guard<std::mutex> lockGuard(createImageIOMutex);
 
   for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
   {

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -219,7 +219,7 @@ ImageToHistogramFilter<TImage>::ThreadedComputeMinimumAndMaximum(const RegionTyp
     ++inputIt;
   }
 
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   for (unsigned int i = 0; i < nbOfComponents; ++i)
   {
     m_Minimum[i] = std::min(m_Minimum[i], min[i]);

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -66,7 +66,7 @@ MaskedImageToHistogramFilter<TImage, TMaskImage>::ThreadedComputeMinimumAndMaxim
     ++inputIt;
     ++maskIt;
   }
-  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(this->m_Mutex);
   for (unsigned int i = 0; i < nbOfComponents; ++i)
   {
     this->m_Minimum[i] = std::min(this->m_Minimum[i], min[i]);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -652,7 +652,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
 {
   if (m_CurrentFillSize > 0)
   {
-    const std::lock_guard<std::mutex> LockHolder(*this->m_ParentJointPDFDerivativesMutexPtr);
+    const std::lock_guard<std::mutex> lockGuard(*this->m_ParentJointPDFDerivativesMutexPtr);
     ReduceBuffer();
   }
 }

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -204,7 +204,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::DynamicThr
   }
 
   this->m_NumberOfLabels.fetch_add(nbOfLabels, std::memory_order_relaxed);
-  const std::lock_guard<std::mutex> mutexHolder(this->m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(this->m_Mutex);
   this->m_WorkUnitResults.push_back(workUnitData);
 }
 

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -314,7 +314,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedUpdateCluste
   }
 
   // TODO improve merge algorithm
-  const std::lock_guard<std::mutex> mutexHolder(m_Mutex);
+  const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   m_UpdateClusterPerThread.push_back(clusterMap);
 }
 


### PR DESCRIPTION
For the sake of consistency: ITK already has lot of local `std::lock_guard` variables named "lockGuard".

Using Notepad++, Find in Files (Regular expression), doing:

    Find what:  const std::lock_guard<([^ ]+)>[ ]+\w+\(
    Replace with:  const std::lock_guard<$1> lockGuard\(