### PR TITLE
STYLE: Remove ` == true` from Boolean expressions

### DIFF
--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -78,7 +78,7 @@ SynchronizeList(FactoryListType & output, FactoryListType & input, bool internal
     }
     if (pos == -1)
     {
-      if (internal == true)
+      if (internal)
       {
         itk::ObjectFactoryBase::RegisterFactoryInternal(factory);
       }

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -182,7 +182,7 @@ struct TBBImageRegionSplitter : public itk::ImageIORegion
   {
     // The following if statement is primarily used to ensure use of
     // is_splittable_in_proportion to avoid unused variable warning.
-    if (TBBImageRegionSplitter::is_splittable_in_proportion == true)
+    if (TBBImageRegionSplitter::is_splittable_in_proportion)
     {
       *this = region; // most things will be the same
       for (int d = static_cast<int>(this->GetImageDimension()) - 1; d >= 0;

--- a/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
@@ -31,11 +31,11 @@ static_assert(
   ValueType{ false } == false,
   "The value type of BooleanStdVectorType should be allowed as a conditional expression, evaluating to false.");
 static_assert(
-  ValueType{ true } == true,
+  ValueType{ true },
   "The value type of BooleanStdVectorType should be allowed as a conditional expression, evaluating to true.");
 static_assert(bool{ ValueType{ false } } == false,
               "The value type of BooleanStdVectorType should support a lossless round-trip from bool value false.");
-static_assert(bool{ ValueType{ true } } == true,
+static_assert(bool{ ValueType{ true } },
               "The value type of BooleanStdVectorType should support a lossless round-trip from bool value true.");
 static_assert(std::is_same_v<decltype(*itk::BooleanStdVectorType{}.data()), ValueType &>,
               "BooleanStdVectorType should have a valid data() member function (unlike std::vector<bool>).");

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -79,14 +79,14 @@ TestIntegersAreSame(const T1 & v1, const T2 & v2)
     std::cout << v2 << std::endl;
     testPassStatus = EXIT_FAILURE;
   }
-  if (itk::Math::AlmostEquals(v2, v1) == true)
+  if (itk::Math::AlmostEquals(v2, v1))
   {
     std::cout << "Error in "
               << "itk::Math::AlmostEquals(v2, v1) " << std::endl;
     std::cout << __FILE__ << ' ' << __LINE__ << ' ' << v2 << " == " << v1 << std::endl;
     testPassStatus = EXIT_FAILURE;
   }
-  if (itk::Math::AlmostEquals(v1, v2) == true)
+  if (itk::Math::AlmostEquals(v1, v2))
   {
     std::cout << "Error in "
               << "itk::Math::AlmostEquals(v1, v2) " << std::endl;
@@ -606,22 +606,21 @@ main(int, char *[])
     constexpr double d = 1.01;
 
     // Test AlmostEquals()
-    if (itk::Math::AlmostEquals(f, d) == true || itk::Math::AlmostEquals(d, f) == true)
+    if (itk::Math::AlmostEquals(f, d) || itk::Math::AlmostEquals(d, f))
     {
       std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
     if (itk::Math::AlmostEquals(f, sc) == false || itk::Math::AlmostEquals(sc, f) == false ||
         itk::Math::AlmostEquals(1.0, 1.0f) == false || itk::Math::AlmostEquals(1.1, 1.1f) == false ||
-        itk::Math::AlmostEquals(1, 1.0) == false || itk::Math::AlmostEquals(2.0, 1.0) == true ||
-        itk::Math::AlmostEquals(1, 2) == true)
+        itk::Math::AlmostEquals(1, 1.0) == false || itk::Math::AlmostEquals(2.0, 1.0) || itk::Math::AlmostEquals(1, 2))
     {
       std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
     }
 
     // Test ExactlyEquals()  it should detect normal inequalities
-    if (itk::Math::ExactlyEquals(f, d) == true || itk::Math::ExactlyEquals(d, f) == true)
+    if (itk::Math::ExactlyEquals(f, d) || itk::Math::ExactlyEquals(d, f))
     {
       std::cout << __FILE__ << ' ' << __LINE__ << ' ' << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
@@ -31,7 +31,7 @@ itkMetaDataDictionaryTest(int, char *[])
   {
     float      tempfloat = 0.0;
     const bool IsValidReturn = itk::ExposeMetaData<float>(MyDictionary, "ASimpleFloatInitalized", tempfloat);
-    if (IsValidReturn == true)
+    if (IsValidReturn)
     {
       std::cout << tempfloat << std::endl;
     }
@@ -158,7 +158,7 @@ itkMetaDataDictionaryTest(int, char *[])
     std::cerr << "Failed to erase ASimpleFloatChanged" << std::endl;
     return EXIT_FAILURE;
   }
-  if (MyDictionary.Erase("itk") == true)
+  if (MyDictionary.Erase("itk"))
   {
     std::cerr << "Failed erase itk" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
@@ -27,18 +27,18 @@ itkMetaProgrammingLibraryTest(int, char *[])
   using namespace itk::mpl;
 
   // Or between constants
-  static_assert(OrC<true, true, true>::Value == true, "Unit test failed");
-  static_assert(OrC<true, true, false>::Value == true, "Unit test failed");
-  static_assert(OrC<true, false, true>::Value == true, "Unit test failed");
-  static_assert(OrC<true, false, false>::Value == true, "Unit test failed");
-  static_assert(OrC<false, true, true>::Value == true, "Unit test failed");
-  static_assert(OrC<false, true, false>::Value == true, "Unit test failed");
-  static_assert(OrC<false, false, true>::Value == true, "Unit test failed");
+  static_assert(OrC<true, true, true>::Value, "Unit test failed");
+  static_assert(OrC<true, true, false>::Value, "Unit test failed");
+  static_assert(OrC<true, false, true>::Value, "Unit test failed");
+  static_assert(OrC<true, false, false>::Value, "Unit test failed");
+  static_assert(OrC<false, true, true>::Value, "Unit test failed");
+  static_assert(OrC<false, true, false>::Value, "Unit test failed");
+  static_assert(OrC<false, false, true>::Value, "Unit test failed");
   static_assert(OrC<false, false, false>::Value == false, "Unit test failed");
 
-  static_assert(OrC<true, true>::Value == true, "Unit test failed");
-  static_assert(OrC<true, false>::Value == true, "Unit test failed");
-  static_assert(OrC<false, true>::Value == true, "Unit test failed");
+  static_assert(OrC<true, true>::Value, "Unit test failed");
+  static_assert(OrC<true, false>::Value, "Unit test failed");
+  static_assert(OrC<false, true>::Value, "Unit test failed");
   static_assert(OrC<false, false>::Value == false, "Unit test failed");
 
   // Or between types
@@ -57,7 +57,7 @@ itkMetaProgrammingLibraryTest(int, char *[])
   static_assert(std::is_same_v<Or<FalseType, FalseType>::Type, FalseType>, "Unit test failed");
 
   // And between constants
-  static_assert(AndC<true, true>::Value == true, "Unit test failed");
+  static_assert(AndC<true, true>::Value, "Unit test failed");
   static_assert(AndC<true, false>::Value == false, "Unit test failed");
   static_assert(AndC<false, true>::Value == false, "Unit test failed");
   static_assert(AndC<false, false>::Value == false, "Unit test failed");
@@ -70,8 +70,8 @@ itkMetaProgrammingLibraryTest(int, char *[])
 
   // Xor between constants
   static_assert(XorC<true, true>::Value == false, "Unit test failed");
-  static_assert(XorC<true, false>::Value == true, "Unit test failed");
-  static_assert(XorC<false, true>::Value == true, "Unit test failed");
+  static_assert(XorC<true, false>::Value, "Unit test failed");
+  static_assert(XorC<false, true>::Value, "Unit test failed");
   static_assert(XorC<false, false>::Value == false, "Unit test failed");
 
   // Xor between types
@@ -82,7 +82,7 @@ itkMetaProgrammingLibraryTest(int, char *[])
 
   // Not between constants
   static_assert(NotC<true>::Value == false, "Unit test failed");
-  static_assert(NotC<false>::Value == true, "Unit test failed");
+  static_assert(NotC<false>::Value, "Unit test failed");
 
   // Not between types
   static_assert(std::is_same_v<Not<TrueType>::Type, FalseType>, "Unit test failed");

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -134,7 +134,7 @@ itkTimeStampTest(int, char *[])
           // been used
           const itk::ModifiedTimeType index = helper.timestamps[k].GetMTime() - min_mtime;
 
-          if (istimestamped[index] == true)
+          if (istimestamped[index])
           {
             iter_success = false;
             std::cerr << helper.timestamps[k].GetMTime() << " was used twice as a timestamp!" << std::endl;

--- a/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
+++ b/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
@@ -134,5 +134,5 @@ itkXMLFileOutputWindowTest(int argc, char * argv[])
   const std::string test3Message{ status ? "TEST THREE PASSED" : "TEST THREE FAILED" };
   std::cout << test3Message << "\n\n" << std::endl;
 
-  return (status == true) ? EXIT_SUCCESS : EXIT_FAILURE;
+  return status ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -145,7 +145,7 @@ template <typename TInputImageType, typename TSparseOutputImageType>
 auto
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChange() -> TimeStepType
 {
-  if (m_PrecomputeFlag == true)
+  if (m_PrecomputeFlag)
   {
     this->PrecalculateChange();
   }

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -187,7 +187,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
     gaussianOperator.SetMaximumError(m_MaximumError[direction]);
     gaussianOperator.SetMaximumKernelWidth(m_MaximumKernelWidth);
 
-    if ((m_UseImageSpacing == true) && (this->GetInputImage()))
+    if (m_UseImageSpacing && (this->GetInputImage()))
     {
       if (this->GetInputImage()->GetSpacing()[direction] == 0.0)
       {
@@ -371,7 +371,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
     {
       typename GaussianFunctionType::InputType pt;
       pt[0] = gaussianNeighborhood.GetOffset(i)[direction] - offset[direction];
-      if ((m_UseImageSpacing == true) && (this->GetInputImage()))
+      if (m_UseImageSpacing && (this->GetInputImage()))
       {
         if (this->GetInputImage()->GetSpacing()[direction] == 0.0)
         {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -235,7 +235,7 @@ template <typename TMesh, typename TQEType>
 TQEType *
 QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedQuadEdge(QEType * e)
 {
-  QEType * temp = (e->IsIsolated() == true) ? e->GetSym() : e;
+  QEType * temp = (e->IsIsolated()) ? e->GetSym() : e;
   QEType * rebuildEdge = temp->GetOprev();
 
   m_OldPointID = temp->GetSym()->GetOrigin();
@@ -296,7 +296,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QETy
   // turn around the face (left or right one) while edges are on the border
   // and push them into a stack (which will be used to delete properly all
   // elements )
-  QEType * temp = (iWasLeftFace == true) ? e : e_sym;
+  QEType * temp = iWasLeftFace ? e : e_sym;
   QEType * e_it = temp;
 
   oToBeDeleted.push(e_it);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeTest1.cxx
@@ -1236,7 +1236,7 @@ itkQuadEdgeTest1(int, char *[])
     quadEdge1->SetOnext(nullptr);
     quadEdge1c->IsEdgeInOnextRing(nullptr);
 
-    if (quadEdge1c->IsEdgeInOnextRing(quadEdge6) == true)
+    if (quadEdge1c->IsEdgeInOnextRing(quadEdge6))
     {
       std::cerr << "Error in IsEdgeInOnextRing() A" << std::endl;
       return EXIT_FAILURE;
@@ -1249,7 +1249,7 @@ itkQuadEdgeTest1(int, char *[])
     quadEdge4->SetOnext(quadEdge5);
     quadEdge5->SetOnext(quadEdge1);
 
-    if (quadEdge1c->IsEdgeInOnextRing(quadEdge6) == true)
+    if (quadEdge1c->IsEdgeInOnextRing(quadEdge6))
     {
       std::cerr << "Error in IsEdgeInOnextRing() B" << std::endl;
       return EXIT_FAILURE;
@@ -1327,7 +1327,7 @@ itkQuadEdgeTest1(int, char *[])
 #ifndef NDEBUG
     quadEdgeA1c->IsLnextGivenSizeCyclic(3); // testing null case
 
-    if (quadEdgeA1c->IsLnextGivenSizeCyclic(3) == true)
+    if (quadEdgeA1c->IsLnextGivenSizeCyclic(3))
     {
       std::cerr << "Error in IsLnextGivenSizeCyclic() A" << std::endl;
       return EXIT_FAILURE;
@@ -1425,7 +1425,7 @@ itkQuadEdgeTest1(int, char *[])
     }
 
     // Check a wrong period on purpose
-    if (quadEdgeA1c->IsLnextGivenSizeCyclic(4) == true)
+    if (quadEdgeA1c->IsLnextGivenSizeCyclic(4))
     {
       std::cerr << "Error in IsLnextGivenSizeCyclic() C" << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -238,7 +238,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   this->m_Transform->SetTransformDomainOrigin(transformDomainOrigin);
   this->m_Transform->SetTransformDomainPhysicalDimensions(transformDomainPhysicalDimensions);
   this->m_Transform->SetTransformDomainDirection(transformDomainDirection);
-  if (this->m_SetTransformDomainMeshSizeViaInitializer == true)
+  if (this->m_SetTransformDomainMeshSizeViaInitializer)
   {
     this->m_Transform->SetTransformDomainMeshSize(this->m_TransformDomainMeshSize);
   }
@@ -254,7 +254,7 @@ BSplineTransformInitializer<TTransform, TImage>::PrintSelf(std::ostream & os, In
 
   itkPrintSelfObjectMacro(Transform);
 
-  if (this->m_SetTransformDomainMeshSizeViaInitializer == true)
+  if (this->m_SetTransformDomainMeshSizeViaInitializer)
   {
     os << indent << "Transform domain mesh size: " << this->m_TransformDomainMeshSize << std::endl;
   }

--- a/Modules/Core/Transform/test/itkSplineKernelTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSplineKernelTransformTest.cxx
@@ -193,7 +193,7 @@ itkSplineKernelTransformTest(int, char *[])
     source2Dit++;
     target2Dit++;
   }
-  if (tps2D->IsLinear() == true) // NOTE TPS is never linear!
+  if (tps2D->IsLinear()) // NOTE TPS is never linear!
   {
     std::cout << "ERROR:  2D TPS reports as being a linear transform." << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -68,7 +68,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  if (this->m_UseInputImageExtremaForScaling == true)
+  if (this->m_UseInputImageExtremaForScaling)
   {
     ImageRegionConstIterator<InputImageType> It(this->GetInput(), this->GetInput()->GetRequestedRegion());
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -76,7 +76,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 
   // Only reset the weights if they were previously set to the image spacing,
   // otherwise, the user may have provided their own weightings.
-  if (f == false && m_UseImageSpacing == true)
+  if (f == false && m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -145,7 +145,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   // Set the weights on the derivatives.
   // Are we using image spacing in the calculations?  If so we must update now
   // in case our input image has changed.
-  if (m_UseImageSpacing == true)
+  if (m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
@@ -131,7 +131,7 @@ itkSignedDanielssonDistanceMapImageFilterTest11(int, char *[])
     return EXIT_FAILURE;
   }
 
-  if (filter2D->GetSquaredDistance() == true)
+  if (filter2D->GetSquaredDistance())
   {
     std::cerr << "filter2D->GetSquaredDistance() == true & it should not" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest11.cxx
@@ -137,7 +137,7 @@ itkSignedMaurerDistanceMapImageFilterTest11(int, char *[])
     return EXIT_FAILURE;
   }
 
-  if (filter2D->GetSquaredDistance() == true)
+  if (filter2D->GetSquaredDistance())
   {
     std::cerr << "filter2D->GetSquaredDistance() == true and it should not be" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -779,7 +779,7 @@ FFTWGlobalConfiguration::SetReadWisdomCache(const bool v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_ReadWisdomCache = v;
-  if (v == true)
+  if (v)
   {
     ImportDefaultWisdomFile();
   }

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
@@ -166,7 +166,7 @@ GPUDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
     // Set up the operator for this dimension
     oper[reverse_i].SetDirection(i);
-    if (this->GetUseImageSpacing() == true)
+    if (this->GetUseImageSpacing())
     {
       if (localInput->GetSpacing()[i] == 0.0)
       {

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -244,7 +244,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
       flag = true;
     }
 
-    if (flag == true)
+    if (flag)
     {
       break;
     }

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -95,7 +95,7 @@ DerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
   oper.CreateDirectional();
   oper.FlipAxes();
 
-  if (m_UseImageSpacing == true)
+  if (m_UseImageSpacing)
   {
     if (this->GetInput()->GetSpacing()[m_Direction] == 0.0)
     {

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -51,7 +51,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateInputR
     // Determine the size of the operator in this dimension.  Note that the
     // Gaussian is built as a 1D operator in each of the specified directions.
     oper.SetDirection(i);
-    if (m_UseImageSpacing == true)
+    if (m_UseImageSpacing)
     {
       oper.SetSpacing(this->GetInput()->GetSpacing()[i]);
     }
@@ -157,7 +157,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
     // Set up the operator for this dimension
     oper[reverse_i].SetDirection(i);
     oper[reverse_i].SetOrder(m_Order[i]);
-    if (m_UseImageSpacing == true)
+    if (m_UseImageSpacing)
     {
       // convert the variance from physical units to pixels
       double s = localInput->GetSpacing()[i];

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -163,7 +163,7 @@ public:
       if (it.GetIndex() == firstNegativeIndex)
       {
         // abs value should be equal to largest freq for odd images
-        if (m_ImageIsOdd == true && m_LargestFrequency != it.GetFrequency() && -m_LargestFrequency != it.GetFrequency())
+        if (m_ImageIsOdd && m_LargestFrequency != it.GetFrequency() && -m_LargestFrequency != it.GetFrequency())
         {
           std::cout << " Frequency value is wrong." << it.GetFrequency() << " should be: " << m_LargestFrequency
                     << std::endl;

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
@@ -50,7 +50,7 @@ ScalarToRGBPixelFunctor<TScalar>::operator()(const TScalar & v) const -> RGBPixe
   TScalar      buf = v;
   const auto * bytes = reinterpret_cast<const unsigned char *>(&buf);
 
-  if (this->m_UseMSBForHashing == true)
+  if (this->m_UseMSBForHashing)
   { // swap bytes
     // always swap regardless of system endianness
     if (ByteSwapper<TScalar>::SystemIsBigEndian())

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -126,7 +126,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
     op[i].FlipAxes();
 
     // Take into account the pixel spacing if necessary
-    if (m_UseImageSpacing == true)
+    if (m_UseImageSpacing)
     {
       if (this->GetInput()->GetSpacing()[i] == 0.0)
       {

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -119,7 +119,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
     // The operator has default values for its direction (0) and its order (1).
     op[i].CreateDirectional();
 
-    if (m_UseImageSpacing == true)
+    if (m_UseImageSpacing)
     {
       if (this->GetInput()->GetSpacing()[i] == 0.0)
       {

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -71,7 +71,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::SetUse
 
   // Only reset the weights if they were previously set to the image spacing,
   // otherwise, the user may have provided their own weightings.
-  if (f == false && m_UseImageSpacing == true)
+  if (f == false && m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -150,7 +150,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Before
   // Set the weights on the derivatives.
   // Are we using image spacing in the calculations?  If so we must update now
   // in case our input image has changed.
-  if (m_UseImageSpacing == true)
+  if (m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -165,7 +165,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Before
   // If using the principle components method, then force this filter to use a
   // single thread because vnl eigensystem objects are not thread-safe.  3D
   // data is ok because we have a special solver.
-  if (m_UsePrincipleComponents == true && ImageDimension != 3)
+  if (m_UsePrincipleComponents && ImageDimension != 3)
   {
     m_RequestedNumberOfWorkUnits = this->GetNumberOfWorkUnits();
     this->SetNumberOfWorkUnits(1);
@@ -213,7 +213,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 
-    if (m_UsePrincipleComponents == true)
+    if (m_UsePrincipleComponents)
     {
       if (ImageDimension == 3)
       { // Use the specialized eigensolve which can be threaded

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -628,7 +628,7 @@ void
 ContourExtractor2DImageFilter<TInputImage>::ClearRequestedRegion()
 {
   itkDebugMacro("Clearing RequestedRegion.");
-  if (this->m_UseCustomRegion == true)
+  if (this->m_UseCustomRegion)
   {
     this->m_UseCustomRegion = false;
     this->Modified();

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -1099,7 +1099,7 @@ NrrdImageIO::Write(const void * buffer)
   }
 
   // set encoding for data: compressed (raw), (uncompressed) raw, or ascii
-  if (this->GetUseCompression() == true && this->m_NrrdCompressionEncoding != nullptr &&
+  if (this->GetUseCompression() && this->m_NrrdCompressionEncoding != nullptr &&
       this->m_NrrdCompressionEncoding->available())
   {
     nio->encoding = this->m_NrrdCompressionEncoding;

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.h
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.h
@@ -120,7 +120,7 @@ itkNrrdImageIOTestReadWriteTest(std::string fn, unsigned int size, std::string i
   try
   {
     writer->SetFileName(fn.c_str());
-    if (compression == true)
+    if (compression)
     {
       writer->UseCompressionOn();
     }

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -74,7 +74,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
     m_OperatorArray[direction].SetMaximumKernelWidth(m_MaximumKernelWidth);
     m_OperatorArray[direction].SetMaximumError(m_MaximumError);
 
-    if ((m_UseImageSpacing == true) && (this->GetInputImage()))
+    if (m_UseImageSpacing && (this->GetInputImage()))
     {
       if (this->GetInputImage()->GetSpacing()[direction] == 0.0)
       {

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -77,7 +77,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
       m_OperatorArray[idx].SetMaximumKernelWidth(m_MaximumKernelWidth);
       m_OperatorArray[idx].SetMaximumError(m_MaximumError);
 
-      if ((m_UseImageSpacing == true) && (this->GetInputImage()))
+      if (m_UseImageSpacing && (this->GetInputImage()))
       {
         if (this->GetInputImage()->GetSpacing()[direction] == 0.0)
         {

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -77,7 +77,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
       m_OperatorArray[idx].SetMaximumKernelWidth(m_MaximumKernelWidth);
       m_OperatorArray[idx].SetMaximumError(m_MaximumError);
 
-      if ((m_UseImageSpacing == true) && (this->GetInputImage()))
+      if (m_UseImageSpacing && (this->GetInputImage()))
       {
         m_OperatorArray[idx].SetSpacing(this->GetInputImage()->GetSpacing()[direction]);
       }

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -257,8 +257,8 @@ public:
     // turned off if any of these flags are turned on.
     if (value == false)
     {
-      if ((this->m_CalculateOrientedBoundingBox == true) || (this->m_CalculateOrientedLabelRegions == true) ||
-          (this->m_CalculateOrientedIntensityRegions == true))
+      if ((this->m_CalculateOrientedBoundingBox) || (this->m_CalculateOrientedLabelRegions) ||
+          (this->m_CalculateOrientedIntensityRegions))
       {
         // We cannot change the value, so return.
         return;
@@ -285,7 +285,7 @@ public:
 
     // CalculateOrientedBoundingBox needs
     // CalculatePixelIndices to be turned on.
-    if (value == true)
+    if (value)
     {
       this->SetCalculatePixelIndices(true);
     }
@@ -303,7 +303,7 @@ public:
 
       // CalculateOrientedLabelImage needs
       // CalculateOrientedBoundingBox to be turned on.
-      if (value == true)
+      if (value)
       {
         SetCalculateOrientedBoundingBox(true);
       }
@@ -322,7 +322,7 @@ public:
 
       // CalculateOrientedIntensityImage needs
       // CalculateOrientedBoundingBox to be turned on.
-      if (value == true)
+      if (value)
       {
         this->SetCalculateOrientedBoundingBox(true);
       }

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -248,7 +248,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       }
     }
 
-    if (m_CalculatePixelIndices == true)
+    if (m_CalculatePixelIndices)
     {
       // Pixel location list
       mapIt->second.m_PixelIndices.push_back(index);
@@ -401,16 +401,16 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     // We can add pi because the orientation of the major axis is symmetric about the origin.
     mapIt->second.m_Orientation = orientation < 0.0 ? orientation + itk::Math::pi : orientation;
 
-    if (m_CalculateOrientedBoundingBox == true)
+    if (m_CalculateOrientedBoundingBox)
     {
       // Calculate the oriented bounding box using the eigenvectors.
       CalculateOrientedBoundingBoxVertices(eig, mapIt->second);
     }
-    if (m_CalculateOrientedLabelRegions == true)
+    if (m_CalculateOrientedLabelRegions)
     {
       CalculateOrientedImage<TLabelImage, TIntensityImage>(eig, mapIt->second, true, this->GetInput());
     }
-    if (m_CalculateOrientedIntensityRegions == true)
+    if (m_CalculateOrientedIntensityRegions)
     {
       // If there is no intensity input defined, the oriented
       // intensity regions cannot be calculated.

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -476,7 +476,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       {
         // mark this pixel so we don't add it twice.
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), m_StatusChanging, bounds_status);
-        if (bounds_status == true)
+        if (bounds_status)
         {
           node = sparsePtr->m_LayerNodeStore->Borrow();
           node->m_Value = statusIt.GetIndex() + m_NeighborList.GetNeighborhoodOffset(i);
@@ -571,7 +571,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
         }
       }
 
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         ++updateIt;
@@ -625,7 +625,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
         }
       }
 
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         ++updateIt;
@@ -1311,7 +1311,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       if (statusIt.GetPixel(neighborIndex) == m_StatusNull)
       {
         statusIt.SetPixel(neighborIndex, to, boundary_status);
-        if (boundary_status == true) // in bounds
+        if (boundary_status) // in bounds
         {
           node = sparsePtr->m_LayerNodeStore->Borrow();
           node->m_Value = statusIt.GetIndex() + m_NeighborList.GetNeighborhoodOffset(i);

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
@@ -50,7 +50,7 @@ WarpHarmonicEnergyCalculator<TInputImage>::SetUseImageSpacing(bool f)
 
   // Only reset the weights if they were previously set to the image spacing,
   // otherwise, the user may have provided their own weightings.
-  if (f == false && m_UseImageSpacing == true)
+  if (f == false && m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -73,7 +73,7 @@ WarpHarmonicEnergyCalculator<TInputImage>::Compute()
   // Set the weights on the derivatives.
   // Are we using image spacing in the calculations?  If so we must update now
   // in case our input image has changed.
-  if (m_UseImageSpacing == true)
+  if (m_UseImageSpacing)
   {
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
@@ -41,7 +41,7 @@ LBFGSOptimizerv4::PrintSelf(std::ostream & os, Indent indent) const
 void
 LBFGSOptimizerv4::VerboseOn()
 {
-  if (m_Verbose == true)
+  if (m_Verbose)
   {
     return;
   }

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -252,7 +252,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 
   // The use of FixedImageIndexes and the use of FixedImageRegion
   // are mutually exclusive, so they should not both be checked.
-  if (this->m_UseFixedImageIndexes == true)
+  if (this->m_UseFixedImageIndexes)
   {
     if (this->m_FixedImageIndexes.empty())
     {

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -436,7 +436,7 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
 
 
   // Expect return false because of point set metrics
-  if (multiVariateMetric->SupportsArbitraryVirtualDomainSamples() == true)
+  if (multiVariateMetric->SupportsArbitraryVirtualDomainSamples())
   {
     std::cerr << "Expected SupportsArbitraryVirtualDomainSamples() to return true, but got false. " << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -414,7 +414,7 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   } // end while
 
-  if (passTest == true)
+  if (passTest)
   {
     std::cout << "Supervised Classifier Test Passed" << std::endl;
   }

--- a/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
@@ -223,7 +223,7 @@ template <typename TInputImage, typename TSparseOutputImage>
 void
 ImplicitManifoldNormalVectorFilter<TInputImage, TSparseOutputImage>::PostProcessOutput()
 {
-  if (m_UnsharpMaskingFlag == true)
+  if (m_UnsharpMaskingFlag)
   {
     typename NodeListType::Pointer       nodelist = this->GetOutput()->GetNodeList();
     typename NodeListType::Iterator      it = nodelist->Begin();

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -234,7 +234,7 @@ public:
   SetUseNegativeFeatures(bool u)
   {
     itkWarningMacro("SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
-    if (u == true)
+    if (u)
     {
       this->SetReverseExpansionDirection(false);
     }

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.hxx
@@ -89,7 +89,7 @@ NarrowBandLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType, TOut
 
   // A positive speed value causes surface expansion, the opposite of the
   // default.  Flip the sign of the propagation and advection weights.
-  if (m_ReverseExpansionDirection == true)
+  if (m_ReverseExpansionDirection)
   {
     this->GetSegmentationFunction()->ReverseExpansionDirection();
   }
@@ -110,7 +110,7 @@ NarrowBandLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType, TOut
   Superclass::GenerateData();
 
   // Reset all the signs of the weights.
-  if (m_ReverseExpansionDirection == true)
+  if (m_ReverseExpansionDirection)
   {
     this->GetSegmentationFunction()->ReverseExpansionDirection();
   }

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -375,7 +375,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
           break;
         }
       }
-      if (bounds_status == true)
+      if (bounds_status)
       {
         // Here record the histogram information
         m_GlobalZHistogram[center_index[m_SplitAxis]]++;
@@ -413,7 +413,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
             }
 
             statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), layer_number, bounds_status);
-            if (bounds_status == true) // In bounds
+            if (bounds_status) // In bounds
             {
               node = m_LayerNodeStore->Borrow();
               node->m_Index = offset_index;
@@ -453,7 +453,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructLaye
       {
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), to, boundary_status);
 
-        if (boundary_status == true) // in bounds
+        if (boundary_status) // in bounds
         {
           node = m_LayerNodeStore->Borrow();
           node->m_Index = statusIt.GetIndex() + m_NeighborList.GetNeighborhoodOffset(i);
@@ -613,7 +613,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLaye
         found_neighbor_flag = true;
       }
     }
-    if (found_neighbor_flag == true)
+    if (found_neighbor_flag)
     {
       // Set the new value using the smallest magnitude
       // found in our "from" neighbors.
@@ -1200,7 +1200,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Iterate()
     }
 
     // The active layer is too small => stop iterating
-    if (this->m_Stop == true)
+    if (this->m_Stop)
     {
       return;
     }
@@ -1221,7 +1221,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Iterate()
     {
       this->CheckLoadBalance();
 
-      if (this->m_BoundaryChanged == true)
+      if (this->m_BoundaryChanged)
       {
         // the situation at this point in time:
         // the OPTIMAL boundaries (that divide work equally) have changed but ...
@@ -1522,7 +1522,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedUpdat
           break;
         }
       }
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         continue;
@@ -1559,7 +1559,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedUpdat
           break;
         }
       }
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         continue;
@@ -2087,7 +2087,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedPropa
         found_neighbor_flag = true;
       }
     }
-    if (found_neighbor_flag == true)
+    if (found_neighbor_flag)
     {
       // Set the new value using the smallest magnitude found in our "from"
       // neighbors

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -281,7 +281,7 @@ public:
   SetUseNegativeFeatures(bool u)
   {
     itkWarningMacro("SetUseNegativeFeatures has been deprecated.  Please use SetReverseExpansionDirection instead");
-    if (u == true)
+    if (u)
     {
       this->SetReverseExpansionDirection(false);
     }

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
@@ -72,14 +72,14 @@ SegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType>::G
 
   // A positive speed value causes surface expansion, the opposite of the
   // default. Flip the sign of the propagation and advection weights.
-  if (m_ReverseExpansionDirection == true)
+  if (m_ReverseExpansionDirection)
   {
     this->GetSegmentationFunction()->ReverseExpansionDirection();
   }
 
   // Allocate the images from which speeds will be sampled.
   // if it is uninitialized and AutoGenerateSpeedAdvection is true
-  if (!this->m_IsInitialized && m_AutoGenerateSpeedAdvection == true)
+  if (!this->m_IsInitialized && m_AutoGenerateSpeedAdvection)
   {
     if (Math::NotExactlyEquals(this->GetSegmentationFunction()->GetPropagationWeight(), 0))
     {
@@ -96,7 +96,7 @@ SegmentationLevelSetImageFilter<TInputImage, TFeatureImage, TOutputPixelType>::G
   Superclass::GenerateData();
 
   // Reset all the signs of the weights.
-  if (m_ReverseExpansionDirection == true)
+  if (m_ReverseExpansionDirection)
   {
     this->GetSegmentationFunction()->ReverseExpansionDirection();
   }

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -133,7 +133,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
     }
   } // end counter
 
-  if (flag == true)
+  if (flag)
   {
     curvature = ValueType{};
   }

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -274,7 +274,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ProcessStatusList(Lay
       if (neighbor_status == SearchForStatus)
       { // mark this pixel so we don't add it twice.
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), m_StatusChanging, bounds_status);
-        if (bounds_status == true)
+        if (bounds_status)
         {
           node = m_LayerNodeStore->Borrow();
           node->m_Value = statusIt.GetIndex() + m_NeighborList.GetNeighborhoodOffset(i);
@@ -358,7 +358,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::UpdateActiveLayerValu
           break;
         }
       }
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         ++updateIt;
@@ -409,7 +409,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::UpdateActiveLayerValu
           break;
         }
       }
-      if (flag == true)
+      if (flag)
       {
         ++layerIt;
         ++updateIt;
@@ -725,7 +725,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
           }
 
           statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), layer_number, bounds_status);
-          if (bounds_status == true) // In bounds.
+          if (bounds_status) // In bounds.
           {
             node = m_LayerNodeStore->Borrow();
             node->m_Value = offset_index;
@@ -762,7 +762,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructLayer(Status
       if (statusIt.GetPixel(m_NeighborList.GetArrayIndex(i)) == m_StatusNull)
       {
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), to, boundary_status);
-        if (boundary_status == true) // in bounds
+        if (boundary_status) // in bounds
         {
           node = m_LayerNodeStore->Borrow();
           node->m_Value = statusIt.GetIndex() + m_NeighborList.GetNeighborhoodOffset(i);
@@ -1069,7 +1069,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLayerValues(
         found_neighbor_flag = true;
       }
     }
-    if (found_neighbor_flag == true)
+    if (found_neighbor_flag)
     {
       // Set the new value using the smallest distance
       // found in our "from" neighbors.

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -51,7 +51,7 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Valu
   -> LevelSetOutputRealType
 {
   // MeanCurvature has should be computed by this point.
-  itkAssertInDebugAndIgnoreInReleaseMacro(iData.MeanCurvature.m_Computed == true);
+  itkAssertInDebugAndIgnoreInReleaseMacro(iData.MeanCurvature.m_Computed);
 
   if (!m_UseCurvatureImage)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -81,7 +81,7 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Value(const LevelSetI
   -> LevelSetOutputRealType
 {
   // Laplacian should be computed by this point.
-  itkAssertInDebugAndIgnoreInReleaseMacro(iData.Laplacian.m_Computed == true);
+  itkAssertInDebugAndIgnoreInReleaseMacro(iData.Laplacian.m_Computed);
 
   LevelSetOutputRealType laplacian = iData.Laplacian.m_Value;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -71,7 +71,7 @@ Relabeler<TScalar, TImageDimension>::GenerateData()
   //
   // Extract the merges up the requested level
   //
-  if (tree->Empty() == true)
+  if (tree->Empty())
   {
     // itkWarningMacro("Empty input.  No relabeling was done.");
     return;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -79,12 +79,12 @@ SegmentTreeGenerator<TScalar>::GenerateData()
   typename SegmentTableType::Pointer input = this->GetInputSegmentTable();
   auto                               mergeList = SegmentTreeType::New();
   auto                               seg = SegmentTableType::New();
-  if (m_ConsumeInput == true) // do not copy input
+  if (m_ConsumeInput) // do not copy input
   {
     input->Modified();
     input->SortEdgeLists();
 
-    if (m_Merge == true)
+    if (m_Merge)
     {
       this->MergeEquivalencies();
     }
@@ -96,7 +96,7 @@ SegmentTreeGenerator<TScalar>::GenerateData()
   {
     seg->Copy(*input); // copy the input
     seg->SortEdgeLists();
-    if (m_Merge == true)
+    if (m_Merge)
     {
       this->MergeEquivalencies();
     }

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -274,7 +274,7 @@ CLANG_PRAGMA_POP
   // flat-region connectivity) and constructs the appropriate Boundary
   // data structures.
   //
-  if (m_DoBoundaryAnalysis == true)
+  if (m_DoBoundaryAnalysis)
   {
     this->InitializeBoundary();
     this->AnalyzeBoundaryFlow(thresholdImage, flatRegions, maximum + NumericTraits<InputPixelType>::OneValue());
@@ -312,13 +312,13 @@ CLANG_PRAGMA_POP
   this->UpdateSegmentTable(thresholdImage, thresholdImage->GetRequestedRegion());
   this->UpdateProgress(0.6);
 
-  if (m_DoBoundaryAnalysis == true)
+  if (m_DoBoundaryAnalysis)
   {
     this->CollectBoundaryInformation(flatRegions);
   }
   this->UpdateProgress(0.7);
 
-  if (m_SortEdgeLists == true)
+  if (m_SortEdgeLists)
   {
     this->GetSegmentTable()->SortEdgeLists();
   }
@@ -561,7 +561,7 @@ Segmenter<TInputImage>::AnalyzeBoundaryFlow(InputImageTypePointer thresholdImage
             isSteepest = false;
           }
 
-          if (isSteepest == true)
+          if (isSteepest)
           {
             // Label this pixel. It will be safely treated as a local
             // minimum by the rest of the segmentation algorithm.


### PR DESCRIPTION
Following C++ Core Guidelines, February 15, 2024, "Don’t add redundant `==` or `!=` to conditions",
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es87-dont-add-redundant--or--to-conditions