### PR TITLE
STYLE: Remove private ObjectFactoryBase member `RegisterInternal()`

### DIFF
--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -226,8 +226,7 @@ public:
     (void)staticFactoryRegistration;
   }
 
-  /** Initialize the static members of ObjectFactoryBase.
-   *  RegisterInternal() and InitializeFactoryList() are called here. */
+  /** Initialize the static members of ObjectFactoryBase. */
   static void
   Initialize();
 
@@ -270,10 +269,6 @@ private:
   itkGetGlobalDeclarationMacro(ObjectFactoryBasePrivate, PimplGlobals);
 
   const std::unique_ptr<OverrideMap> m_OverrideMap;
-
-  /** Register default factories which are not loaded at run time. */
-  static void
-  RegisterInternal();
 
   /** Load dynamic factories from the ITK_AUTOLOAD_PATH */
   static void

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -249,14 +249,9 @@ ObjectFactoryBase::RegisterInternal()
 
   // Guarantee that no internal factories have already been registered.
   itkAssertInDebugAndIgnoreInReleaseMacro(m_PimplGlobals->m_RegisteredFactories.empty());
-  m_PimplGlobals->m_RegisteredFactories.clear();
 
-  // Register all factories registered by the
-  // "RegisterFactoryInternal" method
-  for (auto & internalFactory : m_PimplGlobals->m_InternalFactories)
-  {
-    m_PimplGlobals->m_RegisteredFactories.push_back(internalFactory);
-  }
+  // Register all factories registered by the "RegisterFactoryInternal" method
+  m_PimplGlobals->m_RegisteredFactories = m_PimplGlobals->m_InternalFactories;
 }
 
 /**

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -231,27 +231,16 @@ ObjectFactoryBase::Initialize()
   // Atomically set m_Initialized to true. If it was false before, enter the if.
   if (!m_PimplGlobals->m_Initialized.exchange(true))
   {
-    ObjectFactoryBase::RegisterInternal();
+    // Guarantee that no internal factories have already been registered.
+    itkAssertInDebugAndIgnoreInReleaseMacro(m_PimplGlobals->m_RegisteredFactories.empty());
+
+    // Register all factories registered by the "RegisterFactoryInternal" method
+    m_PimplGlobals->m_RegisteredFactories = m_PimplGlobals->m_InternalFactories;
+
 #if defined(ITK_DYNAMIC_LOADING) && !defined(ITK_WRAPPING)
     ObjectFactoryBase::LoadDynamicFactories();
 #endif
   }
-}
-
-/**
- * Register any factories that are always present in ITK like
- * the OpenGL factory, currently this is not done.
- */
-void
-ObjectFactoryBase::RegisterInternal()
-{
-  itkInitGlobalsMacro(PimplGlobals);
-
-  // Guarantee that no internal factories have already been registered.
-  itkAssertInDebugAndIgnoreInReleaseMacro(m_PimplGlobals->m_RegisteredFactories.empty());
-
-  // Register all factories registered by the "RegisterFactoryInternal" method
-  m_PimplGlobals->m_RegisteredFactories = m_PimplGlobals->m_InternalFactories;
 }
 
 /**


### PR DESCRIPTION
`ObjectFactoryBase::RegisterInternal()` was only called by `Initialize()` anyway.

Avoided a redundant `itkInitGlobalsMacro(PimplGlobals)` call, and replaced `clear` and `push_back` calls by a simple assignment to `m_RegisteredFactories`.
