### PR TITLE
ENH: Fix problems introduced by the latest zlib-ng update

### DIFF
--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/CMakeLists.txt
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/CMakeLists.txt
@@ -1199,6 +1199,7 @@ if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
 endif()
 if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL)
     install(FILES ${ZLIB_PC} DESTINATION "${PKGCONFIG_INSTALL_DIR}")
+	if(FALSE) # ITK change: this messes with ITK's library naming
     # INFO: Mimics official zlib CMake target
     # Generates ZLIB.cmake in case ZLIB_COMPAT=ON and always exports the CMake target ZLIB::ZLIB
     # In case ZLIB_COMPAT=OFF, the CMake target and file follows zlib-ng naming convention
@@ -1215,6 +1216,7 @@ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL)
     install(EXPORT ${EXPORT_NAME}
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${EXPORT_NAME}"
         NAMESPACE ${EXPORT_NAME}::)
+	endif() # ITK change
 endif()
 
 #============================================================================
@@ -1287,6 +1289,7 @@ add_feature_info(INSTALL_UTILS INSTALL_UTILS "Copy minigzip and minideflate duri
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)
 
+if(FALSE) # ITK change: don't define packaging
 #============================================================================
 # CPack
 #============================================================================
@@ -1303,3 +1306,4 @@ if("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
 endif()
 
 include(CPack)
+endif() # ITK change


### PR DESCRIPTION
3edf69be2d57ce66aae925b931cd5a46b35d95db updated zlib-ng

When configuring ITK, a CMake warning is produced:

CMake Warning at C:/Program Files/CMake/share/cmake-3.24/Modules/CPack.cmake:478 (message):
  CPack.cmake has already been included!!
Call Stack (most recent call first):
  Modules/ThirdParty/ZLIB/src/itkzlib-ng/CMakeLists.txt:1305 (include)

In a project which links to ITK,
it can cause link errors due to missing zlib.lib library.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
