### PR TITLE
STYLE: Remove unreachable `break` statements after `return` statements

### DIFF
--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -180,17 +180,13 @@ public:
     {
       case ThreaderEnum::Platform:
         return "Platform";
-        break;
       case ThreaderEnum::Pool:
         return "Pool";
-        break;
       case ThreaderEnum::TBB:
         return "TBB";
-        break;
       case ThreaderEnum::Unknown:
       default:
         return "Unknown";
-        break;
     }
   }
 

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -115,10 +115,8 @@ itkFFTWComplexToComplexFFTImageFilterTest(int argc, char * argv[])
 #ifdef ITK_USE_FFTWF
       case 2:
         return transformImage<float, 2>(inputImageFileName, outputImageFileName);
-        break;
       case 3:
         return transformImage<float, 3>(inputImageFileName, outputImageFileName);
-        break;
 #endif
       default:
         std::cerr << "Unknown image dimension." << std::endl;
@@ -133,10 +131,8 @@ itkFFTWComplexToComplexFFTImageFilterTest(int argc, char * argv[])
 #ifdef ITK_USE_FFTWD
       case 2:
         return transformImage<double, 2>(inputImageFileName, outputImageFileName);
-        break;
       case 3:
         return transformImage<double, 3>(inputImageFileName, outputImageFileName);
-        break;
 #endif
       default:
         std::cerr << "Unknown image dimension." << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -185,58 +185,40 @@ public:
     {
       case MINIMUM:
         return "Minimum";
-        break;
       case MAXIMUM:
         return "Maximum";
-        break;
       case MEAN:
         return "Mean";
-        break;
       case SUM:
         return "Sum";
-        break;
       case STANDARD_DEVIATION:
         return "StandardDeviation";
-        break;
       case VARIANCE:
         return "Variance";
-        break;
       case MEDIAN:
         return "Median";
-        break;
       case MAXIMUM_INDEX:
         return "MaximumIndex";
-        break;
       case MINIMUM_INDEX:
         return "MinimumIndex";
-        break;
       case CENTER_OF_GRAVITY:
         return "CenterOfGravity";
-        break;
       /*      case CENTRAL_MOMENTS:
-              return "CentralMoments";
-              break;*/
+              return "CentralMoments";*/
       case WEIGHTED_PRINCIPAL_MOMENTS:
         return "WeightedPrincipalMoments";
-        break;
       case WEIGHTED_PRINCIPAL_AXES:
         return "WeightedPrincipalAxes";
-        break;
       case KURTOSIS:
         return "Kurtosis";
-        break;
       case SKEWNESS:
         return "Skewness";
-        break;
       case WEIGHTED_ELONGATION:
         return "WeightedElongation";
-        break;
       case HISTOGRAM:
         return "Histogram";
-        break;
       case WEIGHTED_FLATNESS:
         return "WeightedFlatness";
-        break;
     }
     // can't recognize the name
     return Superclass::GetNameFromAttribute(a);


### PR DESCRIPTION
By doing Notepad++ Replace in Files, having:

    Find what:  return (.*);\r\n [ ]* break;
    Replace with:  return $1;
    Filters: itk*.h;itk*.hxx;itk*.cxx
    [v] Match case
    (*) Regular expression
