### PR TITLE
`MersenneTwisterGlobals` replace `std::recursive_mutex` with `std::mutex`, rename data member from "Lock" to "Mutex"

### DIFF
--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -35,7 +35,7 @@ struct MersenneTwisterGlobals
   ~MersenneTwisterGlobals() = default;
 
   MersenneTwisterRandomVariateGenerator::Pointer                  m_StaticInstance{};
-  std::mutex                                                      m_StaticInstanceLock{};
+  std::mutex                                                      m_StaticInstanceMutex{};
   std::atomic<MersenneTwisterRandomVariateGenerator::IntegerType> m_StaticDiffer{};
 };
 
@@ -72,7 +72,7 @@ MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_StaticInstanceMutex);
 
   if (!m_PimplGlobals->m_StaticInstance)
   {

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -35,7 +35,7 @@ struct MersenneTwisterGlobals
   ~MersenneTwisterGlobals() = default;
 
   MersenneTwisterRandomVariateGenerator::Pointer                  m_StaticInstance{};
-  std::recursive_mutex                                            m_StaticInstanceLock{};
+  std::mutex                                                      m_StaticInstanceLock{};
   std::atomic<MersenneTwisterRandomVariateGenerator::IntegerType> m_StaticDiffer{};
 };
 
@@ -72,7 +72,7 @@ MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  const std::lock_guard<std::recursive_mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
+  const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_StaticInstanceLock);
 
   if (!m_PimplGlobals->m_StaticInstance)
   {


### PR DESCRIPTION
Replaced `std::recursive_mutex` with the more lightweight `std::mutex` as type of `MersenneTwisterGlobals::m_StaticInstanceLock`. This mutex is only used by `MersenneTwisterRandomVariateGenerator::GetInstance()`. This member function does not call itself, so the mutex does not need to be "recursive".

Renamed `MersenneTwisterGlobals::m_StaticInstanceLock` to `MersenneTwisterGlobals::m_StaticInstanceLock`
- following pull request #4217 commit 0150e469240879e8181ec10e919107061baca87e _STYLE: Rename private and internal data members from "Lock" to "Mutex"_


