### PR TITLE
ENH: FlatStructuringElement and ShapedNeighborhoodIterator Interop

### DIFF
--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -374,8 +374,15 @@ public:
   /** Add non-zero neighborhood offsets to the active list. The
    * radius of the neighborhood must match the radius of the shaped
    * iterator */
+  template <typename TNeighborPixel>
   void
-  CreateActiveListFromNeighborhood(const NeighborhoodType &);
+  CreateActiveListFromNeighborhood(const Neighborhood<TNeighborPixel, Self::Dimension> &);
+  void
+  CreateActiveListFromNeighborhood(const NeighborhoodType & neighborhood)
+  {
+    // just delegate to the templated version
+    this->CreateActiveListFromNeighborhood<PixelType>(neighborhood);
+  }
 
   /** Reimplements the operator++ method so that only active pixel locations
    * are updated. */

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -113,9 +113,10 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::DeactivateIndex(Nei
 }
 
 template <typename TImage, typename TBoundaryCondition>
+template <typename TNeighborPixel>
 void
 ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::CreateActiveListFromNeighborhood(
-  const NeighborhoodType & neighborhood)
+  const Neighborhood<TNeighborPixel, Self::Dimension> & neighborhood)
 {
   if (this->GetRadius() != neighborhood.GetRadius())
   {
@@ -123,8 +124,8 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::CreateActiveListFro
                                                           << ") does not equal radius of neighborhood("
                                                           << neighborhood.GetRadius() << ')');
   }
-  typename NeighborhoodType::ConstIterator nit;
-  NeighborIndexType                        idx = 0;
+  typename Neighborhood<TNeighborPixel, Self::Dimension>::ConstIterator nit;
+  NeighborIndexType                                                     idx = 0;
   for (nit = neighborhood.Begin(); nit != neighborhood.End(); ++nit, ++idx)
   {
     if (*nit)

--- a/Modules/Core/Common/itk-module.cmake
+++ b/Modules/Core/Common/itk-module.cmake
@@ -27,6 +27,7 @@ itk_module(
   ITKTestKernel
   ITKMesh
   ITKImageIntensity
+  ITKMathematicalMorphology
   ITKIOImageBase
   DESCRIPTION
   "${DOCUMENTATION}")

--- a/Modules/Core/Common/test/itkShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkShapedNeighborhoodIteratorTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkNeighborhoodIteratorTestCommon.hxx"
 #include "itkShapedNeighborhoodIterator.h"
+#include "itkFlatStructuringElement.h"
 
 int
 itkShapedNeighborhoodIteratorTest(int, char *[])
@@ -190,6 +191,18 @@ itkShapedNeighborhoodIteratorTest(int, char *[])
     std::cout << it.GetPixel(off) << std::endl;
   }
   std::cout << it.GetPixel(off) << std::endl;
+
+  println("Testing interoperability with FlatStructuringElement");
+  using StructuringElementType = itk::FlatStructuringElement<4>;
+  const StructuringElementType::RadiusType       radius2 = StructuringElementType::RadiusType::Filled(2);
+  const StructuringElementType                   kernel = StructuringElementType::Cross(radius2);
+  itk::ShapedNeighborhoodIterator<TestImageType> iterator(radius2, img, img->GetBufferedRegion());
+  iterator.CreateActiveListFromNeighborhood(kernel);
+  iterator.SetLocation(loc);
+  for (ci = iterator.Begin(); ci != iterator.End(); ++ci)
+  {
+    std::cout << ci.GetNeighborhoodIndex() << " -> " << ci.GetNeighborhoodOffset() << " = " << ci.Get() << std::endl;
+  }
 
   println("testing operator=");
   itk::ShapedNeighborhoodIterator<TestImageType> oeIt;


### PR DESCRIPTION
Allow interoperability of FlatStructuringElement and ShapedNeighborhoodIterator to allow compilation of the following code:

```cpp
using SE2Type = itk::FlatStructuringElement<2>;
SE2Type::RadiusType r2 = SE2Type::RadiusType::Filled(5);
SE2Type k2 = SE2Type::Ball(r2);

itk::ShapedNeighborhoodIterator<TImage> iterator(r2, image, image->GetBufferedRegion());
iterator.CreateActiveListFromNeighborhood(k2); // this now compiles

```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)

