### PR TITLE
Add checks for unsupported characters within image path and output path

### DIFF
--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1261,6 +1261,27 @@ def imwrite(
     The writer is instantiated with the image type of the image in
     parameter (or, again, with the output image of the filter in parameter).
     """
+
+    # Check if output path exists
+    msg = ""
+    if not os.path.isdir(os.path.dirname(filename)):
+        msg += "\nThe output dir doesn't exist. \n" + f"Filename = {filename}"
+        raise RuntimeError(
+            f"Could not create IO object for writing file {filename}" + msg
+        )
+    # Check if path contains unsupported special characters
+    else:
+        try:
+            filename.encode("ascii")
+        except UnicodeEncodeError:
+            msg += (
+                "\nThe output path contains unsupported special characters for ascii encoding.\n"
+                + f"Filename = {filename}"
+            )
+            raise RuntimeError(
+                f"Could not create IO object for writing file {filename}" + msg
+            )
+
     import itk
 
     img = itk.output(image_or_filter)

--- a/Wrapping/Generators/Python/itk/support/template_class.py
+++ b/Wrapping/Generators/Python/itk/support/template_class.py
@@ -158,6 +158,15 @@ class itkTemplate(Mapping):
             msg = ""
             if not os.path.isfile(inputFileName):
                 msg += "\nThe file doesn't exist. \n" + f"Filename = {inputFileName}"
+            # Check if image path contains not supported special characters.
+            else:
+                try:
+                    inputFileName.encode("ascii")
+                except UnicodeEncodeError:
+                    msg += (
+                        "\nThe image path contains not supported special characters. \n"
+                        + f"Filename = {inputFileName}"
+                    )
             raise RuntimeError(
                 f"Could not create IO object for reading file {inputFileName}" + msg
             )


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## Description
I encountered an issue while attempting to load images using the ITK / SimpleITK framework in my Python script. The traceback indicates that the problem arises when attempting to create an IO object for reading an image file that contains Umlauts (ä, ü, ö) in its path. See: #4388

Providing a more descriptive error message indicating that the path cannot be read due to special characters, such as Umlauts, would be helpful for users to understand and address the issue.

## Changes
I have added a simple filepath check for illegal characters in the _NewImageReader and imwrite routines. Additionally, for the imwrite routine, a check was added to verify if the output directory exists.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

<!-- **Thanks for contributing to ITK!** -->
