### PR TITLE
Add `Size::CalculateProductOfElements()`, let it be called by `ImageRegion::GetNumberOfPixels()`, `Neighborhood::SetRadius`

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -72,14 +72,7 @@ template <unsigned int VImageDimension>
 auto
 ImageRegion<VImageDimension>::GetNumberOfPixels() const -> SizeValueType
 {
-  SizeValueType numPixels = 1;
-
-  for (unsigned int i = 0; i < VImageDimension; ++i)
-  {
-    numPixels *= m_Size[i];
-  }
-
-  return numPixels;
+  return m_Size.CalculateProductOfElements();
 }
 
 template <unsigned int VImageDimension>

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -85,14 +85,7 @@ Neighborhood<TPixel, VDimension, TContainer>::SetRadius(const SizeType & r)
 {
   this->m_Radius = r;
   this->SetSize();
-
-  SizeValueType cumul = NumericTraits<SizeValueType>::OneValue();
-  for (DimensionValueType i = 0; i < VDimension; ++i)
-  {
-    cumul *= m_Size[i];
-  }
-
-  this->Allocate(cumul);
+  this->Allocate(m_Size.CalculateProductOfElements());
   this->ComputeNeighborhoodStrideTable();
   this->ComputeNeighborhoodOffsetTable();
 }

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -211,6 +211,19 @@ public:
     std::fill_n(begin(), size(), value);
   } // MATCH std::array assign, ITK Fill
 
+  /** Multiplies all elements. Yields the number of pixels of an image of this size. */
+  [[nodiscard]] constexpr SizeValueType
+  CalculateProductOfElements() const
+  {
+    SizeValueType product{ 1 };
+
+    for (const SizeValueType value : m_InternalArray)
+    {
+      product *= value;
+    }
+    return product;
+  }
+
   /** Size is an "aggregate" class.  Its data is public (m_InternalArray)
    * allowing for fast and convenient instantiations/assignments.
    * ( See main class documentation for an example of initialization)


### PR DESCRIPTION
Added `CalculateProductOfElements()`, as a convenience function of `Size`, typically useful to determine the total number of pixels (2D) or voxels (3D).

Let `ImageRegion::GetNumberOfPixels()` and `Neighborhood::SetRadius` call `Size::CalculateProductOfElements()`.