### PR TITLE
Combine assignments to `basei[i]` in LinearInterpolateImageFunction, remove `&` from `distance` variables

### DIFF
--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -135,7 +135,7 @@ private:
     IndexType basei;
     basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
 
-    const InternalComputationType & distance = index[0] - static_cast<InternalComputationType>(basei[0]);
+    const InternalComputationType distance = index[0] - static_cast<InternalComputationType>(basei[0]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();
     const RealType &          val0 = inputImagePtr->GetPixel(basei);
@@ -160,10 +160,10 @@ private:
     IndexType basei;
 
     basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
-    const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
+    const InternalComputationType distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
     basei[1] = std::max(Math::Floor<IndexValueType>(index[1]), this->m_StartIndex[1]);
-    const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
+    const InternalComputationType distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();
     const RealType &          val00 = inputImagePtr->GetPixel(basei);
@@ -228,13 +228,13 @@ private:
   {
     IndexType basei;
     basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
-    const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
+    const InternalComputationType distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
     basei[1] = std::max(Math::Floor<IndexValueType>(index[1]), this->m_StartIndex[1]);
-    const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
+    const InternalComputationType distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
     basei[2] = std::max(Math::Floor<IndexValueType>(index[2]), this->m_StartIndex[2]);
-    const InternalComputationType & distance2 = index[2] - static_cast<InternalComputationType>(basei[2]);
+    const InternalComputationType distance2 = index[2] - static_cast<InternalComputationType>(basei[2]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();
     const RealType &          val000 = inputImagePtr->GetPixel(basei);

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -133,8 +133,7 @@ private:
   EvaluateOptimized(const Dispatch<1> &, const ContinuousIndexType & index) const
   {
     IndexType basei;
-    basei[0] = Math::Floor<IndexValueType>(index[0]);
-    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
+    basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
 
     const InternalComputationType & distance = index[0] - static_cast<InternalComputationType>(basei[0]);
 
@@ -160,12 +159,10 @@ private:
   {
     IndexType basei;
 
-    basei[0] = Math::Floor<IndexValueType>(index[0]);
-    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
+    basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
     const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
-    basei[1] = Math::Floor<IndexValueType>(index[1]);
-    basei[1] = std::max(basei[1], this->m_StartIndex[1]);
+    basei[1] = std::max(Math::Floor<IndexValueType>(index[1]), this->m_StartIndex[1]);
     const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();
@@ -230,16 +227,13 @@ private:
   EvaluateOptimized(const Dispatch<3> &, const ContinuousIndexType & index) const
   {
     IndexType basei;
-    basei[0] = Math::Floor<IndexValueType>(index[0]);
-    basei[0] = std::max(basei[0], this->m_StartIndex[0]);
+    basei[0] = std::max(Math::Floor<IndexValueType>(index[0]), this->m_StartIndex[0]);
     const InternalComputationType & distance0 = index[0] - static_cast<InternalComputationType>(basei[0]);
 
-    basei[1] = Math::Floor<IndexValueType>(index[1]);
-    basei[1] = std::max(basei[1], this->m_StartIndex[1]);
+    basei[1] = std::max(Math::Floor<IndexValueType>(index[1]), this->m_StartIndex[1]);
     const InternalComputationType & distance1 = index[1] - static_cast<InternalComputationType>(basei[1]);
 
-    basei[2] = Math::Floor<IndexValueType>(index[2]);
-    basei[2] = std::max(basei[2], this->m_StartIndex[2]);
+    basei[2] = std::max(Math::Floor<IndexValueType>(index[2]), this->m_StartIndex[2]);
     const InternalComputationType & distance2 = index[2] - static_cast<InternalComputationType>(basei[2]);
 
     const TInputImage * const inputImagePtr = this->GetInputImage();


### PR DESCRIPTION
Two little `LinearInterpolateImageFunction` coding style improvements.