### PR TITLE
STYLE: Replace `PushBackInput`, `PushFrontInput` with using-declarations

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkImageTransformer.h
+++ b/Modules/Compatibility/Deprecated/include/itkImageTransformer.h
@@ -252,16 +252,8 @@ protected:
    * methods from the superclass.
    * NOTE: The same code resides in ImageToImageFilter
    */
-  void
-  PushBackInput(const DataObject * input) override
-  {
-    Superclass::PushBackInput(input);
-  }
-  void
-  PushFrontInput(const DataObject * input) override
-  {
-    Superclass::PushFrontInput(input);
-  }
+  using Superclass::PushBackInput;
+  using Superclass::PushFrontInput;
 
   /** Internal structure used for passing image data into the threading library
    */

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -362,16 +362,8 @@ protected:
    * the versions from ProcessObject to avoid warnings about hiding
    * methods from the superclass.
    */
-  void
-  PushBackInput(const DataObject * input) override
-  {
-    Superclass::PushBackInput(input);
-  }
-  void
-  PushFrontInput(const DataObject * input) override
-  {
-    Superclass::PushFrontInput(input);
-  }
+  using Superclass::PushBackInput;
+  using Superclass::PushFrontInput;
 
 private:
   /**


### PR DESCRIPTION
Replaced these member functions with the equivalent using-declarations, as they only just forwarded to their `Superclass` anyway.

Aims to address their lack of coverage, at
https://open.cdash.org/viewCoverageFile.php?buildid=9419378&fileid=57778588

----

Inspired by @jhlegarreta https://discourse.itk.org/t/concerning-coverage-drops/6479 and issue #4486