### PR TITLE
STYLE: Remove temporary vnl_vector_ref from const GetVnlVector overloads

### DIFF
--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -177,11 +177,7 @@ template <typename T, unsigned int VVectorDimension>
 vnl_vector<T>
 CovariantVector<T, VVectorDimension>::GetVnlVector() const
 {
-  // Return a vector_ref<>.  This will be automatically converted to a
-  // vnl_vector<>.  We have to use a const_cast<> which would normally
-  // be prohibited in a const method, but it is safe to do here
-  // because the cast to vnl_vector<> will ultimately copy the data.
-  return vnl_vector_ref<T>(VVectorDimension, const_cast<T *>(this->GetDataPointer()));
+  return vnl_vector<T>(this->GetDataPointer(), VVectorDimension);
 }
 
 } // end namespace itk

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -127,11 +127,7 @@ template <typename T, unsigned int TPointDimension>
 vnl_vector<T>
 Point<T, TPointDimension>::GetVnlVector() const
 {
-  // Return a vector_ref<>.  This will be automatically converted to a
-  // vnl_vector<>.  We have to use a const_cast<> which would normally
-  // be prohibited in a const method, but it is safe to do here
-  // because the cast to vnl_vector<> will ultimately copy the data.
-  return vnl_vector_ref<T>(TPointDimension, const_cast<T *>(this->GetDataPointer()));
+  return vnl_vector<T>(this->GetDataPointer(), TPointDimension);
 }
 
 template <typename T, unsigned int TPointDimension>

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -148,11 +148,7 @@ template <typename T, unsigned int TVectorDimension>
 vnl_vector<T>
 Vector<T, TVectorDimension>::GetVnlVector() const
 {
-  // Return a vector_ref<>.  This will be automatically converted to a
-  // vnl_vector<>.  We have to use a const_cast<> which would normally
-  // be prohibited in a const method, but it is safe to do here
-  // because the cast to vnl_vector<> will ultimately copy the data.
-  return vnl_vector_ref<T>(TVectorDimension, const_cast<T *>(this->GetDataPointer()));
+  return vnl_vector<T>(this->GetDataPointer(), TVectorDimension);
 }
 
 template <typename T, unsigned int TVectorDimension>


### PR DESCRIPTION
The three "const" overloads of `GetVnlVector()` return an vnl_vector, not a vnl_vector_ref, so it is not necessary for these overloads to internally create a temporary vnl_vector_ref.

----
For the record, the original approach for those overloads to create a vnl_vector_ref and convert it to a vnl_vector was by commit a1cd655268082d6a1125ca7c83bbaf59bc0f32ed, "OPT: optimizations", Jim Miller, 2004.