### PR TITLE
Simplify itkCreateAnotherMacro(x) and itkFactorylessNewMacro(x)

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -374,9 +374,8 @@ namespace itk
 #define itkFactorylessNewMacro(x) \
   static Pointer New()            \
   {                               \
-    Pointer smartPtr;             \
     x *     rawPtr = new x;       \
-    smartPtr = rawPtr;            \
+    Pointer smartPtr = rawPtr;    \
     rawPtr->UnRegister();         \
     return smartPtr;              \
   }                               \

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -371,21 +371,16 @@ namespace itk
  * UnRegister() on the rawPtr to compensate for LightObject's constructor
  * initializing an object's reference count to 1 (needed for proper
  * initialization of process objects and data objects cycles). */
-#define itkFactorylessNewMacro(x)                            \
-  static Pointer New()                                       \
-  {                                                          \
-    Pointer smartPtr;                                        \
-    x *     rawPtr = new x;                                  \
-    smartPtr = rawPtr;                                       \
-    rawPtr->UnRegister();                                    \
-    return smartPtr;                                         \
-  }                                                          \
-  ::itk::LightObject::Pointer CreateAnother() const override \
-  {                                                          \
-    ::itk::LightObject::Pointer smartPtr;                    \
-    smartPtr = x::New().GetPointer();                        \
-    return smartPtr;                                         \
-  }                                                          \
+#define itkFactorylessNewMacro(x) \
+  static Pointer New()            \
+  {                               \
+    Pointer smartPtr;             \
+    x *     rawPtr = new x;       \
+    smartPtr = rawPtr;            \
+    rawPtr->UnRegister();         \
+    return smartPtr;              \
+  }                               \
+  itkCreateAnotherMacro(x);       \
   ITK_MACROEND_NOOP_STATEMENT
 
 //

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -319,13 +319,8 @@ namespace itk
   }                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkCreateAnotherMacro(x)                             \
-  ::itk::LightObject::Pointer CreateAnother() const override \
-  {                                                          \
-    ::itk::LightObject::Pointer smartPtr;                    \
-    smartPtr = x::New().GetPointer();                        \
-    return smartPtr;                                         \
-  }                                                          \
+#define itkCreateAnotherMacro(x)                                                               \
+  ::itk::LightObject::Pointer CreateAnother() const override { return x::New().GetPointer(); } \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkCloneMacro(x)                                                  \


### PR DESCRIPTION
Three little style improvements:

- Let `x::CreateAnother()` just return `x::New().GetPointer()`
- Let itkFactorylessNewMacro directly initialize its `smartPtr`
- Let itkFactorylessNewMacro(x) just call itkCreateAnotherMacro(x)