### PR TITLE
Add ValueInitializedIsZeroFilled tests, replace `MakeFilled<Self>(NumericTraits<T>::ZeroValue())` with `Self{}`

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -116,7 +116,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -117,7 +117,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -116,7 +116,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -103,7 +103,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -115,7 +115,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -115,7 +115,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -116,7 +116,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -102,7 +102,7 @@ public:
   static const Self
   ZeroValue()
   {
-    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
+    return Self{};
   }
 
   static const Self

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1719,7 +1719,9 @@ set(ITKCommonGTests
     itkConnectedImageNeighborhoodShapeGTest.cxx
     itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
     itkCopyGTest.cxx
+    itkCovariantVectorGTest.cxx
     itkDerefGTest.cxx
+    itkDiffusionTensor3DGTest.cxx
     itkExceptionObjectGTest.cxx
     itkFixedArrayGTest.cxx
     itkImageNeighborhoodOffsetsGTest.cxx
@@ -1741,9 +1743,12 @@ set(ITKCommonGTests
     itkOffsetGTest.cxx
     itkOptimizerParametersGTest.cxx
     itkPointGTest.cxx
+    itkRGBAPixelGTest.cxx
+    itkRGBPixelGTest.cxx
     itkShapedImageNeighborhoodRangeGTest.cxx
     itkSizeGTest.cxx
     itkSmartPointerGTest.cxx
+    itkSymmetricSecondRankTensorGTest.cxx
     itkVectorContainerGTest.cxx
     itkVectorGTest.cxx
     itkWeakPointerGTest.cxx

--- a/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkCovariantVector.h"
+#include <gtest/gtest.h>
+
+
+// Tests that a CovariantVector that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(CovariantVector, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::CovariantVector<int>{});
+  expectZeroFilled(itk::CovariantVector<float, 2>{});
+  expectZeroFilled(itk::CovariantVector<double, 4>{});
+}

--- a/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
+++ b/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkDiffusionTensor3D.h"
+#include <gtest/gtest.h>
+
+
+// Tests that a DiffusionTensor3D that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(DiffusionTensor3D, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::DiffusionTensor3D<int>{});
+  expectZeroFilled(itk::DiffusionTensor3D<float>{});
+  expectZeroFilled(itk::DiffusionTensor3D<double>{});
+}

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -48,6 +48,22 @@ Expect_Point_can_be_constructed_by_std_array()
 } // namespace
 
 
+// Tests that a Point that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(Point, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::Point<int>{});
+  expectZeroFilled(itk::Point<float, 2>{});
+  expectZeroFilled(itk::Point<double, 4>{});
+}
+
+
 // Tests that a Point can be constructed by specifying
 // its coordinates by an std::array<ValueType, VDimension>.
 TEST(Point, CanBeConstructedByStdArray)

--- a/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkRGBAPixel.h"
+#include <gtest/gtest.h>
+
+
+// Tests that a RGBAPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(RGBAPixel, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::RGBAPixel<>{});
+  expectZeroFilled(itk::RGBAPixel<std::uint8_t>{});
+  expectZeroFilled(itk::RGBAPixel<float>{});
+}

--- a/Modules/Core/Common/test/itkRGBPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkRGBPixel.h"
+#include <gtest/gtest.h>
+
+
+// Tests that a RGBPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(RGBPixel, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::RGBPixel<>{});
+  expectZeroFilled(itk::RGBPixel<std::uint8_t>{});
+  expectZeroFilled(itk::RGBPixel<float>{});
+}

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
@@ -1,0 +1,37 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkSymmetricSecondRankTensor.h"
+#include <gtest/gtest.h>
+
+
+// Tests that a SymmetricSecondRankTensor that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(SymmetricSecondRankTensor, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::SymmetricSecondRankTensor<int>{});
+  expectZeroFilled(itk::SymmetricSecondRankTensor<float, 2>{});
+  expectZeroFilled(itk::SymmetricSecondRankTensor<double, 4>{});
+}

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -48,6 +48,22 @@ Expect_itk_Vector_can_be_constructed_by_std_array()
 } // namespace
 
 
+// Tests that an itk::Vector that is "value-initialized" (by empty braces, `{}`) is zero-filled.
+TEST(Vector, ValueInitializedIsZeroFilled)
+{
+  const auto expectZeroFilled = [](const auto & fixedArray) {
+    for (const auto element : fixedArray)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  };
+
+  expectZeroFilled(itk::Vector<int>{});
+  expectZeroFilled(itk::Vector<float, 2>{});
+  expectZeroFilled(itk::Vector<double, 4>{});
+}
+
+
 // Tests that an itk::Vector can be constructed by specifying
 // its coordinates by an std::array<ValueType, VDimension>.
 TEST(Vector, CanBeConstructedByStdArray)


### PR DESCRIPTION
Tested that a "value-initialized" object of one of the `FixedArray` derived types, `CovariantVector` `DiffusionTensor3D`, `RGBAPixel`, `RGBPixel`, `SymmetricSecondRankTensor`, `Point`, or `Vector` is zero-filled.

Replaced `MakeFilled<Self>(NumericTraits<T>::ZeroValue())` with `Self{}` in the `ZeroValue()` implementation of `NumericTraits` specializations.

----

Used the syntax `T{}` to create "value-initialized" objects of each of those types, see also: https://en.cppreference.com/w/cpp/language/value_initialization