### PR TITLE
Fix 32bits dicom read crash

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -188,12 +188,8 @@ readNoPreambleDicom(std::ifstream & file) // NOTE: This file is duplicated in it
     }
   } while (groupNo == 2);
 
-#if defined(NDEBUG)
-  std::ostringstream itkmsg;
-  itkmsg << "No DICOM magic number found, but the file appears to be DICOM without a preamble.\n"
-         << "Proceeding without caution.";
-  itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());
-#endif
+  itkDebugMacro(<< "No DICOM magic number found, but the file appears to be DICOM without a preamble.");
+
   return true;
 }
 

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -13,7 +13,8 @@ set(ITKIOGDCMTests
     itkGDCMImageOrientationPatientTest.cxx
     itkGDCMLoadImageSpacingTest.cxx
     itkGDCMLegacyMultiFrameTest.cxx
-    itkGDCMImageIONoPreambleTest.cxx)
+    itkGDCMImageIONoPreambleTest.cxx
+    itkGDCMImageIO32bitsStoredTest.cxx)
 
 createtestdriver(ITKIOGDCM "${ITKIOGDCM-Test_LIBRARIES}" "${ITKIOGDCMTests}")
 
@@ -264,6 +265,14 @@ itk_add_test(
   ITKIOGDCMTestDriver
   itkGDCMImageIONoPreambleTest
   DATA{Input/preamble.dcm})
+
+itk_add_test(
+  NAME
+  itkGDCMImageIO32bitsStoredTest
+  COMMAND
+  ITKIOGDCMTestDriver
+  itkGDCMImageIO32bitsStoredTest
+  DATA{Input/image32bitsStoredTest.dcm})
 
 itk_add_test(
   NAME

--- a/Modules/IO/GDCM/test/Input/image32bitsStoredTest.dcm.cid
+++ b/Modules/IO/GDCM/test/Input/image32bitsStoredTest.dcm.cid
@@ -1,0 +1,1 @@
+bafybeihwecykoje6v7td77gmoe7m4ogghvxv4mgtkgdbnyo74jfeut7n44

--- a/Modules/IO/GDCM/test/itkGDCMImageIO32bitsStoredTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIO32bitsStoredTest.cxx
@@ -1,0 +1,79 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGDCMImageIO.h"
+#include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
+
+// Specific ImageIO test
+
+/** This test verifies itkGDCMImageIO does not crash when it encounters
+ * a file that has 32 bits allocated for a pixel.
+ */
+int
+itkGDCMImageIO32bitsStoredTest(int argc, char * argv[])
+{
+  if (argc < 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " DicomImage" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  using InputPixelType = short;
+  using InputImageType = itk::Image<InputPixelType, 3>;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
+  using ImageIOType = itk::GDCMImageIO;
+
+  auto dcmImageIO = ImageIOType::New();
+  bool canRead = dcmImageIO->CanReadFile(argv[1]);
+  std::cerr << "GDCM can read file: " << (canRead ? "yes" : "no") << std::endl;
+  if (canRead)
+  {
+    // All we test is that CanReadFile() does not crash, it is fine if it cannot read the file.
+    return EXIT_SUCCESS;
+  }
+
+  auto reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->SetImageIO(dcmImageIO);
+
+  try
+  {
+    reader->Update();
+  }
+  catch (const itk::ExceptionObject & e)
+  {
+    std::cerr << "exception in file reader " << std::endl;
+    std::cerr << e << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  InputImageType::SizeType extentSize;
+  extentSize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  std::cout << "Read image dimensions: (" << extentSize[0] << ", " << extentSize[1] << ", " << extentSize[2] << ')'
+            << std::endl;
+  if (extentSize[0] == 0 || extentSize[1] == 0 || extentSize[2] == 0)
+  {
+    std::cerr << "File read but empty " << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fix crash in ITK DICOM reader when attempting to read an unusual but valid DICOM file, which has 32 bits allocated.
Fixes the error reported at https://discourse.slicer.org/t/slicer-crashes-while-trying-to-load-dicom-files/34931/3

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.
