### PR TITLE
ENH: Add ULL type to ConnectedComponentImageFilter wrapping

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/wrapping/itkConnectedComponentImageFilter.wrap
+++ b/Modules/Segmentation/ConnectedComponents/wrapping/itkConnectedComponentImageFilter.wrap
@@ -1,7 +1,7 @@
 itk_wrap_class("itk::ConnectedComponentImageFilter" POINTER)
 # Create wrappers from every selected integral (signed and un) type to every
 # selected unsigned type. Also force ulong output for the watershed filter.
-unique(to_types "UL;${WRAP_ITK_INT}")
+unique(to_types "UL;${ITKM_IT};${WRAP_ITK_INT}")
 # Supports too few labels.
 list(REMOVE_ITEM to_types "UC")
 itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${to_types}" 2+)


### PR DESCRIPTION
Currently, by default, `ConnectedComponentImageFilter` can output: US, SS, and UL pixel types, while `RelabelComponentImageFilter` does not accept UL as input, and accepts US, SS, and ULL (IdentifierType). Cast filter is also not wrapped for UL -> ULL conversion. That makes the following code unworkable on Windows:

```python
# components = itk.connected_component_image_filter(foreground, fully_connected=True)  # over 32K labels
ul_type = itk.Image[itk.UL, 3]
cc_filter = itk.ConnectedComponentImageFilter[type(foreground), ul_type].New(foreground) cc_filter.SetFullyConnected(True)
cc_filter.Update()
components = cc_filter.GetOutput()
sorted_components = itk.relabel_component_image_filter(components.astype(itk.ULL))
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
