### PR TITLE
Fix XML namespace of Natvis file, exclude Utilities/Debugger from CI

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -11,6 +11,7 @@ trigger:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 pr:
@@ -20,6 +21,7 @@ pr:
     - LICENSE
     - NOTICE
     - Documentation/*
+    - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
 variables:

--- a/Utilities/Debugger/ITK.natvis
+++ b/Utilities/Debugger/ITK.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Documentation: https://msdn.microsoft.com/en-us/library/jj620914.aspx?f=255&MSPPError=-2147217396 -->
 <!-- e.g. copy into C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Packages\Debugger\Visualizers\ITK.natvis -->
-<AutoVisualizer xmlns="https://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 
   <Type Name="itk::Size&lt;1&gt;">
     <DisplayString>[{m_InternalArray[0]}]</DisplayString>

--- a/Utilities/Debugger/default.natstepfilter
+++ b/Utilities/Debugger/default.natstepfilter
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copy into C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Packages\Debugger\Visualizers\default.natstepfilter -->
-<StepFilter xmlns="https://schemas.microsoft.com/vstudio/debugger/natstepfilter/2010">
+<StepFilter xmlns="http://schemas.microsoft.com/vstudio/debugger/natstepfilter/2010">
   <Function><Name>__security_check_cookie</Name><Action>NoStepInto</Action></Function>
   <Function><Name>__abi_winrt_.*</Name><Action>NoStepInto</Action></Function>
   <Function><Name>_ObjectStublessClient.*</Name><Action>NoStepInto</Action></Function>


### PR DESCRIPTION
The ITK Debug Visualizers for Visual Studio do not seem to work when the XML namespace name starts with "https" (rather than just "http"). This was found by setting the option "Natvis diagnostic messages" to "Verbose", in either Visual Studio 2019 (version 16.11.31) or Visual Studio 2022 (version 17.7.6). It says:

> ITK.natvis(4,2): Fatal error: Expected element with namespace 'http://schemas.microsoft.com/vstudio/debugger/natvis/2010'.

Reverts the change of this particular file from pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3428 commit 9cd0f2053f0cf181ec4412bf896301faf0cc2092 "ENH: Use https instead of http when https works", May 18, 2022.

-- With help from colleagues of mine at LKEB, Leiden University Medical Center.

Also excluded changes in "Utilities/Debugger" (like the proposed one in "ITK.natvis") from triggering the CI.


