### PR TITLE
COMP: Fix Warning for CMP0135 in remote modules (DownloadClangFormat)

### DIFF
--- a/Utilities/ClangFormat/DownloadClangFormat.cmake
+++ b/Utilities/ClangFormat/DownloadClangFormat.cmake
@@ -43,6 +43,8 @@ endif()
 if(ITK_FORBID_DOWNLOADS)
   message(SEND_ERROR "Attempted to download ClangFormat when ITK_FORBID_DOWNLOADS is ON")
 endif()
+cmake_policy(PUSH)
+cmake_policy(SET CMP0135 NEW)
 if(NOT TARGET ClangFormat AND _clang_format_hash)
   ExternalProject_Add(
     ClangFormat
@@ -58,3 +60,4 @@ if(NOT TARGET ClangFormat AND _clang_format_hash)
     LOG_INSTALL 0
     INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/ITKClangFormatConfig.cmake)
 endif()
+cmake_policy(POP)


### PR DESCRIPTION
Example message:
```log
CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.25/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.25/Modules/ExternalProject.cmake:4184 (_ep_add_download_command)
  C:/Dev/ITK-git/Utilities/ClangFormat/DownloadClangFormat.cmake:47 (ExternalProject_Add)
  C:/Dev/ITK-git/CMake/ITKModuleClangFormat.cmake:17 (include)
  C:/Dev/ITK-git/CMake/ITKModuleMacros.cmake:9 (include)
  C:/Dev/ITK-git/CMake/ITKModuleExternal.cmake:159 (include)
  CMakeLists.txt:7 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
Closes #3846.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
