### PR TITLE
COMP: Address clang warnings in a remote module

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -137,7 +137,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 {
   if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) || this->m_NumberOfIntegrationSteps == 0)
   {
-    this->GetOutput()->FillBuffer(itk::NumericTraits<typename DisplacementFieldType::PixelType>::Zero);
+    this->GetOutput()->FillBuffer(itk::NumericTraits<typename DisplacementFieldType::PixelType>::ZeroValue());
     return;
   }
 


### PR DESCRIPTION
Warnings were raised here: https://open.cdash.org/viewBuildError.php?type=1&buildid=9322560

Message of the first one:
```log
Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx:140:98: warning: instantiation of variable 'itk::NumericTraits<itk::Vector<double, 2>>::Zero' required here, but no definition is available [-Wundefined-var-template]
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
