### PR TITLE
STYLE: No longer set `hooks-max-size` for nifti2_io.c, doxygen.config.in

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,12 +51,9 @@ CMakeLists.txt   whitespace=tab-in-indent,no-lf-at-eof our-cmake-style
 *                     hooks-max-size=100000
 Modules/Numerics/FEM/src/dsrc2c.c hooks-max-size=260000
 Modules/ThirdParty/** hooks-max-size=300000 hooks.style=
-Modules/ThirdParty/NIFTI/src/nifti/nifti2/nifti2_io.c hooks-max-size=400000
 Modules/ThirdParty/ZLIB/src/itkzlib-ng/crc32_braid_tbl.h hooks-max-size=700000
 Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx hooks-max-size=120000
 Documentation/docs/releases/* hooks-max-size=300000
-Utilities/Doxygen/doxygen.config.in       hooks-max-size=150000
-Wrapping/Generators/Doc/doxygen.config.in hooks-max-size=150000
 
 # VNL-specific .gitattributes should go into Modules/ThirdParty/VNL/.gitattributes
 # GDCM-specific .gitattributes should go into Modules/ThirdParty/GDCM/src/gdcm/.gitattributes


### PR DESCRIPTION
nifti2_io.c was removed by:
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2630 commit 68221fdd30fb9ba89219a4bd5a47870b2d1cf7e6
"ENH: Prepare for update to NIFTILIB3.0.1", 9 July 2021

The two doxygen.config.in files were removed by:
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3311 commit a96d03fb5f4a4bb470516aa623dbc9b4aaaa6e4f
"COMP: Use modern doxygen_add_docs command ITK_WRAP_DOCS", 11 March 2022
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4500 commit 0c5c63890b2a417708b2fbcc4ebdb4e98247ef9f
"STYLE: Remove doxygen.config.in (superseded by DoxygenConfig.cmake)", 12 March 2024