### PR TITLE
Remove `std::` prefix from uint8_t in MathematicalMorphologyEnums, replace `<cstdint>` with "itkIntTypes.h"

### DIFF
--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -19,12 +19,12 @@
 #ifndef itkConnectedImageNeighborhoodShape_h
 #define itkConnectedImageNeighborhoodShape_h
 
+#include "itkIntTypes.h" // For uintmax_t
 #include "itkMath.h"
 #include "itkOffset.h"
 
 #include <array>
 #include <cassert>
-#include <cstdint> // For uintmax_t
 #include <limits>
 
 namespace itk

--- a/Modules/Core/Common/include/itkSpatialOrientation.h
+++ b/Modules/Core/Common/include/itkSpatialOrientation.h
@@ -28,7 +28,7 @@
 #ifndef itkSpatialOrientation_h
 #define itkSpatialOrientation_h
 
-#include <cstdint>
+#include "itkIntTypes.h"
 #include <ostream>
 
 #include "ITKCommonExport.h"

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -18,10 +18,9 @@
 #ifndef itkImageMaskSpatialObject_hxx
 #define itkImageMaskSpatialObject_hxx
 
+#include "itkIntTypes.h" // For uintmax_t.
 #include "itkMath.h"
 #include "itkImageRegionRange.h"
-
-#include <cstdint> // For uintmax_t.
 
 namespace itk
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
@@ -20,7 +20,7 @@
 
 #include <iostream>
 #include "ITKMathematicalMorphologyExport.h"
-#include <cstdint>
+#include "itkIntTypes.h"
 
 
 namespace itk
@@ -39,7 +39,7 @@ public:
    * \brief Algorithm or implementation used in the dilation/erosion operations.
    * \ingroup ITKMathematicalMorphology
    */
-  enum class Algorithm : std::uint8_t
+  enum class Algorithm : uint8_t
   {
     BASIC = 0,
     HISTO = 1,


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3250 commit c173dfd803acf943d9ab80683ac4133fea29cdf5 "STYLE: Remove `std::` prefix from types that work without it" by Lee Newberg (@Leengit), March 6, 2022.

---
Mentioned at https://discourse.itk.org/t/itkmathematicalmorphologyenums-h-compile-error-with-gcc-13-on-linux/6377/4
