### PR TITLE
WIP: Add `SpatialObject::WorldSpaceContext` class, a faster alternative to SpatialObject::IsInsideInWorldSpace

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -647,6 +647,53 @@ public:
   };
 #endif
 
+  /**
+   * \class WorldSpaceContext
+   * Caches the ObjectToWorldTransformInverse transform during its construction, allowing to speed up the estimation if
+   * a point in the context of the world space is inside the specified spatial object.
+   * \ingroup ITKSpatialObjects
+   */
+  class WorldSpaceContext
+  {
+  public:
+    /** Defaulted default-constructor. Creates an empty context, that does not have a spatial object. */
+    WorldSpaceContext() = default;
+
+    /** Explicit constructor. When the argument is not null, it creates a context that has the spatial object specified
+     * by the argument. When the argument is null, it creates an empty context. */
+    explicit WorldSpaceContext(const SpatialObject * const spatialObject)
+      : m_SpatialObject(spatialObject)
+      , m_ObjectToWorldTransformInverse(spatialObject ? spatialObject->GetObjectToWorldTransformInverse() : nullptr)
+    {}
+
+    /** Tells whether this context has a spatial object. */
+    bool
+    HasSpatialObject() const
+    {
+      return m_SpatialObject != nullptr;
+    }
+
+    /** A faster alternative to SpatialObject::IsInsideInWorldSpace. */
+    bool
+    IsInsideSpatialObject(const PointType & point) const
+    {
+      return m_SpatialObject->IsInsideInObjectSpace(
+        m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point));
+    }
+
+  private:
+    const SpatialObject * m_SpatialObject{};
+    const TransformType * m_ObjectToWorldTransformInverse{};
+  };
+
+
+  /** Creates a context for this spatial object. */
+  WorldSpaceContext
+  CreateWorldSpaceContext() const
+  {
+    return WorldSpaceContext(this);
+  }
+
 protected:
   /** Compute the World transform when the local transform is set
    *  This function should be called each time the local transform

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -192,11 +192,14 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
     IndexType  ind;
     PointType  pnt;
     VectorType mv;
+
+    const auto worldSpaceContext = m_SpatialObject->CreateWorldSpaceContext();
+
     while (!it.IsAtEnd())
     {
       ind = it.GetIndex();
       m_Image->TransformIndexToPhysicalPoint(ind, pnt);
-      if (m_SpatialObject->IsInsideInWorldSpace(pnt))
+      if (worldSpaceContext.IsInsideSpatialObject(pnt))
       {
         mv[0] = it.Get();
         m_Sum += static_cast<AccumulateType>(mv[0]);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -323,3 +323,33 @@ TEST(ImageMaskSpatialObject, CornerPointIsNotInsideMaskOfZeroValues)
   const double cornerPoint[] = { 1.5, 1.5 };
   ASSERT_FALSE(imageMaskSpatialObject->IsInsideInObjectSpace(cornerPoint));
 }
+
+
+// Check that the return value of WorldSpaceContext::IsInsideSpatialObject is equal to the corresponding
+// IsInsideInWorldSpace call.
+TEST(ImageMaskSpatialObject, WorldSpaceContextIsInsideSpatialObjectEqualsIsInsideInWorldSpace)
+{
+  constexpr auto imageDimension = 2U;
+  using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<imageDimension>;
+  using MaskImageType = ImageMaskSpatialObjectType::ImageType;
+  using MaskPixelType = MaskImageType::PixelType;
+  using PointType = MaskImageType::PointType;
+
+  // Create a mask image.
+  const auto maskImage = MaskImageType::New();
+  maskImage->SetRegions(itk::Size<imageDimension>::Filled(2));
+  maskImage->Allocate(true);
+  maskImage->SetPixel({}, MaskPixelType{ 1 });
+  maskImage->SetSpacing(itk::MakeFilled<MaskImageType::SpacingType>(0.5));
+
+  const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
+  imageMaskSpatialObject->SetImage(maskImage);
+
+  const auto worldSpaceContext = imageMaskSpatialObject->CreateWorldSpaceContext();
+
+  for (const double pointValue : { -1.0, 0.0, 0.5, 1.0 })
+  {
+    const PointType point(pointValue);
+    EXPECT_EQ(imageMaskSpatialObject->IsInsideInWorldSpace(point), worldSpaceContext.IsInsideSpatialObject(point));
+  }
+}

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -182,7 +182,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   {
     maskSpatialObject = static_cast<MaskSpatialObjectType *>(this->ProcessObject::GetInput(1));
   }
-  bool useMask(maskSpatialObject.IsNotNull());
+  const typename MaskSpatialObjectType::WorldSpaceContext worldSpaceContext(maskSpatialObject);
 
   // Two cases here .
   // 1. If the Gradients have been specified in multiple images, we will create
@@ -236,12 +236,12 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
       // look up the voxel in the mask image corresponding to
       // the location of the current index.
       bool unmaskedPixel(true);
-      if (useMask)
+      if (worldSpaceContext.HasSpatialObject())
       {
         typename ImageRegionConstIteratorWithIndex<ReferenceImageType>::IndexType index = it.GetIndex();
         typename ReferenceImageType::PointType                                    point;
         refImage->TransformIndexToPhysicalPoint(index, point);
-        unmaskedPixel = maskSpatialObject->IsInsideInWorldSpace(point);
+        unmaskedPixel = worldSpaceContext.IsInsideSpatialObject(point);
       }
 
       if (Math::NotAlmostEquals(b0, itk::NumericTraits<ReferencePixelType>::ZeroValue()) && unmaskedPixel &&
@@ -354,13 +354,13 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
       // look up the voxel in the mask image corresponding to
       // the location of the current index.
       bool unmaskedPixel(true);
-      if (useMask)
+      if (worldSpaceContext.HasSpatialObject())
       {
         typename ImageRegionConstIteratorWithIndex<ReferenceImageType>::IndexType index = git.GetIndex();
         typename ReferenceImageType::PointType                                    point;
 
         gradientImagePointer->TransformIndexToPhysicalPoint(index, point);
-        unmaskedPixel = maskSpatialObject->IsInsideInWorldSpace(point);
+        unmaskedPixel = worldSpaceContext.IsInsideSpatialObject(point);
       }
 
       if (Math::NotAlmostEquals(b0, NumericTraits<ReferencePixelType>::ZeroValue()) && unmaskedPixel &&

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -78,6 +78,8 @@ ImageMomentsCalculator<TImage>::Compute()
     return;
   }
 
+  const typename SpatialObjectType::WorldSpaceContext worldSpaceContext(m_SpatialObjectMask);
+
   ImageRegionConstIteratorWithIndex<ImageType> it(m_Image, m_Image->GetRequestedRegion());
 
   while (!it.IsAtEnd())
@@ -89,7 +91,7 @@ ImageMomentsCalculator<TImage>::Compute()
     Point<double, ImageDimension> physicalPosition;
     m_Image->TransformIndexToPhysicalPoint(indexPosition, physicalPosition);
 
-    if (m_SpatialObjectMask.IsNull() || m_SpatialObjectMask->IsInsideInWorldSpace(physicalPosition))
+    if (m_SpatialObjectMask.IsNull() || worldSpaceContext.IsInsideSpatialObject(physicalPosition))
     {
       m_M0 += value;
 

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -263,6 +263,11 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(Transfo
 
   histogram.Initialize(m_HistogramSize, m_LowerBound, m_UpperBound);
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   ti.GoToBegin();
   while (!ti.IsAtEnd())
   {
@@ -273,7 +278,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(Transfo
       InputPointType inputPoint;
       fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-      if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+      if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
       {
         ++ti;
         continue;
@@ -281,7 +286,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(Transfo
 
       OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-      if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+      if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
       {
         ++ti;
         continue;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -585,6 +585,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
 
   if (m_FixedImageMask.IsNotNull() || m_UseFixedImageSamplesIntensityThreshold)
   {
+    const typename FixedImageMaskType::WorldSpaceContext worldSpaceContext(m_FixedImageMask);
+
     InputPointType inputPoint;
 
     // repeat until we get enough samples to fill the array
@@ -599,7 +601,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
       if (m_FixedImageMask.IsNotNull())
       {
         // If not inside the mask, ignore the point
-        if (!m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+        if (!worldSpaceContext.IsInsideSpatialObject(inputPoint))
         {
           ++regionIter; // jump to next pixel
           if (regionIter.IsAtEnd())

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -77,6 +77,11 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
   MeasureType movingForegroundArea{};
   MeasureType fixedForegroundArea{};
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   // Compute fixedForegroundArea, movingForegroundArea, and
   // intersection. Loop over the fixed image.
   //
@@ -87,7 +92,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
     InputPointType fixedInputPoint;
     fixedImage->TransformIndexToPhysicalPoint(fixedIndex, fixedInputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(fixedInputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(fixedInputPoint))
     {
       ++fi;
       continue;
@@ -109,7 +114,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
     //
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(fixedInputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++fi;
       continue;
@@ -197,6 +202,11 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
   TransformJacobianType jacobian(TFixedImage::ImageDimension, this->m_Transform->GetNumberOfParameters());
   TransformJacobianType jacobianCache;
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   ti.GoToBegin();
   while (!ti.IsAtEnd())
   {
@@ -205,7 +215,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -219,7 +229,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -122,6 +122,11 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
     itkExceptionMacro("Fixed image has not been assigned");
   }
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
   typename FixedImageType::IndexType index;
   FixedIteratorType                  ti(fixedImage, regionForThread);
@@ -136,7 +141,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
     typename Superclass::InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->GetFixedImageMask() && !this->GetFixedImageMask()->IsInsideInWorldSpace(inputPoint))
+    if (this->GetFixedImageMask() && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -144,7 +149,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
 
     typename Superclass::OutputPointType transformedPoint = this->GetTransform()->TransformPoint(inputPoint);
 
-    if (this->GetMovingImageMask() && !this->GetMovingImageMask()->IsInsideInWorldSpace(transformedPoint))
+    if (this->GetMovingImageMask() && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -107,11 +107,13 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     const bool                                          fixedMaskIsPresent = !(this->m_FixedImageMask.IsNull());
     if (fixedMaskIsPresent)
     {
+      const auto worldSpaceContext = Superclass::m_FixedImageMask->CreateWorldSpaceContext();
+
       typename TFixedImage::PointType fixedSpacePhysicalPoint;
       while (!fi.IsAtEnd())
       {
         this->m_FixedImage->TransformIndexToPhysicalPoint(fi.GetIndex(), fixedSpacePhysicalPoint);
-        const bool shouldCheckPixelIntensity = this->m_FixedImageMask->IsInsideInWorldSpace(fixedSpacePhysicalPoint);
+        const bool shouldCheckPixelIntensity = worldSpaceContext.IsInsideSpatialObject(fixedSpacePhysicalPoint);
         if (shouldCheckPixelIntensity)
         {
           const PDFValueType & currValue = fi.Get();
@@ -138,12 +140,13 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
       const bool                                           movingMaskIsPresent = !(this->m_MovingImageMask.IsNull());
       if (movingMaskIsPresent)
       {
+        const auto worldSpaceContext = Superclass::m_MovingImageMask->CreateWorldSpaceContext();
+
         typename TMovingImage::PointType movingSpacePhysicalPoint;
         while (!mi.IsAtEnd())
         {
           this->m_MovingImage->TransformIndexToPhysicalPoint(mi.GetIndex(), movingSpacePhysicalPoint);
-          const bool shouldCheckPixelIntensity =
-            this->m_MovingImageMask->IsInsideInWorldSpace(movingSpacePhysicalPoint);
+          const bool shouldCheckPixelIntensity = worldSpaceContext.IsInsideSpatialObject(movingSpacePhysicalPoint);
           if (shouldCheckPixelIntensity)
           {
             const PDFValueType & currValue = mi.Get();

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -54,6 +54,11 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
     itkExceptionMacro("Fixed image has not been assigned");
   }
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   double MovingValue;
   double FixedValue;
 
@@ -76,7 +81,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -85,7 +90,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
     TransformType const * transform = this->m_Transform;
     OutputPointType       transformedPoint = transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -110,6 +110,11 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
                                      // and the resampled fixed grid after
                                      // transformation.
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   // Number of random picks made from the portion of fixed image within the
   // fixed mask
   SizeValueType numberOfFixedImagePixelsVisited = 0;
@@ -124,7 +129,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
     this->m_FixedImage->TransformIndexToPhysicalPoint(index, iter->FixedImagePointValue);
 
     // If not inside the fixed mask, ignore the point
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(iter->FixedImagePointValue))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(iter->FixedImagePointValue))
     {
       ++randIter; // jump to another random position
       continue;
@@ -145,7 +150,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
 
     // If the transformed point after transformation does not lie within the
     // MovingImageMask, skip it.
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(mappedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(mappedPoint))
     {
       ++randIter;
       continue;

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -61,6 +61,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   AccumulateType sf{};
   AccumulateType sm{};
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   while (!ti.IsAtEnd())
   {
     index = ti.GetIndex();
@@ -68,7 +73,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -76,7 +81,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;
@@ -169,6 +174,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
   DerivativeType derivativeM(ParametersDimension);
   derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   ti.GoToBegin();
   // First compute the sums
   while (!ti.IsAtEnd())
@@ -178,7 +188,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -186,7 +196,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;
@@ -222,7 +232,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -230,7 +240,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;
@@ -355,6 +365,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
   DerivativeType derivativeM1(ParametersDimension);
   derivativeM1.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
 
+  const typename Superclass::FixedImageMaskType::WorldSpaceContext fixedImageMaskWorldSpaceContext(
+    Superclass::m_FixedImageMask);
+  const typename Superclass::MovingImageMaskType::WorldSpaceContext movingImageMaskWorldSpaceContext(
+    Superclass::m_MovingImageMask);
+
   ti.GoToBegin();
   // First compute the sums
   while (!ti.IsAtEnd())
@@ -364,7 +379,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -372,7 +387,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;
@@ -407,7 +422,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
     InputPointType inputPoint;
     fixedImage->TransformIndexToPhysicalPoint(index, inputPoint);
 
-    if (this->m_FixedImageMask && !this->m_FixedImageMask->IsInsideInWorldSpace(inputPoint))
+    if (this->m_FixedImageMask && !fixedImageMaskWorldSpaceContext.IsInsideSpatialObject(inputPoint))
     {
       ++ti;
       continue;
@@ -415,7 +430,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
     OutputPointType transformedPoint = this->m_Transform->TransformPoint(inputPoint);
 
-    if (this->m_MovingImageMask && !this->m_MovingImageMask->IsInsideInWorldSpace(transformedPoint))
+    if (this->m_MovingImageMask && !movingImageMaskWorldSpaceContext.IsInsideSpatialObject(transformedPoint))
     {
       ++ti;
       continue;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -159,13 +159,15 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
       // A null mask implies entire space is to be used.
       if (!this->m_FixedImageMask.IsNull()) // use only masked samples.
       {
+        const auto worldSpaceContext = Superclass::m_FixedImageMask->CreateWorldSpaceContext();
+
         itk::ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage,
                                                                this->m_FixedImage->GetBufferedRegion());
         while (!fi.IsAtEnd())
         {
           typename TFixedImage::PointType fixedSpacePhysicalPoint;
           this->m_FixedImage->TransformIndexToPhysicalPoint(fi.GetIndex(), fixedSpacePhysicalPoint);
-          const bool usePoint = this->m_FixedImageMask->IsInsideInWorldSpace(fixedSpacePhysicalPoint);
+          const bool usePoint = worldSpaceContext.IsInsideSpatialObject(fixedSpacePhysicalPoint);
           if (usePoint)
           {
             const typename TFixedImage::PixelType & currValue = fi.Value();
@@ -201,12 +203,15 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                                               this->m_MovingImage->GetBufferedRegion());
 
       if (!this->m_MovingImageMask.IsNull())
-      { // A null mask implies entire space is to be used.
+      {
+        const auto worldSpaceContext = Superclass::m_MovingImageMask->CreateWorldSpaceContext();
+
+        // A null mask implies entire space is to be used.
         while (!mi.IsAtEnd())
         {
           typename TMovingImage::PointType movingSpacePhysicalPoint;
           this->m_MovingImage->TransformIndexToPhysicalPoint(mi.GetIndex(), movingSpacePhysicalPoint);
-          const bool usePoint = this->m_MovingImageMask->IsInsideInWorldSpace(movingSpacePhysicalPoint);
+          const bool usePoint = worldSpaceContext.IsInsideSpatialObject(movingSpacePhysicalPoint);
           if (usePoint)
           {
             const typename TMovingImage::PixelType & currValue = mi.Value();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -939,6 +939,8 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
     }
   }
 
+  const typename FixedImageMaskType::WorldSpaceContext worldSpaceContext(fixedMaskImage);
+
   const VirtualDomainRegionType &                    virtualDomainRegion = virtualImage->GetRequestedRegion();
   const typename VirtualDomainImageType::SpacingType oneThirdVirtualSpacing = virtualImage->GetSpacing() / 3.0;
 
@@ -985,7 +987,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
             {
               point[d] += randomizer->GetNormalVariate() * oneThirdVirtualSpacing[d];
             }
-            if (!fixedMaskImage || fixedMaskImage->IsInsideInWorldSpace(point))
+            if (!fixedMaskImage || worldSpaceContext.IsInsideSpatialObject(point))
             {
               samplePointSet->SetPoint(index, point);
               ++index;
@@ -1021,7 +1023,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
           {
             point[d] += randomizer->GetNormalVariate() * oneThirdVirtualSpacing[d];
           }
-          if (!fixedMaskImage || fixedMaskImage->IsInsideInWorldSpace(point))
+          if (!fixedMaskImage || worldSpaceContext.IsInsideSpatialObject(point))
           {
             samplePointSet->SetPoint(index, point);
             ++index;


### PR DESCRIPTION
`WorldSpaceContext::IsInsideSpatialObject` serves as a faster alternative to the
existing `SpatialObject::IsInsideInWorldSpace`. `WorldSpaceContext` has already
cached the ObjectToWorldTransformInverse transform during its construction.
`IsInsideSpatialObject` calls the faster
`SpatialObject::IsInsideInObjectSpace(const PointType &)` overload, instead of
the overload with three parameters.

Using VS2022 Release, `WorldSpaceContext::IsInsideSpatialObject` appeared more
than twice as fast as the equivalent `SpatialObject::IsInsideInWorldSpace` call.

----

Update: If the `IsInsideInWorldSpace(const PointType &)` overload proposed by pull request #4440 can make it onto the master branch, I will probably drop this `WorldSpaceContext` proposal (#4434), because then I think `WorldSpaceContext::IsInsideSpatialObject(point)` won't be much faster than the equivalent `SpatialObject::IsInsideInWorldSpace` call anymore.
