### PR TITLE
DOC: Fix `itk::FEMSpatialObjectWriter` Doxygen `brief` description

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
@@ -25,7 +25,7 @@ namespace itk
 {
 /** \class FEMSpatialObjectWriter
  *
- * \brief Read any SpatialObject file with conversion for FEM Objects
+ * \brief Write FEM SpatialObjects to a file
  *
  * \ingroup ITKFEM
  */


### PR DESCRIPTION
Fix `itk::FEMSpatialObjectWriter` Doxygen `brief` description: honor the purpose of the class.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)
