### PR TITLE
STYLE: remove duplicated itkMath.h headers

### DIFF
--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -22,7 +22,6 @@
 #include "itkMath.h"
 #include <cstring>
 #include <cstdlib>
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -21,7 +21,6 @@
 #include "itkMath.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNumericTraits.h"
-#include "itkMath.h"
 
 
 template <typename TPixelType>

--- a/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
+++ b/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
@@ -19,9 +19,6 @@
 #include "itkMath.h"
 #include <iostream>
 
-#include <iostream>
-#include "itkMath.h"
-
 
 namespace
 {

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -21,7 +21,6 @@
 #include "itkMath.h"
 #include "itkNumericTraits.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/BiasCorrection/test/itkCompositeValleyFunctionTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkCompositeValleyFunctionTest.cxx
@@ -18,8 +18,6 @@
 
 #include <iostream>
 #include "itkMath.h"
-
-#include "itkMath.h"
 #include "itkCompositeValleyFunction.h"
 #include "itkStdStreamStateSave.h"
 

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -26,7 +26,6 @@
 #include "itkProgressAccumulator.h"
 #include "itkMath.h"
 #include "vnl/vnl_vector.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -26,7 +26,6 @@
 
 #include <functional>
 #include <queue>
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkNumericTraits.h"
-#include "itkMath.h"
 #include <algorithm>
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -24,7 +24,6 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"
-#include "itkMath.h"
 
 
 namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -25,10 +25,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 #include "itkPrintHelper.h"
-
-#include "itkMath.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -23,7 +23,6 @@
 #include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkVectorImage.h"
-#include "itkMath.h"
 #include "itkTestingMacros.h"
 
 // class to produce a linear image pattern

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -23,7 +23,6 @@
 #include "itkProgressReporter.h"
 #include "vnl/algo/vnl_real_eigensystem.h"
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -21,7 +21,6 @@
 
 #include "itkMath.h"
 #include "itkProgressReporter.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -20,7 +20,6 @@
 #include "itkTextOutput.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"
-#include "itkMath.h"
 #include <iostream>
 
 /**

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
@@ -20,7 +20,6 @@
 #include "itkMath.h"
 #include "vnl/algo/vnl_lbfgs.h"
 #include "itkTestingMacros.h"
-#include "itkMath.h"
 #include <iostream>
 
 /**

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -19,7 +19,6 @@
 #include "itkMath.h"
 #include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
 #include "itkTranslationTransform.h"
-#include "itkMath.h"
 #include "itkTestingMacros.h"
 
 /* Simple test to verify that class builds and runs.

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
@@ -22,10 +22,8 @@
 #include "itkKLMSegmentationRegion.h"
 #include "itkMacro.h"
 #include "ITKKLMRegionGrowingExport.h"
-
 #include "itkMath.h"
 #include "vnl/vnl_vector.h"
-#include "itkMath.h"
 
 namespace itk
 {

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -24,7 +24,6 @@
 #include "itkIterationReporter.h"
 #include "itkMath.h"
 #include "itkNumericTraits.h"
-#include "itkMath.h"
 #include "itkPrintHelper.h"
 
 namespace itk


### PR DESCRIPTION
17 files had `#include "itkMath.h"` twice and one file 3 times.