### PR TITLE
ENH: Add `MersenneTwisterRandomVariateGenerator::ResetNextSeed()`

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -160,6 +160,11 @@ public:
   static Pointer
   GetInstance();
 
+  /** Resets the internal data that is used to calculate the next seed. (Does not reset the initial seed.) Allows
+   * generating a reproducible sequence of pseudo-random numbers. */
+  static void
+  ResetNextSeed();
+
   /** Length of state vector */
   static constexpr IntegerType StateVectorLength = 624;
 

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -81,6 +81,16 @@ MersenneTwisterRandomVariateGenerator::GetInstance()
   return m_PimplGlobals->m_StaticInstance;
 }
 
+
+void
+MersenneTwisterRandomVariateGenerator::ResetNextSeed()
+{
+  itkInitGlobalsMacro(PimplGlobals);
+  const std::lock_guard<std::recursive_mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
+  m_PimplGlobals->m_StaticDiffer = 0;
+}
+
+
 MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
 {
   SetSeed(121212);

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
@@ -59,3 +59,18 @@ TEST(MersenneTwisterRandomVariateGenerator, GetIntegerVariateReturnsSameAsStdMt1
     EXPECT_EQ(generator->GetIntegerVariate(), stdMt19937());
   }
 }
+
+
+TEST(MersenneTwisterRandomVariateGenerator, ResetNextSeed)
+{
+  using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
+
+  const auto globalGenerator = GeneratorType::GetInstance();
+  ASSERT_NE(globalGenerator, nullptr);
+
+  GeneratorType::ResetNextSeed();
+  const auto nextSeed = globalGenerator->GetNextSeed();
+
+  GeneratorType::ResetNextSeed();
+  EXPECT_EQ(globalGenerator->GetNextSeed(), nextSeed);
+}


### PR DESCRIPTION
Allows generating a reproducible sequence of pseudo-random numbers.

----

FYI, I would like to use this member function to write reproducible unit tests for elastix Random Sampler, which internally uses ITK's `ImageRandomConstIteratorWithIndex`. The problem is that `ImageRandomConstIteratorWithIndex` creates a new MersenneTwisterRandomVariateGenerator, and each `MersenneTwisterRandomVariateGenerator::New()` "get the next seed", by calling `GetNextSeed()`: https://github.com/InsightSoftwareConsortium/ITK/blob/75b99671a89a9ef6ba1ad8fda62ba3843ad61b54/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx#L65
The proposed `ResetNextSeed()` would allow multiple `MersenneTwisterRandomVariateGenerator` objects (created by `New()`) to generate the very same sequence of numbers.