### PR TITLE
Fix `Math::Round` calls that have a floating point type as template argument

### DIFF
--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkImageFileWriter.h"
 #include "itkGaussianOperator.h"
 #include "itkImageAlgorithm.h"
+#include "itkIntTypes.h"
 #include "itkVectorImageToImageAdaptor.h"
 #include "itkSpatialNeighborSubsampler.h"
 #include "itkMacro.h"
@@ -43,7 +44,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PatchBasedDenoisingIm
   m_MinProbability(NumericTraits<RealValueType>::min() * 100)
   , // to avoid divide by zero
   m_SigmaUpdateDecimationFactor(
-    static_cast<unsigned int>(Math::Round<double>(1.0 / m_KernelBandwidthFractionPixelsForEstimation)))
+    static_cast<unsigned int>(Math::Round<int64_t>(1.0 / m_KernelBandwidthFractionPixelsForEstimation)))
   , m_NoiseSigma()
   , m_NoiseSigmaSquared()
   , m_SearchSpaceList(ListAdaptorType::New())
@@ -239,10 +240,10 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
 
   // For automatic sigma estimation, select every 'k'th pixel.
   m_SigmaUpdateDecimationFactor =
-    static_cast<unsigned int>(Math::Round<double>(1.0 / m_KernelBandwidthFractionPixelsForEstimation));
+    static_cast<unsigned int>(Math::Round<int64_t>(1.0 / m_KernelBandwidthFractionPixelsForEstimation));
   // For automatic sigma estimation, use at least 1% of pixels.
-  m_SigmaUpdateDecimationFactor = std::min(m_SigmaUpdateDecimationFactor,
-                                           static_cast<unsigned int>(Math::Round<double>(m_TotalNumberPixels / 100.0)));
+  m_SigmaUpdateDecimationFactor = std::min(
+    m_SigmaUpdateDecimationFactor, static_cast<unsigned int>(Math::Round<int64_t>(m_TotalNumberPixels / 100.0)));
   // For automatic sigma estimation, can't use more than 100% of pixels.
   m_SigmaUpdateDecimationFactor = std::max(m_SigmaUpdateDecimationFactor, 1u);
 

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -54,7 +54,7 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double value) -
   {
     return NumericTraits<OutputImagePixelType>::NonpositiveMin();
   }
-  else if (NumericTraits<OutputImagePixelType>::is_integer)
+  else if constexpr (NumericTraits<OutputImagePixelType>::is_integer)
   {
     return Math::Round<OutputImagePixelType>(value);
   }


### PR DESCRIPTION
The ~~three~~ two commits (out of five) from pull request #4409 that seem uncontroversial.

The idea is that _even_ if we do not (yet?) add a compile-time check against using a floating point type as `TReturn` template argument, we should still _avoid_ using a floating point type for `TReturn`! As documented:

https://github.com/InsightSoftwareConsortium/ITK/blob/66ab5b14c476d057ed46a4daba05b710681160e6/Modules/Core/Common/include/itkMath.h#L170-L172

Originally documented 15 years ago:

https://github.com/InsightSoftwareConsortium/ITK/blob/17269cbe9e620c308bf614a13f6acbbb4cc89e48/Code/Common/itkMath.h#L151-L153