### PR TITLE
NearestNeighborExtrapolateImageFunction: use `std::clamp` and move GetStartIndex(), GetEndIndex() calls out of its `for` loops 

### DIFF
--- a/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
@@ -19,6 +19,7 @@
 #define itkNearestNeighborExtrapolateImageFunction_h
 
 #include "itkExtrapolateImageFunction.h"
+#include <algorithm> // For clamp.
 
 namespace itk
 {
@@ -89,15 +90,7 @@ public:
 
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      nindex[j] = Math::RoundHalfIntegerUp<IndexValueType>(index[j]);
-      if (nindex[j] < startIndex[j])
-      {
-        nindex[j] = startIndex[j];
-      }
-      else if (nindex[j] > endIndex[j])
-      {
-        nindex[j] = endIndex[j];
-      }
+      nindex[j] = std::clamp(Math::RoundHalfIntegerUp<IndexValueType>(index[j]), startIndex[j], endIndex[j]);
     }
     return static_cast<OutputType>(this->GetInputImage()->GetPixel(nindex));
   }
@@ -119,18 +112,7 @@ public:
 
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      if (index[j] < startIndex[j])
-      {
-        nindex[j] = startIndex[j];
-      }
-      else if (index[j] > endIndex[j])
-      {
-        nindex[j] = endIndex[j];
-      }
-      else
-      {
-        nindex[j] = index[j];
-      }
+      nindex[j] = std::clamp(index[j], startIndex[j], endIndex[j]);
     }
     return static_cast<OutputType>(this->GetInputImage()->GetPixel(nindex));
   }

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
@@ -84,16 +84,19 @@ public:
   {
     IndexType nindex;
 
+    const IndexType startIndex = this->GetStartIndex();
+    const IndexType endIndex = this->GetEndIndex();
+
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       nindex[j] = Math::RoundHalfIntegerUp<IndexValueType>(index[j]);
-      if (nindex[j] < this->GetStartIndex()[j])
+      if (nindex[j] < startIndex[j])
       {
-        nindex[j] = this->GetStartIndex()[j];
+        nindex[j] = startIndex[j];
       }
-      else if (nindex[j] > this->GetEndIndex()[j])
+      else if (nindex[j] > endIndex[j])
       {
-        nindex[j] = this->GetEndIndex()[j];
+        nindex[j] = endIndex[j];
       }
     }
     return static_cast<OutputType>(this->GetInputImage()->GetPixel(nindex));
@@ -111,15 +114,18 @@ public:
   {
     IndexType nindex;
 
+    const IndexType startIndex = this->GetStartIndex();
+    const IndexType endIndex = this->GetEndIndex();
+
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      if (index[j] < this->GetStartIndex()[j])
+      if (index[j] < startIndex[j])
       {
-        nindex[j] = this->GetStartIndex()[j];
+        nindex[j] = startIndex[j];
       }
-      else if (index[j] > this->GetEndIndex()[j])
+      else if (index[j] > endIndex[j])
       {
-        nindex[j] = this->GetEndIndex()[j];
+        nindex[j] = endIndex[j];
       }
       else
       {

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkZeroFluxNeumannPadImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkTestingMacros.h"
+#include <algorithm> // For clamp.
 
 using ShortImage = itk::Image<short, 2>;
 using FloatImage = itk::Image<float, 2>;
@@ -57,14 +58,8 @@ VerifyFilterOutput(const ShortImage * inputImage, const FloatImage * outputImage
       ShortImage::IndexType borderIdx = idx;
       for (unsigned int i = 0; i < ShortImage::ImageDimension; ++i)
       {
-        if (borderIdx[i] < inputIndex[i])
-        {
-          borderIdx[i] = inputIndex[i];
-        }
-        else if (borderIdx[i] > inputIndex[i] + static_cast<ShortImage::IndexValueType>(inputSize[i]) - 1)
-        {
-          borderIdx[i] = inputIndex[i] + inputSize[i] - 1;
-        }
+        borderIdx[i] = std::clamp(
+          borderIdx[i], inputIndex[i], inputIndex[i] + static_cast<ShortImage::IndexValueType>(inputSize[i]) - 1);
       }
 
       if (itk::Math::NotAlmostEquals(outputIterator.Get(), inputImage->GetPixel(borderIdx)))


### PR DESCRIPTION
Aims to improve code readability, and might improve the performance of `NearestNeighborExtrapolateImageFunction`
member functions `EvaluateAtIndex` and `EvaluateAtContinuousIndex`.