### PR TITLE
ENH: Add RTTI to `itk::FEMScatteredDataPointSetToImageFilter`

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
@@ -142,6 +142,9 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(FEMScatteredDataPointSetToImageFilter, PointSetToImageFilter);
+
   /** Extract dimension from the output image. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 


### PR DESCRIPTION
Add run-time type information to
`itk::FEMScatteredDataPointSetToImageFilter`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)