### PR TITLE
Let SetSingleMethod and Singleton _move_ their `std::function` argument

### DIFF
--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -72,7 +72,7 @@ public:
   void
   SetGlobalInstance(const char * globalName, T * global, std::function<void()> deleteFunc)
   {
-    this->SetGlobalInstancePrivate(globalName, global, deleteFunc);
+    this->SetGlobalInstancePrivate(globalName, global, std::move(deleteFunc));
   }
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
@@ -84,7 +84,7 @@ public:
                     std::function<void(void *)> itkNotUsed(func),
                     std::function<void()>       deleteFunc)
   {
-    this->SetGlobalInstance(globalName, global, deleteFunc);
+    this->SetGlobalInstance(globalName, global, std::move(deleteFunc));
     // Just returns true for backward compatibility (legacy only).
     return true;
   }
@@ -132,7 +132,7 @@ Singleton(const char * globalName, std::function<void()> deleteFunc)
   if (instance == nullptr)
   {
     instance = new T;
-    SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, deleteFunc);
+    SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, std::move(deleteFunc));
   }
   return instance;
 }
@@ -143,7 +143,7 @@ template <typename T>
 [[deprecated("Prefer calling the Singleton(globalName, deleteFunc) overload (without the unused func parameter)!")]] T *
 Singleton(const char * globalName, std::function<void(void *)> itkNotUsed(func), std::function<void()> deleteFunc)
 {
-  return Singleton<T>(globalName, deleteFunc);
+  return Singleton<T>(globalName, std::move(deleteFunc));
 }
 #endif
 

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -80,7 +80,7 @@ PlatformMultiThreader::SetNumberOfWorkUnits(ThreadIdType numberOfWorkUnits)
 void
 PlatformMultiThreader::SetSingleMethod(ThreadFunctionType f, void * data)
 {
-  m_SingleMethod = f;
+  m_SingleMethod = std::move(f);
   m_SingleData = data;
 }
 

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -101,7 +101,7 @@ PoolMultiThreader::~PoolMultiThreader() = default;
 void
 PoolMultiThreader::SetSingleMethod(ThreadFunctionType f, void * data)
 {
-  m_SingleMethod = f;
+  m_SingleMethod = std::move(f);
   m_SingleData = data;
 }
 

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -94,7 +94,7 @@ SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
 void
 SingletonIndex::SetGlobalInstancePrivate(const char * globalName, void * global, std::function<void()> deleteFunc)
 {
-  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, deleteFunc));
+  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, std::move(deleteFunc)));
 }
 
 SingletonIndex *

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -62,7 +62,7 @@ TBBMultiThreader::~TBBMultiThreader() = default;
 void
 TBBMultiThreader::SetSingleMethod(ThreadFunctionType f, void * data)
 {
-  m_SingleMethod = f;
+  m_SingleMethod = std::move(f);
   m_SingleData = data;
 }
 


### PR DESCRIPTION
It's common practice to _move_ rather than to _copy_ `std::function` objects, when possible, as it might yield a performance gain.