### PR TITLE
DOC: More background for supported compilers

### DIFF
--- a/Documentation/docs/supported_compilers.md
+++ b/Documentation/docs/supported_compilers.md
@@ -2,13 +2,27 @@
 
 ITK requires a compiler with C++17 support.
 
+The standard compilers for common operating systems are:
+
+- Windows: [Visual Studio](#visual-studio)
+- Linux: [GCC](#gnu-compiler-collection)
+- macOS: [AppleClang](#appleclang)
+
 ## Visual Studio
+
+Visual Studio includes the MSVC compiler. It can be installed for free with the [*Visual Studio Community Edition*](https://visualstudio.microsoft.com/vs/community/) application. The paid version is [*Visual Studio Professional Edition*](https://visualstudio.microsoft.com/vs/professional/). Note that [*Visual Studio Code (aka VS Code)*](https://code.visualstudio.com/) is a different project and **does not** include a C++ compiler by default.
 
 * VS2017 and earlier: **NOT supported**
 * MSVC toolset v142 (first shipped with VS2019): supported
 * MSVC toolset v143 (first shipped with VS2022): supported
 
-## GNU Compile Collection
+## GNU Compiler Collection
+
+GCC is installed on Ubuntu Linux with:
+
+```sh
+apt install build-essential
+```
 
 * GCC 7 and later [should be supported](https://www.gnu.org/software/gcc/projects/cxx-status.html).
 
@@ -17,9 +31,19 @@ ITK requires a compiler with C++17 support.
 * Clang 5 and later [should be supported](https://clang.llvm.org/cxx_status.html)
 
 ## AppleClang
+
+AppleClang is included with the XCode application and is available from the Apple App Store.
+
+To trigger installation of the Xcode Command Line tools, run:
+
+```sh
+xcode-select --install
+```
+
 * AppleClang 10.0.0 and later (from Xcode 10.0) [should be supported](https://en.wikipedia.org/wiki/Xcode#Version_history)
 
 ## Intel C++ Compiler
+
 * Intel C++ 19.1 and later
 
 ## Future versions


### PR DESCRIPTION
Provide more background and guidance on the standard per-operating system compilers and pointers on how to install them.