### PR TITLE
STYLE: Declare local `radius`, `center` variables in Filtering constexpr

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -103,8 +103,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Calculate iterator radius
-  Size<ImageDimension> radius;
-  radius.Fill(1);
+  static constexpr auto radius = Size<ImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
@@ -135,7 +134,9 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 
-    const SizeValueType center = bit.Size() / 2;
+    static constexpr SizeValueType neighborhoodSize = Math::UnsignedPower(3, ImageDimension);
+    static constexpr SizeValueType center = neighborhoodSize / 2;
+
     while (!bit.IsAtEnd())
     {
       this_one = bit.GetPixel(center);

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
 #include "itkTotalProgressReporter.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -141,7 +142,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 
   // Set the iterator radius to one, which is the value of the first
   // coordinate of the operator radius.
-  const auto radius = Size<InputImageDimension>::Filled(1);
+  static constexpr auto radius = Size<InputImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
@@ -153,10 +154,12 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   // Initialize the x_slice array
   ConstNeighborhoodIterator<InputImageType> nit(radius, inputImage, faceList.front());
 
-  std::slice          x_slice[InputImageDimension];
-  const SizeValueType center = nit.Size() / 2;
+  std::slice x_slice[InputImageDimension];
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
+    static constexpr SizeValueType neighborhoodSize = Math::UnsignedPower(3, InputImageDimension);
+    static constexpr SizeValueType center = neighborhoodSize / 2;
+
     x_slice[i] = std::slice(center - nit.GetStride(i), op[i].GetSize()[0], nit.GetStride(i));
   }
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkDerivativeOperator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkTotalProgressReporter.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -134,7 +135,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
 
   // Set the iterator radius to one, which is the value of the first
   // coordinate of the operator radius.
-  const auto radius = Size<ImageDimension>::Filled(1);
+  static constexpr auto radius = Size<ImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
@@ -147,10 +148,12 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   // Process non-boundary face
   nit = ConstNeighborhoodIterator<TInputImage>(radius, input, faceList.front());
 
-  std::slice          x_slice[ImageDimension];
-  const SizeValueType center = nit.Size() / 2;
+  std::slice x_slice[ImageDimension];
   for (i = 0; i < ImageDimension; ++i)
   {
+    static constexpr SizeValueType neighborhoodSize = Math::UnsignedPower(3, ImageDimension);
+    static constexpr SizeValueType center = neighborhoodSize / 2;
+
     x_slice[i] = std::slice(center - nit.GetStride(i), op[i].GetSize()[0], nit.GetStride(i));
   }
 


### PR DESCRIPTION
Added a local variable, `neighborhoodSize`, to clarify that the size of the neighborhood is in these cases always simply 3^N for an N-dimensional image.

Following Scott Meyers, Effective Modern C++ (2014), "Use `constexpr` whenever possible" and C++ Core Guidelines, ["Use `constexpr` for values that can be computed at compile time"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-constexpr)