### PR TITLE
WIP: STYLE: Use ImageRegion `auto [index, size] = region` structured bindings

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -145,7 +145,7 @@ VTKImageExport<TInputImage>::WholeExtentCallback()
   }
 
   InputRegionType region = input->GetLargestPossibleRegion();
-  auto [index, size] = region;
+  const auto [index, size] = region;
 
   unsigned int i = 0;
   // Fill in the known portion of the extent.
@@ -386,7 +386,7 @@ VTKImageExport<TInputImage>::DataExtentCallback()
   }
 
   InputRegionType region = input->GetBufferedRegion();
-  auto [index, size] = region;
+  const auto [index, size] = region;
 
   unsigned int i = 0;
   for (; i < InputImageDimension; ++i)

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -144,8 +144,7 @@ VTKImageExport<TInputImage>::WholeExtentCallback()
     itkExceptionMacro("Need to set an input");
   }
 
-  InputRegionType region = input->GetLargestPossibleRegion();
-  const auto [index, size] = region;
+  const auto [index, size] = input->GetLargestPossibleRegion();
 
   unsigned int i = 0;
   // Fill in the known portion of the extent.
@@ -385,8 +384,7 @@ VTKImageExport<TInputImage>::DataExtentCallback()
     itkExceptionMacro("Need to set an input");
   }
 
-  InputRegionType region = input->GetBufferedRegion();
-  const auto [index, size] = region;
+  const auto [index, size] = input->GetBufferedRegion();
 
   unsigned int i = 0;
   for (; i < InputImageDimension; ++i)

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -145,8 +145,7 @@ VTKImageExport<TInputImage>::WholeExtentCallback()
   }
 
   InputRegionType region = input->GetLargestPossibleRegion();
-  InputSizeType   size = region.GetSize();
-  InputIndexType  index = region.GetIndex();
+  auto [index, size] = region;
 
   unsigned int i = 0;
   // Fill in the known portion of the extent.
@@ -387,8 +386,7 @@ VTKImageExport<TInputImage>::DataExtentCallback()
   }
 
   InputRegionType region = input->GetBufferedRegion();
-  InputSizeType   size = region.GetSize();
-  InputIndexType  index = region.GetIndex();
+  auto [index, size] = region;
 
   unsigned int i = 0;
   for (; i < InputImageDimension; ++i)

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -113,7 +113,7 @@ VTKImageImport<TOutputImage>::PropagateRequestedRegion(DataObject * outputPtr)
   if (m_PropagateUpdateExtentCallback)
   {
     OutputRegionType region = output->GetRequestedRegion();
-    auto [index, size] = region;
+    const auto [index, size] = region;
 
     int          updateExtent[6];
     unsigned int i = 0;

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -113,8 +113,7 @@ VTKImageImport<TOutputImage>::PropagateRequestedRegion(DataObject * outputPtr)
   if (m_PropagateUpdateExtentCallback)
   {
     OutputRegionType region = output->GetRequestedRegion();
-    OutputSizeType   size = region.GetSize();
-    OutputIndexType  index = region.GetIndex();
+    auto [index, size] = region;
 
     int          updateExtent[6];
     unsigned int i = 0;

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -112,8 +112,7 @@ VTKImageImport<TOutputImage>::PropagateRequestedRegion(DataObject * outputPtr)
   Superclass::PropagateRequestedRegion(output);
   if (m_PropagateUpdateExtentCallback)
   {
-    OutputRegionType region = output->GetRequestedRegion();
-    const auto [index, size] = region;
+    const auto [index, size] = output->GetRequestedRegion();
 
     int          updateExtent[6];
     unsigned int i = 0;

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -392,10 +392,8 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::SetRegion(const RegionTyp
   m_End = m_ConstImage->GetBufferPointer() + m_ConstImage->ComputeOffset(m_EndIndex);
 
   // now determine whether boundary conditions are going to be needed
-  const IndexType bStart = m_ConstImage->GetBufferedRegion().GetIndex();
-  const SizeType  bSize = m_ConstImage->GetBufferedRegion().GetSize();
-  const IndexType rStart = region.GetIndex();
-  const SizeType  rSize = region.GetSize();
+  const auto [bStart, bSize] = m_ConstImage->GetBufferedRegion();
+  const auto [rStart, rSize] = region;
 
   m_NeedToUseBoundaryCondition = false;
   for (DimensionValueType i = 0; i < Dimension; ++i)
@@ -627,8 +625,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::SetBound(const SizeType &
 {
   SizeType                radius = this->GetRadius();
   const OffsetValueType * offset = m_ConstImage->GetOffsetTable();
-  const IndexType         imageBRStart = m_ConstImage->GetBufferedRegion().GetIndex();
-  SizeType                imageBRSize = m_ConstImage->GetBufferedRegion().GetSize();
+  const auto [imageBRStart, imageBRSize] = m_ConstImage->GetBufferedRegion();
 
   // Set the bounds and the wrapping offsets. Inner bounds are the loop
   // indices where the iterator will begin to overlap the edge of the image

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -205,10 +205,8 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::Initialize(const SizeType &   ra
   this->SetEndIndex();
 
   // now determine whether boundary conditions are going to be needed
-  const IndexType bStart = ptr->GetBufferedRegion().GetIndex();
-  const SizeType  bSize = ptr->GetBufferedRegion().GetSize();
-  const IndexType rStart = region.GetIndex();
-  const SizeType  rSize = region.GetSize();
+  const auto [bStart, bSize] = ptr->GetBufferedRegion();
+  const auto [rStart, rSize] = region;
 
   m_NeedToUseBoundaryCondition = false;
   for (DimensionValueType i = 0; i < Dimension; ++i)
@@ -456,9 +454,8 @@ template <typename TImage>
 void
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::SetBound(const SizeType & size)
 {
-  SizeType        radius = this->GetRadius();
-  const IndexType imageBRStart = m_ConstImage->GetBufferedRegion().GetIndex();
-  SizeType        imageBRSize = m_ConstImage->GetBufferedRegion().GetSize();
+  SizeType radius = this->GetRadius();
+  const auto [imageBRStart, imageBRSize] = m_ConstImage->GetBufferedRegion();
 
   // Set the bounds and the wrapping offsets. Inner bounds are the loop
   // indices where the iterator will begin to overlap the edge of the image

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -49,10 +49,8 @@ ImageBoundaryFacesCalculator<TImage>::Compute(const TImage & img, RegionType reg
     return result;
   }
 
-  const IndexType bStart = bufferedRegion.GetIndex();
-  const SizeType  bSize = bufferedRegion.GetSize();
-  const IndexType rStart = regionToProcess.GetIndex();
-  const SizeType  rSize = regionToProcess.GetSize();
+  const auto [bStart, bSize] = bufferedRegion;
+  const auto [rStart, rSize] = regionToProcess;
 
   SizeType  nbSize = rSize;   // Non-boundary region
   IndexType nbStart = rStart; // data.

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -138,11 +138,9 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
   const RegionType & inputLargestPossibleRegion,
   const RegionType & outputRequestedRegion) const -> RegionType
 {
-  IndexType imageIndex = inputLargestPossibleRegion.GetIndex();
-  SizeType  imageSize = inputLargestPossibleRegion.GetSize();
+  auto [imageIndex, imageSize] = inputLargestPossibleRegion;
 
-  IndexType outputIndex = outputRequestedRegion.GetIndex();
-  SizeType  outputSize = outputRequestedRegion.GetSize();
+  auto [outputIndex, outputSize] = outputRequestedRegion;
 
   IndexType inputRequestedIndex;
   SizeType  inputRequestedSize;
@@ -184,8 +182,7 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType &
   -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
-  IndexType  imageIndex = imageRegion.GetIndex();
-  SizeType   imageSize = imageRegion.GetSize();
+  auto [imageIndex, imageSize] = imageRegion;
 
   IndexType lookupIndex;
 

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -181,8 +181,7 @@ auto
 PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType & index, const TInputImage * image) const
   -> OutputPixelType
 {
-  RegionType imageRegion = image->GetLargestPossibleRegion();
-  const auto [imageIndex, imageSize] = imageRegion;
+  const auto [imageIndex, imageSize] = image->GetLargestPossibleRegion();
 
   IndexType lookupIndex;
 

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -138,9 +138,9 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
   const RegionType & inputLargestPossibleRegion,
   const RegionType & outputRequestedRegion) const -> RegionType
 {
-  auto [imageIndex, imageSize] = inputLargestPossibleRegion;
+  const auto [imageIndex, imageSize] = inputLargestPossibleRegion;
 
-  auto [outputIndex, outputSize] = outputRequestedRegion;
+  const auto [outputIndex, outputSize] = outputRequestedRegion;
 
   IndexType inputRequestedIndex;
   SizeType  inputRequestedSize;
@@ -182,7 +182,7 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType &
   -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
-  auto [imageIndex, imageSize] = imageRegion;
+  const auto [imageIndex, imageSize] = imageRegion;
 
   IndexType lookupIndex;
 

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -86,9 +86,9 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRe
   const RegionType & inputLargestPossibleRegion,
   const RegionType & outputRequestedRegion) const -> RegionType
 {
-  auto [inputIndex, inputSize] = inputLargestPossibleRegion;
+  const auto [inputIndex, inputSize] = inputLargestPossibleRegion;
 
-  auto [outputIndex, outputSize] = outputRequestedRegion;
+  const auto [outputIndex, outputSize] = outputRequestedRegion;
 
   IndexType requestIndex;
   SizeType  requestSize;
@@ -154,7 +154,7 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const Inde
   -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
-  auto [imageIndex, imageSize] = imageRegion;
+  const auto [imageIndex, imageSize] = imageRegion;
 
   IndexType lookupIndex;
 

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -86,11 +86,9 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRe
   const RegionType & inputLargestPossibleRegion,
   const RegionType & outputRequestedRegion) const -> RegionType
 {
-  IndexType inputIndex = inputLargestPossibleRegion.GetIndex();
-  SizeType  inputSize = inputLargestPossibleRegion.GetSize();
+  auto [inputIndex, inputSize] = inputLargestPossibleRegion;
 
-  IndexType outputIndex = outputRequestedRegion.GetIndex();
-  SizeType  outputSize = outputRequestedRegion.GetSize();
+  auto [outputIndex, outputSize] = outputRequestedRegion;
 
   IndexType requestIndex;
   SizeType  requestSize;
@@ -156,8 +154,7 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const Inde
   -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
-  IndexType  imageIndex = imageRegion.GetIndex();
-  SizeType   imageSize = imageRegion.GetSize();
+  auto [imageIndex, imageSize] = imageRegion;
 
   IndexType lookupIndex;
 

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -33,7 +33,7 @@ GPUImageDataManager<ImageType>::SetImagePointer(ImageType * img)
   using SizeType = typename ImageType::SizeType;
 
   RegionType region = m_Image->GetBufferedRegion();
-  auto [index, size] = region;
+  const auto [index, size] = region;
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -33,8 +33,7 @@ GPUImageDataManager<ImageType>::SetImagePointer(ImageType * img)
   using SizeType = typename ImageType::SizeType;
 
   RegionType region = m_Image->GetBufferedRegion();
-  IndexType  index = region.GetIndex();
-  SizeType   size = region.GetSize();
+  auto [index, size] = region;
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -32,8 +32,7 @@ GPUImageDataManager<ImageType>::SetImagePointer(ImageType * img)
   using IndexType = typename ImageType::IndexType;
   using SizeType = typename ImageType::SizeType;
 
-  RegionType region = m_Image->GetBufferedRegion();
-  const auto [index, size] = region;
+  const auto [index, size] = m_Image->GetBufferedRegion();
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -58,7 +58,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeBoundingBox()
 
   typename InputImageType::ConstPointer input = this->GetInputImage();
   typename InputImageType::SpacingType  spacing = input->GetSpacing();
-  auto [index, size] = input->GetLargestPossibleRegion();
+  const auto [index, size] = input->GetLargestPossibleRegion();
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -58,8 +58,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeBoundingBox()
 
   typename InputImageType::ConstPointer input = this->GetInputImage();
   typename InputImageType::SpacingType  spacing = input->GetSpacing();
-  typename InputImageType::IndexType    index = input->GetLargestPossibleRegion().GetIndex();
-  typename InputImageType::SizeType     size = input->GetLargestPossibleRegion().GetSize();
+  auto [index, size] = input->GetLargestPossibleRegion();
 
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -163,7 +163,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
     }
     auto indMin = m_Image->TransformPhysicalPointToIndex(ptMin);
     auto indMax = m_Image->TransformPhysicalPointToIndex(ptMax);
-    auto [imageIndex, imageSize] = m_Image->GetLargestPossibleRegion();
+    const auto [imageIndex, imageSize] = m_Image->GetLargestPossibleRegion();
     for (unsigned int i = 0; i < Self::ObjectDimension; ++i)
     {
       if (indMin[i] > indMax[i])

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -161,10 +161,9 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
       ptMin[i] = bounds[i * 2];
       ptMax[i] = bounds[i * 2 + 1];
     }
-    auto      indMin = m_Image->TransformPhysicalPointToIndex(ptMin);
-    auto      indMax = m_Image->TransformPhysicalPointToIndex(ptMax);
-    IndexType imageIndex = m_Image->GetLargestPossibleRegion().GetIndex();
-    SizeType  imageSize = m_Image->GetLargestPossibleRegion().GetSize();
+    auto indMin = m_Image->TransformPhysicalPointToIndex(ptMin);
+    auto indMax = m_Image->TransformPhysicalPointToIndex(ptMax);
+    auto [imageIndex, imageSize] = m_Image->GetLargestPossibleRegion();
     for (unsigned int i = 0; i < Self::ObjectDimension; ++i)
     {
       if (indMin[i] > indMax[i])

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -599,8 +599,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectInte
   IndexValueType lastSlice =
     region.GetIndex()[m_SlicingDirection] + static_cast<IndexValueType>(region.GetSize()[m_SlicingDirection]);
   InputImageRegionType sliceRegion;
-  InputImageIndexType  index = region.GetIndex();
-  InputImageSizeType   size = region.GetSize();
+  auto [index, size] = region;
 
   sliceRegion.SetSize(size);
   BiasFieldType bias = this->EstimateBiasField(sliceRegion, 0, m_InterSliceCorrectionMaximumIteration);
@@ -882,8 +881,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
   SlabRegionVectorType & slabs,
   OutputImageRegionType  requestedRegion)
 {
-  OutputImageIndexType indexFirst = requestedRegion.GetIndex();
-  OutputImageSizeType  size = requestedRegion.GetSize();
+  auto [indexFirst, size] = requestedRegion;
   OutputImageIndexType indexLast = indexFirst;
 
   for (SizeValueType i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -881,7 +881,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
   SlabRegionVectorType & slabs,
   OutputImageRegionType  requestedRegion)
 {
-  auto [indexFirst, size] = requestedRegion;
+  const auto [indexFirst, size] = requestedRegion;
   OutputImageIndexType indexLast = indexFirst;
 
   for (SizeValueType i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -54,8 +54,7 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GetValidReg
 
   InputRegionType inputLargestPossibleRegion = inputPtr->GetLargestPossibleRegion();
 
-  OutputIndexType validIndex = inputLargestPossibleRegion.GetIndex();
-  OutputSizeType  validSize = inputLargestPossibleRegion.GetSize();
+  auto [validIndex, validSize] = inputLargestPossibleRegion;
 
   // Shrink the output largest possible region by the kernel radius.
   KernelSizeType kernelSize = this->GetKernelImage()->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -52,9 +52,7 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GetValidReg
 {
   typename InputImageType::ConstPointer inputPtr = this->GetInput();
 
-  InputRegionType inputLargestPossibleRegion = inputPtr->GetLargestPossibleRegion();
-
-  auto [validIndex, validSize] = inputLargestPossibleRegion;
+  auto [validIndex, validSize] = inputPtr->GetLargestPossibleRegion();
 
   // Shrink the output largest possible region by the kernel radius.
   KernelSizeType kernelSize = this->GetKernelImage()->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -150,11 +150,11 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
   float remainingProgress = 1.0f;
 
   InputRegionType inputLargestRegion = input->GetLargestPossibleRegion();
-  auto [inputLargestIndex, inputLargestSize] = inputLargestRegion;
+  const auto [inputLargestIndex, inputLargestSize] = inputLargestRegion;
   InputRegionType inputRequestedRegion = input->GetRequestedRegion();
-  auto [inputRequestedIndex, inputRequestedSize] = inputRequestedRegion;
+  const auto [inputRequestedIndex, inputRequestedSize] = inputRequestedRegion;
   OutputRegionType outputRequestedRegion = this->GetOutput()->GetRequestedRegion();
-  auto [outputRequestedIndex, outputRequestedSize] = outputRequestedRegion;
+  const auto [outputRequestedIndex, outputRequestedSize] = outputRequestedRegion;
 
   // Pad the input image such that the requested region, expanded by
   // twice the kernel radius, lies entirely within the buffered region.

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -149,15 +149,12 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
 {
   float remainingProgress = 1.0f;
 
-  InputRegionType  inputLargestRegion = input->GetLargestPossibleRegion();
-  InputSizeType    inputLargestSize = inputLargestRegion.GetSize();
-  InputIndexType   inputLargestIndex = inputLargestRegion.GetIndex();
-  InputRegionType  inputRequestedRegion = input->GetRequestedRegion();
-  InputSizeType    inputRequestedSize = inputRequestedRegion.GetSize();
-  InputIndexType   inputRequestedIndex = inputRequestedRegion.GetIndex();
+  InputRegionType inputLargestRegion = input->GetLargestPossibleRegion();
+  auto [inputLargestIndex, inputLargestSize] = inputLargestRegion;
+  InputRegionType inputRequestedRegion = input->GetRequestedRegion();
+  auto [inputRequestedIndex, inputRequestedSize] = inputRequestedRegion;
   OutputRegionType outputRequestedRegion = this->GetOutput()->GetRequestedRegion();
-  OutputSizeType   outputRequestedSize = outputRequestedRegion.GetSize();
-  OutputIndexType  outputRequestedIndex = outputRequestedRegion.GetIndex();
+  auto [outputRequestedIndex, outputRequestedSize] = outputRequestedRegion;
 
   // Pad the input image such that the requested region, expanded by
   // twice the kernel radius, lies entirely within the buffered region.

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -151,8 +151,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
 
   InputRegionType inputLargestRegion = input->GetLargestPossibleRegion();
   const auto [inputLargestIndex, inputLargestSize] = inputLargestRegion;
-  InputRegionType inputRequestedRegion = input->GetRequestedRegion();
-  const auto [inputRequestedIndex, inputRequestedSize] = inputRequestedRegion;
+  const auto [inputRequestedIndex, inputRequestedSize] = input->GetRequestedRegion();
   OutputRegionType outputRequestedRegion = this->GetOutput()->GetRequestedRegion();
   const auto [outputRequestedIndex, outputRequestedSize] = outputRequestedRegion;
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -191,8 +191,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Gau
   ScalarType weight2 = 1.0 - weight1;
 
   const typename ConstantVelocityFieldType::RegionType region = field->GetLargestPossibleRegion();
-  const typename ConstantVelocityFieldType::SizeType   size = region.GetSize();
-  const typename ConstantVelocityFieldType::IndexType  startIndex = region.GetIndex();
+  const auto [startIndex, size] = region;
 
   ImageRegionIteratorWithIndex<ConstantVelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
   ImageRegionConstIteratorWithIndex<ConstantVelocityFieldType> smoothedFieldIt(smoothField,

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -190,8 +190,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Gau
   }
   ScalarType weight2 = 1.0 - weight1;
 
-  const typename ConstantVelocityFieldType::RegionType region = field->GetLargestPossibleRegion();
-  const auto [startIndex, size] = region;
+  const auto [startIndex, size] = field->GetLargestPossibleRegion();
 
   ImageRegionIteratorWithIndex<ConstantVelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
   ImageRegionConstIteratorWithIndex<ConstantVelocityFieldType> smoothedFieldIt(smoothField,

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -184,8 +184,7 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
   ScalarType weight2 = 1.0 - weight1;
 
   const typename DisplacementFieldType::RegionType region = field->GetLargestPossibleRegion();
-  const typename DisplacementFieldType::SizeType   size = region.GetSize();
-  const typename DisplacementFieldType::IndexType  startIndex = region.GetIndex();
+  const auto [startIndex, size] = region;
 
   ImageRegionIteratorWithIndex<DisplacementFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
   ImageRegionConstIteratorWithIndex<DisplacementFieldType> smoothedFieldIt(smoothField,

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -198,7 +198,7 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
 
   using TimeVaryingVelocityFieldIndexType = typename VelocityFieldType::IndexType;
 
-  auto [startIndex, size] = field->GetLargestPossibleRegion();
+  const auto [startIndex, size] = field->GetLargestPossibleRegion();
 
   ImageRegionIteratorWithIndex<VelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
   ImageRegionConstIteratorWithIndex<VelocityFieldType> smoothedFieldIt(smoothField,

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -196,11 +196,9 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
   }
   ScalarType weight2 = 1.0 - weight1;
 
-  using TimeVaryingVelocityFieldSizeType = typename VelocityFieldType::SizeType;
   using TimeVaryingVelocityFieldIndexType = typename VelocityFieldType::IndexType;
 
-  TimeVaryingVelocityFieldSizeType  size = field->GetLargestPossibleRegion().GetSize();
-  TimeVaryingVelocityFieldIndexType startIndex = field->GetLargestPossibleRegion().GetIndex();
+  auto [startIndex, size] = field->GetLargestPossibleRegion();
 
   ImageRegionIteratorWithIndex<VelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
   ImageRegionConstIteratorWithIndex<VelocityFieldType> smoothedFieldIt(smoothField,

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -168,8 +168,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const RegionType & region)
 {
-  const typename DisplacementFieldType::RegionType fullRegion = this->m_ComposedField->GetRequestedRegion();
-  const auto [startIndex, size] = fullRegion;
+  const auto [startIndex, size] = this->m_ComposedField->GetRequestedRegion();
   const typename DisplacementFieldType::PixelType zeroVector{};
 
   ImageRegionIterator<DisplacementFieldType> ItE(this->m_ComposedField, region);

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -169,9 +169,8 @@ void
 InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const RegionType & region)
 {
   const typename DisplacementFieldType::RegionType fullRegion = this->m_ComposedField->GetRequestedRegion();
-  const typename DisplacementFieldType::SizeType   size = fullRegion.GetSize();
-  const typename DisplacementFieldType::IndexType  startIndex = fullRegion.GetIndex();
-  const typename DisplacementFieldType::PixelType  zeroVector{};
+  const auto [startIndex, size] = fullRegion;
+  const typename DisplacementFieldType::PixelType zeroVector{};
 
   ImageRegionIterator<DisplacementFieldType> ItE(this->m_ComposedField, region);
   ImageRegionIterator<RealImageType>         ItS(this->m_ScaledNormImage, region);

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -187,10 +187,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
   {
     typename TimeVaryingVelocityFieldType::PointType spaceTimeOrigin = inputField->GetOrigin();
 
-    using RegionType = typename TimeVaryingVelocityFieldType::RegionType;
-    RegionType region = inputField->GetLargestPossibleRegion();
-
-    auto [lastIndex, size] = region;
+    auto [lastIndex, size] = inputField->GetLargestPossibleRegion();
     for (unsigned int d = 0; d < InputImageDimension; ++d)
     {
       lastIndex[d] += (size[d] - 1);

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -190,8 +190,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     using RegionType = typename TimeVaryingVelocityFieldType::RegionType;
     RegionType region = inputField->GetLargestPossibleRegion();
 
-    typename RegionType::IndexType lastIndex = region.GetIndex();
-    typename RegionType::SizeType  size = region.GetSize();
+    auto [lastIndex, size] = region;
     for (unsigned int d = 0; d < InputImageDimension; ++d)
     {
       lastIndex[d] += (size[d] - 1);

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -53,8 +53,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::SplitRequestedReg
 
   const OutputSizeType & requestedRegionSize = splitRegion.GetSize();
 
-  OutputIndexType splitIndex = splitRegion.GetIndex();
-  OutputSizeType  splitSize = splitRegion.GetSize();
+  auto [splitIndex, splitSize] = splitRegion;
 
   // split on the outermost dimension available
   // and avoid the current dimension

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -139,8 +139,8 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
       OutputImageIndexType index(conjugateIndex);
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
-        OutputImageRegionType outputLargestPossibleRegion = outputPtr->GetLargestPossibleRegion();
-        const auto [outputLargestPossibleRegionIndex, outputLargestPossibleRegionSize] = outputLargestPossibleRegion;
+        const auto [outputLargestPossibleRegionIndex, outputLargestPossibleRegionSize] =
+          outputPtr->GetLargestPossibleRegion();
         if (conjugateIndex[i] != outputLargestPossibleRegionIndex[i])
         {
           index[i] = outputLargestPossibleRegionSize[i] - conjugateIndex[i] + 2 * outputLargestPossibleRegionIndex[i];

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -119,7 +119,7 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
 
   // Now copy the redundant complex conjugate region, if there is one
   // in this thread's output region.
-  auto [outputRegionIndex, outputRegionSize] = outputRegionForThread;
+  const auto [outputRegionIndex, outputRegionSize] = outputRegionForThread;
   OutputImageIndexType outputRegionMaximumIndex = outputRegionIndex + outputRegionSize;
 
   if (outputRegionMaximumIndex[0] > inputRegionMaximumIndex[0])
@@ -140,7 +140,7 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         OutputImageRegionType outputLargestPossibleRegion = outputPtr->GetLargestPossibleRegion();
-        auto [outputLargestPossibleRegionIndex, outputLargestPossibleRegionSize] = outputLargestPossibleRegion;
+        const auto [outputLargestPossibleRegionIndex, outputLargestPossibleRegionSize] = outputLargestPossibleRegion;
         if (conjugateIndex[i] != outputLargestPossibleRegionIndex[i])
         {
           index[i] = outputLargestPossibleRegionSize[i] - conjugateIndex[i] + 2 * outputLargestPossibleRegionIndex[i];

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -119,8 +119,7 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
 
   // Now copy the redundant complex conjugate region, if there is one
   // in this thread's output region.
-  OutputImageIndexType outputRegionIndex = outputRegionForThread.GetIndex();
-  OutputImageSizeType  outputRegionSize = outputRegionForThread.GetSize();
+  auto [outputRegionIndex, outputRegionSize] = outputRegionForThread;
   OutputImageIndexType outputRegionMaximumIndex = outputRegionIndex + outputRegionSize;
 
   if (outputRegionMaximumIndex[0] > inputRegionMaximumIndex[0])
@@ -141,8 +140,7 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         OutputImageRegionType outputLargestPossibleRegion = outputPtr->GetLargestPossibleRegion();
-        OutputImageIndexType  outputLargestPossibleRegionIndex = outputLargestPossibleRegion.GetIndex();
-        OutputImageSizeType   outputLargestPossibleRegionSize = outputLargestPossibleRegion.GetSize();
+        auto [outputLargestPossibleRegionIndex, outputLargestPossibleRegionSize] = outputLargestPossibleRegion;
         if (conjugateIndex[i] != outputLargestPossibleRegionIndex[i])
         {
           index[i] = outputLargestPossibleRegionSize[i] - conjugateIndex[i] + 2 * outputLargestPossibleRegionIndex[i];

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -43,8 +43,7 @@ RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateOut
   // This is all based on the same function in itk::ShrinkImageFilter
   // ShrinkImageFilter also modifies the image spacing, but spacing
   // has no meaning in the result of an FFT.
-  const InputSizeType  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
-  const InputIndexType inputStartIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
+  const auto [inputStartIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
 
   OutputSizeType  outputSize;
   OutputIndexType outputStartIndex;

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -41,10 +41,8 @@ VnlHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Generate
   // reports the beginning and the end of the process.
   ProgressReporter progress(this, 0, 1);
 
-  const InputSizeType   inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
-  const InputIndexType  inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
-  const OutputSizeType  outputSize = outputPtr->GetLargestPossibleRegion().GetSize();
-  const OutputIndexType outputIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
+  const auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
+  const auto [outputIndex, outputSize] = outputPtr->GetLargestPossibleRegion();
 
   // Allocate output buffer memory
   outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -146,8 +146,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
   }
 
   // set safe region for picking feature points depending on whether tensors are computed
-  IndexType safeIndex = region.GetIndex();
-  SizeType  safeSize = region.GetSize();
+  auto [safeIndex, safeSize] = region;
 
   if (m_ComputeStructureTensors)
   {

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -249,7 +249,7 @@ private:
   void
   Init()
   {
-    auto [minIndex, sizeImage] = this->m_Image->GetLargestPossibleRegion();
+    const auto [minIndex, sizeImage] = this->m_Image->GetLargestPossibleRegion();
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; ++dim)
     {
       this->m_ZeroFrequencyIndex[dim] =

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -249,8 +249,7 @@ private:
   void
   Init()
   {
-    IndexType minIndex = this->m_Image->GetLargestPossibleRegion().GetIndex();
-    SizeType  sizeImage = this->m_Image->GetLargestPossibleRegion().GetSize();
+    auto [minIndex, sizeImage] = this->m_Image->GetLargestPossibleRegion();
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; ++dim)
     {
       this->m_ZeroFrequencyIndex[dim] =

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -36,7 +36,7 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   SizeType             sz;
   OutputImageIndexType idx;
 
-  auto [input_idx, input_sz] = inputPtr->GetLargestPossibleRegion();
+  const auto [input_idx, input_sz] = inputPtr->GetLargestPossibleRegion();
 
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -36,8 +36,7 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   SizeType             sz;
   OutputImageIndexType idx;
 
-  InputImageSizeType  input_sz = inputPtr->GetLargestPossibleRegion().GetSize();
-  InputImageIndexType input_idx = inputPtr->GetLargestPossibleRegion().GetIndex();
+  auto [input_idx, input_sz] = inputPtr->GetLargestPossibleRegion();
 
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -57,8 +57,7 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const InputImageType * inputImage = this->GetInput();
 
   // The index and size of the image needed to compute the shift
-  const IndexType outIdx = this->GetOutput()->GetLargestPossibleRegion().GetIndex();
-  const SizeType  outSize = this->GetOutput()->GetLargestPossibleRegion().GetSize();
+  const auto [outIdx, outSize] = this->GetOutput()->GetLargestPossibleRegion();
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -185,7 +185,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::ConvertOutputIndexToInputIndex(
   long         a, b, c; // Output region goes from a to a+b-1
                         // Input region goes from c to c+b-1
   OutputImageIndexType outputRegionStart = outputRegion.GetIndex();
-  auto [inputRegionStart, inputSizes] = inputRegion;
+  const auto [inputRegionStart, inputSizes] = inputRegion;
 
   for (dimCtr = 0; dimCtr < ImageDimension; ++dimCtr)
   {

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -39,10 +39,9 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextOutputRegion(long *
                                                                           std::vector<long> *     sizes,
                                                                           OutputImageRegionType & outputRegion)
 {
-  unsigned int         ctr;
-  int                  done = 0;
-  OutputImageIndexType nextIndex = outputRegion.GetIndex();
-  OutputImageSizeType  nextSize = outputRegion.GetSize();
+  unsigned int ctr;
+  int          done = 0;
+  auto [nextIndex, nextSize] = outputRegion;
 
   //
   // Starting at the first dimension, increment the counter and set a new
@@ -96,10 +95,9 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextInputRegion(long * 
                                                                          std::vector<long> *    sizes,
                                                                          InputImageRegionType & inputRegion)
 {
-  unsigned int        ctr;
-  int                 done = 0;
-  InputImageIndexType nextIndex = inputRegion.GetIndex();
-  InputImageSizeType  nextSize = inputRegion.GetSize();
+  unsigned int ctr;
+  int          done = 0;
+  auto [nextIndex, nextSize] = inputRegion;
 
   //
   // Starting at the first dimension, increment the counter and set a new
@@ -187,8 +185,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::ConvertOutputIndexToInputIndex(
   long         a, b, c; // Output region goes from a to a+b-1
                         // Input region goes from c to c+b-1
   OutputImageIndexType outputRegionStart = outputRegion.GetIndex();
-  InputImageIndexType  inputRegionStart = inputRegion.GetIndex();
-  InputImageSizeType   inputSizes = inputRegion.GetSize();
+  auto [inputRegionStart, inputSizes] = inputRegion;
 
   for (dimCtr = 0; dimCtr < ImageDimension; ++dimCtr)
   {

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -225,8 +225,7 @@ SliceBySliceImageFilter<TInputImage,
 
   this->AllocateOutputs();
 
-  const RegionType requestedRegion = this->GetOutput(0)->GetRequestedRegion();
-  const auto [requestedIndex, requestedSize] = requestedRegion;
+  const auto [requestedIndex, requestedSize] = this->GetOutput(0)->GetRequestedRegion();
 
   InternalRegionType internalOutputRegion;
   InternalRegionType internalInputRegion;

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -226,8 +226,7 @@ SliceBySliceImageFilter<TInputImage,
   this->AllocateOutputs();
 
   const RegionType requestedRegion = this->GetOutput(0)->GetRequestedRegion();
-  const IndexType  requestedIndex = requestedRegion.GetIndex();
-  const SizeType   requestedSize = requestedRegion.GetSize();
+  const auto [requestedIndex, requestedSize] = requestedRegion;
 
   InternalRegionType internalOutputRegion;
   InternalRegionType internalInputRegion;

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -33,8 +33,7 @@ static bool
 VerifyFilterOutput(const ShortImage * inputImage, const FloatImage * outputImage)
 {
   ShortImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  ShortImage::IndexType  inputIndex = inputRegion.GetIndex();
-  ShortImage::SizeType   inputSize = inputRegion.GetSize();
+  auto [inputIndex, inputSize] = inputRegion;
 
   ShortImage::RegionType                             outputRegion = outputImage->GetLargestPossibleRegion();
   itk::ImageRegionConstIteratorWithIndex<FloatImage> outputIterator(outputImage, outputRegion);
@@ -106,12 +105,10 @@ VerifyFilter(const ShortImage *    inputImage,
   }
 
   ShortImage::RegionType outputRegion = padFilter->GetOutput()->GetLargestPossibleRegion();
-  ShortImage::IndexType  outputIndex = outputRegion.GetIndex();
-  ShortImage::SizeType   outputSize = outputRegion.GetSize();
+  auto [outputIndex, outputSize] = outputRegion;
 
   ShortImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  ShortImage::IndexType  inputIndex = inputRegion.GetIndex();
-  ShortImage::SizeType   inputSize = inputRegion.GetSize();
+  auto [inputIndex, inputSize] = inputRegion;
 
   ShortImage::IndexType expectedIndex;
   ShortImage::SizeType  expectedSize;

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -33,7 +33,7 @@ static bool
 VerifyFilterOutput(const ShortImage * inputImage, const FloatImage * outputImage)
 {
   ShortImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = inputRegion;
 
   ShortImage::RegionType                             outputRegion = outputImage->GetLargestPossibleRegion();
   itk::ImageRegionConstIteratorWithIndex<FloatImage> outputIterator(outputImage, outputRegion);
@@ -105,10 +105,10 @@ VerifyFilter(const ShortImage *    inputImage,
   }
 
   ShortImage::RegionType outputRegion = padFilter->GetOutput()->GetLargestPossibleRegion();
-  auto [outputIndex, outputSize] = outputRegion;
+  const auto [outputIndex, outputSize] = outputRegion;
 
   ShortImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = inputRegion;
 
   ShortImage::IndexType expectedIndex;
   ShortImage::SizeType  expectedSize;

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -104,11 +104,9 @@ VerifyFilter(const ShortImage *    inputImage,
     return false;
   }
 
-  ShortImage::RegionType outputRegion = padFilter->GetOutput()->GetLargestPossibleRegion();
-  const auto [outputIndex, outputSize] = outputRegion;
+  const auto [outputIndex, outputSize] = padFilter->GetOutput()->GetLargestPossibleRegion();
 
-  ShortImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  const auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = inputImage->GetLargestPossibleRegion();
 
   ShortImage::IndexType expectedIndex;
   ShortImage::SizeType  expectedSize;

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -157,8 +157,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputIterType outputIter(outputImage, outputImage->GetBufferedRegion());
   using inputIterType = ImageRegionConstIterator<TInputImage>;
 
-  typename TInputImage::SizeType  AccumulatedSize = inputImage->GetLargestPossibleRegion().GetSize();
-  typename TInputImage::IndexType AccumulatedIndex = inputImage->GetLargestPossibleRegion().GetIndex();
+  auto [AccumulatedIndex, AccumulatedSize] = inputImage->GetLargestPossibleRegion();
 
   typename TInputImage::SizeValueType  SizeAccumulateDimension = AccumulatedSize[m_AccumulateDimension];
   const auto                           sizeAccumulateDimensionDouble = static_cast<double>(SizeAccumulateDimension);

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -217,11 +217,11 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
 
   typename TInputImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
 
-  auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = inputRegion;
 
   typename TOutputImage::Pointer outputImage = this->GetOutput();
 
-  auto [outputIndexForThread, outputSizeForThread] = outputRegionForThread;
+  const auto [outputIndexForThread, outputSizeForThread] = outputRegionForThread;
 
   // compute the input region for this thread
   typename TInputImage::RegionType inputRegionForThread = inputRegion;

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -217,13 +217,11 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
 
   typename TInputImage::RegionType inputRegion = inputImage->GetLargestPossibleRegion();
 
-  typename TInputImage::SizeType  inputSize = inputRegion.GetSize();
-  typename TInputImage::IndexType inputIndex = inputRegion.GetIndex();
+  auto [inputIndex, inputSize] = inputRegion;
 
   typename TOutputImage::Pointer outputImage = this->GetOutput();
 
-  typename TOutputImage::SizeType  outputSizeForThread = outputRegionForThread.GetSize();
-  typename TOutputImage::IndexType outputIndexForThread = outputRegionForThread.GetIndex();
+  auto [outputIndexForThread, outputSizeForThread] = outputRegionForThread;
 
   // compute the input region for this thread
   typename TInputImage::RegionType inputRegionForThread = inputRegion;

--- a/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
@@ -46,7 +46,7 @@ CropLabelMapFilter<TInputImage>::GenerateOutputInformation()
   SizeType  size;
   IndexType index;
 
-  auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
+  const auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
 
   SizeType originalCropSize = m_UpperBoundaryCropSize + m_LowerBoundaryCropSize;
 

--- a/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
@@ -46,8 +46,7 @@ CropLabelMapFilter<TInputImage>::GenerateOutputInformation()
   SizeType  size;
   IndexType index;
 
-  SizeType  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
-  IndexType inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
+  auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
 
   SizeType originalCropSize = m_UpperBoundaryCropSize + m_LowerBoundaryCropSize;
 

--- a/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
@@ -45,8 +45,7 @@ PadLabelMapFilter<TInputImage>::GenerateOutputInformation()
   SizeType  size;
   IndexType index;
 
-  SizeType  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
-  IndexType inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
+  auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
 
   SizeType originalPadSize = m_UpperBoundaryPadSize + m_LowerBoundaryPadSize;
 

--- a/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
@@ -45,7 +45,7 @@ PadLabelMapFilter<TInputImage>::GenerateOutputInformation()
   SizeType  size;
   IndexType index;
 
-  auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
+  const auto [inputIndex, inputSize] = inputPtr->GetLargestPossibleRegion();
 
   SizeType originalPadSize = m_UpperBoundaryPadSize + m_LowerBoundaryPadSize;
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -45,7 +45,7 @@ NeedToDoFace(const TRegion AllImage, const TRegion face, const TLine line)
   // find the small dimension of the face - should only be one
   typename TRegion::IndexType ISt = AllImage.GetIndex();
 
-  auto [FSt, FSz] = face;
+  const auto [FSt, FSz] = face;
 
   unsigned int smallDim = 0;
   for (unsigned int i = 0; i < AllImage.GetImageDimension(); ++i)
@@ -89,7 +89,7 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
                 unsigned int &                    end)
 {
   // compute intersection between ray and box
-  auto [ImStart, ImSize] = AllImage;
+  const auto [ImStart, ImSize] = AllImage;
   float        Tfar = NumericTraits<float>::max();
   float        Tnear = NumericTraits<float>::NonpositiveMin();
   float        domdir = NumericTraits<float>::NonpositiveMin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -45,8 +45,7 @@ NeedToDoFace(const TRegion AllImage, const TRegion face, const TLine line)
   // find the small dimension of the face - should only be one
   typename TRegion::IndexType ISt = AllImage.GetIndex();
 
-  typename TRegion::SizeType  FSz = face.GetSize();
-  typename TRegion::IndexType FSt = face.GetIndex();
+  auto [FSt, FSz] = face;
 
   unsigned int smallDim = 0;
   for (unsigned int i = 0; i < AllImage.GetImageDimension(); ++i)
@@ -90,13 +89,12 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
                 unsigned int &                    end)
 {
   // compute intersection between ray and box
-  typename TImage::IndexType ImStart = AllImage.GetIndex();
-  typename TImage::SizeType  ImSize = AllImage.GetSize();
-  float                      Tfar = NumericTraits<float>::max();
-  float                      Tnear = NumericTraits<float>::NonpositiveMin();
-  float                      domdir = NumericTraits<float>::NonpositiveMin();
-  int                        sPos, ePos;
-  unsigned int               perpdir = 0;
+  auto [ImStart, ImSize] = AllImage;
+  float        Tfar = NumericTraits<float>::max();
+  float        Tnear = NumericTraits<float>::NonpositiveMin();
+  float        domdir = NumericTraits<float>::NonpositiveMin();
+  int          sPos, ePos;
+  unsigned int perpdir = 0;
   for (unsigned int i = 0; i < TImage::RegionType::ImageDimension; ++i)
   {
     const auto abs_line_elmt_tmp = itk::Math::abs(line[i]);
@@ -298,16 +296,13 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
   // because it doesn't return faces of the sub-blocks if they don't
   // fall along the edge of the image
   using RegionType = typename TInputImage::RegionType;
-  using SizeType = typename TInputImage::SizeType;
-  using IndexType = typename TInputImage::IndexType;
   using FaceListType = std::list<RegionType>;
   FaceListType faceList;
 
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     RegionType R1, R2;
-    SizeType   S1 = AllImage.GetSize();
-    IndexType  I2 = AllImage.GetIndex();
+    auto [I2, S1] = AllImage;
 
     S1[i] = 1;
     R1 = AllImage;
@@ -386,9 +381,8 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
     }
 
     // figure out how much extra each other dimension needs to be extended
-    typename TInputImage::SizeType  NewSize = RelevantRegion.GetSize();
-    typename TInputImage::IndexType NewStart = RelevantRegion.GetIndex();
-    unsigned int                    NonFaceLen = AllImage.GetSize()[NonFaceDim];
+    auto [NewStart, NewSize] = RelevantRegion;
+    unsigned int NonFaceLen = AllImage.GetSize()[NonFaceDim];
     for (unsigned int i = 0; i < TInputImage::RegionType::ImageDimension; ++i)
     {
       if (i != NonFaceDim)

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -118,8 +118,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   tempPtr->Allocate();
 
   // How big is the input image?
-  typename TInputImage::SizeType  size = inputPtr->GetRequestedRegion().GetSize();
-  typename TInputImage::IndexType startIndex = inputPtr->GetRequestedRegion().GetIndex();
+  auto [startIndex, size] = inputPtr->GetRequestedRegion();
 
   // Iterator Typedefs for this routine
   using TempIterator = ImageRegionIterator<TTempImage>;

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -118,7 +118,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   tempPtr->Allocate();
 
   // How big is the input image?
-  auto [startIndex, size] = inputPtr->GetRequestedRegion();
+  const auto [startIndex, size] = inputPtr->GetRequestedRegion();
 
   // Iterator Typedefs for this routine
   using TempIterator = ImageRegionIterator<TTempImage>;

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -84,8 +84,7 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(gdcmIO, seriesWriter->GetImageIO());
 
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  ImageType::IndexType  start = region.GetIndex();
-  ImageType::SizeType   size = region.GetSize();
+  auto [start, size] = region;
 
 
   std::string format = outputDirectory;

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -83,9 +83,7 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   seriesWriter->SetImageIO(gdcmIO);
   ITK_TEST_SET_GET_VALUE(gdcmIO, seriesWriter->GetImageIO());
 
-  ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  const auto [start, size] = region;
-
+  const auto [start, size] = reader->GetOutput()->GetLargestPossibleRegion();
 
   std::string format = outputDirectory;
   format += "/image%03d.dcm";

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -84,7 +84,7 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(gdcmIO, seriesWriter->GetImageIO());
 
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto [start, size] = region;
+  const auto [start, size] = region;
 
 
   std::string format = outputDirectory;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
@@ -46,7 +46,7 @@ itkImageFileWriterUpdateLargestPossibleRegionTest(int argc, char * argv[])
   writer->SetFileName(argv[2]);
 
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto [index, size] = region;
+  const auto [index, size] = region;
 
   itk::ImageIORegion ioregion(2);
   ioregion.SetIndex(0, index[0]);

--- a/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
@@ -45,8 +45,7 @@ itkImageFileWriterUpdateLargestPossibleRegionTest(int argc, char * argv[])
   writer->SetInput(reader->GetOutput());
   writer->SetFileName(argv[2]);
 
-  ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  const auto [index, size] = region;
+  const auto [index, size] = reader->GetOutput()->GetLargestPossibleRegion();
 
   itk::ImageIORegion ioregion(2);
   ioregion.SetIndex(0, index[0]);

--- a/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
@@ -46,8 +46,7 @@ itkImageFileWriterUpdateLargestPossibleRegionTest(int argc, char * argv[])
   writer->SetFileName(argv[2]);
 
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  ImageType::IndexType  index = region.GetIndex();
-  ImageType::SizeType   size = region.GetSize();
+  auto [index, size] = region;
 
   itk::ImageIORegion ioregion(2);
   ioregion.SetIndex(0, index[0]);

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -79,8 +79,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
   }
 
   RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  IndexType  inputStart = inputRegion.GetIndex();
-  SizeType   inputSize = inputRegion.GetSize();
+  auto [inputStart, inputSize] = inputRegion;
 
   IndexType outputStart;
   SizeType  outputSize;
@@ -131,8 +130,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
 
   // request maximum angular and radial information / to be optimized
 
-  SizeType  inputSize = inputImage->GetLargestPossibleRegion().GetSize();
-  IndexType inputStart = inputImage->GetLargestPossibleRegion().GetIndex();
+  auto [inputStart, inputSize] = inputImage->GetLargestPossibleRegion();
 
   // crop to requested z-axis
   inputSize[m_ZDirection] = outputImage->GetRequestedRegion().GetSize()[2];
@@ -162,8 +160,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
 
   // Crop angular input image size to 180 degrees
   typename InputImageType::RegionType inputROI = m_InputRequestedRegion;
-  typename InputImageType::SizeType   inputROISize = inputROI.GetSize();
-  typename InputImageType::IndexType  inputROIStart = inputROI.GetIndex();
+  auto [inputROIStart, inputROISize] = inputROI;
 
   // the number of projections needed to cover 180 degrees
   const auto   alpha_size = Math::Floor<unsigned int>((180 * (inputROISize[m_AlphaDirection])) / m_AlphaRange);

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -78,8 +78,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
     return;
   }
 
-  RegionType inputRegion = inputImage->GetLargestPossibleRegion();
-  auto [inputStart, inputSize] = inputRegion;
+  auto [inputStart, inputSize] = inputImage->GetLargestPossibleRegion();
 
   IndexType outputStart;
   SizeType  outputSize;

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -228,9 +228,8 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   // Exercise another interpolation mode: LinearInterpolation
   {
     function->SetInterpolationMode(HessianGaussianImageFunctionType::InterpolationModeEnum::LinearInterpolation);
-    const ImageType *              inputImage = reader->GetOutput();
-    typename ImageType::RegionType region = inputImage->GetBufferedRegion();
-    auto [index, size] = region;
+    const ImageType * inputImage = reader->GetOutput();
+    auto [index, size] = inputImage->GetBufferedRegion();
     // Aim for the pixel at the center of the image
     for (unsigned int i = 0; i < Dimension; ++i)
     {

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -230,8 +230,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     function->SetInterpolationMode(HessianGaussianImageFunctionType::InterpolationModeEnum::LinearInterpolation);
     const ImageType *              inputImage = reader->GetOutput();
     typename ImageType::RegionType region = inputImage->GetBufferedRegion();
-    typename ImageType::SizeType   size = region.GetSize();
-    typename ImageType::IndexType  index = region.GetIndex();
+    auto [index, size] = region;
     // Aim for the pixel at the center of the image
     for (unsigned int i = 0; i < Dimension; ++i)
     {

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -73,8 +73,7 @@ protected:
   CreateNarrowBand() override
   {
     // Create a band
-    typename ImageType::SizeType   sz = this->GetInput()->GetRequestedRegion().GetSize();
-    typename ImageType::IndexType  tl = this->GetInput()->GetRequestedRegion().GetIndex();
+    auto [tl, sz] = this->GetInput()->GetRequestedRegion();
     typename Superclass::IndexType in;
 
     for (in [0] = 32 + tl[0]; in[0] < tl[0] + static_cast<long>(sz[0]); in[0]++)

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -73,7 +73,7 @@ protected:
   CreateNarrowBand() override
   {
     // Create a band
-    auto [tl, sz] = this->GetInput()->GetRequestedRegion();
+    const auto [tl, sz] = this->GetInput()->GetRequestedRegion();
     typename Superclass::IndexType in;
 
     for (in [0] = 32 + tl[0]; in[0] < tl[0] + static_cast<long>(sz[0]); in[0]++)

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -101,8 +101,7 @@ SpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceIdentifier & q
   SizeType   searchSize;
   IndexType  endIndex;
 
-  IndexType constraintIndex = this->m_RegionConstraint.GetIndex();
-  SizeType  constraintSize = this->m_RegionConstraint.GetSize();
+  auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
 
   IndexType                            queryIndex;
   typename RegionType::OffsetTableType offsetTable;

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -101,7 +101,7 @@ SpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceIdentifier & q
   SizeType   searchSize;
   IndexType  endIndex;
 
-  auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
+  const auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
 
   IndexType                            queryIndex;
   typename RegionType::OffsetTableType offsetTable;

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -75,7 +75,7 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
   IndexType searchStartIndex;
   IndexType searchEndIndex;
 
-  auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
+  const auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
 
   IndexType                            queryIndex;
   typename RegionType::OffsetTableType offsetTable;

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -75,8 +75,7 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
   IndexType searchStartIndex;
   IndexType searchEndIndex;
 
-  IndexType constraintIndex = this->m_RegionConstraint.GetIndex();
-  SizeType  constraintSize = this->m_RegionConstraint.GetSize();
+  auto [constraintIndex, constraintSize] = this->m_RegionConstraint;
 
   IndexType                            queryIndex;
   typename RegionType::OffsetTableType offsetTable;

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -227,7 +227,7 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PreparePyrami
   ScheduleType movingschedule = m_MovingImagePyramid->GetSchedule();
   itkDebugMacro("MovingImage schedule: " << movingschedule);
 
-  auto [inputStart, inputSize] = m_FixedImageRegion;
+  const auto [inputStart, inputSize] = m_FixedImageRegion;
 
   const SizeValueType numberOfLevels = m_FixedImagePyramid->GetNumberOfLevels();
 

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -227,8 +227,7 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PreparePyrami
   ScheduleType movingschedule = m_MovingImagePyramid->GetSchedule();
   itkDebugMacro("MovingImage schedule: " << movingschedule);
 
-  SizeType  inputSize = m_FixedImageRegion.GetSize();
-  IndexType inputStart = m_FixedImageRegion.GetIndex();
+  auto [inputStart, inputSize] = m_FixedImageRegion;
 
   const SizeValueType numberOfLevels = m_FixedImagePyramid->GetNumberOfLevels();
 

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -422,8 +422,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
     IndexType  outputIndex;
     SizeType   outputSize;
     RegionType outputRegion;
-    IndexType  baseIndex = ptr->GetRequestedRegion().GetIndex();
-    SizeType   baseSize = ptr->GetRequestedRegion().GetSize();
+    auto [baseIndex, baseSize] = ptr->GetRequestedRegion();
 
     for (idim = 0; idim < TOutputImage::ImageDimension; ++idim)
     {
@@ -482,13 +481,10 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
   }
 
   // compute baseIndex and baseSize
-  using SizeType = typename OutputImageType::SizeType;
-  using IndexType = typename OutputImageType::IndexType;
   using RegionType = typename OutputImageType::RegionType;
 
   unsigned int refLevel = m_NumberOfLevels - 1;
-  SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
-  IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
+  auto [baseIndex, baseSize] = this->GetOutput(refLevel)->GetRequestedRegion();
 
   unsigned int idim;
   for (idim = 0; idim < ImageDimension; ++idim)

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -348,13 +348,10 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
   }
 
   // compute baseIndex and baseSize
-  using SizeType = typename OutputImageType::SizeType;
-  using IndexType = typename OutputImageType::IndexType;
   using RegionType = typename OutputImageType::RegionType;
 
   unsigned int refLevel = this->GetNumberOfLevels() - 1;
-  SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
-  IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
+  auto [baseIndex, baseSize] = this->GetOutput(refLevel)->GetRequestedRegion();
 
   unsigned int idim;
   for (idim = 0; idim < ImageDimension; ++idim)

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -791,8 +791,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   }
   RealType weight2 = 1.0 - weight1;
 
-  const typename DisplacementFieldType::RegionType region = field->GetLargestPossibleRegion();
-  const auto [startIndex, size] = region;
+  const auto [startIndex, size] = field->GetLargestPossibleRegion();
 
   ImageRegionConstIteratorWithIndex<DisplacementFieldType> ItF(field, field->GetLargestPossibleRegion());
   ImageRegionIteratorWithIndex<DisplacementFieldType>      ItS(smoothField, smoothField->GetLargestPossibleRegion());

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -792,8 +792,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   RealType weight2 = 1.0 - weight1;
 
   const typename DisplacementFieldType::RegionType region = field->GetLargestPossibleRegion();
-  const typename DisplacementFieldType::SizeType   size = region.GetSize();
-  const typename DisplacementFieldType::IndexType  startIndex = region.GetIndex();
+  const auto [startIndex, size] = region;
 
   ImageRegionConstIteratorWithIndex<DisplacementFieldType> ItF(field, field->GetLargestPossibleRegion());
   ImageRegionIteratorWithIndex<DisplacementFieldType>      ItS(smoothField, smoothField->GetLargestPossibleRegion());

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -776,8 +776,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   gradientField->SetRegions(virtualDomainImage->GetRequestedRegion());
   gradientField->Allocate();
 
-  typename DisplacementFieldType::IndexType gradientFieldIndex = gradientField->GetRequestedRegion().GetIndex();
-  typename DisplacementFieldType::SizeType  gradientFieldSize = gradientField->GetRequestedRegion().GetSize();
+  auto [gradientFieldIndex, gradientFieldSize] = gradientField->GetRequestedRegion();
 
   SizeValueType localCount = 0;
   for (ImageRegionConstIteratorWithOnlyIndex<DisplacementFieldType> ItG(gradientField,

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -776,7 +776,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   gradientField->SetRegions(virtualDomainImage->GetRequestedRegion());
   gradientField->Allocate();
 
-  auto [gradientFieldIndex, gradientFieldSize] = gradientField->GetRequestedRegion();
+  const auto [gradientFieldIndex, gradientFieldSize] = gradientField->GetRequestedRegion();
 
   SizeValueType localCount = 0;
   for (ImageRegionConstIteratorWithOnlyIndex<DisplacementFieldType> ItG(gradientField,

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -206,8 +206,7 @@ PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
   velocityFieldSpacing.Fill(1.0);
   velocityFieldDirection.SetIdentity();
 
-  typename FixedImageType::IndexType     fixedImageIndex = fixedImage->GetBufferedRegion().GetIndex();
-  typename FixedImageType::SizeType      fixedImageSize = fixedImage->GetBufferedRegion().GetSize();
+  auto [fixedImageIndex, fixedImageSize] = fixedImage->GetBufferedRegion();
   typename FixedImageType::PointType     fixedImageOrigin = fixedImage->GetOrigin();
   typename FixedImageType::SpacingType   fixedImageSpacing = fixedImage->GetSpacing();
   typename FixedImageType::DirectionType fixedImageDirection = fixedImage->GetDirection();

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -350,8 +350,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
   ValueType       value;
   StatusType      layer_number;
 
-  typename OutputImageType::SizeType  regionSize = m_OutputImage->GetRequestedRegion().GetSize();
-  typename OutputImageType::IndexType startIndex = m_OutputImage->GetRequestedRegion().GetIndex();
+  auto [startIndex, regionSize] = m_OutputImage->GetRequestedRegion();
   using StartIndexValueType = IndexValueType;
 
   for (NeighborhoodIterator<OutputImageType> outputIt(

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -350,7 +350,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
   ValueType       value;
   StatusType      layer_number;
 
-  auto [startIndex, regionSize] = m_OutputImage->GetRequestedRegion();
+  const auto [startIndex, regionSize] = m_OutputImage->GetRequestedRegion();
   using StartIndexValueType = IndexValueType;
 
   for (NeighborhoodIterator<OutputImageType> outputIt(

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -94,15 +94,12 @@ Segmenter<TInputImage>::GenerateData()
   ImageRegionType thresholdLargestPossibleRegion = this->GetLargestPossibleRegion();
 
   // First we have to find the boundaries and adjust the threshold image size
-  typename ImageRegionType::IndexType tidx = thresholdImageRegion.GetIndex();
-  typename ImageRegionType::SizeType  tsz = thresholdImageRegion.GetSize();
-  typename ImageRegionType::IndexType tlidx = thresholdLargestPossibleRegion.GetIndex();
-  typename ImageRegionType::SizeType  tlsz = thresholdLargestPossibleRegion.GetSize();
+  auto [tidx, tsz] = thresholdImageRegion;
+  auto [tlidx, tlsz] = thresholdLargestPossibleRegion;
   for (i = 0; i < ImageDimension; ++i)
   {
-    ImageRegionType                     reg;
-    typename ImageRegionType::IndexType idx = regionToProcess.GetIndex();
-    typename ImageRegionType::SizeType  sz = regionToProcess.GetSize();
+    ImageRegionType reg;
+    auto [idx, sz] = regionToProcess;
 
     // Set LOW face
     idx[i] = regionToProcess.GetIndex()[i];

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -98,9 +98,8 @@ ImageToVideoFilter<TInputImage, TOutputVideoStream>::GenerateOutputInformation()
   const InputImageType * input = this->GetInput();
 
   // Get first input frame's largest possible spatial region
-  InputImageRegionType                 inputRegion = input->GetLargestPossibleRegion();
-  typename InputImageType::SizeType    inputSize = inputRegion.GetSize();
-  typename InputImageType::IndexType   inputIndex = inputRegion.GetIndex();
+  InputImageRegionType inputRegion = input->GetLargestPossibleRegion();
+  auto [inputIndex, inputSize] = inputRegion;
   typename InputImageType::SpacingType inputSpacing = input->GetSpacing();
   typename InputImageType::PointType   inputOrigin = input->GetOrigin();
 

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -99,7 +99,7 @@ ImageToVideoFilter<TInputImage, TOutputVideoStream>::GenerateOutputInformation()
 
   // Get first input frame's largest possible spatial region
   InputImageRegionType inputRegion = input->GetLargestPossibleRegion();
-  auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = inputRegion;
   typename InputImageType::SpacingType inputSpacing = input->GetSpacing();
   typename InputImageType::PointType   inputOrigin = input->GetOrigin();
 

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -98,8 +98,7 @@ ImageToVideoFilter<TInputImage, TOutputVideoStream>::GenerateOutputInformation()
   const InputImageType * input = this->GetInput();
 
   // Get first input frame's largest possible spatial region
-  InputImageRegionType inputRegion = input->GetLargestPossibleRegion();
-  const auto [inputIndex, inputSize] = inputRegion;
+  const auto [inputIndex, inputSize] = input->GetLargestPossibleRegion();
   typename InputImageType::SpacingType inputSpacing = input->GetSpacing();
   typename InputImageType::PointType   inputOrigin = input->GetOrigin();
 


### PR DESCRIPTION
Replaced initializations of the form:

    SizeType size = region.GetSize();
    IndexType index = region.GetIndex();

By using structured binding of the form `auto [index, size] = region`, as was introduced by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4367 commit 72aa9a602bd92b665acc915d8df4bd00a27c98f0 "ENH: `ImageRegion` support C++17 structured binding"

Did so by Notepad++ Replace in Files, using regular expressions:

    Find what: ^([ ]+)const (.*)\w.+[ ]+(\w+) = (.+)\.GetIndex\(\);\r\n\1const \2\w+[ ]+(\w+) = \4\.GetSize\(\);$
    Replace with: $1const auto [$3, $5] = $4;

    Find what: ^([ ]+)const (.*)\w.+[ ]+(\w+) = (.+)\.GetSize\(\);\r\n\1const \2\w+[ ]+(\w+) = \4\.GetIndex\(\);$
    Replace with: $1const auto [$5, $3] = $4;

    Find what: ^([ ]+)(.*)\w.+[ ]+(\w+) = (.+)\.GetIndex\(\);\r\n\1\2\w+[ ]+(\w+) = \4\.GetSize\(\);$
    Replace with: $1auto [$3, $5] = $4;

    Find what: ^([ ]+)(.*)\w.+[ ]+(\w+) = (.+)\.GetSize\(\);\r\n\1\2\w+[ ]+(\w+) = \4\.GetIndex\(\);$
    Replace with: $1auto [$5, $3] = $4;

Manually added `const` whenever the values of the bindings were not modified, excluded `ImageIORegion`, and removed `Index` and `Size` type aliases that are no longer used after this commit.

----
When reviewing, it may be helpful to ignore whitespace changes: https://github.com/InsightSoftwareConsortium/ITK/pull/4379/files?w=1