### PR TITLE
ENH: Fixed Coverity 2023.6.2 warnings in itkImageRegion.h

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -275,8 +275,8 @@ public:
   bool
   IsInside(const Self & otherRegion) const
   {
-    const auto otherIndex = otherRegion.m_Index;
-    const auto otherSize = otherRegion.m_Size;
+    const auto & otherIndex = otherRegion.m_Index;
+    const auto & otherSize = otherRegion.m_Size;
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {


### PR DESCRIPTION
_Coverity 2023.6.2_:

```
275       bool
276       IsInside(const Self & otherRegion) const
277       {
>>>     CID 331225:  Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "itk::ImageRegion<3u>::IndexType".
278         const auto otherIndex = otherRegion.m_Index;
```

```
275       bool
276       IsInside(const Self & otherRegion) const
277       {
278         const auto otherIndex = otherRegion.m_Index;
>>>     CID 331206:  Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "itk::ImageRegion<3u>::SizeType".
279         const auto otherSize = otherRegion.m_Size;
```

