### PR TITLE
STYLE: Replace tuple with private GlobalObject struct, in SingletonIndex

### DIFF
--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -72,7 +72,7 @@ public:
   void
   SetGlobalInstance(const char * globalName, T * global, std::function<void()> deleteFunc)
   {
-    this->SetGlobalInstancePrivate(globalName, global, std::move(deleteFunc));
+    this->SetGlobalInstancePrivate(globalName, GlobalObject{ global, std::move(deleteFunc) });
   }
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
@@ -99,6 +99,13 @@ public:
   ~SingletonIndex();
 
 private:
+  // Internal struct to store the instance pointer and the delete function object of a global object.
+  struct GlobalObject
+  {
+    void *                Instance{};
+    std::function<void()> DeleteFunc{};
+  };
+
   // may return nullptr if string is not registered already
   //
   // access something like a std::map<std::string, void *> or
@@ -110,14 +117,14 @@ private:
 
   // global is added or set to the singleton index under globalName
   void
-  SetGlobalInstancePrivate(const char * globalName, void * global, std::function<void()> deleteFunc);
+  SetGlobalInstancePrivate(const char * globalName, GlobalObject globalObject);
 
   /** The static GlobalSingleton. This is initialized to nullptr as the first
    * stage of static initialization. It is then populated on the first call to
    * itk::Singleton::Modified() but it can be overridden with SetGlobalSingleton().
    * */
-  std::map<std::string, std::tuple<void *, std::function<void()>>> m_GlobalObjects;
-  static Self *                                                    m_Instance;
+  std::map<std::string, GlobalObject> m_GlobalObjects;
+  static Self *                       m_Instance;
   //  static SingletonIndexPrivate * m_GlobalSingleton;
 };
 

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -86,15 +86,15 @@ SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
   {
     return nullptr;
   }
-  return std::get<0>(it->second);
+  return it->second.Instance;
 }
 
 // If globalName is already registered, set its global as specified,
 // otherwise global is added to the singleton index under globalName
 void
-SingletonIndex::SetGlobalInstancePrivate(const char * globalName, void * global, std::function<void()> deleteFunc)
+SingletonIndex::SetGlobalInstancePrivate(const char * globalName, GlobalObject globalObject)
 {
-  m_GlobalObjects.insert_or_assign(globalName, std::make_tuple(global, std::move(deleteFunc)));
+  m_GlobalObjects.insert_or_assign(globalName, std::move(globalObject));
 }
 
 SingletonIndex *
@@ -118,7 +118,7 @@ SingletonIndex::~SingletonIndex()
 {
   for (auto & pair : m_GlobalObjects)
   {
-    std::get<1>(pair.second)();
+    pair.second.DeleteFunc();
   }
 }
 


### PR DESCRIPTION
A simple `struct` appears more readable than an `std::tuple`, in this case, especially because the struct has a name for each data element (`Instance` and `DeleteFunc`), whereas each tuple data element is only accessed by its number.

---

Inspired by a discussion on `std::tuple` versus `struct`, at:
- https://github.com/isocpp/CppCoreGuidelines/pull/2166