### PR TITLE
ENH: Add `Crop` unit tests to itkImageRegionGTest

### DIFF
--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageRegion.h"
 #include "itkIndexRange.h"
 #include <gtest/gtest.h>
+#include <limits>
 #include <type_traits> // For remove_const_t and remove_reference_t.
 
 
@@ -64,4 +65,111 @@ TEST(ImageRegion, OneSizedRegionIsInsideIffItsIndexIsInside)
   // Check for a 2D and a 3D image region.
   check(itk::ImageRegion<2>(itk::Size<2>::Filled(3)));
   check(itk::ImageRegion<3>(itk::MakeIndex(-1, 0, 1), itk::MakeSize(2, 3, 4)));
+}
+
+
+// Tests that Crop returns false and does not change anything, when it cannot crop. That is when one of the regions is
+// zero-sized, or when the region to be cropped and the crop region don't overlap.
+TEST(ImageRegion, CropReturnsFalseWithoutChangingAnythingWhenItCannotCrop)
+{
+  const auto check = [](const auto & originalRegion, const auto & cropRegion) {
+    auto regionToBeCropped = originalRegion;
+
+    EXPECT_FALSE(regionToBeCropped.Crop(cropRegion));
+    EXPECT_EQ(regionToBeCropped, originalRegion);
+  };
+
+  using RegionType = itk::ImageRegion<2>;
+  using IndexType = RegionType::IndexType;
+  using SizeType = RegionType::SizeType;
+
+  for (const auto indexValue : { std::numeric_limits<itk::IndexValueType>::min(),
+                                 itk::IndexValueType{ -1 },
+                                 itk::IndexValueType{},
+                                 itk::IndexValueType{ 1 },
+                                 std::numeric_limits<itk::IndexValueType>::max() })
+  {
+    const RegionType zeroSizedRegion{ IndexType::Filled(indexValue), SizeType{} };
+    const RegionType nonZeroSizedRegion{ IndexType::Filled(indexValue), SizeType::Filled(1) };
+
+    // Cannot crop when the region to be cropped and/or the crop region is zero-sized.
+    check(zeroSizedRegion, zeroSizedRegion);
+    check(zeroSizedRegion, nonZeroSizedRegion);
+    check(nonZeroSizedRegion, zeroSizedRegion);
+  }
+
+  for (const auto indexValue : { std::numeric_limits<itk::IndexValueType>::min(),
+                                 itk::IndexValueType{ -1 },
+                                 itk::IndexValueType{},
+                                 itk::IndexValueType{ 1 } })
+  {
+    for (const itk::SizeValueType sizeValue : { 1, 2 })
+    {
+      const RegionType region1{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) };
+      const RegionType region2{ IndexType::Filled(indexValue + static_cast<itk::IndexValueType>(sizeValue)),
+                                SizeType::Filled(sizeValue) };
+
+      // Cannot crop when the region to be cropped and the crop region do not overlap.
+      check(region1, region2);
+      check(region2, region1);
+    }
+  }
+}
+
+
+// Tests that Crop returns true, and does not change the region to be cropped, when it is equal to the crop region
+// (assuming that both regions are not zero-sized).
+TEST(ImageRegion, CropDoesNotChangeRegionToBeCroppedWhenCropRegionIsEqual)
+{
+  using RegionType = itk::ImageRegion<2>;
+  using IndexType = RegionType::IndexType;
+  using SizeType = RegionType::SizeType;
+
+  for (const auto indexValue : { std::numeric_limits<itk::IndexValueType>::min(),
+                                 itk::IndexValueType{ -1 },
+                                 itk::IndexValueType{},
+                                 itk::IndexValueType{ 1 } })
+  {
+    for (const itk::SizeValueType sizeValue : { 1, 2 })
+    {
+      const RegionType region{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) };
+      auto             regionToBeCropped = region;
+      EXPECT_TRUE(regionToBeCropped.Crop(region));
+      EXPECT_EQ(regionToBeCropped, region);
+    }
+  }
+}
+
+
+// Tests cropping a larger to a smaller region, and vice versa.
+TEST(ImageRegion, CropLargerToSmallerRegionAndViceVersa)
+{
+  using RegionType = itk::ImageRegion<2>;
+  using IndexType = RegionType::IndexType;
+  using SizeType = RegionType::SizeType;
+
+  for (const auto indexValue : { std::numeric_limits<itk::IndexValueType>::min(),
+                                 itk::IndexValueType{ -1 },
+                                 itk::IndexValueType{},
+                                 itk::IndexValueType{ 1 } })
+  {
+    for (const itk::SizeValueType sizeValue : { 1, 2 })
+    {
+      const RegionType smallerRegion{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) };
+      const RegionType largerRegion{ smallerRegion.GetIndex(), SizeType::Filled(sizeValue + 1) };
+
+      {
+        auto regionToBeCropped = largerRegion;
+
+        EXPECT_TRUE(regionToBeCropped.Crop(smallerRegion));
+        EXPECT_EQ(regionToBeCropped, smallerRegion);
+      }
+      {
+        auto regionToBeCropped = smallerRegion;
+
+        EXPECT_TRUE(regionToBeCropped.Crop(largerRegion));
+        EXPECT_EQ(regionToBeCropped, smallerRegion);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Added three GoogleTest unit tests:

 - CropReturnsFalseWithoutChangingAnythingWhenItCannotCrop
 - CropDoesNotChangeRegionToBeCroppedWhenCropRegionIsEqual
 - CropLargerToSmallerRegionAndViceVersa
