### PR TITLE
STYLE: Remove outdated VERBOSE_DEBUGGING/RGEDEBUG support from "IO/GE"

### DIFF
--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -75,12 +75,6 @@ GE4ImageIO::CanReadFile(const char * FileNameToRead)
 GEImageHeader *
 GE4ImageIO::ReadHeader(const char * FileNameToRead)
 {
-  // #define VERBOSE_DEBUGGING
-#if defined(VERBOSE_DEBUGGING)
-#  define RGEDEBUG(x) x
-#else
-#  define RGEDEBUG(x)
-#endif
   if (FileNameToRead == nullptr || strlen(FileNameToRead) == 0)
   {
     return nullptr;
@@ -99,7 +93,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   // Set modality to UNKNOWN
   strcpy(hdr->modality, "UNK");
 
-  //  RGEDEBUG(char debugbuf[16384];)
   char  tmpStr[IOCommon::ITK_MAXPATHLEN + 1];
   int   intTmp;
   short tmpShort;
@@ -118,7 +111,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
 
   this->GetStringAt(f, SIGNA_STHDR_START * 2 + SIGNA_STHDR_DATE_ASCII * 2, tmpStr, 10);
   tmpStr[10] = '\0';
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Date = %s\n", tmpStr); cerr << debugbuf;)
   strncpy(hdr->date, tmpStr, sizeof(hdr->date) - 1);
   hdr->date[sizeof(hdr->date) - 1] = '\0';
 
@@ -131,14 +123,12 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   /* Get Patient-Number from the STUDY Header */
   this->GetStringAt(f, SIGNA_STHDR_START * 2 + SIGNA_STHDR_PATIENT_ID * 2, tmpStr, 12);
   tmpStr[12] = '\0';
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Patient-Number = %s\n", tmpStr); cerr << debugbuf;)
   strncpy(hdr->patientId, tmpStr, sizeof(hdr->patientId) - 1);
   hdr->patientId[sizeof(hdr->patientId) - 1] = '\0';
 
   /* Get the Exam-Number from the STUDY Header */
   this->GetStringAt(f, SIGNA_STHDR_START * 2 + SIGNA_STHDR_STUDY_NUM * 2, tmpStr, 6);
   tmpStr[6] = '\0';
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Exam-Number = %s\n", tmpStr); cerr << debugbuf;)
   strncpy(hdr->scanId, tmpStr, sizeof(hdr->scanId) - 1);
   hdr->scanId[sizeof(hdr->scanId) - 1] = '\0';
 
@@ -151,7 +141,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
 
   hdr->xFOV = tmpFloat;
   hdr->yFOV = hdr->xFOV;
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "FOV = %fx%f\n", hdr->xFOV, hdr->yFOV); cerr << debugbuf;)
 
   /* Get the Plane from the IMAGE Header */
   this->GetStringAt(f, SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_PLANENAME * 2, tmpStr, 16);
@@ -191,27 +180,20 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
     hdr->coordinateOrientation =
       itk::SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_RSP;
   }
-  // RGEDEBUG(std::snprintf (debugbuf, sizeof(debugbuf), "Plane = %d\n", hdr->imagePlane); cerr <<
-  // debugbuf;)
 
   /* Get the Scan Matrix from the IMAGE Header */
   this->GetShortAt(f, SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_SCANMATRIXX * 2, &(hdr->acqXsize));
   this->GetShortAt(f, (SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_SCANMATRIXY * 2) + sizeof(short), &(hdr->acqYsize));
 
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Scan Matrix = %dx%d\n", hdr->acqXsize, hdr->acqYsize);
-           cerr << debugbuf;)
-
   /* Get Series-Number from SERIES Header */
   this->GetStringAt(f, SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_SERIES_NUM * 2, tmpStr, 3);
   tmpStr[3] = '\0';
   hdr->seriesNumber = std::stoi(tmpStr);
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Series Number = %d\n", hdr->seriesNumber); cerr << debugbuf;)
 
   /* Get Image-Number from IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_IMAGE_NUM * 2, tmpStr, 3);
   tmpStr[3] = '\0';
   hdr->imageNumber = std::stoi(tmpStr);
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Image Number = %d\n", hdr->imageNumber); cerr << debugbuf;)
 
   /* Get Images-Per-Slice from IMAGE Header */
   const int per_slice_status = this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_PHASENUM * 2, tmpStr, 3);
@@ -224,7 +206,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   {
     hdr->imagesPerSlice = 0; // Use default of 0 to mimic previous atoi failure result.
   }
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Images Per Slice = %d\n", hdr->imagesPerSlice); cerr << debugbuf;)
 
   /* Get the Slice Location from the IMAGE Header */
   // hack alert -- and this goes back to a hack in the original code
@@ -235,74 +216,56 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
 
   hdr->sliceLocation = MvtSunf(intTmp);
 
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Location = %f\n", hdr->sliceLocation); cerr << debugbuf;)
-
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_THICK * 2, (char *)&intTmp, sizeof(intTmp));
 
   hdr->sliceThickness = MvtSunf(intTmp);
-
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Thickness = %f\n", hdr->sliceThickness); cerr << debugbuf;)
 
   /* Get the Slice Spacing from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_SPACING * 2, (char *)&intTmp, sizeof(int));
 
   hdr->sliceGap = MvtSunf(intTmp);
 
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Slice Gap = %f\n", hdr->sliceGap); cerr << debugbuf;)
-
   /* Get TR from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TR * 2, (char *)&intTmp, sizeof(int));
 
   hdr->TR = MvtSunf(intTmp);
 
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "TR = %f\n", hdr->TR); cerr << debugbuf;)
-
   /* Get TE from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TE * 2, (char *)&intTmp, sizeof(int));
 
   hdr->TE = MvtSunf(intTmp);
-  //  RGEDEBUG(std::snprintf (debugbuf, sizeof(debugbuf), "TE = %f\n", hdr->TE); cerr << debugbuf;)
 
   /* Get TI from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TI * 2, (char *)&intTmp, sizeof(int));
 
   hdr->TI = MvtSunf(intTmp);
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "TI = %f\n", hdr->TI); cerr << debugbuf;)
 
   /* Get Number of Echos from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_NUMECHOS * 2, &(hdr->numberOfEchoes));
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Number of Echos = %d\n", hdr->numberOfEchoes); cerr << debugbuf;)
 
   /* Get Echo Number from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_ECHONUM * 2, &(hdr->echoNumber));
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Echo Number = %d\n", hdr->echoNumber); cerr << debugbuf;)
 
   /* Get PSD-Name from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_PSD_NAME * 2, tmpStr, 12);
   tmpStr[12] = '\0';
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "PSD Name = %s\n", tmpStr); cerr << debugbuf;)
 
   /* Get X Pixel Dimension from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_X_DIM * 2, &(hdr->imageXsize));
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "X Pixel Dimension = %d\n", hdr->imageXsize); cerr << debugbuf;)
 
   /* Get Y Pixel Dimension from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_Y_DIM * 2, &(hdr->imageYsize));
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Y Pixel Dimension = %d\n", hdr->imageYsize); cerr << debugbuf;)
 
   /* Get Pixel Size from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_PIXELSIZE * 2, (char *)&intTmp, sizeof(int));
 
   hdr->imageXres = MvtSunf(intTmp);
   hdr->imageYres = hdr->imageXres;
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Pixel Size = %fx%f\n", hdr->imageXres, hdr->imageYres);
-           cerr << debugbuf;)
 
   /* Get NEX from the IMAGE Header */
   this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_NEX * 2, (char *)&intTmp, sizeof(int));
 
   hdr->NEX = static_cast<short>(MvtSunf(intTmp));
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "NEX = %d\n", hdr->NEX); cerr << debugbuf;)
 
   /* Get Flip Angle from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_FLIP * 2, &tmpShort);
@@ -315,7 +278,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   {
     hdr->flipAngle = 90;
   }
-  RGEDEBUG(std::snprintf(debugbuf, sizeof(debugbuf), "Flip Angle = %d\n", hdr->flipAngle); cerr << debugbuf;)
 
   // DEBUG: HACK -- what should pulse sequence be?  Is it valid for 4x filters
   // Just setting it to dummy value -- Hans
@@ -326,8 +288,6 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
 
   /* Get the Number of Images from the IMAGE Header */
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_NUMSLICES * 2, &(hdr->numberOfSlices));
-  //  RGEDEBUG(std::snprintf (debugbuf, sizeof(debugbuf), "Number of SLices = %d\n",
-  // hdr->numberOfSlices); cerr << debugbuf;)
 
   //    status = stat (imageFile, &statBuf);
   //    if (status == -1)

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -170,13 +170,6 @@ SwapPixHdr(Ge5xPixelHeader * hdr)
 GEImageHeader *
 GE5ImageIO::ReadHeader(const char * FileNameToRead)
 {
-  //#define VERBOSE_DEBUGGING
-#if defined(VERBOSE_DEBUGGING)
-#  define RGEDEBUG(x) x
-#else
-#  define RGEDEBUG(x)
-#endif
-
   Ge5xPixelHeader imageHdr; // GE 5x Header
   GEImageHeader * curImage;
   bool            pixelHdrFlag;


### PR DESCRIPTION
Enabling `VERBOSE_DEBUGGING` would cause compilation errors (for example, about `debugbuf` being undeclared), which suggests that the option has not been used for a long time. It seems that those `RGEDEBUG` macro calls were only useful during the initial development of `GE4ImageIO`, more than 20 years ago.

"itkGE5ImageIO.cxx" also defined `RGEDEBUG`, but it did not call the macro anyway.

- Triggered by a discussion at https://github.com/InsightSoftwareConsortium/ITK/pull/4492