### PR TITLE
BUG: Remove `numeric_limits<IndexValueType>::max` from ImageRegion GTest

### DIFF
--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -86,8 +86,7 @@ TEST(ImageRegion, CropReturnsFalseWithoutChangingAnythingWhenItCannotCrop)
   for (const auto indexValue : { std::numeric_limits<itk::IndexValueType>::min(),
                                  itk::IndexValueType{ -1 },
                                  itk::IndexValueType{},
-                                 itk::IndexValueType{ 1 },
-                                 std::numeric_limits<itk::IndexValueType>::max() })
+                                 itk::IndexValueType{ 1 } })
   {
     const RegionType zeroSizedRegion{ IndexType::Filled(indexValue), SizeType{} };
     const RegionType nonZeroSizedRegion{ IndexType::Filled(indexValue), SizeType::Filled(1) };


### PR DESCRIPTION
The use of `std::numeric_limits<itk::IndexValueType>::max()` as `indexValue` in `ImageRegion.CropLargerToSmallerRegionAndViceVersa` caused signed integer overflow (undefined behavior). Mac14.x-AppleClang test failures were reported by Jon Haitz Legarreta Gorroño (@jhlegarreta). and debug output was provide by Alexandru Ciobanu (@devbanu), at pull request #4310
