### PR TITLE
STYLE: Remove unused local `ImageRegion` variables

### DIFF
--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -92,9 +92,8 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRe
   IndexType outputIndex = outputRequestedRegion.GetIndex();
   SizeType  outputSize = outputRequestedRegion.GetSize();
 
-  IndexType  requestIndex;
-  SizeType   requestSize;
-  RegionType requestRegion;
+  IndexType requestIndex;
+  SizeType  requestSize;
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -31,8 +31,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   using EllipseType = itk::EllipseSpatialObject<2>;
 
   // Image Definition
-  ImageType::RegionType region;
-  ImageType::SizeType   size;
+  ImageType::SizeType size;
   size.Fill(50);
   ImageType::SpacingType spacing;
   spacing.Fill(1);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -53,7 +53,6 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   KernelType     kernel = this->GetKernel();
   InputSizeType  radius;
   radius.Fill(1);
-  typename TInputImage::RegionType  inputRegion = input->GetBufferedRegion();
   typename TOutputImage::RegionType outputRegion = output->GetBufferedRegion();
 
   // compute the size of the temp image. It is needed to create the progress

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -53,7 +53,6 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   KernelType     kernel = this->GetKernel();
   InputSizeType  radius;
   radius.Fill(1);
-  typename TInputImage::RegionType  inputRegion = input->GetBufferedRegion();
   typename TOutputImage::RegionType outputRegion = output->GetBufferedRegion();
 
   // compute the size of the temp image. It is needed to create the progress

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -485,9 +485,6 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   OutputImageSizeType  outputSize = outputPtr->GetRequestedRegion().GetSize();
   InputImageSizeType   inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
 
-  OutputImageRegionType outputRegion;
-  InputImageRegionType  inputRegion;
-
   // For n dimensions, there are k^n combinations of before, between, and
   // after on these regions.  We are keeping this flexible so that we
   // can handle other blockings imposed by the mirror and wrap algorithms.

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -131,7 +131,6 @@ itkResampleImageTest8(int, char *[])
   using InputImageSizeType = InputImageType::SizeType;
 
   using OutputImageIndexType = OutputImageType::IndexType;
-  using OutputImageRegionType = OutputImageType::RegionType;
   using OutputImageSizeType = OutputImageType::SizeType;
 
   using CoordRepType = double;
@@ -166,9 +165,8 @@ itkResampleImageTest8(int, char *[])
   auto tform = TransformType::New();
 
   // OutputImagePointerType outputImage = OutputImageType::New();
-  OutputImageIndexType  outputIndex = { { 0, 0, 0 } };
-  OutputImageSizeType   outputSize = { { 18, 12, 5 } };
-  OutputImageRegionType outputRegion;
+  OutputImageIndexType outputIndex = { { 0, 0, 0 } };
+  OutputImageSizeType  outputSize = { { 18, 12, 5 } };
 
   // Create a linear interpolation image function
   auto interp = InterpolatorType::New();

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -220,8 +220,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
   typename TInputImage::SizeType  inputSize = inputRegion.GetSize();
   typename TInputImage::IndexType inputIndex = inputRegion.GetIndex();
 
-  typename TOutputImage::Pointer    outputImage = this->GetOutput();
-  typename TOutputImage::RegionType outputRegion = outputImage->GetLargestPossibleRegion();
+  typename TOutputImage::Pointer outputImage = this->GetOutput();
 
   typename TOutputImage::SizeType  outputSizeForThread = outputRegionForThread.GetSize();
   typename TOutputImage::IndexType outputIndexForThread = outputRegionForThread.GetIndex();

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -72,9 +72,8 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
   results->Clear();
   results->SetSample(this->m_Sample);
 
-  RegionType searchRegion;
-  IndexType  searchStartIndex;
-  IndexType  searchEndIndex;
+  IndexType searchStartIndex;
+  IndexType searchEndIndex;
 
   IndexType constraintIndex = this->m_RegionConstraint.GetIndex();
   SizeType  constraintSize = this->m_RegionConstraint.GetSize();

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -96,9 +96,8 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
   this->m_TrainingHistogram->Initialize(
     this->Superclass::m_HistogramSize, this->Superclass::m_LowerBound, this->Superclass::m_UpperBound);
   using TrainingFixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
-  typename FixedImageType::IndexType  index;
-  typename FixedImageType::RegionType fixedRegion;
-  typename HistogramType::IndexType   hIndex;
+  typename FixedImageType::IndexType index;
+  typename HistogramType::IndexType  hIndex;
 
   TrainingFixedIteratorType ti(this->m_TrainingFixedImage, this->m_TrainingFixedImageRegion);
 

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -457,8 +457,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedConnectivity
 
 
   ClusterType cluster(numberOfClusterComponents, &m_Clusters[clusterIndex * numberOfClusterComponents]);
-  typename InputImageType::RegionType localRegion;
-  IndexType                           idx;
+  IndexType   idx;
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1325,7 +1325,6 @@ Segmenter<TInputImage>::GenerateOutputRequestedRegion(DataObject * output)
   ImageBase<ImageDimension> * imgData;
   ImageBase<ImageDimension> * op;
   imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
-  typename TInputImage::RegionType c_reg;
 
   if (imgData)
   {

--- a/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
@@ -75,7 +75,6 @@ itkImageToVideoFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(videoFilter->Update());
 
   auto videoOutput = videoFilter->GetOutput();
-  auto imageRegion = inputImage->GetLargestPossibleRegion();
 
   // Verify start frame and frame duration in output match size of designated temporal axis in input
   ITK_TEST_EXPECT_EQUAL(

--- a/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
+++ b/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
@@ -61,7 +61,6 @@ itkVectorImageToVideoTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(videoFilter->Update());
 
   auto videoOutput = videoFilter->GetOutput();
-  auto imageRegion = inputImage->GetLargestPossibleRegion();
 
   // Verify start frame and frame duration in output match size of designated temporal axis in input
   ITK_TEST_EXPECT_EQUAL(


### PR DESCRIPTION
Fixed ITK.macOS/Darwin/Xcode_13.2.1/clang-1300.0.29.30 warnings that appear when `ImageRegion` is made trivially copyable, saying:

> warning: unused variable 'region' [-Wunused-variable]

Removed an obsolete type alias from itkResampleImageTest8.cxx, to avoid a warning, saying:

> warning: unused type alias 'OutputImageRegionType' [-Wunused-local-typedef]

----

This is in fact a "spin-off" (by-product) of pull request #4344: The "unused variable" warnings only appeared _after_ making `ImageRegion` trivially copyable. 