### PR TITLE
STYLE: Use std::unique_ptr for GradientImageFilter::m_BoundaryCondition

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -21,6 +21,8 @@
 #include "itkImageToImageFilter.h"
 #include "itkCovariantVector.h"
 #include "itkImageRegionIterator.h"
+#include "itkZeroFluxNeumannBoundaryCondition.h"
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -163,7 +165,7 @@ public:
 
 protected:
   GradientImageFilter();
-  ~GradientImageFilter() override;
+  ~GradientImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -226,7 +228,9 @@ private:
   bool m_UseImageDirection{ true };
 
   // allow setting the the m_BoundaryCondition
-  ImageBoundaryCondition<TInputImage, TInputImage> * m_BoundaryCondition{};
+  std::unique_ptr<ImageBoundaryCondition<TInputImage, TInputImage>> m_BoundaryCondition{
+    std::make_unique<ZeroFluxNeumannBoundaryCondition<TInputImage>>()
+  };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -32,16 +32,8 @@ namespace itk
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputImageType>::GradientImageFilter()
 {
-  // default boundary condition
-  m_BoundaryCondition = new ZeroFluxNeumannBoundaryCondition<TInputImage>();
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();
-}
-
-template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
-GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputImageType>::~GradientImageFilter()
-{
-  delete m_BoundaryCondition;
 }
 
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
@@ -49,8 +41,7 @@ void
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>::OverrideBoundaryCondition(
   ImageBoundaryCondition<TInputImage> * boundaryCondition)
 {
-  delete m_BoundaryCondition;
-  m_BoundaryCondition = boundaryCondition;
+  m_BoundaryCondition.reset(boundaryCondition);
 }
 
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
@@ -165,7 +156,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   {
     nit = ConstNeighborhoodIterator<InputImageType>(radius, inputImage, face);
     ImageRegionIterator<OutputImageType> it(outputImage, face);
-    nit.OverrideBoundaryCondition(m_BoundaryCondition);
+    nit.OverrideBoundaryCondition(m_BoundaryCondition.get());
     nit.GoToBegin();
 
     while (!nit.IsAtEnd())
@@ -220,7 +211,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   os << indent << "BoundaryCondition: ";
   if (m_BoundaryCondition != nullptr)
   {
-    os << m_BoundaryCondition << std::endl;
+    os << m_BoundaryCondition.get() << std::endl;
   }
   else
   {


### PR DESCRIPTION
Following C++ Core Guidelines, ["Use `unique_ptr` or `shared_ptr` to avoid forgetting to `delete` objects created using `new`"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-smart).

Defaulted the destructor of `GradientImageFilter`.