### PR TITLE
ENH: Add CompositeTransform to DataObjectDecorator wrapping

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/wrapping/itkImageRegistrationMethodv4.wrap
+++ b/Modules/Registration/RegistrationMethodsv4/wrapping/itkImageRegistrationMethodv4.wrap
@@ -10,6 +10,7 @@ itk_wrap_include("itkMesh.h")
 
 itk_wrap_class("itk::DataObjectDecorator" POINTER)
 foreach(d ${ITK_WRAP_DIMS})
+  itk_wrap_template("CT${ITKM_D}${d}" "itk::CompositeTransform< ${ITKT_D}, ${d} >")
   itk_wrap_template("DFT${ITKM_D}${d}" "itk::DisplacementFieldTransform< ${ITKT_D}, ${d} >")
   itk_wrap_template("BSOUDFT${ITKM_D}${d}" "itk::BSplineSmoothingOnUpdateDisplacementFieldTransform< ${ITKT_D}, ${d} >")
   # necessary for TimeVaryingVelocityFieldImageRegistrationMethodv4


### PR DESCRIPTION
Trying to use DataObjectDecorator<CompositeTransform<double, 3>> in class interface leads to wrapping warnings:
```log
itkANTSRegistration: warning(4): ITK type not wrapped, or currently not known: itk::DataObjectDecorator< itk::CompositeTransform< double, 2 > >
itkANTSRegistration: warning(4): ITK type not wrapped, or currently not known: itk::DataObjectDecorator< itk::CompositeTransform< double, 3 > >
```


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

