### PR TITLE
Use `true` as default member initializer for m_UseImageDirection and m_UseImageSpacing

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.h
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.h
@@ -147,7 +147,7 @@ protected:
 private:
   // flag to take or not the image direction into account
   // when computing the derivatives.
-  bool m_UseImageDirection{};
+  bool m_UseImageDirection{ true };
 };
 } // end namespace itk
 

--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
@@ -24,9 +24,7 @@ namespace itk
 
 template <typename TInputImage, typename TCoordRep>
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::VectorCentralDifferenceImageFunction()
-{
-  this->m_UseImageDirection = true;
-}
+{}
 
 template <typename TInputImage, typename TCoordRep>
 void

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -370,7 +370,7 @@ private:
 
   /** Control whether derivatives use spacing of the input image in
       its calculation. */
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 
   /** The function that will be used in calculating updates for each pixel. */
   typename FiniteDifferenceFunctionType::Pointer m_DifferenceFunction{};

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -27,7 +27,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 FiniteDifferenceImageFilter<TInputImage, TOutputImage>::FiniteDifferenceImageFilter()
 {
-  m_UseImageSpacing = true;
   m_ElapsedIterations = 0;
   m_DifferenceFunction = nullptr;
   m_NumberOfIterations = NumericTraits<IdentifierType>::max();

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -411,7 +411,7 @@ private:
 
   // flag to take or not the image direction into account when computing the
   // derivatives.
-  bool m_UseImageDirection{};
+  bool m_UseImageDirection{ true };
 
   ThreadIdType                          m_NumberOfWorkUnits{};
   std::unique_ptr<vnl_matrix<long>[]>   m_ThreadedEvaluateIndex;

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -51,7 +51,6 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplin
   m_SplineOrder = 0;
   unsigned int SplineOrder = 3;
   this->SetSplineOrder(SplineOrder);
-  this->m_UseImageDirection = true;
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
@@ -260,7 +260,7 @@ private:
 
   // flag to take or not the image direction into account
   // when computing the derivatives.
-  bool m_UseImageDirection{};
+  bool m_UseImageDirection{ true };
 
   // interpolator
   InterpolatorPointer m_Interpolator{};

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -26,8 +26,6 @@ namespace itk
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::CentralDifferenceImageFunction()
 {
-  this->m_UseImageDirection = true;
-
   using LinearInterpolatorType = LinearInterpolateImageFunction<TInputImage, TCoordRep>;
   this->m_Interpolator = LinearInterpolatorType::New();
 }

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
@@ -197,7 +197,7 @@ private:
   unsigned int m_FilterDimensionality{};
 
   /** Flag to indicate whether to use image spacing */
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 
   /** Neighborhood Image Function */
   GaussianFunctionPointer m_GaussianFunction{};

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -36,7 +36,6 @@ GaussianBlurImageFunction<TInputImage, TOutput>::GaussianBlurImageFunction()
     m_MaximumKernelWidth = 32;
     m_Extent[i] = 1.0f;
   }
-  m_UseImageSpacing = true;
 
   m_GaussianFunction = GaussianFunctionType::New();
   m_GaussianFunction->SetMean(mean);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -260,7 +260,7 @@ protected:
   WeightsType m_HalfDerivativeWeights{};
 
 private:
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 
   ThreadIdType m_RequestedNumberOfWorkUnits{};
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -34,7 +34,6 @@ template <typename TInputImage, typename TRealType, typename TOutputImage>
 DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>::
   DisplacementFieldJacobianDeterminantFilter()
 {
-  m_UseImageSpacing = true;
   m_RequestedNumberOfWorkUnits = this->GetNumberOfWorkUnits();
   m_NeighborhoodRadius.Fill(1);
   m_DerivativeWeights.Fill(1.0);

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
@@ -175,7 +175,7 @@ private:
   Array<RealType>       m_MeanDistance{};
   Array<IdentifierType> m_Count{};
   RealType              m_ContourDirectedMeanDistance{};
-  bool                  m_UseImageSpacing{};
+  bool                  m_UseImageSpacing{ true };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -39,7 +39,6 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ContourDirec
   // this filter requires two input images
   this->SetNumberOfRequiredInputs(2);
 
-  m_UseImageSpacing = true;
   m_DistanceMap = nullptr;
   m_ContourDirectedMeanDistance = RealType{};
   this->DynamicMultiThreadingOff();

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
@@ -155,7 +155,7 @@ protected:
 
 private:
   RealType m_MeanDistance{};
-  bool     m_UseImageSpacing{};
+  bool     m_UseImageSpacing{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -32,7 +32,6 @@ ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::ContourMeanDistanceI
   this->SetNumberOfRequiredInputs(2);
 
   m_MeanDistance = RealType{};
-  m_UseImageSpacing = true;
 }
 
 template <typename TInputImage1, typename TInputImage2>

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
@@ -211,7 +211,7 @@ protected:
 private:
   bool m_SquaredDistance{};
   bool m_InputIsBinary{};
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 
   SpacingType m_InputSpacingCache{};
 };

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -43,7 +43,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Dani
 
   m_SquaredDistance = false;
   m_InputIsBinary = false;
-  m_UseImageSpacing = true;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
@@ -149,7 +149,7 @@ protected:
 private:
   RealType m_HausdorffDistance{};
   RealType m_AverageHausdorffDistance{};
-  bool     m_UseImageSpacing{};
+  bool     m_UseImageSpacing{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
@@ -32,7 +32,6 @@ HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::HausdorffDistanceImage
 
   m_HausdorffDistance = RealType{};
   m_AverageHausdorffDistance = RealType{};
-  m_UseImageSpacing = true;
 }
 
 template <typename TInputImage1, typename TInputImage2>

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -233,7 +233,7 @@ protected:
 
 private:
   bool m_SquaredDistance{};
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
   bool m_InsideIsPositive{}; // ON is treated as inside pixels
 };                           // end of SignedDanielssonDistanceMapImageFilter
                              // class

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -46,7 +46,6 @@ SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>
   // Default values
   this->m_SquaredDistance = false; // Should we remove this ?
                                    // doesn't make sense in a SignedDaniel
-  this->m_UseImageSpacing = true;
   this->m_InsideIsPositive = false;
 }
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -219,7 +219,7 @@ private:
   }
 
 
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 
   // flag to take or not the image direction into account
   // when computing the derivatives.

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -223,7 +223,7 @@ private:
 
   // flag to take or not the image direction into account
   // when computing the derivatives.
-  bool m_UseImageDirection{};
+  bool m_UseImageDirection{ true };
 
   // allow setting the the m_BoundaryCondition
   ImageBoundaryCondition<TInputImage, TInputImage> * m_BoundaryCondition{};

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -34,7 +34,6 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 {
   // default boundary condition
   m_BoundaryCondition = new ZeroFluxNeumannBoundaryCondition<TInputImage>();
-  this->m_UseImageSpacing = true;
   this->m_UseImageDirection = true;
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -34,7 +34,6 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 {
   // default boundary condition
   m_BoundaryCondition = new ZeroFluxNeumannBoundaryCondition<TInputImage>();
-  this->m_UseImageDirection = true;
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();
 }

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -255,7 +255,7 @@ private:
   bool m_NormalizeAcrossScale{};
 
   /** Take into account image orientation when computing the Gradient */
-  bool m_UseImageDirection{};
+  bool m_UseImageDirection{ true };
 
   /** Standard deviation of the gaussian */
   SigmaArrayType m_Sigma{};

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -30,7 +30,6 @@ template <typename TInputImage, typename TOutputImage>
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursiveGaussianImageFilter()
 {
   m_NormalizeAcrossScale = false;
-  this->m_UseImageDirection = true;
 
   static_assert(ImageDimension > 0, "Images shall have one dimension at least");
   const unsigned int imageDimensionMinus1 = ImageDimension - 1;

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -494,7 +494,7 @@ protected:
   ComponentWeightsType m_SqrtComponentWeights = ComponentWeightsType::Filled(1);
 
 private:
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
   bool m_UsePrincipleComponents{};
 
   ThreadIdType m_RequestedNumberOfWorkUnits{};

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -33,7 +33,6 @@ namespace itk
 template <typename TInputImage, typename TRealType, typename TOutputImage>
 VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::VectorGradientMagnitudeImageFilter()
 {
-  m_UseImageSpacing = true;
   m_UsePrincipleComponents = true;
   m_RequestedNumberOfWorkUnits = this->GetNumberOfWorkUnits();
   this->DynamicMultiThreadingOn();

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -284,7 +284,7 @@ private:
   /** Mutex lock to protect modification to metric. */
   mutable std::mutex m_MetricCalculationMutex{};
 
-  bool m_UseImageSpacing{};
+  bool m_UseImageSpacing{ true };
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -52,7 +52,6 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
   m_NumberOfPixelsProcessed = 0L;
   m_RMSChange = NumericTraits<double>::max();
   m_SumOfSquaredChange = 0.0;
-  m_UseImageSpacing = true;
 
   m_MovingImageSmoothingFilter = MovingImageSmoothingFilterType::New();
   m_MovingImageSmoothingFilter->SetSigma(m_GradientSmoothingStandardDeviations);


### PR DESCRIPTION
Removed `m_UseImageDirection = true` and `m_UseImageSpacing = true` assignment from the function body of the corresponding constructors.

Following C++ Core Guidelines, ["Prefer initialization to assignment in constructors"](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c49-prefer-initialization-to-assignment-in-constructors)

Default member initializers also have the advantage that those default values will be shown in the API documentation. For example, https://itk.org/Doxygen/html/classitk_1_1GradientImageFilter.html now still says:

    bool 	m_UseImageDirection {}
    bool 	m_UseImageSpacing {}

But it will show the default value `true` for those member variables, once this pull request is processed.
