### PR TITLE
Add `Array2D(numberOfRows, numberOfCols, initialValue)` constructor

### DIFF
--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -25,12 +25,9 @@
 namespace itk
 {
 /** \class Array2D
- *  \brief Array2D class representing a 2D array with size defined
- *  at construction time.
+ *  \brief Array2D class representing a 2D array.
  *
  * This class derives from the vnl_matrix<> class.
- * Its size is assigned at construction time (run time) and can not be
- * changed afterwards.
  *
  * The class is templated over the type of the elements.
  *
@@ -85,8 +82,7 @@ public:
   void
   SetSize(unsigned int m, unsigned int n);
 
-  /** This destructor is not virtual for performance reasons. However, this
-   * means that subclasses cannot allocate memory. */
+  /** Destructor. */
   ~Array2D() override = default;
 };
 

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -53,6 +53,10 @@ public:
   /** Constructs a matrix of the specified number of rows and columns. */
   Array2D(unsigned int numberOfRows, unsigned int numberOfCols);
 
+  /** Constructs a matrix of the specified number of rows and columns, with each element having the specified initial
+   * value. */
+  Array2D(unsigned int numberOfRows, unsigned int numberOfCols, const TValue & initialValue);
+
   /** Copy-constructor. */
   Array2D(const Self & array);
 

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -47,14 +47,23 @@ public:
   using Self = Array2D;
   using VnlMatrixType = vnl_matrix<TValue>;
 
+  /** Default-constructor. Creates a matrix of size zero (0 rows and 0 columns). */
   Array2D() = default;
+
+  /** Constructs a matrix of the specified number of rows and columns. */
   Array2D(unsigned int numberOfRows, unsigned int numberOfCols);
+
+  /** Copy-constructor. */
   Array2D(const Self & array);
+
+  /** Converting constructor. Implicitly converts the specified matrix to an Array2D. */
   Array2D(const VnlMatrixType & matrix);
 
+  /** Copy-assignment operator. */
   Self &
   operator=(const Self & array);
 
+  /** Assigns the specified matrix to an Array2D. */
   Self &
   operator=(const VnlMatrixType & matrix);
 

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -28,6 +28,11 @@ Array2D<TValue>::Array2D(unsigned int numberOfRows, unsigned int numberOfCols)
 {}
 
 template <typename TValue>
+Array2D<TValue>::Array2D(unsigned int numberOfRows, unsigned int numberOfCols, const TValue & initialValue)
+  : vnl_matrix<TValue>(numberOfRows, numberOfCols, initialValue)
+{}
+
+template <typename TValue>
 Array2D<TValue>::Array2D(const VnlMatrixType & matrix)
   : vnl_matrix<TValue>(matrix)
 {}

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1712,6 +1712,7 @@ if(ITK_BUILD_SHARED_LIBS AND ITK_DYNAMIC_LOADING)
 endif()
 
 set(ITKCommonGTests
+    itkArray2DGTest.cxx
     itkAggregateTypesGTest.cxx
     itkBitCastGTest.cxx
     itkBooleanStdVectorGTest.cxx

--- a/Modules/Core/Common/test/itkArray2DGTest.cxx
+++ b/Modules/Core/Common/test/itkArray2DGTest.cxx
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkArray2D.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+
+// Tests that Array2D may be constructed with an initial value for each element.
+TEST(Array2D, ConstructorSupportsInitialValue)
+{
+  const auto checkConstructor =
+    [](const unsigned int numberOfRows, const unsigned int numberOfCols, const auto initialValue) {
+      using ValueType = std::remove_const_t<decltype(initialValue)>;
+
+      const itk::Array2D<ValueType> array2D(numberOfRows, numberOfCols, initialValue);
+
+      EXPECT_EQ(array2D.rows(), numberOfRows);
+      EXPECT_EQ(array2D.columns(), numberOfCols);
+
+      for (const auto & element : array2D)
+      {
+        EXPECT_EQ(element, initialValue);
+      }
+    };
+
+  for (const auto initialValue : { -1, 0, 1 })
+  {
+    checkConstructor(0, 0, initialValue);
+    checkConstructor(1, 2, initialValue);
+  }
+  for (const auto initialValue : { std::numeric_limits<double>::min(), std::numeric_limits<double>::max() })
+  {
+    checkConstructor(0, 0, initialValue);
+    checkConstructor(1, 2, initialValue);
+  }
+}

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -231,9 +231,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::SetNumberOf
   }
 
   // Resize the schedules
-  ScheduleType temp(m_NumberOfLevels, ImageDimension);
-  temp.Fill(0);
-  m_Schedule = temp;
+  m_Schedule = ScheduleType(m_NumberOfLevels, ImageDimension, 0);
 
   // Determine initial shrink factor
   unsigned int startfactor = 1;

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -59,9 +59,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(
   }
 
   // resize the schedules
-  ScheduleType temp(m_NumberOfLevels, ImageDimension);
-  temp.Fill(0);
-  m_Schedule = temp;
+  m_Schedule = ScheduleType(m_NumberOfLevels, ImageDimension, 0);
 
   // determine initial shrink factor
   unsigned int startfactor = 1;

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -258,9 +258,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   pyramid->SetStartingShrinkFactors(factors.Begin());
 
   // check the schedule;
-  ScheduleType temp(numLevels, ImageDimension);
-  temp.Fill(0);
-  schedule = temp;
+  schedule = ScheduleType(numLevels, ImageDimension, 0);
   for (k = 0; k < numLevels; ++k)
   {
     unsigned int denominator = 1 << k;
@@ -409,9 +407,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   schedule.Fill(0);
   pyramid->SetSchedule(schedule);
 
-  ScheduleType temp2(pyramid->GetNumberOfLevels() - 1, ImageDimension);
-  temp2.Fill(1);
-  pyramid->SetSchedule(temp2);
+  pyramid->SetSchedule(ScheduleType(pyramid->GetNumberOfLevels() - 1, ImageDimension, 1));
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
Added a `Array2D(numberOfRows, numberOfCols, initialValue)` constructor, which just calls the corresponding `vnl_matrix` constructor. Added a few use cases, which aim to simplify resetting `ScheduleType` objects.

Updated the documentation of `Array2D`.