### PR TITLE
DOC: Fix git hook commit error message if clang-format is not found

### DIFF
--- a/Utilities/Hooks/pre-commit-style.bash
+++ b/Utilities/Hooks/pre-commit-style.bash
@@ -165,7 +165,7 @@ check_for_clangformat() {
   die "clang-format executable was not found.
 
 A clang-format binary will be downloaded and configured when ITK
-is built with the BUILD_TESTING CMake configuration option enabled.
+is built with the (i) BUILD_TESTING=True and (ii) ITK_USE_CLANG_FORMAT=True CMake configuration options enabled.
 
 Alternatively, install clang-format version $clangformat_required_version or set the executable location with
 


### PR DESCRIPTION
git hook commit error message if clang-format is not found needs to mention CMake flag ITK_USE_CLANG_FORMAT=True

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
