### PR TITLE
COMP: Remove unnecessary `itkFEMSpatialObjectWriter.h` includes

### DIFF
--- a/Modules/Numerics/FEM/test/itkFEMObjectTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMObjectTest.cxx
@@ -18,7 +18,13 @@
 
 
 #include "itkFEMElement2DC0LinearLineStress.h"
-#include "itkFEMSpatialObjectWriter.h"
+#include "itkFEMElementBase.h"
+#include "itkFEMFactoryBase.h"
+#include "itkFEMMaterialLinearElasticity.h"
+#include "itkFEMLoadBCMFC.h"
+#include "itkFEMLoadBC.h"
+#include "itkFEMLoadNode.h"
+#include "itkFEMObject.h"
 
 
 int

--- a/Modules/Numerics/FEM/test/itkFEMObjectTest2.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMObjectTest2.cxx
@@ -18,8 +18,13 @@
 
 
 #include "itkFEMElement2DC0LinearLineStress.h"
-#include "itkFEMSpatialObjectWriter.h"
-
+#include "itkFEMElementBase.h"
+#include "itkFEMFactoryBase.h"
+#include "itkFEMMaterialLinearElasticity.h"
+#include "itkFEMLoadBCMFC.h"
+#include "itkFEMLoadBC.h"
+#include "itkFEMLoadNode.h"
+#include "itkFEMObject.h"
 
 int
 itkFEMObjectTest2(int, char *[])


### PR DESCRIPTION
Remove unnecessary `itkFEMSpatialObjectWriter.h` includes in `FEM` object tests and apply the "include-what-you-use" principle.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)