### PR TITLE
ENH: Extend NearestNeighborInterpolateImageFunc wrapping for RGB

### DIFF
--- a/Modules/Core/ImageFunction/wrapping/itkNearestNeighborInterpolateImageFunction.wrap
+++ b/Modules/Core/ImageFunction/wrapping/itkNearestNeighborInterpolateImageFunction.wrap
@@ -4,6 +4,15 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
   foreach(t ${WRAP_ITK_SCALAR})
     itk_wrap_template("${ITKM_I${t}${d}}${ITKM_D}" "${ITKT_I${t}${d}},${ITKT_D}")
   endforeach()
+  set(vector_dim ${d}) # Wrap only vector dimensions which are the same as image dimensions
+  foreach(v ${WRAP_ITK_VECTOR})
+    itk_wrap_template(
+      "${ITKM_I${v}${vector_dim}${d}}${ITKM_D}"
+      "${ITKT_I${v}${vector_dim}${d}},${ITKT_D}")
+  endforeach()
+  foreach(v ${WRAP_ITK_COLOR})
+    itk_wrap_template("${ITKM_I${v}${d}}${ITKM_D}" "${ITKT_I${v}${d}},${ITKT_D}")
+  endforeach()
 endforeach()
 
 set(PA3DSCI_types "F")


### PR DESCRIPTION
Adding support for vector, RGB, and RGBA pixel types in wrapping
of itkNearestNeighborInterpolateImageFunction.   This will allow,
for example, the wrapped ResampleImageFilter to be called with
an RGB/RGBA pixel type image and use an nearestneighbor interpolator.
Currently only the linear interpolator had RGB/RGBA wrapping.

No C++ code changes were needed.  

Examples and tests already exist, e.g., ResampleImageFilterTest5 for RGBPixel type.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
