### PR TITLE
STYLE: Move `GetSpacing()` calls out of `for` loops

### DIFF
--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -51,12 +51,14 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration(
   double minSpacing;
   if (this->GetUseImageSpacing())
   {
-    minSpacing = this->GetInput()->GetSpacing()[0];
+    const auto & spacing = this->GetInput()->GetSpacing();
+
+    minSpacing = spacing[0];
     for (unsigned int i = 1; i < ImageDimension; ++i)
     {
-      if (this->GetInput()->GetSpacing()[i] < minSpacing)
+      if (spacing[i] < minSpacing)
       {
-        minSpacing = this->GetInput()->GetSpacing()[i];
+        minSpacing = spacing[i];
       }
     }
   }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -146,13 +146,15 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   // in case our input image has changed.
   if (m_UseImageSpacing)
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      if (static_cast<TRealType>(this->GetInput()->GetSpacing()[i]) == 0.0)
+      if (static_cast<TRealType>(spacing[i]) == 0.0)
       {
         itkExceptionMacro("Image spacing in dimension " << i << " is zero.");
       }
-      m_DerivativeWeights[i] = static_cast<TRealType>(1.0 / static_cast<TRealType>(this->GetInput()->GetSpacing()[i]));
+      m_DerivativeWeights[i] = static_cast<TRealType>(1.0 / static_cast<TRealType>(spacing[i]));
       m_HalfDerivativeWeights[i] = 0.5 * m_DerivativeWeights[i];
     }
   }

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -41,12 +41,14 @@ GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter
   double minSpacing;
   if (this->GetUseImageSpacing())
   {
-    minSpacing = this->GetInput()->GetSpacing()[0];
+    const auto & spacing = this->GetInput()->GetSpacing();
+
+    minSpacing = spacing[0];
     for (unsigned int i = 1; i < ImageDimension; ++i)
     {
-      if (this->GetInput()->GetSpacing()[i] < minSpacing)
+      if (spacing[i] < minSpacing)
       {
-        minSpacing = this->GetInput()->GetSpacing()[i];
+        minSpacing = spacing[i];
       }
     }
   }

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -151,13 +151,15 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Before
   // in case our input image has changed.
   if (m_UseImageSpacing)
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      if (static_cast<TRealType>(this->GetInput()->GetSpacing()[i]) == 0.0)
+      if (static_cast<TRealType>(spacing[i]) == 0.0)
       {
         itkExceptionMacro("Image spacing in dimension " << i << " is zero.");
       }
-      m_DerivativeWeights[i] = static_cast<TRealType>(1.0 / static_cast<TRealType>(this->GetInput()->GetSpacing()[i]));
+      m_DerivativeWeights[i] = static_cast<TRealType>(1.0 / static_cast<TRealType>(spacing[i]));
     }
   }
 

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -87,12 +87,14 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GetKernelVarianceArray()
       itkExceptionMacro("Could not get kernel variance! UseImageSpacing is ON but no input image was provided");
     }
 
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     ArrayType adjustedVariance;
     // Adjusted variance = var / (spacing ^ 2)
     for (unsigned int dim = 0; dim < ImageDimension; ++dim)
     {
       // convert the variance from physical units to pixels
-      double s = this->GetInput()->GetSpacing()[dim];
+      double s = spacing[dim];
       s = s * s;
       adjustedVariance[dim] = m_Variance[dim] / s;
     }

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -103,11 +103,13 @@ protected:
     this->m_AttributeValuePerPixel = 1;
     if (m_UseImageSpacing)
     {
+      const auto & spacing = this->GetInput()->GetSpacing();
+
       // compute pixel size
       double psize = 1.0;
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
-        psize *= this->GetInput()->GetSpacing()[i];
+        psize *= spacing[i];
       }
       this->m_AttributeValuePerPixel = static_cast<AttributeType>(psize);
       // std::cout << "m_AttributeValuePerPixel: " <<

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -105,11 +105,13 @@ protected:
     this->m_AttributeValuePerPixel = 1;
     if (m_UseImageSpacing)
     {
+      const auto & spacing = this->GetInput()->GetSpacing();
+
       // compute pixel size
       double psize = 1.0;
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
-        psize *= this->GetInput()->GetSpacing()[i];
+        psize *= spacing[i];
       }
       this->m_AttributeValuePerPixel = static_cast<AttributeType>(psize);
       // std::cout << "m_AttributeValuePerPixel: " <<

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -45,9 +45,11 @@ MultiphaseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputImage, 
     unsigned int i;
     if (m_UseImageSpacing)
     {
+      const auto & spacing = m_LevelSet[0]->GetSpacing();
+
       for (i = 0; i < ImageDimension; ++i)
       {
-        coeffs[i] = 1.0 / m_LevelSet[0]->GetSpacing()[i];
+        coeffs[i] = 1.0 / spacing[i];
       }
     }
     else

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
@@ -75,13 +75,15 @@ WarpHarmonicEnergyCalculator<TInputImage>::Compute()
   // in case our input image has changed.
   if (m_UseImageSpacing)
   {
+    const auto & spacing = m_Image->GetSpacing();
+
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      if (m_Image->GetSpacing()[i] <= 0.0)
+      if (spacing[i] <= 0.0)
       {
         itkExceptionMacro("Image spacing in dimension " << i << " is zero.");
       }
-      m_DerivativeWeights[i] = 1.0 / static_cast<double>(m_Image->GetSpacing()[i]);
+      m_DerivativeWeights[i] = 1.0 / static_cast<double>(spacing[i]);
     }
   }
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -473,10 +473,12 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeAct
 
   if (this->GetUseImageSpacing())
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     SpacePrecisionType minSpacing = NumericTraits<SpacePrecisionType>::max();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      minSpacing = std::min(minSpacing, this->GetInput()->GetSpacing()[i]);
+      minSpacing = std::min(minSpacing, spacing[i]);
     }
     MIN_NORM *= minSpacing;
   }
@@ -1267,10 +1269,12 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
   ValueType                                              MIN_NORM = 1.0e-6;
   if (this->GetUseImageSpacing())
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     SpacePrecisionType minSpacing = NumericTraits<SpacePrecisionType>::max();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      minSpacing = std::min(minSpacing, this->GetInput()->GetSpacing()[i]);
+      minSpacing = std::min(minSpacing, spacing[i]);
     }
     MIN_NORM *= minSpacing;
   }

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -509,10 +509,12 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
 
   if (this->GetUseImageSpacing())
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     SpacePrecisionType minSpacing = NumericTraits<SpacePrecisionType>::max();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      minSpacing = std::min(minSpacing, this->GetInput()->GetSpacing()[i]);
+      minSpacing = std::min(minSpacing, spacing[i]);
     }
     m_ConstantGradientValue = minSpacing;
   }
@@ -782,10 +784,12 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeActiveLayer
 
   if (this->GetUseImageSpacing())
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     SpacePrecisionType minSpacing = NumericTraits<SpacePrecisionType>::max();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      minSpacing = std::min(minSpacing, this->GetInput()->GetSpacing()[i]);
+      minSpacing = std::min(minSpacing, spacing[i]);
     }
     MIN_NORM *= minSpacing;
   }
@@ -858,10 +862,12 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CalculateChange() -> 
   ValueType    MIN_NORM = 1.0e-6;
   if (this->GetUseImageSpacing())
   {
+    const auto & spacing = this->GetInput()->GetSpacing();
+
     SpacePrecisionType minSpacing = NumericTraits<SpacePrecisionType>::max();
     for (i = 0; i < ImageDimension; ++i)
     {
-      minSpacing = std::min(minSpacing, this->GetInput()->GetSpacing()[i]);
+      minSpacing = std::min(minSpacing, spacing[i]);
     }
     MIN_NORM *= minSpacing;
   }


### PR DESCRIPTION
Avoided calling `GetSpacing()` repetitively in a `for` loop, by using a local `spacing` variable.

Cases found by the following regular expressions:

    if \(m_UseImageSpacing\).+    for .+->GetSpacing\(\)\[
    if \(this->GetUseImageSpacing\(\)\).+    for .+->GetSpacing\(\)\[

Aims to improve code readability.