### PR TITLE
BUG: Fix computation of weighted centroid in LabelGeometryImageFilter

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -214,7 +214,7 @@ public:
     LabelPointType                          m_WeightedCentroid;
     SizeValueType                           m_ZeroOrderMoment;
     IndexArrayType                          m_FirstOrderRawMoments;
-    IndexArrayType                          m_FirstOrderWeightedRawMoments;
+    AxesLengthType                          m_FirstOrderWeightedRawMoments;
     SizeValueType                           m_FirstOrderRawCrossMoment;
     RealType                                m_FirstOrderCentralCrossMoment;
     MatrixType                              m_SecondOrderRawMoments;

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -344,9 +344,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       }
       else
       {
-        mapIt->second.m_WeightedCentroid[i] =
-          static_cast<typename LabelPointType::ValueType>(mapIt->second.m_FirstOrderWeightedRawMoments[i]) /
-          mapIt->second.m_Sum;
+        mapIt->second.m_WeightedCentroid[i] = mapIt->second.m_FirstOrderWeightedRawMoments[i] / mapIt->second.m_Sum;
       }
     }
 

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -288,7 +288,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         // FIRST ORDER WEIGHTED RAW MOMENTS
-        mapIt->second.m_FirstOrderWeightedRawMoments[i] += index[i] * (typename LabelIndexType::IndexValueType)value;
+        mapIt->second.m_FirstOrderWeightedRawMoments[i] += index[i] * value;
       }
 
       ++it;


### PR DESCRIPTION
Intensity values were cast to integers, thus making the computation imprecise.

Images below show centroids in red and weighted centroids in green.

Before this PR:
![centroidsOld](https://github.com/InsightSoftwareConsortium/ITK/assets/1792121/a29432ce-093d-47ef-ab4e-03126a89e8b0)

After this PR:
![centroidsNew](https://github.com/InsightSoftwareConsortium/ITK/assets/1792121/c986ad73-1e8c-4be3-b4c6-6b303e8ad812)


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

