### PR TITLE
STYLE: Remove public defaulted default-constructor/destructor pairs

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkVectorCastImageFilter.h
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCastImageFilter.h
@@ -46,8 +46,6 @@ template <typename TInput, typename TOutput>
 class VectorCast
 {
 public:
-  VectorCast() = default;
-  ~VectorCast() = default;
   bool
   operator!=(const VectorCast &) const
   {

--- a/Modules/Core/Common/include/itkBresenhamLine.h
+++ b/Modules/Core/Common/include/itkBresenhamLine.h
@@ -51,10 +51,6 @@ public:
   using OffsetArray = std::vector<OffsetType>;
   using IndexArray = std::vector<IndexType>;
 
-  // constructors
-  BresenhamLine() = default;
-  ~BresenhamLine() = default;
-
   /** Build a line in a specified Direction. */
   OffsetArray
   BuildLine(LType Direction, IdentifierType length);

--- a/Modules/Core/Common/include/itkDefaultPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultPixelAccessor.h
@@ -54,9 +54,6 @@ template <typename TType>
 class ITK_TEMPLATE_EXPORT DefaultPixelAccessor
 {
 public:
-  DefaultPixelAccessor() = default;
-  ~DefaultPixelAccessor() = default;
-
   /** External type alias. It defines the external aspect
    * that this class will exhibit. */
   using ExternalType = TType;

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -344,9 +344,6 @@ public:
   using PointType = typename PointContainerType::Element;
   using WeightContainerType = TWeightContainer;
 
-  BarycentricCombination() = default;
-  ~BarycentricCombination() = default;
-
   static PointType
   Evaluate(const PointContainerPointer & points, const WeightContainerType & weights);
 };

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -764,9 +764,6 @@ public:
   static constexpr EigenValueOrderEnum DoNotOrder = EigenValueOrderEnum::DoNotOrder;
 #endif
 
-  SymmetricEigenAnalysisFixedDimension() = default;
-  ~SymmetricEigenAnalysisFixedDimension() = default;
-
   using MatrixType = TMatrix;
   using EigenMatrixType = TEigenMatrix;
   using VectorType = TVector;

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -28,8 +28,6 @@ template <typename TInput, typename TOutput>
 class TanHelper
 {
 public:
-  TanHelper() = default;
-  ~TanHelper() = default;
   bool
   operator==(const TanHelper & rhs) const
   {

--- a/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
@@ -36,9 +36,6 @@ template <typename TInput1, typename TInput2, typename TInput3, typename TOutput
 class ITK_TEMPLATE_EXPORT LandweberMethod
 {
 public:
-  LandweberMethod() = default;
-  ~LandweberMethod() = default;
-
   bool
   operator==(const LandweberMethod &) const
   {

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
@@ -32,8 +32,6 @@ class TensorFractionalAnisotropyFunction
 {
 public:
   using RealValueType = typename TInput::RealValueType;
-  TensorFractionalAnisotropyFunction() = default;
-  ~TensorFractionalAnisotropyFunction() = default;
   bool
   operator==(const TensorFractionalAnisotropyFunction &) const
   {

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
@@ -32,8 +32,6 @@ class TensorRelativeAnisotropyFunction
 {
 public:
   using RealValueType = typename TInput::RealValueType;
-  TensorRelativeAnisotropyFunction() = default;
-  ~TensorRelativeAnisotropyFunction() = default;
   bool
   operator==(const TensorRelativeAnisotropyFunction &) const
   {

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -58,8 +58,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class AbsoluteValueDifference2
 {
 public:
-  AbsoluteValueDifference2() = default;
-  ~AbsoluteValueDifference2() = default;
   bool
   operator==(const AbsoluteValueDifference2 &) const
   {

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -57,8 +57,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class SquaredDifference2
 {
 public:
-  SquaredDifference2() = default;
-  ~SquaredDifference2() = default;
   bool
   operator==(const SquaredDifference2 &) const
   {

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -48,9 +48,6 @@ template <typename TPixel1, typename TPixel2>
 class JoinFunctor
 {
 public:
-  JoinFunctor() = default;
-  ~JoinFunctor() = default;
-
   /** Standard type alias */
   using Self = JoinFunctor;
 

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput, typename TOutput>
 class Abs
 {
 public:
-  Abs() = default;
-  ~Abs() = default;
   bool
   operator==(const Abs &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Acos
 {
 public:
-  Acos() = default;
-  ~Acos() = default;
   bool
   operator==(const Acos &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -34,8 +34,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT Add2
 {
 public:
-  Add2() = default;
-  ~Add2() = default;
   bool
   operator==(const Add2 &) const
   {
@@ -61,8 +59,6 @@ template <typename TInput1, typename TInput2, typename TInput3, typename TOutput
 class ITK_TEMPLATE_EXPORT Add3
 {
 public:
-  Add3() = default;
-  ~Add3() = default;
   bool
   operator==(const Add3 &) const
   {
@@ -88,8 +84,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT Sub2
 {
 public:
-  Sub2() = default;
-  ~Sub2() = default;
   bool
   operator==(const Sub2 &) const
   {
@@ -115,8 +109,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT Mult
 {
 public:
-  Mult() = default;
-  ~Mult() = default;
   bool
   operator==(const Mult &) const
   {
@@ -142,8 +134,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class ITK_TEMPLATE_EXPORT Div
 {
 public:
-  Div() = default;
-  ~Div() = default;
   bool
   operator==(const Div &) const
   {
@@ -217,9 +207,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class ITK_TEMPLATE_EXPORT Modulus
 {
 public:
-  Modulus() = default;
-  ~Modulus() = default;
-
   bool
   operator==(const Modulus &) const
   {
@@ -368,8 +355,6 @@ template <class TInput1, class TOutput = TInput1>
 class UnaryMinus
 {
 public:
-  UnaryMinus() = default;
-  ~UnaryMinus() = default;
   bool
   operator==(const UnaryMinus &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Asin
 {
 public:
-  Asin() = default;
-  ~Asin() = default;
   bool
   operator==(const Asin &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class Atan2
 {
 public:
-  Atan2() = default;
-  ~Atan2() = default;
   bool
   operator==(const Atan2 &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Atan
 {
 public:
-  Atan() = default;
-  ~Atan() = default;
   bool
   operator==(const Atan &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class Modulus2
 {
 public:
-  Modulus2() = default;
-  ~Modulus2() = default;
   bool
   operator==(const Modulus2 &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
@@ -34,8 +34,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT AND
 {
 public:
-  AND() = default;
-  ~AND() = default;
   bool
   operator==(const AND &) const
   {
@@ -60,8 +58,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT OR
 {
 public:
-  OR() = default;
-  ~OR() = default;
   bool
   operator==(const OR &) const
   {
@@ -86,8 +82,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class ITK_TEMPLATE_EXPORT XOR
 {
 public:
-  XOR() = default;
-  ~XOR() = default;
   bool
   operator==(const XOR &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
@@ -47,8 +47,6 @@ template <typename TInput, typename TOutput>
 class BoundedReciprocal
 {
 public:
-  BoundedReciprocal() = default;
-  ~BoundedReciprocal() = default;
   bool
   operator==(const BoundedReciprocal &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
@@ -36,8 +36,6 @@ template <typename TInput, typename TOutput>
 class ComplexToImaginary
 {
 public:
-  ComplexToImaginary() = default;
-  ~ComplexToImaginary() = default;
   bool
   operator==(const ComplexToImaginary &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
@@ -35,8 +35,6 @@ template <typename TInput, typename TOutput>
 class ComplexToModulus
 {
 public:
-  ComplexToModulus() = default;
-  ~ComplexToModulus() = default;
   bool
   operator==(const ComplexToModulus &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
@@ -36,8 +36,6 @@ template <typename TInput, typename TOutput>
 class ComplexToPhase
 {
 public:
-  ComplexToPhase() = default;
-  ~ComplexToPhase() = default;
   bool
   operator==(const ComplexToPhase &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
@@ -35,8 +35,6 @@ template <typename TInput, typename TOutput>
 class ComplexToReal
 {
 public:
-  ComplexToReal() = default;
-  ~ComplexToReal() = default;
   bool
   operator==(const ComplexToReal &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class ConstrainedValueAddition
 {
 public:
-  ConstrainedValueAddition() = default;
-  ~ConstrainedValueAddition() = default;
   bool
   operator==(const ConstrainedValueAddition &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
@@ -58,8 +58,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class ConstrainedValueDifference
 {
 public:
-  ConstrainedValueDifference() = default;
-  ~ConstrainedValueDifference() = default;
   bool
   operator==(const ConstrainedValueDifference &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Cos
 {
 public:
-  Cos() = default;
-  ~Cos() = default;
   bool
   operator==(const Cos &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -43,8 +43,6 @@ template <typename TInput, typename TOutput>
 class EdgePotential
 {
 public:
-  EdgePotential() = default;
-  ~EdgePotential() = default;
   bool
   operator==(const EdgePotential &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Exp
 {
 public:
-  Exp() = default;
-  ~Exp() = default;
   bool
   operator==(const Exp &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Log10
 {
 public:
-  Log10() = default;
-  ~Log10() = default;
   bool
   operator==(const Log10 &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Log
 {
 public:
-  Log() = default;
-  ~Log() = default;
   bool
   operator==(const Log &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -119,9 +119,6 @@ class ITK_TEMPLATE_EXPORT Equal : public LogicOpBase<TInput1, TInput2, TOutput>
 public:
   using Self = Equal;
 
-  Equal() = default;
-  ~Equal() = default;
-
   bool
   operator==(const Self &) const
   {
@@ -155,9 +152,6 @@ class ITK_TEMPLATE_EXPORT NotEqual : public LogicOpBase<TInput1, TInput2, TOutpu
 {
 public:
   using Self = NotEqual;
-
-  NotEqual() = default;
-  ~NotEqual() = default;
 
   bool
   operator==(const Self &) const
@@ -193,8 +187,6 @@ class ITK_TEMPLATE_EXPORT GreaterEqual : public LogicOpBase<TInput1, TInput2, TO
 {
 public:
   using Self = GreaterEqual;
-  GreaterEqual() = default;
-  ~GreaterEqual() = default;
 
   bool
   operator==(const Self &) const
@@ -230,8 +222,6 @@ class ITK_TEMPLATE_EXPORT Greater : public LogicOpBase<TInput1, TInput2, TOutput
 {
 public:
   using Self = Greater;
-  Greater() = default;
-  ~Greater() = default;
 
   bool
   operator==(const Self &) const
@@ -268,9 +258,6 @@ class ITK_TEMPLATE_EXPORT LessEqual : public LogicOpBase<TInput1, TInput2, TOutp
 public:
   using Self = LessEqual;
 
-  LessEqual() = default;
-  ~LessEqual() = default;
-
   bool
   operator==(const Self &) const
   {
@@ -305,8 +292,6 @@ class ITK_TEMPLATE_EXPORT Less : public LogicOpBase<TInput1, TInput2, TOutput>
 {
 public:
   using Self = Less;
-  Less() = default;
-  ~Less() = default;
 
   bool
   operator==(const Self &) const
@@ -337,9 +322,6 @@ template <typename TInput, typename TOutput = TInput>
 class ITK_TEMPLATE_EXPORT NOT : public LogicOpBase<TInput, TInput, TOutput>
 {
 public:
-  NOT() = default;
-  ~NOT() = default;
-
   bool
   operator==(const NOT &) const
   {
@@ -368,9 +350,6 @@ template <typename TInput1, typename TInput2, typename TInput3, typename TOutput
 class ITK_TEMPLATE_EXPORT TernaryOperator
 {
 public:
-  TernaryOperator() = default;
-  ~TernaryOperator() = default;
-
   bool
   operator==(const TernaryOperator &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
@@ -58,8 +58,6 @@ template <typename TInput1, typename TInput2, typename TOutput>
 class MagnitudeAndPhaseToComplex
 {
 public:
-  MagnitudeAndPhaseToComplex() = default;
-  ~MagnitudeAndPhaseToComplex() = default;
   bool
   operator==(const MagnitudeAndPhaseToComplex &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -38,8 +38,6 @@ class MaskNegatedInput
 public:
   using AccumulatorType = typename NumericTraits<TInput>::AccumulateType;
 
-  MaskNegatedInput() = default;
-  ~MaskNegatedInput() = default;
   bool
   operator==(const MaskNegatedInput &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class Maximum
 {
 public:
-  Maximum() = default;
-  ~Maximum() = default;
   bool
   operator==(const Maximum &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput1, typename TInput2 = TInput1, typename TOutput = TInpu
 class Minimum
 {
 public:
-  Minimum() = default;
-  ~Minimum() = default;
   bool
   operator==(const Minimum &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
@@ -35,8 +35,6 @@ class Add1
 {
 public:
   using AccumulatorType = typename NumericTraits<TInput>::AccumulateType;
-  Add1() = default;
-  ~Add1() = default;
   inline TOutput
   operator()(const std::vector<TInput> & B) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
@@ -38,8 +38,6 @@ public:
   // not sure if this type alias really makes things more clear... could just use
   // TOutput?
 
-  Maximum1() = default;
-  ~Maximum1() = default;
   inline TOutput
   operator()(const std::vector<TInput> & B) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
@@ -43,8 +43,6 @@ public:
   using ComponentType = typename TInput::ComponentType;
   using RealType = typename itk::NumericTraits<ComponentType>::RealType;
 
-  RGBToLuminance() = default;
-  ~RGBToLuminance() = default;
   bool
   operator==(const RGBToLuminance &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Round
 {
 public:
-  Round() = default;
-  ~Round() = default;
   bool
   operator==(const Round &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Sin
 {
 public:
-  Sin() = default;
-  ~Sin() = default;
   bool
   operator==(const Sin &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Sqrt
 {
 public:
-  Sqrt() = default;
-  ~Sqrt() = default;
   bool
   operator==(const Sqrt &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -41,8 +41,6 @@ class Square
 {
 public:
   using RealType = typename NumericTraits<TInput>::RealType;
-  Square() = default;
-  ~Square() = default;
   bool
   operator==(const Square &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -44,8 +44,6 @@ class SymmetricEigenAnalysisFunction
 {
 public:
   using RealValueType = typename TInput::RealValueType;
-  SymmetricEigenAnalysisFunction() = default;
-  ~SymmetricEigenAnalysisFunction() = default;
   using CalculatorType = SymmetricEigenAnalysis<TInput, TOutput>;
   bool
   operator==(const SymmetricEigenAnalysisFunction &) const
@@ -131,8 +129,6 @@ class SymmetricEigenAnalysisFixedDimensionFunction
 {
 public:
   using RealValueType = typename TInput::RealValueType;
-  SymmetricEigenAnalysisFixedDimensionFunction() = default;
-  ~SymmetricEigenAnalysisFixedDimensionFunction() = default;
   using CalculatorType = SymmetricEigenAnalysisFixedDimension<TMatrixDimension, TInput, TOutput>;
   bool
   operator==(const SymmetricEigenAnalysisFixedDimensionFunction &) const

--- a/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
@@ -34,8 +34,6 @@ template <typename TInput, typename TOutput>
 class Tan
 {
 public:
-  Tan() = default;
-  ~Tan() = default;
   bool
   operator==(const Tan &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput1, typename TInput2, typename TInput3, typename TOutput
 class Modulus3
 {
 public:
-  Modulus3() = default;
-  ~Modulus3() = default;
   bool
   operator==(const Modulus3 &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
@@ -33,8 +33,6 @@ template <typename TInput1, typename TInput2, typename TInput3, typename TOutput
 class ModulusSquare3
 {
 public:
-  ModulusSquare3() = default;
-  ~ModulusSquare3() = default;
   bool
   operator==(const ModulusSquare3 &) const
   {

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -48,9 +48,6 @@ template <typename TInput, typename TOutput>
 class VectorMagnitude
 {
 public:
-  VectorMagnitude() = default;
-  ~VectorMagnitude() = default;
-
   bool
   operator==(const VectorMagnitude &) const
   {

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
@@ -54,9 +54,6 @@ template <typename TInput, typename TOutput>
 class ITK_TEMPLATE_EXPORT ChangeLabel
 {
 public:
-  ChangeLabel() = default;
-  ~ChangeLabel() = default;
-
   using ChangeMapType = std::map<TInput, TOutput>;
 
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
@@ -58,8 +58,6 @@ template <typename TPixel>
 class BinaryNot
 {
 public:
-  BinaryNot() = default;
-  ~BinaryNot() = default;
   bool
   operator==(const BinaryNot &) const
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanDilateImageFilter.h
@@ -27,8 +27,6 @@ template <typename TPixel>
 class MaxFunctor
 {
 public:
-  MaxFunctor() = default;
-  ~MaxFunctor() = default;
   inline TPixel
   operator()(const TPixel & A, const TPixel & B) const
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
@@ -28,8 +28,6 @@ template <typename TPixel>
 class MinFunctor
 {
 public:
-  MinFunctor() = default;
-  ~MinFunctor() = default;
   inline TPixel
   operator()(const TPixel & A, const TPixel & B) const
   {


### PR DESCRIPTION
Following the C++ Rule of Zero. May also prevent some clang warnings (https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-with-dtor), saying:

> warning: definition of implicit copy [...] is deprecated because it has a user-declared destructor

Found with Notepad++, using the following regular expression:

    ([^ ]+)\(\) = default;\r\n  ~\1\(\) = default;