### PR TITLE
COMP: Add itkSLICImageFilterTest1 baseline for macOS ARM

### DIFF
--- a/Modules/Segmentation/SuperPixel/test/Data/Baseline/itkSLICImageFilterTest1.2.png.cid
+++ b/Modules/Segmentation/SuperPixel/test/Data/Baseline/itkSLICImageFilterTest1.2.png.cid
@@ -1,0 +1,1 @@
+bafkreibyrioiaqyeltyiy3pb54ijzaj26ueavscmw3gr2stce2vgq5weji


### PR DESCRIPTION
Account for slight output differences observed with

❯ c++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

on a mac M3.

Closes #4514
