### PR TITLE
STYLE: Replace magic number SpatialObject `MaximumDepth = 9999999`

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -30,6 +30,7 @@
 #include "itkAffineTransform.h"
 #include "itkVectorContainer.h"
 #include "itkBoundingBox.h"
+#include <limits>
 
 namespace itk
 {
@@ -65,7 +66,7 @@ public:
 
   static constexpr ObjectDimensionType ObjectDimension = VDimension;
 
-  static constexpr unsigned int MaximumDepth = 9999999;
+  static constexpr unsigned int MaximumDepth = std::numeric_limits<unsigned int>::max();
 
   /** Return the maximum depth that a tree of spatial objects can
    * have.  This provides convenient access to a static constant. */


### PR DESCRIPTION
`MaximumDepth` should just be "as high as possible" (or as _deep_ as possible), in order for a function call like `IsInsideInObjectSpace(point, MaximumDepth)` to go _as deep as possible_.

----

This pull request replaces `9999999` with `std::numeric_limits<unsigned int>::max()`, which is typically `4294967295`  (assuming 32-bit int). That's obviously a lot more than `9999999`, but in practice the depth won't go _near_ either of those two numbers. So I consider this to be a style improvement, not an enhancement.