### PR TITLE
STYLE: Prefer using testing macros in miscellaneous tests

### DIFF
--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
@@ -45,16 +45,8 @@ itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown while reading the input file " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   MeshType::Pointer mesh = reader->GetOutput();
 

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -180,19 +180,8 @@ itkAutoScaledGradientDescentRegistrationTestTemplated(int         numberOfIterat
   std::cout << "GetDoEstimateLearningRateAtEachIteration: " << optimizer->GetDoEstimateLearningRateAtEachIteration()
             << std::endl;
 
-  try
-  {
-    optimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cout << "Exception thrown ! " << std::endl;
-    std::cout << "An error occurred during Optimization:" << std::endl;
-    std::cout << e.GetLocation() << std::endl;
-    std::cout << e.GetDescription() << std::endl;
-    std::cout << e.what() << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(optimizer->StartOptimization());
+
 
   std::cout << "...finished. " << std::endl
             << "StopCondition: " << optimizer->GetStopConditionDescription() << std::endl

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
@@ -175,13 +175,9 @@ itkGradientDescentOptimizerBasev4Test(int, char *[])
 
   /* exercise some methods */
   optimizer->SetMetric(metric);
-  if (optimizer->GetMetric() != metric)
-  {
-    std::cerr << "Set/GetMetric failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_SET_GET_VALUE(metric, optimizer->GetMetric());
 
-  std::cout << "value: " << optimizer->GetCurrentMetricValue() << std::endl;
+  ITK_TEST_SET_GET_VALUE(0.0, optimizer->GetCurrentMetricValue());
 
   optimizer->SetNumberOfWorkUnits(2);
 


### PR DESCRIPTION
Prefer using testing macros in miscellaneous tests:
- Use the `ITK_TRY_EXPECT_EXCEPTION` macro in lieu of `try/catch` blocks to check for expected exceptions for the sake of readability and compactness, and to save typing/avoid boilerplate code.
- Use the `ITK_TEST_SET_GET_VALUE``macro to check for expected values for the sake of readability and compactness, and to save typing/avoid boilerplate code. Take advantage of the commit to make testing the getter methods quantitative by checking their return value.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
