### PR TITLE
PERF: FUTURE: Default default-constructor of `SymmetricSecondRankTensor`

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -104,7 +104,11 @@ public:
 
   /** Default-constructor.
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  SymmetricSecondRankTensor() = default;
+#else
   SymmetricSecondRankTensor() { this->Fill(0); }
+#endif
 
   SymmetricSecondRankTensor(const ComponentType & r) { this->Fill(r); }
 

--- a/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
+++ b/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
@@ -74,6 +74,13 @@ TEST(CommonTypeTraits, RGBPixelIsPOD)
   EXPECT_TRUE(std::is_trivial_v<T>);
   EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
+
+TEST(CommonTypeTraits, SymmetricSecondRankTensorIsPOD)
+{
+  using T = itk::SymmetricSecondRankTensor<float, 3>;
+  EXPECT_TRUE(std::is_trivial_v<T>);
+  EXPECT_TRUE(std::is_standard_layout_v<T>);
+}
 #else
 TEST(CommonTypeTraits, RGBAPixelIsNotPOD)
 {
@@ -90,7 +97,6 @@ TEST(CommonTypeTraits, RGBPixelIsNotPOD)
   EXPECT_FALSE(std::is_trivial_v<T>);
   EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
-#endif
 
 TEST(CommonTypeTraits, SymmetricSecondRankTensorIsNotPOD)
 {
@@ -99,6 +105,7 @@ TEST(CommonTypeTraits, SymmetricSecondRankTensorIsNotPOD)
   EXPECT_FALSE(std::is_trivial_v<T>);
   EXPECT_TRUE(std::is_standard_layout_v<T>);
 }
+#endif
 
 /************ Second Generation FixedArray *************/
 /* Derived from Point */


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4469 commit 755cd10e5421d41f4004be101c888d5ba24be8e4
"PERF: FUTURE: Default default-constructors of `RGBPixel` and `RGBAPixel`"