### PR TITLE
Check `thisClass` argument of `GetNameOfClass` macro calls, fix class name returned by `GetNameOfClass()` overrides

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -51,6 +51,7 @@
 #endif
 
 #include <sstream>
+#include <type_traits> // For is_same, remove_const, and remove_reference.
 
 /** \namespace itk
  * \brief The "itk" namespace contains all Insight Segmentation and
@@ -436,12 +437,20 @@ namespace itk
 /** Macro's used to add `GetNameOfClass()` member functions to polymorphic ITK classes: `itkVirtualGetNameOfClassMacro`
  * adds a virtual `GetNameOfClass()` member function to the class definition, and `itkOverrideGetNameOfClassMacro` adds
  * a `GetNameOfClass()` override. */
-#define itkVirtualGetNameOfClassMacro(thisClass)                     \
-  virtual const char * GetNameOfClass() const { return #thisClass; } \
+#define itkVirtualGetNameOfClassMacro(thisClass)                                                             \
+  virtual const char * GetNameOfClass() const                                                                \
+  {                                                                                                          \
+    static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>); \
+    return #thisClass;                                                                                       \
+  }                                                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkOverrideGetNameOfClassMacro(thisClass)                     \
-  const char * GetNameOfClass() const override { return #thisClass; } \
+#define itkOverrideGetNameOfClassMacro(thisClass)                                                            \
+  const char * GetNameOfClass() const override                                                               \
+  {                                                                                                          \
+    static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>); \
+    return #thisClass;                                                                                       \
+  }                                                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
 #ifdef ITK_FUTURE_LEGACY_REMOVE

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -161,7 +161,7 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkOverrideGetNameOfClassMacro(amoebaTestF1);
+  itkOverrideGetNameOfClassMacro(amoebaTestF2);
 
   using ParametersType = Superclass::ParametersType;
   using MeasureType = Superclass::MeasureType;

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -47,7 +47,7 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkOverrideGetNameOfClassMacro(LBFCostFunction);
+  itkOverrideGetNameOfClassMacro(LBFGSCostFunction);
 
   enum
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
@@ -72,7 +72,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information */
-  itkOverrideGetNameOfClassMacro(BinaryImageToLevelSetImageAdaptorBase);
+  itkOverrideGetNameOfClassMacro(BinaryImageToLevelSetImageAdaptor);
 
   using InputImageType = TInputImage;
   using InputImagePixelType = typename InputImageType::PixelType;


### PR DESCRIPTION
Added a compile-time check on the `thisClass` argument of both `itkVirtualGetNameOfClassMacro` and `itkOverrideGetNameOfClassMacro`. Fixed the class name returned by three `GetNameOfClass()` overrides, including `BinaryImageToLevelSetImageAdaptor::GetNameOfClass()`