### PR TITLE
STYLE: Increase `itk::ListSample::PrintSelf` consistency

### DIFF
--- a/Modules/Numerics/Statistics/include/itkListSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkListSample.hxx
@@ -134,8 +134,7 @@ ListSample<TMeasurementVector>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Internal Data Container: " << &m_InternalContainer << std::endl;
-  os << indent << "Number of samples: " << this->m_InternalContainer.size() << std::endl;
+  os << indent << "InternalContainer: " << &m_InternalContainer << std::endl;
 }
 } // end of namespace Statistics
 } // end of namespace itk


### PR DESCRIPTION
Make `itk::ListSample::PrintSelf` implementation style consistent following the ITK SWG coding style guideline and the available ITK macros:
- Print only the class instance variables.
- Use the `os << indent << "{ivarName}: " << m_ivarName << std::endl` recipe.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)