### PR TITLE
Use "constexpr if" in `MultiThreaderBase::ParallelizeImageRegionRestrictDirection`, and other style improvements

### DIFF
--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -390,7 +390,7 @@ ITK_GCC_PRAGMA_DIAG_POP()
         SplitDimension,
         splitIndex.m_InternalArray,
         splitSize.m_InternalArray,
-        [&](const IndexValueType index[], const SizeValueType size[]) {
+        [restrictedDirection, &requestedRegion, &funcP](const IndexValueType index[], const SizeValueType size[]) {
           ImageRegion<VDimension> restrictedRequestedRegion;
           restrictedRequestedRegion.SetIndex(restrictedDirection, requestedRegion.GetIndex(restrictedDirection));
           restrictedRequestedRegion.SetSize(restrictedDirection, requestedRegion.GetSize(restrictedDirection));

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -373,23 +373,23 @@ ITK_GCC_PRAGMA_DIAG_POP()
     else // Can split, parallelize!
     {
       constexpr unsigned int SplitDimension = VDimension - 1;
-      using SplitRegionType = ImageRegion<SplitDimension>;
 
-      SplitRegionType splitRegion;
+      Index<SplitDimension> splitIndex{};
+      Size<SplitDimension>  splitSize{};
       for (unsigned int splitDimension = 0, dimension = 0; dimension < VDimension; ++dimension)
       {
         if (dimension != restrictedDirection)
         {
-          splitRegion.SetIndex(splitDimension, requestedRegion.GetIndex(dimension));
-          splitRegion.SetSize(splitDimension, requestedRegion.GetSize(dimension));
+          splitIndex[splitDimension] = requestedRegion.GetIndex(dimension);
+          splitSize[splitDimension] = requestedRegion.GetSize(dimension);
           ++splitDimension;
         }
       }
 
       this->ParallelizeImageRegion(
         SplitDimension,
-        splitRegion.GetIndex().m_InternalArray,
-        splitRegion.GetSize().m_InternalArray,
+        splitIndex.m_InternalArray,
+        splitSize.m_InternalArray,
         [&](const IndexValueType index[], const SizeValueType size[]) {
           ImageRegion<VDimension> restrictedRequestedRegion;
           restrictedRequestedRegion.SetIndex(restrictedDirection, requestedRegion.GetIndex(restrictedDirection));

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -378,13 +378,12 @@ ITK_GCC_PRAGMA_DIAG_POP()
       SplitRegionType splitRegion;
       for (unsigned int splitDimension = 0, dimension = 0; dimension < VDimension; ++dimension)
       {
-        if (dimension == restrictedDirection)
+        if (dimension != restrictedDirection)
         {
-          continue;
+          splitRegion.SetIndex(splitDimension, requestedRegion.GetIndex(dimension));
+          splitRegion.SetSize(splitDimension, requestedRegion.GetSize(dimension));
+          ++splitDimension;
         }
-        splitRegion.SetIndex(splitDimension, requestedRegion.GetIndex(dimension));
-        splitRegion.SetSize(splitDimension, requestedRegion.GetSize(dimension));
-        ++splitDimension;
       }
 
       this->ParallelizeImageRegion(
@@ -397,13 +396,12 @@ ITK_GCC_PRAGMA_DIAG_POP()
           restrictedRequestedRegion.SetSize(restrictedDirection, requestedRegion.GetSize(restrictedDirection));
           for (unsigned int splitDimension = 0, dimension = 0; dimension < VDimension; ++dimension)
           {
-            if (dimension == restrictedDirection)
+            if (dimension != restrictedDirection)
             {
-              continue;
+              restrictedRequestedRegion.SetIndex(dimension, index[splitDimension]);
+              restrictedRequestedRegion.SetSize(dimension, size[splitDimension]);
+              ++splitDimension;
             }
-            restrictedRequestedRegion.SetIndex(dimension, index[splitDimension]);
-            restrictedRequestedRegion.SetSize(dimension, size[splitDimension]);
-            ++splitDimension;
           }
           funcP(restrictedRequestedRegion);
         },

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -364,7 +364,7 @@ ITK_GCC_PRAGMA_DIAG_POP()
                                           TFunction                       funcP,
                                           ProcessObject *                 filter)
   {
-    if (VDimension <= 1) // Cannot split, no parallelization
+    if constexpr (VDimension <= 1) // Cannot split, no parallelization
     {
 
       ProgressReporter progress(filter, 0, requestedRegion.GetNumberOfPixels());
@@ -372,7 +372,7 @@ ITK_GCC_PRAGMA_DIAG_POP()
     }
     else // Can split, parallelize!
     {
-      constexpr unsigned int SplitDimension = (VDimension - 1) ? VDimension - 1 : VDimension;
+      constexpr unsigned int SplitDimension = VDimension - 1;
       using SplitRegionType = ImageRegion<SplitDimension>;
 
       SplitRegionType splitRegion;


### PR DESCRIPTION
Style improvements `MultiThreaderBase::ParallelizeImageRegionRestrictDirection`:

 - Replaced an "if" with "constexpr if", allowing to simplify the initialization of `SplitDimension`
 
 - Removed the two `continue` statements, following [C++ Core Guidelines, "Minimize the use of `break`
and `continue` in loops"](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es77-minimize-the-use-of-break-and-continue-in-loops)
 
 - Replaced the local `splitRegion` variable with more lightweight `splitIndex` and `splitSize` variables
 
 - Replaced the default capture `[&]` of the local lambda with an explicit capture list, capturing `restrictedDirection` by value instead of by reference