### PR TITLE
STYLE: ResetNextSeed GTest should not use instance for GetNextSeed call

### DIFF
--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
@@ -64,14 +64,16 @@ TEST(MersenneTwisterRandomVariateGenerator, GetIntegerVariateReturnsSameAsStdMt1
 }
 
 
+// Tests that two GetNextSeed() calls return the very same seed value, when ResetNextSeed() is called before each of
+// those calls.
 TEST(MersenneTwisterRandomVariateGenerator, ResetNextSeed)
 {
-  const auto globalGenerator = MersenneTwisterRandomVariateGenerator::GetInstance();
-  ASSERT_NE(globalGenerator, nullptr);
+  // Call GetInstance() beforehand, to make sure the global instance is there already when calling GetNextSeed().
+  [[maybe_unused]] const auto globalGenerator = MersenneTwisterRandomVariateGenerator::GetInstance();
 
   MersenneTwisterRandomVariateGenerator::ResetNextSeed();
-  const auto nextSeed = globalGenerator->GetNextSeed();
+  const auto seed = MersenneTwisterRandomVariateGenerator::GetNextSeed();
 
   MersenneTwisterRandomVariateGenerator::ResetNextSeed();
-  EXPECT_EQ(globalGenerator->GetNextSeed(), nextSeed);
+  EXPECT_EQ(MersenneTwisterRandomVariateGenerator::GetNextSeed(), seed);
 }


### PR DESCRIPTION
`MersenneTwisterRandomVariateGenerator::GetNextSeed()` is a static member function, so there is no need to call it via an instance of the generator, in the `MersenneTwisterRandomVariateGenerator.ResetNextSeed` unit test.

The commit also adds some documentation to the unit test.

Suggested by clang-tidy:
https://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html

----

Obviously it was my own fault  😸 introduced with:
- https://github.com/InsightSoftwareConsortium/ITK/pull/4247 