### PR TITLE
COMP: Add ULL wrapping for ScanlineFilterCommon

### DIFF
--- a/Modules/Filtering/ImageLabel/wrapping/itkScanlineFilterCommon.wrap
+++ b/Modules/Filtering/ImageLabel/wrapping/itkScanlineFilterCommon.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ScanlineFilterCommon" POINTER)
 itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
-unique(to_types "UL;${WRAP_ITK_INT}")
+unique(to_types "UL;${ITKM_IT};${WRAP_ITK_INT}")
 itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${to_types}" 2+)
 # wrap vector to int combinations because ConnectedComponentImageFilter uses them
 itk_wrap_image_filter_combinations("${WRAP_ITK_VECTOR}" "${WRAP_ITK_INT}" 2+)


### PR DESCRIPTION
Trying to address:

`itkConnectedComponentImageFilter: warning(4): ITK type not wrapped, or currently not known: itk::ScanlineFilterCommon< itk::Image< short, 2 >, itk::Image< unsigned long long, 2 > >`

Introduced by 89edcf37641f794938ea4f08d4ae24f1f68d685c from PR #4294.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

