### PR TITLE
PERF: Make `m_ObjectToWorldTransformInverse->TransformPoint` non-virtual

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -138,7 +138,7 @@ SpatialObject<TDimension>::DerivativeAtInWorldSpace(const PointType &           
                                                     const std::string &          name,
                                                     const DerivativeOffsetType & offset)
 {
-  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point);
   this->DerivativeAtInObjectSpace(pnt, order, value, depth, name, offset);
 }
 
@@ -180,7 +180,7 @@ SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType &   point,
                                                 unsigned int        depth,
                                                 const std::string & name) const
 {
-  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point);
   return IsInsideInObjectSpace(pnt, depth, name);
 }
 
@@ -188,7 +188,7 @@ template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::IsInsideInWorldSpace(const PointType & point) const
 {
-  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point);
   return IsInsideInObjectSpace(pnt);
 }
 
@@ -239,7 +239,7 @@ SpatialObject<TDimension>::IsEvaluableAtInWorldSpace(const PointType &   point,
                                                      unsigned int        depth,
                                                      const std::string & name) const
 {
-  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point);
   return this->IsEvaluableAtInObjectSpace(pnt, depth, name);
 }
 
@@ -303,7 +303,7 @@ SpatialObject<TDimension>::ValueAtInWorldSpace(const PointType &   point,
                                                unsigned int        depth,
                                                const std::string & name) const
 {
-  const PointType pnt = m_ObjectToWorldTransformInverse->TransformPoint(point);
+  const PointType pnt = m_ObjectToWorldTransformInverse->TransformType::TransformPoint(point);
   return this->ValueAtInObjectSpace(pnt, value, depth, name);
 }
 


### PR DESCRIPTION
Suppressed the virtual call mechanism for
`m_ObjectToWorldTransformInverse->TransformPoint(point)` by explicit qualification with the `TransformType` scope, in the five `SpatialObject` "InWorldSpace" member functions.

A performance improvement of more than 13 % was observed, from more than 0.36 sec. (before this commit) to less than 0.31 sec. (after this commit) when calling IsInsideInWorldSpace(point) 2^25 times, using VS2022 Release.

---

Some background info:

`TransformType` is an alias for `AffineTransform<ScalarType, VDimension>`: https://github.com/InsightSoftwareConsortium/ITK/blob/2ca2351340a1a008beee2a2531c44117a9cfb19a/Modules/Core/SpatialObjects/include/itkSpatialObject.h#L99


`m_ObjectToWorldTransformInverse` is a `const` pointer, meaning that it always points to the very same `AffineTransform` instance, during its lifetime: https://github.com/InsightSoftwareConsortium/ITK/blob/2ca2351340a1a008beee2a2531c44117a9cfb19a/Modules/Core/SpatialObjects/include/itkSpatialObject.h#L724