### PR TITLE
ENH: Update KWStyle to avoid a CMake warning during its configure step

### DIFF
--- a/Utilities/KWStyle/BuildKWStyle.cmake
+++ b/Utilities/KWStyle/BuildKWStyle.cmake
@@ -23,7 +23,7 @@ if(NOT TARGET KWStyle)
   ExternalProject_Add(
     KWStyle
     GIT_REPOSITORY "https://github.com/Kitware/KWStyle.git"
-    GIT_TAG 1173206c0e7f4bc70dc3af641daf6e33f4042772
+    GIT_TAG 51ede352f6634d965444720f63b4f3e660fe5d42
     UPDATE_COMMAND ""
     DOWNLOAD_DIR ${KWStyle_SOURCE_DIR}
     SOURCE_DIR ${KWStyle_SOURCE_DIR}


### PR DESCRIPTION
Closes #4426. Integrates changes from https://github.com/Kitware/KWStyle/pull/108.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
