### PR TITLE
Fixed parameter preservation after identity

### DIFF
--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -99,7 +99,9 @@ MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimensio
   m_MatrixMTime.Modified();
   m_Offset.Fill(OutputVectorValueType{});
   m_Translation.Fill(OutputVectorValueType{});
-  m_Center.Fill(InputPointValueType{});
+  // Fixed parameters must be preserved when setting the transform to identity
+  // the center is part of the stationary fixed parameters
+  // and should not be modified by SetIdentity. m_Center.Fill(InputPointValueType{});
   m_Singular = false;
   m_InverseMatrix.SetIdentity();
   m_InverseMatrixMTime = m_MatrixMTime;

--- a/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
@@ -33,3 +33,18 @@ TEST(Euler3DTransform, SetFixedParametersThrowsWhenSizeIsLessThanInputSpaceDimen
     ASSERT_THROW(transform->SetFixedParameters(fixedParameters), itk::ExceptionObject);
   }
 }
+
+TEST(Euler3DTransform, TestSetGetCenterAfterSetIdentity)
+{
+  using EulerTransformType = itk::Euler3DTransform<>;
+
+  // Testing preservation of the center of rotation
+  auto                        eulerTransformWithCenter = EulerTransformType::New();
+  const itk::Point<double, 3> centerOfRotation({ 200, 400, 300 });
+  eulerTransformWithCenter->SetCenter(centerOfRotation);
+  EXPECT_EQ(eulerTransformWithCenter->GetCenter(), centerOfRotation);
+  eulerTransformWithCenter->SetIdentity();
+  // The center of rotation should be preserved when the transform is set to identity.
+  // Reseting a transform to identity should not affect the FixedParameters.
+  EXPECT_EQ(eulerTransformWithCenter->GetCenter(), centerOfRotation);
+}

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -156,6 +156,7 @@ itkSimilarity2DTransformTest(int, char *[])
   }
 
   // 15 degrees in radians
+  transform->SetCenter({}); // Explicitly reset center to default values
   transform->SetIdentity();
   const double angle = 15.0 * std::atan(1.0f) / 45.0;
   const double sinth = std::sin(angle);


### PR DESCRIPTION
When setting a transform to represent an Identity mapping, it is crucial that the stationary component of the transform is preserved.
    
```python
tfm.SetCenter( [1,2,3] );
tfm.SetIdentity();
out=tfm.GetCenter();
assert( out == [1,2,3] );
```

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
files (if any)
