### PR TITLE
Replace `if (x > a[i]) x = a[i]` with `x = std::min(x, a[i])`, and `if (x < a[i]) x = a[i]` with `x = std::max(x, a[i])`

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -20,6 +20,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageRegion.h"
 #include "itkConstSliceIterator.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -106,10 +107,7 @@ ImageBoundaryFacesCalculator<TImage>::Compute(const TImage & img, RegionType reg
         }
 
         // Boundary region cannot be outside the region to process
-        if (fSize[j] > rSize[j])
-        {
-          fSize[j] = rSize[j];
-        }
+        fSize[j] = std::min(fSize[j], rSize[j]);
       }
       // avoid unsigned overflow if the non-boundary region is too small to
       // process

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -20,6 +20,7 @@
 
 #include "itkInterpolateImageFunction.h"
 #include "itkVariableLengthVector.h"
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -133,10 +134,7 @@ private:
   {
     IndexType basei;
     basei[0] = Math::Floor<IndexValueType>(index[0]);
-    if (basei[0] < this->m_StartIndex[0])
-    {
-      basei[0] = this->m_StartIndex[0];
-    }
+    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
 
     const InternalComputationType & distance = index[0] - static_cast<InternalComputationType>(basei[0]);
 
@@ -163,17 +161,11 @@ private:
     IndexType basei;
 
     basei[0] = Math::Floor<IndexValueType>(index[0]);
-    if (basei[0] < this->m_StartIndex[0])
-    {
-      basei[0] = this->m_StartIndex[0];
-    }
+    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
     const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
     basei[1] = Math::Floor<IndexValueType>(index[1]);
-    if (basei[1] < this->m_StartIndex[1])
-    {
-      basei[1] = this->m_StartIndex[1];
-    }
+    basei[1] = std::max(basei[1], this->m_StartIndex[1]);
     const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();
@@ -239,24 +231,15 @@ private:
   {
     IndexType basei;
     basei[0] = Math::Floor<IndexValueType>(index[0]);
-    if (basei[0] < this->m_StartIndex[0])
-    {
-      basei[0] = this->m_StartIndex[0];
-    }
+    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
     const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
     basei[1] = Math::Floor<IndexValueType>(index[1]);
-    if (basei[1] < this->m_StartIndex[1])
-    {
-      basei[1] = this->m_StartIndex[1];
-    }
+    basei[1] = std::max(basei[1], this->m_StartIndex[1]);
     const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
     basei[2] = Math::Floor<IndexValueType>(index[2]);
-    if (basei[2] < this->m_StartIndex[2])
-    {
-      basei[2] = this->m_StartIndex[2];
-    }
+    basei[2] = std::max(basei[2], this->m_StartIndex[2]);
     const InternalComputationType & distance2 = index[2] - static_cast<InternalComputationType>(basei[2]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
@@ -21,7 +21,7 @@
 #include "itkConceptChecking.h"
 
 #include "itkMath.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -85,10 +85,7 @@ LinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateUnoptimized(cons
       {
         // Take care of the case where the pixel is just
         // in the outer lower boundary of the image grid.
-        if (neighIndex[dim] < this->m_StartIndex[dim])
-        {
-          neighIndex[dim] = this->m_StartIndex[dim];
-        }
+        neighIndex[dim] = std::max(neighIndex[dim], this->m_StartIndex[dim]);
         overlap *= 1.0 - distance[dim];
       }
 

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
@@ -21,6 +21,7 @@
 #include "itkConceptChecking.h"
 
 #include "itkMath.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -77,10 +78,7 @@ LinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateUnoptimized(cons
         ++(neighIndex[dim]);
         // Take care of the case where the pixel is just
         // in the outer upper boundary of the image grid.
-        if (neighIndex[dim] > this->m_EndIndex[dim])
-        {
-          neighIndex[dim] = this->m_EndIndex[dim];
-        }
+        neighIndex[dim] = std::min(neighIndex[dim], this->m_EndIndex[dim]);
         overlap *= distance[dim];
       }
       else

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -20,7 +20,7 @@
 
 
 #include "itkMath.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -81,10 +81,7 @@ VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuo
         neighIndex[dim] = baseIndex[dim];
         // Take care of the case where the pixel is just
         // in the outer lower boundary of the image grid.
-        if (neighIndex[dim] < this->m_StartIndex[dim])
-        {
-          neighIndex[dim] = this->m_StartIndex[dim];
-        }
+        neighIndex[dim] = std::max(neighIndex[dim], this->m_StartIndex[dim]);
         overlap *= 1.0 - distance[dim];
       }
       upper >>= 1;

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkMath.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -72,10 +73,7 @@ VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuo
         neighIndex[dim] = baseIndex[dim] + 1;
         // Take care of the case where the pixel is just
         // in the outer upper boundary of the image grid.
-        if (neighIndex[dim] > this->m_EndIndex[dim])
-        {
-          neighIndex[dim] = this->m_EndIndex[dim];
-        }
+        neighIndex[dim] = std::min(neighIndex[dim], this->m_EndIndex[dim]);
         overlap *= distance[dim];
       }
       else

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNumericTraits.h"
 #include <cstdlib>
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -227,10 +228,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(
     }
 
     // cap to the volume extents
-    if (zmin < extent[4])
-    {
-      zmin = extent[4];
-    }
+    zmin = std::max(zmin, extent[4]);
     if (zmax >= extent[5])
     {
       zmax = extent[5] + 1;

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -19,6 +19,7 @@
 #define itkContourSpatialObject_hxx
 
 #include "itkNumericTraits.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -81,10 +82,7 @@ ContourSpatialObject<TDimension>::GetOrientationInObjectSpace() const
     PointType curpoint = it->GetPositionInObjectSpace();
     for (unsigned int i = 0; i < TDimension; ++i)
     {
-      if (minPnt[i] > curpoint[i])
-      {
-        minPnt[i] = curpoint[i];
-      }
+      minPnt[i] = std::min(minPnt[i], curpoint[i]);
       if (maxPnt[i] < curpoint[i])
       {
         maxPnt[i] = curpoint[i];

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -19,7 +19,7 @@
 #define itkContourSpatialObject_hxx
 
 #include "itkNumericTraits.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -83,10 +83,7 @@ ContourSpatialObject<TDimension>::GetOrientationInObjectSpace() const
     for (unsigned int i = 0; i < TDimension; ++i)
     {
       minPnt[i] = std::min(minPnt[i], curpoint[i]);
-      if (maxPnt[i] < curpoint[i])
-      {
-        maxPnt[i] = curpoint[i];
-      }
+      maxPnt[i] = std::max(maxPnt[i], curpoint[i]);
     }
     ++it;
   }

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -19,7 +19,7 @@
 #define itkPolygonSpatialObject_hxx
 
 #include "itkMath.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -71,10 +71,7 @@ PolygonSpatialObject<TDimension>::GetOrientationInObjectSpace() const
     for (unsigned int i = 0; i < TDimension; ++i)
     {
       minPnt[i] = std::min(minPnt[i], curpoint[i]);
-      if (maxPnt[i] < curpoint[i])
-      {
-        maxPnt[i] = curpoint[i];
-      }
+      maxPnt[i] = std::max(maxPnt[i], curpoint[i]);
     }
     ++it;
   }

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -19,6 +19,7 @@
 #define itkPolygonSpatialObject_hxx
 
 #include "itkMath.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -69,10 +70,7 @@ PolygonSpatialObject<TDimension>::GetOrientationInObjectSpace() const
     PointType curpoint = it->GetPositionInObjectSpace();
     for (unsigned int i = 0; i < TDimension; ++i)
     {
-      if (minPnt[i] > curpoint[i])
-      {
-        minPnt[i] = curpoint[i];
-      }
+      minPnt[i] = std::min(minPnt[i], curpoint[i]);
       if (maxPnt[i] < curpoint[i])
       {
         maxPnt[i] = curpoint[i];

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -23,6 +23,7 @@
 #include "itkMeanSampleFilter.h"
 #include "itkCovarianceSampleFilter.h"
 #include "itkImageMaskSpatialObject.h"
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -173,10 +174,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
         indMin[i] = indMax[i];
         indMax[i] = tmpI;
       }
-      if (indMin[i] < imageIndex[i])
-      {
-        indMin[i] = imageIndex[i];
-      }
+      indMin[i] = std::max(indMin[i], imageIndex[i]);
       size[i] = indMax[i] - indMin[i] + 1;
       if (indMin[i] + size[i] < imageIndex[i] + imageSize[i])
       {

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -25,6 +25,7 @@
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "itkCastImageFilter.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -262,10 +263,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeJacobianWit
       {
         difIndex[0][col] = startingIndex[col];
       }
-      if (difIndex[3][col] > upperIndex[col])
-      {
-        difIndex[3][col] = upperIndex[col];
-      }
+      difIndex[3][col] = std::min(difIndex[3][col], upperIndex[col]);
 
       OutputVectorType pixDisp[4];
       for (unsigned int i = 0; i < 4; ++i)

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -25,7 +25,7 @@
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "itkCastImageFilter.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -259,10 +259,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeJacobianWit
       difIndex[1][col] -= 1;
       difIndex[2][col] += 1;
       difIndex[3][col] += 2;
-      if (difIndex[0][col] < startingIndex[col])
-      {
-        difIndex[0][col] = startingIndex[col];
-      }
+      difIndex[0][col] = std::max(difIndex[0][col], startingIndex[col]);
       difIndex[3][col] = std::min(difIndex[3][col], upperIndex[col]);
 
       OutputVectorType pixDisp[4];

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -22,6 +22,7 @@
 
 #include "itkReflectiveImageRegionConstIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include <algorithm> // For max.
 
 namespace itk
 {
@@ -120,10 +121,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
 
   for (unsigned int dim = 0; dim < InputImageDimension; ++dim)
   {
-    if (maxLength < size[dim])
-    {
-      maxLength = size[dim];
-    }
+    maxLength = std::max(maxLength, size[dim]);
   }
 
   ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, region);

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -22,6 +22,7 @@
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkTotalProgressReporter.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -50,10 +51,7 @@ GridImageSource<TOutputImage>::BeforeThreadedGenerateData()
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    if (this->m_GridOffset[i] > this->m_GridSpacing[i])
-    {
-      this->m_GridOffset[i] = this->m_GridSpacing[i];
-    }
+    this->m_GridOffset[i] = std::min(this->m_GridOffset[i], this->m_GridSpacing[i]);
     PixelArrayType pixels = m_PixelArrays->CreateElementAt(i);
     pixels.set_size(this->GetSize()[i]);
     pixels.fill(1);

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageScanlineConstIterator.h"
 #include "itkTotalProgressReporter.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -87,10 +88,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::MergeMap(MapType & m1, Map
       // bounding box is min,max pairs
       for (unsigned int ii = 0; ii < (ImageDimension * 2); ii += 2)
       {
-        if (labelStats.m_BoundingBox[ii] > m2_value.second.m_BoundingBox[ii])
-        {
-          labelStats.m_BoundingBox[ii] = m2_value.second.m_BoundingBox[ii];
-        }
+        labelStats.m_BoundingBox[ii] = std::min(labelStats.m_BoundingBox[ii], m2_value.second.m_BoundingBox[ii]);
         if (labelStats.m_BoundingBox[ii + 1] < m2_value.second.m_BoundingBox[ii + 1])
         {
           labelStats.m_BoundingBox[ii + 1] = m2_value.second.m_BoundingBox[ii + 1];
@@ -222,10 +220,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::ThreadedStreamedGenerateDa
       for (unsigned int i = 0; i < (2 * TInputImage::ImageDimension); i += 2)
       {
         const IndexType & index = it.GetIndex();
-        if (labelStats.m_BoundingBox[i] > index[i / 2])
-        {
-          labelStats.m_BoundingBox[i] = index[i / 2];
-        }
+        labelStats.m_BoundingBox[i] = std::min(labelStats.m_BoundingBox[i], index[i / 2]);
         if (labelStats.m_BoundingBox[i + 1] < index[i / 2])
         {
           labelStats.m_BoundingBox[i + 1] = index[i / 2];

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageScanlineConstIterator.h"
 #include "itkTotalProgressReporter.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -89,10 +89,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::MergeMap(MapType & m1, Map
       for (unsigned int ii = 0; ii < (ImageDimension * 2); ii += 2)
       {
         labelStats.m_BoundingBox[ii] = std::min(labelStats.m_BoundingBox[ii], m2_value.second.m_BoundingBox[ii]);
-        if (labelStats.m_BoundingBox[ii + 1] < m2_value.second.m_BoundingBox[ii + 1])
-        {
-          labelStats.m_BoundingBox[ii + 1] = m2_value.second.m_BoundingBox[ii + 1];
-        }
+        labelStats.m_BoundingBox[ii + 1] =
+          std::max(labelStats.m_BoundingBox[ii + 1], m2_value.second.m_BoundingBox[ii + 1]);
       }
 
       // if enabled, update the histogram for this label
@@ -221,10 +219,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::ThreadedStreamedGenerateDa
       {
         const IndexType & index = it.GetIndex();
         labelStats.m_BoundingBox[i] = std::min(labelStats.m_BoundingBox[i], index[i / 2]);
-        if (labelStats.m_BoundingBox[i + 1] < index[i / 2])
-        {
-          labelStats.m_BoundingBox[i + 1] = index[i / 2];
-        }
+        labelStats.m_BoundingBox[i + 1] = std::max(labelStats.m_BoundingBox[i + 1], index[i / 2]);
       }
 
       labelStats.m_Sum += value;

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkImageRegion.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionReverseIterator.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -74,10 +74,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   for (unsigned int i = 0; i < inputPtr->GetImageDimension(); ++i)
   {
     inputIndex[i] -= m_Repetitions;
-    if (inputIndex[i] < inputLargestPossibleRegionIndex[i])
-    {
-      inputIndex[i] = inputLargestPossibleRegionIndex[i];
-    }
+    inputIndex[i] = std::max(inputIndex[i], inputLargestPossibleRegionIndex[i]);
 
     inputSize[i] += m_Repetitions;
     inputSize[i] = std::min(inputSize[i], inputLargestPossibleRegionSize[i]);

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkImageRegion.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionReverseIterator.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -79,10 +80,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
     }
 
     inputSize[i] += m_Repetitions;
-    if (inputSize[i] > inputLargestPossibleRegionSize[i])
-    {
-      inputSize[i] = inputLargestPossibleRegionSize[i];
-    }
+    inputSize[i] = std::min(inputSize[i], inputLargestPossibleRegionSize[i]);
   }
 
   inputRegion.SetIndex(inputIndex);

--- a/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkMetaImageIO.h"
 #include "itkTestingMacros.h"
+#include <algorithm> // For min.
 
 int
 itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
@@ -53,7 +54,7 @@ itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
   ImageType::SizeType   fullsize;
   ImageType::IndexType  index;
 
-  unsigned int numberOfPieces = 10;
+  itk::SizeValueType numberOfPieces = 10;
 
   // We decide how we want to read the image and we split accordingly
   // The image is read slice by slice
@@ -65,10 +66,7 @@ itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
   size[1] = fullsize[1];
   size[2] = 0;
 
-  if (numberOfPieces > fullsize[2])
-  {
-    numberOfPieces = fullsize[2];
-  }
+  numberOfPieces = std::min(numberOfPieces, fullsize[2]);
   unsigned int zsize = fullsize[2] / numberOfPieces;
 
   // Setup the writer

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkAffineTransform.h"
 #include "itkResampleImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -219,10 +220,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     for (unsigned int i = 0; i < (2 * ImageDimension); i += 2)
     {
       // Update min
-      if (mapIt->second.m_BoundingBox[i] > index[i / 2])
-      {
-        mapIt->second.m_BoundingBox[i] = index[i / 2];
-      }
+      mapIt->second.m_BoundingBox[i] = std::min(mapIt->second.m_BoundingBox[i], index[i / 2]);
       // Update max
       if (mapIt->second.m_BoundingBox[i + 1] < index[i / 2])
       {

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -26,7 +26,7 @@
 #include "itkAffineTransform.h"
 #include "itkResampleImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
-#include <algorithm> // For min.
+#include <algorithm> // For min and max.
 
 namespace itk
 {
@@ -222,10 +222,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       // Update min
       mapIt->second.m_BoundingBox[i] = std::min(mapIt->second.m_BoundingBox[i], index[i / 2]);
       // Update max
-      if (mapIt->second.m_BoundingBox[i + 1] < index[i / 2])
-      {
-        mapIt->second.m_BoundingBox[i + 1] = index[i / 2];
-      }
+      mapIt->second.m_BoundingBox[i + 1] = std::max(mapIt->second.m_BoundingBox[i + 1], index[i / 2]);
     }
 
     // VOLUME

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -23,6 +23,7 @@
 #include "itkPointSet.h"
 #include "itkObjectToObjectMetric.h"
 #include "itkPrintHelper.h"
+#include <algorithm> // For min.
 
 namespace itk
 {
@@ -59,10 +60,7 @@ RegistrationParameterScalesEstimator<TMetric>::EstimateMaximumStepSize() -> Floa
 
   for (SizeValueType d = 0; d < dim; ++d)
   {
-    if (minSpacing > spacing[d])
-    {
-      minSpacing = spacing[d];
-    }
+    minSpacing = std::min(minSpacing, spacing[d]);
   }
 
   return minSpacing;

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -209,10 +209,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::ComputeMaximumVoxelShift(cons
   FloatType maxShift{};
   for (SizeValueType s = 0; s < sampleShifts.size(); ++s)
   {
-    if (maxShift < sampleShifts[s])
-    {
-      maxShift = sampleShifts[s];
-    }
+    maxShift = std::max(maxShift, sampleShifts[s]);
   }
 
   return maxShift;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageToImageMetricv4.h"
 
 #include "itkAffineTransform.h"
+#include <algorithm> // For max.
 
 /**
  *  \class RegistrationParameterScalesEstimatorTestMetric for test.
@@ -183,10 +184,7 @@ public:
 
       for (itk::SizeValueType p = 0; p < numPara; ++p)
       {
-        if (norms[p] < squaredNorms[p])
-        {
-          norms[p] = squaredNorms[p];
-        }
+        norms[p] = std::max(norms[p], squaredNorms[p]);
       }
     } // for numSamples
 


### PR DESCRIPTION
- Follow-up to pull request #4470