### PR TITLE
ENH: KernelTransform's PointSet should use minimal point data

### DIFF
--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -116,7 +116,11 @@ public:
    * specifically, the source and target landmark lists. */
   using PointSetTraitsType =
     DefaultStaticMeshTraits<TParametersValueType, VDimension, VDimension, TParametersValueType, TParametersValueType>;
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  using PointSetType = PointSet<unsigned char, VDimension, PointSetTraitsType>;
+#else
   using PointSetType = PointSet<InputPointType, VDimension, PointSetTraitsType>;
+#endif
 
   using PointSetPointer = typename PointSetType::Pointer;
   using PointsContainer = typename PointSetType::PointsContainer;


### PR DESCRIPTION
This data is not used, so it is better to have a lighter-weight char, instead of the heavier `PointType` there. Having `PointType` there might also confuse someone into thinking that point coordinates should be provided there, or might be retrieved from it.


## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

