### PR TITLE
STYLE: Remove `as_ref()` when calling `is_equal` on direction matrices

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -414,8 +414,7 @@ ImageBase<VImageDimension>::IsCongruentImageGeometry(const ImageBase * otherImag
 
   return this->GetOrigin().GetVnlVector().is_equal(otherImage->GetOrigin().GetVnlVector(), coordinateTol) &&
          this->GetSpacing().GetVnlVector().is_equal(otherImage->GetSpacing().GetVnlVector(), coordinateTol) &&
-         this->GetDirection().GetVnlMatrix().as_ref().is_equal(otherImage->GetDirection().GetVnlMatrix().as_ref(),
-                                                               directionTolerance);
+         this->GetDirection().GetVnlMatrix().is_equal(otherImage->GetDirection().GetVnlMatrix(), directionTolerance);
 }
 
 

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -207,8 +207,8 @@ ImageSink<TInputImage>::VerifyInputInformation() ITKv5_CONST
 
       if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
           !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
-          !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix().as_ref(),
-                                                                      this->m_DirectionTolerance))
+          !inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
+                                                             this->m_DirectionTolerance))
       {
         std::ostringstream originString, spacingString, directionString;
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
@@ -227,8 +227,8 @@ ImageSink<TInputImage>::VerifyInputInformation() ITKv5_CONST
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
-        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
-              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), this->m_DirectionTolerance))
+        if (!inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
+                                                               this->m_DirectionTolerance))
         {
           directionString.setf(std::ios::scientific);
           directionString.precision(7);

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -203,8 +203,8 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CO
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
-        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
-              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), this->m_DirectionTolerance))
+        if (!inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
+                                                               this->m_DirectionTolerance))
         {
           directionString.setf(std::ios::scientific);
           directionString.precision(7);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -422,8 +422,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::VerifyFixedParamet
       originString << "InverseDisplacementField Spacing: " << inverseFieldSpacing
                    << ", DisplacementField Spacing: " << fieldSpacing << std::endl;
     }
-    if (!inverseFieldDirection.GetVnlMatrix().as_ref().is_equal(fieldDirection.GetVnlMatrix().as_ref(),
-                                                                directionTolerance))
+    if (!inverseFieldDirection.GetVnlMatrix().is_equal(fieldDirection.GetVnlMatrix(), directionTolerance))
     {
       unequalDirections = true;
       originString << "InverseDisplacementField Direction: " << inverseFieldDirection

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -388,8 +388,8 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::GenerateInputReq
     this->m_DefFieldSameInformation =
       (outputPtr->GetOrigin().GetVnlVector().is_equal(fieldPtr->GetOrigin().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetSpacing().GetVnlVector().is_equal(fieldPtr->GetSpacing().GetVnlVector(), coordinateTol)) &&
-      (outputPtr->GetDirection().GetVnlMatrix().as_ref().is_equal(fieldPtr->GetDirection().GetVnlMatrix().as_ref(),
-                                                                  this->GetDirectionTolerance()));
+      (outputPtr->GetDirection().GetVnlMatrix().is_equal(fieldPtr->GetDirection().GetVnlMatrix(),
+                                                         this->GetDirectionTolerance()));
 
     if (this->m_DefFieldSameInformation)
     {

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -511,8 +511,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
 
   if (!this->GetVirtualOrigin().GetVnlVector().is_equal(field->GetOrigin().GetVnlVector(), coordinateTol) ||
       !this->GetVirtualSpacing().GetVnlVector().is_equal(field->GetSpacing().GetVnlVector(), coordinateTol) ||
-      !this->GetVirtualDirection().GetVnlMatrix().as_ref().is_equal(field->GetDirection().GetVnlMatrix().as_ref(),
-                                                                    directionTol))
+      !this->GetVirtualDirection().GetVnlMatrix().is_equal(field->GetDirection().GetVnlMatrix(), directionTol))
   {
     std::ostringstream originString, spacingString, directionString;
     originString << "Virtual Origin: " << this->GetVirtualOrigin()


### PR DESCRIPTION
The `vnl_matrix_fixed::as_ref()` calls are no longer necessary, now that `vnl_matrix_fixed` directly supports `is_equal`:

- VXL pull request https://github.com/vxl/vxl/pull/317 commit https://github.com/vxl/vxl/commit/aa373fc84efa2d0e2ae3c0b3716bbf8dda554e71 "ENH: Encourage unified container interface.", Davis Vigneault (@sudomakeinstall), June 16, 2016