### PR TITLE
PERF: FUTURE: Default default-constructors of `RGBPixel` and `RGBAPixel`

### DIFF
--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -78,7 +78,12 @@ public:
 
   /** Default-constructor.
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  RGBAPixel() = default;
+#else
   RGBAPixel() { this->Fill(0); }
+#endif
+
   /** Pass-through constructor for the Array base class. */
   template <typename TRGBAPixelValueType>
   RGBAPixel(const RGBAPixel<TRGBAPixelValueType> & r)

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -77,7 +77,11 @@ public:
 
   /** Default-constructor.
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  RGBPixel() = default;
+#else
   RGBPixel() { this->Fill(0); }
+#endif
 
 #if defined(ITK_LEGACY_REMOVE)
   /** Explicit constructor to fill Red=Blug=Green= r. */

--- a/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
+++ b/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
@@ -60,6 +60,21 @@ TEST(CommonTypeTraits, PointIsPOD)
   EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
 
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+TEST(CommonTypeTraits, RGBAPixelIsPOD)
+{
+  using T = itk::RGBAPixel<unsigned int>;
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
+}
+
+TEST(CommonTypeTraits, RGBPixelIsPOD)
+{
+  using T = itk::RGBPixel<unsigned int>;
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
+}
+#else
 TEST(CommonTypeTraits, RGBAPixelIsNotPOD)
 {
   using T = itk::RGBAPixel<unsigned int>;
@@ -75,6 +90,7 @@ TEST(CommonTypeTraits, RGBPixelIsNotPOD)
   EXPECT_FALSE(std::is_trivial_v<T>);
   EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
+#endif
 
 TEST(CommonTypeTraits, SymmetricSecondRankTensorIsNotPOD)
 {


### PR DESCRIPTION
Will make `image.Allocate()` and `image.Allocate(false)` calls much, much
faster, for RGB and RGBA images, when `ITK_FUTURE_LEGACY_REMOVE` is enabled.
An `Allocate()` call on a 1024x1024x1024 RGB image was observed to take more than
1.3 sec. before this commit, and less than 0.001 sec. after this commit, having
`ITK_FUTURE_LEGACY_REMOVE=ON`, using Visual C++ 2019 Release. Even
`image.Allocate(true)` (`initializePixels` = true) appears slightly faster now
with `ITK_FUTURE_LEGACY_REMOVE`.

Adjusted unit tests tests from itkCommonTypeTraitsGTest, because `RGBPixel` and
`RGBAPixel` become "trivial" types when they get defaulted default-constructors.