### PR TITLE
Let `SpatialObject` directly access `m_ObjectToWorldTransform`, use `std::transform` for `transformedCorners`

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -402,7 +402,7 @@ SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const -> const Bou
   auto itTrans = transformedCorners->begin();
   while (it != corners.end())
   {
-    const PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
+    const PointType pnt = this->m_ObjectToWorldTransform->TransformPoint(*it);
     *itTrans = pnt;
     ++it;
     ++itTrans;
@@ -511,7 +511,7 @@ SpatialObject<TDimension>::ProtectedComputeObjectToWorldTransform()
   m_ObjectToWorldTransform->SetParameters(this->GetObjectToParentTransform()->GetParameters());
   if (this->HasParent())
   {
-    m_ObjectToWorldTransform->Compose(this->GetParent()->GetObjectToWorldTransform(), false);
+    m_ObjectToWorldTransform->Compose(this->GetParent()->m_ObjectToWorldTransform, false);
   }
 
   if (!m_ObjectToWorldTransform->GetInverse(m_ObjectToWorldTransformInverse))
@@ -565,7 +565,7 @@ SpatialObject<TDimension>::ComputeObjectToParentTransform()
   if (this->HasParent())
   {
     auto inverse = TransformType::New();
-    if (this->GetParent()->GetObjectToWorldTransform()->GetInverse(inverse))
+    if (this->GetParent()->m_ObjectToWorldTransform->GetInverse(inverse))
     {
       m_ObjectToParentTransform->Compose(inverse, true);
     }
@@ -632,7 +632,7 @@ SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const -> const Boundin
   auto itTrans = transformedCorners->begin();
   while (it != corners.end())
   {
-    const PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
+    const PointType pnt = this->m_ObjectToWorldTransform->TransformPoint(*it);
     *itTrans = pnt;
     ++it;
     ++itTrans;
@@ -1015,7 +1015,7 @@ SpatialObject<TDimension>::SetParent(Self * parent)
   if (parent != m_Parent)
   {
     Self *                oldParent = m_Parent;
-    const TransformType * oldObjectWorldTransform = this->GetObjectToWorldTransform();
+    const TransformType * oldObjectWorldTransform = this->m_ObjectToWorldTransform;
 
     m_Parent = parent;
     if (parent != nullptr)
@@ -1251,7 +1251,7 @@ SpatialObject<TDimension>::CopyInformation(const DataObject * data)
   this->SetProperty(source->GetProperty());
 
   // copy the ivars
-  this->SetObjectToWorldTransform(source->GetObjectToWorldTransform());
+  this->SetObjectToWorldTransform(source->m_ObjectToWorldTransform);
   this->SetDefaultInsideValue(source->GetDefaultInsideValue());
   this->SetDefaultOutsideValue(source->GetDefaultOutsideValue());
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -398,15 +398,9 @@ SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const -> const Bou
   auto       transformedCorners = PointsContainer::New();
   transformedCorners->Reserve(static_cast<typename PointsContainer::ElementIdentifier>(corners.size()));
 
-  auto it = corners.begin();
-  auto itTrans = transformedCorners->begin();
-  while (it != corners.end())
-  {
-    const PointType pnt = this->m_ObjectToWorldTransform->TransformPoint(*it);
-    *itTrans = pnt;
-    ++it;
-    ++itTrans;
-  }
+  std::transform(corners.cbegin(), corners.cend(), transformedCorners->begin(), [this](const auto & point) {
+    return m_ObjectToWorldTransform->TransformPoint(point);
+  });
 
   m_FamilyBoundingBoxInWorldSpace->SetPoints(transformedCorners);
   m_FamilyBoundingBoxInWorldSpace->ComputeBoundingBox();
@@ -628,15 +622,9 @@ SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const -> const Boundin
   auto       transformedCorners = PointsContainer::New();
   transformedCorners->Reserve(static_cast<typename PointsContainer::ElementIdentifier>(corners.size()));
 
-  auto it = corners.begin();
-  auto itTrans = transformedCorners->begin();
-  while (it != corners.end())
-  {
-    const PointType pnt = this->m_ObjectToWorldTransform->TransformPoint(*it);
-    *itTrans = pnt;
-    ++it;
-    ++itTrans;
-  }
+  std::transform(corners.cbegin(), corners.cend(), transformedCorners->begin(), [this](const auto & point) {
+    return m_ObjectToWorldTransform->TransformPoint(point);
+  });
 
   m_MyBoundingBoxInWorldSpace->SetPoints(transformedCorners);
   m_MyBoundingBoxInWorldSpace->ComputeBoundingBox();


### PR DESCRIPTION
Two little style improvements:
- Let `SpatialObject` directly access `m_ObjectToWorldTransform` (similar to pull request #4435)
- Use `std::transform` for `transformedCorners`