### PR TITLE
Add and use `itk::ImageBase::AllocateInitialized()`

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -83,7 +83,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterat
   typename TTempImage::RegionType tempRegion = this->m_Image->GetBufferedRegion();
 
   m_TemporaryPointer->SetRegions(tempRegion);
-  m_TemporaryPointer->Allocate(true); // initialize buffer to zero
+  m_TemporaryPointer->AllocateInitialized();
 
   // Initialize the queue by adding the start index assuming one of
   // the m_Seeds is "inside" This might not be true, in which

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -242,6 +242,14 @@ public:
   virtual void
   Allocate(bool initialize = false);
 
+  /** Allocates the pixel buffer of the image, zero-initializing its pixels. `AllocateInitialized()` is equivalent to
+   * `Allocate(true)`. It is just intended to make the code more readable. */
+  void
+  AllocateInitialized()
+  {
+    return this->Allocate(true);
+  }
+
   /** Set the region object that defines the size and starting index
    * for the largest possible region this image could represent.  This
    * is used in determining how much memory would be needed to load an

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -93,7 +93,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   typename TTempImage::RegionType tempRegion = this->m_Image->GetBufferedRegion();
 
   m_TempPtr->SetRegions(tempRegion);
-  m_TempPtr->Allocate(true); // initialize buffer to zero
+  m_TempPtr->AllocateInitialized();
 
   // Initialize the queue by adding the start index assuming one of
   // the m_Seeds is "inside" This might not be true, in which

--- a/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
@@ -199,7 +199,7 @@ itkAdaptorComparisonTest(int, char *[])
   auto vector_image = VectorImageType::New();
 
   scalar_image->SetRegions(region);
-  scalar_image->Allocate(true); // initialize buffer to zero
+  scalar_image->AllocateInitialized();
 
   vector_image->SetRegions(region);
   vector_image->Allocate();

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -281,7 +281,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     region.SetSize(size);
 
     image->SetRegions(region);
-    image->Allocate(true); // initialize buffer to zero
+    image->AllocateInitialized();
 
     using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType  iter(image, image->GetBufferedRegion());

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -252,7 +252,7 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
   SizeType   imageSize;
   imageSize.Fill(1);
   image->SetRegions(imageSize);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   // Create a radius, (just) large enough for all offsets activated below here.
   SizeType radius;

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -81,12 +81,12 @@ itkImageAlgorithmCopyTest2(int, char *[])
 
   auto image2 = Short3DImageType::New();
   image2->SetRegions(region);
-  image2->Allocate(true); // initialize buffer to zero
+  image2->AllocateInitialized();
 
 
   auto image3 = Float3DImageType::New();
   image3->SetRegions(region);
-  image3->Allocate(true); // initialize buffer to zero
+  image3->AllocateInitialized();
 
   std::cout << "Copying two images of same type" << std::endl;
   itk::ImageAlgorithm::Copy(image1.GetPointer(), image2.GetPointer(), region, region);

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -144,7 +144,7 @@ CreateSmallImage()
   imageSize.Fill(0);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
-  image->Allocate(true);
+  image->AllocateInitialized();
   return image;
 }
 
@@ -538,7 +538,7 @@ TEST(ImageBufferRange, SupportsVectorImage)
   const typename ImageType::SizeType imageSize = { { sizeX, sizeY, sizeZ } };
   image->SetRegions(imageSize);
   image->SetVectorLength(vectorLength);
-  image->Allocate(true);
+  image->AllocateInitialized();
   PixelType fillPixelValue(vectorLength);
   fillPixelValue.Fill(42);
   image->FillBuffer(fillPixelValue);

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -43,7 +43,7 @@ itkImageDuplicatorTest(int, char *[])
     std::cout << "Creating simulated image: ";
     auto m_Image = ImageType::New();
     m_Image->SetRegions(region);
-    m_Image->Allocate(true); // initialize buffer to zero
+    m_Image->AllocateInitialized();
 
     itk::ImageRegionIterator<ImageType> it(m_Image, region);
     it.GoToBegin();

--- a/Modules/Core/Common/test/itkImageGTest.cxx
+++ b/Modules/Core/Common/test/itkImageGTest.cxx
@@ -86,9 +86,7 @@ Expect_allocated_initialized_image_equal_to_itself()
 
   const auto image = TImage::New();
   image->SetRegions(SizeType::Filled(2));
-
-  // Allocate and initialize the image:
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   Expect_equal_to_itself(*image);
 }
@@ -102,11 +100,11 @@ Expect_unequal_when_sizes_differ()
 
   const auto image1 = TImage::New();
   image1->SetRegions(SizeType::Filled(2));
-  image1->Allocate(true);
+  image1->AllocateInitialized();
 
   const auto image2 = TImage::New();
   image2->SetRegions(SizeType::Filled(3));
-  image2->Allocate(true);
+  image2->AllocateInitialized();
 
   Expect_unequal(*image1, *image2);
 }

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -60,7 +60,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
   region.SetSize(size);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   using RandomIteratorType = itk::ImageRandomIteratorWithIndex<ImageType>;
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -471,7 +471,7 @@ TEST(ImageRegionRange, SupportsVectorImage)
   const typename ImageType::SizeType imageSize = { { sizeX, sizeY, sizeZ } };
   image->SetRegions(imageSize);
   image->SetVectorLength(vectorLength);
-  image->Allocate(true);
+  image->AllocateInitialized();
   PixelType fillPixelValue(vectorLength);
   fillPixelValue.Fill(42);
   image->FillBuffer(fillPixelValue);
@@ -634,7 +634,7 @@ TEST(ImageRegionRange, ThrowsInReleaseWhenIterationRegionIsOutsideBufferedRegion
   const SizeType  imageSize{ { 3, 4 } };
 
   image->SetRegions(RegionType{ imageIndex, imageSize });
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
     *image, RegionType{ imageIndex, imageSize + SizeType::Filled(1) });

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -54,7 +54,7 @@ itkLineIteratorTest(int argc, char * argv[])
 
   auto output = ImageType::New();
   output->SetRegions(region);
-  output->Allocate(true); // initialize buffer to zero
+  output->AllocateInitialized();
 
   // First test: empty line
   IndexType startIndex;

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -78,11 +78,11 @@ ReallocateImage()
   SizeType size = { { 5, 3 } };
 
   testImage->SetRegions(size);
-  testImage->Allocate(true); // initialize buffer to zero
+  testImage->AllocateInitialized();
 
   SizeType size2 = { { 100, 100 } };
   testImage->SetRegions(size2);
-  testImage->Allocate(true); // initialize buffer to zero
+  testImage->AllocateInitialized();
 }
 
 int

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -125,7 +125,7 @@ CreateSmallImage()
   imageSize.Fill(0);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
-  image->Allocate(true);
+  image->AllocateInitialized();
   return image;
 }
 
@@ -623,7 +623,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsVectorImage)
   const typename ImageType::SizeType imageSize = { { sizeX, sizeY, sizeZ } };
   image->SetRegions(imageSize);
   image->SetVectorLength(vectorLength);
-  image->Allocate(true);
+  image->AllocateInitialized();
   PixelType fillPixelValue(vectorLength);
   fillPixelValue.Fill(42);
   image->FillBuffer(fillPixelValue);
@@ -1006,7 +1006,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsArbitraryBufferedRegionIndex)
 
   const auto image = ImageType::New();
   image->SetRegions(bufferedRegion);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   // Set a 'magic value' at the begin of the buffered region.
   const ImageType::PixelType   magicPixelValue = 42;

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -66,7 +66,7 @@ DoConvolution(typename ImageType::Pointer inputImage, unsigned long int directio
 
   auto outputImage = ImageType::New();
   outputImage->SetRegions(inputImage->GetRequestedRegion());
-  outputImage->Allocate(true);
+  outputImage->AllocateInitialized();
 
   IteratorType                             out(outputImage, inputImage->GetRequestedRegion());
   itk::NeighborhoodInnerProduct<ImageType> innerProduct;

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -72,7 +72,7 @@ itkGPUImageTest(int argc, char * argv[])
 
   dest = ItkImage1f::New();
   dest->SetRegions(region);
-  dest->Allocate(true); // initialize buffer to zero
+  dest->AllocateInitialized();
 
   // check pixel value
   ItkImage1f::IndexType idx;

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -214,7 +214,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
   typename InternalImageType::RegionType region;
   region.SetSize(size);
   m_InternalImage->SetRegions(region);
-  m_InternalImage->Allocate(true); // initialize buffer to zero
+  m_InternalImage->AllocateInitialized();
 }
 
 /** Evaluate the function at the specified point */

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -40,7 +40,7 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
   region.SetSize(size);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   for (unsigned int i = 0; i < FloatImage::ImageDimension; ++i)
   {

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -42,7 +42,7 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   region.SetSize(size);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -42,7 +42,7 @@ TestGaussianDerivativeImageFunction()
   region.SetSize(size);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -58,7 +58,7 @@ Expect_EvaluateAtIndex_returns_zero_when_all_pixels_are_zero(const typename TIma
 {
   const auto image = TImage::New();
   image->SetRegions(imageSize);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   const auto imageFunction = itk::SumOfSquaresImageFunction<TImage>::New();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -52,7 +52,7 @@ Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero(
   const auto image = itk::Image<TPixel, VImageDimension>::New();
 
   image->SetRegions(imageRegion);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   EXPECT_EQ(ComputeAxisAlignedBoundingBoxRegionInImageGridSpace(*image).GetSize(), itk::Size<VImageDimension>{});
 }
@@ -87,9 +87,7 @@ Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the
   const auto image = itk::Image<TPixel, VImageDimension>::New();
 
   image->SetRegions(imageRegion);
-
-  // Initialize all pixels to zero.
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   const itk::ImageRegionIndexRange<VImageDimension> indexRange{ imageRegion };
 
@@ -250,7 +248,7 @@ TEST(ImageMaskSpatialObject, IsInsideSingleNonZeroPixel)
   // Create an image filled with zero valued pixels.
   const auto image = ImageType::New();
   image->SetRegions(SizeType::Filled(8));
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   constexpr itk::IndexValueType indexValue{ 4 };
   image->SetPixel({ { indexValue, indexValue } }, 1);
@@ -277,7 +275,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
   // Create an image filled with zero valued pixels.
   const auto image = ImageType::New();
   image->SetRegions(SizeType::Filled(10));
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   // Set the value of a pixel to non-zero.
   constexpr itk::IndexValueType indexValue{ 8 };
@@ -316,7 +314,7 @@ TEST(ImageMaskSpatialObject, CornerPointIsNotInsideMaskOfZeroValues)
   // Create a mask image, and fill the image with zero vales.
   const auto image = itk::Image<unsigned char>::New();
   image->SetRegions(itk::Size<>{ { 2, 2 } });
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   const auto imageMaskSpatialObject = itk::ImageMaskSpatialObject<2>::New();
   imageMaskSpatialObject->SetImage(image);
@@ -336,7 +334,7 @@ TEST(ImageMaskSpatialObject, IsInsideInWorldSpaceOverloads)
   // Create a mask image.
   const auto maskImage = MaskImageType::New();
   maskImage->SetRegions(itk::Size<imageDimension>::Filled(2));
-  maskImage->Allocate(true);
+  maskImage->AllocateInitialized();
   maskImage->SetPixel({}, MaskPixelType{ 1 });
   maskImage->SetSpacing(itk::MakeFilled<MaskImageType::SpacingType>(0.5));
 
@@ -372,7 +370,7 @@ TEST(ImageMaskSpatialObject, StoresRegionsFromMaskImage)
       // Create a mask image.
       const auto maskImage = MaskImageType::New();
       maskImage->SetRegions(RegionType{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
-      maskImage->Allocate(true);
+      maskImage->AllocateInitialized();
 
       const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
       imageMaskSpatialObject->SetImage(maskImage);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -50,7 +50,7 @@ itkImageMaskSpatialObjectTest(int, char *[])
   region.SetIndex(index);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   ImageType::RegionType insideRegion;
   ImageType::SizeType   insideSize = { { 30, 30, 30 } };

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -80,7 +80,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   ImageType::RegionType  insideRegion;
   constexpr unsigned int INSIDE_SIZE = 30;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -67,7 +67,7 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
   imageMaskSpatialObject->SetImage(image);

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -48,7 +48,7 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
   region.SetSize(size);
 
   inputImage->SetRegions(region);
-  inputImage->Allocate(true); // initialize buffer to zero
+  inputImage->AllocateInitialized();
 
   InputImageType::DirectionType direction;
   direction[0][0] = 1.0;

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -156,7 +156,7 @@ CLANG_SUPPRESS_Wfloat_equal
     RealImagePointer logBiasField = RealImageType::New();
     logBiasField->CopyInformation(inputImage);
     logBiasField->SetRegions(inputImage->GetLargestPossibleRegion());
-    logBiasField->Allocate(true); // initialize buffer to zero
+    logBiasField->AllocateInitialized();
 
     RealImagePointer logSharpenedImage = RealImageType::New();
     logSharpenedImage->CopyInformation(inputImage);

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
@@ -45,9 +45,7 @@ itkConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
   auto                  deltaFunctionImage = ImageType::New();
   deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->Allocate(true); // initialize
-                                      // buffer
-                                      // to zero
+  deltaFunctionImage->AllocateInitialized();
 
   // Set the middle pixel (rounded up) to 1.
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -56,7 +56,7 @@ itkFFTConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
   auto                  deltaFunctionImage = ImageType::New();
   deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->Allocate(true); // initialize buffer to zero
+  deltaFunctionImage->AllocateInitialized();
 
   // Set the middle pixel (rounded up) to 1
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -100,7 +100,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   this->m_ScaledNormImage->CopyInformation(displacementField);
   this->m_ScaledNormImage->SetRegions(displacementField->GetRequestedRegion());
-  this->m_ScaledNormImage->Allocate(true); // initialize buffer to zero
+  this->m_ScaledNormImage->AllocateInitialized();
 
   SizeValueType numberOfPixelsInRegion = (displacementField->GetRequestedRegion()).GetNumberOfPixels();
   this->m_MaxErrorNorm = NumericTraits<RealType>::max();

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
@@ -46,7 +46,7 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);
-  inputImage2D->Allocate(true);
+  inputImage2D->AllocateInitialized();
 
   // Set pixel (4,4) with the value 1
   // and pixel (1,6) with the value 2

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -64,7 +64,7 @@ test(int testIdx)
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);
-  inputImage2D->Allocate(true);
+  inputImage2D->AllocateInitialized();
 
   if (!testIdx)
   {

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
@@ -43,7 +43,7 @@ itkSignedDanielssonDistanceMapImageFilterTest11(int, char *[])
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);
-  inputImage2D->Allocate(true);
+  inputImage2D->AllocateInitialized();
 
   /* Set pixel (4,4) with the value 1
    * The SignedDanielsson Distance is performed for each pixel with a value > 0

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
@@ -43,7 +43,7 @@ itkSignedMaurerDistanceMapImageFilterTest11(int, char *[])
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);
-  inputImage2D->Allocate(true);
+  inputImage2D->AllocateInitialized();
 
   /* Set pixel (4,4) with the value 1
    * The SignedMaurer Distance is performed for each pixel with a value > 0

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -103,7 +103,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   m_RadiusImage->SetOrigin(inputImage->GetOrigin());
   m_RadiusImage->SetSpacing(inputImage->GetSpacing());
   m_RadiusImage->SetDirection(inputImage->GetDirection());
-  m_RadiusImage->Allocate(true); // initialize buffer to zero
+  m_RadiusImage->AllocateInitialized();
 
   ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -150,7 +150,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
   m_SimplifyAccumulator->SetOrigin(inputImage->GetOrigin());
   m_SimplifyAccumulator->SetSpacing(inputImage->GetSpacing());
   m_SimplifyAccumulator->SetDirection(inputImage->GetDirection());
-  m_SimplifyAccumulator->Allocate(true); // Initialize buffer to zero.
+  m_SimplifyAccumulator->AllocateInitialized();
 
   Index<2> index;
   Index<2> maxIndex;

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -138,8 +138,7 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
     typename ScalesImageType::Pointer scalesImage = dynamic_cast<ScalesImageType *>(this->ProcessObject::GetOutput(1));
 
     scalesImage->SetBufferedRegion(scalesImage->GetRequestedRegion());
-    scalesImage->Allocate(true); // initialize
-                                 // buffer to zero
+    scalesImage->AllocateInitialized();
   }
 
   if (m_GenerateHessianOutput)

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -58,7 +58,7 @@ Test_GetCircles_should_return_empty_list_when_NumberOfCircles_is_set_to_zero()
   const auto                image = ImageType::New();
   const ImageType::SizeType size = { { 64, 64 } };
   image->SetRegions(size);
-  image->Allocate(true);
+  image->AllocateInitialized();
   const unsigned int center[] = { 16, 16 };
   constexpr double   radius = 7.0;
   CreateCircle<ImageType>(image, center, radius);
@@ -259,7 +259,7 @@ Test_Center_IsInside_SpatialObject_from_GetCircles()
   const auto                image = ImageType::New();
   const ImageType::SizeType imageSize = { { 16, 32 } };
   image->SetRegions(imageSize);
-  image->Allocate(true);
+  image->AllocateInitialized();
   const double center[] = { 6.0, 9.0 };
   const double radius = 1.0;
   CreateCircle<ImageType>(image, center, radius);
@@ -326,7 +326,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   region.SetIndex(index);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   // Create 3 circles
   constexpr unsigned int circles = 3;
@@ -354,7 +354,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   // Allocate Hough Space image (accumulator)
   auto m_HoughSpaceImage = ImageType::New();
   m_HoughSpaceImage->SetRegions(region);
-  m_HoughSpaceImage->Allocate(true); // initialize buffer to zero
+  m_HoughSpaceImage->AllocateInitialized();
 
   // Apply gradient filter to the input image
   using CastingFilterType = itk::CastImageFilter<ImageType, HoughImageType>;

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -50,7 +50,7 @@ Test_GetLines_should_return_empty_list_when_input_image_is_entirely_black()
   const auto                image = ImageType::New();
   const ImageType::SizeType size = { { 32, 32 } };
   image->SetRegions(size);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   const auto filter = FilterType::New();
   filter->SetInput(image);
@@ -81,7 +81,7 @@ Test_GetLines_should_return_empty_list_when_NumberOfLines_is_set_to_zero()
   };
   const ImageType::SizeType size = { { sizeX, sizeY } };
   image->SetRegions(size);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   // Place some line segment in the image.
   for (itk::IndexValueType x = 1; x < (sizeX - 1); ++x)
@@ -150,7 +150,7 @@ itkHoughTransform2DLinesImageTest(int, char *[])
   region.SetIndex(index);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   // Create a line
   constexpr unsigned int lines = 1;

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -54,10 +54,10 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
 
   region = input->GetOutput()->GetBufferedRegion();
   mask1->SetRegions(region);
-  mask1->Allocate(true); // initialize buffer to zero
+  mask1->AllocateInitialized();
 
   mask2->SetRegions(region);
-  mask2->Allocate(true); // initialize buffer to zero
+  mask2->AllocateInitialized();
 
 
   size = region.GetSize();

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -71,9 +71,8 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  // initialize the image with default-valued pixels (in this case, 0.0)
   inputImage->SetRegions(region);
-  inputImage->Allocate(true);
+  inputImage->AllocateInitialized();
 
   // Set the metadata for the image
   myImageType::PointType     origin;

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -39,7 +39,7 @@ makeTestableScalarImage(typename InternalImageType::Pointer internalImage, std::
   OutputImageType::Pointer outputImage = OutputImageType::New();
   outputImage->CopyInformation(internalImage);
   outputImage->SetRegions(internalImage->GetBufferedRegion());
-  outputImage->Allocate(true);
+  outputImage->AllocateInitialized();
 
   auto myiterator = itk::ImageRegionConstIterator<InternalImageType>(internalImage, internalImage->GetBufferedRegion());
   auto myOutiterator = itk::ImageRegionIterator<OutputImageType>(outputImage, outputImage->GetBufferedRegion());

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -170,7 +170,7 @@ itkSliceBySliceImageFilterTest(int argc, char * argv[])
     ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
     region.SetIndex(0, 10);
     image->SetRegions(region);
-    image->Allocate(true);
+    image->AllocateInitialized();
   }
 
   ImageType::SpacingType spacing;

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -177,7 +177,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   outputImagePtr->SetRequestedRegion(inputImagePtr->GetRequestedRegion());
   outputImagePtr->SetBufferedRegion(inputImagePtr->GetBufferedRegion());
   outputImagePtr->SetLargestPossibleRegion(inputImagePtr->GetLargestPossibleRegion());
-  outputImagePtr->Allocate(true); // initialize buffer to zero
+  outputImagePtr->AllocateInitialized();
 
   InputImageConstIteratorType inputIt(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
   OutputImageIteratorType     outputIt(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
@@ -328,7 +328,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   itkDebugMacro("Projection image origin:" << origin);
 
   projectionImagePtr->SetRegions(projectionRegion);
-  projectionImagePtr->Allocate(true); // initialize buffer to zero
+  projectionImagePtr->AllocateInitialized();
 
   using ProjectionImageIteratorType = ImageRegionIterator<ProjectionImageType>;
   ProjectionImageIteratorType projectionIt(projectionImagePtr, projectionImagePtr->GetLargestPossibleRegion());

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -38,7 +38,7 @@ makeTestableScalarImage(typename InternalImageType::Pointer internalImage, std::
   OutputImageType::Pointer outputImage = OutputImageType::New();
   outputImage->CopyInformation(internalImage);
   outputImage->SetRegions(internalImage->GetBufferedRegion());
-  outputImage->Allocate(true);
+  outputImage->AllocateInitialized();
 
   auto myiterator = itk::ImageRegionConstIterator<InternalImageType>(internalImage, internalImage->GetBufferedRegion());
   auto myOutiterator = itk::ImageRegionIterator<OutputImageType>(outputImage, outputImage->GetBufferedRegion());

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -31,7 +31,7 @@ zeroSizeCase()
   auto p_image = ImageType::New();
 
   // The image region is empty by default: do not set any region to it and allocate memory
-  p_image->Allocate(true);
+  p_image->AllocateInitialized();
 
   p_filter->SetInput(p_image);
   p_filter->Update();

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -31,8 +31,7 @@ CreateImagex(LocalImageType::Pointer & image)
   LocalImageType::RegionType region(start, size);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer
-                         // to zero
+  image->AllocateInitialized();
 }
 
 int

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
@@ -48,8 +48,7 @@ itkImageFileWriterTest2(int argc, char * argv[])
   region.SetIndex(index);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer
-                         // to zero
+  image->AllocateInitialized();
 
   image->TransformIndexToPhysicalPoint(index, originalPoint);
   std::cout << "Original Starting Index: " << index << std::endl;

--- a/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
@@ -49,7 +49,7 @@ struct ITKWriteImageFunctionTest : public ::testing::Test
 
     image->SetRegions(region);
 
-    image->Allocate(true);
+    image->AllocateInitialized();
     return image;
   }
 };

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -52,8 +52,7 @@ itkJPEGImageIOTest2(int argc, char * argv[])
   region.SetIndex(start);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer
-                         // to zero
+  image->AllocateInitialized();
 
   ImageType::SpacingType spacing;
 

--- a/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
@@ -55,7 +55,7 @@ itkNiftiLargeImageRegionReadTest(int argc, char * argv[])
   {
     auto image = ImageType::New();
     image->SetRegions(region);
-    image->Allocate(true);
+    image->AllocateInitialized();
     itk::WriteImage(image, fname);
   }
 

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -45,7 +45,7 @@ itkNiftiWriteCoerceOrthogonalDirectionTest(int argc, char * argv[])
   region.SetIndex(startIndex);
   auto image1 = ImageType::New();
   image1->SetRegions(region);
-  image1->Allocate(true);
+  image1->AllocateInitialized();
 
   ImageType::DirectionType mat1;
   mat1.SetIdentity();

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
@@ -52,7 +52,7 @@ itkTIFFImageIOTest2(int argc, char * argv[])
   region.SetIndex(start);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   ImageType::SpacingType spacing;
 

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -190,8 +190,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
   pRegion.SetSize(pSize);
   pRegion.SetIndex(pStart);
   projectionLine->SetRegions(pRegion);
-  projectionLine->Allocate(true); // initialize
-                                  // buffer to zero
+  projectionLine->AllocateInitialized();
 
   ProjectionLineType::IndexType pIdx;
   const unsigned int            pLineHalfShift = pSize[0] - inputROISize[m_RDirection] / 2;
@@ -220,8 +219,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
 
   auto FFTSlice = FFTSliceType::New();
   FFTSlice->SetRegions(FFTSliceRegion);
-  FFTSlice->Allocate(true); // initialize
-                            // buffer to zero
+  FFTSlice->AllocateInitialized();
 
   FFTSliceIteratorType    FFTSliceIt(FFTSlice, FFTSliceRegion);
   FFTSliceType::IndexType sIdx;

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
@@ -40,9 +40,7 @@ RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::CreateHeavisideFunc
   this->m_HeavisideFunctionOfLevelSetImage = InputImageType::New();
   this->m_HeavisideFunctionOfLevelSetImage->CopyInformation(image);
   this->m_HeavisideFunctionOfLevelSetImage->SetRegions(region);
-  this->m_HeavisideFunctionOfLevelSetImage->Allocate(true); // initialize
-                                                            // buffer
-                                                            // to zero
+  this->m_HeavisideFunctionOfLevelSetImage->AllocateInitialized();
 
   const InputPointType origin = image->GetOrigin();
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -81,8 +81,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * 
 
   auto visitedImage = ImageType::New();
   visitedImage->SetRegions(region);
-  visitedImage->Allocate(true); // initialize
-                                // buffer to zero
+  visitedImage->AllocateInitialized();
 
   for (; !shapedFloodIt.IsAtEnd(); ++shapedFloodIt)
   {

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
@@ -51,8 +51,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2(int, char *[])
 
     auto inputImage = ImageType::New();
     inputImage->SetRegions(region);
-    inputImage->Allocate(true); // initialize
-                                // buffer to zero
+    inputImage->AllocateInitialized();
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
@@ -53,8 +53,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3(int, char *[])
 
     auto inputImage = ImageType::New();
     inputImage->SetRegions(region);
-    inputImage->Allocate(true); // initialize
-                                // buffer to zero
+    inputImage->AllocateInitialized();
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -58,8 +58,7 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   region.SetIndex(idx);
 
   inImage->SetRegions(region);
-  inImage->Allocate(true); // initialize buffer
-                           // to zero
+  inImage->AllocateInitialized();
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -72,8 +72,7 @@ CreateMaskImage()
 
   MaskImageType::RegionType region(start, size);
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer
-                         // to zero
+  image->AllocateInitialized();
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
@@ -114,8 +113,7 @@ CreateLargerMaskImage()
 
   MaskImageType::RegionType region(start, size);
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer
-                         // to zero
+  image->AllocateInitialized();
   return image;
 }
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -61,8 +61,7 @@ itkImageToListSampleFilterTest2(int, char *[])
 
   auto maskImage = MaskImageType::New();
   maskImage->SetRegions(region);
-  maskImage->Allocate(true); // initialize
-                             // buffer to zero
+  maskImage->AllocateInitialized();
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -69,8 +69,7 @@ itkImageToListSampleFilterTest3(int, char *[])
 
   auto maskImage = MaskImageType::New();
   maskImage->SetRegions(region);
-  maskImage->Allocate(true); // initialize
-                             // buffer to zero
+  maskImage->AllocateInitialized();
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -84,8 +84,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   region.SetIndex(idx);
 
   inImage->SetRegions(region);
-  inImage->Allocate(true); // initialize buffer
-                           // to zero
+  inImage->AllocateInitialized();
 
   SizeType szConstraint;
   szConstraint[0] = 23;

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -60,7 +60,7 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   region.SetIndex(idx);
 
   inImage->SetRegions(region);
-  inImage->Allocate(true); // initialize buffer to zero
+  inImage->AllocateInitialized();
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -67,7 +67,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   // Create fixed image
   auto fixedImage = FixedImageType::New();
   fixedImage->SetRegions(fixedImageSize);
-  fixedImage->Allocate(true); // initialize buffer to zero
+  fixedImage->AllocateInitialized();
   fixedImage->Update();
 
   FixedImageIteratorType fixedIt(fixedImage, fixedImage->GetBufferedRegion());
@@ -86,7 +86,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   // Create moving image
   auto movingImage = MovingImageType::New();
   movingImage->SetRegions(movingImageSize);
-  movingImage->Allocate(true); // initialize buffer to zero
+  movingImage->AllocateInitialized();
   movingImage->Update();
 
   MovingImageIteratorType movingIt(movingImage, movingImage->GetBufferedRegion());
@@ -162,12 +162,12 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
 
   auto xGradImage = GradientImageType::New();
   xGradImage->SetRegions(movingImageSize);
-  xGradImage->Allocate(true); // initialize buffer to zero
+  xGradImage->AllocateInitialized();
   xGradImage->Update();
 
   auto yGradImage = GradientImageType::New();
   yGradImage->SetRegions(movingImageSize);
-  yGradImage->Allocate(true); // initialize buffer to zero
+  yGradImage->AllocateInitialized();
   yGradImage->Update();
 
   GradientImageIteratorType xGradIt(xGradImage, xGradImage->GetBufferedRegion());

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -134,14 +134,12 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   auto imgMovingMask = MovingImageType::New();
   imgMovingMask->CopyInformation(imgMoving);
   imgMovingMask->SetRegions(region);
-  imgMovingMask->Allocate(true); // initialize
-                                 // buffer to zero
+  imgMovingMask->AllocateInitialized();
 
   auto imgFixedMask = FixedImageType::New();
   imgFixedMask->CopyInformation(imgFixed);
   imgFixedMask->SetRegions(region);
-  imgFixedMask->Allocate(true); // initialize
-                                // buffer to zero
+  imgFixedMask->AllocateInitialized();
 
   int NumberFixedImageMaskVoxels = 0;
   { // Set up a mask that only has every 10th voxel listed is used in

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -120,8 +120,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
       this->m_MattesAssociate->m_ThreaderJointPDF[workUnitID]->SetRegions(jointPDFRegion);
       this->m_MattesAssociate->m_ThreaderJointPDF[workUnitID]->SetOrigin(origin);
       this->m_MattesAssociate->m_ThreaderJointPDF[workUnitID]->SetSpacing(spacing);
-      // NOTE: true = initialize to zero
-      this->m_MattesAssociate->m_ThreaderJointPDF[workUnitID]->Allocate(true);
+      this->m_MattesAssociate->m_ThreaderJointPDF[workUnitID]->AllocateInitialized();
     }
   }
 
@@ -183,7 +182,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
     {
       this->m_MattesAssociate->m_JointPDFDerivatives = JointPDFDerivativesType::New();
       this->m_MattesAssociate->m_JointPDFDerivatives->SetRegions(jointPDFDerivativesRegion);
-      this->m_MattesAssociate->m_JointPDFDerivatives->Allocate(true);
+      this->m_MattesAssociate->m_JointPDFDerivatives->AllocateInitialized();
     }
     else
     {

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -141,12 +141,12 @@ TestMattesMetricWithAffineTransform(TInterpolator * const interpolator, const bo
   auto imgMovingMask = MovingImageType::New();
   imgMovingMask->CopyInformation(imgMoving);
   imgMovingMask->SetRegions(region);
-  imgMovingMask->Allocate(true); // initialize buffer to zero
+  imgMovingMask->AllocateInitialized();
 
   auto imgFixedMask = FixedImageType::New();
   imgFixedMask->CopyInformation(imgFixed);
   imgFixedMask->SetRegions(region);
-  imgFixedMask->Allocate(true); // initialize buffer to zero
+  imgFixedMask->AllocateInitialized();
 
   {
     {

--- a/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
@@ -242,7 +242,7 @@ itkBayesianClassifierImageFilterTest(int argc, char * argv[])
     priorsImage->CopyInformation(priorsInputImage);
     priorsImage->SetRegions(inputImage->GetLargestPossibleRegion());
     priorsImage->SetNumberOfComponentsPerPixel(5);
-    priorsImage->Allocate(true);
+    priorsImage->AllocateInitialized();
 
     testStatus = TestBayesianClassifierImageFilterWithPriors<ReaderType::OutputImageType,
                                                              BayesianInitializerType,

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -258,7 +258,7 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
   kmeansLabelImage->SetSpacing(maskReader->GetOutput()->GetSpacing());
   kmeansLabelImage->SetDirection(maskReader->GetOutput()->GetDirection());
   kmeansLabelImage->SetOrigin(maskReader->GetOutput()->GetOrigin());
-  kmeansLabelImage->Allocate(true);
+  kmeansLabelImage->AllocateInitialized();
 
   using LabelMapStatisticsFilterType = itk::LabelStatisticsImageFilter<LabelImageType, LabelImageType>;
   auto statisticsNonBrainFilter = LabelMapStatisticsFilterType::New();

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -40,7 +40,7 @@ CreateTestImageA()
 
   auto image = ImageType::New();
   image->SetRegions(ImageType::RegionType(itk::MakeSize(2u, 2u, 2u)));
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   for (size_t i = 0; i < 8; ++i)
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -141,7 +141,7 @@ TEST(RelabelComponentImageFilter, big_zero)
   typename ImageType::RegionType region;
   region.SetSize({ { 512, 512, 512 } });
   image->SetRegions(region);
-  image->Allocate(true);
+  image->AllocateInitialized();
 
   auto filter = itk::RelabelComponentImageFilter<ImageType, ImageType>::New();
   filter->SetInput(image);

--- a/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
@@ -58,7 +58,7 @@ itkBinaryMaskToNarrowBandPointSetFilterTest(int argc, char * argv[])
   region.SetSize(size);
 
   binaryMask->SetRegions(region);
-  binaryMask->Allocate(true); // initialize buffer to zero
+  binaryMask->AllocateInitialized();
 
   size[0] = 60;
   size[1] = 60;

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
@@ -53,7 +53,7 @@ itkWatershedImageFilterTest(int, char *[])
 
   auto longimage2D = LongImageType2D::New();
   longimage2D->SetRegions(region);
-  longimage2D->Allocate(true); // initialize buffer to zero
+  longimage2D->AllocateInitialized();
 
   itk::ImageRegionIterator<ImageType2D> it2D(image2D, image2D->GetRequestedRegion());
 


### PR DESCRIPTION
The existing three possible ways to call `Allocate(bool = false)` (either by `Allocate(true)`, `Allocate(false)`, or `Allocate()`) may accidentally be confused, especially by novice ITK users.

The proposed `AllocateZeroInitializedPixelBuffer()` is intended to reduce the chance of such a confusion, and improve code readability. It is equivalent to `Allocate(true)`.

----
For the record, "AllocateZeroInitializedPixelBuffer" was renamed to "AllocateInitialized", as suggested at https://github.com/InsightSoftwareConsortium/ITK/pull/4479#issuecomment-1964624698