### PR TITLE
ENH: Add test for `itk::XMLFilterWatcher`

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -186,7 +186,9 @@ set(ITKCommon2Tests
     itkImageRegionSplitterMultidimensionalTest.cxx
     itkMetaDataObjectTest.cxx
     # itkVectorMultiplyTest.cxx
-    itkXMLFileOutputWindowTest.cxx)
+    itkXMLFileOutputWindowTest.cxx
+    itkXMLFilterWatcherTest.cxx)
+
 if(ITK_BUILD_SHARED_LIBS AND ITK_DYNAMIC_LOADING)
   list(APPEND ITKCommon2Tests itkDownCastTest.cxx)
 endif()
@@ -1666,6 +1668,16 @@ itk_add_test(
   ITKCommon2TestDriver
   itkXMLFileOutputWindowTest
   ${ITK_TEST_OUTPUT_DIR}/itkXMLFileOutputWindowTest.xml)
+
+itk_add_test(
+  NAME
+  itkXMLFilterWatcherTest
+  COMMAND
+  ITKCommon2TestDriver
+  --redirectOutput
+  ${ITK_TEST_OUTPUT_DIR}/itkXMLFilterWatcherTest.txt
+  itkXMLFilterWatcherTest
+  DATA{${ITK_DATA_ROOT}/Input/cthead1.png})
 
 if(ITK_BUILD_SHARED_LIBS AND ITK_DYNAMIC_LOADING)
   macro(BuildClientTestLibrary _name _type)

--- a/Modules/Core/Common/test/itkXMLFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkXMLFilterWatcherTest.cxx
@@ -1,0 +1,52 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkXMLFilterWatcher.h"
+#include "itkTestingMacros.h"
+
+
+int
+itkXMLFilterWatcherTest(int argc, char * argv[])
+{
+  if (argc != 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFileName" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  constexpr unsigned int Dimension = 2;
+
+  using PixelType = float;
+  using ImageType = itk::Image<PixelType, Dimension>;
+
+  using FilterType = itk::ImageFileReader<ImageType>;
+
+  auto reader = FilterType::New();
+
+  reader->SetFileName(argv[1]);
+
+  itk::XMLFilterWatcher watcher(reader, "filter");
+
+  reader->Update();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add test for `itk::XMLFilterWatcher`: the watcher is applied to an image reading filter, and the progress updates written to the standard output by the filter are redirected to a text file through the CMake `--redirectOutput` option.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)