### PR TITLE
PERF: Add SpatialObject IsInsideInWorldSpace(const PointType &) overload

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -332,7 +332,12 @@ public:
    * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
    * `SetObjectToWorldTransform(transform)` */
   virtual bool
-  IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
+  IsInsideInWorldSpace(const PointType & point, unsigned int depth, const std::string & name = "") const;
+
+  /** Overload, optimized for depth = 0 and name = "": `spatialObject.IsInsideInWorldSpace(point)` is equivalent to
+   * `spatialObject.IsInsideInWorldSpace(point, 0, "")`, but much faster. */
+  bool
+  IsInsideInWorldSpace(const PointType & point) const;
 
   /** World space equivalent to IsEvaluableAtInObjectSpace
    * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -186,6 +186,14 @@ SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType &   point,
 
 template <unsigned int TDimension>
 bool
+SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType & point) const
+{
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  return IsInsideInObjectSpace(pnt);
+}
+
+template <unsigned int TDimension>
+bool
 SpatialObject<TDimension>::IsInsideChildrenInObjectSpace(const PointType &   point,
                                                          unsigned int        depth,
                                                          const std::string & name) const

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -323,3 +323,31 @@ TEST(ImageMaskSpatialObject, CornerPointIsNotInsideMaskOfZeroValues)
   const double cornerPoint[] = { 1.5, 1.5 };
   ASSERT_FALSE(imageMaskSpatialObject->IsInsideInObjectSpace(cornerPoint));
 }
+
+// Check that the IsInsideInWorldSpace overloads yield the same result, when depth = 0 and name = "".
+TEST(ImageMaskSpatialObject, IsInsideInWorldSpaceOverloads)
+{
+  constexpr auto imageDimension = 2U;
+  using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<imageDimension>;
+  using MaskImageType = ImageMaskSpatialObjectType::ImageType;
+  using MaskPixelType = MaskImageType::PixelType;
+  using PointType = MaskImageType::PointType;
+
+  // Create a mask image.
+  const auto maskImage = MaskImageType::New();
+  maskImage->SetRegions(itk::Size<imageDimension>::Filled(2));
+  maskImage->Allocate(true);
+  maskImage->SetPixel({}, MaskPixelType{ 1 });
+  maskImage->SetSpacing(itk::MakeFilled<MaskImageType::SpacingType>(0.5));
+
+  const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
+  imageMaskSpatialObject->SetImage(maskImage);
+
+  for (const double pointValue : { -1.0, 0.0, 0.5, 1.0 })
+  {
+    const PointType point(pointValue);
+
+    EXPECT_EQ(imageMaskSpatialObject->IsInsideInWorldSpace(point),
+              imageMaskSpatialObject->IsInsideInWorldSpace(point, 0, ""));
+  }
+}


### PR DESCRIPTION
A performance improvement of more than 35% was observed, from more than 0.62 sec. to less than 0.38 sec. when calling IsInsideInWorldSpace(point) 2^25 times, using VS2022 Release.

----

Of course, this may yield a performance improvement for all classes that call `IsInsideInWorldSpace(point)`, including:
- SpatialObjectToImageStatisticsCalculator
- DiffusionTensor3DReconstructionImageFilter
- ImageMomentsCalculator
- HistogramImageToImageMetric
- ImageToImageMetric
- KappaStatisticImageToImageMetric
- MatchCardinalityImageToImageMetric
- MattesMutualInformationImageToImageMetric
- MeanReciprocalSquareDifferenceImageToImageMetric
- MutualInformationImageToImageMetric
- NormalizedCorrelationImageToImageMetric
- JointHistogramMutualInformationImageToImageMetricv4
- MattesMutualInformationImageToImageMetricv4
- ImageRegistrationMethodv4
