### PR TITLE
Examples, PyUtils: Replace itkTypeMacro with itkOverrideGetNameOfClassMacro

### DIFF
--- a/Examples/Filtering/CompositeFilterExample.cxx
+++ b/Examples/Filtering/CompositeFilterExample.cxx
@@ -86,7 +86,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information */
-  itkTypeMacro(CompositeExampleImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(CompositeExampleImageFilter);
 
   //  Software Guide : BeginLatex
   //

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ParticleSwarmOptimizerDOMReader, DOMReader);
+  itkOverrideGetNameOfClassMacro(ParticleSwarmOptimizerDOMReader);
 
 protected:
   ParticleSwarmOptimizerDOMReader() = default;

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ParticleSwarmOptimizerDOMWriter, DOMWriter);
+  itkOverrideGetNameOfClassMacro(ParticleSwarmOptimizerDOMWriter);
 
 protected:
   ParticleSwarmOptimizerDOMWriter() = default;

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ParticleSwarmOptimizerSAXReader, XMLReader);
+  itkOverrideGetNameOfClassMacro(ParticleSwarmOptimizerSAXReader);
 
   /**
    * Virtual method defined in itk::XMLReaderBase.

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ParticleSwarmOptimizerSAXWriter, XMLWriterBase);
+  itkOverrideGetNameOfClassMacro(ParticleSwarmOptimizerSAXWriter);
 
   /**
    * Virtual method defined in itk::XMLWriterBase.

--- a/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
@@ -161,7 +161,7 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
-  itkTypeMacro(IterationCallback, Superclass);
+  itkOverrideGetNameOfClassMacro(IterationCallback);
   itkNewMacro(Self);
 
   /** Type defining the optimizer. */
@@ -265,7 +265,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimpleImageToSpatialObjectMetric, ImageToSpatialObjectMetric);
+  itkOverrideGetNameOfClassMacro(SimpleImageToSpatialObjectMetric);
 
   static constexpr unsigned int ParametricSpaceDimension = 3;
 

--- a/Examples/Statistics/WeightedSampleStatistics.cxx
+++ b/Examples/Statistics/WeightedSampleStatistics.cxx
@@ -67,7 +67,7 @@ public:
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** Standard macros. */
-  itkTypeMacro(ExampleWeightFunction, FunctionBase);
+  itkOverrideGetNameOfClassMacro(ExampleWeightFunction);
   itkNewMacro(Self);
 
   /** Input type */

--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.h
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.h
@@ -49,7 +49,7 @@ public:
   using Pointer = SmartPointer<Self>;
 
   ///! Run-time type information (and related methods).
-  itkTypeMacro(PyCommand, Command);
+  itkOverrideGetNameOfClassMacro(PyCommand);
 
   ///! Method for creation through the object factory.
   itkNewMacro(Self);

--- a/Wrapping/Generators/Python/PyUtils/itkPyImageFilter.h
+++ b/Wrapping/Generators/Python/PyUtils/itkPyImageFilter.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PyImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PyImageFilter);
 
   /** Some convenient type alias. */
   using InputImageType = TInputImage;


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4373 commit 2c264ea2ef62e916c6ef947599ce659cc8fce5fe
"STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`"

----
Addresses "ITK_FUTURE_LEGACY_REMOVE" compile errors from RogueResearch19/Mac12.x-AppleClang-dbg-Universal at https://open.cdash.org/viewBuildError.php?buildid=9269183 saying:
```

/Users/builder/externalExamples/Filtering/CompositeFilterExample.cxx:89:3: error: static_assert failed "In a future revision of ITK, the macro `itkTypeMacro(thisClass, superclass)` will be removed. Please call `itkOverrideGetNameOfClassMacro(thisClass)` instead!"
  itkTypeMacro(CompositeExampleImageFilter, ImageToImageFilter);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:449:5: note: expanded from macro 'itkTypeMacro'
    static_assert(false,                                                                                           \
    ^             ~~~~~
1 error generated.
```




Reported by @dzenanz at https://github.com/InsightSoftwareConsortium/ITK/pull/4367#issuecomment-1874040923