### PR TITLE
BUG: Fix `CachedCurrentPosition` ivar initialization numeric traits arg

### DIFF
--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -25,7 +25,7 @@ SingleValuedNonLinearVnlOptimizerv4::SingleValuedNonLinearVnlOptimizerv4()
   this->m_Command = CommandType::New();
   this->m_Command->SetCallbackFunction(this, &SingleValuedNonLinearVnlOptimizerv4::IterationReport);
 
-  this->m_CachedCurrentPosition.Fill(NumericTraits<DerivativeType::ValueType>::ZeroValue());
+  this->m_CachedCurrentPosition.Fill(NumericTraits<ParametersType::ValueType>::ZeroValue());
   this->m_CachedDerivative.Fill(NumericTraits<DerivativeType::ValueType>::ZeroValue());
 }
 


### PR DESCRIPTION
Fix `itk::SingleValuedNonLinearVnlOptimizerv4::CachedCurrentPosition` ivar initialization numeric trait template argument type.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)