### PR TITLE
Add error message to static_assert in `GetNameOfClass()` macro, add `itkInternalGetNameOfClassImplementationMacro`

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -435,11 +435,13 @@ namespace itk
 
 
 // Internal macro (not part of the public ITK API), used to implement `GetNameOfClass()` member functions.
-#define itkInternalGetNameOfClassImplementationMacro(thisClass)                                              \
-  {                                                                                                          \
-    static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>); \
-    return #thisClass;                                                                                       \
-  }                                                                                                          \
+#define itkInternalGetNameOfClassImplementationMacro(thisClass)                                             \
+  {                                                                                                         \
+    static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>, \
+                  "The macro argument `" #thisClass                                                         \
+                  "` appears incorrect! It should correspond with the name of this class!");                \
+    return #thisClass;                                                                                      \
+  }                                                                                                         \
   ITK_MACROEND_NOOP_STATEMENT
 
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -434,24 +434,23 @@ namespace itk
 #endif
 
 
-/** Macro's used to add `GetNameOfClass()` member functions to polymorphic ITK classes: `itkVirtualGetNameOfClassMacro`
- * adds a virtual `GetNameOfClass()` member function to the class definition, and `itkOverrideGetNameOfClassMacro` adds
- * a `GetNameOfClass()` override. */
-#define itkVirtualGetNameOfClassMacro(thisClass)                                                             \
-  virtual const char * GetNameOfClass() const                                                                \
+// Internal macro (not part of the public ITK API), used to implement `GetNameOfClass()` member functions.
+#define itkInternalGetNameOfClassImplementationMacro(thisClass)                                              \
   {                                                                                                          \
     static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>); \
     return #thisClass;                                                                                       \
   }                                                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkOverrideGetNameOfClassMacro(thisClass)                                                            \
-  const char * GetNameOfClass() const override                                                               \
-  {                                                                                                          \
-    static_assert(std::is_same_v<thisClass, std::remove_const_t<std::remove_reference_t<decltype(*this)>>>); \
-    return #thisClass;                                                                                       \
-  }                                                                                                          \
-  ITK_MACROEND_NOOP_STATEMENT
+
+/** Macro's used to add `GetNameOfClass()` member functions to polymorphic ITK classes: `itkVirtualGetNameOfClassMacro`
+ * adds a virtual `GetNameOfClass()` member function to the class definition, and `itkOverrideGetNameOfClassMacro` adds
+ * a `GetNameOfClass()` override. */
+#define itkVirtualGetNameOfClassMacro(thisClass) \
+  virtual const char * GetNameOfClass() const itkInternalGetNameOfClassImplementationMacro(thisClass)
+
+#define itkOverrideGetNameOfClassMacro(thisClass) \
+  const char * GetNameOfClass() const override itkInternalGetNameOfClassImplementationMacro(thisClass)
 
 #ifdef ITK_FUTURE_LEGACY_REMOVE
 #  define itkTypeMacro(thisClass, superclass)                                                                      \


### PR DESCRIPTION
The added error message could be helpful when doing fixes like
- https://github.com/InsightSoftwareConsortium/ITK/pull/4398 (by @jhlegarreta)