### PR TITLE
BUG: Wrap LBFGSOptimizerBaseHelperv4 before LBFGSOptimizerBasev4

### DIFF
--- a/Modules/Numerics/Optimizersv4/wrapping/CMakeLists.txt
+++ b/Modules/Numerics/Optimizersv4/wrapping/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_wrap_module(ITKOptimizersv4)
 set(WRAPPER_SUBMODULE_ORDER
     itkVnlTypes
-    itkLBFGSOptimizerBasev4
     itkLBFGSOptimizerBaseHelperv4
+    itkLBFGSOptimizerBasev4
     itkLBFGSBOptimizerv4
     itkLBFGSOptimizerv4
     itkAmoebaOptimizerv4


### PR DESCRIPTION
LBFGSOptimizerBasev4 uses the LBFGSOptimizerBasev4 in its interface with the GetOptimizer method. Wrap LBFGSOptimizerBaseHelperv4 before LBFGSOptimizerBasev4 so LBFGSOptimizerBaseHelperv4 wrapper definition is available.