### PR TITLE
STYLE: Remove prompt and spaces in Markdown documentation bash blocks

### DIFF
--- a/Documentation/docs/contributing/dashboard.md
+++ b/Documentation/docs/contributing/dashboard.md
@@ -11,11 +11,11 @@ The `dashboard` branch contains a dashboard client helper script. Use these
 commands to track it:
 
 ```bash
-   $ mkdir -p ~/Dashboards/ITKScripts
-   $ cd ~/Dashboards/ITKScripts
-   $ git init
-   $ git remote add -t dashboard origin https://itk.org/ITK.git
-   $ git pull origin
+mkdir -p ~/Dashboards/ITKScripts
+cd ~/Dashboards/ITKScripts
+git init
+git remote add -t dashboard origin https://itk.org/ITK.git
+git pull origin
 ```
 
 The `itk_common.cmake` script contains setup instructions in its top comments.
@@ -23,7 +23,7 @@ The `itk_common.cmake` script contains setup instructions in its top comments.
 Update the dashboard branch to get the latest version of this script by simply running
 
 ```bash
-   $ git pull origin
+git pull origin
 ```
 
 Here is
@@ -37,13 +37,13 @@ If you find bugs in the hooks themselves or would like to add new features, the
 can be edited in the usual Git manner:
 
 ```bash
-   $ git checkout -b my_topic_branch
+git checkout -b my_topic_branch
 ```
 
 Make your edits, test it, and commit the result. Create a patch file with:
 
 ```bash
-   $ git format-patch origin/dashboard
+git format-patch origin/dashboard
 ```
 
 And post the results to the [ITK discussion].

--- a/Documentation/docs/contributing/data.md
+++ b/Documentation/docs/contributing/data.md
@@ -21,7 +21,7 @@ developer setup instructions before proceeding. In particular, run
 `SetupForDevelopment.sh`:
 
 ```bash
-   $ ./Utilities/SetupForDevelopment.sh
+./Utilities/SetupForDevelopment.sh
 ```
 
 Workflow
@@ -53,8 +53,8 @@ For more details, see the description and procedures in [Upload Binary Data].
 Copy the data content link file into your local source tree.
 
 ```bash
-   $ mkdir -p Modules/.../test/Baseline
-   $ cp ~/MyTest.png.cid Modules/.../test/Baseline/MyTest.png.cid
+mkdir -p Modules/.../test/Baseline
+cp ~/MyTest.png.cid Modules/.../test/Baseline/MyTest.png.cid
 ```
 (add-test)=
 ### Add Test
@@ -64,7 +64,7 @@ Edit the test `CMakeLists.txt` file and reference the data file in an
 to the test directory:
 
 ```bash
-   $ edit Modules/.../test/CMakeLists.txt
+edit Modules/.../test/CMakeLists.txt
 
    itk_add_test(NAME MyTest COMMAND ... --compare DATA{Baseline/MyTest.png,:} ...)
 ```
@@ -85,9 +85,9 @@ Continue to create the topic and edit other files as necessary. Add the content
 link and commit it along with the other changes:
 
 ```bash
-   $ git add Modules/.../test/Baseline/MyTest.png.cid
-   $ git add Modules/.../test/CMakeLists.txt
-   $ git commit
+git add Modules/.../test/Baseline/MyTest.png.cid
+git add Modules/.../test/CMakeLists.txt
+git commit
 ```
 
 Building
@@ -116,7 +116,7 @@ among multiple builds. Configure for each build the advanced cache entry
 build trees, e.g. "`/home/user/.ExternalData`":
 
 ```bash
-   $ cmake -DExternalData_OBJECT_STORES=/home/user/.ExternalData ../ITK
+cmake -DExternalData_OBJECT_STORES=/home/user/.ExternalData ../ITK
 ```
 
 The `ExternalData` module will store downloaded objects in the local store

--- a/Documentation/docs/contributing/index.md
+++ b/Documentation/docs/contributing/index.md
@@ -21,14 +21,14 @@ Before you begin, perform initial setup:
   3. Follow the [download instructions] to create a local ITK clone:
 
 ```bash
-   $ git clone https://github.com/InsightSoftwareConsortium/ITK
+git clone https://github.com/InsightSoftwareConsortium/ITK
 ```
 
   4. Run the developer setup script [`SetupForDevelopment.sh`] to prepare your
      ITK work tree and create Git command aliases used below:
 
 ```bash
-   $ ./Utilities/SetupForDevelopment.sh
+./Utilities/SetupForDevelopment.sh
 ```
 
 This script helps configure your GitHub fork remote, Git client-side hooks,
@@ -68,8 +68,8 @@ Update
 Update your local `master` branch:
 
 ```bash
-   $ git checkout master
-   $ git pullall
+git checkout master
+git pullall
 ```
 
 (create-a-topic)=
@@ -83,19 +83,19 @@ feature or fix to be developed given just the branch name.
 To start a new topic branch:
 
 ```bash
-   $ git fetch upstream
+git fetch upstream
 ```
 
 For new development, start the topic from `upstream/master`:
 
 ```bash
-   $ git checkout -b my-topic upstream/master
+git checkout -b my-topic upstream/master
 ```
 
 For release branch fixes, start the topic from `upstream/release`:
 
 ```bash
-   $ git checkout -b my-topic upstream/release
+git checkout -b my-topic upstream/release
 ```
 
 (*You may visit the* Pro Git: Basic Branching *resource in [Git Help] for
@@ -105,13 +105,13 @@ Edit files and create commits (repeat as needed). Add a prefix to your commit
 message (see below).
 
 ```bash
-   $ edit file1 file2 file3
+edit file1 file2 file3
 ```
 (*To add data follow [these instructions](data.md).*)
 
-```bash
-   $ git add file1 file2 file3
-   $ git commit
+```sh
+git add file1 file2 file3
+git commit
 ```
 
 (*You may visit the* Pro Git: Recording Changes *resource in [Git Help] for
@@ -204,19 +204,19 @@ upstream repository.
 Checkout the topic if it is not your current branch:
 
 ```bash
-   $ git checkout my-topic
+git checkout my-topic
 ```
 
 Check what commits will be pushed to GitHub for review:
 
 ```bash
-   $ git prepush
+git prepush
 ```
 
 Push commits in your topic branch for review by the community:
 
 ```bash
-   $ git review-push --force
+git review-push --force
 ```
 
 A URL will be provided in the terminal -- visit this url to review the topic
@@ -241,7 +241,7 @@ test can be re-executed by adding a comment to the pull request with the
 content `/azp run <ConfigurationName>`. For example:
 
 ```
-    /azp run ITK.Linux
+/azp run ITK.Linux
 ```
 
 After the topic has been merged, it is tested on many
@@ -265,14 +265,14 @@ Once a topic is approved during GitHub review, proceed to the
 Checkout the topic if it is not your current branch:
 
 ```bash
-   $ git checkout my-topic
+git checkout my-topic
 ```
 
 To revise the most recent commit on the topic edit files and add changes
 normally and then amend the commit:
 
 ```bash
-   $ git commit --amend
+git commit --amend
 ```
 
 (*You may visit the* Pro Git: Changing the Last Commit *resource in [Git Help]
@@ -281,7 +281,7 @@ for further information on revising and rewriting your commit history.*)
 To revise commits further back on the topic, say the `3`rd commit back:
 
 ```bash
-   $ git rebase -i HEAD~3
+git rebase -i HEAD~3
 ```
 
 (*Substitute the correct number of commits back, as low as `1`.*)
@@ -316,17 +316,17 @@ Here are the recommended steps to merge a topic to both `release` and `master`
 branches, assuming the topic branch is forked off the `release` branch:
 
 ```bash
-   $ git checkout release
-   $ git merge --no-ff my-topic
-   $ git push upstream release
+git checkout release
+git merge --no-ff my-topic
+git push upstream release
 ```
 
 and do:
 
 ```bash
-   $ git checkout master
-   $ git merge --no-ff release
-   $ git push upstream master
+git checkout master
+git merge --no-ff release
+git push upstream master
 ```
 
 to merge the `release` branch back to `master`.
@@ -340,14 +340,14 @@ After a topic has been merged upstream, delete your local branch for the topic.
 Checkout and update the `master` branch:
 
 ```bash
-   $ git checkout master
-   $ git pullall
+git checkout master
+git pullall
 ```
 
 Delete the local topic branch:
 
 ```bash
-   $ git branch -d my-topic
+git branch -d my-topic
 ```
 
 The `branch -d` command works only when the topic branch has been correctly

--- a/Documentation/docs/contributing/python_packaging.md
+++ b/Documentation/docs/contributing/python_packaging.md
@@ -35,15 +35,15 @@ In addition, the environment variables `MANYLINUX_VERSION` and `IMAGE_TAG` may b
 For example:
 
 ```bash
-$ git clone https://github.com/InsightSoftwareConsortium/ITKPythonPackage.git
+git clone https://github.com/InsightSoftwareConsortium/ITKPythonPackage.git
 [...]
 
-$ pushd ITKPythonPackage
-$ export MANYLINUX_VERSION=2014
-$ ./scripts/dockcross-manylinux-build-wheels.sh cp38
+pushd ITKPythonPackage
+export MANYLINUX_VERSION=2014
+./scripts/dockcross-manylinux-build-wheels.sh cp38
 [...]
 
-$ ls -1 dist/
+ls -1 dist/
 itk-5.3.0.dev20231108-cp38-cp38m-manylinux2014_x86_64.whl
 ```
 
@@ -58,13 +58,13 @@ First, install the Python.org macOS Python distributions. This step requires sud
 Then, run [macpython-build-wheels.sh](https://github.com/InsightSoftwareConsortium/ITKPythonPackage/blob/master/scripts/macpython-build-wheels.sh) to build the wheels. A Python version may be targetd by passing a trailing argument to the script. See ITKPythonPackage for environment variables used by `macpython-build-wheels.sh`.
 
 ```bash
-$ git clone https://github.com/InsightSoftwareConsortium/ITKPythonPackage.git
+git clone https://github.com/InsightSoftwareConsortium/ITKPythonPackage.git
 [...]
 
-$ ./scripts/macpython-build-wheels.sh cp38
+./scripts/macpython-build-wheels.sh cp38
 [...]
 
-$ ls -1 dist/
+ls -1 dist/
 itk-5.3.0.dev20231108-cp38-cp38m-macosx_10_9_x86_64.whl
 ```
 

--- a/Documentation/docs/contributing/updating_third_party.md
+++ b/Documentation/docs/contributing/updating_third_party.md
@@ -28,19 +28,19 @@ Here's an example of updating the `DoubleConversion` project from tag 1.1.6 to
 3.0.0, starting with updating the third-party repo
 
 ```bash
-   $ cd ./Modules/ThirdParty/DoubleConversion
-   $ git checkout for/itk
-   $ git fetch origin
-   $ git rebase --onto doubleconversion-1.1.6 doubleconversion-3.0.0
-   $ git push
+cd ./Modules/ThirdParty/DoubleConversion
+git checkout for/itk
+git fetch origin
+git rebase --onto doubleconversion-1.1.6 doubleconversion-3.0.0
+git push
 ```
 
 Now import into ITK
 
 ```bash
-   $ cd ./Modules/ThirdParty/twisted
-   $ git checkout -b update_doubleconversion
-   $ ./UpdateFromUpstream.sh
+cd ./Modules/ThirdParty/twisted
+git checkout -b update_doubleconversion
+./UpdateFromUpstream.sh
 ```
 
 Now you can review the change and make a merge request from the branch as normal.
@@ -66,14 +66,14 @@ The basic steps to import a project `foo` based on the tag `foo-3.0.0` looks
 like this:
 
 ```bash
-   $ git clone https://github.com/InsightSoftwareConsortium/foo.git
-   $ cd foo/
-   $ git remote add insight git@github.com:InsightSoftwareConsortium/ITK.git:Modules/ThirdParty/foo.git
-   $ git push -u insight
-   $ git push -u insight --tags
-   $ git checkout foo-3.0.0
-   $ git checkout -b for/itk
-   $ git push --set-upstream insight for/itk
+git clone https://github.com/InsightSoftwareConsortium/foo.git
+cd foo/
+git remote add insight git@github.com:InsightSoftwareConsortium/ITK.git:Modules/ThirdParty/foo.git
+git push -u insight
+git push -u insight --tags
+git checkout foo-3.0.0
+git checkout -b for/itk
+git push --set-upstream insight for/itk
 ```
 
 Making the initial import involves filling out the project's
@@ -89,13 +89,13 @@ party module's `UpdateFromUpstream.sh` script should have.
 Make sure `UpdateFromUpstream.sh` is executable before commit. On Unix, run:
 
 ```bash
-   $ chmod u+x UpdateFromUpstream.sh && git add -u UpdateFromUpstream.sh
+chmod u+x UpdateFromUpstream.sh && git add -u UpdateFromUpstream.sh
 ```
 
 On Windows, run:
 
 ```bash
-   $ git update-index --chmod=+x UpdateFromUpstream.sh
+git update-index --chmod=+x UpdateFromUpstream.sh
 ```
 
 Also add an entry to `CMakeLists.txt` and `itk-module.cmake` as appropriate.

--- a/Documentation/docs/contributing/upload_binary_data.md
+++ b/Documentation/docs/contributing/upload_binary_data.md
@@ -129,14 +129,14 @@ Install the <span class="title-ref">w3</span> CLI with the
 [@web3-storage/w3] [Node.js] package:
 
 ``` shell
-$ npm install --location=global @web3-storage/w3
+npm install --location=global @web3-storage/w3
 ```
 
 Login in and create an API token at
 [web3.storage] then pass it into `w3 token`:
 
 ``` shell
-$ w3 token
+w3 token
 ? Paste your API token for api.web3.storage › <your token here>
 
 ⁂ API token saved
@@ -146,7 +146,7 @@ Create an <span class="title-ref">w3externaldata</span> bash/zsh
 function:
 
 ``` shell
-$ function w3externaldata() { w3 put $1 --no-wrap | tail -n 1 | awk -F "/ipfs/" '{print $2}' | tee $1.cid }
+function w3externaldata() { w3 put $1 --no-wrap | tail -n 1 | awk -F "/ipfs/" '{print $2}' | tee $1.cid }
 ```
 
 Call the function with the file to be uploaded. This command will
@@ -154,7 +154,7 @@ generate the <span class="title-ref">\<filename\>.cid</span> content
 link:
 
 ``` shell
-$ w3externaldata <filename>
+w3externaldata <filename>
 # Packed 1 file (0.3MB)
 ⁂ Stored 1 file
 bafkreifpfhcc3gc7zo2ds3ktyyl5qrycwisyaolegp47cl27i4swxpa2ey
@@ -180,7 +180,7 @@ Move the content link file to the **source tree** at the location where the
 actual file is desired in the build tree. Stage the new file to your commit:
 
 ```bash
-   $ git add -- path/to/file.cid
+git add -- path/to/file.cid
 ```
 
 [Alt Link]: https://content-link-upload.itk.eth.limo

--- a/Documentation/docs/learn/python_quick_start.md
+++ b/Documentation/docs/learn/python_quick_start.md
@@ -5,7 +5,7 @@
 To install the ITK Python package:
 
 ```bash
-$ pip install itk
+pip install itk
 ```
 
 ## Usage


### PR DESCRIPTION
Remove prompt symbol and spaces in Markdown documentation bash blocks: allows to copy and paste the commands directly.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)