### PR TITLE
STYLE: Remove pre-C++17 definitions of static `constexpr` data members

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -595,10 +595,6 @@ MakeIndex(const T... values)
   return Index<sizeof...(T)>{ { toValueType(values)... } };
 }
 
-
-// static constexpr definition explicitly needed in C++11
-template <unsigned int VDimension>
-constexpr unsigned int Index<VDimension>::Dimension;
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -526,10 +526,6 @@ swap(Offset<VDimension> & one, Offset<VDimension> & two)
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }
 
-// static constexpr definition explicitly needed in C++11
-template <unsigned int VDimension>
-constexpr unsigned int Offset<VDimension>::Dimension;
-
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -496,11 +496,6 @@ MakeSize(const T... values)
   return Size<sizeof...(T)>{ { toValueType(values)... } };
 }
 
-
-// static constexpr definition explicitly needed in C++11
-template <unsigned int VDimension>
-constexpr unsigned int Size<VDimension>::Dimension;
-
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/src/itkNumericTraits.cxx
+++ b/Modules/Core/Common/src/itkNumericTraits.cxx
@@ -27,57 +27,6 @@
 namespace itk
 {
 
-/* Add definition for static constexpr members
-
-Reason: You have to provide the definition of the static member as well as the
-declaration. The declaration and the initializer go inside the class,
-but the member definition has to be in a single separate compilation unit.
-*/
-constexpr bool NumericTraits<bool>::Zero;
-constexpr bool NumericTraits<bool>::One;
-
-constexpr unsigned char NumericTraits<unsigned char>::Zero;
-constexpr unsigned char NumericTraits<unsigned char>::One;
-
-constexpr signed char NumericTraits<signed char>::Zero;
-constexpr signed char NumericTraits<signed char>::One;
-
-constexpr char NumericTraits<char>::Zero;
-constexpr char NumericTraits<char>::One;
-
-constexpr unsigned short NumericTraits<unsigned short>::Zero;
-constexpr unsigned short NumericTraits<unsigned short>::One;
-
-constexpr short NumericTraits<short>::Zero;
-constexpr short NumericTraits<short>::One;
-
-constexpr unsigned int NumericTraits<unsigned int>::Zero;
-constexpr unsigned int NumericTraits<unsigned int>::One;
-
-constexpr int NumericTraits<int>::Zero;
-constexpr int NumericTraits<int>::One;
-
-constexpr unsigned long NumericTraits<unsigned long>::Zero;
-constexpr unsigned long NumericTraits<unsigned long>::One;
-
-constexpr long NumericTraits<long>::Zero;
-constexpr long NumericTraits<long>::One;
-
-constexpr long long NumericTraits<long long>::Zero;
-constexpr long long NumericTraits<long long>::One;
-
-constexpr unsigned long long NumericTraits<unsigned long long>::Zero;
-constexpr unsigned long long NumericTraits<unsigned long long>::One;
-
-constexpr float NumericTraits<float>::Zero;
-constexpr float NumericTraits<float>::One;
-
-constexpr double NumericTraits<double>::Zero;
-constexpr double NumericTraits<double>::One;
-
-constexpr long double NumericTraits<long double>::Zero;
-constexpr long double NumericTraits<long double>::One;
-
 #if !defined(ITK_LEGACY_REMOVE)
 template <>
 const std::complex<char> NumericTraits<std::complex<char>>::Zero = std::complex<char>(0, 0);

--- a/Modules/Numerics/FEM/src/itkFEMUtility.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMUtility.cxx
@@ -23,19 +23,6 @@ namespace itk
 namespace fem
 {
 
-/* Add definition for static constexpr members
-
-Reason: You have to provide the definition of the static member as well as the
-declaration. The declaration and the initializer go inside the class,
-but the member definition has to be in a single separate compilation unit.
-*/
-
-constexpr double GaussIntegrate::zero;
-constexpr double GaussIntegrate::one;
-constexpr double GaussIntegrate::two;
-constexpr double GaussIntegrate::z[110];
-constexpr double GaussIntegrate::w[110];
-
 /**
  * Numerical integration (Gauss-Legendre formula).
  * Integrates function f(x) from x=a to x=b in n points.


### PR DESCRIPTION
According to C++17, "a `constexpr` static data member may be redundantly redeclared outside the class with no initializer", but then it says: "This usage is deprecated."

Cases found by Notepad++ regular expression `^constexpr .+::\w+.+;`

Follow-up to pull request #3985 commit 014ea433aaef9f931a24fba6a7a416b14473280a "STYLE: Remove pre-C++17 definition constexpr data member `SupportSize`"