### PR TITLE
Replace `std::min` and `std::max` calls with `std::clamp`,  in "Colormap", `ProgressTransformer`, `SliceImageFilter`, and `MultiThreaderBase`.

### DIFF
--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -323,10 +323,8 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
     }
 
     // limit the number of threads to m_GlobalMaximumNumberOfThreads
-    threadCount = std::min(threadCount, ThreadIdType{ ITK_MAX_THREADS });
-
     // verify that the default number of threads is larger than zero
-    threadCount = std::max(threadCount, NumericTraits<ThreadIdType>::OneValue());
+    threadCount = std::clamp(threadCount, ThreadIdType{ 1 }, ThreadIdType{ ITK_MAX_THREADS });
 
     m_PimplGlobals->m_GlobalDefaultNumberOfThreads = threadCount;
   }

--- a/Modules/Core/Common/src/itkProgressTransformer.cxx
+++ b/Modules/Core/Common/src/itkProgressTransformer.cxx
@@ -41,10 +41,8 @@ ProgressTransformer::ProgressTransformer(float start, float end, ProcessObject *
   : m_TargetFilter(targetFilter)
   , m_ProgressTag(0)
 {
-  m_Start = std::max(start, 0.0f);
-  m_Start = std::min(m_Start, 1.0f);
-  m_End = std::max(end, 0.0f);
-  m_End = std::min(m_End, 1.0f);
+  m_Start = std::clamp(start, 0.0f, 1.0f);
+  m_End = std::clamp(end, 0.0f, 1.0f);
   m_Dummy = DummyProcess::New();
 
   m_ProgressCommand = CommandType::New();
@@ -56,8 +54,7 @@ void
 ProgressTransformer::UpdateProgress()
 {
   float progress = m_Dummy->GetProgress();
-  progress = std::max(progress, 0.0f);
-  progress = std::min(progress, 1.0f);
+  progress = std::clamp(progress, 0.0f, 1.0f);
 
   progress = m_Start + progress * (m_End - m_Start); // transform progress
   m_TargetFilter->UpdateProgress(progress);

--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -97,9 +97,7 @@ protected:
 
     auto     d = static_cast<RealType>(maxInputValue - minInputValue);
     RealType value = (static_cast<RealType>(v) - static_cast<RealType>(minInputValue)) / d;
-
-    value = std::max(0.0, value);
-    value = std::min(1.0, value);
+    value = std::clamp(value, 0.0, 1.0);
     return value;
   }
 

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
@@ -33,17 +33,13 @@ HSVColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
   // Apply the color mapping.
   // Apply the color mapping.
   RealType red = itk::Math::abs(5.0 * (value - 0.5)) - 5.0 / 6.0;
-
-  red = std::min(red, 1.0);
-  red = std::max(0.0, red);
+  red = std::clamp(red, 0.0, 1.0);
 
   RealType green = -itk::Math::abs(5.0 * (value - 11.0 / 30.0)) + 11.0 / 6.0;
-  green = std::min(green, 1.0);
-  green = std::max(0.0, green);
+  green = std::clamp(green, 0.0, 1.0);
 
   RealType blue = -itk::Math::abs(5.0 * (value - 19.0 / 30.0)) + 11.0 / 6.0;
-  blue = std::min(blue, 1.0);
-  blue = std::max(0.0, blue);
+  blue = std::clamp(blue, 0.0, 1.0);
 
   // Set the rgb components after rescaling the values.
   RGBPixelType pixel;

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
@@ -32,17 +32,13 @@ HotColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   // Apply the color mapping.
   RealType red = 63.0 / 26.0 * value - 1.0 / 13.0;
-
-  red = std::max(0.0, red);
-  red = std::min(1.0, red);
+  red = std::clamp(red, 0.0, 1.0);
 
   RealType green = 63.0 / 26.0 * value - 11.0 / 13.0;
-  green = std::max(0.0, green);
-  green = std::min(1.0, green);
+  green = std::clamp(green, 0.0, 1.0);
 
   RealType blue = 4.5 * value - 3.5;
-  blue = std::max(0.0, blue);
-  blue = std::min(1.0, blue);
+  blue = std::clamp(blue, 0.0, 1.0);
 
   // Set the rgb components after rescaling the values.
   RGBPixelType pixel;

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
@@ -32,17 +32,13 @@ JetColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   // Apply the color mapping.
   RealType red = -itk::Math::abs(3.95 * (value - 0.7460)) + 1.5;
-
-  red = std::min(red, 1.0);
-  red = std::max(0.0, red);
+  red = std::clamp(red, 0.0, 1.0);
 
   RealType green = -itk::Math::abs(3.95 * (value - 0.492)) + 1.5;
-  green = std::min(green, 1.0);
-  green = std::max(0.0, green);
+  green = std::clamp(green, 0.0, 1.0);
 
   RealType blue = -itk::Math::abs(3.95 * (value - 0.2385)) + 1.5;
-  blue = std::min(blue, 1.0);
-  blue = std::max(0.0, blue);
+  blue = std::clamp(blue, 0.0, 1.0);
 
   // Set the rgb components after rescaling the values.
   RGBPixelType pixel;

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -130,8 +130,7 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   InputIndexType start;
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
-    start[i] = std::max(m_Start[i], inputIndex[i]);
-    start[i] = std::min(start[i], static_cast<IndexValueType>(inputIndex[i] + inputSize[i] - 1));
+    start[i] = std::clamp(m_Start[i], inputIndex[i], static_cast<IndexValueType>(inputIndex[i] + inputSize[i] - 1));
   }
 
   // Define/declare an iterator that will walk the output region for this thread
@@ -179,8 +178,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   {
     // clamp to valid index range and don't include one past end, so
     // that a zero size RR would be valid
-    start[i] = std::max(m_Start[i], inputIndex[i]);
-    start[i] = std::min(start[i], static_cast<IndexValueType>(inputIndex[i] + inputSize[i] - 1));
+    start[i] = std::clamp(m_Start[i], inputIndex[i], static_cast<IndexValueType>(inputIndex[i] + inputSize[i] - 1));
   }
 
 
@@ -247,14 +245,17 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     outputSpacing[i] = inputSpacing[i] * itk::Math::abs(m_Step[i]);
 
     // clamp start, inclusive start interval
-    IndexValueType start = std::max(m_Start[i], inputIndex[i] - static_cast<int>(m_Step[i] < 0));
-    start =
-      std::min(start, static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - static_cast<int>(m_Step[i] < 0));
+    IndexValueType start =
+      std::clamp(m_Start[i],
+                 inputIndex[i] - static_cast<int>(m_Step[i] < 0),
+                 static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - static_cast<int>(m_Step[i] < 0));
 
     // clamp stop as open interval
     // Based on the sign of the step include 1 after the end.
-    IndexValueType stop = std::max(m_Stop[i], inputIndex[i] - static_cast<int>(m_Step[i] < 0));
-    stop = std::min(stop, static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - static_cast<int>(m_Step[i] < 0));
+    IndexValueType stop =
+      std::clamp(m_Stop[i],
+                 inputIndex[i] - static_cast<int>(m_Step[i] < 0),
+                 static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - static_cast<int>(m_Step[i] < 0));
 
     // If both the numerator and the denominator have the same sign,
     // then the range is a valid and non-zero sized. Truncation is the


### PR DESCRIPTION
Follow-up to:
- pull request #3992
- pull request #4182

Use cases mostly found by Notepad++ regular expression `(.+) = std::m..\(.+;\r\n\1 = std::m..\(`.