### PR TITLE
Replace `NumericTraits<T>::ZeroValue()` with `T{}` or `0U`

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
@@ -29,7 +29,7 @@ BackwardDifferenceOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients
 
   coeff[0] = -1.0 * NumericTraits<PixelType>::OneValue();
   coeff[1] = NumericTraits<PixelType>::OneValue();
-  coeff[2] = NumericTraits<PixelType>::ZeroValue();
+  coeff[2] = PixelType{};
 
   return coeff;
 }

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -134,7 +134,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
   {
     if (this->GetMTime() > m_BoundsMTime)
     {
-      m_Bounds.Fill(NumericTraits<CoordRepType>::ZeroValue());
+      m_Bounds.Fill(CoordRepType{});
       m_BoundsMTime.Modified();
     }
     return false;
@@ -146,7 +146,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
     // start by initializing the values
     if (m_PointsContainer->Size() < 1)
     {
-      m_Bounds.Fill(NumericTraits<CoordRepType>::ZeroValue());
+      m_Bounds.Fill(CoordRepType{});
       m_BoundsMTime.Modified();
       return false;
     }
@@ -285,7 +285,7 @@ auto
 BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetDiagonalLength2() const
   -> AccumulateType
 {
-  typename NumericTraits<CoordRepType>::AccumulateType dist2 = NumericTraits<CoordRepType>::ZeroValue();
+  typename NumericTraits<CoordRepType>::AccumulateType dist2 = CoordRepType{};
 
   if (this->ComputeBoundingBox())
   {

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -387,7 +387,7 @@ public:
   CoordRepType
   GetBoundingBoxDiagonalLength2()
   {
-    return NumericTraits<CoordRepType>::ZeroValue();
+    return CoordRepType{};
   }
 
   /** Intersect the given bounding box (bounds[PointDimension*2]) with a line

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -57,7 +57,7 @@ ColorTable<TComponent>::UseDiscreteColors()
   else
   {
     scale = NumericTraits<TComponent>::OneValue();
-    shift = NumericTraits<TComponent>::ZeroValue();
+    shift = TComponent{};
   }
 
   m_Color[0].Set((TComponent)(0.9 * scale + shift), (TComponent)(shift), (TComponent)(shift));
@@ -123,7 +123,7 @@ ColorTable<TComponent>::UseGrayColors(unsigned int n)
   else
   {
     range = NumericTraits<TComponent>::OneValue();
-    minimum = NumericTraits<TComponent>::ZeroValue();
+    minimum = TComponent{};
   }
   typename NumericTraits<TComponent>::RealType delta;
   if (m_NumberOfColors > 1)
@@ -178,7 +178,7 @@ ColorTable<TComponent>::UseHeatColors(unsigned int n)
   else
   {
     scale = NumericTraits<TComponent>::OneValue();
-    shift = NumericTraits<TComponent>::ZeroValue();
+    shift = TComponent{};
   }
   // Converting from TComponent to RealType may introduce a rounding error, so do static_cast
   constexpr auto max_value_converted =
@@ -238,7 +238,7 @@ ColorTable<TComponent>::UseRandomColors(unsigned int n)
   }
   else
   {
-    minimum = NumericTraits<TComponent>::ZeroValue();
+    minimum = TComponent{};
     maximum = NumericTraits<TComponent>::OneValue();
   }
   for (i = 0; i < n; ++i)

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -61,7 +61,7 @@ CompensatedSummationAddElement(TFloat & compensation, TFloat & sum, const TFloat
 template <typename TFloat>
 CompensatedSummation<TFloat>::CompensatedSummation(const TFloat value)
   : m_Sum(value)
-  , m_Compensation(NumericTraits<AccumulateType>::ZeroValue())
+  , m_Compensation(AccumulateType{})
 {}
 
 template <typename TFloat>
@@ -138,8 +138,8 @@ template <typename TFloat>
 void
 CompensatedSummation<TFloat>::ResetToZero()
 {
-  this->m_Sum = NumericTraits<AccumulateType>::ZeroValue();
-  this->m_Compensation = NumericTraits<AccumulateType>::ZeroValue();
+  this->m_Sum = AccumulateType{};
+  this->m_Compensation = AccumulateType{};
 }
 
 template <typename TFloat>
@@ -147,7 +147,7 @@ CompensatedSummation<TFloat> &
 CompensatedSummation<TFloat>::operator=(const FloatType & rhs)
 {
   this->m_Sum = rhs;
-  this->m_Compensation = NumericTraits<AccumulateType>::ZeroValue();
+  this->m_Compensation = AccumulateType{};
 
   return *this;
 }

--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -771,7 +771,7 @@ struct HasZero
     {
       T a;
 
-      a = NumericTraits<T>::ZeroValue();
+      a = T{};
       Detail::IgnoreUnusedVariable(a);
     }
   };

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -101,7 +101,7 @@ template <typename T, unsigned int VVectorDimension>
 typename CovariantVector<T, VVectorDimension>::ValueType CovariantVector<T, VVectorDimension>::operator*(
   const Self & other) const
 {
-  typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
+  typename NumericTraits<T>::AccumulateType value = T{};
   for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
@@ -113,7 +113,7 @@ template <typename T, unsigned int VVectorDimension>
 typename CovariantVector<T, VVectorDimension>::ValueType CovariantVector<T, VVectorDimension>::operator*(
   const Vector<T, VVectorDimension> & other) const
 {
-  typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
+  typename NumericTraits<T>::AccumulateType value = T{};
   for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
@@ -115,14 +115,14 @@ DiffusionTensor3D<T>::GetRelativeAnisotropy() const -> RealValueType
   // zero.
   if (trace < NumericTraits<RealValueType>::min())
   {
-    return NumericTraits<RealValueType>::ZeroValue();
+    return RealValueType{};
   }
 
   const RealValueType anisotropy = 3.0 * isp - trace * trace;
 
-  if (anisotropy < NumericTraits<RealValueType>::ZeroValue())
+  if (anisotropy < RealValueType{})
   {
-    return NumericTraits<RealValueType>::ZeroValue();
+    return RealValueType{};
   }
 
   const auto relativeAnisotropySquared = static_cast<RealValueType>(anisotropy / (std::sqrt(3.0) * trace));

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -202,7 +202,7 @@ public:
 
     this->m_IsAtEnd = true;
     // Initialize the temporary image
-    m_TemporaryPointer->FillBuffer(NumericTraits<typename TTempImage::PixelType>::ZeroValue());
+    m_TemporaryPointer->FillBuffer(typename TTempImage::PixelType{});
 
     for (unsigned int i = 0; i < m_Seeds.size(); ++i)
     {

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
@@ -28,7 +28,7 @@ ForwardDifferenceOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients(
 {
   CoefficientVector coeff(3);
 
-  coeff[0] = NumericTraits<PixelType>::ZeroValue();
+  coeff[0] = PixelType{};
   coeff[1] = -1.0 * NumericTraits<PixelType>::OneValue();
   coeff[2] = NumericTraits<PixelType>::OneValue();
 

--- a/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
@@ -27,16 +27,14 @@ template <typename TInput, typename TOutput>
 auto
 HeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const -> OutputType
 {
-  return (input >= NumericTraits<InputType>::ZeroValue()) ? NumericTraits<OutputType>::OneValue()
-                                                          : NumericTraits<OutputType>::ZeroValue();
+  return (input >= InputType{}) ? NumericTraits<OutputType>::OneValue() : OutputType{};
 }
 
 template <typename TInput, typename TOutput>
 auto
 HeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const -> OutputType
 {
-  return (Math::ExactlyEquals(input, NumericTraits<InputType>::ZeroValue())) ? NumericTraits<OutputType>::OneValue()
-                                                                             : NumericTraits<OutputType>::ZeroValue();
+  return (Math::ExactlyEquals(input, InputType{})) ? NumericTraits<OutputType>::OneValue() : OutputType{};
 }
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -577,9 +577,7 @@ struct AlmostEqualsScalarVsComplex
   static bool
   AlmostEqualsFunction(TScalarType scalarVariable, TComplexType complexVariable)
   {
-    if (!AlmostEqualsScalarComparer(
-          complexVariable.imag(),
-          itk::NumericTraits<typename itk::NumericTraits<TComplexType>::ValueType>::ZeroValue()))
+    if (!AlmostEqualsScalarComparer(complexVariable.imag(), typename itk::NumericTraits<TComplexType>::ValueType{}))
     {
       return false;
     }

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -276,7 +276,7 @@ public:
   inline vnl_matrix_fixed<T, VColumns, VRows>
   GetInverse() const
   {
-    if (vnl_determinant(m_Matrix) == NumericTraits<T>::ZeroValue())
+    if (vnl_determinant(m_Matrix) == T{})
     {
       itkGenericExceptionMacro("Singular matrix. Determinant is 0.");
     }

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -170,7 +170,7 @@ protected:
   {
     for (unsigned int i = 0; i < this->Size(); ++i)
     {
-      this->operator[](i) = NumericTraits<PixelType>::ZeroValue();
+      this->operator[](i) = PixelType{};
     }
   }
 

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -189,7 +189,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
   /** Return the length of the scalar. This API is needed for
    * VariableLengthVector because
@@ -368,7 +368,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -474,7 +474,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -596,7 +596,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -700,7 +700,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -802,7 +802,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -905,7 +905,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1007,7 +1007,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1129,7 +1129,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1232,7 +1232,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1335,7 +1335,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1439,7 +1439,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1542,7 +1542,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1653,7 +1653,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1757,7 +1757,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1852,7 +1852,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a scalar to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 };
 
@@ -1978,7 +1978,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a complex to " << s);
     }
-    m = NumericTraits<ValueType>::ZeroValue();
+    m = ValueType{};
   }
 
 #if defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -91,7 +91,7 @@ public:
   {
     Self b(a.Size());
 
-    b.Fill(NumericTraits<T>::ZeroValue());
+    b.Fill(T{});
     return b;
   }
 
@@ -121,7 +121,7 @@ public:
   SetLength(Array<T> & m, const unsigned int s)
   {
     m.SetSize(s);
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Get the length of the input array. */

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -157,7 +157,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a CovariantVector of length " << D << " to " << s);
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the length of the vector. */

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -160,7 +160,7 @@ public:
       itkGenericExceptionMacro("Cannot set the size of a DiffusionTensor3D "
                                "to anything other than 6.");
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the size of the tensor. Always returns 6. */

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -153,7 +153,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a FixedArray of length " << D << " to " << s);
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the length of the array. */

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -144,7 +144,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a Point of length " << D << " to " << s);
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the dimensionality of the point. */

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -185,7 +185,7 @@ public:
       itkGenericExceptionMacro("Cannot set the size of a RGBAPixel to anything other "
                                "than 4.");
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the dimensionality of the pixel. Always returns 4. */

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -185,7 +185,7 @@ public:
       itkGenericExceptionMacro("Cannot set the size of a RGBPixel to anything other "
                                "than 3.");
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the dimensionality of the pixel. Always returns 3. */

--- a/Modules/Core/Common/include/itkNumericTraitsStdVector.h
+++ b/Modules/Core/Common/include/itkNumericTraitsStdVector.h
@@ -113,7 +113,7 @@ public:
   static const Self
   ZeroValue(const Self & a)
   {
-    Self b(a.Size(), NumericTraits<T>::ZeroValue());
+    Self b(a.Size(), T{});
     return b;
   }
 

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -160,7 +160,7 @@ public:
                                "of dimension "
                                << D << " ( = size of " << D * (D + 1) / 2 << ") to " << s);
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the size of the underlying FixedArray. */

--- a/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
@@ -115,7 +115,7 @@ public:
   {
     Self b(a.Size());
 
-    b.Fill(NumericTraits<T>::ZeroValue());
+    b.Fill(T{});
     return b;
   }
 
@@ -142,7 +142,7 @@ public:
     bool flag = false;
     for (unsigned int i = 0; i < GetLength(a); ++i)
     {
-      if (a[i] > NumericTraits<ValueType>::ZeroValue())
+      if (a[i] > ValueType{})
       {
         flag = true;
       }
@@ -170,7 +170,7 @@ public:
     bool flag = false;
     for (unsigned int i = 0; i < GetLength(a); ++i)
     {
-      if (a[i] < NumericTraits<ValueType>::ZeroValue())
+      if (a[i] < ValueType{})
       {
         flag = true;
       }
@@ -202,7 +202,7 @@ public:
   SetLength(VariableLengthVector<T> & m, const unsigned int s)
   {
     m.SetSize(s);
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the size of the vector. */

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -135,7 +135,7 @@ public:
     bool flag = false;
     for (unsigned int i = 0; i < GetLength(a); ++i)
     {
-      if (a[i] > NumericTraits<ValueType>::ZeroValue())
+      if (a[i] > ValueType{})
       {
         flag = true;
       }
@@ -199,7 +199,7 @@ public:
     {
       itkGenericExceptionMacro("Cannot set the size of a Vector of length " << D << " to " << s);
     }
-    m.Fill(NumericTraits<T>::ZeroValue());
+    m.Fill(T{});
   }
 
   /** Return the size of the vector. */

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -197,7 +197,7 @@ template <typename T, unsigned int TPointDimension>
 void
 Point<T, TPointDimension>::SetToBarycentricCombination(const Self * P, const double * weights, unsigned int N)
 {
-  this->Fill(NumericTraits<T>::ZeroValue()); // put this point to null
+  this->Fill(T{}); // put this point to null
   double weightSum = 0.0;
   for (unsigned int j = 0; j < N - 1; ++j)
   {
@@ -225,7 +225,7 @@ BarycentricCombination<TPointContainer, TWeightContainer>::Evaluate(const PointC
 {
   using ValueType = typename PointType::ValueType;
   PointType barycentre;
-  barycentre.Fill(NumericTraits<ValueType>::ZeroValue()); // set to null
+  barycentre.Fill(ValueType{}); // set to null
 
   typename TPointContainer::Iterator point = points->Begin();
   typename TPointContainer::Iterator final = points->End();

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -36,7 +36,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::PointSetToImageFilter()
   this->m_Spacing.Fill(1.0);
   this->m_Direction.SetIdentity();
   this->m_InsideValue = NumericTraits<ValueType>::OneValue();
-  this->m_OutsideValue = NumericTraits<ValueType>::ZeroValue();
+  this->m_OutsideValue = ValueType{};
 }
 
 template <typename TInputPointSet, typename TOutputImage>
@@ -143,7 +143,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   bool specified = false;
   for (i = 0; i < OutputImageDimension; ++i)
   {
-    if (m_Size[i] != NumericTraits<SizeValueType>::ZeroValue())
+    if (m_Size[i] != SizeValueType{})
     {
       specified = true;
       break;
@@ -169,8 +169,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   specified = false;
   for (i = 0; i < OutputImageDimension; ++i)
   {
-    if (Math::NotExactlyEquals(m_Spacing[i],
-                               NumericTraits<typename NumericTraits<SpacingType>::ValueType>::ZeroValue()))
+    if (Math::NotExactlyEquals(m_Spacing[i], typename NumericTraits<SpacingType>::ValueType{}))
     {
       specified = true;
       break;
@@ -185,7 +184,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   specified = false;
   for (i = 0; i < OutputImageDimension; ++i)
   {
-    if (Math::NotExactlyEquals(m_Origin[i], NumericTraits<typename NumericTraits<PointType>::ValueType>::ZeroValue()))
+    if (Math::NotExactlyEquals(m_Origin[i], typename NumericTraits<PointType>::ValueType{}))
     {
       specified = true;
       break;

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -498,7 +498,7 @@ QuadrilateralCell<TCellInterface>::EvaluateLocation(int &                     it
 
   for (unsigned int ii = 0; ii < PointDimension; ++ii)
   {
-    x[ii] = NumericTraits<CoordRepType>::ZeroValue();
+    x[ii] = CoordRepType{};
   }
 
   for (unsigned int ii = 0; ii < NumberOfPoints; ++ii)

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -91,15 +91,15 @@ template <typename ValueType, typename MeanType>
 void
 ResourceProbe<ValueType, MeanType>::Reset()
 {
-  this->m_TotalValue = NumericTraits<ValueType>::ZeroValue();
-  this->m_StartValue = NumericTraits<ValueType>::ZeroValue();
+  this->m_TotalValue = ValueType{};
+  this->m_StartValue = ValueType{};
   this->m_MinimumValue = NumericTraits<ValueType>::max();
   this->m_MaximumValue = NumericTraits<ValueType>::NonpositiveMin();
-  this->m_StandardDeviation = NumericTraits<ValueType>::ZeroValue();
+  this->m_StandardDeviation = ValueType{};
 
-  this->m_NumberOfStarts = NumericTraits<CountType>::ZeroValue();
-  this->m_NumberOfStops = NumericTraits<CountType>::ZeroValue();
-  this->m_NumberOfIteration = NumericTraits<CountType>::ZeroValue();
+  this->m_NumberOfStarts = CountType{};
+  this->m_NumberOfStops = CountType{};
+  this->m_NumberOfIteration = CountType{};
 
   this->m_ProbeValueList.clear();
 }
@@ -223,13 +223,12 @@ ResourceProbe<ValueType, MeanType>::GetStandardDeviation()
                  diff.begin(),
                  // Subtract mean from every value;
                  [realMean](const ValueType v) { return (static_cast<InternalComputeType>(v) - realMean); });
-  const InternalComputeType sqsum =
-    std::inner_product(diff.begin(), diff.end(), diff.begin(), NumericTraits<InternalComputeType>::ZeroValue());
+  const InternalComputeType sqsum = std::inner_product(diff.begin(), diff.end(), diff.begin(), InternalComputeType{});
 
   const InternalComputeType sz = static_cast<InternalComputeType>(this->m_ProbeValueList.size()) - 1.0;
   if (sz <= 0.0)
   {
-    this->m_StandardDeviation = NumericTraits<ValueType>::ZeroValue();
+    this->m_StandardDeviation = ValueType{};
   }
   else
   {
@@ -351,7 +350,7 @@ ResourceProbe<ValueType, MeanType>::ExpandedReport(std::ostream & os,
   ValueType ratioOfMeanToMinimum;
   if (Math::ExactlyEquals(this->GetMinimum(), 0.0))
   {
-    ratioOfMeanToMinimum = NumericTraits<ValueType>::ZeroValue();
+    ratioOfMeanToMinimum = ValueType{};
   }
   else
   {
@@ -361,7 +360,7 @@ ResourceProbe<ValueType, MeanType>::ExpandedReport(std::ostream & os,
   ValueType ratioOfMaximumToMean;
   if (Math::ExactlyEquals(this->GetMean(), 0.0))
   {
-    ratioOfMaximumToMean = NumericTraits<ValueType>::ZeroValue();
+    ratioOfMaximumToMean = ValueType{};
   }
   else
   {
@@ -433,7 +432,7 @@ ResourceProbe<ValueType, MeanType>::JSONReport(std::ostream & os)
   ValueType ratioOfMeanToMinimum;
   if (Math::ExactlyEquals(this->GetMinimum(), 0.0))
   {
-    ratioOfMeanToMinimum = NumericTraits<ValueType>::ZeroValue();
+    ratioOfMeanToMinimum = ValueType{};
   }
   else
   {
@@ -443,7 +442,7 @@ ResourceProbe<ValueType, MeanType>::JSONReport(std::ostream & os)
   ValueType ratioOfMaximumToMean;
   if (Math::ExactlyEquals(this->GetMean(), 0.0))
   {
-    ratioOfMaximumToMean = NumericTraits<ValueType>::ZeroValue();
+    ratioOfMaximumToMean = ValueType{};
   }
   else
   {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -194,7 +194,7 @@ public:
 
     this->m_IsAtEnd = true;
     // Initialize the temporary image
-    m_TempPtr->FillBuffer(NumericTraits<typename TTempImage::PixelType>::ZeroValue());
+    m_TempPtr->FillBuffer(typename TTempImage::PixelType{});
 
     for (unsigned int i = 0; i < m_Seeds.size(); ++i)
     {

--- a/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
@@ -34,7 +34,7 @@ SinRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType &
   {
     if (static_cast<RealType>(input) <= -this->GetEpsilon())
     {
-      return NumericTraits<OutputType>::ZeroValue();
+      return OutputType{};
     }
     else
     {
@@ -52,7 +52,7 @@ SinRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const I
 {
   if (itk::Math::abs(static_cast<RealType>(input)) >= this->GetEpsilon())
   {
-    return NumericTraits<OutputType>::ZeroValue();
+    return OutputType{};
   }
   else
   {

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -224,7 +224,7 @@ template <typename T, unsigned int VDimension>
 void
 SymmetricSecondRankTensor<T, VDimension>::SetIdentity()
 {
-  this->Fill(NumericTraits<T>::ZeroValue());
+  this->Fill(T{});
   for (unsigned int i = 0; i < Dimension; ++i)
   {
     (*this)(i, i) = NumericTraits<T>::OneValue();

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -78,14 +78,14 @@ TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, co
 
   CoordRepType v21_l2 = v21.GetSquaredNorm();
 
-  if (Math::NotAlmostEquals(v21_l2, NumericTraits<CoordRepType>::ZeroValue()))
+  if (Math::NotAlmostEquals(v21_l2, CoordRepType{}))
   {
     v21 /= std::sqrt(v21_l2);
   }
 
   VectorType   v23 = iC - iB;
   CoordRepType v23_l2 = v23.GetSquaredNorm();
-  if (Math::NotAlmostEquals(v23_l2, NumericTraits<CoordRepType>::ZeroValue()))
+  if (Math::NotAlmostEquals(v23_l2, CoordRepType{}))
   {
     v23 /= std::sqrt(v23_l2);
   }
@@ -110,7 +110,7 @@ TriangleHelper<TPoint>::ComputeBarycenter(const CoordRepType & iA1,
 
   CoordRepType total = iA1 + iA2 + iA3;
 
-  if (Math::AlmostEquals(total, NumericTraits<CoordRepType>::ZeroValue()))
+  if (Math::AlmostEquals(total, CoordRepType{}))
   {
     // in such case there is no barycenter;
     oPt.Fill(0.);
@@ -243,7 +243,7 @@ TriangleHelper<TPoint>::ComputeMixedArea(const PointType & iP1, const PointType 
   {
     auto area = static_cast<CoordRepType>(TriangleType::ComputeArea(iP1, iP2, iP3));
 
-    if ((iP2 - iP1) * (iP3 - iP1) < NumericTraits<CoordRepType>::ZeroValue())
+    if ((iP2 - iP1) * (iP3 - iP1) < CoordRepType{})
     {
       return 0.5 * area;
     }

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -103,7 +103,7 @@ template <typename T, unsigned int TVectorDimension>
 auto
 Vector<T, TVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
-  typename NumericTraits<RealValueType>::AccumulateType sum = NumericTraits<T>::ZeroValue();
+  typename NumericTraits<RealValueType>::AccumulateType sum = T{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
@@ -200,7 +200,7 @@ operator>>(std::istream & is, Vector<T, TVectorDimension> & vct)
 template <typename T, unsigned int TVectorDimension>
 typename Vector<T, TVectorDimension>::ValueType Vector<T, TVectorDimension>::operator*(const Self & other) const
 {
-  typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
+  typename NumericTraits<T>::AccumulateType value = T{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -48,9 +48,9 @@ template <typename T>
 void
 Versor<T>::SetIdentity()
 {
-  m_X = NumericTraits<T>::ZeroValue();
-  m_Y = NumericTraits<T>::ZeroValue();
-  m_Z = NumericTraits<T>::ZeroValue();
+  m_X = T{};
+  m_Y = T{};
+  m_Z = T{};
   m_W = NumericTraits<T>::OneValue();
 }
 
@@ -209,11 +209,11 @@ Versor<T>::GetAxis() const -> VectorType
 
   const RealType vectorNorm = std::sqrt(ax * ax + ay * ay + az * az);
 
-  if (vectorNorm == NumericTraits<RealType>::ZeroValue())
+  if (vectorNorm == RealType{})
   {
-    axis[0] = NumericTraits<T>::ZeroValue();
-    axis[1] = NumericTraits<T>::ZeroValue();
-    axis[2] = NumericTraits<T>::ZeroValue();
+    axis[0] = T{};
+    axis[1] = T{};
+    axis[2] = T{};
   }
   else
   {
@@ -468,8 +468,8 @@ Versor<T>::SetRotationAroundX(ValueType angle)
   const ValueType cosangle2 = std::cos(angle / 2.0);
 
   m_X = sinangle2;
-  m_Y = NumericTraits<T>::ZeroValue();
-  m_Z = NumericTraits<T>::ZeroValue();
+  m_Y = T{};
+  m_Z = T{};
   m_W = cosangle2;
 }
 
@@ -480,9 +480,9 @@ Versor<T>::SetRotationAroundY(ValueType angle)
   const ValueType sinangle2 = std::sin(angle / 2.0);
   const ValueType cosangle2 = std::cos(angle / 2.0);
 
-  m_X = NumericTraits<T>::ZeroValue();
+  m_X = T{};
   m_Y = sinangle2;
-  m_Z = NumericTraits<T>::ZeroValue();
+  m_Z = T{};
   m_W = cosangle2;
 }
 
@@ -493,8 +493,8 @@ Versor<T>::SetRotationAroundZ(ValueType angle)
   const ValueType sinangle2 = std::sin(angle / 2.0);
   const ValueType cosangle2 = std::cos(angle / 2.0);
 
-  m_X = NumericTraits<T>::ZeroValue();
-  m_Y = NumericTraits<T>::ZeroValue();
+  m_X = T{};
+  m_Y = T{};
   m_Z = sinangle2;
   m_W = cosangle2;
 }

--- a/Modules/Core/Common/src/itkRealTimeInterval.cxx
+++ b/Modules/Core/Common/src/itkRealTimeInterval.cxx
@@ -42,8 +42,8 @@ namespace itk
  */
 RealTimeInterval::RealTimeInterval()
 {
-  this->m_Seconds = itk::NumericTraits<SecondsDifferenceType>::ZeroValue();
-  this->m_MicroSeconds = itk::NumericTraits<MicroSecondsDifferenceType>::ZeroValue();
+  this->m_Seconds = SecondsDifferenceType{};
+  this->m_MicroSeconds = MicroSecondsDifferenceType{};
 }
 
 /**

--- a/Modules/Core/Common/src/itkRealTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkRealTimeStamp.cxx
@@ -68,8 +68,8 @@ namespace itk
  */
 RealTimeStamp::RealTimeStamp()
 {
-  this->m_Seconds = itk::NumericTraits<SecondsCounterType>::ZeroValue();
-  this->m_MicroSeconds = itk::NumericTraits<MicroSecondsCounterType>::ZeroValue();
+  this->m_Seconds = SecondsCounterType{};
+  this->m_MicroSeconds = MicroSecondsCounterType{};
 }
 
 /**

--- a/Modules/Core/Common/test/itkBoundingBoxTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxTest.cxx
@@ -38,7 +38,7 @@ itkBoundingBoxTest(int, char *[])
     const BB::BoundsArrayType & bounds = myBox->GetBounds();
     for (unsigned int i = 0; i < bounds.Size(); ++i)
     {
-      if (itk::Math::NotExactlyEquals(bounds[i], itk::NumericTraits<BB::CoordRepType>::ZeroValue()))
+      if (itk::Math::NotExactlyEquals(bounds[i], BB::CoordRepType{}))
       {
         std::cerr << "Bounding Box initialization test failed" << std::endl;
         std::cerr << bounds << std::endl;
@@ -52,7 +52,7 @@ itkBoundingBoxTest(int, char *[])
     BB::PointType center = myBox->GetCenter();
     for (unsigned int i = 0; i < 1; ++i)
     {
-      if (itk::Math::NotExactlyEquals(center[i], itk::NumericTraits<BB::CoordRepType>::ZeroValue()))
+      if (itk::Math::NotExactlyEquals(center[i], BB::CoordRepType{}))
       {
         std::cerr << "Empty Box GetCenter initialization test failed" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
@@ -105,7 +105,7 @@ itkCompensatedSummationTest(int, char *[])
   }
 
   floatAccumulator.ResetToZero();
-  if (itk::Math::NotAlmostEquals(floatAccumulator.GetSum(), itk::NumericTraits<FloatType>::ZeroValue()))
+  if (itk::Math::NotAlmostEquals(floatAccumulator.GetSum(), FloatType{}))
   {
     std::cerr << "GetSize() did return the correct value!" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -53,7 +53,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
 
   ImageType::PixelType value;
 
-  value = itk::NumericTraits<ImageType::PixelType>::ZeroValue();
+  value = ImageType::PixelType{};
 
   // Store information on the Image
   std::cout << "Storing data on the image ... " << std::endl;
@@ -70,7 +70,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   IteratorType ot(myImage, region);
   std::cout << "Verifying the data forwards... ";
 
-  value = itk::NumericTraits<ImageType::PixelType>::ZeroValue();
+  value = ImageType::PixelType{};
 
   while (!ot.IsAtEnd())
   {
@@ -120,7 +120,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   ConstIteratorType cot(myImage, region);
   std::cout << "Const Iterator: Verifying the data forwards... ";
 
-  value = itk::NumericTraits<ImageType::PixelType>::ZeroValue();
+  value = ImageType::PixelType{};
 
   while (!cot.IsAtEnd())
   {

--- a/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
+++ b/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
@@ -84,7 +84,7 @@ DoCastWithRangeCheckTest(const T1 * = nullptr, const T2 * = nullptr)
   bool pass = true;
   pass &= DoCastWithRangeCheckTestVerify<T1, T2>(itk::NumericTraits<T2>::NonpositiveMin());
   pass &= DoCastWithRangeCheckTestVerify<T1, T2>(itk::NumericTraits<T2>::max());
-  pass &= DoCastWithRangeCheckTestVerify<T1, T2>(itk::NumericTraits<T2>::ZeroValue());
+  pass &= DoCastWithRangeCheckTestVerify<T1, T2>(T2{});
   pass &= DoCastWithRangeCheckTestVerify<T1, T2>(itk::NumericTraits<T2>::OneValue());
   pass &= DoCastWithRangeCheckTestVerify<T1, T2>(static_cast<T2>(itk::NumericTraits<T2>::OneValue() * minus_one));
 

--- a/Modules/Core/Common/test/itkTimeProbeTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbeTest.cxx
@@ -65,18 +65,17 @@ itkTimeProbeTest(int, char *[])
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (localTimer.GetNumberOfStops() != itk::NumericTraits<itk::TimeProbe::CountType>::ZeroValue())
+  if (localTimer.GetNumberOfStops() != itk::TimeProbe::CountType{})
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (itk::Math::NotExactlyEquals(localTimer.GetTotal(),
-                                  itk::NumericTraits<itk::TimeProbe::TimeStampType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(localTimer.GetTotal(), itk::TimeProbe::TimeStampType{}))
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (itk::Math::NotExactlyEquals(localTimer.GetMean(), itk::NumericTraits<itk::TimeProbe::TimeStampType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(localTimer.GetMean(), itk::TimeProbe::TimeStampType{}))
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkTimeProbeTest2.cxx
+++ b/Modules/Core/Common/test/itkTimeProbeTest2.cxx
@@ -109,18 +109,17 @@ itkTimeProbeTest2(int, char *[])
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (localTimer.GetNumberOfStops() != itk::NumericTraits<itk::TimeProbe::CountType>::ZeroValue())
+  if (localTimer.GetNumberOfStops() != itk::TimeProbe::CountType{})
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (itk::Math::NotExactlyEquals(localTimer.GetTotal(),
-                                  itk::NumericTraits<itk::TimeProbe::TimeStampType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(localTimer.GetTotal(), itk::TimeProbe::TimeStampType{}))
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;
   }
-  if (itk::Math::NotExactlyEquals(localTimer.GetMean(), itk::NumericTraits<itk::TimeProbe::TimeStampType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(localTimer.GetMean(), itk::TimeProbe::TimeStampType{}))
   {
     std::cerr << "Reset() failure" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -125,7 +125,7 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CalculateChange() -
   DenseFDThreadStruct str;
 
   str.Filter = this;
-  str.TimeStep = NumericTraits<TimeStepType>::ZeroValue(); // Not used during the
+  str.TimeStep = TimeStepType{}; // Not used during the
   // calculate change step.
   this->GetMultiThreader()->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   this->GetMultiThreader()->SetSingleMethod(this->CalculateChangeThreaderCallback, &str);
@@ -136,7 +136,7 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CalculateChange() -
   ThreadIdType workUnitCount = this->GetMultiThreader()->GetNumberOfWorkUnits();
 
   str.TimeStepList.clear();
-  str.TimeStepList.resize(workUnitCount, NumericTraits<TimeStepType>::ZeroValue());
+  str.TimeStepList.resize(workUnitCount, TimeStepType{});
 
   str.ValidTimeStepList.clear();
   str.ValidTimeStepList.resize(workUnitCount, false);

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -153,7 +153,7 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Calc
   // Set up for multithreaded processing.
   FDThreadStruct str;
   str.Filter = this;
-  str.TimeStep = NumericTraits<TimeStepType>::ZeroValue();
+  str.TimeStep = TimeStepType{};
   // Not used during the calculate change step for normals.
 
   this->GetMultiThreader()->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());

--- a/Modules/Core/ImageAdaptors/include/itkAbsImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAbsImageAdaptor.h
@@ -51,13 +51,13 @@ public:
   static inline void
   Set(TInternalType & output, const TExternalType & input)
   {
-    output = (TInternalType)((input > NumericTraits<TExternalType>::ZeroValue()) ? input : -input);
+    output = (TInternalType)((input > TExternalType{}) ? input : -input);
   }
 
   static inline TExternalType
   Get(const TInternalType & input)
   {
-    return (TExternalType)((input > NumericTraits<TInternalType>::ZeroValue()) ? input : -input);
+    return (TExternalType)((input > TInternalType{}) ? input : -input);
   }
 };
 } // end namespace Accessor

--- a/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
@@ -94,7 +94,7 @@ public:
 
   /** Constructors */
   AddPixelAccessor()
-    : m_Value(NumericTraits<TPixel>::ZeroValue())
+    : m_Value(TPixel{})
   {}
   AddPixelAccessor(const Self & apa)
     : m_Value(apa.m_Value)

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -474,7 +474,7 @@ itkVectorImageTest(int, char * argv[])
       VectorImageType::IndexType           start;
       itk::VariableLengthVector<PixelType> f(VectorLength);
       itk::VariableLengthVector<PixelType> ZeroPixel(VectorLength);
-      ZeroPixel.Fill(itk::NumericTraits<PixelType>::ZeroValue());
+      ZeroPixel.Fill(PixelType{});
       for (unsigned int i = 0; i < VectorLength; ++i)
       {
         f[i] = i;

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -46,7 +46,7 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::BSplineDecomposition
     m_Scratch[i] = 0;
   }
 
-  m_DataLength.Fill(itk::NumericTraits<typename TInputImage::SizeType::SizeValueType>::ZeroValue());
+  m_DataLength.Fill(typename TInputImage::SizeType::SizeValueType{});
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -132,7 +132,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
     // is in-bounds, so we don't do anything else if the point is out of bounds.
     if (index[dim] < start[dim] + 1 || index[dim] > (start[dim] + static_cast<OffsetValueType>(size[dim]) - 2))
     {
-      derivative[dim] = NumericTraits<OutputValueType>::ZeroValue();
+      derivative[dim] = OutputValueType{};
       continue;
     }
 
@@ -200,7 +200,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
       // bounds checking
       if (dimOutOfBounds[dim])
       {
-        componentDerivative[dim] = NumericTraits<OutputValueType>::ZeroValue();
+        componentDerivative[dim] = OutputValueType{};
         continue;
       }
 
@@ -283,7 +283,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
     neighPoint1[dim] = point[dim] - offset;
     if (!this->IsInsideBuffer(neighPoint1))
     {
-      orientedDerivative[dim] = NumericTraits<DerivativeValueType>::ZeroValue();
+      orientedDerivative[dim] = DerivativeValueType{};
       neighPoint1[dim] = point[dim];
       neighPoint2[dim] = point[dim];
       continue;
@@ -291,7 +291,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
     neighPoint2[dim] = point[dim] + offset;
     if (!this->IsInsideBuffer(neighPoint2))
     {
-      orientedDerivative[dim] = NumericTraits<DerivativeValueType>::ZeroValue();
+      orientedDerivative[dim] = DerivativeValueType{};
       neighPoint1[dim] = point[dim];
       neighPoint2[dim] = point[dim];
       continue;
@@ -347,14 +347,14 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
 
   ScalarDerivativeType componentDerivativeOut;
   ScalarDerivativeType componentDerivative;
-  componentDerivative.Fill(NumericTraits<OutputValueType>::ZeroValue());
+  componentDerivative.Fill(OutputValueType{});
 
   for (unsigned int dim = 0; dim < Self::ImageDimension; ++dim)
   {
     // initialize to quiet compiler warnings
     neighPixels[dim][0] = zeroPixel;
     neighPixels[dim][1] = zeroPixel;
-    delta[dim] = NumericTraits<PointValueType>::ZeroValue();
+    delta[dim] = PointValueType{};
     dimOutOfBounds[dim] = true;
   }
 
@@ -376,7 +376,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
 
         if (dimOutOfBounds[dim])
         {
-          componentDerivative[dim] = NumericTraits<OutputValueType>::ZeroValue();
+          componentDerivative[dim] = OutputValueType{};
           neighPoint1[dim] = point[dim];
           neighPoint2[dim] = point[dim];
           continue;
@@ -406,7 +406,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
       }
       else
       {
-        componentDerivative[dim] = NumericTraits<OutputValueType>::ZeroValue();
+        componentDerivative[dim] = OutputValueType{};
       }
     }
 
@@ -474,7 +474,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
     if (cindex[dim] < static_cast<ContinuousIndexValueType>(start[dim] + 1) ||
         cindex[dim] > static_cast<ContinuousIndexValueType>(start[dim] + static_cast<OffsetValueType>(size[dim]) - 2))
     {
-      derivative[dim] = NumericTraits<DerivativeValueType>::ZeroValue();
+      derivative[dim] = DerivativeValueType{};
       continue;
     }
 
@@ -545,7 +545,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
     {
       if (dimOutOfBounds[dim])
       {
-        componentDerivative[dim] = NumericTraits<DerivativeValueType>::ZeroValue();
+        componentDerivative[dim] = DerivativeValueType{};
         continue;
       }
 

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -54,11 +54,11 @@ CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   }
 
 
-  covariance.fill(NumericTraits<PixelComponentRealType>::ZeroValue());
+  covariance.fill(PixelComponentRealType{});
 
   using MeanVectorType = vnl_vector<PixelComponentRealType>;
   MeanVectorType mean(VectorDimension);
-  mean.fill(NumericTraits<PixelComponentRealType>::ZeroValue());
+  mean.fill(PixelComponentRealType{});
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition
   typename InputImageType::SizeType kernelSize;

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -517,7 +517,7 @@ private:
     const typename TInputImage::PixelType &   tempPixel = inputImagePtr->GetPixel(idx);
     const unsigned int                        sizeOfVarLengthVector = tempPixel.GetSize();
     tempZeros.SetSize(sizeOfVarLengthVector);
-    tempZeros.Fill(NumericTraits<RealTypeScalarRealType>::ZeroValue());
+    tempZeros.Fill(RealTypeScalarRealType{});
   }
 
   template <typename RealTypeScalarRealType>
@@ -525,7 +525,7 @@ private:
   MakeZeroInitializer(const TInputImage * const itkNotUsed(inputImagePtr), RealTypeScalarRealType & tempZeros) const
   {
     // All other cases
-    tempZeros = NumericTraits<RealTypeScalarRealType>::ZeroValue();
+    tempZeros = RealTypeScalarRealType{};
   }
 };
 } // end namespace itk

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -36,7 +36,7 @@ MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & ind
 {
   RealType sum;
 
-  sum = NumericTraits<RealType>::ZeroValue();
+  sum = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -51,7 +51,7 @@ ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexT
   const unsigned int VectorDimension = PixelType::Dimension;
 
   covariance = vnl_matrix<PixelComponentRealType>(VectorDimension, VectorDimension);
-  covariance.fill(NumericTraits<PixelComponentRealType>::ZeroValue());
+  covariance.fill(PixelComponentRealType{});
 
   if (!this->GetInputImage())
   {

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -37,7 +37,7 @@ SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexTy
 {
   RealType sumOfSquares;
 
-  sumOfSquares = NumericTraits<RealType>::ZeroValue();
+  sumOfSquares = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -46,8 +46,8 @@ VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType &
   RealType sumOfSquares;
   RealType var;
 
-  sum = NumericTraits<RealType>::ZeroValue();
-  sumOfSquares = NumericTraits<RealType>::ZeroValue();
+  sum = RealType{};
+  sumOfSquares = RealType{};
 
   if (!this->GetInputImage())
   {

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -173,7 +173,7 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   }
   for (itk::SizeValueType n = 0; n < VectorLength; ++n)
   {
-    if (itk::Math::NotAlmostEquals(indexOutput(n, 0), itk::NumericTraits<OutputValueType>::ZeroValue()))
+    if (itk::Math::NotAlmostEquals(indexOutput(n, 0), OutputValueType{}))
     {
       std::cout << "ERROR: Index: " << index << " expected output dim 0 to be 0. << std::endl; " << std::endl;
       result = EXIT_FAILURE;
@@ -220,7 +220,7 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   }
   for (itk::SizeValueType n = 0; n < VectorLength; ++n)
   {
-    if (itk::Math::NotAlmostEquals(indexOutput(n, 1), itk::NumericTraits<OutputValueType>::ZeroValue()))
+    if (itk::Math::NotAlmostEquals(indexOutput(n, 1), OutputValueType{}))
     {
       std::cout << "ERROR: Index: " << index << " expected output dim 1 to be 0. " << std::endl;
       result = EXIT_FAILURE;

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -114,7 +114,7 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
   {
     std::cout << "Index: " << index << " is inside the BufferedRegion." << std::endl;
   }
-  if (itk::Math::NotExactlyEquals(indexOutput[0], itk::NumericTraits<OutputValueType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(indexOutput[0], OutputValueType{}))
   {
     std::cout << "ERROR: Index: " << index << " - expected result dim 0 to have value 0. " << std::endl;
     result = EXIT_FAILURE;
@@ -157,7 +157,7 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
   {
     std::cout << "Index: " << index << " is inside the BufferedRegion." << std::endl;
   }
-  if (itk::Math::NotExactlyEquals(indexOutput[1], itk::NumericTraits<OutputValueType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(indexOutput[1], OutputValueType{}))
   {
     std::cout << "ERROR: Index: " << index << " - expected result dim 1 to have value 0. " << std::endl;
     result = EXIT_FAILURE;

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -41,8 +41,8 @@ namespace itk
 template <typename TInputMesh, typename TOutputMesh>
 ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::ConnectedRegionsMeshFilter()
   : m_ExtractionMode(Self::LargestRegion)
-  , m_NumberOfCellsInRegion(NumericTraits<SizeValueType>::ZeroValue())
-  , m_RegionNumber(NumericTraits<IdentifierType>::ZeroValue())
+  , m_NumberOfCellsInRegion(SizeValueType{})
+  , m_RegionNumber(IdentifierType{})
 
 {
   m_ClosestPoint.Fill(0);

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -40,7 +40,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::TriangleMeshToBinaryI
   }
 
   m_InsideValue = NumericTraits<ValueType>::OneValue();
-  m_OutsideValue = NumericTraits<ValueType>::ZeroValue();
+  m_OutsideValue = ValueType{};
   m_Direction.GetVnlMatrix().set_identity();
 
   m_Tolerance = 1e-5;

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -121,7 +121,7 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
   itkDebugMacro("pointLine " << pointLine);
 
   // we must use long here because this is the exact type specified by scanf
-  long numberOfPoints = NumericTraits<PointIdentifier>::ZeroValue();
+  long numberOfPoints = PointIdentifier{};
 
   if (sscanf(pointLine.c_str(), "%ld", &numberOfPoints) != 1)
   {
@@ -187,8 +187,8 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
   //
 
   // we must use long here because this is the exact type specified by scanf
-  long numberOfPolygons = NumericTraits<CellIdentifier>::ZeroValue();
-  long numberOfIndices = NumericTraits<CellIdentifier>::ZeroValue();
+  long numberOfPolygons = CellIdentifier{};
+  long numberOfIndices = CellIdentifier{};
 
   if (sscanf(polygonLine.c_str(), "%ld %ld", &numberOfPolygons, &numberOfIndices) != 2)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -320,14 +320,14 @@ public:
     (void)cellId;
     (void)featureId;
     (void)cellSet;
-    return NumericTraits<CellIdentifier>::ZeroValue();
+    return CellIdentifier{};
   }
 
   /** NOTE ALEX: this method do not use CellFeature and thus could be recoded */
   CellIdentifier
   GetCellNeighbors(CellIdentifier itkNotUsed(cellId), std::set<CellIdentifier> * itkNotUsed(cellSet))
   {
-    return NumericTraits<CellIdentifier>::ZeroValue();
+    return CellIdentifier{};
   }
 
   /** overloaded method for backward compatibility */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
@@ -24,11 +24,11 @@ namespace itk
 template <typename TMesh>
 QuadEdgeMeshTopologyChecker<TMesh>::QuadEdgeMeshTopologyChecker()
 {
-  m_ExpectedNumberOfPoints = NumericTraits<PointIdentifier>::ZeroValue();
-  m_ExpectedNumberOfEdges = NumericTraits<CellIdentifier>::ZeroValue();
-  m_ExpectedNumberOfFaces = NumericTraits<CellIdentifier>::ZeroValue();
-  m_ExpectedNumberOfBoundaries = NumericTraits<CellIdentifier>::ZeroValue();
-  m_ExpectedGenus = NumericTraits<OffsetValueType>::ZeroValue();
+  m_ExpectedNumberOfPoints = PointIdentifier{};
+  m_ExpectedNumberOfEdges = CellIdentifier{};
+  m_ExpectedNumberOfFaces = CellIdentifier{};
+  m_ExpectedNumberOfBoundaries = CellIdentifier{};
+  m_ExpectedGenus = OffsetValueType{};
   m_Mesh = nullptr;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -39,8 +39,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::IsInsideInObjectSpace(const PointTyp
 
   const IndexType index = image->TransformPhysicalPointToIndex(point);
 
-  return Superclass::GetBufferedRegion().IsInside(index) &&
-         Math::NotExactlyEquals(image->GetPixel(index), NumericTraits<PixelType>::ZeroValue());
+  return Superclass::GetBufferedRegion().IsInside(index) && Math::NotExactlyEquals(image->GetPixel(index), PixelType{});
 }
 
 
@@ -143,7 +142,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
   const auto HasForegroundPixels = [&image](const RegionType & region) {
     for (const PixelType pixelValue : ImageRegionRange{ image, region })
     {
-      constexpr auto zeroValue = NumericTraits<PixelType>::ZeroValue();
+      constexpr auto zeroValue = PixelType{};
 
       if (pixelValue != zeroValue)
       {

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -55,7 +55,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::AllocateImage(con
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     size[i] = image->DimSize()[i];
-    if (Math::ExactlyEquals(image->ElementSpacing()[i], NumericTraits<typename SpacingType::ValueType>::ZeroValue()))
+    if (Math::ExactlyEquals(image->ElementSpacing()[i], typename SpacingType::ValueType{}))
     {
       spacing[i] = 1;
     }

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -155,7 +155,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingB
   if (it == end)
   {
     typename BoundingBoxType::PointType pnt;
-    pnt.Fill(NumericTraits<typename BoundingBoxType::PointType::ValueType>::ZeroValue());
+    pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
     return;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -39,7 +39,7 @@ void
 SpatialObject<TDimension>::Clear()
 {
   typename BoundingBoxType::PointType pnt;
-  pnt.Fill(NumericTraits<typename BoundingBoxType::PointType::ValueType>::ZeroValue());
+  pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
   m_FamilyBoundingBoxInObjectSpace->SetMinimum(pnt);
   m_FamilyBoundingBoxInObjectSpace->SetMaximum(pnt);
   m_FamilyBoundingBoxInWorldSpace->SetMinimum(pnt);
@@ -602,7 +602,7 @@ void
 SpatialObject<TDimension>::ComputeMyBoundingBox()
 {
   typename BoundingBoxType::PointType pnt;
-  pnt.Fill(NumericTraits<typename BoundingBoxType::PointType::ValueType>::ZeroValue());
+  pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
   if (m_MyBoundingBoxInObjectSpace->GetMinimum() != pnt || m_MyBoundingBoxInObjectSpace->GetMaximum() != pnt)
   {
     m_MyBoundingBoxInObjectSpace->SetMinimum(pnt);
@@ -639,7 +639,7 @@ SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const st
   itkDebugMacro("Computing Bounding Box");
 
   typename BoundingBoxType::PointType zeroPnt;
-  zeroPnt.Fill(NumericTraits<typename BoundingBoxType::PointType::ValueType>::ZeroValue());
+  zeroPnt.Fill(typename BoundingBoxType::PointType::ValueType{});
   m_FamilyBoundingBoxInObjectSpace->SetMinimum(zeroPnt);
   m_FamilyBoundingBoxInObjectSpace->SetMaximum(zeroPnt);
   bool bbDefined = false;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -336,8 +336,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
     double val = 0;
 
     bool evaluable = InputObject->ValueAtInWorldSpace(objectPoint, val, m_ChildrenDepth);
-    if (Math::NotExactlyEquals(m_InsideValue, NumericTraits<ValueType>::ZeroValue()) ||
-        Math::NotExactlyEquals(m_OutsideValue, NumericTraits<ValueType>::ZeroValue()))
+    if (Math::NotExactlyEquals(m_InsideValue, ValueType{}) || Math::NotExactlyEquals(m_OutsideValue, ValueType{}))
     {
       if (evaluable)
       {

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -128,7 +128,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
   if (it == end)
   {
     typename BoundingBoxType::PointType pnt;
-    pnt.Fill(NumericTraits<typename BoundingBoxType::PointType::ValueType>::ZeroValue());
+    pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
     return;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -201,7 +201,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
       const bool isInside = maskSO->IsInsideInWorldSpace(point);
       double     value{};
       maskSO->ValueAtInWorldSpace(point, value);
-      const bool isZero = (itk::Math::ExactlyEquals(value, itk::NumericTraits<PixelType>::ZeroValue()));
+      const bool isZero = (itk::Math::ExactlyEquals(value, PixelType{}));
       if ((isInside && isZero) || (!isInside && !isZero))
       {
         ImageType::IndexType pointIndex = image->TransformPhysicalPointToIndex(point);

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -269,12 +269,9 @@ itkMetaArrowConverterTest(int argc, char * argv[])
   mDirectionNorm[0] = mDirection[0];
   mDirectionNorm[1] = mDirection[1];
   mDirectionNorm[2] = mDirection[2];
-  if (itk::Math::NotExactlyEquals(mDirection[0],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()) ||
-      itk::Math::NotExactlyEquals(mDirection[1],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()) ||
-      itk::Math::NotExactlyEquals(mDirection[2],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(mDirection[0], SpatialObjectType::VectorType::ValueType{}) ||
+      itk::Math::NotExactlyEquals(mDirection[1], SpatialObjectType::VectorType::ValueType{}) ||
+      itk::Math::NotExactlyEquals(mDirection[2], SpatialObjectType::VectorType::ValueType{}))
   {
     mDirectionNorm.Normalize();
   }
@@ -344,12 +341,9 @@ itkMetaArrowConverterTest(int argc, char * argv[])
 
   // check direction (note: need to normalize before comparing)
   SpatialObjectType::VectorType reLoadDirectionNorm = reLoad->GetDirectionInWorldSpace();
-  if (itk::Math::NotExactlyEquals(reLoadDirectionNorm[0],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()) ||
-      itk::Math::NotExactlyEquals(reLoadDirectionNorm[1],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()) ||
-      itk::Math::NotExactlyEquals(reLoadDirectionNorm[2],
-                                  itk::NumericTraits<SpatialObjectType::VectorType::ValueType>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(reLoadDirectionNorm[0], SpatialObjectType::VectorType::ValueType{}) ||
+      itk::Math::NotExactlyEquals(reLoadDirectionNorm[1], SpatialObjectType::VectorType::ValueType{}) ||
+      itk::Math::NotExactlyEquals(reLoadDirectionNorm[2], SpatialObjectType::VectorType::ValueType{}))
   {
     reLoadDirectionNorm.Normalize();
   }

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -82,8 +82,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   std::cout << "Sample covariance = " << calculator->GetCovarianceMatrix();
 
   if (calculator->GetMean() != itk::MakeFilled<CalculatorType::VectorType>(255) ||
-      itk::Math::NotAlmostEquals(calculator->GetCovarianceMatrix()[0][0],
-                                 itk::NumericTraits<CalculatorType::MatrixType::ValueType>::ZeroValue()))
+      itk::Math::NotAlmostEquals(calculator->GetCovarianceMatrix()[0][0], CalculatorType::MatrixType::ValueType{}))
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -33,7 +33,7 @@ template <typename TInputImage, typename TOutputImage>
 ComparisonImageFilter<TInputImage, TOutputImage>::ComparisonImageFilter()
 {
   // Set the default DifferenceThreshold.
-  m_DifferenceThreshold = NumericTraits<OutputPixelType>::ZeroValue();
+  m_DifferenceThreshold = OutputPixelType{};
 
   // Set the default ToleranceRadius.
   m_ToleranceRadius = 0;
@@ -41,8 +41,8 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ComparisonImageFilter()
   // Initialize statistics about difference image.
   m_MinimumDifference = NumericTraits<OutputPixelType>::max();
   m_MaximumDifference = NumericTraits<OutputPixelType>::NonpositiveMin();
-  m_MeanDifference = NumericTraits<RealType>::ZeroValue();
-  m_TotalDifference = NumericTraits<AccumulateType>::ZeroValue();
+  m_MeanDifference = RealType{};
+  m_TotalDifference = AccumulateType{};
   m_NumberOfPixelsWithDifferences = 0;
   m_IgnoreBoundaryPixels = false;
   m_VerifyInputInformation = true;
@@ -82,8 +82,8 @@ ComparisonImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   // Initialize statistics about difference image.
   m_MinimumDifference = NumericTraits<OutputPixelType>::max();
   m_MaximumDifference = NumericTraits<OutputPixelType>::NonpositiveMin();
-  m_MeanDifference = NumericTraits<RealType>::ZeroValue();
-  m_TotalDifference = NumericTraits<AccumulateType>::ZeroValue();
+  m_MeanDifference = RealType{};
+  m_TotalDifference = AccumulateType{};
   m_NumberOfPixelsWithDifferences = 0;
 
   // Resize the thread temporaries
@@ -95,7 +95,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   // Initialize the temporaries
   m_ThreadMinimumDifference.Fill(NumericTraits<OutputPixelType>::max());
   m_ThreadMaximumDifference.Fill(NumericTraits<OutputPixelType>::NonpositiveMin());
-  m_ThreadDifferenceSum.Fill(NumericTraits<AccumulateType>::ZeroValue());
+  m_ThreadDifferenceSum.Fill(AccumulateType{});
   m_ThreadNumberOfPixels.Fill(0);
 }
 
@@ -215,7 +215,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const Out
         else
         {
           // Difference is below threshold.
-          out.Set(NumericTraits<OutputPixelType>::ZeroValue());
+          out.Set(OutputPixelType{});
         }
 
         // Update progress.
@@ -226,7 +226,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const Out
     {
       for (out.GoToBegin(); !out.IsAtEnd(); ++out)
       {
-        out.Set(NumericTraits<OutputPixelType>::ZeroValue());
+        out.Set(OutputPixelType{});
         progress.CompletedPixel();
       }
     }

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -44,7 +44,7 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::StretchIntensityImageFil
   : m_Scale(1.0)
   , m_Shift(0.0)
   , m_InputMinimum(NumericTraits<InputPixelType>::max())
-  , m_InputMaximum(NumericTraits<InputPixelType>::ZeroValue())
+  , m_InputMaximum(InputPixelType{})
   , m_OutputMinimum(NumericTraits<OutputPixelType>::NonpositiveMin())
   , m_OutputMaximum(NumericTraits<OutputPixelType>::max())
 {

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -503,7 +503,7 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Tran
   constexpr SizeType supportSize = WeightsFunctionType::SupportSize;
   const RegionType   supportRegion(supportIndex, supportSize);
 
-  outputPoint.Fill(NumericTraits<ScalarType>::ZeroValue());
+  outputPoint.Fill(ScalarType{});
 
   using IteratorType = ImageScanlineConstIterator<ImageType>;
   IteratorType                coeffIterator[SpaceDimension];

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -543,7 +543,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::TransformPoint
     constexpr auto   supportSize = SizeType::Filled(SplineOrder + 1);
     const RegionType supportRegion(supportIndex, supportSize);
 
-    outputPoint.Fill(NumericTraits<ScalarType>::ZeroValue());
+    outputPoint.Fill(ScalarType{});
 
     using IteratorType = ImageScanlineConstIterator<ImageType>;
     IteratorType                coeffIterator[SpaceDimension];

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -30,7 +30,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComposeScaleSkewVersor3
   : Superclass(ParametersDimension)
 {
   m_Scale.Fill(NumericTraits<TParametersValueType>::OneValue());
-  m_Skew.Fill(NumericTraits<TParametersValueType>::ZeroValue());
+  m_Skew.Fill(TParametersValueType{});
 }
 
 // Constructor with arguments
@@ -182,7 +182,7 @@ void
 ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetIdentity()
 {
   m_Scale.Fill(NumericTraits<ScaleVectorValueType>::OneValue());
-  m_Skew.Fill(NumericTraits<SkewVectorValueType>::ZeroValue());
+  m_Skew.Fill(SkewVectorValueType{});
   Superclass::SetIdentity();
 }
 

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
@@ -34,7 +34,7 @@ ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, VDimension>::Co
                                                                                        GMatrixType & gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
-  const TParametersValueType factor = (r > 1e-8) ? (-1.0 / r) : NumericTraits<TParametersValueType>::ZeroValue();
+  const TParametersValueType factor = (r > 1e-8) ? (-1.0 / r) : TParametersValueType{};
   const TParametersValueType radial = m_Alpha * r;
 
   for (unsigned int i = 0; i < VDimension; ++i)

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -27,7 +27,7 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform()
   : Superclass(ParametersDimension)
 {
   m_ComputeZYX = false;
-  m_AngleX = m_AngleY = m_AngleZ = NumericTraits<ScalarType>::ZeroValue();
+  m_AngleX = m_AngleY = m_AngleZ = ScalarType{};
   this->m_FixedParameters.SetSize(SpaceDimension + 1);
   this->m_FixedParameters.Fill(0.0);
 }
@@ -52,7 +52,7 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform(unsigned int parameters
   : Superclass(parametersDimension)
 {
   m_ComputeZYX = false;
-  m_AngleX = m_AngleY = m_AngleZ = NumericTraits<ScalarType>::ZeroValue();
+  m_AngleX = m_AngleY = m_AngleZ = ScalarType{};
   this->m_FixedParameters.SetSize(SpaceDimension + 1);
   this->m_FixedParameters.Fill(0.0);
 }
@@ -192,7 +192,7 @@ Euler3DTransform<TParametersValueType>::ComputeMatrixParameters()
     }
     else
     {
-      m_AngleX = NumericTraits<ScalarType>::ZeroValue();
+      m_AngleX = ScalarType{};
       double x = this->GetMatrix()[1][1];
       double y = -this->GetMatrix()[0][1];
       m_AngleZ = std::atan2(y, x);
@@ -214,7 +214,7 @@ Euler3DTransform<TParametersValueType>::ComputeMatrixParameters()
     }
     else
     {
-      m_AngleZ = NumericTraits<ScalarType>::ZeroValue();
+      m_AngleZ = ScalarType{};
       double x = this->GetMatrix()[0][0];
       double y = this->GetMatrix()[1][0];
       m_AngleY = std::atan2(y, x);

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -81,7 +81,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 const typename KernelTransform<TParametersValueType, VDimension>::GMatrixType &
   KernelTransform<TParametersValueType, VDimension>::ComputeReflexiveG(PointsIterator) const
 {
-  m_GMatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
+  m_GMatrix.fill(TParametersValueType{});
   m_GMatrix.fill_diagonal(m_Stiffness);
 
   return m_GMatrix;
@@ -326,7 +326,7 @@ KernelTransform<TParametersValueType, VDimension>::TransformPoint(const InputPoi
 
   using ValueType = typename OutputPointType::ValueType;
 
-  result.Fill(NumericTraits<ValueType>::ZeroValue());
+  result.Fill(ValueType{});
 
   // TODO:  It is unclear if the following line is needed.
   this->ComputeDeformationContribution(thisPoint, result);

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -97,9 +97,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 {
   m_Matrix.SetIdentity();
   m_MatrixMTime.Modified();
-  m_Offset.Fill(NumericTraits<OutputVectorValueType>::ZeroValue());
-  m_Translation.Fill(NumericTraits<OutputVectorValueType>::ZeroValue());
-  m_Center.Fill(NumericTraits<InputPointValueType>::ZeroValue());
+  m_Offset.Fill(OutputVectorValueType{});
+  m_Translation.Fill(OutputVectorValueType{});
+  m_Center.Fill(InputPointValueType{});
   m_Singular = false;
   m_InverseMatrix.SetIdentity();
   m_InverseMatrixMTime = m_MatrixMTime;
@@ -206,7 +206,7 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
 
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<ScalarType>::ZeroValue();
+    result[i] = ScalarType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += inverseMatrix[j][i] * vec[j]; // Inverse transposed

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -27,7 +27,7 @@ template <typename TParametersValueType>
 Rigid2DTransform<TParametersValueType>::Rigid2DTransform()
   : Superclass(ParametersDimension)
 {
-  m_Angle = NumericTraits<TParametersValueType>::ZeroValue();
+  m_Angle = TParametersValueType{};
 }
 
 
@@ -35,7 +35,7 @@ template <typename TParametersValueType>
 Rigid2DTransform<TParametersValueType>::Rigid2DTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
-  m_Angle = NumericTraits<TParametersValueType>::ZeroValue();
+  m_Angle = TParametersValueType{};
 }
 
 
@@ -43,7 +43,7 @@ template <typename TParametersValueType>
 Rigid2DTransform<TParametersValueType>::Rigid2DTransform(unsigned int, unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
-  m_Angle = NumericTraits<TParametersValueType>::ZeroValue();
+  m_Angle = TParametersValueType{};
 }
 
 template <typename TParametersValueType>
@@ -176,7 +176,7 @@ void
 Rigid2DTransform<TParametersValueType>::SetIdentity()
 {
   this->Superclass::SetIdentity();
-  m_Angle = NumericTraits<TParametersValueType>::ZeroValue();
+  m_Angle = TParametersValueType{};
 }
 
 

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -167,8 +167,7 @@ ScalableAffineTransform<TParametersValueType, VDimension>::ComputeMatrix()
     typename MatrixType::InternalMatrixType & imat = mat.GetVnlMatrix();
     for (unsigned int i = 0; i < VDimension; ++i)
     {
-      if (Math::NotAlmostEquals(m_MatrixScale[i],
-                                NumericTraits<typename NumericTraits<InputVectorType>::ValueType>::ZeroValue()) &&
+      if (Math::NotAlmostEquals(m_MatrixScale[i], typename NumericTraits<InputVectorType>::ValueType{}) &&
           Math::NotAlmostEquals(m_Scale[i], 0.0))
       {
         imat.put(i, i, m_Scale[i] / m_MatrixScale[i] * this->GetMatrix()[i][i]);

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
@@ -28,7 +28,7 @@ ScaleSkewVersor3DTransform<TParametersValueType>::ScaleSkewVersor3DTransform()
   : Superclass(ParametersDimension)
 {
   m_Scale.Fill(NumericTraits<TParametersValueType>::OneValue());
-  m_Skew.Fill(NumericTraits<TParametersValueType>::ZeroValue());
+  m_Skew.Fill(TParametersValueType{});
 }
 
 // Constructor with arguments
@@ -184,7 +184,7 @@ void
 ScaleSkewVersor3DTransform<TParametersValueType>::SetIdentity()
 {
   m_Scale.Fill(NumericTraits<ScaleVectorValueType>::OneValue());
-  m_Skew.Fill(NumericTraits<SkewVectorValueType>::ZeroValue());
+  m_Skew.Fill(SkewVectorValueType{});
   Superclass::SetIdentity();
 }
 

--- a/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
@@ -27,9 +27,8 @@ ThinPlateR2LogRSplineKernelTransform<TParametersValueType, VDimension>::ComputeG
 {
   const TParametersValueType r = x.GetNorm();
 
-  gmatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
-  const TParametersValueType R2logR =
-    (r > 1e-8) ? r * r * std::log(r) : NumericTraits<TParametersValueType>::ZeroValue();
+  gmatrix.fill(TParametersValueType{});
+  const TParametersValueType R2logR = (r > 1e-8) ? r * r * std::log(r) : TParametersValueType{};
 
   gmatrix.fill_diagonal(R2logR);
 }
@@ -48,8 +47,7 @@ ThinPlateR2LogRSplineKernelTransform<TParametersValueType, VDimension>::ComputeD
   {
     InputVectorType            position = thisPoint - sp->Value();
     const TParametersValueType r = position.GetNorm();
-    const TParametersValueType R2logR =
-      (r > 1e-8) ? r * r * std::log(r) : NumericTraits<TParametersValueType>::ZeroValue();
+    const TParametersValueType R2logR = (r > 1e-8) ? r * r * std::log(r) : TParametersValueType{};
     for (unsigned int odim = 0; odim < VDimension; ++odim)
     {
       result[odim] += R2logR * this->m_DMatrix(odim, lnd);

--- a/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
@@ -27,7 +27,7 @@ ThinPlateSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const
 {
   const TParametersValueType r = x.GetNorm();
 
-  gmatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
+  gmatrix.fill(TParametersValueType{});
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     gmatrix[i][i] = r;

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -130,7 +130,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
   OutputVectorType result;
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<TParametersValueType>::ZeroValue();
+    result[i] = TParametersValueType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
@@ -152,7 +152,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
   OutputVnlVectorType result;
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<ParametersValueType>::ZeroValue();
+    result[i] = ParametersValueType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
@@ -183,7 +183,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
 
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<ParametersValueType>::ZeroValue();
+    result[i] = ParametersValueType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
@@ -205,7 +205,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCov
   OutputCovariantVectorType result;
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<TParametersValueType>::ZeroValue();
+    result[i] = TParametersValueType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[j][i] * vector[j];
@@ -236,7 +236,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCov
 
   for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    result[i] = NumericTraits<ParametersValueType>::ZeroValue();
+    result[i] = ParametersValueType{};
     for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[j][i] * vector[j];

--- a/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
@@ -27,7 +27,7 @@ VolumeSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const In
 {
   const TParametersValueType r = x.GetNorm();
 
-  gmatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
+  gmatrix.fill(TParametersValueType{});
   const TParametersValueType r3 = r * r * r;
   for (unsigned int i = 0; i < VDimension; ++i)
   {

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -103,7 +103,7 @@ itkBSplineDeformableTransformTest1()
    */
   unsigned long  numberOfParameters = transform->GetNumberOfParameters();
   ParametersType parameters(numberOfParameters);
-  parameters.Fill(itk::NumericTraits<ParametersType::ValueType>::ZeroValue());
+  parameters.Fill(ParametersType::ValueType{});
 
   /**
    * Define N * N-D grid of spline coefficients by wrapping the

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -133,7 +133,7 @@ itkBSplineTransformTest1()
    */
   unsigned long  numberOfParameters = transform->GetNumberOfParameters();
   ParametersType parameters(numberOfParameters);
-  parameters.Fill(itk::NumericTraits<ParametersType::ValueType>::ZeroValue());
+  parameters.Fill(ParametersType::ValueType{});
 
   /**
    * Define N * N-D grid of spline coefficients by wrapping the
@@ -647,7 +647,7 @@ itkBSplineTransformTest3()
    */
   unsigned long  numberOfParameters = transform->GetNumberOfParameters();
   ParametersType parameters(numberOfParameters);
-  parameters.Fill(itk::NumericTraits<ParametersType::ValueType>::ZeroValue());
+  parameters.Fill(ParametersType::ValueType{});
 
   /**
    * Define N * N-D grid of spline coefficients by wrapping the

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -94,7 +94,7 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
   PixelRealType dx_aug;
   PixelRealType dx_dim;
 
-  delta = NumericTraits<PixelRealType>::ZeroValue();
+  delta = PixelRealType{};
 
   // Calculate the centralized derivatives for each dimension.
   for (i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
@@ -64,8 +64,8 @@ ScalarAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   fit = faceList.begin();
 
   // Now do the actual processing
-  accumulator = NumericTraits<AccumulateType>::ZeroValue();
-  counter = NumericTraits<SizeValueType>::ZeroValue();
+  accumulator = AccumulateType{};
+  counter = SizeValueType{};
 
   // First process the non-boundary region
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -64,7 +64,7 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
 
   // Now do the actual processing
   accumulator = 0.0;
-  counter = NumericTraits<SizeValueType>::ZeroValue();
+  counter = SizeValueType{};
 
   // First process the non-boundary region
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
@@ -148,7 +148,7 @@ VectorGradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighb
   // Compute update value
   for (k = 0; k < VectorDimension; ++k)
   {
-    delta[k] = NumericTraits<ScalarValueType>::ZeroValue();
+    delta[k] = ScalarValueType{};
 
     for (i = 0; i < ImageDimension; ++i)
     {

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::AntiAliasBinaryImageFilter()
   : m_UpperBinaryValue(NumericTraits<BinaryValueType>::OneValue())
-  , m_LowerBinaryValue(NumericTraits<BinaryValueType>::ZeroValue())
+  , m_LowerBinaryValue(BinaryValueType{})
   , m_InputImage(nullptr)
 {
   m_CurvatureFunction = CurvatureFunctionType::New();

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -45,7 +45,7 @@ CLANG_SUPPRESS_Wfloat_equal
   template <typename TInputImage, typename TMaskImage, typename TOutputImage>
   N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::N4BiasFieldCorrectionImageFilter()
     : m_MaskLabel(NumericTraits<MaskPixelType>::OneValue())
-    , m_CurrentConvergenceMeasurement(NumericTraits<RealType>::ZeroValue())
+    , m_CurrentConvergenceMeasurement(RealType{})
 
   {
     // implicit:
@@ -129,13 +129,13 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         ++numberOfIncludedPixels;
         auto && logInputPixel = logInputImageBufferRange[indexValue];
 
-        if (logInputPixel > NumericTraits<typename InputImageType::PixelType>::ZeroValue())
+        if (logInputPixel > typename InputImageType::PixelType{})
         {
           logInputPixel = std::log(static_cast<RealType>(logInputPixel));
         }
@@ -278,7 +278,7 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         RealType pixel = unsharpenedImageBufferRange[indexValue];
@@ -302,7 +302,7 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         RealType pixel = unsharpenedImageBufferRange[indexValue];
@@ -450,7 +450,7 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         RealType     cidx = (unsharpenedImageBufferRange[indexValue] - binMinimum) / histogramSlope;
@@ -519,7 +519,7 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         PointType point;
@@ -665,7 +665,7 @@ CLANG_SUPPRESS_Wfloat_equal
     for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
-           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+           (!useMaskLabel && maskImageBufferRange[indexValue] != MaskPixelType{})) &&
           (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
       {
         RealType pixel = std::exp(subtracterImageBufferRange[indexValue]);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -37,7 +37,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel>
 BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologicalOpeningImageFilter()
 {
   m_ForegroundValue = NumericTraits<PixelType>::max();
-  m_BackgroundValue = NumericTraits<PixelType>::ZeroValue();
+  m_BackgroundValue = PixelType{};
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -29,7 +29,7 @@ template <typename TInputImage, typename TKernel>
 BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::BinaryOpeningByReconstructionImageFilter()
 {
   m_ForegroundValue = NumericTraits<PixelType>::max();
-  m_BackgroundValue = NumericTraits<PixelType>::ZeroValue();
+  m_BackgroundValue = PixelType{};
   m_FullyConnected = false;
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -81,7 +81,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
     }
     else
     {
-      ot.Set(NumericTraits<OutputImagePixelType>::ZeroValue());
+      ot.Set(OutputImagePixelType{});
     }
     ++it;
     ++ot;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
@@ -24,7 +24,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 ErodeObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::ErodeObjectMorphologyImageFilter()
 {
-  m_BackgroundValue = NumericTraits<PixelType>::ZeroValue();
+  m_BackgroundValue = PixelType{};
 
   m_ErodeBoundaryCondition.SetConstant(NumericTraits<PixelType>::max());
   this->OverrideBoundaryCondition(&m_ErodeBoundaryCondition);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -32,7 +32,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel>
 ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::ObjectMorphologyImageFilter()
   : m_Kernel()
 {
-  m_DefaultBoundaryCondition.SetConstant(NumericTraits<PixelType>::ZeroValue());
+  m_DefaultBoundaryCondition.SetConstant(PixelType{});
   m_BoundaryCondition = &m_DefaultBoundaryCondition;
 
   m_UseBoundaryCondition = false;
@@ -92,7 +92,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
 ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::BeforeThreadedGenerateData()
 {
-  if (Math::ExactlyEquals(m_ObjectValue, NumericTraits<typename TInputImage::PixelType>::ZeroValue()))
+  if (Math::ExactlyEquals(m_ObjectValue, typename TInputImage::PixelType{}))
   {
     this->GetOutput()->FillBuffer(1);
   }

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
@@ -106,7 +106,7 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::ComputeConvolut
     // Pad the kernel if necessary to an odd size in each dimension.
     using PadImageFilterType = ConstantPadImageFilter<TImage, TImage>;
     auto kernelPadImageFilter = PadImageFilterType::New();
-    kernelPadImageFilter->SetConstant(NumericTraits<KernelImagePixelType>::ZeroValue());
+    kernelPadImageFilter->SetConstant(KernelImagePixelType{});
     kernelPadImageFilter->SetPadLowerBound(this->GetKernelPadSize());
     kernelPadImageFilter->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
     kernelPadImageFilter->ReleaseDataFlagOn();

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -363,7 +363,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     using KernelPadType = ConstantPadImageFilter<InternalImageType, InternalImageType>;
     using KernelPadPointer = typename KernelPadType::Pointer;
     KernelPadPointer kernelPadder = KernelPadType::New();
-    kernelPadder->SetConstant(NumericTraits<TInternalPrecision>::ZeroValue());
+    kernelPadder->SetConstant(TInternalPrecision{});
     kernelPadder->SetPadUpperBound(kernelUpperBound);
     kernelPadder->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
     kernelPadder->SetInput(normalizeFilter->GetOutput());
@@ -378,7 +378,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     using KernelPadType = ConstantPadImageFilter<KernelImageType, InternalImageType>;
     using KernelPadPointer = typename KernelPadType::Pointer;
     KernelPadPointer kernelPadder = KernelPadType::New();
-    kernelPadder->SetConstant(NumericTraits<TInternalPrecision>::ZeroValue());
+    kernelPadder->SetConstant(TInternalPrecision{});
     kernelPadder->SetPadUpperBound(kernelUpperBound);
     kernelPadder->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
     kernelPadder->SetInput(kernel);

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -157,7 +157,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
   OutputPixelRealType                       value;
   OutputPixelRealType                       numerator;
   OutputPixelRealType                       denominator;
-  OutputPixelRealType                       zero = NumericTraits<OutputPixelType>::ZeroValue();
+  OutputPixelRealType                       zero = OutputPixelType{};
 
   realTemplateSize = static_cast<OutputPixelRealType>(templateSize);
   for (const auto & face : faceList)

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
@@ -49,11 +49,11 @@ BinaryMinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType 
 
   if (avgValue < m_Threshold)
   {
-    return (std::min(update, NumericTraits<PixelType>::ZeroValue()));
+    return (std::min(update, PixelType{}));
   }
   else
   {
-    return (std::max(update, NumericTraits<PixelType>::ZeroValue()));
+    return (std::max(update, PixelType{}));
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
@@ -95,7 +95,7 @@ public:
   {
     auto * ans = new GlobalDataStruct();
 
-    ans->m_MaxChange = NumericTraits<ScalarValueType>::ZeroValue();
+    ans->m_MaxChange = ScalarValueType{};
     return ans;
   }
 
@@ -136,7 +136,7 @@ protected:
    * values that are needed in calculating the time step. */
   struct GlobalDataStruct
   {
-    GlobalDataStruct() { m_MaxChange = NumericTraits<ScalarValueType>::ZeroValue(); }
+    GlobalDataStruct() { m_MaxChange = ScalarValueType{}; }
 
     ~GlobalDataStruct() = default;
 

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -95,7 +95,7 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
 
   if (magnitudeSqr < 1e-9)
   {
-    return NumericTraits<PixelType>::ZeroValue();
+    return PixelType{};
   }
 
   // compute the update value = mean curvature * magnitude

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -78,7 +78,7 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
 
   for (opIter = m_StencilOperator.Begin(); opIter < opEnd; ++opIter)
   {
-    *opIter = NumericTraits<PixelType>::ZeroValue();
+    *opIter = PixelType{};
 
     RadiusValueType length = 0;
     for (j = 0; j < ImageDimension; ++j)
@@ -131,7 +131,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
 
   center = it.Size() / 2;
 
-  gradMagnitude = NumericTraits<PixelType>::ZeroValue();
+  gradMagnitude = PixelType{};
   for (j = 0; j < ImageDimension; ++j)
   {
     stride = it.GetStride((SizeValueType)j);
@@ -339,7 +339,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
   }
   theta = std::acos(gradient[2]);
 
-  if (Math::AlmostEquals(gradient[0], NumericTraits<PixelType>::ZeroValue()))
+  if (Math::AlmostEquals(gradient[0], PixelType{}))
   {
     phi = Math::pi * 0.5;
   }
@@ -412,11 +412,11 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
 
   if (avgValue < threshold)
   {
-    return (std::max(update, NumericTraits<PixelType>::ZeroValue()));
+    return (std::max(update, PixelType{}));
   }
   else
   {
-    return (std::min(update, NumericTraits<PixelType>::ZeroValue()));
+    return (std::min(update, PixelType{}));
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -401,7 +401,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::EnforceConstraints()
   {
     for (unsigned int ic = 0; ic < m_NumIndependentComponents; ++ic)
     {
-      if (m_ImageMin[ic] < NumericTraits<PixelValueType>::ZeroValue())
+      if (m_ImageMin[ic] < PixelValueType{})
       {
         itkExceptionMacro("When using POISSON or RICIAN noise models, "
                           << "all components of all pixels in the image must "
@@ -879,9 +879,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
   // If these occur, default to the standard eigen analysis.
   // These basically enforce that the spdMatrix is in fact
   // symmetric positive definite.
-  if ((I3 < NumericTraits<RealTensorValueT>::epsilon()) || (D0 < NumericTraits<RealTensorValueT>::ZeroValue()) ||
-      (D3 < NumericTraits<RealTensorValueT>::ZeroValue()) || (D5 < NumericTraits<RealTensorValueT>::ZeroValue()) ||
-      (D0 * D3 < DSq1) || (D0 * D5 < DSq2) || (D3 * D5 < DSq4) || (n < NumericTraits<RealTensorValueT>::epsilon()))
+  if ((I3 < NumericTraits<RealTensorValueT>::epsilon()) || (D0 < RealTensorValueT{}) || (D3 < RealTensorValueT{}) ||
+      (D5 < RealTensorValueT{}) || (D0 * D3 < DSq1) || (D0 * D5 < DSq2) || (D3 * D5 < DSq4) ||
+      (n < NumericTraits<RealTensorValueT>::epsilon()))
   {
     spdMatrix.ComputeEigenAnalysis(eigenVals, eigenVecs);
     return;
@@ -1852,8 +1852,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate() 
 
     // If second derivative is zero or negative, compute update using gradient
     // descent
-    if ((Math::ExactlyEquals(itk::Math::abs(secondDerivative), NumericTraits<RealValueType>::ZeroValue())) ||
-        (secondDerivative < 0))
+    if ((Math::ExactlyEquals(itk::Math::abs(secondDerivative), RealValueType{})) || (secondDerivative < 0))
     {
       itkDebugMacro("** Second derivative NOT POSITIVE");
       sigmaUpdate[ic] = -itk::Math::sgn(firstDerivative) * kernelSigma * 0.3;

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -244,14 +244,13 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
         unmaskedPixel = maskSpatialObject->IsInsideInWorldSpace(point);
       }
 
-      if (Math::NotAlmostEquals(b0, itk::NumericTraits<ReferencePixelType>::ZeroValue()) && unmaskedPixel &&
-          (b0 >= m_Threshold))
+      if (Math::NotAlmostEquals(b0, ReferencePixelType{}) && unmaskedPixel && (b0 >= m_Threshold))
       {
         for (unsigned int i = 0; i < m_NumberOfGradientDirections; ++i)
         {
           GradientPixelType b = gradientItContainer[i]->Get();
 
-          if (Math::AlmostEquals(b, itk::NumericTraits<GradientPixelType>::ZeroValue()))
+          if (Math::AlmostEquals(b, GradientPixelType{}))
           {
             B[i] = 0;
           }
@@ -338,7 +337,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     {
       GradientVectorType b = git.Get();
 
-      typename NumericTraits<ReferencePixelType>::AccumulateType b0 = NumericTraits<ReferencePixelType>::ZeroValue();
+      typename NumericTraits<ReferencePixelType>::AccumulateType b0 = ReferencePixelType{};
 
       // Average the baseline image pixels
       for (const auto & i : baselineind)
@@ -363,12 +362,11 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
         unmaskedPixel = maskSpatialObject->IsInsideInWorldSpace(point);
       }
 
-      if (Math::NotAlmostEquals(b0, NumericTraits<ReferencePixelType>::ZeroValue()) && unmaskedPixel &&
-          (b0 >= m_Threshold))
+      if (Math::NotAlmostEquals(b0, ReferencePixelType{}) && unmaskedPixel && (b0 >= m_Threshold))
       {
         for (unsigned int i = 0; i < m_NumberOfGradientDirections; ++i)
         {
-          if (Math::AlmostEquals(b[gradientind[i]], NumericTraits<typename GradientVectorType::ValueType>::ZeroValue()))
+          if (Math::AlmostEquals(b[gradientind[i]], typename GradientVectorType::ValueType{}))
           {
             B[i] = 0;
           }

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -125,8 +125,8 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
     this->m_ComposedField->DisconnectPipeline();
 
     // Multithread processing to multiply each element of the composed field by 1 / spacing
-    this->m_MeanErrorNorm = NumericTraits<RealType>::ZeroValue();
-    this->m_MaxErrorNorm = NumericTraits<RealType>::ZeroValue();
+    this->m_MeanErrorNorm = RealType{};
+    this->m_MaxErrorNorm = RealType{};
 
     float               newProgress = static_cast<float>(2 * iteration - 1) / (2 * m_MaximumNumberOfIterations);
     ProgressTransformer pt(oldProgress, newProgress, this);

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -137,7 +137,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 {
   if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) || this->m_NumberOfIntegrationSteps == 0)
   {
-    this->GetOutput()->FillBuffer(itk::NumericTraits<typename DisplacementFieldType::PixelType>::ZeroValue());
+    this->GetOutput()->FillBuffer(typename DisplacementFieldType::PixelType{});
     return;
   }
 

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -106,7 +106,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   image->SetSpacing(spacing);
   image->SetOrigin(origin);
   image->SetDirection(inputDirection);
-  image->FillBuffer(itk::NumericTraits<ScalarPixelType>::ZeroValue());
+  image->FillBuffer(ScalarPixelType{});
 
   float     incrValue = 100.0;
   IndexType pixelIndex;

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -41,7 +41,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ContourDirec
 
   m_UseImageSpacing = true;
   m_DistanceMap = nullptr;
-  m_ContourDirectedMeanDistance = NumericTraits<RealType>::ZeroValue();
+  m_ContourDirectedMeanDistance = RealType{};
   this->DynamicMultiThreadingOff();
 }
 
@@ -124,7 +124,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::BeforeThread
   m_Count.SetSize(numberOfWorkUnits);
 
   // Initialize the temporaries
-  m_MeanDistance.Fill(NumericTraits<RealType>::ZeroValue());
+  m_MeanDistance.Fill(RealType{});
   m_Count.Fill(0);
 
   // Compute Signed distance from non-zero pixels in the second image
@@ -161,7 +161,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::AfterThreade
   }
   else
   {
-    m_ContourDirectedMeanDistance = NumericTraits<RealType>::ZeroValue();
+    m_ContourDirectedMeanDistance = RealType{};
   }
 }
 
@@ -204,7 +204,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ThreadedGene
     {
       // First test
       // If current pixel is not on, let's continue
-      if (Math::NotExactlyEquals(bit.GetCenterPixel(), NumericTraits<InputImage1PixelType>::ZeroValue()))
+      if (Math::NotExactlyEquals(bit.GetCenterPixel(), InputImage1PixelType{}))
       {
         bool bIsOnContour = false;
 
@@ -212,7 +212,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ThreadedGene
         {
           // Second test if at least one neighbour pixel is off
           // the center pixel belongs to contour
-          if (Math::ExactlyEquals(bit.GetPixel(i), NumericTraits<InputImage1PixelType>::ZeroValue()))
+          if (Math::ExactlyEquals(bit.GetPixel(i), InputImage1PixelType{}))
           {
             bIsOnContour = true;
             break;

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -31,7 +31,7 @@ ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::ContourMeanDistanceI
   // this filter requires two input images
   this->SetNumberOfRequiredInputs(2);
 
-  m_MeanDistance = NumericTraits<RealType>::ZeroValue();
+  m_MeanDistance = RealType{};
   m_UseImageSpacing = true;
 }
 

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -111,7 +111,7 @@ void
 DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::BeforeThreadedGenerateData()
 {
   // initialize accumulators
-  m_MaxDistance = NumericTraits<RealType>::ZeroValue();
+  m_MaxDistance = RealType{};
   m_PixelCount = 0;
   m_Sum = 0;
 
@@ -168,11 +168,11 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DynamicThreade
   // do the work
   while (!it1.IsAtEnd())
   {
-    if (Math::NotExactlyEquals(it1.Get(), NumericTraits<InputImage1PixelType>::ZeroValue()))
+    if (Math::NotExactlyEquals(it1.Get(), InputImage1PixelType{}))
     {
       // The signed distance map is calculated, but we want the calculation based on the
       // unsigned int distance map.  Therefore, we set all distance map values less than 0 to 0.
-      const RealType val2 = std::max(static_cast<RealType>(it2.Get()), NumericTraits<RealType>::ZeroValue());
+      const RealType val2 = std::max(static_cast<RealType>(it2.Get()), RealType{});
       maxDistance = std::max(maxDistance, val2);
       sum += val2;
       ++pixelCount;

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
@@ -30,8 +30,8 @@ HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::HausdorffDistanceImage
   // this filter requires two input images
   this->SetNumberOfRequiredInputs(2);
 
-  m_HausdorffDistance = NumericTraits<RealType>::ZeroValue();
-  m_AverageHausdorffDistance = NumericTraits<RealType>::ZeroValue();
+  m_HausdorffDistance = RealType{};
+  m_AverageHausdorffDistance = RealType{};
   m_UseImageSpacing = true;
 }
 

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 IsoContourDistanceImageFilter<TInputImage, TOutputImage>::IsoContourDistanceImageFilter()
 {
-  m_LevelSetValue = NumericTraits<InputPixelType>::ZeroValue();
+  m_LevelSetValue = InputPixelType{};
 
   m_FarValue = 10 * NumericTraits<PixelType>::OneValue();
 
@@ -204,7 +204,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     }
     else
     {
-      outIt.Set(NumericTraits<PixelType>::ZeroValue());
+      outIt.Set(PixelType{});
     }
     ++inIt;
     ++outIt;

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -35,7 +35,7 @@ public:
   {
     if (input)
     {
-      return NumericTraits<InputPixelType>::ZeroValue();
+      return InputPixelType{};
     }
     else
     {

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -31,7 +31,7 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::SignedMaurerDistanceMapImageFilter()
-  : m_BackgroundValue(NumericTraits<InputPixelType>::ZeroValue())
+  : m_BackgroundValue(InputPixelType{})
   , m_Spacing()
   , m_InputCache(nullptr)
 {
@@ -126,7 +126,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::GenerateData()
   binaryFilter->SetLowerThreshold(this->m_BackgroundValue);
   binaryFilter->SetUpperThreshold(this->m_BackgroundValue);
   binaryFilter->SetInsideValue(NumericTraits<OutputPixelType>::max());
-  binaryFilter->SetOutsideValue(NumericTraits<OutputPixelType>::ZeroValue());
+  binaryFilter->SetOutsideValue(OutputPixelType{});
   binaryFilter->SetInput(inputPtr);
   binaryFilter->SetNumberOfWorkUnits(numberOfWorkUnits);
   progressAcc->RegisterInternalFilter(binaryFilter, 0.1f);
@@ -138,7 +138,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::GenerateData()
   using BorderFilterType = BinaryContourImageFilter<OutputImageType, OutputImageType>;
   auto borderFilter = BorderFilterType::New();
   borderFilter->SetInput(binaryFilter->GetOutput());
-  borderFilter->SetForegroundValue(NumericTraits<OutputPixelType>::ZeroValue());
+  borderFilter->SetForegroundValue(OutputPixelType{});
   borderFilter->SetBackgroundValue(NumericTraits<OutputPixelType>::max());
   borderFilter->SetFullyConnected(true);
   borderFilter->SetNumberOfWorkUnits(numberOfWorkUnits);

--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
@@ -44,8 +44,8 @@ itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
   image1->Allocate();
   image2->Allocate();
 
-  image1->FillBuffer(itk::NumericTraits<Pixel1Type>::ZeroValue());
-  image2->FillBuffer(itk::NumericTraits<Pixel2Type>::ZeroValue());
+  image1->FillBuffer(Pixel1Type{});
+  image2->FillBuffer(Pixel2Type{});
 
   using RegionType = Image1Type::RegionType;
   RegionType region1;

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -52,8 +52,8 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
   image1->Allocate();
   image2->Allocate();
 
-  image1->FillBuffer(itk::NumericTraits<Pixel1Type>::ZeroValue());
-  image2->FillBuffer(itk::NumericTraits<Pixel2Type>::ZeroValue());
+  image1->FillBuffer(Pixel1Type{});
+  image2->FillBuffer(Pixel2Type{});
 
   using RegionType = Image1Type::RegionType;
   RegionType region1;

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -44,8 +44,8 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
   image1->Allocate();
   image2->Allocate();
 
-  image1->FillBuffer(itk::NumericTraits<Pixel1Type>::ZeroValue());
-  image2->FillBuffer(itk::NumericTraits<Pixel2Type>::ZeroValue());
+  image1->FillBuffer(Pixel1Type{});
+  image2->FillBuffer(Pixel2Type{});
 
   using RegionType = Image1Type::RegionType;
   RegionType region1;

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
@@ -50,8 +50,8 @@ itkHausdorffDistanceImageFilterTest(int argc, char * argv[])
   image1->Allocate();
   image2->Allocate();
 
-  image1->FillBuffer(itk::NumericTraits<Pixel1Type>::ZeroValue());
-  image2->FillBuffer(itk::NumericTraits<Pixel2Type>::ZeroValue());
+  image1->FillBuffer(Pixel1Type{});
+  image2->FillBuffer(Pixel2Type{});
 
   using RegionType = Image1Type::RegionType;
   RegionType region1;

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
@@ -64,7 +64,7 @@ itkReflectiveImageRegionIteratorTest(int, char *[])
     // set the pixel index as value
     nit.Set(nit.GetIndex());
     // Set the number of visits to zero
-    vit.Set(itk::NumericTraits<ImageVisitsType::PixelType>::ZeroValue());
+    vit.Set(ImageVisitsType::PixelType{});
     ++nit;
     ++vit;
   }

--- a/Modules/Filtering/FFT/test/itkRealFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkRealFFTTest.h
@@ -203,7 +203,7 @@ test_fft(unsigned int * SizeOfDimensions)
     TPixel val = originalImageIterator.Value();
     TPixel val2 = inverseFFTImageIterator.Value();
     TPixel diff = itk::Math::abs(val - val2);
-    if (itk::Math::NotAlmostEquals(val, itk::NumericTraits<TPixel>::ZeroValue()))
+    if (itk::Math::NotAlmostEquals(val, TPixel{}))
     {
       diff /= itk::Math::abs(val);
     }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
@@ -40,7 +40,7 @@ FastMarchingBase<TInput, TOutput>::FastMarchingBase()
   m_SpeedConstant = 1.;
   m_InverseSpeed = -1.;
   m_NormalizationFactor = 1.;
-  m_TargetReachedValue = NumericTraits<OutputPixelType>::ZeroValue();
+  m_TargetReachedValue = OutputPixelType{};
   m_TopologyCheck = TopologyCheckEnum::Nothing;
   m_LargeValue = NumericTraits<OutputPixelType>::max();
   m_TopologyValue = m_LargeValue;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
@@ -249,7 +249,7 @@ FastMarchingExtensionImageFilter<TLevelSet, TAuxValue, VAuxDimension, TSpeedImag
       }
       else
       {
-        auxVal = NumericTraits<AuxValueType>::ZeroValue();
+        auxVal = AuxValueType{};
       }
 
       this->GetAuxiliaryImage(k)->SetPixel(index, auxVal);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
@@ -258,7 +258,7 @@ FastMarchingExtensionImageFilterBase<TInput, TOutput, TAuxValue, VAuxDimension>:
       }
       else
       {
-        auxVal = NumericTraits<AuxValueType>::ZeroValue();
+        auxVal = AuxValueType{};
       }
 
       this->m_AuxImages[k]->SetPixel(iNode, auxVal);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -33,8 +33,8 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::FastMarchi
   , m_AlivePoints(nullptr)
   , m_TrialPoints(nullptr)
   , m_ForbiddenPoints(nullptr)
-  , m_AliveValue(NumericTraits<OutputPixelType>::ZeroValue())
-  , m_TrialValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_AliveValue(OutputPixelType{})
+  , m_TrialValue(OutputPixelType{})
 
 {}
 
@@ -107,7 +107,7 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GenerateDa
 
   if (m_ForbiddenImage.IsNotNull())
   {
-    SetPointsFromImage(m_ForbiddenImage, Traits::Forbidden, NumericTraits<OutputPixelType>::ZeroValue());
+    SetPointsFromImage(m_ForbiddenImage, Traits::Forbidden, OutputPixelType{});
     is_ok = true;
   }
 
@@ -138,7 +138,7 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::SetPointsF
       for (it.GoToBegin(); !it.IsAtEnd(); ++it)
       {
         // Test if index value is greater than zero, if so add the node
-        if (Math::NotAlmostEquals(it.Get(), NumericTraits<ImagePixelType>::ZeroValue()))
+        if (Math::NotAlmostEquals(it.Get(), ImagePixelType{}))
         {
           nodes->push_back(NodePairType(it.GetIndex(), iValue));
         } // end if image iterator > zero
@@ -149,7 +149,7 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::SetPointsF
       for (it.GoToBegin(); !it.IsAtEnd(); ++it)
       {
         // Test if index value is greater than zero, if so add the node
-        if (Math::AlmostEquals(it.Get(), NumericTraits<ImagePixelType>::ZeroValue()))
+        if (Math::AlmostEquals(it.Get(), ImagePixelType{}))
         {
           nodes->push_back(NodePairType(it.GetIndex(), iValue));
         } // end if image iterator > zero

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
@@ -77,8 +77,8 @@ public:
 protected:
   FastMarchingNumberOfElementsStoppingCriterion()
     : Superclass()
-    , m_CurrentNumberOfElements(NumericTraits<IdentifierType>::ZeroValue())
-    , m_TargetNumberOfElements(NumericTraits<IdentifierType>::ZeroValue())
+    , m_CurrentNumberOfElements(IdentifierType{})
+    , m_TargetNumberOfElements(IdentifierType{})
   {}
 
   ~FastMarchingNumberOfElementsStoppingCriterion() override = default;
@@ -95,7 +95,7 @@ protected:
   void
   Reset() override
   {
-    this->m_CurrentNumberOfElements = NumericTraits<IdentifierType>::ZeroValue();
+    this->m_CurrentNumberOfElements = IdentifierType{};
   }
 };
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
@@ -177,8 +177,8 @@ protected:
   /** Constructor */
   FastMarchingReachedTargetNodesStoppingCriterion()
     : Superclass()
-    , m_TargetOffset(NumericTraits<OutputPixelType>::ZeroValue())
-    , m_StoppingValue(NumericTraits<OutputPixelType>::ZeroValue())
+    , m_TargetOffset(OutputPixelType{})
+    , m_StoppingValue(OutputPixelType{})
   {}
 
   /** Destructor */

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
@@ -57,8 +57,8 @@ public:
   void
   Reinitialize()
   {
-    m_CurrentValue = NumericTraits<OutputPixelType>::ZeroValue();
-    m_PreviousValue = NumericTraits<OutputPixelType>::ZeroValue();
+    m_CurrentValue = OutputPixelType{};
+    m_PreviousValue = OutputPixelType{};
 
     this->Reset();
   }
@@ -79,8 +79,8 @@ protected:
     : Superclass()
     , m_Domain(nullptr)
   {
-    m_CurrentValue = NumericTraits<OutputPixelType>::ZeroValue();
-    m_PreviousValue = NumericTraits<OutputPixelType>::ZeroValue();
+    m_CurrentValue = OutputPixelType{};
+    m_PreviousValue = OutputPixelType{};
   }
 
   /** Destructor */

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
@@ -71,7 +71,7 @@ public:
 protected:
   FastMarchingThresholdStoppingCriterion()
     : Superclass()
-    , m_Threshold(NumericTraits<OutputPixelType>::ZeroValue())
+    , m_Threshold(OutputPixelType{})
   {}
 
   ~FastMarchingThresholdStoppingCriterion() override = default;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -105,7 +105,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelS
 
     GradientPixelType zeroGradient;
     using GradientPixelValueType = typename GradientPixelType::ValueType;
-    zeroGradient.Fill(NumericTraits<GradientPixelValueType>::ZeroValue());
+    zeroGradient.Fill(GradientPixelValueType{});
     for (gradientIt.GoToBegin(); !gradientIt.IsAtEnd(); ++gradientIt)
     {
       gradientIt.Set(zeroGradient);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
@@ -74,7 +74,7 @@ FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::InitializeOutput(Out
 
   GradientPixelType zeroGradient;
   using GradientPixelValueType = typename GradientPixelType::ValueType;
-  zeroGradient.Fill(NumericTraits<GradientPixelValueType>::ZeroValue());
+  zeroGradient.Fill(GradientPixelValueType{});
 
   while (!gradientIt.IsAtEnd())
   {

--- a/Modules/Filtering/FastMarching/include/itkLevelSetNode.h
+++ b/Modules/Filtering/FastMarching/include/itkLevelSetNode.h
@@ -134,7 +134,7 @@ public:
 
   /** Default constructor */
   LevelSetNode()
-    : m_Value(NumericTraits<PixelType>::ZeroValue())
+    : m_Value(PixelType{})
   {
     m_Index.Fill(0);
   }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -65,7 +65,7 @@ protected:
   const OutputPixelType
   GetOutputValue(OutputDomainType *, const NodeType &) const override
   {
-    return NumericTraits<OutputPixelType>::ZeroValue();
+    return OutputPixelType{};
   }
 
   unsigned char

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -37,7 +37,7 @@ public:
   {
     m_LowerThreshold = NumericTraits<TInput>::NonpositiveMin();
     m_UpperThreshold = NumericTraits<TInput>::max();
-    m_OutsideValue = NumericTraits<TOutput>::ZeroValue();
+    m_OutsideValue = TOutput{};
     m_InsideValue = NumericTraits<TOutput>::max();
   }
 

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -33,7 +33,7 @@ SimilarityIndexImageFilter<TInputImage1, TInputImage2>::SimilarityIndexImageFilt
   // this filter requires two input images
   this->SetNumberOfRequiredInputs(2);
 
-  m_SimilarityIndex = NumericTraits<RealType>::ZeroValue();
+  m_SimilarityIndex = RealType{};
   this->DynamicMultiThreadingOff();
 }
 
@@ -103,9 +103,9 @@ SimilarityIndexImageFilter<TInputImage1, TInputImage2>::BeforeThreadedGenerateDa
   m_CountOfIntersection.SetSize(numberOfWorkUnits);
 
   // Initialize the temporaries
-  m_CountOfImage1.Fill(NumericTraits<SizeValueType>::ZeroValue());
-  m_CountOfImage2.Fill(NumericTraits<SizeValueType>::ZeroValue());
-  m_CountOfIntersection.Fill(NumericTraits<SizeValueType>::ZeroValue());
+  m_CountOfImage1.Fill(SizeValueType{});
+  m_CountOfImage2.Fill(SizeValueType{});
+  m_CountOfIntersection.Fill(SizeValueType{});
 }
 
 template <typename TInputImage1, typename TInputImage2>
@@ -132,7 +132,7 @@ SimilarityIndexImageFilter<TInputImage1, TInputImage2>::AfterThreadedGenerateDat
   // compute overlap
   if (!countImage1 && !countImage2)
   {
-    m_SimilarityIndex = NumericTraits<RealType>::ZeroValue();
+    m_SimilarityIndex = RealType{};
     return;
   }
 
@@ -155,12 +155,12 @@ SimilarityIndexImageFilter<TInputImage1, TInputImage2>::ThreadedGenerateData(con
   while (!it1.IsAtEnd())
   {
     bool nonzero = false;
-    if (it1.Get() != NumericTraits<InputImage1PixelType>::ZeroValue())
+    if (it1.Get() != InputImage1PixelType{})
     {
       m_CountOfImage1[threadId]++;
       nonzero = true;
     }
-    if (Math::NotExactlyEquals(it2.Get(), NumericTraits<InputImage2PixelType>::ZeroValue()))
+    if (Math::NotExactlyEquals(it2.Get(), InputImage2PixelType{}))
     {
       m_CountOfImage2[threadId]++;
       if (nonzero)

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -31,8 +31,8 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::CannyEdgeDetectionImageFilter()
-  : m_UpperThreshold(NumericTraits<OutputImagePixelType>::ZeroValue())
-  , m_LowerThreshold(NumericTraits<OutputImagePixelType>::ZeroValue())
+  : m_UpperThreshold(OutputImagePixelType{})
+  , m_LowerThreshold(OutputImagePixelType{})
 {
   m_Variance.Fill(0.0);
   m_MaximumError.Fill(0.01);
@@ -286,7 +286,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::HysteresisThresholding
   ImageRegionIterator<TOutputImage> uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
   while (!uit.IsAtEnd())
   {
-    uit.Value() = NumericTraits<OutputImagePixelType>::ZeroValue();
+    uit.Value() = OutputImagePixelType{};
     ++uit;
   }
 

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -84,7 +84,7 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
     }
     else
     {
-      oit.Set(NumericTraits<OutputPixelType>::ZeroValue());
+      oit.Set(OutputPixelType{});
     }
 
     ++it;

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -91,7 +91,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
 
     if (!signConstraintsSatisfied)
     {
-      oit.Set(NumericTraits<OutputPixelType>::ZeroValue());
+      oit.Set(OutputPixelType{});
       ++it;
       ++oit;
       progress.CompletedPixel();

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -168,7 +168,7 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   cumulativeImage->SetRegions(outputImage->GetRequestedRegion());
   cumulativeImage->CopyInformation(inputImage);
   cumulativeImage->Allocate();
-  cumulativeImage->FillBuffer(NumericTraits<InternalRealType>::ZeroValue());
+  cumulativeImage->FillBuffer(InternalRealType{});
 
   m_DerivativeFilter->SetInput(inputImage);
 

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -111,7 +111,7 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   // just to be sure. Thanks to Hauke Heibel.
   if (m_NonNegativeHessianBasedMeasure)
   {
-    m_UpdateBuffer->FillBuffer(itk::NumericTraits<BufferValueType>::ZeroValue());
+    m_UpdateBuffer->FillBuffer(BufferValueType{});
   }
   else
   {

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -30,9 +30,9 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::SimpleContourExtractorImageFilter()
   : m_InputForegroundValue(NumericTraits<InputPixelType>::max())
-  , m_InputBackgroundValue(NumericTraits<InputPixelType>::ZeroValue())
+  , m_InputBackgroundValue(InputPixelType{})
   , m_OutputForegroundValue(NumericTraits<OutputPixelType>::max())
-  , m_OutputBackgroundValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_OutputBackgroundValue(OutputPixelType{})
 {
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
@@ -32,7 +32,7 @@ ZeroCrossingBasedEdgeDetectionImageFilter<TInputImage, TOutputImage>::ZeroCrossi
 {
   m_Variance.Fill(1.0);
   m_MaximumError.Fill(0.01);
-  m_BackgroundValue = NumericTraits<OutputImagePixelType>::ZeroValue();
+  m_BackgroundValue = OutputImagePixelType{};
   m_ForegroundValue = NumericTraits<OutputImagePixelType>::OneValue();
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
@@ -42,7 +42,7 @@ namespace itk
  *  By default, zero-crossing pixels are labeled with a default "foreground"
  *  value of itk::NumericTraits<OutputDataType>::OneValue(), where OutputDataType is
  *  the data type of the output image.  All other pixels are labeled with a
- *  default "background" value of itk::NumericTraits<OutputDataType>::ZeroValue().
+ *  default "background" value of OutputDataType{}.
  *
  *  \par Parameters
  *  There are two parameters for this filter.  ForegroundValue is the value

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -30,7 +30,7 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 ZeroCrossingImageFilter<TInputImage, TOutputImage>::ZeroCrossingImageFilter()
-  : m_BackgroundValue(NumericTraits<OutputImagePixelType>::ZeroValue())
+  : m_BackgroundValue(OutputImagePixelType{})
   , m_ForegroundValue(NumericTraits<OutputImagePixelType>::OneValue())
 {
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -147,7 +147,7 @@ public:
 
 protected:
   MaskNeighborhoodOperatorImageFilter()
-    : m_DefaultValue(NumericTraits<OutputPixelType>::ZeroValue())
+    : m_DefaultValue(OutputPixelType{})
   {}
   ~MaskNeighborhoodOperatorImageFilter() override = default;
   void

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -77,8 +77,8 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
     while (!bit.IsAtEnd())
     {
-      sum = NumericTraits<InputRealType>::ZeroValue();
-      sumOfSquares = NumericTraits<InputRealType>::ZeroValue();
+      sum = InputRealType{};
+      sumOfSquares = InputRealType{};
       for (i = 0; i < neighborhoodSize; ++i)
       {
         value = static_cast<InputRealType>(bit.GetPixel(i));

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -114,7 +114,7 @@ NullImageToImageFilterDriver<TInputImage, TOutputImage>::InitializePixel(const D
 {
   for (unsigned int i = 0; i < InputPixelDimension; ++i)
   {
-    pixel[i] = NumericTraits<typename PixelTraits<InputPixelType>::ValueType>::ZeroValue();
+    pixel[i] = typename PixelTraits<InputPixelType>::ValueType{};
   }
 }
 
@@ -122,7 +122,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 NullImageToImageFilterDriver<TInputImage, TOutputImage>::InitializePixel(const Dispatch<1> &, InputPixelType & pixel)
 {
-  pixel = NumericTraits<InputPixelType>::ZeroValue();
+  pixel = InputPixelType{};
 }
 
 /**

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -152,14 +152,14 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::BandPass(FrequencyIter
   {
     if (scalarFrequency < this->m_LowFrequencyThreshold || scalarFrequency > this->m_HighFrequencyThreshold)
     {
-      freqIt.Set(NumericTraits<PixelType>::ZeroValue());
+      freqIt.Set(PixelType{});
     }
   }
   else // Stop Band
   {
     if (scalarFrequency > this->m_LowFrequencyThreshold && scalarFrequency < this->m_HighFrequencyThreshold)
     {
-      freqIt.Set(NumericTraits<PixelType>::ZeroValue());
+      freqIt.Set(PixelType{});
     }
   }
 
@@ -175,7 +175,7 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::BandPass(FrequencyIter
       }
       else
       {
-        freqIt.Set(NumericTraits<PixelType>::ZeroValue());
+        freqIt.Set(PixelType{});
       }
     }
   }
@@ -191,7 +191,7 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::BandPass(FrequencyIter
       }
       else
       {
-        freqIt.Set(NumericTraits<PixelType>::ZeroValue());
+        freqIt.Set(PixelType{});
       }
     }
   }

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -154,7 +154,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Befor
   auto serode = SliceErodeType::New();
   using RadiusType = typename SliceKernelType::RadiusType;
   RadiusType srad;
-  srad.Fill(NumericTraits<typename RadiusType::SizeValueType>::ZeroValue());
+  srad.Fill(typename RadiusType::SizeValueType{});
   for (unsigned int i = 0, j = 0; i < ImageDimension; ++i)
   {
     if (j != static_cast<unsigned int>(m_SliceDimension))

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
@@ -54,7 +54,7 @@ public:
     // LabelOverlayFunctorImageFilter) Inside LabelOverlayFunctorImageFilter,
     // the values are always initialized
     m_Opacity = 1.0;
-    m_BackgroundValue = NumericTraits<TLabel>::ZeroValue();
+    m_BackgroundValue = TLabel{};
   }
 
   inline TRGBPixel

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
@@ -26,7 +26,7 @@ template <typename TInputImage, typename TLabelImage, typename TOutputImage>
 LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::LabelOverlayImageFilter()
 {
   m_Opacity = 0.5;
-  m_BackgroundValue = NumericTraits<LabelPixelType>::ZeroValue();
+  m_BackgroundValue = LabelPixelType{};
 }
 
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
@@ -85,8 +85,8 @@ public:
     // LabelToRGBImageFilter)
     // Inside LabelToRGBImageFilter, the values are always initialized
     NumericTraits<TRGBPixel>::SetLength(m_BackgroundColor, 3);
-    m_BackgroundColor.Fill(NumericTraits<ValueType>::ZeroValue());
-    m_BackgroundValue = NumericTraits<TLabel>::ZeroValue();
+    m_BackgroundColor.Fill(ValueType{});
+    m_BackgroundValue = TLabel{};
   }
 
   inline TRGBPixel

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.hxx
@@ -36,9 +36,9 @@ namespace itk
 template <typename TLabelImage, typename TOutputImage>
 LabelToRGBImageFilter<TLabelImage, TOutputImage>::LabelToRGBImageFilter()
 {
-  m_BackgroundValue = NumericTraits<LabelPixelType>::ZeroValue();
+  m_BackgroundValue = LabelPixelType{};
   NumericTraits<OutputPixelType>::SetLength(m_BackgroundColor, 3);
-  m_BackgroundColor.Fill(NumericTraits<OutputPixelValueType>::ZeroValue());
+  m_BackgroundColor.Fill(OutputPixelValueType{});
 }
 
 template <typename TLabelImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
@@ -61,7 +61,7 @@ itkLabelToRGBImageFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 
   typename FilterType::OutputPixelType backgroundColor;
-  backgroundColor.Fill(itk::NumericTraits<typename FilterType::OutputPixelValueType>::ZeroValue());
+  backgroundColor.Fill(typename FilterType::OutputPixelValueType{});
   filter->SetBackgroundColor(backgroundColor);
   ITK_TEST_SET_GET_VALUE(backgroundColor, filter->GetBackgroundColor());
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -205,7 +205,7 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Genera
   auto cumulativeImage = CumulativeImageType::New();
   cumulativeImage->SetRegions(inputImage->GetBufferedRegion());
   cumulativeImage->Allocate();
-  cumulativeImage->FillBuffer(NumericTraits<InternalRealType>::ZeroValue());
+  cumulativeImage->FillBuffer(InternalRealType{});
   // The output's information must match the input's information
   cumulativeImage->CopyInformation(this->GetInput());
 

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -320,10 +320,10 @@ protected:
     unsigned int i, j;
     TRealType    dx, sum, accum;
 
-    accum = NumericTraits<TRealType>::ZeroValue();
+    accum = TRealType{};
     for (i = 0; i < ImageDimension; ++i)
     {
-      sum = NumericTraits<TRealType>::ZeroValue();
+      sum = TRealType{};
       for (j = 0; j < VectorDimension; ++j)
       {
         dx = m_DerivativeWeights[i] * m_SqrtComponentWeights[j] * 0.5 * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -226,7 +226,7 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
   myGradImage1DType::Pointer scalarPixelGradImage = nullptr;
   myScalarPixelType          pixelBorder;
   myScalarPixelType          pixelFill;
-  pixelBorder = itk::NumericTraits<myScalarPixelType>::ZeroValue();
+  pixelBorder = myScalarPixelType{};
   pixelFill = static_cast<myScalarPixelType>(100.0);
   runResult = itkGradientRecursiveGaussianFilterTest3Run<myImageScalarType, myGradImage1DType, myComponents1D>(
     pixelBorder, pixelFill, scalarPixelGradImage, argv[2]);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -241,12 +241,12 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
       {
         U[i] = static_cast<RealType>(totalNumberOfSpans[i]) - epsilon[i];
       }
-      if (U[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(U[i]) <= epsilon[i])
+      if (U[i] < RealType{} && itk::Math::abs(U[i]) <= epsilon[i])
       {
-        U[i] = NumericTraits<RealType>::ZeroValue();
+        U[i] = RealType{};
       }
 
-      if (U[i] < NumericTraits<RealType>::ZeroValue() || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
+      if (U[i] < RealType{} || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
       {
         itkExceptionMacro("The collapse point component "
                           << U[i] << " is outside the corresponding parametric domain of [0, " << totalNumberOfSpans[i]

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -171,12 +171,12 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTy
     {
       p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
     }
-    if (p[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
+    if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<RealType>::ZeroValue();
+      p[i] = RealType{};
     }
 
-    if (p[i] < NumericTraits<CoordRepType>::ZeroValue() || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }
@@ -320,12 +320,12 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradient(const
     {
       p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
     }
-    if (p[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
+    if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<RealType>::ZeroValue();
+      p[i] = RealType{};
     }
 
-    if (p[i] < NumericTraits<CoordRepType>::ZeroValue() || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }
@@ -488,12 +488,12 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessian(const 
     {
       p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
     }
-    if (p[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
+    if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<RealType>::ZeroValue();
+      p[i] = RealType{};
     }
 
-    if (p[i] < NumericTraits<CoordRepType>::ZeroValue() || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -362,7 +362,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::BeforeT
       this->m_DeltaLatticePerThread[n] = PointDataImageType::New();
       this->m_DeltaLatticePerThread[n]->SetRegions(size);
       this->m_DeltaLatticePerThread[n]->Allocate();
-      this->m_DeltaLatticePerThread[n]->FillBuffer(NumericTraits<PointDataType>::ZeroValue());
+      this->m_DeltaLatticePerThread[n]->FillBuffer(PointDataType{});
     }
   }
 }
@@ -470,12 +470,12 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
       {
         p[i] = static_cast<RealType>(totalNumberOfSpans) - epsilon[i];
       }
-      if (p[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(p[i]) <= epsilon[i])
+      if (p[i] < RealType{} && itk::Math::abs(p[i]) <= epsilon[i])
       {
-        p[i] = NumericTraits<RealType>::ZeroValue();
+        p[i] = RealType{};
       }
 
-      if (p[i] < NumericTraits<RealType>::ZeroValue() || p[i] >= static_cast<RealType>(totalNumberOfSpans))
+      if (p[i] < RealType{} || p[i] >= static_cast<RealType>(totalNumberOfSpans))
       {
         itkExceptionMacro("The reparameterized point component "
                           << p[i] << " is outside the corresponding parametric domain of [0, " << totalNumberOfSpans
@@ -623,12 +623,12 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
       {
         U[i] = static_cast<RealType>(totalNumberOfSpans[i]) - epsilon[i];
       }
-      if (U[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(U[i]) <= epsilon[i])
+      if (U[i] < RealType{} && itk::Math::abs(U[i]) <= epsilon[i])
       {
-        U[i] = NumericTraits<RealType>::ZeroValue();
+        U[i] = RealType{};
       }
 
-      if (U[i] < NumericTraits<RealType>::ZeroValue() || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
+      if (U[i] < RealType{} || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
       {
         itkExceptionMacro("The collapse point component "
                           << U[i] << " is outside the corresponding parametric domain of [0, " << totalNumberOfSpans[i]
@@ -705,7 +705,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
     this->m_PhiLattice = PointDataImageType::New();
     this->m_PhiLattice->SetRegions(size);
     this->m_PhiLattice->Allocate();
-    this->m_PhiLattice->FillBuffer(NumericTraits<PointDataType>::ZeroValue());
+    this->m_PhiLattice->FillBuffer(PointDataType{});
 
     ImageRegionIterator<PointDataImageType> ItP(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
 
@@ -713,7 +713,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
     {
       PointDataType P;
       P.Fill(0);
-      if (Math::NotAlmostEquals(ItO.Get(), NumericTraits<typename PointDataType::ValueType>::ZeroValue()))
+      if (Math::NotAlmostEquals(ItO.Get(), typename PointDataType::ValueType{}))
       {
         P = ItD.Get() / ItO.Get();
         for (unsigned int i = 0; i < P.Size(); ++i)
@@ -963,12 +963,12 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
       {
         U[i] = static_cast<RealType>(totalNumberOfSpans[i]) - epsilon[i];
       }
-      if (U[i] < NumericTraits<RealType>::ZeroValue() && itk::Math::abs(U[i]) <= epsilon[i])
+      if (U[i] < RealType{} && itk::Math::abs(U[i]) <= epsilon[i])
       {
-        U[i] = NumericTraits<RealType>::ZeroValue();
+        U[i] = RealType{};
       }
 
-      if (U[i] < NumericTraits<RealType>::ZeroValue() || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
+      if (U[i] < RealType{} || U[i] >= static_cast<RealType>(totalNumberOfSpans[i]))
       {
         itkExceptionMacro("The collapse point component "
                           << U[i] << " is outside the corresponding parametric domain of [0, " << totalNumberOfSpans[i]

--- a/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 ConstantPadImageFilter<TInputImage, TOutputImage>::ConstantPadImageFilter()
 {
-  m_InternalBoundaryCondition.SetConstant(NumericTraits<OutputImagePixelType>::ZeroValue());
+  m_InternalBoundaryCondition.SetConstant(OutputImagePixelType{});
   this->InternalSetBoundaryCondition(&m_InternalBoundaryCondition);
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 CyclicShiftImageFilter<TInputImage, TOutputImage>::CyclicShiftImageFilter()
 {
-  m_Shift.Fill(NumericTraits<OffsetValueType>::ZeroValue());
+  m_Shift.Fill(OffsetValueType{});
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();
 }

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -64,7 +64,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
 
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
   {
-    if (It.Get() != itk::NumericTraits<PixelType>::ZeroValue())
+    if (It.Get() != PixelType{})
     {
       // We extract both the 2-D location of the point
       // and the pixel value of that point.

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -145,7 +145,7 @@ public:
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
-    if (itk::Math::NotAlmostEquals(B, NumericTraits<TInput2>::ZeroValue()))
+    if (itk::Math::NotAlmostEquals(B, TInput2{}))
     {
       return (TOutput)(A / B);
     }
@@ -169,7 +169,7 @@ public:
   DivideOrZeroOut()
   {
     m_Threshold = 1e-5 * NumericTraits<TDenominator>::OneValue();
-    m_Constant = NumericTraits<TOutput>::ZeroValue();
+    m_Constant = TOutput{};
   };
 
   ~DivideOrZeroOut() = default;
@@ -218,7 +218,7 @@ public:
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
-    if (B != NumericTraits<TInput2>::ZeroValue())
+    if (B != TInput2{})
     {
       return static_cast<TOutput>(A % B);
     }

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -104,8 +104,7 @@ protected:
 
     const auto * input =
       dynamic_cast<const typename Superclass::DecoratedInput2ImagePixelType *>(this->ProcessObject::GetInput(1));
-    if (input != nullptr &&
-        itk::Math::AlmostEquals(input->Get(), itk::NumericTraits<typename TInputImage2::PixelType>::ZeroValue()))
+    if (input != nullptr && itk::Math::AlmostEquals(input->Get(), typename TInputImage2::PixelType{}))
     {
       itkGenericExceptionMacro("The constant value used as denominator should not be set to zero");
     }

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -27,10 +27,10 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename THistogramMeasurement>
 HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::HistogramMatchingImageFilter()
-  : m_SourceMinValue(NumericTraits<THistogramMeasurement>::ZeroValue())
-  , m_SourceMaxValue(NumericTraits<THistogramMeasurement>::ZeroValue())
-  , m_ReferenceMinValue(NumericTraits<THistogramMeasurement>::ZeroValue())
-  , m_ReferenceMaxValue(NumericTraits<THistogramMeasurement>::ZeroValue())
+  : m_SourceMinValue(THistogramMeasurement{})
+  , m_SourceMaxValue(THistogramMeasurement{})
+  , m_ReferenceMinValue(THistogramMeasurement{})
+  , m_ReferenceMaxValue(THistogramMeasurement{})
   , m_SourceHistogram(HistogramType::New())
   , m_OutputHistogram(HistogramType::New())
 
@@ -437,7 +437,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
   typename HistogramType::IndexType             index(1);
   typename HistogramType::MeasurementVectorType measurement(1);
   using MeasurementType = typename HistogramType::MeasurementType;
-  measurement[0] = NumericTraits<MeasurementType>::ZeroValue();
+  measurement[0] = MeasurementType{};
 
   {
     // put each image pixel into the histogram

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -63,7 +63,7 @@ public:
   LogicOpBase()
   {
     m_ForegroundValue = itk::NumericTraits<TOutput>::OneValue();
-    m_BackgroundValue = itk::NumericTraits<TOutput>::ZeroValue();
+    m_BackgroundValue = TOutput{};
   }
 
   ~LogicOpBase() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -94,7 +94,7 @@ private:
   TPixelType
   DefaultOutsideValue(TPixelType *)
   {
-    return NumericTraits<TPixelType>::ZeroValue();
+    return TPixelType{};
   }
 
   template <typename TValue>
@@ -274,12 +274,12 @@ private:
     // output image. If not, throw an exception.
     VariableLengthVector<TValue> currentValue = this->GetFunctor().GetOutsideValue();
     VariableLengthVector<TValue> zeroVector(currentValue.GetSize());
-    zeroVector.Fill(NumericTraits<TValue>::ZeroValue());
+    zeroVector.Fill(TValue{});
 
     if (currentValue == zeroVector)
     {
       zeroVector.SetSize(this->GetOutput()->GetVectorLength());
-      zeroVector.Fill(NumericTraits<TValue>::ZeroValue());
+      zeroVector.Fill(TValue{});
       this->GetFunctor().SetOutsideValue(zeroVector);
     }
     else if (this->GetFunctor().GetOutsideValue().GetSize() != this->GetOutput()->GetVectorLength())

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -92,7 +92,7 @@ private:
   TPixelType
   DefaultOutsideValue(TPixelType *)
   {
-    return NumericTraits<TPixelType>::ZeroValue();
+    return TPixelType{};
   }
 
   template <typename TValue>
@@ -273,12 +273,12 @@ private:
     // output image. If not, throw an exception.
     VariableLengthVector<TValue> currentValue = this->GetFunctor().GetOutsideValue();
     VariableLengthVector<TValue> zeroVector(currentValue.GetSize());
-    zeroVector.Fill(NumericTraits<TValue>::ZeroValue());
+    zeroVector.Fill(TValue{});
 
     if (currentValue == zeroVector)
     {
       zeroVector.SetSize(this->GetOutput()->GetVectorLength());
-      zeroVector.Fill(NumericTraits<TValue>::ZeroValue());
+      zeroVector.Fill(TValue{});
       this->GetFunctor().SetOutsideValue(zeroVector);
     }
     else if (this->GetFunctor().GetOutsideValue().GetSize() != this->GetOutput()->GetVectorLength())

--- a/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
@@ -38,7 +38,7 @@ public:
   inline TOutput
   operator()(const std::vector<TInput> & B) const
   {
-    AccumulatorType sum = NumericTraits<TOutput>::ZeroValue();
+    AccumulatorType sum = TOutput{};
 
     for (unsigned int i = 0; i < B.size(); ++i)
     {

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
@@ -39,7 +39,7 @@ RescaleIntensityImageFilter<TInputImage, TOutputImage>::RescaleIntensityImageFil
   : m_Scale(1.0)
   , m_Shift(0.0)
   , m_InputMinimum(NumericTraits<InputPixelType>::max())
-  , m_InputMaximum(NumericTraits<InputPixelType>::ZeroValue())
+  , m_InputMaximum(InputPixelType{})
   , m_OutputMinimum(NumericTraits<OutputPixelType>::NonpositiveMin())
   , m_OutputMaximum(NumericTraits<OutputPixelType>::max())
 {}
@@ -69,8 +69,7 @@ RescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
     this->m_Scale = (static_cast<RealType>(this->m_OutputMaximum) - static_cast<RealType>(this->m_OutputMinimum)) /
                     (static_cast<RealType>(this->m_InputMaximum) - static_cast<RealType>(this->m_InputMinimum));
   }
-  else if (itk::Math::NotAlmostEquals(this->m_InputMaximum,
-                                      NumericTraits<typename NumericTraits<InputPixelType>::ValueType>::ZeroValue()))
+  else if (itk::Math::NotAlmostEquals(this->m_InputMaximum, typename NumericTraits<InputPixelType>::ValueType{}))
   {
     this->m_Scale = (static_cast<RealType>(this->m_OutputMaximum) - static_cast<RealType>(this->m_OutputMinimum)) /
                     static_cast<RealType>(this->m_InputMaximum);

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -37,15 +37,15 @@ template <typename TInputImage, typename TOutputImage>
 VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::VectorRescaleIntensityImageFilter()
   : m_Scale(1.0)
   , m_Shift(1.0)
-  , m_InputMaximumMagnitude(NumericTraits<InputRealType>::ZeroValue())
-  , m_OutputMaximumMagnitude(NumericTraits<OutputRealType>::ZeroValue())
+  , m_InputMaximumMagnitude(InputRealType{})
+  , m_OutputMaximumMagnitude(OutputRealType{})
 {}
 
 template <typename TInputImage, typename TOutputImage>
 void
 VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  if (m_OutputMaximumMagnitude < NumericTraits<OutputRealType>::ZeroValue())
+  if (m_OutputMaximumMagnitude < OutputRealType{})
   {
     itkExceptionMacro("Maximum output value cannot be negative. You are passing " << m_OutputMaximumMagnitude);
   }

--- a/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
@@ -107,8 +107,7 @@ itkVectorRescaleIntensityImageFilterTest(int, char *[])
     const OutputPixelType outputValue = ot.Get();
     for (unsigned int k = 0; k < VectorDimension; ++k)
     {
-      if (itk::Math::NotAlmostEquals(outputValue[k],
-                                     itk::NumericTraits<itk::NumericTraits<OutputPixelType>::ValueType>::ZeroValue()))
+      if (itk::Math::NotAlmostEquals(outputValue[k], itk::NumericTraits<OutputPixelType>::ValueType{}))
       {
         if (!itk::Math::FloatAlmostEqual(
               static_cast<double>(outputValue[k]), static_cast<double>(pixelValue[k] * factor), 10, tolerance))

--- a/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
@@ -46,7 +46,7 @@ itkChangeLabelImageFilterTest(int, char *[])
 
   // limit to a few labels
   InputPixelType upper = 10;
-  source->SetMin(itk::NumericTraits<InputPixelType>::ZeroValue());
+  source->SetMin(InputPixelType{});
   source->SetMax(upper);
   source->SetSize(sizeArray);
 

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
@@ -31,7 +31,7 @@ PeakSignalToNoiseRatioCalculator<TInputImage>::PeakSignalToNoiseRatioCalculator(
   m_Valid = false;
   m_Image = nullptr;
   m_NoisyImage = nullptr;
-  m_Output = NumericTraits<InputPixelType>::ZeroValue();
+  m_Output = InputPixelType{};
 }
 
 template <class TInputImage>

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -33,13 +33,13 @@ ImageMomentsCalculator<TImage>::ImageMomentsCalculator()
   m_Valid = false;
   m_Image = nullptr;
   m_SpatialObjectMask = nullptr;
-  m_M0 = NumericTraits<ScalarType>::ZeroValue();
-  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
-  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
-  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
-  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
-  m_Pm.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
-  m_Pa.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  m_M0 = ScalarType{};
+  m_M1.Fill(typename VectorType::ValueType{});
+  m_M2.Fill(typename MatrixType::ValueType{});
+  m_Cg.Fill(typename VectorType::ValueType{});
+  m_Cm.Fill(typename MatrixType::ValueType{});
+  m_Pm.Fill(typename VectorType::ValueType{});
+  m_Pa.Fill(typename MatrixType::ValueType{});
 }
 
 //----------------------------------------------------------------------
@@ -65,11 +65,11 @@ template <typename TImage>
 void
 ImageMomentsCalculator<TImage>::Compute()
 {
-  m_M0 = NumericTraits<ScalarType>::ZeroValue();
-  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
-  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
-  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
-  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  m_M0 = ScalarType{};
+  m_M1.Fill(typename VectorType::ValueType{});
+  m_M2.Fill(typename MatrixType::ValueType{});
+  m_Cg.Fill(typename VectorType::ValueType{});
+  m_Cm.Fill(typename MatrixType::ValueType{});
 
   using IndexType = typename ImageType::IndexType;
 

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -149,7 +149,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetTotalOverlap() const -> RealTyp
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }
@@ -200,7 +200,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap() const -> RealTyp
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }
@@ -267,7 +267,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity() const -> Rea
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }
@@ -310,7 +310,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError() const -> R
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }
@@ -364,7 +364,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> R
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }
@@ -421,7 +421,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseDiscoveryRate() const -> R
   for (auto mapIt = this->m_LabelSetMeasures.begin(); mapIt != this->m_LabelSetMeasures.end(); ++mapIt)
   {
     // Do not include the background in the final value.
-    if (mapIt->first == NumericTraits<LabelType>::ZeroValue())
+    if (mapIt->first == LabelType{})
     {
       continue;
     }

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -122,18 +122,18 @@ public:
     LabelStatistics()
     {
       // initialized to the default values
-      m_Count = NumericTraits<IdentifierType>::ZeroValue();
-      m_Sum = NumericTraits<RealType>::ZeroValue();
-      m_SumOfSquares = NumericTraits<RealType>::ZeroValue();
+      m_Count = IdentifierType{};
+      m_Sum = RealType{};
+      m_SumOfSquares = RealType{};
 
       // Set such that the first pixel encountered can be compared
       m_Minimum = NumericTraits<RealType>::max();
       m_Maximum = NumericTraits<RealType>::NonpositiveMin();
 
       // Default these to zero
-      m_Mean = NumericTraits<RealType>::ZeroValue();
-      m_Sigma = NumericTraits<RealType>::ZeroValue();
-      m_Variance = NumericTraits<RealType>::ZeroValue();
+      m_Mean = RealType{};
+      m_Sigma = RealType{};
+      m_Variance = RealType{};
 
       const unsigned int imageDimension = Self::ImageDimension;
       m_BoundingBox.resize(imageDimension * 2);
@@ -149,18 +149,18 @@ public:
     LabelStatistics(int size, RealType lowerBound, RealType upperBound)
     {
       // initialized to the default values
-      m_Count = NumericTraits<IdentifierType>::ZeroValue();
-      m_Sum = NumericTraits<RealType>::ZeroValue();
-      m_SumOfSquares = NumericTraits<RealType>::ZeroValue();
+      m_Count = IdentifierType{};
+      m_Sum = RealType{};
+      m_SumOfSquares = RealType{};
 
       // Set such that the first pixel encountered can be compared
       m_Minimum = NumericTraits<RealType>::max();
       m_Maximum = NumericTraits<RealType>::NonpositiveMin();
 
       // Default these to zero
-      m_Mean = NumericTraits<RealType>::ZeroValue();
-      m_Sigma = NumericTraits<RealType>::ZeroValue();
-      m_Variance = NumericTraits<RealType>::ZeroValue();
+      m_Mean = RealType{};
+      m_Sigma = RealType{};
+      m_Variance = RealType{};
 
       const unsigned int imageDimension = Self::ImageDimension;
       m_BoundingBox.resize(imageDimension * 2);

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -137,7 +137,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::AfterStreamedGenerateData(
     }
     else
     {
-      labelStats.m_Variance = NumericTraits<RealType>::ZeroValue();
+      labelStats.m_Variance = RealType{};
     }
 
     // sigma
@@ -323,7 +323,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType lab
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<PixelType>::ZeroValue();
+    return PixelType{};
   }
   else
   {
@@ -341,7 +341,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType labe
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<PixelType>::ZeroValue();
+    return PixelType{};
   }
   else
   {
@@ -359,7 +359,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType la
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<PixelType>::ZeroValue();
+    return PixelType{};
   }
   else
   {
@@ -377,7 +377,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<PixelType>::ZeroValue();
+    return PixelType{};
   }
   else
   {

--- a/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
@@ -53,12 +53,12 @@ public:
 
   MeanAccumulator(SizeValueType size) { m_Size = size; }
 
-  ~MeanAccumulator() { m_Size = NumericTraits<SizeValueType>::ZeroValue(); }
+  ~MeanAccumulator() { m_Size = SizeValueType{}; }
 
   inline void
   Initialize()
   {
-    m_Sum = NumericTraits<TAccumulate>::ZeroValue();
+    m_Sum = TAccumulate{};
   }
 
   inline void

--- a/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
@@ -63,7 +63,7 @@ public:
   inline void
   Initialize()
   {
-    m_Sum = NumericTraits<TAccumulate>::ZeroValue();
+    m_Sum = TAccumulate{};
     m_Values.clear();
   }
 
@@ -80,7 +80,7 @@ public:
     // to avoid division by zero
     if (m_Size <= 1)
     {
-      return NumericTraits<RealType>::ZeroValue();
+      return RealType{};
     }
 
     typename NumericTraits<TInputPixel>::RealType mean = ((RealType)m_Sum) / m_Size;

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -34,8 +34,8 @@ StatisticsImageFilter<TInputImage>::StatisticsImageFilter()
   Self::SetMean(NumericTraits<RealType>::max());
   Self::SetSigma(NumericTraits<RealType>::max());
   Self::SetVariance(NumericTraits<RealType>::max());
-  Self::SetSum(NumericTraits<RealType>::ZeroValue());
-  Self::SetSumOfSquares(NumericTraits<RealType>::ZeroValue());
+  Self::SetSum(RealType{});
+  Self::SetSumOfSquares(RealType{});
 }
 
 template <typename TInputImage>
@@ -60,9 +60,9 @@ StatisticsImageFilter<TInputImage>::BeforeStreamedGenerateData()
   Superclass::BeforeStreamedGenerateData();
 
   // Resize the thread temporaries
-  m_Count = NumericTraits<SizeValueType>::ZeroValue();
-  m_SumOfSquares = NumericTraits<RealType>::ZeroValue();
-  m_ThreadSum = NumericTraits<RealType>::ZeroValue();
+  m_Count = SizeValueType{};
+  m_SumOfSquares = RealType{};
+  m_ThreadSum = RealType{};
   m_ThreadMin = NumericTraits<PixelType>::max();
   m_ThreadMax = NumericTraits<PixelType>::NonpositiveMin();
 }
@@ -99,8 +99,8 @@ void
 StatisticsImageFilter<TInputImage>::ThreadedStreamedGenerateData(const RegionType & regionForThread)
 {
 
-  CompensatedSummation<RealType> sum = NumericTraits<RealType>::ZeroValue();
-  CompensatedSummation<RealType> sumOfSquares = NumericTraits<RealType>::ZeroValue();
+  CompensatedSummation<RealType> sum = RealType{};
+  CompensatedSummation<RealType> sumOfSquares = RealType{};
   SizeValueType                  count{};
   PixelType                      min = NumericTraits<PixelType>::max();
   PixelType                      max = NumericTraits<PixelType>::NonpositiveMin();

--- a/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
@@ -56,7 +56,7 @@ public:
   inline void
   Initialize()
   {
-    m_Sum = NumericTraits<TOutputPixel>::ZeroValue();
+    m_Sum = TOutputPixel{};
   }
 
   inline void

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -98,7 +98,7 @@ itkImageMomentsTest(int argc, char * argv[])
   image->SetSpacing(spacing);
   image->Allocate();
 
-  image->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+  image->FillBuffer(PixelType{});
 
   /* Set a few mass points within the image */
   /* FIXME: The method used here to set the points is klutzy,

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
@@ -45,7 +45,7 @@ protected:
 
 
     static typename ImageType::Pointer
-    CreateImage(PixelType fillValue = itk::NumericTraits<PixelType>::ZeroValue())
+    CreateImage(PixelType fillValue = PixelType{})
     {
       auto image = ImageType::New();
 

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <typename TImage, typename TAttributeAccessor>
 AttributeOpeningLabelMapFilter<TImage, TAttributeAccessor>::AttributeOpeningLabelMapFilter()
 {
-  m_Lambda = NumericTraits<AttributeValueType>::ZeroValue();
+  m_Lambda = AttributeValueType{};
   m_ReverseOrdering = false;
   // create the output image for the removed objects
   this->SetNumberOfRequiredOutputs(2);

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 template <typename TInputImage>
 BinaryGrindPeakImageFilter<TInputImage>::BinaryGrindPeakImageFilter()
   : m_ForegroundValue(NumericTraits<InputImagePixelType>::max())
-  , m_BackgroundValue(NumericTraits<InputImagePixelType>::ZeroValue())
+  , m_BackgroundValue(InputImagePixelType{})
 
 {}
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
@@ -117,7 +117,7 @@ public:
 
   /**
    * Set/Get the value used as "background" in the output image.
-   * Defaults to NumericTraits<PixelType>::ZeroValue().
+   * Defaults to PixelType{}.
    */
   itkSetMacro(BackgroundValue, OutputImagePixelType);
   itkGetConstMacro(BackgroundValue, OutputImagePixelType);

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -30,7 +30,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 LabelMapMaskImageFilter<TInputImage, TOutputImage>::LabelMapMaskImageFilter()
   : m_Label(NumericTraits<InputImagePixelType>::OneValue())
-  , m_BackgroundValue(NumericTraits<OutputImagePixelType>::ZeroValue())
+  , m_BackgroundValue(OutputImagePixelType{})
 
 {
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <typename TLabel, unsigned int VImageDimension>
 LabelObject<TLabel, VImageDimension>::LabelObject()
 {
-  m_Label = NumericTraits<LabelType>::ZeroValue();
+  m_Label = LabelType{};
   m_LineContainer.clear();
 }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
@@ -23,9 +23,9 @@ namespace itk
 {
 template <unsigned int VImageDimension>
 LabelObjectLine<VImageDimension>::LabelObjectLine()
-  : m_Length(NumericTraits<SizeValueType>::ZeroValue())
+  : m_Length(SizeValueType{})
 {
-  m_Index.Fill(NumericTraits<IndexValueType>::ZeroValue());
+  m_Index.Fill(IndexValueType{});
 }
 
 template <unsigned int VImageDimension>

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -78,7 +78,7 @@ ObjectByObjectLabelMapFilter<TInputImage,
   m_BI2LM->SetNumberOfWorkUnits(1);
 
   // to be sure that no one will use an uninitialized value
-  m_Label = itk::NumericTraits<InputImagePixelType>::ZeroValue();
+  m_Label = InputImagePixelType{};
 }
 
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -352,7 +352,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   }
   else
   {
-    if (Math::NotAlmostEquals(principalMoments[0], itk::NumericTraits<typename VectorType::ValueType>::ZeroValue()))
+    if (Math::NotAlmostEquals(principalMoments[0], typename VectorType::ValueType{}))
     {
       const double flatnessRatio = principalMoments[1] / principalMoments[0];
       flatness = 0.0;
@@ -361,8 +361,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
         flatness = std::sqrt(flatnessRatio);
       }
     }
-    if (Math::NotAlmostEquals(principalMoments[ImageDimension - 2],
-                              itk::NumericTraits<typename VectorType::ValueType>::ZeroValue()))
+    if (Math::NotAlmostEquals(principalMoments[ImageDimension - 2], typename VectorType::ValueType{}))
     {
       const double elongationRatio = principalMoments[ImageDimension - 1] / principalMoments[ImageDimension - 2];
       elongation = 0.0;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -271,8 +271,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
       elongation = 1;
       flatness = 1;
     }
-    else if (Math::NotAlmostEquals(principalMoments[0],
-                                   itk::NumericTraits<typename VectorType::ValueType>::ZeroValue()))
+    else if (Math::NotAlmostEquals(principalMoments[0], typename VectorType::ValueType{}))
     {
       //    elongation = principalMoments[ImageDimension-1] /
       // principalMoments[0];

--- a/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
@@ -72,7 +72,7 @@ itkStatisticsUniqueLabelMapFilterTest1(int argc, char * argv[])
   using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
   auto labelMapConverter = LabelImageToLabelMapFilterType::New();
   labelMapConverter->SetInput(reader->GetOutput());
-  labelMapConverter->SetBackgroundValue(itk::NumericTraits<PixelType>::ZeroValue());
+  labelMapConverter->SetBackgroundValue(PixelType{});
 
   using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template <typename TImage, typename TKernel, typename TFunction1>
 AnchorErodeDilateImageFilter<TImage, TKernel, TFunction1>::AnchorErodeDilateImageFilter()
-  : m_Boundary(NumericTraits<InputImagePixelType>::ZeroValue())
+  : m_Boundary(InputImagePixelType{})
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -26,8 +26,8 @@ namespace itk
 {
 template <typename TImage, typename TKernel, typename TCompare1, typename TCompare2>
 AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::AnchorOpenCloseImageFilter()
-  : m_Boundary1(NumericTraits<InputImagePixelType>::ZeroValue())
-  , m_Boundary2(NumericTraits<InputImagePixelType>::ZeroValue())
+  : m_Boundary1(InputImagePixelType{})
+  , m_Boundary2(InputImagePixelType{})
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
@@ -44,7 +44,7 @@ BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neigh
   {
     // if structuring element is positive, use the pixel under that element
     // in the image
-    if (*kernel_it > NumericTraits<KernelPixelType>::ZeroValue())
+    if (*kernel_it > KernelPixelType{})
     {
       // note we use GetPixel() on the SmartNeighborhoodIterator to
       // respect boundary conditions

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
@@ -44,7 +44,7 @@ BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neighb
   {
     // if structuring element is positive, use the pixel under that element
     // in the image
-    if (*kernel_it > NumericTraits<KernelPixelType>::ZeroValue())
+    if (*kernel_it > KernelPixelType{})
     {
       // note we use GetPixel() on the NeighborhoodIterator in order
       // to respect boundary conditions.

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
@@ -77,7 +77,7 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::ZeroValue(). */
+   * OutputPixelType{}. */
   itkSetMacro(OutsideValue, OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -33,7 +33,7 @@ DoubleThresholdImageFilter<TInputImage, TOutputImage>::DoubleThresholdImageFilte
   m_Threshold3 = NumericTraits<InputPixelType>::max();
   m_Threshold4 = NumericTraits<InputPixelType>::max();
 
-  m_OutsideValue = NumericTraits<OutputPixelType>::ZeroValue();
+  m_OutsideValue = OutputPixelType{};
   m_InsideValue = NumericTraits<OutputPixelType>::max();
 
   m_FullyConnected = false;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -29,7 +29,7 @@ template <typename TInputImage, typename TOutputImage>
 GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GrayscaleConnectedClosingImageFilter()
 
 {
-  m_Seed.Fill(NumericTraits<typename InputImageIndexType::OffsetValueType>::ZeroValue());
+  m_Seed.Fill(typename InputImageIndexType::OffsetValueType{});
   m_FullyConnected = false;
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -29,7 +29,7 @@ template <typename TInputImage, typename TOutputImage>
 GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GrayscaleConnectedOpeningImageFilter()
 
 {
-  m_Seed.Fill(NumericTraits<typename InputImageIndexType::OffsetValueType>::ZeroValue());
+  m_Seed.Fill(typename InputImageIndexType::OffsetValueType{});
   m_FullyConnected = false;
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
@@ -45,7 +45,7 @@ GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate
   {
     // if structuring element is positive, use the pixel under that element
     // in the image plus the structuring element value
-    if (*kernel_it > NumericTraits<KernelPixelType>::ZeroValue())
+    if (*kernel_it > KernelPixelType{})
     {
       // add the structuring element value to the pixel value, note we use
       // GetPixel() on SmartNeighborhoodIterator to respect boundary

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
@@ -45,7 +45,7 @@ GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(
   {
     // if structuring element is positive, use the pixel under that element
     // in the image minus the structuring element value
-    if (*kernel_it > NumericTraits<KernelPixelType>::ZeroValue())
+    if (*kernel_it > KernelPixelType{})
     {
       // subtract the structuring element value to the pixel value,
       // note we use GetPixel() on SmartNeighborhoodIterator to respect

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -43,9 +43,9 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   MaskedMovingHistogramImageFilter()
 {
   this->SetNumberOfRequiredInputs(2);
-  this->m_FillValue = NumericTraits<OutputPixelType>::ZeroValue();
+  this->m_FillValue = OutputPixelType{};
   this->m_MaskValue = NumericTraits<MaskPixelType>::max();
-  this->m_BackgroundMaskValue = NumericTraits<MaskPixelType>::ZeroValue();
+  this->m_BackgroundMaskValue = MaskPixelType{};
   this->m_GenerateOutputMask = true;
   this->SetGenerateOutputMask(false);
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::MorphologyImageFilter()
 {
-  m_DefaultBoundaryCondition.SetConstant(NumericTraits<PixelType>::ZeroValue());
+  m_DefaultBoundaryCondition.SetConstant(PixelType{});
   m_BoundaryCondition = &m_DefaultBoundaryCondition;
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
@@ -179,7 +179,7 @@ public:
     }
     else
     {
-      return NumericTraits<TInputPixel>::ZeroValue();
+      return TInputPixel{};
     }
   }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.hxx
@@ -25,7 +25,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TKernel, typename THistogram>
 MovingHistogramMorphologyImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::
   MovingHistogramMorphologyImageFilter()
-  : m_Boundary(NumericTraits<PixelType>::ZeroValue())
+  : m_Boundary(PixelType{})
 {}
 
 template <typename TInputImage, typename TOutputImage, typename TKernel, typename THistogram>

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
@@ -26,7 +26,7 @@ namespace itk
 {
 template <typename TImage, typename TKernel, typename TFunction1>
 VanHerkGilWermanErodeDilateImageFilter<TImage, TKernel, TFunction1>::VanHerkGilWermanErodeDilateImageFilter()
-  : m_Boundary(NumericTraits<InputImagePixelType>::ZeroValue())
+  : m_Boundary(InputImagePixelType{})
 {
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -62,7 +62,7 @@ GetImage(const itk::FlatStructuringElement<VDimension> & flatElement)
     }
     else
     {
-      img_it.Set(NumericTraits<PixelType>::ZeroValue());
+      img_it.Set(PixelType{});
     }
   }
   return image;
@@ -103,7 +103,7 @@ itkFlatStructuringElementTest2(int argc, char * argv[])
   using RescaleType = itk::RescaleIntensityImageFilter<ImageUCType, ImageUCType>;
   auto rescale = RescaleType::New();
   rescale->SetInput(testImg);
-  rescale->SetOutputMinimum(itk::NumericTraits<bool>::ZeroValue());
+  rescale->SetOutputMinimum(bool{});
   rescale->SetOutputMaximum(itk::NumericTraits<bool>::OneValue());
 
   using castFilterType = itk::CastImageFilter<ImageUCType, ImageBoolType>;

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -32,7 +32,7 @@ namespace itk
 template <typename TInputImage>
 ContourExtractor2DImageFilter<TInputImage>::ContourExtractor2DImageFilter()
 {
-  this->m_ContourValue = NumericTraits<InputRealType>::ZeroValue();
+  this->m_ContourValue = InputRealType{};
   this->m_ReverseContourOrientation = false;
   this->m_VertexConnectHighPixels = false;
   this->m_LabelContours = false;

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
@@ -131,7 +131,7 @@ public:
 protected:
   ExtractOrthogonalSwath2DImageFilter()
   {
-    m_DefaultPixelValue = NumericTraits<ImagePixelType>::ZeroValue();
+    m_DefaultPixelValue = ImagePixelType{};
     m_Size[0] = 512;
     m_Size[1] = 16 * 2 + 1; // must be odd
     m_Origin[0] = m_Origin[1] = 0.0;

--- a/Modules/Filtering/Path/include/itkPath.h
+++ b/Modules/Filtering/Path/include/itkPath.h
@@ -84,7 +84,7 @@ public:
   virtual inline InputType
   StartOfInput() const
   {
-    return NumericTraits<InputType>::ZeroValue();
+    return InputType{};
   }
 
   /** Where does the path end (what is the last valid input value)?  This value

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -40,7 +40,7 @@ PathToImageFilter<TInputPath, TOutputImage>::PathToImageFilter()
   }
 
   m_PathValue = NumericTraits<ValueType>::OneValue();
-  m_BackgroundValue = NumericTraits<ValueType>::ZeroValue();
+  m_BackgroundValue = ValueType{};
 }
 
 /** Set the Input SpatialObject */

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -26,8 +26,8 @@ namespace itk
 template <typename TInputMesh, typename TOutputMesh>
 CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::CleanQuadEdgeMeshFilter()
 {
-  this->m_AbsoluteTolerance = NumericTraits<InputCoordRepType>::ZeroValue();
-  this->m_RelativeTolerance = NumericTraits<InputCoordRepType>::ZeroValue();
+  this->m_AbsoluteTolerance = InputCoordRepType{};
+  this->m_RelativeTolerance = InputCoordRepType{};
 
   this->m_BoundingBox = BoundingBoxType::New();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -92,7 +92,7 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
 
     if (area < itk::Math::eps)
     {
-      return NumericTraits<OutputCoordRepType>::ZeroValue();
+      return OutputCoordRepType{};
     }
     else
     {
@@ -101,7 +101,7 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
   }
   else
   {
-    return NumericTraits<OutputCoordRepType>::ZeroValue();
+    return OutputCoordRepType{};
   }
 }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -79,7 +79,7 @@ protected:
     this->m_TopologicalChange = true;
     this->m_SizeCriterion = true;
     this->m_NumberOfElements = 0;
-    this->m_MeasureBound = itk::NumericTraits<MeasureType>::ZeroValue();
+    this->m_MeasureBound = MeasureType{};
   }
 
   ~QuadEdgeMeshDecimationCriterion() override = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -47,9 +47,9 @@ public:
 
   // *****************************************************************
   QuadEdgeMeshDecimationQuadricElementHelper()
-    : m_Coefficients(itk::NumericTraits<CoordType>::ZeroValue())
-    , m_A(PointDimension, PointDimension, itk::NumericTraits<CoordType>::ZeroValue())
-    , m_B(itk::NumericTraits<CoordType>::ZeroValue())
+    : m_Coefficients(CoordType{})
+    , m_A(PointDimension, PointDimension, CoordType{})
+    , m_B(CoordType{})
     , m_SVDAbsoluteThreshold(static_cast<CoordType>(1e-6))
     , m_SVDRelativeThreshold(static_cast<CoordType>(1e-3))
   {
@@ -58,8 +58,8 @@ public:
 
   QuadEdgeMeshDecimationQuadricElementHelper(const CoefficientVectorType & iCoefficients)
     : m_Coefficients(iCoefficients)
-    , m_A(PointDimension, PointDimension, itk::NumericTraits<CoordType>::ZeroValue())
-    , m_B(itk::NumericTraits<CoordType>::ZeroValue())
+    , m_A(PointDimension, PointDimension, CoordType{})
+    , m_B(CoordType{})
     , m_SVDAbsoluteThreshold(static_cast<CoordType>(1e-3))
     , m_SVDRelativeThreshold(static_cast<CoordType>(1e-3))
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -164,7 +164,7 @@ public:
       oValue += TriangleHelper<InputPointType>::Cotangent(pt1, ptB, pt2);
     }
 
-    return std::max(NumericTraits<InputCoordRepType>::ZeroValue(), oValue);
+    return std::max(InputCoordRepType{}, oValue);
   }
 };
 

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -125,7 +125,7 @@ BoxAccumulateFunction(const TInputImage *               inputImage,
   itk_impl_details::setConnectivityEarlyBox(&noutIt, true);
 
   ConstantBoundaryCondition<OutputImageType> oBC;
-  oBC.SetConstant(NumericTraits<OutputPixelType>::ZeroValue());
+  oBC.SetConstant(OutputPixelType{});
   noutIt.OverrideBoundaryCondition(&oBC);
   // This uses several iterators. An alternative and probably better
   // approach would be to copy the input to the output and convolve
@@ -618,7 +618,7 @@ BoxSquareAccumulateFunction(const TInputImage *               inputImage,
   itk_impl_details::setConnectivityEarlyBox(&noutIt, true);
 
   ConstantBoundaryCondition<OutputImageType> oBC;
-  oBC.SetConstant(NumericTraits<OutputPixelType>::ZeroValue());
+  oBC.SetConstant(OutputPixelType{});
   noutIt.OverrideBoundaryCondition(&oBC);
   // This uses several iterators. An alternative and probably better
   // approach would be to copy the input to the output and convolve

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -89,7 +89,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
   {
     neighborhoodRange.SetLocation(index);
 
-    auto sum = NumericTraits<InputRealType>::ZeroValue();
+    auto sum = InputRealType{};
 
     for (const InputPixelType pixelValue : neighborhoodRange)
     {

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -206,7 +206,7 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     inputImage->SetRegions(region);
     inputImage->Allocate();
     inputImage->SetSpacing(spacing);
-    inputImage->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+    inputImage->FillBuffer(PixelType{});
 
     IndexType index;
     index[0] = (size[0] - 1) / 2; // the middle pixel
@@ -487,7 +487,7 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     inputImage->SetRegions(region);
     inputImage->Allocate();
     inputImage->SetSpacing(spacing);
-    inputImage->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+    inputImage->FillBuffer(PixelType{});
 
     IndexType index;
     index[0] = (size[0] - 1) / 2; // the middle pixel

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
@@ -71,7 +71,7 @@ public:
   {
     m_LowerThreshold = NumericTraits<TInput>::NonpositiveMin();
     m_UpperThreshold = NumericTraits<TInput>::max();
-    m_OutsideValue = NumericTraits<TOutput>::ZeroValue();
+    m_OutsideValue = TOutput{};
     m_InsideValue = NumericTraits<TOutput>::max();
   }
 
@@ -160,7 +160,7 @@ public:
   using InputPixelObjectType = SimpleDataObjectDecorator<InputPixelType>;
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::ZeroValue(). */
+   * OutputPixelType{}. */
   itkSetMacro(OutsideValue, OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
@@ -36,7 +36,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 BinaryThresholdImageFilter<TInputImage, TOutputImage>::BinaryThresholdImageFilter()
   : m_InsideValue(NumericTraits<OutputPixelType>::max())
-  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_OutsideValue(OutputPixelType{})
 {
   // We are going to create the object with a few default inputs to
   // hold the threshold values.

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
@@ -154,7 +154,7 @@ protected:
   {
     m_ForegroundValue = NumericTraits<OutputPixelType>::max();
     m_BackgroundValue = NumericTraits<OutputPixelType>::NonpositiveMin();
-    m_ThresholdValue = NumericTraits<InputPixelType>::ZeroValue();
+    m_ThresholdValue = InputPixelType{};
   }
 
   ~BinaryThresholdProjectionImageFilter() override = default;

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -138,7 +138,7 @@ public:
   }
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::ZeroValue(). */
+   * OutputPixelType{}. */
   itkSetMacro(OutsideValue, OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -29,8 +29,8 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::HistogramThresholdImageFilter()
   : m_InsideValue(NumericTraits<OutputPixelType>::max())
-  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
-  , m_Threshold(NumericTraits<InputPixelType>::ZeroValue())
+  , m_OutsideValue(OutputPixelType{})
+  , m_Threshold(InputPixelType{})
   , m_MaskValue(NumericTraits<MaskPixelType>::max())
 
 {

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -32,7 +32,7 @@ HuangThresholdCalculator<THistogram, TOutput>::GenerateData()
   const HistogramType * histogram = this->GetInput();
 
   TotalAbsoluteFrequencyType total = histogram->GetTotalFrequency();
-  if (total == NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue())
+  if (total == TotalAbsoluteFrequencyType{})
   {
     itkExceptionMacro("Histogram is empty");
   }

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -26,7 +26,7 @@ namespace itk
 template <typename TInputImage, typename TMaskImage>
 KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::KappaSigmaThresholdImageCalculator()
   : m_MaskValue(NumericTraits<MaskPixelType>::max())
-  , m_Output(NumericTraits<InputPixelType>::ZeroValue())
+  , m_Output(InputPixelType{})
 {}
 
 template <typename TInputImage, typename TMaskImage>

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
@@ -78,7 +78,7 @@ public:
   using MaskImagePointer = typename TMaskImage::Pointer;
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::ZeroValue(). */
+   * OutputPixelType{}. */
   itkSetMacro(OutsideValue, OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
@@ -26,9 +26,9 @@ namespace itk
 template <typename TInputImage, typename TMaskImage, typename TOutputImage>
 KappaSigmaThresholdImageFilter<TInputImage, TMaskImage, TOutputImage>::KappaSigmaThresholdImageFilter()
   : m_MaskValue(NumericTraits<MaskPixelType>::max())
-  , m_Threshold(NumericTraits<InputPixelType>::ZeroValue())
+  , m_Threshold(InputPixelType{})
   , m_InsideValue(NumericTraits<OutputPixelType>::max())
-  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_OutsideValue(OutputPixelType{})
 {}
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage>

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -27,7 +27,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::OtsuMultipleThresholdsCalcula
 
 {
   m_Output.resize(m_NumberOfThresholds);
-  std::fill(m_Output.begin(), m_Output.end(), NumericTraits<MeasurementType>::ZeroValue());
+  std::fill(m_Output.begin(), m_Output.end(), MeasurementType{});
 }
 
 template <typename TInputHistogram>
@@ -77,7 +77,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
       }
       else
       {
-        classMean[j] = NumericTraits<MeanType>::ZeroValue();
+        classMean[j] = MeanType{};
       }
 
       // Set higher thresholds adjacent to their previous ones, and update mean
@@ -92,7 +92,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
         }
         else
         {
-          classMean[k] = NumericTraits<MeanType>::ZeroValue();
+          classMean[k] = MeanType{};
         }
       }
 
@@ -112,7 +112,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
       }
       else
       {
-        classMean[numberOfClasses - 1] = NumericTraits<MeanType>::ZeroValue();
+        classMean[numberOfClasses - 1] = MeanType{};
       }
 
       // Exit the for loop if a threshold has been incremented
@@ -200,7 +200,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
     }
     else
     {
-      classMean[j] = NumericTraits<MeanType>::ZeroValue();
+      classMean[j] = MeanType{};
     }
     meanSum += classMean[j] * static_cast<MeanType>(classFrequency[j]);
   }
@@ -212,7 +212,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
   }
   else
   {
-    classMean[numberOfClasses - 1] = NumericTraits<MeanType>::ZeroValue();
+    classMean[numberOfClasses - 1] = MeanType{};
   }
 
   //
@@ -297,7 +297,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::Compute()
     if (m_ValleyEmphasis)
     {
       // Sum relevant weights to get valley emphasis factor
-      valleyEmphasisFactor = NumericTraits<WeightType>::ZeroValue();
+      valleyEmphasisFactor = WeightType{};
       for (j = 0; j < numberOfClasses - 1; ++j)
       {
         valleyEmphasisFactor += imgPDF[thresholdIndexes[j]];

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -109,10 +109,7 @@ public:
   itkGetConstMacro(NumberOfThresholds, SizeValueType);
 
   /** Set/Get the offset which labels have to start from. Default is 0. */
-  itkSetClampMacro(LabelOffset,
-                   OutputPixelType,
-                   NumericTraits<OutputPixelType>::ZeroValue(),
-                   NumericTraits<OutputPixelType>::max());
+  itkSetClampMacro(LabelOffset, OutputPixelType, OutputPixelType{}, NumericTraits<OutputPixelType>::max());
   itkGetConstMacro(LabelOffset, OutputPixelType);
 
   /** Set/Get the use of valley emphasis. Default is false. */

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -25,7 +25,7 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 OtsuMultipleThresholdsImageFilter<TInputImage, TOutputImage>::OtsuMultipleThresholdsImageFilter()
-  : m_LabelOffset(NumericTraits<OutputPixelType>::ZeroValue())
+  : m_LabelOffset(OutputPixelType{})
 
 {
   m_Thresholds.clear();

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
@@ -32,7 +32,7 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::GenerateData()
   const HistogramType * histogram = this->GetInput();
 
   TotalAbsoluteFrequencyType total = histogram->GetTotalFrequency();
-  if (total == NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue())
+  if (total == TotalAbsoluteFrequencyType{})
   {
     itkExceptionMacro("Histogram is empty");
   }
@@ -188,7 +188,7 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding(con
     double ent_back = 0.0;
     for (InstanceIdentifier ih = 0; ih <= it; ++ih)
     {
-      if (histogram->GetFrequency(ih, 0) != NumericTraits<AbsoluteFrequencyType>::ZeroValue())
+      if (histogram->GetFrequency(ih, 0) != AbsoluteFrequencyType{})
       {
         double x = (normHisto[ih] / P1[it]);
         ent_back -= x * std::log(x);
@@ -199,7 +199,7 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::MaxEntropyThresholding(con
     double ent_obj = 0.0;
     for (InstanceIdentifier ih = it + 1; ih < m_Size; ++ih)
     {
-      if (histogram->GetFrequency(ih, 0) != NumericTraits<AbsoluteFrequencyType>::ZeroValue())
+      if (histogram->GetFrequency(ih, 0) != AbsoluteFrequencyType{})
       {
         double x = (normHisto[ih] / P2[it]);
         ent_obj -= x * std::log(x);

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
@@ -97,7 +97,7 @@ public:
 #endif
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<PixelType>::ZeroValue(). */
+   * PixelType{}. */
   itkSetMacro(OutsideValue, PixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -40,7 +40,7 @@ namespace itk
 
 template <typename TImage>
 ThresholdImageFilter<TImage>::ThresholdImageFilter()
-  : m_OutsideValue(NumericTraits<PixelType>::ZeroValue())
+  : m_OutsideValue(PixelType{})
   , m_Lower(NumericTraits<PixelType>::NonpositiveMin())
   , m_Upper(NumericTraits<PixelType>::max())
 {

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
@@ -197,10 +197,7 @@ public:
   }
 
   /** Set the offset which labels have to start from. */
-  itkSetClampMacro(LabelOffset,
-                   OutputPixelType,
-                   NumericTraits<OutputPixelType>::ZeroValue(),
-                   NumericTraits<OutputPixelType>::max());
+  itkSetClampMacro(LabelOffset, OutputPixelType, OutputPixelType{}, NumericTraits<OutputPixelType>::max());
   itkGetConstMacro(LabelOffset, OutputPixelType);
 
 protected:

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
@@ -35,7 +35,7 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 ThresholdLabelerImageFilter<TInputImage, TOutputImage>::ThresholdLabelerImageFilter()
-  : m_LabelOffset(NumericTraits<OutputPixelType>::ZeroValue())
+  : m_LabelOffset(OutputPixelType{})
 {
   m_Thresholds.clear();
   m_RealThresholds.clear();

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
@@ -47,7 +47,7 @@ itkBinaryThresholdImageFilterTest(int, char *[])
 
   InputImageType::SizeValueType sizeArray[Dimension] = { 3, 3, 3 };
 
-  source->SetMin(itk::NumericTraits<InputPixelType>::ZeroValue());
+  source->SetMin(InputPixelType{});
   source->SetMax(itk::NumericTraits<InputPixelType>::max());
   source->SetSize(sizeArray);
 

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -60,7 +60,7 @@ public:
   itkSetMacro(Value, typename TOutputImage::PixelType);
 
 protected:
-  DemoImageSource() { m_Value = NumericTraits<typename TOutputImage::PixelType>::ZeroValue(); }
+  DemoImageSource() { m_Value = typename TOutputImage::PixelType{}; }
   ~DemoImageSource() override = default;
 
   /** Does the real work. */

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -272,7 +272,7 @@ HDF5ReadWriteTest(const char * fileName)
   }
 
   itk::Array<char> metaDataCharArray2;
-  metaDataCharArray2.Fill(itk::NumericTraits<char>::ZeroValue());
+  metaDataCharArray2.Fill(char{});
   if (!itk::ExposeMetaData<itk::Array<char>>(metaDict2, "TestCharArray", metaDataCharArray2) ||
       metaDataCharArray2 != metaDataCharArray)
   {

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -125,8 +125,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   std::cout << "Image of vector pixels write-read [PASSED]" << std::endl;
 
   std::cout << "Test << operator:: Vector1 = " << vector1 << "[PASSED]" << std::endl;
-  std::cout << "Test NumericTraits<Vector<double,4>>::ZeroValue() " << itk::NumericTraits<PixelType>::ZeroValue()
-            << std::endl;
+  std::cout << "Test NumericTraits<Vector<double,4>>::ZeroValue() " << PixelType{} << std::endl;
   std::cout << "Test NumericTraits <Vector <double,4 > >::OneValue() " << itk::NumericTraits<PixelType>::OneValue()
             << std::endl;
 

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -66,7 +66,7 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
       switch (cnt % 4)
       {
         case 0:
-          i.Set(itk::NumericTraits<PixelType>::ZeroValue());
+          i.Set(PixelType{});
           break;
         case 1:
           i.Set(itk::NumericTraits<PixelType>::OneValue());
@@ -228,7 +228,7 @@ MRCImageIOTester<TImageType>::Read(const std::string & filePrefix, std::string &
       switch (cnt % 4)
       {
         case 0:
-          if (itk::Math::NotExactlyEquals(iter.Get(), itk::NumericTraits<PixelType>::ZeroValue()))
+          if (itk::Math::NotExactlyEquals(iter.Get(), PixelType{}))
           {
             pixelsGood = false;
           }

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -21,11 +21,11 @@
 namespace itk
 {
 MeshIOBase::MeshIOBase()
-  : m_NumberOfPoints(itk::NumericTraits<SizeValueType>::ZeroValue())
-  , m_NumberOfCells(itk::NumericTraits<SizeValueType>::ZeroValue())
-  , m_NumberOfPointPixels(itk::NumericTraits<SizeValueType>::ZeroValue())
-  , m_NumberOfCellPixels(itk::NumericTraits<SizeValueType>::ZeroValue())
-  , m_CellBufferSize(itk::NumericTraits<SizeValueType>::ZeroValue())
+  : m_NumberOfPoints(SizeValueType{})
+  , m_NumberOfCells(SizeValueType{})
+  , m_NumberOfPointPixels(SizeValueType{})
+  , m_NumberOfCellPixels(SizeValueType{})
+  , m_CellBufferSize(SizeValueType{})
 
 {}
 

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
@@ -115,7 +115,7 @@ protected:
   /** Write points to output stream */
   template <typename T>
   void
-  WritePoints(T * buffer, std::ofstream & outputFile, T label = itk::NumericTraits<T>::ZeroValue())
+  WritePoints(T * buffer, std::ofstream & outputFile, T label = T{})
   {
     outputFile.precision(6);
     SizeValueType index = 0;
@@ -131,7 +131,7 @@ protected:
 
   template <typename T>
   void
-  WriteCells(T * buffer, std::ofstream & outputFile, T label = itk::NumericTraits<T>::ZeroValue())
+  WriteCells(T * buffer, std::ofstream & outputFile, T label = T{})
   {
     constexpr unsigned int numberOfCellPoints = 3;
     SizeValueType          index = 0;

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -245,81 +245,78 @@ FreeSurferAsciiMeshIO::WritePoints(void * buffer)
   {
     case IOComponentEnum::UCHAR:
     {
-      WritePoints(static_cast<unsigned char *>(buffer), outputFile, itk::NumericTraits<unsigned char>::ZeroValue());
+      WritePoints(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
     case IOComponentEnum::CHAR:
     {
-      WritePoints(static_cast<char *>(buffer), outputFile, itk::NumericTraits<char>::ZeroValue());
+      WritePoints(static_cast<char *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::USHORT:
     {
-      WritePoints(static_cast<unsigned short *>(buffer), outputFile, itk::NumericTraits<unsigned short>::ZeroValue());
+      WritePoints(static_cast<unsigned short *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::SHORT:
     {
-      WritePoints(static_cast<short *>(buffer), outputFile, itk::NumericTraits<short>::ZeroValue());
+      WritePoints(static_cast<short *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::UINT:
     {
-      WritePoints(static_cast<unsigned int *>(buffer), outputFile, itk::NumericTraits<unsigned int>::ZeroValue());
+      WritePoints(static_cast<unsigned int *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::INT:
     {
-      WritePoints(static_cast<int *>(buffer), outputFile, itk::NumericTraits<int>::ZeroValue());
+      WritePoints(static_cast<int *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::ULONG:
     {
-      WritePoints(static_cast<unsigned long *>(buffer), outputFile, itk::NumericTraits<unsigned long>::ZeroValue());
+      WritePoints(static_cast<unsigned long *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::LONG:
     {
-      WritePoints(static_cast<long *>(buffer), outputFile, itk::NumericTraits<long>::ZeroValue());
+      WritePoints(static_cast<long *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::ULONGLONG:
     {
-      WritePoints(static_cast<unsigned long long *>(buffer),
-                  outputFile,
-                  static_cast<unsigned long long>(itk::NumericTraits<unsigned long>::ZeroValue()));
+      WritePoints(static_cast<unsigned long long *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::LONGLONG:
     {
-      WritePoints(
-        static_cast<long long *>(buffer), outputFile, static_cast<long long>(itk::NumericTraits<long>::ZeroValue()));
+      WritePoints(static_cast<long long *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::FLOAT:
     {
-      WritePoints(static_cast<float *>(buffer), outputFile, 0.0f);
+      WritePoints(static_cast<float *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::DOUBLE:
     {
-      WritePoints(static_cast<double *>(buffer), outputFile, 0.0);
+      WritePoints(static_cast<double *>(buffer), outputFile);
 
       break;
     }
     case IOComponentEnum::LDOUBLE:
     {
-      WritePoints(static_cast<long double *>(buffer), outputFile, itk::NumericTraits<long double>::ZeroValue());
+      WritePoints(static_cast<long double *>(buffer), outputFile);
 
       break;
     }
@@ -396,15 +393,12 @@ FreeSurferAsciiMeshIO::WriteCells(void * buffer)
     }
     case IOComponentEnum::ULONGLONG:
     {
-      WriteCells(static_cast<unsigned long long *>(buffer),
-                 outputFile,
-                 static_cast<unsigned long long>(itk::NumericTraits<unsigned long>::ZeroValue()));
+      WriteCells(static_cast<unsigned long long *>(buffer), outputFile);
       break;
     }
     case IOComponentEnum::LONGLONG:
     {
-      WriteCells(
-        static_cast<long long *>(buffer), outputFile, static_cast<long long>(itk::NumericTraits<long>::ZeroValue()));
+      WriteCells(static_cast<long long *>(buffer), outputFile);
       break;
     }
     case IOComponentEnum::FLOAT:

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -27,7 +27,7 @@ OFFMeshIO::OFFMeshIO()
 {
   this->AddSupportedWriteExtension(".off");
   this->SetByteOrderToBigEndian();
-  m_PointsStartPosition = itk::NumericTraits<StreamOffsetType>::ZeroValue();
+  m_PointsStartPosition = StreamOffsetType{};
   m_TriangleCellType = true;
 }
 

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -740,7 +740,7 @@ protected:
       // documentation.
       if (this->m_NumberOfPointPixelComponents == 3)
       {
-        T zero(itk::NumericTraits<T>::ZeroValue());
+        T zero(T{});
         T e12;
         while (i < num)
         {
@@ -931,7 +931,7 @@ protected:
       const SizeValueType num = this->m_NumberOfCellPixelComponents * this->m_NumberOfCellPixels;
       if (this->m_NumberOfCellPixelComponents == 2)
       {
-        T zero(itk::NumericTraits<T>::ZeroValue());
+        T zero(T{});
         T e12;
         while (i < num)
         {

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -319,8 +319,8 @@ VTKPolyDataMeshIO::ReadMeshInformation()
   }
 
   // Initialize number of cells
-  this->m_NumberOfCells = itk::NumericTraits<SizeValueType>::ZeroValue();
-  this->m_CellBufferSize = itk::NumericTraits<SizeValueType>::ZeroValue();
+  this->m_NumberOfCells = SizeValueType{};
+  this->m_CellBufferSize = SizeValueType{};
   MetaDataDictionary & metaDic = this->GetMetaDataDictionary();
 
   // Searching the vtk file

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -172,7 +172,7 @@ itkRawImageIOTest4(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  value = itk::NumericTraits<PixelType>::ZeroValue();
+  value = PixelType{};
   for (unsigned int i = 0; i < numberOfPixels; ++i)
   {
     PixelType swappedValue = value;

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -723,7 +723,7 @@ WriteTensorBuffer(std::ostream &              os,
   ImageIOBase::SizeType i = 0;
   if (components == 3)
   {
-    PrintType zero(itk::NumericTraits<TComponent>::ZeroValue());
+    PrintType zero(TComponent{});
     PrintType e12;
     while (i < num)
     {

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -114,7 +114,7 @@ public:
         switch (cnt % 4)
         {
           case 0:
-            i.Set(itk::NumericTraits<PixelType>::ZeroValue());
+            i.Set(PixelType{});
             break;
           case 1:
             i.Set(itk::NumericTraits<PixelType>::OneValue());
@@ -123,7 +123,7 @@ public:
             i.Set(itk::NumericTraits<PixelType>::OneValue());
             break;
           case 3:
-            i.Set(itk::NumericTraits<PixelType>::ZeroValue());
+            i.Set(PixelType{});
         }
         ++cnt;
         ++i;
@@ -234,7 +234,7 @@ public:
         {
           case 0:
             // Comparison with complex???
-            if (itk::Math::NotExactlyEquals(iter.Get(), itk::NumericTraits<PixelType>::ZeroValue()))
+            if (itk::Math::NotExactlyEquals(iter.Get(), PixelType{}))
             {
               pixelsGood = false;
             }
@@ -252,7 +252,7 @@ public:
             }
             break;
           case 3:
-            if (itk::Math::NotExactlyEquals(iter.Get(), itk::NumericTraits<PixelType>::ZeroValue()))
+            if (itk::Math::NotExactlyEquals(iter.Get(), PixelType{}))
             {
               pixelsGood = false;
             }

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
@@ -66,7 +66,7 @@ itkVTKImageIO2Test2(int argc, char * argv[])
       switch (cnt * 3 % 5)
       {
         case 0:
-          i.Set(itk::NumericTraits<PixelType>::ZeroValue());
+          i.Set(PixelType{});
           break;
         case 1:
           i.Set(itk::NumericTraits<PixelType>::OneValue());

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -54,7 +54,7 @@ public:
   itkSetMacro(Value, typename TOutputImage::PixelType);
 
 protected:
-  ConstantImageSource() { m_Value = NumericTraits<typename TOutputImage::PixelType>::ZeroValue(); }
+  ConstantImageSource() { m_Value = typename TOutputImage::PixelType{}; }
   ~ConstantImageSource() override = default;
 
   /** Does the real work. */

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -110,7 +110,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
 
   kernelImage->SetRegions(region);
   kernelImage->Allocate();
-  kernelImage->FillBuffer(itk::NumericTraits<TOutput>::ZeroValue());
+  kernelImage->FillBuffer(TOutput{});
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -123,7 +123,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
 
   kernelImage->SetRegions(region);
   kernelImage->Allocate();
-  kernelImage->FillBuffer(itk::NumericTraits<TOutput>::ZeroValue());
+  kernelImage->FillBuffer(TOutput{});
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;
@@ -146,7 +146,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   for (unsigned int i = 0; i < Self::ImageDimension2; ++i)
   {
     // Reset kernel image
-    kernelImage->FillBuffer(itk::NumericTraits<TOutput>::ZeroValue());
+    kernelImage->FillBuffer(TOutput{});
     kernelImage->SetPixel(centerIndex, itk::NumericTraits<TOutput>::OneValue());
 
     for (unsigned int direction = 0; direction < Self::ImageDimension2; ++direction)

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -116,7 +116,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
 
   kernelImage->SetRegions(region);
   kernelImage->Allocate();
-  kernelImage->FillBuffer(itk::NumericTraits<TOutput>::ZeroValue());
+  kernelImage->FillBuffer(TOutput{});
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;
@@ -154,7 +154,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
       ++orderArray[j];
 
       // Reset kernel image
-      kernelImage->FillBuffer(itk::NumericTraits<TOutput>::ZeroValue());
+      kernelImage->FillBuffer(TOutput{});
       kernelImage->SetPixel(centerIndex, itk::NumericTraits<TOutput>::OneValue());
 
       for (unsigned int direction = 0; direction < Self::ImageDimension2; ++direction)

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 
 template <typename TDisplacementField, typename TOutputImage>
 GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GridForwardWarpImageFilter()
-  : m_BackgroundValue(NumericTraits<PixelType>::ZeroValue())
+  : m_BackgroundValue(PixelType{})
   , m_ForegroundValue(NumericTraits<PixelType>::OneValue())
 {}
 

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -157,7 +157,7 @@ public:
     {
       // initialized to the default values
       this->m_Label = 0;
-      this->m_Sum = NumericTraits<RealType>::ZeroValue();
+      this->m_Sum = RealType{};
 
       const unsigned int imageDimension = Self::ImageDimension;
 

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -621,7 +621,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetIntegratedIntensity(L
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -640,7 +640,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelTy
   {
     // label does not exist, return a default value
     LabelPointType emptyCentroid;
-    emptyCentroid.Fill(NumericTraits<typename LabelPointType::ValueType>::ZeroValue());
+    emptyCentroid.Fill(typename LabelPointType::ValueType{});
     return emptyCentroid;
   }
   else
@@ -661,7 +661,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetWeightedCentroid(Labe
   {
     // label does not exist, return a default value
     LabelPointType emptyCentroid;
-    emptyCentroid.Fill(NumericTraits<typename LabelPointType::ValueType>::ZeroValue());
+    emptyCentroid.Fill(typename LabelPointType::ValueType{});
     return emptyCentroid;
   }
   else
@@ -719,7 +719,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixel
   {
     // label does not exist, return a default value
     LabelPointType emptyAxesLength;
-    emptyAxesLength.Fill(NumericTraits<typename AxesLengthType::ValueType>::ZeroValue());
+    emptyAxesLength.Fill(typename AxesLengthType::ValueType{});
     return emptyAxesLength;
   }
   else
@@ -756,7 +756,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEccentricity(LabelPix
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -774,7 +774,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetElongation(LabelPixel
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -792,7 +792,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientation(LabelPixe
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -810,7 +810,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixe
   if (mapIt == m_LabelGeometryMapper.end())
   {
     BoundingBoxType emptyBox;
-    emptyBox.Fill(NumericTraits<typename BoundingBoxType::ValueType>::ZeroValue());
+    emptyBox.Fill(typename BoundingBoxType::ValueType{});
     // label does not exist, return a default value
     return emptyBox;
   }
@@ -830,7 +830,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxVolume(Lab
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -849,7 +849,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(Label
   {
     // label does not exist, return a default value
     LabelSizeType emptySize;
-    emptySize.Fill(NumericTraits<typename LabelSizeType::SizeValueType>::ZeroValue());
+    emptySize.Fill(typename LabelSizeType::SizeValueType{});
     return emptySize;
   }
   else
@@ -891,7 +891,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVo
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    return NumericTraits<RealType>::ZeroValue();
+    return RealType{};
   }
   else
   {
@@ -911,10 +911,10 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxSi
   {
     // label does not exist, return a default value
     //     LabelSizeType emptySize;
-    //     emptySize.Fill( NumericTraits<LabelSizeType::SizeValueType>::ZeroValue());
+    //     emptySize.Fill( LabelSizeType::SizeValueType{});
     //     return emptySize;
     LabelPointType emptySize;
-    emptySize.Fill(NumericTraits<typename LabelPointType::ValueType>::ZeroValue());
+    emptySize.Fill(typename LabelPointType::ValueType{});
     return emptySize;
   }
   else
@@ -935,7 +935,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxOr
   {
     // label does not exist, return a default value
     LabelPointType emptySize;
-    emptySize.Fill(NumericTraits<typename LabelPointType::ValueType>::ZeroValue());
+    emptySize.Fill(typename LabelPointType::ValueType{});
     return emptySize;
   }
   else

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1331,7 +1331,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   // Get the output pointer and clear its contents
   OutputImagePointer output = this->GetOutput();
 
-  output->FillBuffer(NumericTraits<OutputPixelType>::ZeroValue());
+  output->FillBuffer(OutputPixelType{});
 
   // Set the values in the levelset image for the active layer.
   this->InitializeActiveLayerValues();

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -34,12 +34,12 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::RegionBasedLevelSetF
   m_Lambda1 = NumericTraits<ScalarValueType>::OneValue();
   m_Lambda2 = NumericTraits<ScalarValueType>::OneValue();
 
-  m_OverlapPenaltyWeight = NumericTraits<ScalarValueType>::ZeroValue();
-  m_AreaWeight = NumericTraits<ScalarValueType>::ZeroValue();
-  m_VolumeMatchingWeight = NumericTraits<ScalarValueType>::ZeroValue();
-  m_ReinitializationSmoothingWeight = NumericTraits<ScalarValueType>::ZeroValue();
-  m_CurvatureWeight = m_AdvectionWeight = NumericTraits<ScalarValueType>::ZeroValue();
-  m_Volume = NumericTraits<ScalarValueType>::ZeroValue();
+  m_OverlapPenaltyWeight = ScalarValueType{};
+  m_AreaWeight = ScalarValueType{};
+  m_VolumeMatchingWeight = ScalarValueType{};
+  m_ReinitializationSmoothingWeight = ScalarValueType{};
+  m_CurvatureWeight = m_AdvectionWeight = ScalarValueType{};
+  m_Volume = ScalarValueType{};
 
   m_FunctionId = 0;
 
@@ -62,7 +62,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::InitializeZeroVector
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    ans[i] = NumericTraits<ScalarValueType>::ZeroValue();
+    ans[i] = ScalarValueType{};
   }
 
   return ans;
@@ -156,9 +156,9 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeGlobalTimeSte
   }
 
   // Reset the values
-  d->m_MaxCurvatureChange = NumericTraits<ScalarValueType>::ZeroValue();
-  d->m_MaxGlobalChange = NumericTraits<ScalarValueType>::ZeroValue();
-  d->m_MaxAdvectionChange = NumericTraits<ScalarValueType>::ZeroValue();
+  d->m_MaxCurvatureChange = ScalarValueType{};
+  d->m_MaxGlobalChange = ScalarValueType{};
+  d->m_MaxAdvectionChange = ScalarValueType{};
 
   return dt;
 }
@@ -253,7 +253,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
   ScalarValueType curvature{};
   ScalarValueType globalTerm{};
   VectorType      advection_field;
-  ScalarValueType x_energy, advection_term = NumericTraits<ScalarValueType>::ZeroValue();
+  ScalarValueType x_energy, advection_term = ScalarValueType{};
 
   // Access the global data structure
   auto * gd = (GlobalDataStruct *)globalData;
@@ -264,7 +264,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
 
   // Computing the curvature term
   // Used to regularized using the length of contour
-  if ((dh != 0.) && (this->m_CurvatureWeight != NumericTraits<ScalarValueType>::ZeroValue()))
+  if ((dh != 0.) && (this->m_CurvatureWeight != ScalarValueType{}))
   {
     curvature = this->ComputeCurvature(it, offset, gd);
     curvature_term = this->m_CurvatureWeight * curvature * this->CurvatureSpeed(it, offset, gd) * dh;
@@ -274,14 +274,14 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
 
   // Computing the laplacian term
   // Used in maintaining squared distance function
-  if (this->m_ReinitializationSmoothingWeight != NumericTraits<ScalarValueType>::ZeroValue())
+  if (this->m_ReinitializationSmoothingWeight != ScalarValueType{})
   {
     laplacian_term = this->ComputeLaplacian(gd) - curvature;
 
     laplacian_term *= this->m_ReinitializationSmoothingWeight * this->LaplacianSmoothingSpeed(it, offset, gd);
   }
 
-  if ((dh != 0.) && (m_AdvectionWeight != NumericTraits<ScalarValueType>::ZeroValue()))
+  if ((dh != 0.) && (m_AdvectionWeight != ScalarValueType{}))
   {
     advection_field = this->AdvectionField(it, offset, gd);
 
@@ -290,7 +290,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
       x_energy = m_AdvectionWeight * advection_field[i];
 
       // TODO: Is this condition right ?
-      if (x_energy > NumericTraits<ScalarValueType>::ZeroValue())
+      if (x_energy > ScalarValueType{})
       {
         advection_term += advection_field[i] * gd->m_dx_backward[i];
       }

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
@@ -26,7 +26,7 @@ namespace itk
 {
 template <typename TInputImage, typename TGradientImage>
 RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::RobustAutomaticThresholdCalculator()
-  : m_Output(NumericTraits<InputPixelType>::ZeroValue())
+  : m_Output(InputPixelType{})
 {}
 
 template <typename TInputImage, typename TGradientImage>

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
@@ -92,7 +92,7 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::ZeroValue(). */
+   * OutputPixelType{}. */
   itkSetMacro(OutsideValue, OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
@@ -26,9 +26,9 @@ namespace itk
 {
 template <typename TInputImage, typename TGradientImage, typename TOutputImage>
 RobustAutomaticThresholdImageFilter<TInputImage, TGradientImage, TOutputImage>::RobustAutomaticThresholdImageFilter()
-  : m_Threshold(NumericTraits<InputPixelType>::ZeroValue())
+  : m_Threshold(InputPixelType{})
   , m_InsideValue(NumericTraits<OutputPixelType>::max())
-  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_OutsideValue(OutputPixelType{})
 {
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
@@ -104,7 +104,7 @@ StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::Ge
     {
       if (this->m_MaskImage && !this->m_MaskImage->GetPixel(It.GetIndex()))
       {
-        ItO.SetCenterPixel(NumericTraits<OutputPixelType>::ZeroValue());
+        ItO.SetCenterPixel(OutputPixelType{});
         progress.CompletedPixel();
         continue;
       }

--- a/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -125,7 +125,7 @@ itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
   output->SetRequestedRegion(inputImage->GetRequestedRegion());
   output->SetBufferedRegion(inputImage->GetBufferedRegion());
   output->Allocate();
-  output->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+  output->FillBuffer(PixelType{});
 
 
   // Step over input and output images

--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -126,7 +126,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
   output->SetRequestedRegion(inputImage->GetRequestedRegion());
   output->SetBufferedRegion(inputImage->GetBufferedRegion());
   output->Allocate();
-  output->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+  output->FillBuffer(PixelType{});
 
 
   // Step over input and output images

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -120,7 +120,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   output->SetRequestedRegion(reader->GetOutput()->GetRequestedRegion());
   output->SetBufferedRegion(reader->GetOutput()->GetBufferedRegion());
   output->Allocate();
-  output->FillBuffer(itk::NumericTraits<PixelType>::ZeroValue());
+  output->FillBuffer(PixelType{});
 
 
   // Step over input and output images

--- a/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
@@ -55,8 +55,8 @@ public:
 
   /** Default constructor. */
   LoadPoint()
-    : m_Point(2, NumericTraits<Float>::ZeroValue())
-    , m_ForcePoint(2, NumericTraits<Float>::ZeroValue())
+    : m_Point(2, Float{})
+    , m_ForcePoint(2, Float{})
   {
     // Default initialization of 2D point and force vector
   }

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -104,7 +104,7 @@ template <unsigned int VDimension>
 auto
 Solver<VDimension>::GetTimeStep() const -> Float
 {
-  return NumericTraits<Float>::ZeroValue();
+  return Float{};
 }
 
 template <unsigned int VDimension>

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
@@ -39,7 +39,7 @@ public:
   TIndexType  m_Index;
   signed char m_NodeState{ 0 };
   BandNode()
-    : m_Data(NumericTraits<TDataType>::ZeroValue())
+    : m_Data(TDataType{})
   {}
 };
 

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -85,7 +85,7 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::GenerateData()
   wui.ThreadFunction = nullptr;
 
   TimeStepType              timeStep;
-  std::vector<TimeStepType> timeStepList(numberOfWorkUnits, NumericTraits<TimeStepType>::ZeroValue());
+  std::vector<TimeStepType> timeStepList(numberOfWorkUnits, TimeStepType{});
   BooleanStdVectorType      validTimeStepList(numberOfWorkUnits, true);
 
   // Implement iterative loop in thread function

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -26,7 +26,7 @@ SingleValuedVnlCostFunctionAdaptor::SingleValuedVnlCostFunctionAdaptor(unsigned 
   m_ScalesInitialized = false;
   m_NegateCostFunction = false;
   m_Reporter = Object::New();
-  m_CachedValue = NumericTraits<MeasureType>::ZeroValue();
+  m_CachedValue = MeasureType{};
   m_CachedDerivative.Fill(0);
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -39,9 +39,9 @@ ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::S
   bool doOnlyInitialization)
 {
   this->m_ConjugateGradient.SetSize(this->m_Metric->GetNumberOfParameters());
-  this->m_ConjugateGradient.Fill(itk::NumericTraits<TInternalComputationValueType>::ZeroValue());
+  this->m_ConjugateGradient.Fill(TInternalComputationValueType{});
   this->m_LastGradient.SetSize(this->m_Metric->GetNumberOfParameters());
-  this->m_LastGradient.Fill(itk::NumericTraits<TInternalComputationValueType>::ZeroValue());
+  this->m_LastGradient.Fill(TInternalComputationValueType{});
   Superclass::StartOptimization(doOnlyInitialization);
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -28,7 +28,7 @@ GradientDescentLineSearchOptimizerv4Template<
 {
   this->m_MaximumLineSearchIterations = 20;
   this->m_LineSearchIterations = 0U;
-  this->m_LowerLimit = itk::NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_LowerLimit = TInternalComputationValueType{};
   this->m_UpperLimit = 5.0;
   this->m_Phi = 1.618034;
   this->m_Resphi = 2 - this->m_Phi;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -27,7 +27,7 @@ GradientDescentLineSearchOptimizerv4Template<
   TInternalComputationValueType>::GradientDescentLineSearchOptimizerv4Template()
 {
   this->m_MaximumLineSearchIterations = 20;
-  this->m_LineSearchIterations = NumericTraits<unsigned int>::ZeroValue();
+  this->m_LineSearchIterations = 0U;
   this->m_LowerLimit = itk::NumericTraits<TInternalComputationValueType>::ZeroValue();
   this->m_UpperLimit = 5.0;
   this->m_Phi = 1.618034;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -43,7 +43,7 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GradientD
   this->m_StopCondition = StopConditionObjectToObjectOptimizerEnum::MAXIMUM_NUMBER_OF_ITERATIONS;
   this->m_StopConditionDescription << this->GetNameOfClass() << ": ";
 
-  this->m_MaximumStepSizeInPhysicalUnits = NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_MaximumStepSizeInPhysicalUnits = TInternalComputationValueType{};
 
   this->m_UseConvergenceMonitoring = true;
   this->m_ConvergenceWindowSize = 50;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -30,7 +30,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::GradientDesce
   , m_CurrentBestValue(NumericTraits<MeasureType>::max())
 
 {
-  this->m_PreviousGradient.Fill(NumericTraits<TInternalComputationValueType>::ZeroValue());
+  this->m_PreviousGradient.Fill(TInternalComputationValueType{});
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -110,7 +110,7 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::StartOptimizati
 {
   itkDebugMacro("StartOptimization");
   auto maxOpt = static_cast<SizeValueType>(this->m_OptimizersList.size());
-  if (maxOpt == NumericTraits<SizeValueType>::ZeroValue())
+  if (maxOpt == SizeValueType{})
   {
     itkExceptionMacro(" No optimizers are set.");
   }

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -414,7 +414,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   else
   {
     VirtualOriginType origin;
-    origin.Fill(NumericTraits<typename VirtualOriginType::ValueType>::ZeroValue());
+    origin.Fill(typename VirtualOriginType::ValueType{});
     return origin;
   }
 }
@@ -541,7 +541,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   if (this->m_NumberOfValidPoints == 0)
   {
     value = NumericTraits<MeasureType>::max();
-    derivative.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+    derivative.Fill(DerivativeValueType{});
     itkWarningMacro("No valid points were found during metric evaluation. "
                     "For image metrics, verify that the images overlap appropriately. "
                     "For instance, you can align the image centers by translation. "

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
@@ -28,7 +28,7 @@ ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::ObjectToObjectM
 {
   // Don't call SetGradientSource, to avoid valgrind warning.
   this->m_GradientSource = GradientSourceEnum::GRADIENT_SOURCE_MOVING;
-  this->m_Value = NumericTraits<MeasureType>::ZeroValue();
+  this->m_Value = MeasureType{};
 }
 
 //-------------------------------------------------------------------

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -36,7 +36,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::QuasiNewtonOptimi
   // rate estimation. it may be initialized either by calling
   // SetMaximumNewtonStepSizeInPhysicalUnits manually or by using m_ScalesEstimator
   // automatically. and the former has higher priority than the latter.
-  this->m_MaximumNewtonStepSizeInPhysicalUnits = NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_MaximumNewtonStepSizeInPhysicalUnits = TInternalComputationValueType{};
 
   /** Threader for Quasi-Newton method */
   using OptimizerType = QuasiNewtonOptimizerv4EstimateNewtonStepThreaderTemplate<TInternalComputationValueType>;
@@ -259,7 +259,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::ResetNewtonStep(I
   const SizeValueType numLocalPara = this->m_Metric->GetNumberOfLocalParameters();
 
   // Initialize Hessian to identity matrix
-  m_HessianArray[loc].Fill(NumericTraits<TInternalComputationValueType>::ZeroValue());
+  m_HessianArray[loc].Fill(TInternalComputationValueType{});
 
   for (unsigned int i = 0; i < numLocalPara; ++i)
   {
@@ -271,7 +271,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::ResetNewtonStep(I
   {
     // Set to zero for invalid Newton steps.
     // They must be defined since they will be used during step scale estimation.
-    this->m_NewtonStep[offset + p] = NumericTraits<TInternalComputationValueType>::ZeroValue();
+    this->m_NewtonStep[offset + p] = TInternalComputationValueType{};
   }
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -287,7 +287,7 @@ RegistrationParameterScalesEstimator<TMetric>::ComputeSquaredJacobianNorms(const
 
     for (SizeValueType p = 0; p < numPara; ++p)
     {
-      squareNorms[p] = NumericTraits<typename ParametersType::ValueType>::ZeroValue();
+      squareNorms[p] = typename ParametersType::ValueType{};
       for (SizeValueType d = 0; d < dim; ++d)
       {
         squareNorms[p] += jacobian[d][p] * jacobian[d][p];
@@ -300,7 +300,7 @@ RegistrationParameterScalesEstimator<TMetric>::ComputeSquaredJacobianNorms(const
 
     for (SizeValueType p = 0; p < numPara; ++p)
     {
-      squareNorms[p] = NumericTraits<typename ParametersType::ValueType>::ZeroValue();
+      squareNorms[p] = typename ParametersType::ValueType{};
       for (SizeValueType d = 0; d < dim; ++d)
       {
         squareNorms[p] += jacobian[d][p] * jacobian[d][p];

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
@@ -38,7 +38,7 @@ RegistrationParameterScalesFromJacobian<TMetric>::EstimateScales(ScalesType & pa
 
   const auto numSamples = static_cast<const SizeValueType>(this->m_SamplePoints.size());
 
-  norms.Fill(NumericTraits<typename ParametersType::ValueType>::ZeroValue());
+  norms.Fill(typename ParametersType::ValueType{});
   parameterScales.Fill(NumericTraits<typename ScalesType::ValueType>::OneValue());
 
   // checking each sample point
@@ -107,7 +107,7 @@ RegistrationParameterScalesFromJacobian<TMetric>::EstimateLocalStepScales(const 
   const SizeValueType numLocals = numAllPara / numPara;
 
   localStepScales.SetSize(numLocals);
-  localStepScales.Fill(NumericTraits<typename ScalesType::ValueType>::ZeroValue());
+  localStepScales.Fill(typename ScalesType::ValueType{});
 
   // checking each sample point
   for (SizeValueType c = 0; c < numSamples; ++c)

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -73,7 +73,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateScales(ScalesType & p
   {
     // For local support, we need to refill deltaParameters with zeros at each loop
     // since smoothing may change the values around the local voxel.
-    deltaParameters.Fill(NumericTraits<typename ParametersType::ValueType>::ZeroValue());
+    deltaParameters.Fill(typename ParametersType::ValueType{});
     deltaParameters[offset + i] = this->m_SmallParameterVariation;
 
     maxShift = this->ComputeMaximumVoxelShift(deltaParameters);
@@ -147,7 +147,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateStepScale(const Param
   }
   if (maxStep <= NumericTraits<FloatType>::epsilon())
   {
-    return NumericTraits<FloatType>::ZeroValue();
+    return FloatType{};
   }
   else
   {
@@ -185,7 +185,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateLocalStepScales(const
   const SizeValueType numLocals = numAllPara / numPara;
 
   localStepScales.SetSize(numLocals);
-  localStepScales.Fill(NumericTraits<typename ScalesType::ValueType>::ZeroValue());
+  localStepScales.Fill(typename ScalesType::ValueType{});
 
   const auto numSamples = static_cast<const SizeValueType>(this->m_SamplePoints.size());
   for (SizeValueType c = 0; c < numSamples; ++c)

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -57,7 +57,7 @@ void
 WindowConvergenceMonitoringFunction<TScalar>::ClearEnergyValues()
 {
   Superclass::ClearEnergyValues();
-  this->m_TotalEnergy = NumericTraits<RealType>::ZeroValue();
+  this->m_TotalEnergy = RealType{};
 }
 
 template <typename TScalar>

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -25,8 +25,8 @@ SingleValuedNonLinearVnlOptimizerv4::SingleValuedNonLinearVnlOptimizerv4()
   this->m_Command = CommandType::New();
   this->m_Command->SetCallbackFunction(this, &SingleValuedNonLinearVnlOptimizerv4::IterationReport);
 
-  this->m_CachedCurrentPosition.Fill(NumericTraits<ParametersType::ValueType>::ZeroValue());
-  this->m_CachedDerivative.Fill(NumericTraits<DerivativeType::ValueType>::ZeroValue());
+  this->m_CachedCurrentPosition.Fill(ParametersType::ValueType{});
+  this->m_CachedDerivative.Fill(DerivativeType::ValueType{});
 }
 
 SingleValuedNonLinearVnlOptimizerv4::~SingleValuedNonLinearVnlOptimizerv4()

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -24,7 +24,7 @@ SingleValuedVnlCostFunctionAdaptorv4::SingleValuedVnlCostFunctionAdaptorv4(unsig
 {
   m_ScalesInitialized = false;
   m_Reporter = Object::New();
-  m_CachedValue = NumericTraits<MeasureType>::ZeroValue();
+  m_CachedValue = MeasureType{};
   m_CachedDerivative.Fill(0);
 }
 

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
@@ -57,14 +57,14 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    derivative.Fill(itk::NumericTraits<ParametersValueType>::ZeroValue());
+    derivative.Fill(ParametersValueType{});
   }
 
   void
   GetValueAndDerivative(MeasureType & value, DerivativeType & derivative) const override
   {
     value = itk::NumericTraits<MeasureType>::OneValue();
-    derivative.Fill(itk::NumericTraits<ParametersValueType>::ZeroValue());
+    derivative.Fill(ParametersValueType{});
   }
 
   unsigned int

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -72,7 +72,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    derivative.Fill(itk::NumericTraits<ParametersValueType>::ZeroValue());
+    derivative.Fill(ParametersValueType{});
   }
 
   void
@@ -187,7 +187,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    derivative.Fill(itk::NumericTraits<ParametersValueType>::ZeroValue());
+    derivative.Fill(ParametersValueType{});
   }
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -68,7 +68,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    derivative.Fill(itk::NumericTraits<ParametersValueType>::ZeroValue());
+    derivative.Fill(ParametersValueType{});
   }
 
   void

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -120,7 +120,7 @@ CovarianceSampleFilter<TSample>::GenerateData()
 
   MatrixType output = decoratedOutput->Get();
   output.SetSize(measurementVectorSize, measurementVectorSize);
-  output.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  output.Fill(typename MatrixType::ValueType{});
 
   auto * decoratedMeanOutput =
     itkDynamicCastInDebugMode<MeasurementVectorDecoratedType *>(this->ProcessObject::GetOutput(1));

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -35,7 +35,7 @@ Histogram<TMeasurement, TFrequencyContainer>::Histogram()
 {
   for (unsigned int i = 0; i < this->GetMeasurementVectorSize() + 1; ++i)
   {
-    this->m_OffsetTable[i] = itk::NumericTraits<InstanceIdentifier>::ZeroValue();
+    this->m_OffsetTable[i] = InstanceIdentifier{};
   }
 }
 
@@ -45,7 +45,7 @@ Histogram<TMeasurement, TFrequencyContainer>::Size() const -> InstanceIdentifier
 {
   if (this->GetMeasurementVectorSize() == 0)
   {
-    return itk::NumericTraits<InstanceIdentifier>::ZeroValue();
+    return InstanceIdentifier{};
   }
   InstanceIdentifier size = 1;
   for (unsigned int i = 0; i < this->GetMeasurementVectorSize(); ++i)

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
@@ -93,7 +93,7 @@ HistogramToRunLengthFeaturesFilter<THistogram>::GenerateData()
   for (HistogramIterator hit = inputHistogram->Begin(); hit != inputHistogram->End(); ++hit)
   {
     MeasurementType frequency = hit.GetFrequency();
-    if (Math::ExactlyEquals(frequency, NumericTraits<MeasurementType>::ZeroValue()))
+    if (Math::ExactlyEquals(frequency, MeasurementType{}))
     {
       continue;
     }

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -122,7 +122,7 @@ HistogramToTextureFeaturesFilter<THistogram>::GenerateData()
   {
     RelativeFrequencyType frequency = *rFreqIterator;
     ++rFreqIterator;
-    if (Math::AlmostEquals(frequency, NumericTraits<RelativeFrequencyType>::ZeroValue()))
+    if (Math::AlmostEquals(frequency, RelativeFrequencyType{}))
     {
       continue; // no use doing these calculations if we're just multiplying by
                 // zero.

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -34,7 +34,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Sc
   : m_NumberOfBinsPerAxis(Self::DefaultBinsPerAxis)
   , m_Min(NumericTraits<PixelType>::NonpositiveMin())
   , m_Max(NumericTraits<PixelType>::max())
-  , m_MinDistance(NumericTraits<RealType>::ZeroValue())
+  , m_MinDistance(RealType{})
   , m_MaxDistance(NumericTraits<RealType>::max())
   , m_InsidePixelValue(NumericTraits<PixelType>::OneValue())
 {
@@ -190,7 +190,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
       MeasurementType centerBinMax = this->GetOutput()->GetBinMaxFromValue(0, centerPixelIntensity);
       MeasurementType lastBinMax = this->GetOutput()->GetDimensionMaxs(0)[this->GetOutput()->GetSize(0) - 1];
 
-      PixelType pixelIntensity(NumericTraits<PixelType>::ZeroValue());
+      PixelType pixelIntensity(PixelType{});
       IndexType index;
 
       index = centerIndex + offset;

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -113,7 +113,7 @@ SpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceIdentifier & q
   {
     if (queryIndex[dim] < static_cast<IndexValueType>(m_Radius[dim]))
     {
-      searchIndex[dim] = std::max(NumericTraits<IndexValueType>::ZeroValue(), constraintIndex[dim]);
+      searchIndex[dim] = std::max(IndexValueType{}, constraintIndex[dim]);
     }
     else
     {

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -66,7 +66,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointer
     using ValueType = typename MeasurementVectorTraitsTypes<MeasurementVectorType>::ValueType;
     MeasurementVectorType standardDeviation;
     NumericTraits<MeasurementVectorType>::SetLength(standardDeviation, this->GetMeasurementVectorSize());
-    standardDeviation.Fill(NumericTraits<ValueType>::ZeroValue());
+    standardDeviation.Fill(ValueType{});
     typename MeasurementVectorRealDecoratedType::Pointer decoratedStandardDeviation =
       MeasurementVectorRealDecoratedType::New();
     decoratedStandardDeviation->Set(standardDeviation);
@@ -78,7 +78,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointer
     using ValueType = typename MeasurementVectorTraitsTypes<MeasurementVectorType>::ValueType;
     MeasurementVectorType mean;
     NumericTraits<MeasurementVectorType>::SetLength(mean, this->GetMeasurementVectorSize());
-    mean.Fill(NumericTraits<ValueType>::ZeroValue());
+    mean.Fill(ValueType{});
     typename MeasurementVectorRealDecoratedType::Pointer decoratedStandardDeviation =
       MeasurementVectorRealDecoratedType::New();
     decoratedStandardDeviation->Set(mean);

--- a/Modules/Numerics/Statistics/include/itkSubsample.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsample.hxx
@@ -29,7 +29,7 @@ template <typename TSample>
 Subsample<TSample>::Subsample()
 {
   m_Sample = nullptr;
-  m_TotalFrequency = NumericTraits<AbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = AbsoluteFrequencyType{};
   m_ActiveDimension = 0;
 }
 
@@ -78,7 +78,7 @@ Subsample<TSample>::InitializeWithAllInstances()
   auto                            idIter = m_IdHolder.begin();
   typename TSample::ConstIterator iter = m_Sample->Begin();
   typename TSample::ConstIterator last = m_Sample->End();
-  m_TotalFrequency = NumericTraits<AbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = AbsoluteFrequencyType{};
   while (iter != last)
   {
     *idIter++ = iter.GetInstanceIdentifier();
@@ -114,7 +114,7 @@ void
 Subsample<TSample>::Clear()
 {
   m_IdHolder.clear();
-  m_TotalFrequency = NumericTraits<AbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = AbsoluteFrequencyType{};
   this->Modified();
 }
 

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -89,7 +89,7 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
   {
     if (queryIndex[dim] < static_cast<IndexValueType>(this->m_Radius[dim]))
     {
-      searchStartIndex[dim] = std::max(NumericTraits<IndexValueType>::ZeroValue(), constraintIndex[dim]);
+      searchStartIndex[dim] = std::max(IndexValueType{}, constraintIndex[dim]);
     }
     else
     {

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
@@ -63,7 +63,7 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
   typename KdTreeNodeType::CentroidType weightedCentroid;
   NumericTraits<typename KdTreeNodeType::CentroidType>::SetLength(weightedCentroid, this->GetMeasurementVectorSize());
   MeasurementVectorType tempVector;
-  weightedCentroid.Fill(NumericTraits<MeasurementType>::ZeroValue());
+  weightedCentroid.Fill(MeasurementType{});
 
   for (i = beginIndex; i < endIndex; ++i)
   {

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
@@ -70,7 +70,7 @@ WeightedCovarianceSampleFilter<TSample>::ComputeCovarianceMatrixWithWeightingFun
 
   MatrixType output = decoratedOutput->Get();
   output.SetSize(measurementVectorSize, measurementVectorSize);
-  output.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  output.Fill(typename MatrixType::ValueType{});
 
   auto * decoratedMeanOutput =
     itkDynamicCastInDebugMode<MeasurementVectorDecoratedType *>(this->ProcessObject::GetOutput(1));
@@ -167,7 +167,7 @@ WeightedCovarianceSampleFilter<TSample>::ComputeCovarianceMatrixWithWeights()
 
   MatrixType output = decoratedOutput->Get();
   output.SetSize(measurementVectorSize, measurementVectorSize);
-  output.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  output.Fill(typename MatrixType::ValueType{});
 
   auto * decoratedMeanOutput =
     itkDynamicCastInDebugMode<MeasurementVectorDecoratedType *>(this->ProcessObject::GetOutput(1));

--- a/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
@@ -24,7 +24,7 @@ namespace Statistics
 DenseFrequencyContainer2::DenseFrequencyContainer2()
 {
   m_FrequencyContainer = FrequencyContainerType::New();
-  m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = TotalAbsoluteFrequencyType{};
 }
 
 void
@@ -37,8 +37,8 @@ DenseFrequencyContainer2::Initialize(SizeValueType length)
 void
 DenseFrequencyContainer2::SetToZero()
 {
-  m_FrequencyContainer->Fill(NumericTraits<AbsoluteFrequencyType>::ZeroValue());
-  m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+  m_FrequencyContainer->Fill(AbsoluteFrequencyType{});
+  m_TotalFrequency = TotalAbsoluteFrequencyType{};
 }
 
 bool
@@ -59,7 +59,7 @@ DenseFrequencyContainer2::GetFrequency(const InstanceIdentifier id) const
 {
   if (id >= m_FrequencyContainer->Size())
   {
-    return NumericTraits<AbsoluteFrequencyType>::ZeroValue();
+    return AbsoluteFrequencyType{};
   }
   return (*m_FrequencyContainer)[id];
 }

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -23,7 +23,7 @@ namespace Statistics
 {
 SparseFrequencyContainer2::SparseFrequencyContainer2()
 {
-  m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = TotalAbsoluteFrequencyType{};
 }
 
 void SparseFrequencyContainer2::Initialize(SizeValueType)
@@ -38,10 +38,10 @@ SparseFrequencyContainer2::SetToZero()
   auto end = m_FrequencyContainer.end();
   while (iter != end)
   {
-    iter->second = NumericTraits<AbsoluteFrequencyType>::ZeroValue();
+    iter->second = AbsoluteFrequencyType{};
     ++iter;
   }
-  m_TotalFrequency = NumericTraits<TotalAbsoluteFrequencyType>::ZeroValue();
+  m_TotalFrequency = TotalAbsoluteFrequencyType{};
 }
 
 bool

--- a/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
+++ b/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
@@ -73,7 +73,7 @@ itkDenseFrequencyContainer2Test(int, char *[])
       return EXIT_FAILURE;
     }
 
-    if (container->GetFrequency(binOutOfBound) != itk::NumericTraits<AbsoluteFrequencyType>::ZeroValue())
+    if (container->GetFrequency(binOutOfBound) != AbsoluteFrequencyType{})
     {
       std::cerr << "GetFrequency() method should have returned zero frequency since the bin index is out of bound \n"
                 << std::endl;

--- a/Modules/Numerics/Statistics/test/itkSparseFrequencyContainer2Test.cxx
+++ b/Modules/Numerics/Statistics/test/itkSparseFrequencyContainer2Test.cxx
@@ -67,7 +67,7 @@ itkSparseFrequencyContainer2Test(int, char *[])
   container->SetToZero();
   for (unsigned int bin = 0; bin < numberOfBins; ++bin)
   {
-    if (container->GetFrequency(bin) != itk::NumericTraits<AbsoluteFrequencyType>::ZeroValue())
+    if (container->GetFrequency(bin) != AbsoluteFrequencyType{})
     {
       std::cout << "Failed !" << std::endl;
       std::cout << "Stored Frequency in bin is not zero after SetToZero() method invocation" << std::endl;

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -178,7 +178,7 @@ void
 BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, TSimilarities>::
   BeforeThreadedGenerateData()
 {
-  this->m_PointsCount = itk::NumericTraits<SizeValueType>::ZeroValue();
+  this->m_PointsCount = SizeValueType{};
   FeaturePointsConstPointer featurePoints = this->GetFeaturePoints();
   if (featurePoints)
   {

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -300,7 +300,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
-    if (Math::AlmostEquals(m_Variance[iDimension], NumericTraits<MovedGradientPixelType>::ZeroValue()))
+    if (Math::AlmostEquals(m_Variance[iDimension], MovedGradientPixelType{}))
     {
       continue;
     }

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -33,7 +33,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::HistogramImageToImageMet
   m_DerivativeStepLength = 0.1;
   m_DerivativeStepLengthScales.Fill(1);
   m_UpperBoundIncreaseFactor = 0.001;
-  m_PaddingValue = NumericTraits<FixedImagePixelType>::ZeroValue();
+  m_PaddingValue = FixedImagePixelType{};
   m_Histogram = HistogramType::New();
   m_Histogram->SetMeasurementVectorSize(2);
   m_LowerBoundSetByUser = false;
@@ -194,7 +194,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const Tran
 
   // Calculate gradient.
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   auto pHistogram = HistogramType::New();
   pHistogram->SetMeasurementVectorSize(2);

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -180,15 +180,15 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   using ArrayType = Array<double>;
 
   ArrayType sum1(ParametersDimension);
-  sum1.Fill(NumericTraits<typename ArrayType::ValueType>::ZeroValue());
+  sum1.Fill(typename ArrayType::ValueType{});
 
   ArrayType sum2(ParametersDimension);
-  sum2.Fill(NumericTraits<typename ArrayType::ValueType>::ZeroValue());
+  sum2.Fill(typename ArrayType::ValueType{});
 
   int fixedArea = 0;
   int movingArea = 0;

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -102,7 +102,7 @@ public:
   GetDerivative(const TransformParametersType &, DerivativeType & derivative) const override
   {
     itkWarningMacro("This metric does not provide metric derivatives.");
-    derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+    derivative.Fill(typename DerivativeType::ValueType{});
   }
 
   /**  Get the value of the metric at a particular parameter

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -67,7 +67,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
   std::vector<SizeValueType>::iterator        cIt;
   for (mIt = m_ThreadMatches.begin(), cIt = m_ThreadCounts.begin(); mIt != m_ThreadMatches.end(); ++mIt, ++cIt)
   {
-    *mIt = NumericTraits<MeasureType>::ZeroValue();
+    *mIt = MeasureType{};
     *cIt = 0;
   }
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -306,7 +306,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     for (ThreadIdType workUnitID = 0; workUnitID < this->m_NumberOfWorkUnits; ++workUnitID)
     {
       this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.SetSize(this->GetNumberOfParameters());
-      this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.Fill(NumericTraits<MeasureType>::ZeroValue());
+      this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.Fill(MeasureType{});
     }
   }
 
@@ -699,7 +699,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
   DerivativeType &       derivative) const
 {
   // Set output values to zero
-  value = NumericTraits<MeasureType>::ZeroValue();
+  value = MeasureType{};
 
   if (this->m_UseExplicitPDFDerivatives)
   {
@@ -715,7 +715,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
     this->m_PRatioArray.Fill(0.0);
     for (ThreadIdType workUnitID = 0; workUnitID < this->m_NumberOfWorkUnits; ++workUnitID)
     {
-      this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.Fill(NumericTraits<MeasureType>::ZeroValue());
+      this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.Fill(MeasureType{});
     }
     this->m_ImplicitDerivativesSecondPass = false;
   }

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -113,7 +113,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();
@@ -211,7 +211,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -102,7 +102,7 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Paramet
 
   for (unsigned int i = 0; i < this->m_NumberOfWorkUnits; ++i)
   {
-    m_PerThread[i].m_MSE = NumericTraits<MeasureType>::ZeroValue();
+    m_PerThread[i].m_MSE = MeasureType{};
   }
 
   // Set up the parameters in the transform
@@ -196,7 +196,7 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
   // Reset the joint pdfs to zero
   for (unsigned int i = 0; i < this->m_NumberOfWorkUnits; ++i)
   {
-    m_PerThread[i].m_MSE = NumericTraits<MeasureType>::ZeroValue();
+    m_PerThread[i].m_MSE = MeasureType{};
   }
 
   // Set output values to zero

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -108,7 +108,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();
@@ -205,7 +205,7 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -266,7 +266,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
                                                                                       MeasureType &          value,
                                                                                       DerivativeType & derivative) const
 {
-  value = NumericTraits<MeasureType>::ZeroValue();
+  value = MeasureType{};
   unsigned int   numberOfParameters = this->m_Transform->GetNumberOfParameters();
   DerivativeType temp(numberOfParameters);
   temp.Fill(0);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -115,7 +115,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   }
   else
   {
-    measure = NumericTraits<MeasureType>::ZeroValue();
+    measure = MeasureType{};
   }
 
   return measure;
@@ -161,13 +161,13 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeF(ParametersDimension);
-  derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeF.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeM(ParametersDimension);
-  derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeM.Fill(typename DerivativeType::ValueType{});
 
   ti.GoToBegin();
   // First compute the sums
@@ -298,7 +298,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
   {
     for (unsigned int i = 0; i < ParametersDimension; ++i)
     {
-      derivative[i] = NumericTraits<MeasureType>::ZeroValue();
+      derivative[i] = MeasureType{};
     }
   }
 }
@@ -344,16 +344,16 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeF(ParametersDimension);
-  derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeF.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeM(ParametersDimension);
-  derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeM.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeM1(ParametersDimension);
-  derivativeM1.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeM1.Fill(typename DerivativeType::ValueType{});
 
   ti.GoToBegin();
   // First compute the sums
@@ -483,9 +483,9 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
   {
     for (unsigned int i = 0; i < ParametersDimension; ++i)
     {
-      derivative[i] = NumericTraits<MeasureType>::ZeroValue();
+      derivative[i] = MeasureType{};
     }
-    value = NumericTraits<MeasureType>::ZeroValue();
+    value = MeasureType{};
   }
 }
 

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -101,7 +101,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
   }
   else
   {
-    measure = NumericTraits<MeasureType>::ZeroValue();
+    measure = MeasureType{};
   }
 
   return measure;
@@ -141,16 +141,16 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeF(ParametersDimension);
-  derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeF.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeM(ParametersDimension);
-  derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeM.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeO(ParametersDimension);
-  derivativeO.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeO.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();
@@ -244,7 +244,7 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
   {
     for (unsigned int i = 0; i < ParametersDimension; ++i)
     {
-      derivative[i] = NumericTraits<MeasureType>::ZeroValue();
+      derivative[i] = MeasureType{};
     }
   }
 }
@@ -284,16 +284,16 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
-  derivative.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivative.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeF(ParametersDimension);
-  derivativeF.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeF.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeM(ParametersDimension);
-  derivativeM.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeM.Fill(typename DerivativeType::ValueType{});
 
   DerivativeType derivativeO(ParametersDimension);
-  derivativeO.Fill(NumericTraits<typename DerivativeType::ValueType>::ZeroValue());
+  derivativeO.Fill(typename DerivativeType::ValueType{});
 
   PointIterator pointItr = fixedPointSet->GetPoints()->Begin();
   PointIterator pointEnd = fixedPointSet->GetPoints()->End();
@@ -388,9 +388,9 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
   {
     for (unsigned int i = 0; i < ParametersDimension; ++i)
     {
-      derivative[i] = NumericTraits<MeasureType>::ZeroValue();
+      derivative[i] = MeasureType{};
     }
-    value = NumericTraits<MeasureType>::ZeroValue();
+    value = MeasureType{};
   }
 }
 

--- a/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
@@ -62,7 +62,7 @@ itkBSplineTransformParametersAdaptorTest(int, char *[])
   using ParametersType = TransformType::ParametersType;
   unsigned long  numberOfParameters = transform->GetNumberOfParameters();
   ParametersType parameters(numberOfParameters);
-  parameters.Fill(itk::NumericTraits<ParametersType::ValueType>::ZeroValue());
+  parameters.Fill(ParametersType::ValueType{});
 
   /**
    * Set the parameters in the transform

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -28,7 +28,7 @@ template <typename TMoving, typename TFixed>
 FiniteDifferenceFunctionLoad<TMoving, TFixed>::FiniteDifferenceFunctionLoad()
   : m_MovingImage(nullptr)
   , m_FixedImage(nullptr)
-  , m_Gamma(NumericTraits<Float>::ZeroValue())
+  , m_Gamma(Float{})
 {
   m_MovingSize.Fill(0);
   m_FixedSize.Fill(0);

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -326,9 +326,9 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   OffsetValueType numberOfFillZero =
     this->m_ANTSAssociate->GetVirtualRegion().GetIndex(0) - (scanRegion.GetIndex(0) - scanParameters.radius[0]);
 
-  if (numberOfFillZero < NumericTraits<OffsetValueType>::ZeroValue())
+  if (numberOfFillZero < OffsetValueType{})
   {
-    numberOfFillZero = NumericTraits<OffsetValueType>::ZeroValue();
+    numberOfFillZero = OffsetValueType{};
   }
 
   scanParameters.numberOfFillZero = numberOfFillZero;
@@ -337,11 +337,11 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   scanParameters.windowLength = scanIt.Size();
   scanParameters.scanRegionBeginIndexDim0 = scanIt.GetBeginIndex()[0];
 
-  scanMem.fixedA = NumericTraits<QueueRealType>::ZeroValue();
-  scanMem.movingA = NumericTraits<QueueRealType>::ZeroValue();
-  scanMem.sFixedMoving = NumericTraits<QueueRealType>::ZeroValue();
-  scanMem.sFixedFixed = NumericTraits<QueueRealType>::ZeroValue();
-  scanMem.sMovingMoving = NumericTraits<QueueRealType>::ZeroValue();
+  scanMem.fixedA = QueueRealType{};
+  scanMem.movingA = QueueRealType{};
+  scanMem.sFixedMoving = QueueRealType{};
+  scanMem.sFixedFixed = QueueRealType{};
+  scanMem.sMovingMoving = QueueRealType{};
 
   scanMem.fixedImageGradient.Fill(0.0);
   scanMem.movingImageGradient.Fill(0.0);
@@ -538,7 +538,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
     if (!(sFixedFixed > NumericTraits<LocalRealType>::epsilon() &&
           sMovingMoving > NumericTraits<LocalRealType>::epsilon()))
     {
-      deriv.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+      deriv.Fill(DerivativeValueType{});
       return;
     }
 
@@ -563,7 +563,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
     for (NumberOfParametersType par = 0; par < numberOfLocalParameters; ++par)
     {
-      deriv[par] = NumericTraits<DerivativeValueType>::ZeroValue();
+      deriv[par] = DerivativeValueType{};
       for (ImageDimensionType dim = 0; dim < TImageToImageMetric::MovingImageDimension; ++dim)
       {
         deriv[par] += derivWRTImage[dim] * jacobian(dim, par);

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
@@ -78,8 +78,8 @@ CorrelationImageToImageMetricv4<TFixedImage,
 
   Superclass::InitializeForIteration();
 
-  this->m_AverageFix = NumericTraits<MeasureType>::ZeroValue();
-  this->m_AverageMov = NumericTraits<MeasureType>::ZeroValue();
+  this->m_AverageFix = MeasureType{};
+  this->m_AverageMov = MeasureType{};
 
   // compute the average intensity of the sampled pixels
   // Invoke the pipeline in the helper threader

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -66,21 +66,14 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
   // Set initial values.
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
-    m_CorrelationMetricValueDerivativePerThreadVariables[i].fm =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
-    m_CorrelationMetricValueDerivativePerThreadVariables[i].f2 =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
-    m_CorrelationMetricValueDerivativePerThreadVariables[i].m2 =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
-    m_CorrelationMetricValueDerivativePerThreadVariables[i].f =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
-    m_CorrelationMetricValueDerivativePerThreadVariables[i].m =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
+    m_CorrelationMetricValueDerivativePerThreadVariables[i].fm = InternalComputationValueType{};
+    m_CorrelationMetricValueDerivativePerThreadVariables[i].f2 = InternalComputationValueType{};
+    m_CorrelationMetricValueDerivativePerThreadVariables[i].m2 = InternalComputationValueType{};
+    m_CorrelationMetricValueDerivativePerThreadVariables[i].f = InternalComputationValueType{};
+    m_CorrelationMetricValueDerivativePerThreadVariables[i].m = InternalComputationValueType{};
 
-    this->m_CorrelationMetricValueDerivativePerThreadVariables[i].mdm.Fill(
-      NumericTraits<DerivativeValueType>::ZeroValue());
-    this->m_CorrelationMetricValueDerivativePerThreadVariables[i].fdm.Fill(
-      NumericTraits<DerivativeValueType>::ZeroValue());
+    this->m_CorrelationMetricValueDerivativePerThreadVariables[i].mdm.Fill(DerivativeValueType{});
+    this->m_CorrelationMetricValueDerivativePerThreadVariables[i].fdm.Fill(DerivativeValueType{});
   }
 }
 
@@ -97,7 +90,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
 
   /* Store the number of valid points the enclosing class \c
    * m_NumberOfValidPoints by collecting the valid points per thread. */
-  this->m_CorrelationAssociate->m_NumberOfValidPoints = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_CorrelationAssociate->m_NumberOfValidPoints = SizeValueType{};
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
     this->m_CorrelationAssociate->m_NumberOfValidPoints +=
@@ -116,7 +109,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
     "CorrelationImageToImageMetricv4: NumberOfValidPoints: " << this->m_CorrelationAssociate->m_NumberOfValidPoints);
 
   /* Accumulate the metric value from threads and store */
-  this->m_CorrelationAssociate->m_Value = NumericTraits<InternalComputationValueType>::ZeroValue();
+  this->m_CorrelationAssociate->m_Value = InternalComputationValueType{};
   InternalComputationValueType fm{};
   InternalComputationValueType f2{};
   InternalComputationValueType m2{};
@@ -143,8 +136,8 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
     fdm.SetSize(globalDerivativeSize);
     mdm.SetSize(globalDerivativeSize);
 
-    fdm.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
-    mdm.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+    fdm.Fill(DerivativeValueType{});
+    mdm.Fill(DerivativeValueType{});
 
     const auto fc = static_cast<InternalComputationValueType>(2.0);
 

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
@@ -49,8 +49,8 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
   // Set initial values.
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
-    this->m_CorrelationMetricPerThreadVariables[i].FixSum = NumericTraits<InternalComputationValueType>::ZeroValue();
-    this->m_CorrelationMetricPerThreadVariables[i].MovSum = NumericTraits<InternalComputationValueType>::ZeroValue();
+    this->m_CorrelationMetricPerThreadVariables[i].FixSum = InternalComputationValueType{};
+    this->m_CorrelationMetricPerThreadVariables[i].MovSum = InternalComputationValueType{};
   }
 }
 
@@ -62,7 +62,7 @@ CorrelationImageToImageMetricv4HelperThreader<TDomainPartitioner, TImageToImageM
 
   /* Store the number of valid points the enclosing class \c
    * m_NumberOfValidPoints by collecting the valid points per thread. */
-  this->m_CorrelationAssociate->m_NumberOfValidPoints = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_CorrelationAssociate->m_NumberOfValidPoints = SizeValueType{};
 
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
 

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
@@ -82,7 +82,7 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
     dimension = MovingImageDimension;
   }
 
-  this->m_Normalizer = NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_Normalizer = TInternalComputationValueType{};
   for (ImageDimensionType k = 0; k < dimension; ++k)
   {
     this->m_Normalizer += imageSpacing[k] * imageSpacing[k];

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -98,7 +98,7 @@ DemonsImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner, TIma
   if (itk::Math::abs(speedValue) < this->m_DemonsAssociate->GetIntensityDifferenceThreshold() ||
       denominator < this->m_DemonsAssociate->GetDenominatorThreshold())
   {
-    localDerivativeReturn.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+    localDerivativeReturn.Fill(DerivativeValueType{});
     return true;
   }
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -292,7 +292,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
       this->m_DerivativeResult->SetSize(globalDerivativeSize);
     }
     /* Clear derivative final result. */
-    this->m_DerivativeResult->Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+    this->m_DerivativeResult->Fill(DerivativeValueType{});
   }
 }
 
@@ -308,7 +308,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
                                  FixedImagePixelType &    mappedFixedPixelValue) const
 {
   bool pointIsValid = true;
-  mappedFixedPixelValue = NumericTraits<FixedImagePixelType>::ZeroValue();
+  mappedFixedPixelValue = FixedImagePixelType{};
 
   // map the point into fixed space
   this->LocalTransformPoint(virtualPoint, mappedFixedPoint);
@@ -349,7 +349,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
                                   MovingImagePixelType &   mappedMovingPixelValue) const
 {
   bool pointIsValid = true;
-  mappedMovingPixelValue = NumericTraits<MovingImagePixelType>::ZeroValue();
+  mappedMovingPixelValue = MovingImagePixelType{};
 
   // map the point into moving space
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
@@ -91,10 +91,8 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
   // Set initial values.
   for (ThreadIdType workUnit = 0; workUnit < numWorkUnitsUsed; ++workUnit)
   {
-    this->m_GetValueAndDerivativePerThreadVariables[workUnit].NumberOfValidPoints =
-      NumericTraits<SizeValueType>::ZeroValue();
-    this->m_GetValueAndDerivativePerThreadVariables[workUnit].Measure =
-      NumericTraits<InternalComputationValueType>::ZeroValue();
+    this->m_GetValueAndDerivativePerThreadVariables[workUnit].NumberOfValidPoints = SizeValueType{};
+    this->m_GetValueAndDerivativePerThreadVariables[workUnit].Measure = InternalComputationValueType{};
     if (this->m_Associate->GetComputeDerivative())
     {
       if (this->m_Associate->m_MovingTransform->GetTransformCategory() !=
@@ -120,7 +118,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
   const ThreadIdType numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
   /* Store the number of valid points the enclosing class \c
    * m_NumberOfValidPoints by collecting the valid points per thread. */
-  this->m_Associate->m_NumberOfValidPoints = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_Associate->m_NumberOfValidPoints = SizeValueType{};
   for (ThreadIdType i = 0; i < numWorkUnitsUsed; ++i)
   {
     this->m_Associate->m_NumberOfValidPoints += this->m_GetValueAndDerivativePerThreadVariables[i].NumberOfValidPoints;
@@ -153,7 +151,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
   if (this->m_Associate->VerifyNumberOfValidPoints(this->m_Associate->m_Value,
                                                    *(this->m_Associate->m_DerivativeResult)))
   {
-    this->m_Associate->m_Value = NumericTraits<MeasureType>::ZeroValue();
+    this->m_Associate->m_Value = MeasureType{};
     /* Accumulate the metric value from threads and store the average. */
     for (ThreadIdType threadId = 0; threadId < numWorkUnitsUsed; ++threadId)
     {

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -96,9 +96,9 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 {
   if (calcDerivative)
   {
-    derivativeReturn.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+    derivativeReturn.Fill(DerivativeValueType{});
   }
-  value = NumericTraits<MeasureType>::ZeroValue();
+  value = MeasureType{};
 
   /**
    * first term only
@@ -110,7 +110,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 
   probabilityStar /= this->m_TotalNumberOfPoints;
 
-  if (Math::AlmostEquals(probabilityStar, NumericTraits<RealType>::ZeroValue()))
+  if (Math::AlmostEquals(probabilityStar, RealType{}))
   {
     return;
   }
@@ -141,7 +141,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
     {
       RealType gaussian = this->m_MovingDensityFunction->GetGaussian(neighbors[n])->Evaluate(samplePoint);
 
-      if (Math::AlmostEquals(gaussian, NumericTraits<RealType>::ZeroValue()))
+      if (Math::AlmostEquals(gaussian, RealType{}))
       {
         continue;
       }

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -49,8 +49,8 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
     this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->SetRegions(
       this->m_Associate->m_JointPDF->GetLargestPossibleRegion());
     this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->Allocate();
-    this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->FillBuffer(NumericTraits<SizeValueType>::ZeroValue());
-    this->m_JointHistogramMIPerThreadVariables[i].JointHistogramCount = NumericTraits<SizeValueType>::ZeroValue();
+    this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->FillBuffer(SizeValueType{});
+    this->m_JointHistogramMIPerThreadVariables[i].JointHistogramCount = SizeValueType{};
   }
 }
 
@@ -113,7 +113,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
   const ThreadIdType numberOfWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
 
   using JointHistogramPixelType = typename JointHistogramType::PixelType;
-  this->m_Associate->m_JointHistogramTotalCount = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_Associate->m_JointHistogramTotalCount = SizeValueType{};
   for (ThreadIdType i = 0; i < numberOfWorkUnitsUsed; ++i)
   {
     this->m_Associate->m_JointHistogramTotalCount += this->m_JointHistogramMIPerThreadVariables[i].JointHistogramCount;
@@ -121,7 +121,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
 
   if (this->m_Associate->m_JointHistogramTotalCount == 0)
   {
-    this->m_Associate->m_JointPDF->FillBuffer(NumericTraits<SizeValueType>::ZeroValue());
+    this->m_Associate->m_JointPDF->FillBuffer(SizeValueType{});
     return;
   }
 
@@ -141,7 +141,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
   JointHistogramPixelType jointHistogramPixel;
   while (!jointPDFIt.IsAtEnd())
   {
-    jointHistogramPixel = NumericTraits<JointHistogramPixelType>::ZeroValue();
+    jointHistogramPixel = JointHistogramPixelType{};
     for (ThreadIdType i = 0; i < numberOfWorkUnitsUsed; ++i)
     {
       jointHistogramPixel += jointHistogramPerThreadIts[i].Get();

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -152,7 +152,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   } // end if-block to check non-zero bin contribution
   else
   {
-    scalingfactor = NumericTraits<InternalComputationValueType>::ZeroValue();
+    scalingfactor = InternalComputationValueType{};
   }
 
   /* Use a pre-allocated jacobian object for efficiency */
@@ -211,7 +211,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
     rightpoint[0] = 1.0;
   }
   InternalComputationValueType delta = rightpoint[0] - leftpoint[0];
-  if (delta > NumericTraits<InternalComputationValueType>::ZeroValue())
+  if (delta > InternalComputationValueType{})
   {
     InternalComputationValueType deriv =
       this->m_ThreaderFixedImageMarginalPDFInterpolator[threadId]->Evaluate(rightpoint) -
@@ -220,7 +220,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   }
   else
   {
-    return NumericTraits<InternalComputationValueType>::ZeroValue();
+    return InternalComputationValueType{};
   }
 }
 
@@ -258,7 +258,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
     rightpoint[0] = 1.0;
   }
   InternalComputationValueType delta = rightpoint[0] - leftpoint[0];
-  if (delta > NumericTraits<InternalComputationValueType>::ZeroValue())
+  if (delta > InternalComputationValueType{})
   {
     InternalComputationValueType deriv =
       this->m_JointHistogramMIPerThreadVariables[threadId].MovingImageMarginalPDFInterpolator->Evaluate(rightpoint) -
@@ -267,7 +267,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   }
   else
   {
-    return NumericTraits<InternalComputationValueType>::ZeroValue();
+    return InternalComputationValueType{};
   }
 }
 
@@ -312,7 +312,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
 
   InternalComputationValueType delta = rightpoint[ind] - leftpoint[ind];
   InternalComputationValueType deriv{};
-  if (delta > NumericTraits<InternalComputationValueType>::ZeroValue())
+  if (delta > InternalComputationValueType{})
   {
     deriv = this->m_JointHistogramMIPerThreadVariables[threadId].JointPDFInterpolator->Evaluate(rightpoint) -
             this->m_JointHistogramMIPerThreadVariables[threadId].JointPDFInterpolator->Evaluate(leftpoint);

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -40,14 +40,14 @@ JointHistogramMutualInformationImageToImageMetricv4<
 {
   // Initialize histogram properties
   this->m_NumberOfHistogramBins = 20;
-  this->m_FixedImageTrueMin = NumericTraits<TInternalComputationValueType>::ZeroValue();
-  this->m_FixedImageTrueMax = NumericTraits<TInternalComputationValueType>::ZeroValue();
-  this->m_MovingImageTrueMin = NumericTraits<TInternalComputationValueType>::ZeroValue();
-  this->m_MovingImageTrueMax = NumericTraits<TInternalComputationValueType>::ZeroValue();
-  this->m_FixedImageBinSize = NumericTraits<TInternalComputationValueType>::ZeroValue();
-  this->m_MovingImageBinSize = NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_FixedImageTrueMin = TInternalComputationValueType{};
+  this->m_FixedImageTrueMax = TInternalComputationValueType{};
+  this->m_MovingImageTrueMin = TInternalComputationValueType{};
+  this->m_MovingImageTrueMax = TInternalComputationValueType{};
+  this->m_FixedImageBinSize = TInternalComputationValueType{};
+  this->m_MovingImageBinSize = TInternalComputationValueType{};
   this->m_Padding = 2;
-  this->m_JointPDFSum = NumericTraits<TInternalComputationValueType>::ZeroValue();
+  this->m_JointPDFSum = TInternalComputationValueType{};
   this->m_Log2 = std::log(2.0);
   this->m_VarianceForJointPDFSmoothing = 1.5;
 
@@ -245,7 +245,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   }
 
   // Optionally smooth the joint pdf
-  if (this->m_VarianceForJointPDFSmoothing > NumericTraits<JointPDFValueType>::ZeroValue())
+  if (this->m_VarianceForJointPDFSmoothing > JointPDFValueType{})
   {
     using DgType = DiscreteGaussianImageFilter<JointPDFType, JointPDFType>;
     auto dg = DgType::New();

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -155,7 +155,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
         this->m_MattesAssociate->GetNumberOfParameters());
       // Initialize to zero because we accumulate, and so skipped points will
       // behave properly
-      this->m_MattesAssociate->m_LocalDerivativeByParzenBin[n].Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+      this->m_MattesAssociate->m_LocalDerivativeByParzenBin[n].Fill(DerivativeValueType{});
     }
   }
   if (this->m_MattesAssociate->GetComputeDerivative() && !this->m_MattesAssociate->HasLocalSupport())
@@ -422,7 +422,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   /* Store the number of valid points in the enclosing class
    * m_NumberOfValidPoints by collecting the valid points per thread.
    * We do this here because we're skipping Superclass::AfterThreadedExecution*/
-  this->m_MattesAssociate->m_NumberOfValidPoints = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_MattesAssociate->m_NumberOfValidPoints = SizeValueType{};
   for (ThreadIdType workUnitID = 0; workUnitID < localNumberOfWorkUnitsUsed; ++workUnitID)
   {
     this->m_MattesAssociate->m_NumberOfValidPoints +=

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -43,7 +43,7 @@ MeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader<
   /** Only the voxelwise contribution given the point pairs. */
   FixedImagePixelType diff = fixedImageValue - movingImageValue;
   const unsigned int  nComponents = NumericTraits<FixedImagePixelType>::GetLength(diff);
-  metricValueReturn = NumericTraits<MeasureType>::ZeroValue();
+  metricValueReturn = MeasureType{};
 
   for (unsigned int nc = 0; nc < nComponents; ++nc)
   {
@@ -68,7 +68,7 @@ MeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader<
 
   for (unsigned int par = 0; par < this->GetCachedNumberOfLocalParameters(); ++par)
   {
-    localDerivativeReturn[par] = NumericTraits<DerivativeValueType>::ZeroValue();
+    localDerivativeReturn[par] = DerivativeValueType{};
     for (unsigned int nc = 0; nc < nComponents; ++nc)
     {
       MeasureType diffValue = DefaultConvertPixelTraits<FixedImagePixelType>::GetNthComponent(nc, diff);

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -289,7 +289,7 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
   {
     derivativeResult.SetSize(this->GetNumberOfParameters());
   }
-  derivativeResult.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+  derivativeResult.Fill(DerivativeValueType{});
 
   DerivativeType metricDerivative;
   MeasureType    metricValue{};

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -259,7 +259,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   {
     derivative.SetSize(PointDimension * this->m_FixedTransformedPointSet->GetNumberOfPoints());
   }
-  derivative.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+  derivative.Fill(DerivativeValueType{});
 
   /*
    * Split pointset in nWorkUnits ranges and sum individually
@@ -288,7 +288,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
       MovingTransformJacobianType jacobianCache;
 
       DerivativeType threadLocalTransformDerivative(numberOfLocalParameters);
-      threadLocalTransformDerivative.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+      threadLocalTransformDerivative.Fill(DerivativeValueType{});
 
       CompensatedDerivative threadDerivativeSum(numberOfLocalParameters);
 
@@ -330,7 +330,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
         }
 
         // Map into parameter space
-        threadLocalTransformDerivative.Fill(NumericTraits<DerivativeValueType>::ZeroValue());
+        threadLocalTransformDerivative.Fill(DerivativeValueType{});
 
         if (this->m_CalculateValueAndDerivativeInTangentSpace)
         {

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -141,7 +141,7 @@ itkDemonsImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   using FixedRescaleFilterType = itk::RescaleIntensityImageFilter<FixedImageType, FixedImageType>;
   auto fixedRescaleFilter = FixedRescaleFilterType::New();
   fixedRescaleFilter->SetInput(fixedImage);
-  fixedRescaleFilter->SetOutputMinimum(itk::NumericTraits<PixelType>::ZeroValue());
+  fixedRescaleFilter->SetOutputMinimum(PixelType{});
   fixedRescaleFilter->SetOutputMaximum(itk::NumericTraits<PixelType>::OneValue());
   fixedRescaleFilter->Update();
   fixedImage = fixedRescaleFilter->GetOutput();
@@ -149,7 +149,7 @@ itkDemonsImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   using MovingRescaleFilterType = itk::RescaleIntensityImageFilter<MovingImageType, MovingImageType>;
   auto movingRescaleFilter = MovingRescaleFilterType::New();
   movingRescaleFilter->SetInput(movingImage);
-  movingRescaleFilter->SetOutputMinimum(itk::NumericTraits<PixelType>::ZeroValue());
+  movingRescaleFilter->SetOutputMinimum(PixelType{});
   movingRescaleFilter->SetOutputMaximum(itk::NumericTraits<PixelType>::OneValue());
   movingRescaleFilter->Update();
   movingImage = movingRescaleFilter->GetOutput();

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -219,8 +219,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   bool derivative2IsZero = true;
   for (itk::SizeValueType n = 0; n < metric->GetNumberOfParameters(); ++n)
   {
-    if (itk::Math::NotExactlyEquals(derivative2[n],
-                                    itk::NumericTraits<typename PointSetMetricType::DerivativeValueType>::ZeroValue()))
+    if (itk::Math::NotExactlyEquals(derivative2[n], typename PointSetMetricType::DerivativeValueType{}))
     {
       derivative2IsZero = false;
     }

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -68,7 +68,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
   typename TImage::PointType origin;
-  origin.Fill(itk::NumericTraits<CoordinateRepresentationType>::ZeroValue());
+  origin.Fill(CoordinateRepresentationType{});
 
   typename TImage::DirectionType direction;
   direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
@@ -91,7 +91,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
     {
       if (it.GetIndex()[n] < boundary || (static_cast<itk::OffsetValueType>(size[n]) - it.GetIndex()[n]) <= boundary)
       {
-        it.Set(itk::NumericTraits<PixelType>::ZeroValue());
+        it.Set(PixelType{});
         break;
       }
     }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -277,7 +277,7 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   resample->SetOutputOrigin(fixedImage->GetOrigin());
   resample->SetOutputSpacing(fixedImage->GetSpacing());
   resample->SetOutputDirection(fixedImage->GetDirection());
-  resample->SetDefaultPixelValue(itk::NumericTraits<FixedImageType::PixelType>::ZeroValue());
+  resample->SetDefaultPixelValue(FixedImageType::PixelType{});
   resample->Update();
 
   // write out the displacement field

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -96,7 +96,7 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
   typename TImage::PointType origin;
-  origin.Fill(itk::NumericTraits<CoordinateRepresentationType>::ZeroValue());
+  origin.Fill(CoordinateRepresentationType{});
 
   typename TImage::DirectionType direction;
   direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
@@ -119,7 +119,7 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
     {
       if (it.GetIndex()[n] < boundary || (static_cast<itk::OffsetValueType>(size[n]) - it.GetIndex()[n]) <= boundary)
       {
-        it.Set(itk::NumericTraits<PixelType>::ZeroValue());
+        it.Set(PixelType{});
         break;
       }
     }

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -128,7 +128,7 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
   MeasureType                     weightedMetricValue{};
   MultiMetricType::DerivativeType metricDerivative;
   MultiMetricType::DerivativeType DerivResultOfGetValueAndDerivativeTruth(multiVariateMetric->GetNumberOfParameters());
-  DerivResultOfGetValueAndDerivativeTruth.Fill(itk::NumericTraits<MultiMetricType::DerivativeValueType>::ZeroValue());
+  DerivResultOfGetValueAndDerivativeTruth.Fill(MultiMetricType::DerivativeValueType{});
   MultiMetricType::DerivativeValueType totalMagnitude{};
 
   for (itk::SizeValueType i = 0; i < multiVariateMetric->GetNumberOfMetrics(); ++i)

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -605,7 +605,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
     virtualDomainImage->GetLargestPossibleRegion().GetNumberOfPixels() * ImageDimension;
   MetricDerivativeType metricDerivative(metricDerivativeSize);
 
-  metricDerivative.Fill(NumericTraits<typename MetricDerivativeType::ValueType>::ZeroValue());
+  metricDerivative.Fill(typename MetricDerivativeType::ValueType{});
   this->m_Metric->GetValueAndDerivative(value, metricDerivative);
 
   // Ensure that the size of the optimizer weights is the same as the
@@ -680,7 +680,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   }
 
   RealType scale = this->m_LearningRate;
-  if (maxNorm > NumericTraits<RealType>::ZeroValue())
+  if (maxNorm > RealType{})
   {
     scale /= maxNorm;
   }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -351,7 +351,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
   TPointSet>::GetMetricDerivativePointSetForAllTimePoints(VelocityFieldPointSetType * velocityFieldPointSet,
                                                           WeightsContainerType *      velocityFieldWeights)
 {
-  this->m_CurrentMetricValue = NumericTraits<MeasureType>::ZeroValue();
+  this->m_CurrentMetricValue = MeasureType{};
 
   SizeValueType numberOfIntegrationSteps = this->m_NumberOfTimePointSamples + 2;
 
@@ -727,7 +727,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
 
   RealType value;
 
-  metricDerivative.Fill(NumericTraits<typename MetricDerivativeType::ValueType>::ZeroValue());
+  metricDerivative.Fill(typename MetricDerivativeType::ValueType{});
   this->m_Metric->GetValueAndDerivative(value, metricDerivative);
 
   this->m_CurrentMetricValue += value;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -145,7 +145,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   {
     updateDerivative.Fill(0);
     MeasureType value{};
-    this->m_CurrentMetricValue = NumericTraits<MeasureType>::ZeroValue();
+    this->m_CurrentMetricValue = MeasureType{};
 
     // Time index zero brings the moving image closest to the fixed image
     for (IndexValueType timePoint = 0; timePoint < numberOfTimePoints; ++timePoint)
@@ -264,7 +264,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
       }
       this->m_Metric->Initialize();
 
-      metricDerivative.Fill(NumericTraits<typename MetricDerivativeType::ValueType>::ZeroValue());
+      metricDerivative.Fill(typename MetricDerivativeType::ValueType{});
       this->m_Metric->GetValueAndDerivative(value, metricDerivative);
 
       // Ensure that the size of the optimizer weights is the same as the

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -47,7 +47,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
 
   // Set up the boundary condition to be zero padded (used on output image)
   ConstantBoundaryCondition<TOutputImage> BC;
-  BC.SetConstant(NumericTraits<OutputPixelType>::ZeroValue());
+  BC.SetConstant(OutputPixelType{});
 
   // Neighborhood iterators.  Let's use a shaped neighborhood so we can
   // restrict the access to face connected neighbors. These iterators
@@ -117,10 +117,10 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
     oit.GoToBegin();
     while (!mit.IsAtEnd())
     {
-      if (mit.Get() == NumericTraits<MaskPixelType>::ZeroValue())
+      if (mit.Get() == MaskPixelType{})
       {
         // mark pixel as unlabeled
-        oit.Set(NumericTraits<OutputPixelType>::ZeroValue());
+        oit.Set(OutputPixelType{});
       }
 
       ++mit;
@@ -144,7 +144,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
     originalLabel = label;
 
     // If the pixel is not background
-    if (label != NumericTraits<OutputPixelType>::ZeroValue())
+    if (label != OutputPixelType{})
     {
       // loop over the "previous" neighbors to find labels.  this loop
       // may establish one or more new equivalence classes
@@ -158,7 +158,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
 
         // if the previous pixel has a label, verify equivalence or
         // establish a new equivalence
-        if (neighborLabel != NumericTraits<OutputPixelType>::ZeroValue())
+        if (neighborLabel != OutputPixelType{})
         {
           // see if current pixel is connected to its neighbor
           neighborValue = isIt.Get();
@@ -225,7 +225,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
   {
     label = oit.Get();
     // if pixel has a label, write out the final equivalence
-    if (label != NumericTraits<OutputPixelType>::ZeroValue())
+    if (label != OutputPixelType{})
     {
       oit.Set(eqTable->Lookup(label));
     }

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -60,14 +60,13 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   ot.GoToBegin();
   for (; !it.IsAtEnd(); ++it, ++ot)
   {
-    if (Math::NotExactlyEquals(it.Get(),
-                               NumericTraits<typename ImageRegionConstIterator<TInputImage>::PixelType>::ZeroValue()))
+    if (Math::NotExactlyEquals(it.Get(), typename ImageRegionConstIterator<TInputImage>::PixelType{}))
     {
       ot.Set(NumericTraits<typename TOutputImage::PixelType>::max());
     }
     else
     {
-      ot.Set(NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
+      ot.Set(typename TOutputImage::PixelType{});
     }
   }
   equivalenceTable[0] = 0;

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
@@ -76,7 +76,7 @@ RelabelComponentImageFilter<TInputImage, TOutputImage>::ParallelComputeLabels(co
       const auto inputValue = it.Get();
 
       // if the input pixel is not the background
-      if (inputValue != NumericTraits<LabelType>::ZeroValue())
+      if (inputValue != LabelType{})
       {
         // label is not currently in the map
         mapIt = localSizeMap.insert(mapIt, { inputValue, initialSize });
@@ -182,7 +182,7 @@ RelabelComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
     {
       // map small objects to the background
       ++NumberOfObjectsRemoved;
-      relabelMap.insert({ sizeVectorPair.first, NumericTraits<OutputPixelType>::ZeroValue() });
+      relabelMap.insert({ sizeVectorPair.first, OutputPixelType{} });
     }
     else
     {
@@ -217,7 +217,7 @@ RelabelComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
 
 
   // After the objects stats are computed add in the background label so the relabelMap can be directly applied.
-  relabelMap.insert({ NumericTraits<LabelType>::ZeroValue(), NumericTraits<OutputPixelType>::ZeroValue() });
+  relabelMap.insert({ LabelType{}, OutputPixelType{} });
 
   // Second pass: walk just the output requested region and relabel
   // the necessary pixels.

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -54,7 +54,7 @@ template <typename TInput>
 class SimilarPixelsFunctor
 {
 public:
-  SimilarPixelsFunctor() { m_Threshold = NumericTraits<TInput>::ZeroValue(); }
+  SimilarPixelsFunctor() { m_Threshold = TInput{}; }
 
   ~SimilarPixelsFunctor() = default;
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -54,7 +54,7 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage,
 
   // Initialize values for the threshold filters
   // Default. Use ITK set macro "SetOutsideValue" to change
-  m_OutsideValue = NumericTraits<OutputPixelType>::ZeroValue();
+  m_OutsideValue = OutputPixelType{};
 
   // Default. Use ITK set macro "SetInsideValue" to change
   m_InsideValue = NumericTraits<OutputPixelType>::max();

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -76,7 +76,7 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());
-  threshold->SetOutsideValue(itk::NumericTraits<InternalPixelType>::ZeroValue());
+  threshold->SetOutsideValue(InternalPixelType{});
   threshold->SetLowerThreshold(threshold_low);
   threshold->SetUpperThreshold(threshold_hi);
   threshold->Update();

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -72,7 +72,7 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<RGBPixelType>::OneValue());
-  threshold->SetOutsideValue(itk::NumericTraits<RGBPixelType>::ZeroValue());
+  threshold->SetOutsideValue(RGBPixelType{});
   threshold->SetLowerThreshold(threshold_low);
   threshold->SetUpperThreshold(threshold_hi);
   threshold->Update();

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -74,7 +74,7 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());
-  threshold->SetOutsideValue(itk::NumericTraits<InternalPixelType>::ZeroValue());
+  threshold->SetOutsideValue(InternalPixelType{});
   threshold->SetLowerThreshold(threshold_low);
   threshold->SetUpperThreshold(threshold_hi);
   threshold->Update();
@@ -85,7 +85,7 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
   mask->SetRegions(threshold->GetOutput()->GetLargestPossibleRegion());
   mask->CopyInformation(threshold->GetOutput());
   mask->Allocate();
-  mask->FillBuffer(itk::NumericTraits<MaskPixelType>::ZeroValue());
+  mask->FillBuffer(MaskPixelType{});
 
   MaskImageType::RegionType maskRegion = mask->GetLargestPossibleRegion();
   MaskImageType::SizeType   maskSize = maskRegion.GetSize();

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -101,7 +101,7 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
 
   threshold->SetInput(change->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());
-  threshold->SetOutsideValue(itk::NumericTraits<InternalPixelType>::ZeroValue());
+  threshold->SetOutsideValue(InternalPixelType{});
   threshold->SetLowerThreshold(threshold_low);
   threshold->SetUpperThreshold(threshold_hi);
   threshold->Update();
@@ -132,7 +132,7 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
   finalThreshold->SetLowerThreshold(1); // object #1
   finalThreshold->SetUpperThreshold(1); // object #1
   finalThreshold->SetInsideValue(255);
-  finalThreshold->SetOutsideValue(itk::NumericTraits<WritePixelType>::ZeroValue());
+  finalThreshold->SetOutsideValue(WritePixelType{});
 
   try
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -71,7 +71,7 @@ itkScalarConnectedComponentImageFilterTest(int argc, char * argv[])
   mask->SetRegions(reader->GetOutput()->GetLargestPossibleRegion());
   mask->CopyInformation(reader->GetOutput());
   mask->Allocate();
-  mask->FillBuffer(itk::NumericTraits<MaskPixelType>::ZeroValue());
+  mask->FillBuffer(MaskPixelType{});
 
   MaskImageType::RegionType maskRegion = mask->GetLargestPossibleRegion();
   MaskImageType::SizeType   maskSize = maskRegion.GetSize();

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -248,9 +248,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
     vpos[1] = ic[1];
     vpos[2] = ic[2];
 
-    if (Math::AlmostEquals(
-          data->normal[0],
-          itk::NumericTraits<itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType>::ZeroValue()))
+    if (Math::AlmostEquals(data->normal[0], itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType{}))
     {
       dp[0] = 1e-6;
     }
@@ -259,9 +257,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
       dp[0] = data->normal[0];
     }
 
-    if (Math::AlmostEquals(
-          data->normal[1],
-          itk::NumericTraits<itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType>::ZeroValue()))
+    if (Math::AlmostEquals(data->normal[1], itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType{}))
     {
       dp[1] = 1e-6;
     }
@@ -270,9 +266,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
       dp[1] = data->normal[1];
     }
 
-    if (Math::AlmostEquals(
-          data->normal[2],
-          itk::NumericTraits<itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType>::ZeroValue()))
+    if (Math::AlmostEquals(data->normal[2], itk::NumericTraits<SimplexMeshGeometry::CovariantVectorType>::ValueType{}))
     {
       dp[2] = 1e-6;
     }

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -36,7 +36,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::BinaryMedianImageFilter()
 {
   m_Radius.Fill(1);
   m_ForegroundValue = NumericTraits<InputPixelType>::max();
-  m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  m_BackgroundValue = InputPixelType{};
   this->ThreaderUpdateProgressOff();
 }
 

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -276,7 +276,7 @@ public:
 
 protected:
   MultiLabelSTAPLEImageFilter()
-    : m_LabelForUndecidedPixels(NumericTraits<OutputPixelType>::ZeroValue())
+    : m_LabelForUndecidedPixels(OutputPixelType{})
     , m_TerminationUpdateThreshold(1e-5)
   {}
   ~MultiLabelSTAPLEImageFilter() override = default;

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
@@ -152,7 +152,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 VotingBinaryHoleFillingImageFilter<TInputImage, TOutputImage>::AfterThreadedGenerateData()
 {
-  this->m_NumberOfPixelsChanged = NumericTraits<SizeValueType>::ZeroValue();
+  this->m_NumberOfPixelsChanged = SizeValueType{};
 
   unsigned int numberOfWorkUnits = this->GetNumberOfWorkUnits();
   this->m_Count.SetSize(numberOfWorkUnits);

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -34,7 +34,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::VotingBinaryImageFilter()
 {
   m_Radius.Fill(1);
   m_ForegroundValue = NumericTraits<InputPixelType>::max();
-  m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  m_BackgroundValue = InputPixelType{};
   m_BirthThreshold = 1;
   m_SurvivalThreshold = 1;
   this->ThreaderUpdateProgressOff();

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
@@ -35,7 +35,7 @@ VotingBinaryIterativeHoleFillingImageFilter<TInputImage>::VotingBinaryIterativeH
 {
   m_Radius.Fill(1);
   m_ForegroundValue = NumericTraits<InputPixelType>::max();
-  m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  m_BackgroundValue = InputPixelType{};
   m_MaximumNumberOfIterations = 10;
   m_CurrentNumberOfIterations = 0;
   m_MajorityThreshold = 1;

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
@@ -120,7 +120,7 @@ protected:
   CannySegmentationLevelSetFunction()
   {
     m_Variance = 0.0;
-    m_Threshold = NumericTraits<ScalarValueType>::ZeroValue();
+    m_Threshold = ScalarValueType{};
     m_Caster = CastImageFilter<FeatureImageType, ImageType>::New();
     m_Canny = CannyEdgeDetectionImageFilter<ImageType, ImageType>::New();
     m_Distance = DanielssonDistanceMapImageFilter<ImageType, ImageType>::New();

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -107,7 +107,7 @@ CollidingFrontsImageFilter<TInputImage, TOutputImage>::GenerateData()
     OutputImageRegionType region = outputImage->GetRequestedRegion();
     outputImage->SetBufferedRegion(region);
     outputImage->Allocate();
-    outputImage->FillBuffer(NumericTraits<OutputPixelType>::ZeroValue());
+    outputImage->FillBuffer(OutputPixelType{});
 
     using FunctionType = BinaryThresholdImageFunction<OutputImageType>;
     using IteratorType = FloodFilledImageFunctionConditionalConstIterator<OutputImageType, FunctionType>;

--- a/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
@@ -29,12 +29,12 @@ ImplicitManifoldNormalVectorFilter<TInputImage, TSparseOutputImage>::ImplicitMan
   m_NormalFunction = nullptr;
 
   // set defaults for parameters
-  m_IsoLevelLow = NumericTraits<NodeValueType>::ZeroValue();
-  m_IsoLevelHigh = NumericTraits<NodeValueType>::ZeroValue();
+  m_IsoLevelLow = NodeValueType{};
+  m_IsoLevelHigh = NodeValueType{};
   m_MaxIteration = 25;
   m_MinVectorNorm = static_cast<NodeValueType>(1.0e-6);
   m_UnsharpMaskingFlag = false;
-  m_UnsharpMaskingWeight = NumericTraits<NodeValueType>::ZeroValue();
+  m_UnsharpMaskingWeight = NodeValueType{};
 
   // compute constants used in computations
   unsigned int j;
@@ -134,7 +134,7 @@ ImplicitManifoldNormalVectorFilter<TInputImage, TSparseOutputImage>::InitializeN
   // Normal vector computation -- use positive quadrant of neighborhood
   for (j = 0; j < ImageDimension; ++j) // derivative axis
   {
-    normalvector[j] = NumericTraits<NodeValueType>::ZeroValue();
+    normalvector[j] = NodeValueType{};
     for (counter = 0; counter < m_NumVertex; ++counter)
     {
       position = center;
@@ -163,7 +163,7 @@ ImplicitManifoldNormalVectorFilter<TInputImage, TSparseOutputImage>::InitializeN
   {
     for (j = 0; j < ImageDimension; ++j) // derivative axis
     {
-      derivative = NumericTraits<NodeValueType>::ZeroValue();
+      derivative = NodeValueType{};
       if (i != j)
       {
         for (counter = 0; counter < m_NumVertex; ++counter)

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.h
@@ -67,7 +67,7 @@ public:
   {
     Superclass::Initialize(r);
 
-    this->SetAdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue());
+    this->SetAdvectionWeight(ScalarValueType{});
     this->SetPropagationWeight(-1.0 * NumericTraits<ScalarValueType>::OneValue());
     this->SetCurvatureWeight(NumericTraits<ScalarValueType>::OneValue());
   }
@@ -81,7 +81,7 @@ public:
   void
   SetAdvectionWeight(const ScalarValueType value) override
   {
-    if (Math::ExactlyEquals(value, NumericTraits<ScalarValueType>::ZeroValue()))
+    if (Math::ExactlyEquals(value, ScalarValueType{}))
     {
       Superclass::SetAdvectionWeight(value);
     }

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
@@ -133,7 +133,7 @@ public:
   virtual ScalarValueType
   PropagationSpeed(const NeighborhoodType &, const FloatOffsetType &, GlobalDataStruct * = 0) const
   {
-    return NumericTraits<ScalarValueType>::ZeroValue();
+    return ScalarValueType{};
   }
 
   /** Curvature speed.  Can be used to spatially modify the effects of
@@ -239,9 +239,9 @@ public:
   {
     auto * ans = new GlobalDataStruct();
 
-    ans->m_MaxAdvectionChange = NumericTraits<ScalarValueType>::ZeroValue();
-    ans->m_MaxPropagationChange = NumericTraits<ScalarValueType>::ZeroValue();
-    ans->m_MaxCurvatureChange = NumericTraits<ScalarValueType>::ZeroValue();
+    ans->m_MaxAdvectionChange = ScalarValueType{};
+    ans->m_MaxPropagationChange = ScalarValueType{};
+    ans->m_MaxCurvatureChange = ScalarValueType{};
     return ans;
   }
 
@@ -334,10 +334,10 @@ public:
 protected:
   LevelSetFunction()
     : m_EpsilonMagnitude(static_cast<ScalarValueType>(1.0e-5))
-    , m_AdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue())
-    , m_PropagationWeight(NumericTraits<ScalarValueType>::ZeroValue())
-    , m_CurvatureWeight(NumericTraits<ScalarValueType>::ZeroValue())
-    , m_LaplacianSmoothingWeight(NumericTraits<ScalarValueType>::ZeroValue())
+    , m_AdvectionWeight(ScalarValueType{})
+    , m_PropagationWeight(ScalarValueType{})
+    , m_CurvatureWeight(ScalarValueType{})
+    , m_LaplacianSmoothingWeight(ScalarValueType{})
   {}
 
   ~LevelSetFunction() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -180,7 +180,7 @@ LevelSetFunction<TImageType>::InitializeZeroVectorConstant() -> VectorType
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    ans[i] = NumericTraits<ScalarValueType>::ZeroValue();
+    ans[i] = ScalarValueType{};
   }
 
   return ans;
@@ -252,9 +252,9 @@ LevelSetFunction<TImageType>::ComputeGlobalTimeStep(void * GlobalData) const -> 
   dt /= maxScaleCoefficient;
 
   // reset the values
-  d->m_MaxAdvectionChange = NumericTraits<ScalarValueType>::ZeroValue();
-  d->m_MaxPropagationChange = NumericTraits<ScalarValueType>::ZeroValue();
-  d->m_MaxCurvatureChange = NumericTraits<ScalarValueType>::ZeroValue();
+  d->m_MaxAdvectionChange = ScalarValueType{};
+  d->m_MaxPropagationChange = ScalarValueType{};
+  d->m_MaxCurvatureChange = ScalarValueType{};
 
   return dt;
 }

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.h
@@ -155,7 +155,7 @@ protected:
   virtual ScalarValueType
   OtherPropagationSpeed(const NeighborhoodType &, const FloatOffsetType &, GlobalDataStruct * = 0) const
   {
-    return NumericTraits<ScalarValueType>::ZeroValue();
+    return ScalarValueType{};
   }
 
 private:

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -38,7 +38,7 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::LevelSetFunctionWit
 
   this->SetPropagationWeight(NumericTraits<ScalarValueType>::OneValue());
   m_RefitWeight = NumericTraits<ScalarValueType>::OneValue();
-  m_OtherPropagationWeight = NumericTraits<ScalarValueType>::ZeroValue();
+  m_OtherPropagationWeight = ScalarValueType{};
   m_MinVectorNorm = static_cast<ScalarValueType>(1.0e-6);
 }
 
@@ -89,7 +89,7 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
     stride[j] = neighborhood.GetStride(j);
     indicator[j] = one << j;
   }
-  curvature = NumericTraits<ScalarValueType>::ZeroValue();
+  curvature = ScalarValueType{};
 
   for (counterN = 0; counterN < m_NumVertex; ++counterN)
   {
@@ -105,7 +105,7 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
     // compute the normal vector
     for (j = 0; j < TImageType::ImageDimension; ++j) // derivative axis
     {
-      normalvector[j] = NumericTraits<ScalarValueType>::ZeroValue();
+      normalvector[j] = ScalarValueType{};
       for (counterP = 0; counterP < m_NumVertex; ++counterP)
       {
         positionP = positionN;

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -36,8 +36,8 @@ NormalVectorDiffusionFunction<TSparseImageType>::NormalVectorDiffusionFunction()
   this->SetRadius(r);
   this->SetTimeStep(static_cast<TimeStepType>(0.5 / ImageDimension));
   m_NormalProcessType = 0;
-  m_ConductanceParameter = NumericTraits<NodeValueType>::ZeroValue();
-  m_FluxStopConstant = NumericTraits<NodeValueType>::ZeroValue();
+  m_ConductanceParameter = NodeValueType{};
+  m_FluxStopConstant = NodeValueType{};
 }
 
 template <typename TSparseImageType>
@@ -84,7 +84,7 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
     {
       for (j = 0; j < ImageDimension; ++j)
       {
-        CenterNode->m_Flux[i][j] = NumericTraits<NodeValueType>::ZeroValue();
+        CenterNode->m_Flux[i][j] = NodeValueType{};
       }
     }
     else
@@ -147,7 +147,7 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
       // now compute the intrinsic derivative
       for (j = 0; j < ImageDimension; ++j) // component axis
       {
-        DotProduct = NumericTraits<NodeValueType>::ZeroValue();
+        DotProduct = NodeValueType{};
         for (k = 0; k < ImageDimension; ++k) // derivative axis
         {
           DotProduct += (gradient[k][j] * CenterNode->m_ManifoldNormal[i][k]);
@@ -185,7 +185,7 @@ NormalVectorDiffusionFunction<TSparseImageType>::ComputeSparseUpdate(Neighborhoo
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
 
-  change = NumericTraits<NormalVectorType>::ZeroValue();
+  change = NormalVectorType{};
   for (i = 0; i < ImageDimension; ++i) // flux offset axis
   {
     NextNode = it.GetNext(i);

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -573,7 +573,7 @@ protected:
   TimeStepType
   CalculateChange() override
   {
-    return NumericTraits<TimeStepType>::ZeroValue();
+    return TimeStepType{};
   }
 
   /** This method does the actual work of calculating change over a region

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -100,7 +100,7 @@ typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Valu
 template <typename TInputImage, typename TOutputImage>
 typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ValueType
   ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::m_ValueZero =
-    NumericTraits<typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ValueType>::ZeroValue();
+    typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ValueType{};
 
 template <typename TInputImage, typename TOutputImage>
 typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType
@@ -1067,7 +1067,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Iterate()
 {
-  m_TimeStep = NumericTraits<TimeStepType>::ZeroValue();
+  m_TimeStep = TimeStepType{};
 
   MultiThreaderBase * mt = this->GetMultiThreader();
   mt->SetNumberOfWorkUnits(m_NumOfWorkUnits);
@@ -1300,7 +1300,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
     // neighborhood.  This is used by some level set functions in sampling a
     // speed, advection, or curvature term.
     if (this->m_InterpolateSurfaceLocation &&
-        Math::NotExactlyEquals((centerValue = outputIt.GetCenterPixel()), NumericTraits<ValueType>::ZeroValue()))
+        Math::NotExactlyEquals((centerValue = outputIt.GetCenterPixel()), ValueType{}))
     {
       // Surface is at the zero crossing, so distance to surface is:
       // phi(x) / norm(grad(phi)), where phi(x) is the center of the

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
@@ -36,7 +36,7 @@ SegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType>::S
   this->SetNumberOfLayers(TInputImage::ImageDimension);
   m_SegmentationFunction = nullptr;
   m_AutoGenerateSpeedAdvection = true;
-  this->SetIsoSurfaceValue(NumericTraits<ValueType>::ZeroValue());
+  this->SetIsoSurfaceValue(ValueType{});
 
   // Provide some reasonable defaults which will at least prevent infinite
   // looping.

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
@@ -117,7 +117,7 @@ public:
   {
     Superclass::Initialize(r);
 
-    this->SetAdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue());
+    this->SetAdvectionWeight(ScalarValueType{});
     this->SetPropagationWeight(NumericTraits<ScalarValueType>::OneValue());
     this->SetCurvatureWeight(NumericTraits<ScalarValueType>::OneValue());
   }
@@ -125,7 +125,7 @@ public:
 protected:
   ShapeDetectionLevelSetFunction()
   {
-    this->SetAdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue());
+    this->SetAdvectionWeight(ScalarValueType{});
     this->SetPropagationWeight(NumericTraits<ScalarValueType>::OneValue());
     this->SetCurvatureWeight(NumericTraits<ScalarValueType>::OneValue());
   }

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
@@ -139,10 +139,10 @@ public:
   {
     auto * ans = new ShapePriorGlobalDataStruct();
 
-    ans->m_MaxAdvectionChange = NumericTraits<ScalarValueType>::ZeroValue();
-    ans->m_MaxPropagationChange = NumericTraits<ScalarValueType>::ZeroValue();
-    ans->m_MaxCurvatureChange = NumericTraits<ScalarValueType>::ZeroValue();
-    ans->m_MaxShapePriorChange = NumericTraits<ScalarValueType>::ZeroValue();
+    ans->m_MaxAdvectionChange = ScalarValueType{};
+    ans->m_MaxPropagationChange = ScalarValueType{};
+    ans->m_MaxCurvatureChange = ScalarValueType{};
+    ans->m_MaxShapePriorChange = ScalarValueType{};
     return ans;
   }
 

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -27,7 +27,7 @@ template <typename TImageType, typename TFeatureImageType>
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ShapePriorSegmentationLevelSetFunction()
 {
   m_ShapeFunction = nullptr;
-  m_ShapePriorWeight = NumericTraits<ScalarValueType>::ZeroValue();
+  m_ShapePriorWeight = ScalarValueType{};
 }
 
 template <typename TImageType, typename TFeatureImageType>
@@ -54,7 +54,7 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeUp
   PixelType value = this->Superclass::ComputeUpdate(neighborhood, gd, offset);
 
   // Add the shape prior term
-  if (m_ShapeFunction && Math::NotExactlyEquals(m_ShapePriorWeight, NumericTraits<ScalarValueType>::ZeroValue()))
+  if (m_ShapeFunction && Math::NotExactlyEquals(m_ShapePriorWeight, ScalarValueType{}))
   {
     IndexType                               idx = neighborhood.GetIndex();
     ContinuousIndex<double, ImageDimension> cdx;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -43,12 +43,12 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::SparseFiel
   this->SetIsoSurfaceValue(0);
   m_MaxRefitIteration = 100;
   m_MaxNormalIteration = 25;
-  m_RMSChangeNormalProcessTrigger = NumericTraits<ValueType>::ZeroValue();
+  m_RMSChangeNormalProcessTrigger = ValueType{};
   m_CurvatureBandWidth = static_cast<ValueType>(ImageDimension) + 0.5;
   m_NormalProcessType = 0;
-  m_NormalProcessConductance = NumericTraits<ValueType>::ZeroValue();
+  m_NormalProcessConductance = ValueType{};
   m_NormalProcessUnsharpFlag = false;
-  m_NormalProcessUnsharpWeight = NumericTraits<ValueType>::ZeroValue();
+  m_NormalProcessUnsharpWeight = ValueType{};
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -100,7 +100,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
     indicator[j] = one << j;
   }
 
-  curvature = NumericTraits<ValueType>::ZeroValue();
+  curvature = ValueType{};
 
   for (counter = 0; counter < m_NumVertex; ++counter)
   {
@@ -135,7 +135,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
 
   if (flag == true)
   {
-    curvature = NumericTraits<ValueType>::ZeroValue();
+    curvature = ValueType{};
   }
   curvature *= m_DimConst;
   return curvature;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -986,7 +986,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLayerValues(
   unsigned int i;
   ValueType    value, value_temp, delta;
 
-  value = NumericTraits<ValueType>::ZeroValue(); // warnings
+  value = ValueType{}; // warnings
   bool                         found_neighbor_flag;
   typename LayerType::Iterator toIt;
   LayerNodeType *              node;

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.h
@@ -112,7 +112,7 @@ public:
   {
     Superclass::Initialize(r);
 
-    this->SetAdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue());
+    this->SetAdvectionWeight(ScalarValueType{});
     this->SetPropagationWeight(-1.0 * NumericTraits<ScalarValueType>::OneValue());
     this->SetCurvatureWeight(NumericTraits<ScalarValueType>::OneValue());
   }

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.h
@@ -136,7 +136,7 @@ public:
   {
     Superclass::Initialize(r);
 
-    this->SetAdvectionWeight(NumericTraits<ScalarValueType>::ZeroValue());
+    this->SetAdvectionWeight(ScalarValueType{});
     this->SetPropagationWeight(-1.0 * NumericTraits<ScalarValueType>::OneValue());
     this->SetCurvatureWeight(NumericTraits<ScalarValueType>::OneValue());
   }
@@ -147,8 +147,8 @@ protected:
     MeanVectorType       mean(NumberOfComponents);
     CovarianceMatrixType covariance(NumberOfComponents, NumberOfComponents);
 
-    mean.Fill(NumericTraits<typename FeatureScalarType::ValueType>::ZeroValue());
-    covariance.Fill(NumericTraits<typename FeatureScalarType::ValueType>::ZeroValue());
+    mean.Fill(typename FeatureScalarType::ValueType{});
+    covariance.Fill(typename FeatureScalarType::ValueType{});
 
     m_Mahalanobis = MahalanobisFunctionType::New();
     m_Mahalanobis->SetMean(mean);

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -97,7 +97,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
 
   while (!inputIt.IsAtEnd())
   {
-    if (inputIt.Get() != NumericTraits<InputImagePixelType>::ZeroValue())
+    if (inputIt.Get() != InputImagePixelType{})
     {
       innerPart->AddIndex(inputIt.GetIndex());
       internalIt.Set(LevelSetType::MinusThreeLayer());
@@ -374,7 +374,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDi
 
   while (!iIt.IsAtEnd())
   {
-    if (iIt.Get() != NumericTraits<InputImagePixelType>::ZeroValue())
+    if (iIt.Get() != InputImagePixelType{})
     {
       innerPart->AddIndex(iIt.GetIndex());
       labelIt.Set(LevelSetType::MinusThreeLayer());
@@ -517,7 +517,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
 
   while (!inputIt.IsAtEnd())
   {
-    if (inputIt.Get() != NumericTraits<InputImagePixelType>::ZeroValue())
+    if (inputIt.Get() != InputImagePixelType{})
     {
       innerPart->AddIndex(inputIt.GetIndex());
       internalIt.Set(LevelSetType::MinusOneLayer());
@@ -576,7 +576,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
 
     if (ZeroSet)
     {
-      layer.insert(LayerPairType(idx, NumericTraits<LevelSetOutputType>::ZeroValue()));
+      layer.insert(LayerPairType(idx, LevelSetOutputType{}));
       this->m_InternalImage->SetPixel(idx, LevelSetType::ZeroLayer());
     }
 
@@ -632,7 +632,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
     {
       LayerIdType tempValue = i.Get();
 
-      if (tempValue != NumericTraits<LayerIdType>::ZeroValue())
+      if (tempValue != LayerIdType{})
       {
         if (tempValue == LevelSetType::MinusOneLayer())
         {

--- a/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
@@ -544,7 +544,7 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateMeanCurvature(const InputTyp
     }
 
     data.MeanCurvature.m_Computed = true;
-    data.MeanCurvature.m_Value = NumericTraits<OutputRealType>::ZeroValue();
+    data.MeanCurvature.m_Value = OutputRealType{};
 
     for (unsigned int i = 0; i < Dimension; ++i)
     {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
@@ -139,14 +139,14 @@ public:
       , ForwardGradient("ForwardGradient")
       , BackwardGradient("BackwardGradient")
     {
-      Value.m_Value = NumericTraits<OutputType>::ZeroValue();
-      Gradient.m_Value.Fill(NumericTraits<OutputRealType>::ZeroValue());
-      Hessian.m_Value.Fill(NumericTraits<OutputRealType>::ZeroValue());
-      Laplacian.m_Value = NumericTraits<OutputRealType>::ZeroValue();
-      GradientNorm.m_Value = NumericTraits<OutputRealType>::ZeroValue();
-      MeanCurvature.m_Value = NumericTraits<OutputRealType>::ZeroValue();
-      ForwardGradient.m_Value.Fill(NumericTraits<OutputRealType>::ZeroValue());
-      BackwardGradient.m_Value.Fill(NumericTraits<OutputRealType>::ZeroValue());
+      Value.m_Value = OutputType{};
+      Gradient.m_Value.Fill(OutputRealType{});
+      Hessian.m_Value.Fill(OutputRealType{});
+      Laplacian.m_Value = OutputRealType{};
+      GradientNorm.m_Value = OutputRealType{};
+      MeanCurvature.m_Value = OutputRealType{};
+      ForwardGradient.m_Value.Fill(OutputRealType{});
+      BackwardGradient.m_Value.Fill(OutputRealType{});
     }
 
     LevelSetDataType(const LevelSetDataType & iData)

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -36,7 +36,7 @@ template <typename TInput, unsigned int VDimension, typename TOutput, typename T
 bool
 LevelSetBase<TInput, VDimension, TOutput, TDomain>::IsInside(const InputType & iP) const
 {
-  return (this->Evaluate(iP) <= NumericTraits<OutputType>::ZeroValue());
+  return (this->Evaluate(iP) <= OutputType{});
 }
 
 // ----------------------------------------------------------------------------
@@ -134,7 +134,7 @@ LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateMeanCurvature(const 
     }
 
     ioData.MeanCurvature.m_Computed = true;
-    ioData.MeanCurvature.m_Value = NumericTraits<OutputRealType>::ZeroValue();
+    ioData.MeanCurvature.m_Value = OutputRealType{};
 
     for (unsigned int i = 0; i < Dimension; ++i)
     {
@@ -186,7 +186,7 @@ void
 LevelSetBase<TInput, VDimension, TOutput, TDomain>::SetRequestedRegionToLargestPossibleRegion()
 {
   m_RequestedNumberOfRegions = NumericTraits<RegionType>::OneValue();
-  m_RequestedRegion = NumericTraits<RegionType>::ZeroValue();
+  m_RequestedRegion = RegionType{};
 }
 
 // ----------------------------------------------------------------------------

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -162,7 +162,7 @@ public:
         image->SetRequestedRegion(otherImage->GetRequestedRegion());
         image->SetLargestPossibleRegion(otherImage->GetLargestPossibleRegion());
         image->Allocate();
-        image->FillBuffer(NumericTraits<OutputPixelType>::ZeroValue());
+        image->FillBuffer(OutputPixelType{});
 
         temp_ls->SetImage(image);
         newContainer[it->first] = temp_ls;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
@@ -65,7 +65,7 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::ComputeConsistentRegion
       const OutputImagePixelType segmentPixel = oIt.Get();
       const InputImagePixelType  nextPixel = iIt.Get();
 
-      if ((nextPixel != firstCornerPixelValue) || (segmentPixel != NumericTraits<OutputImagePixelType>::ZeroValue()))
+      if ((nextPixel != firstCornerPixelValue) || (segmentPixel != OutputImagePixelType{}))
       {
         const InputImageIndexType & stopIdx = iIt.GetIndex();
         InputImageSizeType          sizeOfRegion;
@@ -102,7 +102,7 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GenerateData()
   this->m_OutputImage = this->GetOutput();
   this->m_OutputImage->SetBufferedRegion(region);
   this->m_OutputImage->Allocate();
-  this->m_OutputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  this->m_OutputImage->FillBuffer(OutputImagePixelType{});
 
   InputImageIndexType end;
 
@@ -128,7 +128,7 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     // outputPixel is null when it has not been processed yet,
     // or there is nothing to be processed
-    if ((!inputPixel.empty()) && (outputPixel == NumericTraits<OutputImagePixelType>::ZeroValue()))
+    if ((!inputPixel.empty()) && (outputPixel == OutputImagePixelType{}))
     {
       InputImageRegionType subRegion;
       InputImageSizeType   sizeOfRegion;
@@ -144,7 +144,7 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GenerateData()
 
           // Check if the input list pixels are different, or
           // the output image already has been assigned to another region
-          if ((nextPixel != inputPixel) || (currentOutputPixel != NumericTraits<OutputImagePixelType>::ZeroValue()))
+          if ((nextPixel != inputPixel) || (currentOutputPixel != OutputImagePixelType{}))
           {
             sameOverlappingLevelSetIds = false;
           }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -36,7 +36,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::LevelSetEquationAdvec
   this->m_TermName = "Advection term";
   this->m_RequiredData.insert("BackwardGradient");
   this->m_RequiredData.insert("ForwardGradient");
-  this->m_DerivativeSigma = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  this->m_DerivativeSigma = LevelSetOutputRealType{};
   this->m_AutoGenerateAdvectionImage = true;
 }
 
@@ -73,7 +73,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::GenerateAdvectionImag
 
   AdvectionImagePointer gradientImage;
 
-  if (Math::NotAlmostEquals(m_DerivativeSigma, NumericTraits<LevelSetOutputRealType>::ZeroValue()))
+  if (Math::NotAlmostEquals(m_DerivativeSigma, LevelSetOutputRealType{}))
   {
     using DerivativeFilterType = GradientRecursiveGaussianImageFilter<InputImageType, AdvectionImageType>;
 
@@ -159,7 +159,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
   {
     LevelSetOutputRealType component = advectionField[dim];
 
-    if (component > NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (component > LevelSetOutputRealType{})
     {
       oValue += component * backwardGradient[dim];
     }
@@ -185,7 +185,7 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
   {
     LevelSetOutputRealType component = advectionField[dim];
 
-    if (component > NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (component > LevelSetOutputRealType{})
     {
       oValue += component * iData.BackwardGradient.m_Value[dim];
     }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -66,7 +66,7 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSet
   LevelSetOutputRealType value;
   if (pixel > 0)
   {
-    value = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+    value = LevelSetOutputRealType{};
   }
   else
   {
@@ -85,7 +85,7 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSet
   LevelSetOutputRealType value;
   if (pixel > 0)
   {
-    value = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+    value = LevelSetOutputRealType{};
   }
   else
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
@@ -25,9 +25,9 @@ namespace itk
 
 template <typename TInput, typename TLevelSetContainer>
 LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::LevelSetEquationChanAndVeseInternalTerm()
-  : m_Mean(NumericTraits<InputPixelRealType>::ZeroValue())
-  , m_TotalValue(NumericTraits<InputPixelRealType>::ZeroValue())
-  , m_TotalH(NumericTraits<LevelSetOutputRealType>::ZeroValue())
+  : m_Mean(InputPixelRealType{})
+  , m_TotalValue(InputPixelRealType{})
+  , m_TotalH(LevelSetOutputRealType{})
 {
   this->m_TermName = "Internal Chan And Vese term";
   this->m_RequiredData.insert("Value");
@@ -47,7 +47,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Update()
   }
   else
   {
-    this->m_Mean = NumericTraits<InputPixelRealType>::ZeroValue();
+    this->m_Mean = InputPixelRealType{};
   }
 }
 
@@ -55,8 +55,8 @@ template <typename TInput, typename TLevelSetContainer>
 void
 LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::InitializeParameters()
 {
-  this->m_TotalValue = NumericTraits<InputPixelRealType>::ZeroValue();
-  this->m_TotalH = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  this->m_TotalValue = InputPixelRealType{};
+  this->m_TotalH = LevelSetOutputRealType{};
   this->SetUp();
 }
 
@@ -136,7 +136,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const
   {
     itkWarningMacro("m_Heaviside is nullptr");
   }
-  return NumericTraits<LevelSetOutputPixelType>::ZeroValue();
+  return LevelSetOutputPixelType{};
 }
 
 template <typename TInput, typename TLevelSetContainer>
@@ -166,7 +166,7 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const
   {
     itkWarningMacro("m_Heaviside is nullptr");
   }
-  return NumericTraits<LevelSetOutputPixelType>::ZeroValue();
+  return LevelSetOutputPixelType{};
 }
 
 template <typename TInput, typename TLevelSetContainer>

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -31,7 +31,7 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::LevelSetEquationTermB
   this->m_CurrentLevelSetId = LevelSetIdentifierType();
 
   this->m_Coefficient = NumericTraits<LevelSetOutputRealType>::OneValue();
-  this->m_CFLContribution = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  this->m_CFLContribution = LevelSetOutputRealType{};
   this->m_TermName = "";
 }
 
@@ -72,7 +72,7 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelS
   }
   else
   {
-    return NumericTraits<LevelSetOutputRealType>::ZeroValue();
+    return LevelSetOutputRealType{};
   }
 }
 // ----------------------------------------------------------------------------
@@ -90,7 +90,7 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelS
   }
   else
   {
-    return NumericTraits<LevelSetOutputRealType>::ZeroValue();
+    return LevelSetOutputRealType{};
   }
 }
 // ----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ template <typename TInputImage, typename TLevelSetContainer>
 void
 LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::SetUp()
 {
-  this->m_CFLContribution = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+  this->m_CFLContribution = LevelSetOutputRealType{};
 
   if (this->m_CurrentLevelSetPointer.IsNull())
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -96,7 +96,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::AddTerm(const Te
     }
 
     m_Container[iId] = iTerm;
-    m_TermContribution[iId] = NumericTraits<LevelSetOutputPixelType>::ZeroValue();
+    m_TermContribution[iId] = LevelSetOutputPixelType{};
     m_NameContainer[iTerm->GetTermName()] = iTerm;
 
     RequiredDataType termRequiredData = iTerm->GetRequiredData();
@@ -155,7 +155,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::PushTerm(TermTyp
     ++id;
 
     m_Container[id] = iTerm;
-    m_TermContribution[id] = NumericTraits<LevelSetOutputPixelType>::ZeroValue();
+    m_TermContribution[id] = LevelSetOutputPixelType{};
     m_NameContainer[iTerm->GetTermName()] = iTerm;
 
     RequiredDataType termRequiredData = iTerm->GetRequiredData();
@@ -336,7 +336,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Update()
   while (term_it != term_end)
   {
     (term_it->second)->Update();
-    (cfl_it->second) = NumericTraits<LevelSetOutputPixelType>::ZeroValue();
+    (cfl_it->second) = LevelSetOutputPixelType{};
     ++term_it;
     ++cfl_it;
   }
@@ -358,7 +358,7 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ComputeCFLContri
   {
     LevelSetOutputRealType cfl = (term_it->second)->GetCFLContribution();
 
-    if (Math::AlmostEquals(cfl, NumericTraits<LevelSetOutputRealType>::ZeroValue()))
+    if (Math::AlmostEquals(cfl, LevelSetOutputRealType{}))
     {
       cfl = (cfl_it->second);
     }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
@@ -114,7 +114,7 @@ LevelSetEvolution<TEquationContainer, LevelSetDenseImage<TImage>>::ComputeTimeSt
   // if the time step is not globally set
   if (!this->m_UserGloballyDefinedTimeStep)
   {
-    if ((this->m_Alpha > NumericTraits<LevelSetOutputRealType>::ZeroValue()) &&
+    if ((this->m_Alpha > LevelSetOutputRealType{}) &&
         (this->m_Alpha < NumericTraits<LevelSetOutputRealType>::OneValue()))
     {
       LevelSetOutputRealType contribution = this->m_EquationContainer->ComputeCFLContribution();
@@ -182,9 +182,9 @@ LevelSetEvolution<TEquationContainer, LevelSetDenseImage<TImage>>::ReinitializeT
 
     ThresholdFilterPointer thresh = ThresholdFilterType::New();
     thresh->SetLowerThreshold(NumericTraits<LevelSetOutputType>::NonpositiveMin());
-    thresh->SetUpperThreshold(NumericTraits<LevelSetOutputType>::ZeroValue());
+    thresh->SetUpperThreshold(LevelSetOutputType{});
     thresh->SetInsideValue(NumericTraits<LevelSetOutputType>::OneValue());
-    thresh->SetOutsideValue(NumericTraits<LevelSetOutputType>::ZeroValue());
+    thresh->SetOutsideValue(LevelSetOutputType{});
     thresh->SetInput(image);
     thresh->Update();
 
@@ -291,7 +291,7 @@ LevelSetEvolution<TEquationContainer,
 {
   if (!this->m_UserGloballyDefinedTimeStep)
   {
-    if ((this->m_Alpha > NumericTraits<LevelSetOutputRealType>::ZeroValue()) &&
+    if ((this->m_Alpha > LevelSetOutputRealType{}) &&
         (this->m_Alpha < NumericTraits<LevelSetOutputRealType>::OneValue()))
     {
       LevelSetOutputRealType contribution = this->m_EquationContainer->ComputeCFLContribution();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -210,7 +210,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::Evolve()
 
   while (!this->m_StoppingCriterion->IsSatisfied())
   {
-    this->m_RMSChangeAccumulator = NumericTraits<LevelSetOutputRealType>::ZeroValue();
+    this->m_RMSChangeAccumulator = LevelSetOutputRealType{};
 
     // one iteration over all container
     // update each level set based on the different equations provided

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.hxx
@@ -25,9 +25,9 @@ namespace itk
 template <typename TLevelSetContainer>
 LevelSetEvolutionStoppingCriterion<TLevelSetContainer>::LevelSetEvolutionStoppingCriterion()
 {
-  this->m_RMSChangeAccumulator = NumericTraits<OutputRealType>::ZeroValue();
-  this->m_NumberOfIterations = NumericTraits<IterationIdType>::ZeroValue();
-  this->m_CurrentIteration = NumericTraits<IterationIdType>::ZeroValue();
+  this->m_RMSChangeAccumulator = OutputRealType{};
+  this->m_NumberOfIterations = IterationIdType{};
+  this->m_CurrentIteration = IterationIdType{};
 }
 } // namespace itk
 #endif

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.hxx
@@ -27,7 +27,7 @@ template <typename TInput, unsigned int VDimension, typename TOutput>
 LevelSetImage<TInput, VDimension, TOutput>::LevelSetImage()
 {
   this->m_NeighborhoodScales.Fill(NumericTraits<OutputRealType>::OneValue());
-  this->m_DomainOffset.Fill(NumericTraits<OffsetValueType>::ZeroValue());
+  this->m_DomainOffset.Fill(OffsetValueType{});
 }
 } // namespace itk
 #endif // itkLevelSetImage_hxx

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -28,8 +28,8 @@ namespace itk
 
 template <unsigned int VDimension, typename TEquationContainer>
 UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::UpdateMalcolmSparseLevelSet()
-  : m_CurrentLevelSetId(NumericTraits<IdentifierType>::ZeroValue())
-  , m_RMSChangeAccumulator(NumericTraits<LevelSetOutputRealType>::ZeroValue())
+  : m_CurrentLevelSetId(IdentifierType{})
+  , m_RMSChangeAccumulator(LevelSetOutputRealType{})
 
 {
   this->m_Offset.Fill(0);
@@ -143,11 +143,11 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::FillUpdateContainer
 
     LevelSetOutputType value{};
 
-    if (update > NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (update > LevelSetOutputRealType{})
     {
       value = NumericTraits<LevelSetOutputType>::OneValue();
     }
-    if (update < NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (update < LevelSetOutputRealType{})
     {
       value = -NumericTraits<LevelSetOutputType>::OneValue();
     }
@@ -196,11 +196,11 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithUnPhasedP
 
     const LevelSetOutputType update = upIt->second;
 
-    if (update != NumericTraits<LevelSetOutputType>::ZeroValue())
+    if (update != LevelSetOutputType{})
     {
       oldValue = LevelSetType::ZeroLayer();
 
-      if (update > NumericTraits<LevelSetOutputType>::ZeroValue())
+      if (update > LevelSetOutputType{})
       {
         newValue = LevelSetType::PlusOneLayer();
       }
@@ -289,7 +289,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithPhasedPro
     LevelSetInputType  currentIdx = nodeIt->first;
     LevelSetInputType  inputIndex = currentIdx + this->m_Offset;
 
-    if (Math::NotAlmostEquals(update, NumericTraits<LevelSetOutputRealType>::ZeroValue()))
+    if (Math::NotAlmostEquals(update, LevelSetOutputRealType{}))
     {
       // only allow positiveUpdate forces
       if (iContraction)

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
@@ -26,8 +26,8 @@ namespace itk
 
 template <unsigned int VDimension, typename TEquationContainer>
 UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateShiSparseLevelSet()
-  : m_CurrentLevelSetId(NumericTraits<IdentifierType>::ZeroValue())
-  , m_RMSChangeAccumulator(NumericTraits<LevelSetOutputRealType>::ZeroValue())
+  : m_CurrentLevelSetId(IdentifierType{})
+  , m_RMSChangeAccumulator(LevelSetOutputRealType{})
 {
   this->m_Offset.Fill(0);
   this->m_OutputLevelSet = LevelSetType::New();
@@ -95,7 +95,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Update()
     for (typename NeighborhoodIteratorType::Iterator i = neighIt.Begin(); !i.IsAtEnd(); ++i)
     {
       LevelSetOutputType tempValue = i.Get();
-      if (tempValue > NumericTraits<LevelSetOutputType>::ZeroValue())
+      if (tempValue > LevelSetOutputType{})
       {
         toBeDeleted = false;
         break;
@@ -140,7 +140,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Update()
     for (typename NeighborhoodIteratorType::Iterator i = neighIt.Begin(); !i.IsAtEnd(); ++i)
     {
       LevelSetOutputType tempValue = i.Get();
-      if (tempValue < NumericTraits<LevelSetOutputType>::ZeroValue())
+      if (tempValue < LevelSetOutputType{})
       {
         toBeDeleted = false;
         break;
@@ -212,7 +212,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerPlusOne()
     // update the level set
     LevelSetOutputRealType update = termContainer->Evaluate(inputIndex);
 
-    if (update < NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (update < LevelSetOutputRealType{})
     {
       if (Con(currentIndex, currentValue, update))
       {
@@ -310,7 +310,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerMinusOne()
     // update for the current level set
     LevelSetOutputRealType update = termContainer->Evaluate(inputIndex);
 
-    if (update > NumericTraits<LevelSetOutputRealType>::ZeroValue())
+    if (update > LevelSetOutputRealType{})
     {
       if (Con(currentIndex, currentValue, update))
       {
@@ -404,7 +404,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Con(const LevelSetInput
 
       LevelSetOutputRealType neighborUpdate = termContainer->Evaluate(tempIdx + this->m_Offset);
 
-      if (neighborUpdate * currentUpdate > NumericTraits<LevelSetOutputType>::ZeroValue())
+      if (neighborUpdate * currentUpdate > LevelSetOutputType{})
       {
         return true;
       }

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -26,8 +26,8 @@ namespace itk
 template <unsigned int VDimension, typename TLevelSetValueType, typename TEquationContainer>
 UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>::UpdateWhitakerSparseLevelSet()
   : m_TimeStep(NumericTraits<LevelSetOutputType>::OneValue())
-  , m_RMSChangeAccumulator(NumericTraits<LevelSetOutputType>::ZeroValue())
-  , m_CurrentLevelSetId(NumericTraits<IdentifierType>::ZeroValue())
+  , m_RMSChangeAccumulator(LevelSetOutputType{})
+  , m_CurrentLevelSetId(IdentifierType{})
   , m_MinStatus(LevelSetType::MinusThreeLayer())
   , m_MaxStatus(LevelSetType::PlusThreeLayer())
 {

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -61,7 +61,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   IdentifierType numberOfLevelSetFunctions = 2;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -66,7 +66,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   IdentifierType numberOfLevelSetFunctions = 10;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -78,7 +78,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);
@@ -171,8 +171,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   index[1] = 20;
 
   std::cout << maskTerm0->Evaluate(index) << std::endl;
-  if (itk::Math::NotAlmostEquals(maskTerm0->Evaluate(index),
-                                 itk::NumericTraits<BinaryMaskTermType::LevelSetOutputRealType>::ZeroValue()))
+  if (itk::Math::NotAlmostEquals(maskTerm0->Evaluate(index), BinaryMaskTermType::LevelSetOutputRealType{}))
   {
     return EXIT_FAILURE;
   }

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -87,7 +87,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -90,7 +90,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -85,7 +85,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -84,7 +84,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -78,7 +78,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);
@@ -198,8 +198,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   index[1] = 5;
 
   std::cout << penaltyTerm0->Evaluate(index) << std::endl;
-  if (itk::Math::NotAlmostEquals(penaltyTerm0->Evaluate(index),
-                                 itk::NumericTraits<OverlapPenaltyTermType::LevelSetOutputRealType>::ZeroValue()))
+  if (itk::Math::NotAlmostEquals(penaltyTerm0->Evaluate(index), OverlapPenaltyTermType::LevelSetOutputRealType{}))
   {
     return EXIT_FAILURE;
   }

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -84,7 +84,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -92,7 +92,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -91,7 +91,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
   input->Allocate();
-  input->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  input->FillBuffer(InputPixelType{});
 
   index.Fill(910);
   size.Fill(80);
@@ -119,7 +119,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -92,7 +92,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
   input->Allocate();
-  input->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  input->FillBuffer(InputPixelType{});
 
   index.Fill(910);
   size.Fill(80);
@@ -120,7 +120,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -92,7 +92,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
   input->Allocate();
-  input->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  input->FillBuffer(InputPixelType{});
 
   index.Fill(910);
   size.Fill(80);
@@ -120,7 +120,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -92,7 +92,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
   input->Allocate();
-  input->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  input->FillBuffer(InputPixelType{});
 
   index.Fill(910);
   size.Fill(80);
@@ -120,7 +120,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
@@ -79,7 +79,7 @@ itkSingleLevelSetMalcolmImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
@@ -79,7 +79,7 @@ itkSingleLevelSetShiImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
@@ -81,7 +81,7 @@ itkSingleLevelSetWhitakerImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
@@ -81,7 +81,7 @@ itkSingleLevelSetWhitakerImage2DWithCurvatureTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
@@ -83,7 +83,7 @@ itkSingleLevelSetWhitakerImage2DWithLaplacianTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
@@ -81,7 +81,7 @@ itkSingleLevelSetWhitakerImage2DWithPropagationTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
@@ -84,7 +84,7 @@ itkTwoLevelSetMalcolmImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
@@ -84,7 +84,7 @@ itkTwoLevelSetShiImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
@@ -86,7 +86,7 @@ itkTwoLevelSetWhitakerImage2DTest(int argc, char * argv[])
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer(itk::NumericTraits<InputPixelType>::ZeroValue());
+  binary->FillBuffer(InputPixelType{});
 
   InputImageType::RegionType region;
   InputImageType::IndexType  index;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -530,7 +530,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
 
   // Variable to store the modified pixel vector value.
   InputImagePixelType changedPixelVec;
-  changedPixelVec.Fill(NumericTraits<typename InputImagePixelType::ValueType>::ZeroValue());
+  changedPixelVec.Fill(typename InputImagePixelType::ValueType{});
 
   // Set a variable to store the offset index.
   LabelledImageIndexType offsetIndex3D;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -39,8 +39,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::ConfidenceConnectedIm
   m_Seeds.clear();
   m_InitialNeighborhoodRadius = 1;
   m_ReplaceValue = NumericTraits<OutputImagePixelType>::OneValue();
-  m_Mean = NumericTraits<InputRealType>::ZeroValue();
-  m_Variance = NumericTraits<InputRealType>::ZeroValue();
+  m_Mean = InputRealType{};
+  m_Variance = InputRealType{};
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -137,7 +137,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
   outputImage->Allocate();
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
 
   // Compute the statistics of the seed point
 
@@ -148,8 +148,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   InputRealType lower;
   InputRealType upper;
 
-  m_Mean = itk::NumericTraits<InputRealType>::ZeroValue();
-  m_Variance = itk::NumericTraits<InputRealType>::ZeroValue();
+  m_Mean = InputRealType{};
+  m_Variance = InputRealType{};
 
   if (m_InitialNeighborhoodRadius > 0)
   {
@@ -312,8 +312,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     secondFunction->ThresholdBetween(m_ReplaceValue, m_ReplaceValue);
 
     typename NumericTraits<typename InputImageType::PixelType>::RealType sum, sumOfSquares;
-    sum = NumericTraits<InputRealType>::ZeroValue();
-    sumOfSquares = NumericTraits<InputRealType>::ZeroValue();
+    sum = InputRealType{};
+    sumOfSquares = InputRealType{};
     typename TOutputImage::SizeValueType numberOfSamples = 0;
 
     SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
@@ -378,7 +378,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     // upper] bounds prescribed, the pixel is added to the output
     // segmentation and its neighbors become candidates for the
     // iterator to walk.
-    outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+    outputImage->FillBuffer(OutputImagePixelType{});
     IteratorType thirdIt(outputImage, function, m_Seeds);
     thirdIt.GoToBegin();
     try

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -232,7 +232,7 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
   outputImage->Allocate();
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
 
   using FunctionType = BinaryThresholdImageFunction<InputImageType, double>;
 

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -37,7 +37,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::IsolatedConnectedImageF
   m_Seeds1.clear();
   m_Seeds2.clear();
   m_ReplaceValue = NumericTraits<OutputImagePixelType>::OneValue();
-  m_IsolatedValue = NumericTraits<InputImagePixelType>::ZeroValue();
+  m_IsolatedValue = InputImagePixelType{};
   m_IsolatedValueTolerance = NumericTraits<InputImagePixelType>::OneValue();
   m_FindUpperThreshold = true;
   m_ThresholdingFailed = false;
@@ -186,7 +186,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
   outputImage->Allocate();
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
 
   using FunctionType = BinaryThresholdImageFunction<InputImageType>;
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType>;
@@ -219,7 +219,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     {
       ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 100, cumulatedProgress, progressWeight);
       cumulatedProgress += progressWeight;
-      outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+      outputImage->FillBuffer(OutputImagePixelType{});
       function->ThresholdBetween(m_Lower, static_cast<InputImagePixelType>(guess));
       it.GoToBegin();
       while (!it.IsAtEnd())
@@ -246,7 +246,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         ++si;
       }
 
-      if (Math::NotExactlyEquals(seedIntensitySum, NumericTraits<InputRealType>::ZeroValue()))
+      if (Math::NotExactlyEquals(seedIntensitySum, InputRealType{}))
       {
         upper = guess;
       }
@@ -284,7 +284,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     {
       ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 100, cumulatedProgress, progressWeight);
       cumulatedProgress += progressWeight;
-      outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+      outputImage->FillBuffer(OutputImagePixelType{});
       function->ThresholdBetween(static_cast<InputImagePixelType>(guess), m_Upper);
       it.GoToBegin();
       while (!it.IsAtEnd())
@@ -311,7 +311,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
         ++si;
       }
 
-      if (Math::NotExactlyEquals(seedIntensitySum, NumericTraits<InputRealType>::ZeroValue()))
+      if (Math::NotExactlyEquals(seedIntensitySum, InputRealType{}))
       {
         lower = guess;
       }
@@ -334,7 +334,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // now rerun the algorithm with the thresholds that separate the seeds.
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 100, cumulatedProgress, progressWeight);
 
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
   if (m_FindUpperThreshold)
   {
     function->ThresholdBetween(m_Lower, m_IsolatedValue);
@@ -378,7 +378,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     ++si2;
   }
   if (Math::NotAlmostEquals(seed1IntensitySum, m_ReplaceValue * m_Seeds1.size()) ||
-      Math::NotExactlyEquals(seed2IntensitySum, NumericTraits<InputRealType>::ZeroValue()))
+      Math::NotExactlyEquals(seed2IntensitySum, InputRealType{}))
   {
     m_ThresholdingFailed = true;
   }

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -111,7 +111,7 @@ NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Zero the output
   outputImage->SetBufferedRegion(outputImage->GetRequestedRegion());
   outputImage->Allocate();
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
 
   using FunctionType = NeighborhoodBinaryThresholdImageFunction<InputImageType>;
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType>;

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -128,7 +128,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
   outputImage->Allocate();
-  outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+  outputImage->FillBuffer(OutputImagePixelType{});
 
   // Compute the statistics of the seed point
   using VectorMeanImageFunctionType = VectorMeanImageFunction<InputImageType>;
@@ -155,8 +155,8 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   covariance = CovarianceMatrixType(dimension, dimension);
   mean = MeanVectorType(dimension);
 
-  covariance.fill(NumericTraits<ComponentRealType>::ZeroValue());
-  mean.fill(NumericTraits<ComponentRealType>::ZeroValue());
+  covariance.fill(ComponentRealType{});
+  mean.fill(ComponentRealType{});
 
   using MeanFunctionVectorType = typename VectorMeanImageFunctionType::OutputType;
   using CovarianceFunctionMatrixType = typename CovarianceImageFunctionType::OutputType;
@@ -266,8 +266,8 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     covariance = CovarianceMatrixType(dimension, dimension);
     mean = MeanVectorType(dimension);
 
-    covariance.fill(NumericTraits<ComponentRealType>::ZeroValue());
-    mean.fill(NumericTraits<ComponentRealType>::ZeroValue());
+    covariance.fill(ComponentRealType{});
+    mean.fill(ComponentRealType{});
 
     SizeValueType num{};
 
@@ -319,7 +319,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     // upper] bounds prescribed, the pixel is added to the output
     // segmentation and its neighbors become candidates for the
     // iterator to walk.
-    outputImage->FillBuffer(NumericTraits<OutputImagePixelType>::ZeroValue());
+    outputImage->FillBuffer(OutputImagePixelType{});
     IteratorType thirdIt(outputImage, m_ThresholdFunction, m_Seeds);
     thirdIt.GoToBegin();
     try

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -27,11 +27,11 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 IsolatedWatershedImageFilter<TInputImage, TOutputImage>::IsolatedWatershedImageFilter()
 {
-  m_Threshold = NumericTraits<InputImagePixelType>::ZeroValue();
+  m_Threshold = InputImagePixelType{};
   m_Seed1.Fill(0);
   m_Seed2.Fill(0);
   m_ReplaceValue1 = NumericTraits<OutputImagePixelType>::OneValue();
-  m_ReplaceValue2 = NumericTraits<OutputImagePixelType>::ZeroValue();
+  m_ReplaceValue2 = OutputImagePixelType{};
   m_IsolatedValue = 0.0;
   m_IsolatedValueTolerance = 0.001;
   m_UpperValueLimit = 1.0;
@@ -168,7 +168,7 @@ IsolatedWatershedImageFilter<TInputImage, TOutputImage>::GenerateData()
     }
     else
     {
-      ot.Set(NumericTraits<OutputImagePixelType>::ZeroValue());
+      ot.Set(OutputImagePixelType{});
     }
     ++it;
     ++ot;

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::MorphologicalWatershedImageFilter()
-  : m_Level(NumericTraits<InputImagePixelType>::ZeroValue())
+  : m_Level(InputImagePixelType{})
 {}
 
 
@@ -82,7 +82,7 @@ MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::GenerateData()
   auto rmin = RMinType::New();
   rmin->SetInput(input);
   rmin->SetFullyConnected(m_FullyConnected);
-  rmin->SetBackgroundValue(NumericTraits<OutputImagePixelType>::ZeroValue());
+  rmin->SetBackgroundValue(OutputImagePixelType{});
   rmin->SetForegroundValue(NumericTraits<OutputImagePixelType>::max());
 
   // label the components
@@ -99,7 +99,7 @@ MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::GenerateData()
   wshed->SetFullyConnected(m_FullyConnected);
   wshed->SetMarkWatershedLine(m_MarkWatershedLine);
 
-  if (m_Level != NumericTraits<InputImagePixelType>::ZeroValue())
+  if (m_Level != InputImagePixelType{})
   {
     // insert a h-minima filter to remove the smallest minima
     //

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
@@ -83,10 +83,10 @@ itkMorphologicalWatershedImageFilterTest(int argc, char * argv[])
   using RescaleType = itk::IntensityWindowingImageFilter<ImageType, ImageType>;
   auto rescaler = RescaleType::New();
   rescaler->SetInput(filter->GetOutput());
-  rescaler->SetWindowMinimum(itk::NumericTraits<PixelType>::ZeroValue());
+  rescaler->SetWindowMinimum(PixelType{});
   rescaler->SetWindowMaximum(minMaxCalculator->GetMaximum());
   rescaler->SetOutputMaximum(itk::NumericTraits<PixelType>::max());
-  rescaler->SetOutputMinimum(itk::NumericTraits<PixelType>::ZeroValue());
+  rescaler->SetOutputMinimum(PixelType{});
 
   // Write output image
   using WriterType = itk::ImageFileWriter<ImageType>;

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -73,7 +73,7 @@ RGBImageTotalAbsDifference(const itk::Image<itk::RGBPixel<TPixelValue>, VDimensi
       localDiff += itk::Math::abs(validPx[i] - testPx[i]);
     }
 
-    if (localDiff != itk::NumericTraits<TPixelValue>::ZeroValue())
+    if (localDiff != TPixelValue{})
     {
       IterType testIt2 = testIt;
       ++testIt2;
@@ -170,7 +170,7 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
   ComponentType itkIplDiff1 = RGBImageTotalAbsDifference<ComponentType, Dimension>(baselineImage, outIplITK);
 
   // Check results of IplImage -> itk::Image
-  if (itkIplDiff1 != itk::NumericTraits<ComponentType>::ZeroValue())
+  if (itkIplDiff1 != ComponentType{})
   {
     std::cerr << "Images didn't match for pixel type " << typeid(PixelType).name()
               << " for IplImage -> ITK (RGB), with image difference = " << itkIplDiff1 << std::endl;
@@ -185,7 +185,7 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
   ComponentType itkCvMatDiff = RGBImageTotalAbsDifference<ComponentType, Dimension>(baselineImage, outMatITK);
 
   // Check results of cv::Mat -> itk::Image
-  if (itkCvMatDiff != itk::NumericTraits<ComponentType>::ZeroValue())
+  if (itkCvMatDiff != ComponentType{})
   {
     std::cerr << "Images didn't match for pixel type " << typeid(PixelType).name() << " for cv::Mat -> ITK (RGB)"
               << std::endl;

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -95,7 +95,7 @@ VideoFileWriter<TInputVideoStream>::Write()
   }
 
   // Make sure FramesPerSecond and FourCC have been set
-  if (Math::ExactlyEquals(m_FramesPerSecond, NumericTraits<TemporalRatioType>::ZeroValue()) || m_FourCC.length() == 0)
+  if (Math::ExactlyEquals(m_FramesPerSecond, TemporalRatioType{}) || m_FourCC.length() == 0)
   {
     itkExceptionMacro("Cannot write with FramesPerSecond or FourCC unset");
   }

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -25,10 +25,10 @@ namespace itk
 {
 
 VideoIOBase::VideoIOBase()
-  : m_FrameTotal(NumericTraits<SizeValueType>::ZeroValue())
-  , m_CurrentFrame(NumericTraits<SizeValueType>::ZeroValue())
-  , m_IFrameInterval(NumericTraits<SizeValueType>::ZeroValue())
-  , m_LastIFrame(NumericTraits<SizeValueType>::ZeroValue())
+  : m_FrameTotal(SizeValueType{})
+  , m_CurrentFrame(SizeValueType{})
+  , m_IFrameInterval(SizeValueType{})
+  , m_LastIFrame(SizeValueType{})
 
 {}
 


### PR DESCRIPTION
For any type `T` that is supported by `NumericTraits<T>`, the expression `NumericTraits<T>::ZeroValue()` is just equivalent to `T{}`. `T{}` appears preferred, because it is more generic, and it may yield faster code than the corresponding `NumericTraits<T>::ZeroValue()` function call.

Using Notepad++, Replace in Files:

    Find what: itk::NumericTraits<(\w+)>::ZeroValue\(\)
    Find what: NumericTraits<(\w+)>::ZeroValue\(\)
    Replace with: $1{}
    Filters: itk*.hxx;itk*.h;itk*.cxx
    Directory: ITK\Modules
    [v] Match case
    (*) Regular expression

Excluded "itkNumericTraitsTest.cxx", because it purposely calls `NumericTraits::ZeroValue()` as part of the test.

Follow-up to pull request #4017 commit 5ac803e290fb2d5b642ed4e23622f9236b50fdeb "STYLE: Replace `T var{ NumericTraits<T>::ZeroValue() }` with `T var{}`"

Also follows up to:
- pull request #3950 by Hans Johnson (@hjmjohnson)