### PR TITLE
COMP: Locally ignore Clang `-Wmismatched-tags` warnings in `ImageRegion`

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -424,6 +424,13 @@ operator<<(std::ostream & os, const ImageRegion<VImageDimension> & region);
 
 namespace std
 {
+#if defined(__clang__)
+#  pragma GCC diagnostic push
+// Old Clang compiler versions (before Clang 7.0.0) produced some unimportant warnings, like: "warning: 'tuple_size'
+// defined as a struct template here but previously declared as a class template"
+#  pragma GCC diagnostic ignored "-Wmismatched-tags"
+#endif
+
 // NOLINTBEGIN(cert-dcl58-cpp)
 // Locally suppressed the following warning from Clang-Tidy (LLVM 17.0.1), as it appears undeserved.
 // > warning: modification of 'std' namespace can result in undefined behavior [cert-dcl58-cpp]
@@ -448,6 +455,10 @@ struct tuple_element<VTupleIndex, itk::ImageRegion<VImageDimension>>
 };
 
 // NOLINTEND(cert-dcl58-cpp)
+
+#if defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
 } // namespace std
 
 #undef itkRegionOverrideMacro


### PR DESCRIPTION
After pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4367 commit 72aa9a602bd92b665acc915d8df4bd00a27c98f0 (ENH: `ImageRegion` support C++17 structured binding), a few unimportant `-Wmismatched-tags` warnings appeared from Mac10.13-AppleClang-rel-x86_64, at
https://open.cdash.org/build/9256915 as was reported to me by mail, from Dženan Zukić (@dzenanz) and Sean McBride (@seanm).

This commit locally disables those warnings, following https://github.com/Naios/continuable/blob/121265df7123cf672ea8db917eaca2d0fbd9aef5/include/continuable/continuable-result.hpp#L291-L308 by Denis Blank (@Naios).
