### PR TITLE
STYLE: Remove duplicate `#include` directives

### DIFF
--- a/Modules/Compatibility/Deprecated/test/itkSpawnThreadTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkSpawnThreadTest.cxx
@@ -22,7 +22,6 @@
 #include "itkTimeProbe.h"
 #include "itkConfigure.h"
 #include "itksys/SystemTools.hxx"
-#include "itkMutexLock.h"
 
 struct SharedThreadData
 {

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -43,7 +43,6 @@
 #include <algorithm> // For clamp.
 #include <iostream>
 #include <string>
-#include <algorithm>
 #include <cctype>
 #include <utility> // For move.
 

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -30,7 +30,6 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
-#include <algorithm>
 
 #if defined(ITK_USE_PTHREADS)
 #  include "itkPlatformMultiThreaderPosix.cxx"

--- a/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
+++ b/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
@@ -34,7 +34,6 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <ctime>
-#include <cstring>
 #include "itkTestingMacros.h"
 
 void

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
@@ -22,7 +22,6 @@
 #include "metaImage.h"
 #include "itkMetaConverterBase.h"
 #include "itkImageSpatialObject.h"
-#include "itkMetaConverterBase.h"
 
 namespace itk
 {

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -31,7 +31,6 @@
 #include "itkMetaLandmarkConverter.h"
 #include "itkMetaLineConverter.h"
 #include "itkMetaSurfaceConverter.h"
-#include "itkMetaLandmarkConverter.h"
 #include "itkMetaArrowConverter.h"
 #include "itkMetaContourConverter.h"
 

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -24,7 +24,6 @@
 #include "itkTestingMacros.h"
 #include "itkTubeSpatialObject.h"
 #include "itkGroupSpatialObject.h"
-#include "itkTestingMacros.h"
 
 
 int

--- a/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
@@ -24,7 +24,6 @@
 #include "itkImageFileWriter.h"
 #include "itkMaskFeaturePointSelectionFilter.h"
 #include "itkImageFileReader.h"
-#include "itkImageFileWriter.h"
 #include "itkRGBPixel.h"
 #include "itkRegionOfInterestImageFilter.h"
 #include "itkTestingMacros.h"

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -26,7 +26,6 @@
 #include "itkImageRegionIterator.h"
 #include "itkOffset.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkShapedNeighborhoodIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 
 /*

--- a/Modules/IO/ImageBase/include/itkImageIOFactory.h
+++ b/Modules/IO/ImageBase/include/itkImageIOFactory.h
@@ -21,7 +21,6 @@
 
 #include "itkObject.h"
 #include "itkImageIOBase.h"
-#include "ITKIOImageBaseExport.h"
 
 namespace itk
 {

--- a/Modules/IO/MeshBase/include/itkMeshIOFactory.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOFactory.h
@@ -21,7 +21,6 @@
 
 #include "itkObject.h"
 #include "itkMeshIOBase.h"
-#include "ITKIOMeshBaseExport.h"
 
 namespace itk
 {

--- a/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
@@ -26,7 +26,6 @@
 #include "itkTransformFactory.h"
 #include "itkSimilarity2DTransform.h"
 #include "itkBSplineTransform.h"
-#include "itkTestingMacros.h"
 #include "itksys/SystemTools.hxx"
 
 template <typename ScalarType>

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -22,7 +22,6 @@
 #include "itkCompositeTransform.h"
 #include "itkCompositeTransformIOHelper.h"
 #include "itkVersion.h"
-#include "itkMINCTransformIO.h"
 #include "itkMINCImageIO.h"
 #include "itkMINCImageIOFactory.h"
 #include "itkImageFileReader.h"

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -39,7 +39,6 @@
 #include "itkGPUImage.h"
 #include "itkGPUKernelManager.h"
 #include "itkGPUContextManager.h"
-#include "itkGPUDemonsRegistrationFilter.h"
 #include "itkMacro.h"
 #include "itkTestingMacros.h"
 

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -38,9 +38,6 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
-
-#include "itkCommand.h"
-
 #include <iostream>
 #include <fstream>
 #include "itkTestingMacros.h"


### PR DESCRIPTION
Found using Notepad++ v8.6.2, Find in Files:

    Find what: ^(#include "[^ ]+").+^\1
    Find what: ^(#include <[^ ]+>).+^\1
    Filters: itk*.hxx;itk*.h;itk*.cxx
    [v] Match case
    (*) Regular expression
    [v] . matches newline

Following pull requests like:

- https://github.com/InsightSoftwareConsortium/ITK/pull/4436 commit 3cafe87c588969d7e567aac053cdf2aeab83fd31
"STYLE: remove duplicated itkMath.h headers", by Mihail Isakov (@issakomi)

- https://github.com/InsightSoftwareConsortium/ITK/pull/3904 commit 48025bd985d17c53cb11ca4dc739cb83d4cc4802
"ENH: Remove `itkMath.h` duplicate include", by Jon Haitz Legarreta Gorroño (@jhlegarreta)