### PR TITLE
COMP: Fix name of class assertion failure in FEM module

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -583,7 +583,7 @@ public:
   ~FEMExceptionLinearSystemBounds() noexcept override;
 
   /** Type related information. */
-  itkOverrideGetNameOfClassMacro(FEMExceptionLinearSystem);
+  itkOverrideGetNameOfClassMacro(FEMExceptionLinearSystemBounds);
 };
 } // end namespace fem
 } // end namespace itk


### PR DESCRIPTION
Fix name of class assertion failure for
`itk::fem::FEMExceptionLinearSystemBounds`: use the correct class name.

Fixes:
```
M:\Dashboard\ITK\Modules\Numerics\FEM\include\itkFEMLinearSystemWrapper.h(586,3):
error C2607: static assertion failed
[M:\Dashboard\ITK-build\Modules\Numerics\FEM\src\ITKFEM.vcxproj]
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=9299844

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)