### PR TITLE
Let `ImageSpatialObject` update the image regions of its base class, let `ImageMaskSpatialObject` use these image regions

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -39,7 +39,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::IsInsideInObjectSpace(const PointTyp
 
   const IndexType index = image->TransformPhysicalPointToIndex(point);
 
-  return image->GetBufferedRegion().IsInside(index) &&
+  return Superclass::GetBufferedRegion().IsInside(index) &&
          Math::NotExactlyEquals(image->GetPixel(index), NumericTraits<PixelType>::ZeroValue());
 }
 
@@ -163,7 +163,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
     return RegionType{ minIndex, regionSize };
   };
 
-  const RegionType requestedRegion = image.GetRequestedRegion();
+  const RegionType requestedRegion = Superclass::GetRequestedRegion();
 
   if (requestedRegion.GetNumberOfPixels() == 0)
   {

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -124,6 +124,10 @@ public:
   SetInterpolator(InterpolatorType * interpolator);
   itkGetConstMacro(Interpolator, InterpolatorType *);
 
+  /** Updates the regions of this spatial object in accordance with its current image, and calls its Superclass. */
+  void
+  Update() override;
+
 protected:
   /** Compute the boundaries of the image spatial object. */
   void
@@ -148,6 +152,10 @@ private:
 #endif
 
   typename InterpolatorType::Pointer m_Interpolator{};
+
+  /** Updates the regions of this spatial object in accordance with its current image. */
+  void
+  UpdateImageRegions();
 
 #if !defined(ITK_LEGACY_REMOVE)
   template <typename T>

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -149,6 +149,8 @@ ImageSpatialObject<TDimension, PixelType>::SetImage(const ImageType * image)
     }
 
     m_Image = image;
+    UpdateImageRegions();
+
     if (m_Interpolator)
     {
       m_Interpolator->SetInputImage(m_Image);
@@ -184,6 +186,32 @@ ImageSpatialObject<TDimension, PixelType>::InternalClone() const
 
   return loPtr;
 }
+
+
+template <unsigned int TDimension, typename PixelType>
+void
+ImageSpatialObject<TDimension, PixelType>::Update()
+{
+  UpdateImageRegions();
+
+  // Call the Superclass Update() after (not before) updating the image regions! The effect of Superclass::Update()
+  // may depend partially on the image regions.
+  Superclass::Update();
+}
+
+
+template <unsigned int TDimension, typename PixelType>
+void
+ImageSpatialObject<TDimension, PixelType>::UpdateImageRegions()
+{
+  if (m_Image)
+  {
+    Superclass::SetLargestPossibleRegion(m_Image->GetLargestPossibleRegion());
+    Superclass::SetBufferedRegion(m_Image->GetBufferedRegion());
+    Superclass::SetRequestedRegion(m_Image->GetRequestedRegion());
+  }
+}
+
 
 template <unsigned int TDimension, typename PixelType>
 void

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -351,3 +351,47 @@ TEST(ImageMaskSpatialObject, IsInsideInWorldSpaceOverloads)
               imageMaskSpatialObject->IsInsideInWorldSpace(point, 0, ""));
   }
 }
+
+
+// Check that regions of the mask image are stored in the spatial object.
+TEST(ImageMaskSpatialObject, StoresRegionsFromMaskImage)
+{
+  using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<>;
+  using MaskImageType = ImageMaskSpatialObjectType::ImageType;
+
+  // Test image regions of various indices and sizes:
+  for (const itk::IndexValueType indexValue : { -1, 0, 1 })
+  {
+    // Just test some small sizes, to make the test run fast:
+    for (itk::SizeValueType sizeValue{ 2 }; sizeValue < 4; ++sizeValue)
+    {
+      using RegionType = MaskImageType::RegionType;
+      using IndexType = MaskImageType::IndexType;
+      using SizeType = MaskImageType::SizeType;
+
+      // Create a mask image.
+      const auto maskImage = MaskImageType::New();
+      maskImage->SetRegions(RegionType{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
+      maskImage->Allocate(true);
+
+      const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
+      imageMaskSpatialObject->SetImage(maskImage);
+
+      EXPECT_EQ(imageMaskSpatialObject->GetLargestPossibleRegion(), maskImage->GetLargestPossibleRegion());
+      EXPECT_EQ(imageMaskSpatialObject->GetBufferedRegion(), maskImage->GetBufferedRegion());
+      EXPECT_EQ(imageMaskSpatialObject->GetRequestedRegion(), maskImage->GetRequestedRegion());
+
+      // Modify one of the image regions.
+      maskImage->SetRequestedRegion(RegionType{ IndexType::Filled(indexValue + 1), SizeType::Filled(sizeValue - 1) });
+
+      // Note: when an image region is modified _after_ calling SetImage, the user must call Update() to keep the
+      // regions of the spatial object up-to-date.
+      imageMaskSpatialObject->Update();
+
+      // Do the same checks after the Update():
+      EXPECT_EQ(imageMaskSpatialObject->GetLargestPossibleRegion(), maskImage->GetLargestPossibleRegion());
+      EXPECT_EQ(imageMaskSpatialObject->GetBufferedRegion(), maskImage->GetBufferedRegion());
+      EXPECT_EQ(imageMaskSpatialObject->GetRequestedRegion(), maskImage->GetRequestedRegion());
+    }
+  }
+}


### PR DESCRIPTION
`SpatialObject` stores the image regions of the spatial object. It appears reasonable for its derived class `ImageSpatialObject` to keep them up-to-date, in accordance with its image.

A significant performance improvement of `ImageMaskSpatialObject` is then achieved by using the buffered region and the requested region as cached in its base class, instead of calling the virtual functions `GetBufferedRegion()` and `GetRequestedRegion()` from its image.

----

It's interesting to see that the common base class `itk::SpatialObject` already has those data members to cache the image regions (`m_LargestPossibleRegion`, `m_RequestedRegion`, `m_BufferedRegion`), but it looks like they weren't used anywhere, as far as I can see:

https://github.com/InsightSoftwareConsortium/ITK/blob/436423d798e63e72444dd4a9d8787ffd34c5eb60/Modules/Core/SpatialObjects/include/itkSpatialObject.h#L731-L733

For the record, those data members were added to `itk::SpatialObject` with commit 433987062ccaee80c9a7d2f6c1ff857fe96cf929 "ENH: Removed NDimensionalSpatialObject", Julien Jomier (@jjomier), 10 February 2003.