### PR TITLE
STYLE: remove unnecessary itkImageFileWriter.h header

### DIFF
--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -23,7 +23,6 @@
 #include "itkResampleImageFilter.h"
 #include "itkIdentityTransform.h"
 #include "itkLinearInterpolateImageFunction.h"
-#include "itkImageFileWriter.h"
 #include "itkGaussianOperator.h"
 #include "itkImageAlgorithm.h"
 #include "itkVectorImageToImageAdaptor.h"

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -21,7 +21,6 @@
 #include "itkImageRegionIterator.h"
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkLaplacianImageFilter.h"
-#include "itkImageFileWriter.h"
 
 namespace itk
 {

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
@@ -21,7 +21,6 @@
 #include "itkImageRegionIterator.h"
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkLaplacianImageFilter.h"
-#include "itkImageFileWriter.h"
 
 namespace itk
 {

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkVectorThresholdSegmentationLevelSetImageFilter.h"
 #include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkMath.h"


### PR DESCRIPTION
Unused and unnecessary _itkImageFileWriter.h_ in _Filtering_ and _Segmentation_ modules.