### PR TITLE
DOC: Fix Doxygen class names

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-/** \class itkTreeIteratorClone
+/** \class TreeIteratorClone
  *  \brief itkTreeIteratorClone class
  *  \ingroup DataRepresentation
  *  \ingroup ITKDeprecated

--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -43,7 +43,7 @@ public:
 extern ITKCommon_EXPORT std::ostream &
                         operator<<(std::ostream & out, const FloatingPointExceptionsEnums::ExceptionAction value);
 
-/** \class itkFloatingPointExceptions
+/** \class FloatingPointExceptions
  *  \brief Allows floating point exceptions to be caught during program execution.
  *
  * Allows floating point exceptions to be caught during program execution.

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
@@ -24,7 +24,7 @@
 namespace itk
 {
 /**
- * \class QuadEdgeMeshScalarDataVTKPolyData
+ * \class QuadEdgeMeshScalarDataVTKPolyDataWriter
  *
  * \brief This class saves a QuadMesh into a VTK-legacy file format,
  *        including its scalar data associated with points.

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -55,7 +55,7 @@ public:
 // Define how to print enumeration
 extern ITKTransform_EXPORT std::ostream &
                            operator<<(std::ostream & out, const TransformBaseTemplateEnums::TransformCategory value);
-/** \class itkTransformBaseTemplate
+/** \class TransformBaseTemplate
  *
  * This class is an abstract class to represent a spatial transform.
  *

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
@@ -33,7 +33,7 @@
 
 namespace itk
 {
-/** \class itkBSplineCenteredL2ResampleImageFilterBase
+/** \class BSplineCenteredL2ResampleImageFilterBase
  * \brief Uses the "Centered L2" B-Spline pyramid implementation of B-Spline Filters
  *        to up/down sample an image by a factor of 2.
  *

--- a/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
@@ -27,7 +27,7 @@ namespace itk
 namespace fem
 {
 /**
- * \class itkFEMLoadNoisyLandmark
+ * \class FEMLoadNoisyLandmark
  * \brief This landmark is derived from the motion of a specific landmark, but
  * allows the existence of noise or outliers
  *


### PR DESCRIPTION
- DOC: Remove `itk` prefix to class names in Doxygen `class` command
- DOC: Fix `QuadEdgeMeshScalarDataVTKPolyDataWriter` Doxygen `class` name

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)
