### PR TITLE
 WIP: Check that `Math::Round` template argument is an integer type

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -33,6 +33,7 @@
 #include "itkMathDetail.h"
 #include "itkConceptChecking.h"
 #include <vnl/vnl_math.h>
+#include <type_traits>
 
 /* Only maintain backwards compatibility with old versions
  * of VXL back to the point where vnl_math:: was introduced
@@ -177,6 +178,10 @@ template <typename TReturn, typename TInput>
 inline TReturn
 Round(TInput x)
 {
+  static_assert(
+    sizeof(TReturn) > sizeof(int64_t) || std::is_integral_v<TReturn>,
+    "Math::Round template argument `TReturn` must be an integer type. If a floating point result is preferred, "
+    "consider using std::round (from <cmath>), or cast the result of a Math::Round call to a floating point type!");
   return RoundHalfIntegerUp<TReturn, TInput>(x);
 }
 

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -21,6 +21,7 @@
 
 #include "itkMath.h"
 #include "itkProgressReporter.h"
+#include <cmath> // For round.
 
 namespace itk
 {
@@ -101,7 +102,7 @@ HuangThresholdCalculator<THistogram, TOutput>::GenerateData()
   for (InstanceIdentifier threshold = m_FirstBin; threshold < m_LastBin; ++threshold)
   {
     double entropy = 0.;
-    auto   mu = Math::Round<MeasurementType>(W[threshold] / S[threshold]);
+    auto   mu = static_cast<MeasurementType>(std::round(W[threshold] / S[threshold]));
 
     typename HistogramType::MeasurementVectorType v(1);
     v[0] = mu;
@@ -121,7 +122,7 @@ HuangThresholdCalculator<THistogram, TOutput>::GenerateData()
 
         entropy += Smu[diff] * histogram->GetFrequency(i, 0);
       }
-      mu = Math::Round<MeasurementType>((W[m_LastBin] - W[threshold]) / (S[m_LastBin] - S[threshold]));
+      mu = static_cast<MeasurementType>(std::round((W[m_LastBin] - W[threshold]) / (S[m_LastBin] - S[threshold])));
       v[0] = mu;
 
       bool status = histogram->GetIndex(v, muFullIdx);


### PR DESCRIPTION
The `TReturn` template argument of `Math::Round` must be an integer type, according to https://github.com/InsightSoftwareConsortium/ITK/blob/66ab5b14c476d057ed46a4daba05b710681160e6/Modules/Core/Common/include/itkMath.h#L127

And indeed, `Math::Round` is internally optimized to produce an integer value. Otherwise, the user may consider calling `std::round` instead.
