### PR TITLE
DOC: Add `GetNameOfClass` macro's to DOXYGEN_PREDEFINED

### DIFF
--- a/Utilities/Doxygen/DoxygenConfig.cmake
+++ b/Utilities/Doxygen/DoxygenConfig.cmake
@@ -128,6 +128,8 @@ set(DOXYGEN_PREDEFINED
     "itkCreateAnotherMacro(type)=         virtual::itk::LightObject::Pointer CreateAnother() const;"
     "itkFactorylessNewMacro(x)=                   static Pointer New();                   virtual ::itk::LightObject::Pointer CreateAnother() const;"
     "itkTypeMacro(thisClass,superclass)=                   virtual const char *GetNameOfClass() const;"
+    "itkVirtualGetNameOfClassMacro(thisClass)= virtual const char * GetNameOfClass() const;"
+    "itkOverrideGetNameOfClassMacro(thisClass)= const char * GetNameOfClass() const override;"
     "itkEventMacro(thisClass,superclass)=                   class thisClass : public superclass {};"
     "itkDeclareExceptionMacro(newexcp,parentexcp,whatmessage)=         namespace itk {         class newexcp : public parentexcp {        public:       newexcp(const char *file, unsigned int lineNumber) :        parentexcp(file, lineNumber)          { this->SetDescription(whatmessage); }          newexcp(const std::string & file, unsigned int lineNumber) :          parentexcp(file, lineNumber)          { this->SetDescription(whatmessage); }          itkTypeMacro(newexcp, , parentexcp);         };        }"
     "itkConceptMacro(thisName,thisConcept)=                   /* This class requires thisName                       in the form of thisConcept */"


### PR DESCRIPTION
Currently, the itkVirtualGetNameOfClassMacro and itkOverrideGetNameOfClassMacro calls do not get expanded properly by Doxygen. This commit aims to fix the output from Doxygen at https://itk.org/Doxygen/html/