### PR TITLE
STYLE: Use the superclass name in itkTypeMacro

### DIFF
--- a/Modules/IO/BMP/include/itkBMPImageIO.h
+++ b/Modules/IO/BMP/include/itkBMPImageIO.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(BMPImageIO, Superclass);
+  itkTypeMacro(BMPImageIO, ImageIOBase);
 
   /** Getter for the FileLowerLeft attribute. */
   itkGetConstMacro(FileLowerLeft, bool);

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -120,7 +120,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GDCMImageIO, Superclass);
+  itkTypeMacro(GDCMImageIO, ImageIOBase);
 
   /*-------- This part of the interface deals with reading data. ------ */
 

--- a/Modules/IO/GE/include/itkGE4ImageIO.h
+++ b/Modules/IO/GE/include/itkGE4ImageIO.h
@@ -70,7 +70,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GE4ImageIO, Superclass);
+  itkTypeMacro(GE4ImageIO, IPLCommonImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/GE/include/itkGE5ImageIO.h
+++ b/Modules/IO/GE/include/itkGE5ImageIO.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GE5ImageIO, Superclass);
+  itkTypeMacro(GE5ImageIO, IPLCommonImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/GE/include/itkGEAdwImageIO.h
+++ b/Modules/IO/GE/include/itkGEAdwImageIO.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GEAdwImageIO, Superclass);
+  itkTypeMacro(GEAdwImageIO, IPLCommonImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/GIPL/include/itkGiplImageIO.h
+++ b/Modules/IO/GIPL/include/itkGiplImageIO.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GiplImageIO, Superclass);
+  itkTypeMacro(GiplImageIO, ImageIOBase);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/IPL/include/itkIPLCommonImageIO.h
+++ b/Modules/IO/IPL/include/itkIPLCommonImageIO.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IPLCommonImageIO, Superclass);
+  itkTypeMacro(IPLCommonImageIO, ImageIOBase);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -86,7 +86,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageIOBase, Superclass);
+  itkTypeMacro(ImageIOBase, LightProcessObject);
 
   /** Set/Get the name of the file to be read. */
   itkSetStringMacro(FileName);

--- a/Modules/IO/MINC/include/itkMINCImageIO.h
+++ b/Modules/IO/MINC/include/itkMINCImageIO.h
@@ -81,7 +81,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MINCImageIO, Superclass);
+  itkTypeMacro(MINCImageIO, ImageIOBase);
 
   /** Right now MINC supports up to 3D with multiple components */
   bool

--- a/Modules/IO/Meta/include/itkMetaImageIO.h
+++ b/Modules/IO/Meta/include/itkMetaImageIO.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MetaImageIO, Superclass);
+  itkTypeMacro(MetaImageIO, ImageIOBase);
 
   /** The different types of ImageIO's can support data of varying
    * dimensionality. For example, some file formats are strictly 2D

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -108,7 +108,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(NiftiImageIO, Superclass);
+  itkTypeMacro(NiftiImageIO, ImageIOBase);
 
   //-------- This part of the interfaces deals with reading data. -----
 

--- a/Modules/IO/PhilipsREC/include/itkPhilipsPAR.h
+++ b/Modules/IO/PhilipsREC/include/itkPhilipsPAR.h
@@ -223,7 +223,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PhilipsPAR, Superclass);
+  itkTypeMacro(PhilipsPAR, LightProcessObject);
 
   // Reads the PAR file parameters in "parFile" and stores the PAR parameters in
   // pPar.

--- a/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIO.h
+++ b/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIO.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PhilipsRECImageIO, Superclass);
+  itkTypeMacro(PhilipsRECImageIO, ImageIOBase);
 
   /** Special types used for Philips PAR meta data. */
   using EchoTimesContainerType = VectorContainer<unsigned int, double>;

--- a/Modules/IO/Siemens/include/itkSiemensVisionImageIO.h
+++ b/Modules/IO/Siemens/include/itkSiemensVisionImageIO.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SiemensVisionImageIO, Superclass);
+  itkTypeMacro(SiemensVisionImageIO, IPLCommonImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -64,7 +64,7 @@ public:
   using Pointer = SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(TransformIOBaseTemplate, Superclass);
+  itkTypeMacro(TransformIOBaseTemplate, LightProcessObject);
 
   /** Transform types */
   using ScalarType = TParametersValueType; // For backwards compatibility

--- a/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
+++ b/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
@@ -46,7 +46,7 @@ public:
   using FixedParametersValueType = typename TransformType::FixedParametersValueType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(TxtTransformIOTemplate, Superclass);
+  itkTypeMacro(TxtTransformIOTemplate, TransformIOBaseTemplate);
   itkNewMacro(Self);
 
   /** Determine the file type. Returns true if this ImageIO can read the

--- a/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
+++ b/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
@@ -42,7 +42,7 @@ public:
   using ConstTransformListType = typename TransformIOBaseTemplate<ParametersValueType>::ConstTransformListType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MatlabTransformIOTemplate, Superclass);
+  itkTypeMacro(MatlabTransformIOTemplate, TransformIOBaseTemplate);
   itkNewMacro(Self);
 
   /** Determine the file type. Returns true if this ImageIO can read the

--- a/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
+++ b/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VoxBoCUBImageIO, Superclass);
+  itkTypeMacro(VoxBoCUBImageIO, ImageIOBase);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
@@ -58,7 +58,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ConjugateGradientLineSearchOptimizerv4Template, Superclass);
+  itkTypeMacro(ConjugateGradientLineSearchOptimizerv4Template, GradientDescentLineSearchOptimizerv4Template);
 
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
@@ -92,7 +92,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExhaustiveOptimizerv4, Superclass);
+  itkTypeMacro(ExhaustiveOptimizerv4, ObjectToObjectOptimizerBaseTemplate);
 
   /** Steps type */
   using StepsType = Array<SizeValueType>;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -52,7 +52,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiStartOptimizerv4Template, Superclass);
+  itkTypeMacro(MultiStartOptimizerv4Template, ObjectToObjectOptimizerBaseTemplate);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
@@ -81,7 +81,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OnePlusOneEvolutionaryOptimizerv4, Superclass);
+  itkTypeMacro(OnePlusOneEvolutionaryOptimizerv4, ObjectToObjectOptimizerBaseTemplate);
 
   /** Type of the Cost Function   */
   using CostFunctionType = SingleValuedCostFunctionv4;

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OpenCVVideoIO, Superclass);
+  itkTypeMacro(OpenCVVideoIO, VideoIOBase);
 
   /** Close the reader and writer and reset members */
   virtual void

--- a/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
+++ b/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VXLVideoIO, Superclass);
+  itkTypeMacro(VXLVideoIO, VideoIOBase);
 
   /** Close the reader and writer and reset members */
   void

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -86,7 +86,7 @@ public:
   using CameraIDType = SizeValueType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VideoIOBase, Superclass);
+  itkTypeMacro(VideoIOBase, ImageIOBase);
 
   /** Close the reader and writer and reset members */
   virtual void


### PR DESCRIPTION
Use the superclass name instead of the `Superclass` alias in `itkTypeMacro`: use the literal name as the macro is designed to use the literal name for run-time type information: https://github.com/InsightSoftwareConsortium/ITK/blob/8844ee6549ebdc1294a17d471f8a65311440bd74/Modules/Core/Common/include/itkMacro.h#L438

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)