### PR TITLE
PERF: Let SpatialObject directly access m_ObjectToWorldTransformInverse

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -317,18 +317,27 @@ public:
   itkSetMacro(DefaultOutsideValue, double);
   itkGetConstMacro(DefaultOutsideValue, double);
 
-  /** World space equivalent to ValueAtInObjectSpace */
+  /** World space equivalent to ValueAtInObjectSpace
+   * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
+   * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
+   * `SetObjectToWorldTransform(transform)` */
   virtual bool
   ValueAtInWorldSpace(const PointType &   point,
                       double &            value,
                       unsigned int        depth = 0,
                       const std::string & name = "") const;
 
-  /** World space equivalent to IsInsideInObjectSpace */
+  /** World space equivalent to IsInsideInObjectSpace
+   * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
+   * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
+   * `SetObjectToWorldTransform(transform)` */
   virtual bool
   IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
 
-  /** World space equivalent to IsEvaluableAtInObjectSpace */
+  /** World space equivalent to IsEvaluableAtInObjectSpace
+   * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
+   * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
+   * `SetObjectToWorldTransform(transform)` */
   virtual bool
   IsEvaluableAtInWorldSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
 
@@ -342,7 +351,10 @@ public:
                             const std::string &          name = "",
                             const DerivativeOffsetType & offset = MakeFilled<DerivativeOffsetType>(1));
 
-  /** Return the n-th order derivative value at the specified point. */
+  /** Return the n-th order derivative value at the specified point.
+   * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
+   * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
+   * `SetObjectToWorldTransform(transform)` */
   virtual void
   DerivativeAtInWorldSpace(const PointType &            point,
                            short unsigned int           order,

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -138,7 +138,7 @@ SpatialObject<TDimension>::DerivativeAtInWorldSpace(const PointType &           
                                                     const std::string &          name,
                                                     const DerivativeOffsetType & offset)
 {
-  const PointType pnt = this->GetObjectToWorldTransformInverse()->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
   this->DerivativeAtInObjectSpace(pnt, order, value, depth, name, offset);
 }
 
@@ -180,7 +180,7 @@ SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType &   point,
                                                 unsigned int        depth,
                                                 const std::string & name) const
 {
-  const PointType pnt = this->GetObjectToWorldTransformInverse()->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
   return IsInsideInObjectSpace(pnt, depth, name);
 }
 
@@ -231,7 +231,7 @@ SpatialObject<TDimension>::IsEvaluableAtInWorldSpace(const PointType &   point,
                                                      unsigned int        depth,
                                                      const std::string & name) const
 {
-  const PointType pnt = this->GetObjectToWorldTransformInverse()->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
   return this->IsEvaluableAtInObjectSpace(pnt, depth, name);
 }
 
@@ -295,7 +295,7 @@ SpatialObject<TDimension>::ValueAtInWorldSpace(const PointType &   point,
                                                unsigned int        depth,
                                                const std::string & name) const
 {
-  const PointType pnt = this->GetObjectToWorldTransformInverse()->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
   return this->ValueAtInObjectSpace(pnt, value, depth, name);
 }
 


### PR DESCRIPTION
Replaced `this->GetObjectToWorldTransformInverse()` calls with direct access to m_ObjectToWorldTransformInverse. A performance improvement greater than 6% was observed, from more than 0.74 sec. down to less than 0.69 sec, when calling `IsInsideInWorldSpace` 2^25 times (as tested on VS2019 Release).