### PR TITLE
ENH: Make VectorContainer::size_type public, test nested `vector` types

### DIFF
--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -63,32 +63,8 @@ public:
 private:
   /** Quick access to the STL vector type that was inherited. */
   using VectorType = std::vector<Element>;
-  using size_type = typename VectorType::size_type;
   using VectorIterator = typename VectorType::iterator;
   using VectorConstIterator = typename VectorType::const_iterator;
-
-protected:
-  /** Provide pass-through constructors corresponding to all the STL
-   * vector constructors.  These are for internal use only since this is also
-   * an Object which must be constructed through the "New()" routine. */
-  VectorContainer() = default;
-  VectorContainer(size_type n)
-    : Object()
-    , VectorType(n)
-  {}
-  VectorContainer(size_type n, const Element & x)
-    : Object()
-    , VectorType(n, x)
-  {}
-  VectorContainer(const Self & r)
-    : Object()
-    , VectorType(r.CastToSTLConstContainer())
-  {}
-  template <typename TInputIterator>
-  VectorContainer(TInputIterator first, TInputIterator last)
-    : Object()
-    , VectorType(first, last)
-  {}
 
 public:
   /** This type is provided to Adapt this container as an STL container */
@@ -154,8 +130,7 @@ public:
   using typename STLContainerType::const_reference;
   using typename STLContainerType::iterator;
   using typename STLContainerType::const_iterator;
-  // already declared before
-  // using STLContainerType::size_type;
+  using typename STLContainerType::size_type;
   using typename STLContainerType::difference_type;
   using typename STLContainerType::value_type;
   using typename STLContainerType::allocator_type;
@@ -562,6 +537,29 @@ public:
    */
   void
   Initialize();
+
+protected:
+  /** Provide pass-through constructors corresponding to all the STL
+   * vector constructors.  These are for internal use only since this is also
+   * an Object which must be constructed through the "New()" routine. */
+  VectorContainer() = default;
+  VectorContainer(size_type n)
+    : Object()
+    , VectorType(n)
+  {}
+  VectorContainer(size_type n, const Element & x)
+    : Object()
+    , VectorType(n, x)
+  {}
+  VectorContainer(const Self & r)
+    : Object()
+    , VectorType(r.CastToSTLConstContainer())
+  {}
+  template <typename TInputIterator>
+  VectorContainer(TInputIterator first, TInputIterator last)
+    : Object()
+    , VectorType(first, last)
+  {}
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -34,6 +34,44 @@ template class itk::VectorContainer<TestedElementIdentifierType, std::string>;
 
 namespace
 {
+template <typename T1, typename T2>
+constexpr void
+AssertSameType()
+{
+  static_assert(std::is_same_v<T1, T2>);
+}
+
+
+template <typename TElementIdentifier, typename TElement>
+constexpr bool
+AssertVectorContainerHasSamePublicNestedTypesAsStdVector()
+{
+  using VectorContainerType = itk::VectorContainer<TElementIdentifier, TElement>;
+  using StdVectorType = std::vector<TElement>;
+
+  // Check the list of nested types of `std::vector` from section [vector.overview] of the C++ Standard Working Draft of
+  // 2023-05-10, from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf.
+  AssertSameType<typename VectorContainerType::value_type, typename StdVectorType::value_type>();
+  AssertSameType<typename VectorContainerType::allocator_type, typename StdVectorType::allocator_type>();
+  AssertSameType<typename VectorContainerType::pointer, typename StdVectorType::pointer>();
+  AssertSameType<typename VectorContainerType::const_pointer, typename StdVectorType::const_pointer>();
+  AssertSameType<typename VectorContainerType::reference, typename StdVectorType::reference>();
+  AssertSameType<typename VectorContainerType::const_reference, typename StdVectorType::const_reference>();
+  AssertSameType<typename VectorContainerType::size_type, typename StdVectorType::size_type>();
+  AssertSameType<typename VectorContainerType::difference_type, typename StdVectorType::difference_type>();
+  AssertSameType<typename VectorContainerType::iterator, typename StdVectorType::iterator>();
+  AssertSameType<typename VectorContainerType::const_iterator, typename StdVectorType::const_iterator>();
+  AssertSameType<typename VectorContainerType::reverse_iterator, typename StdVectorType::reverse_iterator>();
+  AssertSameType<typename VectorContainerType::const_reverse_iterator,
+                 typename StdVectorType::const_reverse_iterator>();
+  return true;
+}
+
+
+static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<TestedElementIdentifierType, int>());
+static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<TestedElementIdentifierType, bool>());
+
+
 template <typename TElementIdentifier, typename TElement>
 void
 ExpectContainerHasValueOfCreatedElementAtIdentifier(const TElementIdentifier identifier, const TElement value)


### PR DESCRIPTION
Moved the `protected` section to the end of the `VectorContainer` definition, allowing it to use `size_type` from the `public` section.

Tested that all nested types of `std::vector` are directly accessible from `itk::VectorContainer`.