### PR TITLE
COMP: Update Eigen with ITK patch

### DIFF
--- a/Modules/ThirdParty/Eigen3/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/Eigen3/UpdateFromUpstream.sh
@@ -8,7 +8,7 @@ readonly name="Eigen3"
 readonly ownership="Eigen Upstream <kwrobot@kitware.com>"
 readonly subtree="Modules/ThirdParty/Eigen3/src/itkeigen"
 readonly repo="https://github.com/InsightSoftwareConsortium/eigen"
-readonly tag="for/itk-20231108-master-4d54c43d"
+readonly tag="for/itk-20240108-master-4d54c43d"
 readonly paths="
 Eigen/Cholesky
 Eigen/CholmodSupport

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/util/DisableStupidWarnings.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/util/DisableStupidWarnings.h
@@ -20,7 +20,20 @@
   #ifndef EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS
     #pragma warning( push )
   #endif
-  #pragma warning( disable : 4100 4101 4127 4181 4211 4244 4273 4324 4503 4512 4522 4700 4714 4717 4800)
+  #define EIGEN_STUPID_WARNINGS_BASE 4100 4101 4127 4181 4211 4244 4273 4324 4503 4512 4522 4700 4714 4717 4800
+  // ITK Patch to disable MSVC 2019 warnings. See Issue #4376
+  // 4348 - Redefinition of default parameter (IndexedViewSelector)
+  #if _MSC_FULL_VER < 192930040
+    #define EIGEN_STUPID_WARNINGS_EXTRAS 4348
+  #else
+    #define EIGEN_STUPID_WARNINGS_EXTRAS
+  #endif
+  #define EIGEN_STUPID_WARNINGS EIGEN_STUPID_WARNINGS_BASE EIGEN_STUPID_WARNINGS_EXTRAS
+  #pragma warning( disable : EIGEN_STUPID_WARNINGS)
+  #undef EIGEN_STUPID_WARNINGS
+  #undef EIGEN_STUPID_WARNINGS_BASE
+  #undef EIGEN_STUPID_WARNINGS_EXTRAS
+
   // We currently rely on has_denorm in tests, and need it defined correctly for half/bfloat16.
   #ifndef _SILENCE_CXX23_DENORM_DEPRECATION_WARNING
     #define EIGEN_REENABLE_CXX23_DENORM_DEPRECATION_WARNING 1


### PR DESCRIPTION
Update to:
https://github.com/InsightSoftwareConsortium/eigen/tree/for/itk-20240108-master-4d54c43d

Eigen itself hasn't been updated, only the following patch is added on
top:

COMP: ITK: disable warning 4348 in old MSCV
Fix InsightSoftwareConsortium/ITK#4376

Setup in a way to disable warnings conditionally of `_MSC_VER`


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->