### PR TITLE
STYLE: FUTURE_LEGACY_REMOVE virtual SpatialObject InWorldSpace functions

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -320,19 +320,29 @@ public:
   /** World space equivalent to ValueAtInObjectSpace
    * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
    * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
-   * `SetObjectToWorldTransform(transform)` */
-  virtual bool
-  ValueAtInWorldSpace(const PointType &   point,
-                      double &            value,
-                      unsigned int        depth = 0,
-                      const std::string & name = "") const;
+   * `SetObjectToWorldTransform(transform)`
+   * \note This member function is not meant to be overridden. In the future, it may not be declared `virtual` anymore.
+   */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  virtual
+#endif
+    bool
+    ValueAtInWorldSpace(const PointType &   point,
+                        double &            value,
+                        unsigned int        depth = 0,
+                        const std::string & name = "") const;
 
   /** World space equivalent to IsInsideInObjectSpace
    * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
    * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
-   * `SetObjectToWorldTransform(transform)` */
-  virtual bool
-  IsInsideInWorldSpace(const PointType & point, unsigned int depth, const std::string & name = "") const;
+   * `SetObjectToWorldTransform(transform)`
+   * \note This member function is not meant to be overridden. In the future, it may not be declared `virtual` anymore.
+   */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  virtual
+#endif
+    bool
+    IsInsideInWorldSpace(const PointType & point, unsigned int depth, const std::string & name = "") const;
 
   /** Overload, optimized for depth = 0 and name = "": `spatialObject.IsInsideInWorldSpace(point)` is equivalent to
    * `spatialObject.IsInsideInWorldSpace(point, 0, "")`, but much faster. */
@@ -342,9 +352,14 @@ public:
   /** World space equivalent to IsEvaluableAtInObjectSpace
    * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
    * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
-   * `SetObjectToWorldTransform(transform)` */
-  virtual bool
-  IsEvaluableAtInWorldSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
+   * `SetObjectToWorldTransform(transform)`
+   * \note This member function is not meant to be overridden. In the future, it may not be declared `virtual` anymore.
+   */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  virtual
+#endif
+    bool
+    IsEvaluableAtInWorldSpace(const PointType & point, unsigned int depth = 0, const std::string & name = "") const;
 
 
   /** Return the n-th order derivative value at the specified point. */
@@ -359,14 +374,19 @@ public:
   /** Return the n-th order derivative value at the specified point.
    * \note This member function assumes that the internal `ObjectToWorldTransformInverse` transform is up-to-date. This
    * transform may be updated explicitly by calling `GetObjectToWorldTransformInverse()`, `Update()`, or
-   * `SetObjectToWorldTransform(transform)` */
-  virtual void
-  DerivativeAtInWorldSpace(const PointType &            point,
-                           short unsigned int           order,
-                           CovariantVectorType &        value,
-                           unsigned int                 depth = 0,
-                           const std::string &          name = "",
-                           const DerivativeOffsetType & offset = MakeFilled<DerivativeOffsetType>(1));
+   * `SetObjectToWorldTransform(transform)`
+   * \note This member function is not meant to be overridden. In the future, it may not be declared `virtual` anymore.
+   */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  virtual
+#endif
+    void
+    DerivativeAtInWorldSpace(const PointType &            point,
+                             short unsigned int           order,
+                             CovariantVectorType &        value,
+                             unsigned int                 depth = 0,
+                             const std::string &          name = "",
+                             const DerivativeOffsetType & offset = MakeFilled<DerivativeOffsetType>(1));
 
 
   /*********************/


### PR DESCRIPTION
Made a first step towards removing the `virtual` keyword from four `SpatialObject` "InWorldSpace" member functions, in the future:

    ValueAtInWorldSpace
    IsInsideInWorldSpace
    IsEvaluableAtInWorldSpace
    DerivativeAtInWorldSpace

These member functions are not really meant to be overridden. Removing these `virtual` keyword may yield a run-time performance improvement.

Following C++ Core Guidelines, October 12, 2023, "Don’t make a function `virtual` without reason",
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-virtual

---

Note that none of the thirteen derived SpatialObject classes of ITK does override any of those four member functions. So it appears that they really don't need to be declared `virtual`.