### PR TITLE
COMP: Fix MultiThreaderSingle typos

### DIFF
--- a/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
@@ -39,9 +39,9 @@ PlatformMultiThreader::MultipleMethodExecute()
   ThreadIdType thread_loop;
 
   // obey the global maximum number of threads limit
-  if (m_NumberOfWorkUnits > m_GlobalMaximumNumberOfThreads)
+  if (m_NumberOfWorkUnits > MultiThreaderBase::GetGlobalMaximumNumberOfThreads())
   {
-    m_NumberOfWorkUnits = m_GlobalMaximumNumberOfThreads;
+    m_NumberOfWorkUnits = MultiThreaderBase::GetGlobalMaximumNumberOfThreads();
   }
 
   for (thread_loop = 0; thread_loop < m_NumberOfWorkUnits; ++thread_loop)


### PR DESCRIPTION
The top of MultipleMethodExecute() in itkPlatformMultiThreaderSingle.cxx was outdated. I have copied two lines from itkPlatformMultiThreaderWindows.cxx in order to fix it. This problem was mentioned in as an issue but not yet fixed: https://github.com/InsightSoftwareConsortium/ITK/issues/3163.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or *behavior not changed*)
- [x] Updated API documentation (or *API not changed*)
