### PR TITLE
STYLE: Replace `expectZeroFilled` lambda's with ExpectEachElementIsZero

### DIFF
--- a/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
@@ -18,20 +18,14 @@
 
 // First include the header file to be tested:
 #include "itkCovariantVector.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 
 // Tests that a CovariantVector that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(CovariantVector, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::CovariantVector<int>{});
-  expectZeroFilled(itk::CovariantVector<float, 2>{});
-  expectZeroFilled(itk::CovariantVector<double, 4>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::CovariantVector<int>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::CovariantVector<float, 2>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::CovariantVector<double, 4>{});
 }

--- a/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
+++ b/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
@@ -18,20 +18,14 @@
 
 // First include the header file to be tested:
 #include "itkDiffusionTensor3D.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 
 // Tests that a DiffusionTensor3D that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(DiffusionTensor3D, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::DiffusionTensor3D<int>{});
-  expectZeroFilled(itk::DiffusionTensor3D<float>{});
-  expectZeroFilled(itk::DiffusionTensor3D<double>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::DiffusionTensor3D<int>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::DiffusionTensor3D<float>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::DiffusionTensor3D<double>{});
 }

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -18,6 +18,7 @@
 
 // First include the header file to be tested:
 #include "itkPoint.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 #include <initializer_list>
@@ -51,16 +52,9 @@ Expect_Point_can_be_constructed_by_std_array()
 // Tests that a Point that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(Point, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::Point<int>{});
-  expectZeroFilled(itk::Point<float, 2>{});
-  expectZeroFilled(itk::Point<double, 4>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Point<int>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Point<float, 2>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Point<double, 4>{});
 }
 
 

--- a/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
@@ -18,20 +18,14 @@
 
 // First include the header file to be tested:
 #include "itkRGBAPixel.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 
 // Tests that a RGBAPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(RGBAPixel, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::RGBAPixel<>{});
-  expectZeroFilled(itk::RGBAPixel<std::uint8_t>{});
-  expectZeroFilled(itk::RGBAPixel<float>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBAPixel<>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBAPixel<std::uint8_t>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBAPixel<float>{});
 }

--- a/Modules/Core/Common/test/itkRGBPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelGTest.cxx
@@ -18,20 +18,14 @@
 
 // First include the header file to be tested:
 #include "itkRGBPixel.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 
 // Tests that a RGBPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(RGBPixel, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::RGBPixel<>{});
-  expectZeroFilled(itk::RGBPixel<std::uint8_t>{});
-  expectZeroFilled(itk::RGBPixel<float>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBPixel<>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBPixel<std::uint8_t>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::RGBPixel<float>{});
 }

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -155,6 +155,18 @@ public:
     return true;
   }
 
+
+  // Checks that each element of the specified range is zero.
+  template <typename TRange>
+  static void
+  ExpectEachElementIsZero(const TRange & range)
+  {
+    for (const auto & element : range)
+    {
+      EXPECT_EQ(element, 0);
+    }
+  }
+
 private:
   template <typename TRange>
   static void

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
@@ -18,20 +18,14 @@
 
 // First include the header file to be tested:
 #include "itkSymmetricSecondRankTensor.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 
 // Tests that a SymmetricSecondRankTensor that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(SymmetricSecondRankTensor, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::SymmetricSecondRankTensor<int>{});
-  expectZeroFilled(itk::SymmetricSecondRankTensor<float, 2>{});
-  expectZeroFilled(itk::SymmetricSecondRankTensor<double, 4>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::SymmetricSecondRankTensor<int>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::SymmetricSecondRankTensor<float, 2>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::SymmetricSecondRankTensor<double, 4>{});
 }

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -18,6 +18,7 @@
 
 // First include the header file to be tested:
 #include "itkVector.h"
+#include "itkRangeGTestUtilities.h"
 #include <gtest/gtest.h>
 
 #include <initializer_list>
@@ -51,16 +52,9 @@ Expect_itk_Vector_can_be_constructed_by_std_array()
 // Tests that an itk::Vector that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(Vector, ValueInitializedIsZeroFilled)
 {
-  const auto expectZeroFilled = [](const auto & fixedArray) {
-    for (const auto element : fixedArray)
-    {
-      EXPECT_EQ(element, 0);
-    }
-  };
-
-  expectZeroFilled(itk::Vector<int>{});
-  expectZeroFilled(itk::Vector<float, 2>{});
-  expectZeroFilled(itk::Vector<double, 4>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Vector<int>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Vector<float, 2>{});
+  itk::RangeGTestUtilities::ExpectEachElementIsZero(itk::Vector<double, 4>{});
 }
 
 


### PR DESCRIPTION
Added `ExpectEachElementIsZero(const TRange &)` to the internal utilities of `itk::RangeGTestUtilities`.

Removed duplicated lambda definitions from the `ValueInitializedIsZeroFilled` unit tests that were introduced by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4454 commit aa38dce1a520efde6120d6ed5c939f568581b8f6 (by myself, honestly, accidentally violating [the DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)  😸).