### PR TITLE
BUG: DCMTK reader wrongly rejects file with preamble

### DIFF
--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -212,6 +212,16 @@ itk_add_test(
   itkDCMTKImageIONoPreambleTest
   DATA{Input/NoPreambleDicomTest.dcm})
 
+# Re-use the test driver to ensure that CanReadFile returns true for a file
+# with a preamble.
+itk_add_test(
+  NAME
+  itkDCMTKImageIOPreambleCanReadTest
+  COMMAND
+  ITKIODCMTKTestDriver
+  itkDCMTKImageIONoPreambleTest
+  DATA{Input/preamble.dcm})
+
 itk_add_test(
   NAME itkDCMTKImageIOSpacingTest
   COMMAND ITKIODCMTKTestDriver itkDCMTKImageIOSpacingTest

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -60,6 +60,28 @@ itk_add_test(
 
 itk_add_test(
   NAME
+  itkDCMTKImageIOTest5
+  COMMAND
+  ITKIODCMTKTestDriver
+  itkDCMTKImageIOTest
+  DATA{Input/preamble.dcm}
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.dcm
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.png
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest5.dcm)
+
+itk_add_test(
+  NAME
+  itkDCMTKImageIOTest6
+  COMMAND
+  ITKIODCMTKTestDriver
+  itkDCMTKImageIOTest
+  DATA{Input/no_preamble.dcm}
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.dcm
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.png
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest6.dcm)
+
+itk_add_test(
+  NAME
   itkDCMTKSeriesReadImageWrite
   COMMAND
   ITKIODCMTKTestDriver

--- a/Modules/IO/DCMTK/test/Input/no_preamble.dcm.cid
+++ b/Modules/IO/DCMTK/test/Input/no_preamble.dcm.cid
@@ -1,0 +1,1 @@
+bafkreidvhgcecqrku7u63wbzocw52mragf5i4ycbixcon5yohdlfctr63y

--- a/Modules/IO/DCMTK/test/Input/preamble.dcm.cid
+++ b/Modules/IO/DCMTK/test/Input/preamble.dcm.cid
@@ -1,0 +1,1 @@
+bafkreibhyvtpyhwha2y5zjtx5mn4uod5mf33vwvtem3f5whyvivjpcde2a

--- a/Modules/IO/GDCM/test/Baseline/no_preamble.mha.cid
+++ b/Modules/IO/GDCM/test/Baseline/no_preamble.mha.cid
@@ -1,0 +1,1 @@
+bafkreicwoy4frgs5faincl6oqr6osu4zgn3dt74iyqphmthj7hs3x2y2w4

--- a/Modules/IO/GDCM/test/Baseline/preamble.mha.cid
+++ b/Modules/IO/GDCM/test/Baseline/preamble.mha.cid
@@ -1,0 +1,1 @@
+bafkreicwoy4frgs5faincl6oqr6osu4zgn3dt74iyqphmthj7hs3x2y2w4

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -255,6 +255,16 @@ itk_add_test(
   itkGDCMImageIONoPreambleTest
   DATA{Input/NoPreambleDicomTest.dcm})
 
+# Re-use the test driver to ensure that CanReadFile returns true for a file
+# with a preamble.
+itk_add_test(
+  NAME
+  itkGDCMImageIOPreambleCanReadTest
+  COMMAND
+  ITKIOGDCMTestDriver
+  itkGDCMImageIONoPreambleTest
+  DATA{Input/preamble.dcm})
+
 itk_add_test(
   NAME
   itkGDCMImageReadWriteTest_RGB

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -350,6 +350,32 @@ itk_add_test(
   ${ITK_TEST_OUTPUT_DIR}/single-bit.mha
   scalar)
 
+itk_add_test(
+  NAME
+  itkGDCMImageReadWriteTest_preamble
+  COMMAND
+  ITKIOGDCMTestDriver
+  --compare
+  DATA{Baseline/preamble.mha}
+  ${ITK_TEST_OUTPUT_DIR}/preamble.mha
+  itkGDCMImageReadWriteTest
+  DATA{Input/preamble.dcm}
+  ${ITK_TEST_OUTPUT_DIR}/preamble.mha
+  scalar)
+
+itk_add_test(
+  NAME
+  itkGDCMImageReadWriteTest_no_preamble
+  COMMAND
+  ITKIOGDCMTestDriver
+  --compare
+  DATA{Baseline/no_preamble.mha}
+  ${ITK_TEST_OUTPUT_DIR}/no_preamble.mha
+  itkGDCMImageReadWriteTest
+  DATA{Input/no_preamble.dcm}
+  ${ITK_TEST_OUTPUT_DIR}/no_preamble.mha
+  scalar)
+
 function(AddComplianceTest fileName)
   itk_add_test(
     NAME

--- a/Modules/IO/GDCM/test/Input/no_preamble.dcm.cid
+++ b/Modules/IO/GDCM/test/Input/no_preamble.dcm.cid
@@ -1,0 +1,1 @@
+bafkreidvhgcecqrku7u63wbzocw52mragf5i4ycbixcon5yohdlfctr63y

--- a/Modules/IO/GDCM/test/Input/preamble.dcm.cid
+++ b/Modules/IO/GDCM/test/Input/preamble.dcm.cid
@@ -1,0 +1,1 @@
+bafkreibhyvtpyhwha2y5zjtx5mn4uod5mf33vwvtem3f5whyvivjpcde2a


### PR DESCRIPTION
A previous optimization didn't take into account the preamble of a dicom file.  This adds a check.

Fixes #4108 