### PR TITLE
ENH: Update Montage remote module

### DIFF
--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -50,4 +50,4 @@ itk_fetch_module(
   GIT_REPOSITORY
   ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMontage.git
   GIT_TAG
-  b91741f4f1746449dc70f08c7cc13c26cafa7d98)
+  53f0970fe3ed9a257c8e7f1e6b1ab547840f8fa8)


### PR DESCRIPTION
Addressing:

```log
M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(42,3): error C3203: 'Image': unspecialized class template can't be used as a template argument for template parameter '<unnamed-symbol>', expected a real type [M:\Dashboard\ITK-build\Modules\Remote\Montage\test\MontageTestDriver.vcxproj]

  M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(42,3):
  the template instantiation context (the oldest one first) is
  	M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(363,12):
  	see reference to function template instantiation 'int PhaseCorrelationRegistration<3,double,double>(int,char *[])' being compiled
  	M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(152,1):
  	see reference to class template instantiation 'itk::HyperSphereImageSource<double,3>' being compiled
  	M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(42,3):
  	while compiling class template member function 'const char *itk::HyperSphereImageSource<double,3>::GetNameOfClass(void) const'

M:\Dashboard\ITK\Modules\Remote\Montage\test\itkMontagePCMTestSynthetic.cxx(42,3): error C2607: static assertion failed [M:\Dashboard\ITK-build\Modules\Remote\Montage\test\MontageTestDriver.vcxproj]
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

