### PR TITLE
PERF: Fixed COPY_INSTEAD_OF_MOVE in MultiThreaderBase

### DIFF
--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -337,7 +337,7 @@ ITK_GCC_PRAGMA_DIAG_POP()
       VDimension,
       requestedRegion.GetIndex().m_InternalArray,
       requestedRegion.GetSize().m_InternalArray,
-      [funcP](const IndexValueType index[], const SizeValueType size[]) {
+      [&funcP](const IndexValueType index[], const SizeValueType size[]) {
         ImageRegion<VDimension> region;
         for (unsigned int d = 0; d < VDimension; ++d)
         {


### PR DESCRIPTION
Detected by Coverity 2023.6.2.
In my tests (Linux, GCC 12.2) this avoids copy of `32 bytes * number of threads` for multi-threaded filters.

```
330  template <unsigned int VDimension>
331  ITK_TEMPLATE_EXPORT void
332  ParallelizeImageRegion(const ImageRegion<VDimension> &           requestedRegion,
333                         TemplatedThreadingFunctorType<VDimension> funcP,
334                         ProcessObject *                           filter)
335  {
336    this->ParallelizeImageRegion(
337      VDimension,
338      requestedRegion.GetIndex().m_InternalArray,
339      requestedRegion.GetSize().m_InternalArray,
   CID 315595 (1-2 of 2): COPY_INSTEAD_OF_MOVE (COPY_INSTEAD_OF_MOVE)1. copy_constructor_call:
   funcP is copied in call to copy constructor std::function<void (itk::ImageRegion<3u> const &)>,
   when it could be moved instead.
   Use std::move(funcP) instead of funcP.
340      [funcP](const IndexValueType index[], const SizeValueType size[]) {
341        ImageRegion<VDimension> region;
342        for (unsigned int d = 0; d < VDimension; ++d)
343        {
344          region.SetIndex(d, index[d]);
345          region.SetSize(d, size[d]);
346        }
347        funcP(region);
348      },
349      filter);
350  }
```
