### PR TITLE
DOC: Add ITK scientific ecosystem section to documentation

### DIFF
--- a/Documentation/docs/index.md
+++ b/Documentation/docs/index.md
@@ -49,3 +49,11 @@ migration_guides/index
 contributing/code_of_conduct
 contributing/index
 ```
+
+
+```{toctree}
+:maxdepth: 1
+:caption: 🌱 Scientific ecosystem
+
+scientific_ecosystem/itk_ecosystem.md
+```

--- a/Documentation/docs/scientific_ecosystem/itk_ecosystem.md
+++ b/Documentation/docs/scientific_ecosystem/itk_ecosystem.md
@@ -1,0 +1,34 @@
+# ITK ecosystem
+
+Together with the core ITK codebase, a number of other projects and
+frameworks are maintained allowing to leverage the power of ITK beyond
+its natural boundaries:
+
+- [ITK/VTK Viewer](https://kitware.github.io/itk-vtk-viewer/docs/index.html)
+  is a web-based image, mesh, and point set viewer.
+- [itk-viewer](https://itk-viewer.on.fleek.co/) is a multi-dimensional
+  web-based image, mesh, and point set viewer.
+- [itk-wasm](https://wasm.itk.org/en/latest/) combines ITK and
+  [WebAssembly](https://webassembly.org/) to enable high-performance
+  spatial analysis in a web browser or system-level environments and
+  reproducible execution across programming languages and hardware
+  architectures.
+- [itkwidgets](https://itkwidgets.readthedocs.io/en/latest/) is an
+  elegant Python interface for visualization on the web platform to
+  interactively generate insights into multidimensional images, point
+  sets, and geometry.
+- [scikit-build](https://scikit-build.org) is a Python build system for
+  CPython C/C++/Fortran/Cython extensions using [CMake](https://cmake.org).
+
+## Legacy tools
+
+Other legacy projects that offered ITK's power through other interfaces
+or sets of pipelines were:
+
+- [Praxix](https://code.google.com/archive/p/praxix/) was a collection
+  of command line programs for image processing using ITK.
+- [ITK One Shot](https://github.com/daviddoria/ITK_OneShot) was a short
+  programs which perform specific operations on images.
+- [ITKApps](https://github.com/InsightSoftwareConsortium/ITKApps) were
+  a variety of applications written with ITK, ranging from simple uses
+  of the toolkit to complex and GUI-based applications.


### PR DESCRIPTION
Add ITK scientific ecosystem section to documentation:
- Include other tools developed around ITK that allow to leverage its use beyond its natural boundaries.
- Transition the wiki command line tools page: https://itk.org/Wiki/ITK/CommandLineTools
- Mention `ITKApps` as a set of legacy tools that leveraged ITK's capabilities without completely transitioning the corresponding https://itk.org/Wiki/ITK/Insight_Applications wiki page, as the instructions refer to old releases and tools.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
