### PR TITLE
zlib-ng 2024-01-10 (74253725)

### DIFF
--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zconf.h.in
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zconf.h.in
@@ -116,6 +116,9 @@
 #ifndef ZEXPORTVA
 #  define ZEXPORTVA Z_EXPORTVA
 #endif
+#ifndef FAR
+#  define FAR
+#endif
 
 /* Legacy zlib typedefs for backwards compatibility. Don't assume stdint.h is defined. */
 typedef unsigned char Byte;

--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zlib.h.in
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zlib.h.in
@@ -49,11 +49,11 @@
 extern "C" {
 #endif
 
-#define ZLIBNG_VERSION "2.1.5"
-#define ZLIBNG_VERNUM 0x020105F0L   /* MMNNRRSM: major minor revision status modified */
+#define ZLIBNG_VERSION "2.1.6"
+#define ZLIBNG_VERNUM 0x020106F0L   /* MMNNRRSM: major minor revision status modified */
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 1
-#define ZLIBNG_VER_REVISION 5
+#define ZLIBNG_VER_REVISION 6
 #define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
 #define ZLIBNG_VER_STATUSH 0xF      /* Hex values: 0=devel, 1-E=beta, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */

--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zutil.c
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/zutil.c
@@ -21,7 +21,7 @@ z_const char * const PREFIX(z_errmsg)[10] = {
 };
 
 const char PREFIX3(vstring)[] =
-    " zlib-ng 2.1.5";
+    " zlib-ng 2.1.6";
 
 #ifdef ZLIB_COMPAT
 const char * Z_EXPORT zlibVersion(void) {


### PR DESCRIPTION
This is the tagged version 2.1.6 of `zlib-ng`.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

