### PR TITLE
ENH: Add `get()` member function to itk::SmartPointer

### DIFF
--- a/Modules/Core/Common/include/itkSmartPointer.h
+++ b/Modules/Core/Common/include/itkSmartPointer.h
@@ -134,6 +134,15 @@ public:
     return m_Pointer;
   }
 
+  /** Returns the stored (raw) pointer. Equivalent to `GetPointer()`, but then following the Standard C++ Library naming
+   * conversion (like `std::shared_ptr::get()`). */
+  ObjectType *
+  get() const noexcept
+  {
+    return m_Pointer;
+  }
+
+
   /** Overload operator assignment.
    *
    * This method is also implicitly used for move semantics.

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -357,3 +357,15 @@ TEST(SmartPointer, ConvertingRegisterCount)
     EXPECT_TRUE(d1ptr.IsNull());
   }
 }
+
+
+// Tests that `smartPointer.get()` is equivalent to `smartPointer.GetPointer()`.
+TEST(SmartPointer, GetIsEquivalentToGetPointer)
+{
+  const auto check = [](auto && smartPointer) { EXPECT_EQ(smartPointer.get(), smartPointer.GetPointer()); };
+
+  check(itk::Object::New());
+  check(itk::Object::Pointer{});
+  check(itk::Object::ConstPointer{});
+  check(itk::SmartPointer<itk::Object>{});
+}


### PR DESCRIPTION
Eases code that uses both `itk` and `std` smart pointers. Also serves as a convenient shorter alternative to the somewhat lengthy "GetPointer()".