### PR TITLE
STYLE: Replace `Allocate(); FillBuffer(0)` with `AllocateInitialized()`

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -184,16 +184,12 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParame
     }
   }
 
-  PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
-
   auto velocityField = ConstantVelocityFieldType::New();
   velocityField->SetSpacing(spacing);
   velocityField->SetOrigin(origin);
   velocityField->SetDirection(direction);
   velocityField->SetRegions(size);
-  velocityField->Allocate();
-  velocityField->FillBuffer(zeroDisplacement);
+  velocityField->AllocateInitialized();
 
   this->SetConstantVelocityField(velocityField);
 }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -516,16 +516,12 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::SetFixedParameters
     }
   }
 
-  PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
-
   auto displacementField = DisplacementFieldType::New();
   displacementField->SetSpacing(spacing);
   displacementField->SetOrigin(origin);
   displacementField->SetDirection(direction);
   displacementField->SetRegions(size);
-  displacementField->Allocate();
-  displacementField->FillBuffer(zeroDisplacement);
+  displacementField->AllocateInitialized();
 
   this->SetDisplacementField(displacementField);
 
@@ -536,8 +532,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::SetFixedParameters
     inverseDisplacementField->SetOrigin(origin);
     inverseDisplacementField->SetDirection(direction);
     inverseDisplacementField->SetRegions(size);
-    inverseDisplacementField->Allocate();
-    inverseDisplacementField->FillBuffer(zeroDisplacement);
+    inverseDisplacementField->AllocateInitialized();
 
     this->SetInverseDisplacementField(inverseDisplacementField);
   }

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -179,16 +179,12 @@ VelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParameters(
     }
   }
 
-  PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
-
   auto velocityField = VelocityFieldType::New();
   velocityField->SetSpacing(spacing);
   velocityField->SetOrigin(origin);
   velocityField->SetDirection(direction);
   velocityField->SetRegions(size);
-  velocityField->Allocate();
-  velocityField->FillBuffer(zeroDisplacement);
+  velocityField->AllocateInitialized();
 
   this->SetVelocityField(velocityField);
 }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -454,8 +454,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     m_ConnectedComponentImage->SetSpacing(m_OutputSpacing);
     m_ConnectedComponentImage->SetRegions(m_BufferedRegion);
     m_ConnectedComponentImage->SetDirection(m_OutputDirection);
-    m_ConnectedComponentImage->Allocate();
-    m_ConnectedComponentImage->FillBuffer(0);
+    m_ConnectedComponentImage->AllocateInitialized();
   }
 
   // Allocate memory for the PointTypeImage

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -167,8 +167,7 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   CumulativeImagePointer cumulativeImage = CumulativeImageType::New();
   cumulativeImage->SetRegions(outputImage->GetRequestedRegion());
   cumulativeImage->CopyInformation(inputImage);
-  cumulativeImage->Allocate();
-  cumulativeImage->FillBuffer(InternalRealType{});
+  cumulativeImage->AllocateInitialized();
 
   m_DerivativeFilter->SetInput(inputImage);
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -204,8 +204,7 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Genera
 
   auto cumulativeImage = CumulativeImageType::New();
   cumulativeImage->SetRegions(inputImage->GetBufferedRegion());
-  cumulativeImage->Allocate();
-  cumulativeImage->FillBuffer(InternalRealType{});
+  cumulativeImage->AllocateInitialized();
   // The output's information must match the input's information
   cumulativeImage->CopyInformation(this->GetInput());
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -356,13 +356,11 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::BeforeT
     {
       this->m_OmegaLatticePerThread[n] = RealImageType::New();
       this->m_OmegaLatticePerThread[n]->SetRegions(size);
-      this->m_OmegaLatticePerThread[n]->Allocate();
-      this->m_OmegaLatticePerThread[n]->FillBuffer(0.0);
+      this->m_OmegaLatticePerThread[n]->AllocateInitialized();
 
       this->m_DeltaLatticePerThread[n] = PointDataImageType::New();
       this->m_DeltaLatticePerThread[n]->SetRegions(size);
-      this->m_DeltaLatticePerThread[n]->Allocate();
-      this->m_DeltaLatticePerThread[n]->FillBuffer(PointDataType{});
+      this->m_DeltaLatticePerThread[n]->AllocateInitialized();
     }
   }
 }
@@ -426,8 +424,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
   }
   RealImagePointer neighborhoodWeightImage = RealImageType::New();
   neighborhoodWeightImage->SetRegions(size);
-  neighborhoodWeightImage->Allocate();
-  neighborhoodWeightImage->FillBuffer(0.0);
+  neighborhoodWeightImage->AllocateInitialized();
 
   ImageRegionIteratorWithIndex<RealImageType> ItW(neighborhoodWeightImage,
                                                   neighborhoodWeightImage->GetRequestedRegion());
@@ -704,8 +701,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
     }
     this->m_PhiLattice = PointDataImageType::New();
     this->m_PhiLattice->SetRegions(size);
-    this->m_PhiLattice->Allocate();
-    this->m_PhiLattice->FillBuffer(PointDataType{});
+    this->m_PhiLattice->AllocateInitialized();
 
     ImageRegionIterator<PointDataImageType> ItP(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -519,8 +519,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
   // std::cout << boundingBox << "  " << lRegion << "  " << elRegion << std::endl;
   // now initialize the image
   lineImage->SetRegions(elRegion);
-  lineImage->Allocate();
-  lineImage->FillBuffer(VectorLineType());
+  lineImage->AllocateInitialized();
 
   // std::cout << "lineContainer.size(): " << lineContainer.size() << std::endl;
 

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -109,8 +109,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
   region.SetSize(size);
 
   kernelImage->SetRegions(region);
-  kernelImage->Allocate();
-  kernelImage->FillBuffer(TOutput{});
+  kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -122,8 +122,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   region.SetSize(size);
 
   kernelImage->SetRegions(region);
-  kernelImage->Allocate();
-  kernelImage->FillBuffer(TOutput{});
+  kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -115,8 +115,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
   region.SetSize(size);
 
   kernelImage->SetRegions(region);
-  kernelImage->Allocate();
-  kernelImage->FillBuffer(TOutput{});
+  kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
   typename KernelImageType::IndexType centerIndex;

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -267,16 +267,13 @@ TimeVaryingBSplineVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTran
   using UpsampleFilterType = ResampleImageFilter<ComponentImageType, ComponentImageType, ParametersValueType>;
   using DecompositionFilterType = BSplineDecompositionImageFilter<ComponentImageType, ComponentImageType>;
 
-  constexpr VectorType zeroVector{};
-
   TimeVaryingVelocityFieldControlPointLatticePointer requiredLattice =
     TimeVaryingVelocityFieldControlPointLatticeType::New();
   requiredLattice->SetRegions(requiredLatticeSize);
   requiredLattice->SetOrigin(requiredLatticeOrigin);
   requiredLattice->SetSpacing(requiredLatticeSpacing);
   requiredLattice->SetDirection(requiredLatticeDirection);
-  requiredLattice->Allocate();
-  requiredLattice->FillBuffer(zeroVector);
+  requiredLattice->AllocateInitialized();
 
   // Loop over dimension: each direction is upsampled separately.
   for (SizeValueType j = 0; j < TotalDimension - 1; ++j)

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -48,8 +48,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
     this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->CopyInformation(this->m_Associate->m_JointPDF);
     this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->SetRegions(
       this->m_Associate->m_JointPDF->GetLargestPossibleRegion());
-    this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->Allocate();
-    this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->FillBuffer(SizeValueType{});
+    this->m_JointHistogramMIPerThreadVariables[i].JointHistogram->AllocateInitialized();
     this->m_JointHistogramMIPerThreadVariables[i].JointHistogramCount = SizeValueType{};
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
@@ -243,15 +243,12 @@ typename BSplineSyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTra
 
   if (this->m_Metric->GetMetricCategory() == ObjectToObjectMetricBaseTemplateEnums::MetricCategory::POINT_SET_METRIC)
   {
-    constexpr DisplacementVectorType zeroVector{};
-
     VirtualImageBaseConstPointer virtualDomainImage = this->GetCurrentLevelVirtualDomainImage();
 
     metricGradientField = DisplacementFieldType::New();
     metricGradientField->CopyInformation(virtualDomainImage);
     metricGradientField->SetRegions(virtualDomainImage->GetLargestPossibleRegion());
-    metricGradientField->Allocate();
-    metricGradientField->FillBuffer(zeroVector);
+    metricGradientField->AllocateInitialized();
 
     this->m_Metric->SetFixedObject(fixedPointSets[0]);
     this->m_Metric->SetMovingObject(movingPointSets[0]);

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -72,19 +72,15 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
 
       VirtualImageBaseConstPointer virtualDomainImage = this->GetCurrentLevelVirtualDomainImage();
 
-      constexpr DisplacementVectorType zeroVector{};
-
       auto fixedDisplacementField = DisplacementFieldType::New();
       fixedDisplacementField->CopyInformation(virtualDomainImage);
       fixedDisplacementField->SetRegions(virtualDomainImage->GetBufferedRegion());
-      fixedDisplacementField->Allocate();
-      fixedDisplacementField->FillBuffer(zeroVector);
+      fixedDisplacementField->AllocateInitialized();
 
       auto fixedInverseDisplacementField = DisplacementFieldType::New();
       fixedInverseDisplacementField->CopyInformation(virtualDomainImage);
       fixedInverseDisplacementField->SetRegions(virtualDomainImage->GetBufferedRegion());
-      fixedInverseDisplacementField->Allocate();
-      fixedInverseDisplacementField->FillBuffer(zeroVector);
+      fixedInverseDisplacementField->AllocateInitialized();
 
       this->m_FixedToMiddleTransform->SetDisplacementField(fixedDisplacementField);
       this->m_FixedToMiddleTransform->SetInverseDisplacementField(fixedInverseDisplacementField);
@@ -92,14 +88,12 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
       auto movingDisplacementField = DisplacementFieldType::New();
       movingDisplacementField->CopyInformation(virtualDomainImage);
       movingDisplacementField->SetRegions(virtualDomainImage->GetBufferedRegion());
-      movingDisplacementField->Allocate();
-      movingDisplacementField->FillBuffer(zeroVector);
+      movingDisplacementField->AllocateInitialized();
 
       auto movingInverseDisplacementField = DisplacementFieldType::New();
       movingInverseDisplacementField->CopyInformation(virtualDomainImage);
       movingInverseDisplacementField->SetRegions(virtualDomainImage->GetBufferedRegion());
-      movingInverseDisplacementField->Allocate();
-      movingInverseDisplacementField->FillBuffer(zeroVector);
+      movingInverseDisplacementField->AllocateInitialized();
 
       this->m_MovingToMiddleTransform->SetDisplacementField(movingDisplacementField);
       this->m_MovingToMiddleTransform->SetInverseDisplacementField(movingInverseDisplacementField);
@@ -572,13 +566,10 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   if (this->m_DownsampleImagesForMetricDerivatives &&
       this->m_Metric->GetMetricCategory() != ObjectToObjectMetricBaseTemplateEnums::MetricCategory::POINT_SET_METRIC)
   {
-    const DisplacementVectorType zeroVector{};
-
     auto identityField = DisplacementFieldType::New();
     identityField->CopyInformation(virtualDomainImage);
     identityField->SetRegions(virtualDomainImage->GetLargestPossibleRegion());
-    identityField->Allocate();
-    identityField->FillBuffer(zeroVector);
+    identityField->AllocateInitialized();
 
     DisplacementFieldTransformPointer identityDisplacementFieldTransform = DisplacementFieldTransformType::New();
     identityDisplacementFieldTransform->SetDisplacementField(identityField);

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -122,13 +122,10 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
     }
   }
 
-  constexpr DisplacementVectorType zeroVector{};
-
   auto identityField = DisplacementFieldType::New();
   identityField->CopyInformation(virtualDomainImage);
   identityField->SetRegions(virtualDomainImage->GetLargestPossibleRegion());
-  identityField->Allocate();
-  identityField->FillBuffer(zeroVector);
+  identityField->AllocateInitialized();
 
   this->m_IdentityDisplacementFieldTransform = DisplacementFieldTransformType::New();
   this->m_IdentityDisplacementFieldTransform->SetDisplacementField(identityField);

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -106,8 +106,7 @@ CollidingFrontsImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     OutputImageRegionType region = outputImage->GetRequestedRegion();
     outputImage->SetBufferedRegion(region);
-    outputImage->Allocate();
-    outputImage->FillBuffer(OutputPixelType{});
+    outputImage->AllocateInitialized();
 
     using FunctionType = BinaryThresholdImageFunction<OutputImageType>;
     using IteratorType = FloodFilledImageFunctionConditionalConstIterator<OutputImageType, FunctionType>;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -161,8 +161,7 @@ public:
         image->SetBufferedRegion(otherImage->GetBufferedRegion());
         image->SetRequestedRegion(otherImage->GetRequestedRegion());
         image->SetLargestPossibleRegion(otherImage->GetLargestPossibleRegion());
-        image->Allocate();
-        image->FillBuffer(OutputPixelType{});
+        image->AllocateInitialized();
 
         temp_ls->SetImage(image);
         newContainer[it->first] = temp_ls;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
@@ -101,8 +101,7 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   this->m_OutputImage = this->GetOutput();
   this->m_OutputImage->SetBufferedRegion(region);
-  this->m_OutputImage->Allocate();
-  this->m_OutputImage->FillBuffer(OutputImagePixelType{});
+  this->m_OutputImage->AllocateInitialized();
 
   InputImageIndexType end;
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -137,8 +137,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Zero the output
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
-  outputImage->Allocate();
-  outputImage->FillBuffer(OutputImagePixelType{});
+  outputImage->AllocateInitialized();
 
   // Compute the statistics of the seed point
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -231,8 +231,7 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Zero the output
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
-  outputImage->Allocate();
-  outputImage->FillBuffer(OutputImagePixelType{});
+  outputImage->AllocateInitialized();
 
   using FunctionType = BinaryThresholdImageFunction<InputImageType, double>;
 

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -185,8 +185,7 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Zero the output
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
-  outputImage->Allocate();
-  outputImage->FillBuffer(OutputImagePixelType{});
+  outputImage->AllocateInitialized();
 
   using FunctionType = BinaryThresholdImageFunction<InputImageType>;
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType>;

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -127,8 +127,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Zero the output
   OutputImageRegionType region = outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion(region);
-  outputImage->Allocate();
-  outputImage->FillBuffer(OutputImagePixelType{});
+  outputImage->AllocateInitialized();
 
   // Compute the statistics of the seed point
   using VectorMeanImageFunctionType = VectorMeanImageFunction<InputImageType>;

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -673,8 +673,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::GenerateData()
     m_MarkerImage = MarkerImageType::New();
     m_MarkerImage->CopyInformation(inputImage);
     m_MarkerImage->SetBufferedRegion(region);
-    m_MarkerImage->Allocate();
-    m_MarkerImage->FillBuffer(NumericTraits<typename MarkerImageType::PixelType>::Zero);
+    m_MarkerImage->AllocateInitialized();
 
 
     this->GetMultiThreader()->ParallelizeArray(

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -64,8 +64,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Zero the output
   outputImage->SetBufferedRegion(outputImage->GetRequestedRegion());
-  outputImage->Allocate();
-  outputImage->FillBuffer(z);
+  outputImage->AllocateInitialized();
 
   using InputIterator = ImageRegionConstIterator<InputImageType>;
   using OutputIterator = ImageRegionConstIterator<OutputImageType>;


### PR DESCRIPTION
Replaced lines of code of the form

    image>Allocate();
    image>FillBuffer(zero);

With `image->AllocateInitialized();`.

Cases found by the regular expression `^(.+->)Allocate.+;\r\n\1FillBuffer`.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4479 commit 47fe345cd81c8126e1a50d43c751cc67d6ebfc47
"ENH: Add `AllocateInitialized()` to ImageBase"