### PR TITLE
STYLE: Replace `std::bind` in ThreadPool::AddWork with lambda expression

### DIFF
--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -89,7 +89,7 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
     using return_type = std::invoke_result_t<Function, Arguments...>;
 
     auto task = std::make_shared<std::packaged_task<return_type()>>(
-      std::bind(std::forward<Function>(function), std::forward<Arguments>(arguments)...));
+      [function, arguments...]() -> return_type { return function(arguments...); });
 
     std::future<return_type> res = task->get_future();
     {


### PR DESCRIPTION
Inspired by pull request https://github.com/SimpleITK/SimpleITK/pull/1994 commit https://github.com/SimpleITK/SimpleITK/commit/0dc078f88fbde2f773a9c09c4ad96f2d772725c6 "Use clang-tidy with modernize-avoid-bind", by Bradley Lowekamp (@blowekamp).