### PR TITLE
ENH: Increase `itk::ShapeOpeningLabelMapFilter` coverage

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
@@ -58,6 +58,8 @@ itkShapeOpeningLabelMapFilterTest1(int argc, char * argv[])
   using LabelOpeningType = itk::ShapeOpeningLabelMapFilter<LabelMapType>;
   auto opening = LabelOpeningType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(opening, ShapeOpeningLabelMapFilter, InPlaceLabelMapFilter);
+
   // testing get and set macros for Lambda
   double lambda = std::stod(argv[3]);
   opening->SetLambda(lambda);


### PR DESCRIPTION
Increase `itk::ShapeOpeningLabelMapFilter` coverage: exercise basic object methods using the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)