### PR TITLE
COMP: Skip Python-Wrapping of ITKVtkGlue

### DIFF
--- a/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
@@ -1,8 +1,5 @@
 # Forward include directories to CastXML
-if(NOT
-   VTK_RENDERING_BACKEND
-   STREQUAL
-   "None")
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   foreach(_vtk_lib IN LISTS ITKVtkGlue_VTK_LIBRARIES)
     get_target_property(_vtk_lib_include_dirs ${_vtk_lib} INTERFACE_INCLUDE_DIRECTORIES)
     if(_vtk_lib_include_dirs)
@@ -11,15 +8,21 @@ if(NOT
   endforeach()
 endif()
 
-itk_wrap_module(ITKVtkGlue)
-if("${VTK_VERSION}" VERSION_LESS 7.0.0)
-  message(WARNING "The ITKVtkGlue module can only built with Python 3 and VTK >= 7.\n"
-                  "Only the c++ version of the module will be built.")
+# Python provides native conversion between ITK and VTK
+if(ITK_WRAP_PYTHON)
+  message(STATUS "ITK_WRAP_PYTHON is turned on - skipping ITKVtkGlue, since native version is available https://docs.itk.org/en/latest/learn/python_quick_start.html#itk-and-vtk.")
 else()
-  list(APPEND WRAPPER_SWIG_LIBRARY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/VtkGlue.i")
-  set(WRAPPER_LIBRARY_DEPENDS ITKCommon ITKVTK)
+  itk_wrap_module(ITKVtkGlue)
+  if("${VTK_VERSION}" VERSION_LESS 7.0.0)
+    message(WARNING
+      "The ITKVtkGlue module can only built with Python 3 and VTK >= 7.\n"
+      "Only the c++ version of the module will be built.")
+  else()
+    list(APPEND WRAPPER_SWIG_LIBRARY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/VtkGlue.i")
+    set(WRAPPER_LIBRARY_DEPENDS ITKCommon ITKVTK)
 
-  set(WRAPPER_LIBRARY_LINK_LIBRARIES ${ITK_LIBRARIES})
+    set(WRAPPER_LIBRARY_LINK_LIBRARIES ${ITK_LIBRARIES})
 
-  itk_auto_load_and_end_wrap_submodules()
+    itk_auto_load_and_end_wrap_submodules()
+  endif()
 endif()


### PR DESCRIPTION
Python wrapping of VTKGlue Bridge crashed during compilation and native bridge exists. Discussed here https://discourse.itk.org/t/itk-5-3-0-5-4rc-build-errors-shared-libs-python-wrappings-itkvtkglue-vs-2022-win11.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.