### PR TITLE
Documentation improvements on overriding `SpatialObject` member functions

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -47,8 +47,8 @@ namespace itk
  * spatial objects can be plugged to a spatial object as children.  To
  * implement your own spatial object, you need to derive from the
  * following class, which requires overriding just a few virtual functions.
- * Examples of such functions are ValueAtInWorldSpace(),
- * IsEvaluableAtInWorldSpace(), and IsInsideInWorldSpace(), each of which has a
+ * Examples of such functions are ValueAtInObjectSpace(),
+ * IsInsideInObjectSpace(), and ComputeMyBoundingBox(), each of which has a
  * meaning specific to each particular object type.
  * \ingroup ITKSpatialObjects
  */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -240,11 +240,11 @@ public:
 
   /**********************************************************************/
   /* These are the three member functions that a subclass will typically
-   *    overwrite.
+   *    override.
    *    * ComputeMyBoundingBox (protected:)
    *    * IsInsideInObjectSpace
    *    * Update
-   *  Optionally, a subclass may also wish to overwrite
+   *  Optionally, a subclass may also wish to override
    *    * ValueAtInObjectSpace
    *    * IsEvaluableAtInObjectSpace - if the extent is beyond IsInside.
    */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -46,10 +46,10 @@ namespace itk
  * system, and a list of inverse transformation to go backward.  Any
  * spatial objects can be plugged to a spatial object as children.  To
  * implement your own spatial object, you need to derive from the
- * following class, which requires the definition of just a few pure
- * virtual functions.  Examples of such functions are ValueAtInWorldSpace(),
- * IsEvaluableAtInWorldSpace(), and IsInsideInWorldSpace(), each of which has a meaning
- * specific to each particular object type.
+ * following class, which requires overriding just a few virtual functions.
+ * Examples of such functions are ValueAtInWorldSpace(),
+ * IsEvaluableAtInWorldSpace(), and IsInsideInWorldSpace(), each of which has a
+ * meaning specific to each particular object type.
  * \ingroup ITKSpatialObjects
  */
 


### PR DESCRIPTION
Replaced SpatialObject examples of virtual functions that one may override, as `ValueAtInWorldSpace`,
`IsEvaluableAtInWorldSpace`, and `IsInsideInWorldSpace` may not need to be overridden. Actually it appears that none of the thirteen derived SpatialObject classes of ITK itself does override any of those three member functions!


Used the word "override" more consistently, and removed the term "pure virtual function".