### PR TITLE
FUTURE_LEGACY_REMOVE ImageToImageMetric members m_InterpolatorIsBSpline and m_TransformIsBSpline

### DIFF
--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -459,8 +459,12 @@ protected:
    * only inspecting the parameters within the support region
    * of a mapped point.  */
 
-  /** Boolean to indicate if the transform is BSpline deformable. */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** Boolean to indicate if the transform is BSpline deformable.
+  \deprecated `m_TransformIsBSpline` is intended to be removed, in the future. Please use `m_BSplineTransform`
+  instead. For example, `if (m_TransformIsBSpline)` may be rewritten as `if (m_BSplineTransform)`. */
   bool m_TransformIsBSpline{ false };
+#endif
 
   /** The number of BSpline transform weights is the number of
    * of parameter in the support region (per dimension ). */

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -537,8 +537,13 @@ protected:
                                 ImageDerivativesType & movingImageGradient,
                                 ThreadIdType           threadId) const;
 
-  /** Boolean to indicate if the interpolator BSpline. */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** Boolean to indicate if the interpolator BSpline.
+  \deprecated `m_InterpolatorIsBSpline` is intended to be removed, in the future. Please use `m_BSplineInterpolator`
+  instead. For example, `if (m_InterpolatorIsBSpline)` may be rewritten as `if (m_BSplineInterpolator)`. */
   bool m_InterpolatorIsBSpline{ false };
+#endif
+
   /** Pointer to BSplineInterpolator. */
   typename BSplineInterpolatorType::Pointer m_BSplineInterpolator{};
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -370,12 +370,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
   //  [3] Precomputing the indices of the parameters within the
   //      the support region of each sample point.
   //
-  m_TransformIsBSpline = true;
-
   auto * testPtr2 = dynamic_cast<BSplineTransformType *>(this->m_Transform.GetPointer());
   if (!testPtr2)
   {
-    m_TransformIsBSpline = false;
     m_BSplineTransform = nullptr;
     itkDebugMacro("Transform is not BSplineDeformable");
   }
@@ -386,7 +383,11 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     itkDebugMacro("Transform is BSplineDeformable");
   }
 
-  if (this->m_TransformIsBSpline)
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  m_TransformIsBSpline = m_BSplineTransform != nullptr;
+#endif
+
+  if (m_BSplineTransform)
   {
     // First, deallocate memory that may have been used from previous run of the Metric
     this->m_BSplineTransformWeightsArray.SetSize(1, 1);
@@ -772,7 +773,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int      
     transform = this->m_Transform;
   }
 
-  if (!m_TransformIsBSpline)
+  if (!m_BSplineTransform)
   {
     // Use generic transform to compute mapped position
     mappedPoint = transform->TransformPoint(m_FixedImageSamples[sampleNumber].point);
@@ -882,7 +883,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(uns
     transform = this->m_Transform;
   }
 
-  if (!m_TransformIsBSpline)
+  if (!m_BSplineTransform)
   {
     // Use generic transform to compute mapped position
     mappedPoint = transform->TransformPoint(m_FixedImageSamples[sampleNumber].point);
@@ -1257,7 +1258,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "UseSequentialSampling: " << (m_UseSequentialSampling ? "On" : "Off") << std::endl;
   os << indent << "ReseedIterator: " << (m_ReseedIterator ? "On" : "Off") << std::endl;
   os << indent << "RandomSeed: " << m_RandomSeed << std::endl;
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
   os << indent << "TransformIsBSpline: " << (m_TransformIsBSpline ? "On" : "Off") << std::endl;
+#endif
 
   os << indent
      << "NumBSplineWeights: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumBSplineWeights)

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -335,13 +335,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
   //  Otherwise, we instantiate an external central difference
   //  derivative calculator.
   //
-  m_InterpolatorIsBSpline = true;
-
   auto * testPtr = dynamic_cast<BSplineInterpolatorType *>(this->m_Interpolator.GetPointer());
   if (!testPtr)
   {
-    m_InterpolatorIsBSpline = false;
-
     m_DerivativeCalculator = DerivativeFunctionType::New();
     m_DerivativeCalculator->UseImageDirectionOn();
 
@@ -359,6 +355,10 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     m_DerivativeCalculator = nullptr;
     itkDebugMacro("Interpolator is BSpline");
   }
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  m_InterpolatorIsBSpline = m_BSplineInterpolator != nullptr;
+#endif
 
   //
   //  Check if the transform is of type BSplineTransform.
@@ -839,7 +839,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int      
       sampleOk = sampleOk && m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
     }
 
-    if (m_InterpolatorIsBSpline)
+    if (m_BSplineInterpolator)
     {
       // Check if mapped point inside image buffer
       sampleOk = sampleOk && m_BSplineInterpolator->IsInsideBuffer(mappedPoint);
@@ -951,7 +951,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(uns
       sampleOk = sampleOk && m_MovingImageMask->IsInsideInWorldSpace(mappedPoint);
     }
 
-    if (m_InterpolatorIsBSpline)
+    if (m_BSplineInterpolator)
     {
       // Check if mapped point inside image buffer
       sampleOk = sampleOk && m_BSplineInterpolator->IsInsideBuffer(mappedPoint);
@@ -980,7 +980,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ComputeImageDerivatives(const Mov
                                                                        ImageDerivativesType &       gradient,
                                                                        ThreadIdType                 threadId) const
 {
-  if (m_InterpolatorIsBSpline)
+  if (m_BSplineInterpolator)
   {
     // Computed moving image gradient using derivative BSpline kernel.
     gradient = m_BSplineInterpolator->EvaluateDerivative(mappedPoint, threadId);
@@ -1301,7 +1301,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
     os << "(null)" << std::endl;
   }
 
+#ifndef ITK_FUTURE_LEGACY_REMOVE
   os << indent << "InterpolatorIsBSpline: " << (m_InterpolatorIsBSpline ? "On" : "Off") << std::endl;
+#endif
 
   itkPrintSelfObjectMacro(BSplineInterpolator);
   itkPrintSelfObjectMacro(DerivativeCalculator);

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -911,7 +911,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputePDF
     precomputedWeight = this->m_PRatioArray[pdfFixedIndex][pdfMovingIndex];
   }
 
-  if (!this->m_TransformIsBSpline)
+  if (!this->m_BSplineTransform)
   {
     /**
      * Generic version which works for all transforms.


### PR DESCRIPTION
m_TransformIsBSpline is always just equal to `m_BSplineTransform != nullptr`, and m_InterpolatorIsBSpline is always just equal to `m_BSplineInterpolator != nullptr`, so these Boolean data members are redundant and not really necessary.