### PR TITLE
STYLE: Replace "the the" with "the" in comments

### DIFF
--- a/Modules/Compatibility/Deprecated/test/itkSimpleFastMutexLockTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkSimpleFastMutexLockTest.cxx
@@ -57,7 +57,7 @@ itkSimpleFastMutexLockTest(int, char *[])
     }
     nblock.Unlock();
     nblock.Lock();
-    // Ensure the the TryLock() does not cause a deadlock.
+    // Ensure the TryLock() does not cause a deadlock.
     // If the lock isn't recursive, it will block forever and the CTest
     // timeout will cause the test to fail.
     nblock.Unlock();

--- a/Modules/Core/Common/include/itkImageToImageFilterDetail.h
+++ b/Modules/Core/Common/include/itkImageToImageFilterDetail.h
@@ -295,7 +295,7 @@ ImageToImageFilterDefaultCopyRegion(const typename BinaryUnsignedIntDispatch<D1,
  * This function object is used by the default implementation of
  * ImageToImageFilter::GenerateInputRequestedRegion(). It can also
  * be used in routines like ImageSource::ThreadedGenerateData()
- * where a filter may need to map the the output region for a
+ * where a filter may need to map the output region for a
  * particular thread to an input region.
  *
  * This copier uses a "dispatch pattern" to call one of three

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -342,7 +342,7 @@ public:
 
   /** \brief Increment the progress of the process object.
    *
-   * Atomically add the the current progress and may invoke observers of the ProgressEvent. Progress is represented in
+   * Atomically add the current progress and may invoke observers of the ProgressEvent. Progress is represented in
    * [0.0,1.0] or percentage. This method will invoke the ProgressEvent when called by the same as the pipeline.
    *
    * Multiple threads may call this method and the total progress will be atomically incremented.

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
@@ -40,7 +40,7 @@ namespace itk
  * possible, and so m_Origin and m_Spacing should be ignored.  They exist only
  * to allow the possibility of running a "spatially-aware" filter in raw index
  * space, as if the SpecialCoordinatesImage data was laid out on a regular grid.
- * Note that this may or may not produce useful results, and it is up the the
+ * Note that this may or may not produce useful results, and it is up the
  * user to determine the appropriateness of running a filter designed for normal
  * images on special-coordinates images.
  *

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -465,7 +465,7 @@ ProcessObject::SetOutput(const DataObjectIdentifierType & name, DataObject * out
     this->SetOutput(key, newOutput);
 
     // If we had an output object before, copy the requested region
-    // ivars and release data flag to the the new output
+    // ivars and release data flag to the new output
     if (oldOutput)
     {
       newOutput->SetRequestedRegion(oldOutput);

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -129,7 +129,7 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   // Get the Smart Pointer to the Filter Output
   MeshType::Pointer outputMesh = filter->GetOutput();
 
-  // Get the the point container
+  // Get the point container
   MeshType::PointsContainer::Iterator beginPoint = outputMesh->GetPoints()->Begin();
 
   MeshType::PointsContainer::Iterator endPoint = outputMesh->GetPoints()->End();

--- a/Modules/Core/Mesh/test/itkInteriorExteriorMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkInteriorExteriorMeshFilterTest.cxx
@@ -114,7 +114,7 @@ itkInteriorExteriorMeshFilterTest(int, char *[])
   MeshType::Pointer outputMesh = filter->GetOutput();
 
 
-  // Get the the point container
+  // Get the point container
   MeshType::PointsContainerPointer transformedPoints = outputMesh->GetPoints();
 
 

--- a/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
@@ -275,7 +275,7 @@ itkMeshSourceGraftOutputTest(int, char *[])
   std::cout << "Output Mesh has " << outputMesh->GetNumberOfPoints();
   std::cout << "   points " << std::endl;
 
-  // Get the the point container
+  // Get the point container
   MeshType::PointsContainerPointer transformedPoints = outputMesh->GetPoints();
 
 

--- a/Modules/Core/Mesh/test/itkTransformMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTransformMeshFilterTest.cxx
@@ -137,7 +137,7 @@ itkTransformMeshFilterTest(int, char *[])
   std::cout << "Output Mesh from WithBaseTransform has " << outputMeshFromWithBase->GetNumberOfPoints() << "   points "
             << std::endl;
 
-  // Get the the point container
+  // Get the point container
   MeshType::PointsContainerPointer transformedPoints = outputMesh->GetPoints();
 
   MeshType::PointsContainerPointer transformedPointsFromWithBase = outputMeshFromWithBase->GetPoints();

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
@@ -128,7 +128,7 @@ public:
   bool
   VerifyDownStreamFilterExecutedPropagation();
 
-  /** Verifies the the GenerateData executed the expected number of
+  /** Verifies the GenerateData executed the expected number of
    * times.
    *
    * If expectedNumber is positive then the number of updates must

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.h
@@ -28,7 +28,7 @@ namespace itk
  * This class implements a vector-valued version of
  * AnisotropicDiffusionFunction.  Typically in vector-valued diffusion, vector
  * components are diffused independently of one another using a conductance
- * term that is linked across the components. Refer to the the documentation of
+ * term that is linked across the components. Refer to the documentation of
  * AnisotropicDiffusionFunction for an overview of anisotropic diffusion.  The
  * way that the conductance term is calculated is specific to the specific type
  * of diffusion function.

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
@@ -52,7 +52,7 @@ testMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,
  * This file tests the functionality of the MinMaxCurvatureFlowImageFilter.
  * The test uses a binary image of a circle/sphere with intensity value
  * of 0 (black). The background is white ( intensity = 255 ).
- * X% salt and pepper noise is added to the the input image. Specifically,
+ * X% salt and pepper noise is added to the input image. Specifically,
  * X% of the pixels is replaced with a value chosen from a uniform
  * distribution between 0 and 255.
  *

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -355,7 +355,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // Third Stage
   // traverse structure of border and SE CCs, and paint output image
 
-  // Let's consider the the set of the ON elements of the input image as X.
+  // Let's consider the set of the ON elements of the input image as X.
   //
   // Let's consider the structuring element as B = {B0, B1, ..., Bn},
   // where Bi denotes a connected component of B.

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -349,7 +349,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // Third Stage
   // traverse structure of border and SE CCs, and paint output image
 
-  // Let's consider the the set of the ON elements of the input image as X.
+  // Let's consider the set of the ON elements of the input image as X.
   //
   // Let's consider the structuring element as B = {B0, B1, ..., Bn},
   // where Bi denotes a connected component of B.

--- a/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
@@ -54,7 +54,7 @@ testBinaryMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,
  * This file tests the functionality of the BinaryMinMaxCurvatureFlowImageFilter.
  * The test uses a binary image of a circle/sphere with intensity value
  * of 0 (black). The background is white ( intensity = 255 ).
- * X% salt and pepper noise is added to the the input image. Specifically,
+ * X% salt and pepper noise is added to the input image. Specifically,
  * X% of the pixels is replaced with a value chosen from a uniform
  * distribution between 0 and 255.
  *

--- a/Modules/Filtering/FFT/test/itkFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkFFTTest.h
@@ -147,7 +147,7 @@ test_fft(unsigned int * SizeOfDimensions)
   {
     sizes[i] = complexImageSize[i];
   }
-  /* Print out the the frequency domain data obtained after performing
+  /* Print out the frequency domain data obtained after performing
    * the forward transform. */
   std::cout << "Frequency domain data after forward transform:" << std::endl;
   for (unsigned int i = 0; i < sizes[2]; ++i)
@@ -370,7 +370,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
     sizesB[i] = complexImageSizeB[i];
   }
 
-  // Print out the the frequency domain data obtained after performing
+  // Print out the frequency domain data obtained after performing
   // the forward transform.
   std::cout << "Frequency domain data after forward transform:" << std::endl;
   for (unsigned int i = 0; i < sizesA[2]; ++i)

--- a/Modules/Filtering/FFT/test/itkRealFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkRealFFTTest.h
@@ -135,7 +135,7 @@ test_fft(unsigned int * SizeOfDimensions)
     sizes[i] = complexImageSize[i];
   }
 
-  /* Print out the the frequency domain data obtained after performing
+  /* Print out the frequency domain data obtained after performing
    * the forward transform. */
   std::cout << "Frequency domain data after forward transform:" << std::endl;
   for (unsigned int i = 0; i < sizes[2]; ++i)
@@ -321,7 +321,7 @@ test_fft_rtc(unsigned int * SizeOfDimensions)
     sizesB[i] = complexImageSizeB[i];
   }
 
-  // Print out the the frequency domain data obtained after performing
+  // Print out the frequency domain data obtained after performing
   // the forward transform.
   std::cout << "Frequency domain data after forward transform:" << std::endl;
   for (unsigned int i = 0; i < sizesA[2]; ++i)

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
@@ -84,7 +84,7 @@ namespace itk
  * ConfidenceWeight should be left to the default of 1.0.
  *
  * You must provide a foreground value using SetForegroundValue that the STAPLE
- * algorithm will use to identify positively classified pixels in the the input
+ * algorithm will use to identify positively classified pixels in the input
  * images.  All other values in the image will be treated as background values.
  * For example, if your input segmentations consist of 1's everywhere inside
  * the segmented region, then use SetForegroundValue(1).

--- a/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
@@ -123,7 +123,7 @@ itkConstrainedValueDifferenceImageFilterTest(int argc, char * argv[])
   // Execute the filter
   filter->Update();
 
-  // Get the the filter output
+  // Get the filter output
   OutputImageType::Pointer outputImage = filter->GetOutput();
 
   // Write the result image

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -28,7 +28,7 @@ namespace itk
  * \brief A filter to enhance M-dimensional objects in N-dimensional images
  *
  * The objectness measure is a generalization of Frangi's vesselness measure,
- * which is based on the analysis of the the Hessian eigen system. The filter
+ * which is based on the analysis of the Hessian eigen system. The filter
  * can enhance blob-like structures (M=0), vessel-like structures (M=1), 2D
  * plate-like structures (M=2), hyper-plate-like structures (M=3) in N-dimensional
  * images, with M<N.

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -71,7 +71,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
   scales[2] = 3.0;
   scales[3] = 5.0;
 
-  // changing the size of the object with the the size of the
+  // changing the size of the object with the size of the
   // gaussian should produce the same results
   for (double objectSize : scales)
   {

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
@@ -78,7 +78,7 @@ public:
   /** Type used to store gabor parameters. */
   using ArrayType = FixedArray<double, Self::ImageDimension>;
 
-  /** Set/Get the the standard deviation in each direction. */
+  /** Set/Get the standard deviation in each direction. */
   itkSetMacro(Sigma, ArrayType);
   itkGetConstReferenceMacro(Sigma, ArrayType);
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -53,7 +53,7 @@ namespace itk
  * covariance vector A*A' where A is a matrix with p x t, p = number of
  * pixels or voxels in each images and t = number of training images, we
  * calculate the eigen vectors of the inner product matrix A'*A. The resulting
- * eigen vectors (E) are then multiplied with the the matrix A to get the
+ * eigen vectors (E) are then multiplied with the matrix A to get the
  * principal components. The covariance matrix has a dimension of p x p. Since
  * number of pixels in any image being typically very high the eigen
  * decomposition becomes computationally expensive. The inner product on the

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
@@ -116,7 +116,7 @@ LabelImageToLabelMapFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
       }
       else
       {
-        // go the the next pixel
+        // go the next pixel
         ++it;
       }
     }

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -279,7 +279,7 @@ public:
   GetLabels() const;
 
   /**
-   * Return the the label objects available in the label map
+   * Return the label objects available in the label map
    */
   LabelObjectVectorType
   GetLabelObjects() const;

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -319,7 +319,7 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing)
   EXPECT_NEAR(19.36, labelObject->GetPhysicalSize(), 1e-10);
   // Because the sign of the Eigen vectors is not
   // unique, therefore the axes may not always point in the same
-  // direction making origin not unique. Therefore we check the expected origin the the list of vertices.
+  // direction making origin not unique. Therefore we check the expected origin the list of vertices.
   EXPECT_TRUE(Utils::TestListHasPoint(labelObject->GetOrientedBoundingBoxVertices(), itk::MakePoint(4.5, 9.35, 23.1)));
   // labelObject->GetPrincipalAxes(); omitted
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);

--- a/Modules/Filtering/Path/include/itkPathConstIterator.hxx
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.hxx
@@ -63,7 +63,7 @@ template <typename TImage, typename TPath>
 void
 PathConstIterator<TImage, TPath>::GoToBegin()
 {
-  // Go the the beginning
+  // Go the beginning
   m_CurrentPathPosition = m_Path->StartOfInput();
 
   // But don't visit the first index twice for closed paths (unless told to)

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
@@ -96,7 +96,7 @@ protected:
                               size_t                 size);
 
   /** Convert to RGB output. */
-  /** Each RGB output component is set the the
+  /** Each RGB output component is set the
    * input Gray value. */
   static void
   ConvertGrayToRGB(const InputPixelType * inputData, OutputPixelType * outputData, size_t size);

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -278,7 +278,7 @@ ImageFileWriter<TInputImage>::Write()
     InputImageRegionType streamRegion;
     ImageIORegionAdaptor<TInputImage::ImageDimension>::Convert(streamIORegion, streamRegion, largestRegion.GetIndex());
 
-    // execute the the upstream pipeline with the requested
+    // execute the upstream pipeline with the requested
     // region for streaming
     nonConstInput->SetRequestedRegion(streamRegion);
     nonConstInput->PropagateRequestedRegion();

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -489,8 +489,8 @@ public:
    * LargestPossibleRegion (unless it was dimensionally clipped) and
    * greater or equal to the RequestedRegion
    *
-   * the resulting IORegion may be a greater dimensions the the
-   * requested IORegion, if the the derived class is unable to read
+   * the resulting IORegion may be a greater dimensions the
+   * requested IORegion, if the derived class is unable to read
    * the requested region. For example if the file has a size of [ 10,
    * 10, 10] but the requested region is [10, 10] the return may be 3 dimensions.
    */

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -66,7 +66,7 @@ template <typename TOutputImage>
 int
 ImageSeriesReader<TOutputImage>::ComputeMovingDimensionIndex(ReaderType * reader)
 {
-  // This method computes the the dimension index which we are going
+  // This method computes the dimension index which we are going
   // to be moving in for slices
 
   unsigned int movingDimension = reader->GetImageIO()->GetNumberOfDimensions();

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
@@ -70,7 +70,7 @@ void
 TransformFactoryBase::RegisterDefaultTransforms()
 {
   //
-  // make sure that the the factory instance has
+  // make sure that the factory instance has
   // been created. All normal paths to this method
   // already do this but this makes certain sure it's done
   (void)TransformFactoryBase::GetFactory();

--- a/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
@@ -43,7 +43,7 @@ namespace itk
  * no convergence checking is done.
  * The first four components of p are assumed to be the four components
  * of the quaternion. After each update, the quaternion is normalized to
- * have a magnitude of one. This ensures the the transform is purely rigid.
+ * have a magnitude of one. This ensures the transform is purely rigid.
  *
  * \sa GradientDescentOptimizer
  * \ingroup Numerics Optimizers

--- a/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
@@ -38,7 +38,7 @@ namespace itk
  *  where  \f$q_I\f$ is the frequency of measurement vector, I.
  *
  * \f$p\f$ is the frequency of a measurement vector by the sum of all frequencies =
- * Probability of the the measurement vector
+ * Probability of the measurement vector
  *
  * The output image is of type double.
  *

--- a/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
@@ -33,7 +33,7 @@ namespace itk
  *  where \f$q_I\f$ is the frequency of measurement vector, I.
  *
  * This is the frequency of a measurement vector by the sum of all frequencies =
- * Probability of the the measurement vector
+ * Probability of the measurement vector
  *
  * The output image is of type float.
  *

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -747,7 +747,7 @@ public:
   Search(const MeasurementVectorType &, double, InstanceIdentifierVectorType &) const;
 
   /** Returns true if the intermediate k-nearest neighbors exist within
-   * the the bounding box defined by the lowerBound and the
+   * the bounding box defined by the lowerBound and the
    * upperBound. Otherwise returns false. Returns false if the ball
    * defined by the distance between the query point and the farthest
    * neighbor touch the surface of the bounding box. */

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -46,7 +46,7 @@ public:
       the frequency by one does not change the total frequency (because of lack of
       precision). Using double type will also ultimately fall into the same problem.
       Hence in the new statistics framework, InstanceIdentifier/FrequencyTypes are
-      set to the the largest possible integer on the machine */
+      set to the largest possible integer on the machine */
   using InstanceIdentifier = IdentifierType;
 
   /** Type defined for representing the frequency of measurement vectors */

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
@@ -166,7 +166,7 @@ protected:
   DataObject::Pointer
   MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
-  /** We need to create our own GenerateOutputInformation because the the
+  /** We need to create our own GenerateOutputInformation because the
    * default version from ProcessObject result in a dynamic_cast of the input
    * pointer to the output pointer type in PointSet::CopyInformation.  This does
    * not work since they are different types. */

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -828,8 +828,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::CommonGetV
 
   // NOTE: Since the m_ThreaderFixedImageMarginalPDF is the sum of mass
   // in the fixed image dimension, accumulating these values gives the
-  // same answer as computing the the sum of individual values over
-  // the the entire histogram.  IMPORTANT NOTICE: THIS MAKES AN
+  // same answer as computing the sum of individual values over
+  // the entire histogram.  IMPORTANT NOTICE: THIS MAKES AN
   // ASSUMPTION OF CONSERVATION OF MASS OF THE BSPLINE SMOOTHING.  The
   // sum of all the values should equal the number of samples being
   // used, since each sample contributes only one sample somewhere in

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
@@ -112,7 +112,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This is value is only available for the previous iteration and
    * NOT the current iteration. */
   double

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -191,7 +191,7 @@ public:
   /** Get the metric value.
    *
    * The metric value is the mean square difference in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    */
   virtual double
   GetMetric() const

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -495,7 +495,7 @@ public:
   itkGetConstReferenceMacro(UseMovingImageGradientFilter, bool);
   itkBooleanMacro(UseMovingImageGradientFilter);
 
-  /** Get number of work units to used in the the most recent
+  /** Get number of work units to used in the most recent
    * evaluation.  Only valid after GetValueAndDerivative() or
    * GetValue() has been called. */
   virtual ThreadIdType
@@ -510,7 +510,7 @@ public:
   GetMaximumNumberOfWorkUnits() const;
 
 #if !defined(ITK_LEGACY_REMOVE)
-  /** Get number of threads to used in the the most recent
+  /** Get number of threads to used in the most recent
    * evaluation.  Only valid after GetValueAndDerivative() or
    * GetValue() has been called.
    *

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -96,7 +96,7 @@ public:
   itkGetConstMacro(CovarianceKNeighborhood, unsigned int);
 
   /**
-   * Set the evaluation K neighborhood.  To evaluate the the manifold parzen
+   * Set the evaluation K neighborhood.  To evaluate the manifold parzen
    * windows function, one could sum the value contributed by each Gaussian or
    * to speed calculation, we could sum the value contributed by the nearest
    * K Gaussians.  Default = 50.

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
@@ -172,7 +172,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This is value is only available for the previous iteration and
    * NOT the current iteration. */
   virtual double

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
@@ -102,7 +102,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This is value is only available for the previous iteration and
    * NOT the current iteration. */
   virtual double

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -166,7 +166,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+   * computed over the overlapping region between the two images. */
   virtual double
   GetMetric() const
   {

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -120,7 +120,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This value is calculated for the current iteration */
   virtual double
   GetMetric() const;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -200,7 +200,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+   * computed over the overlapping region between the two images. */
   virtual double
   GetMetric() const
   {

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
@@ -104,7 +104,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This value is calculated for the current iteration */
   virtual double
   GetMetric() const;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -165,7 +165,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+   * computed over the overlapping region between the two images. */
   virtual double
   GetMetric() const
   {

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.h
@@ -130,7 +130,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This is value is only available for the previous iteration and
    * NOT the current iteration. */
   virtual double

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -167,7 +167,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+   * computed over the overlapping region between the two images. */
   virtual double
   GetMetric() const
   {

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.h
@@ -109,7 +109,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images.
+   * computed over the overlapping region between the two images.
    * This value is calculated for the current iteration */
   virtual double
   GetMetric() const;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -170,7 +170,7 @@ public:
 
   /** Get the metric value. The metric value is the mean square difference
    * in intensity between the fixed image and transforming moving image
-   * computed over the the overlapping region between the two images. */
+   * computed over the overlapping region between the two images. */
   virtual double
   GetMetric() const
   {

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -846,7 +846,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedAlloc
     m_Data[ThreadId].m_ZHistogram[i] = 0;
   }
 
-  // Every thread must have its own copy of the the GlobalData struct.
+  // Every thread must have its own copy of the GlobalData struct.
   m_Data[ThreadId].globalData = this->GetDifferenceFunction()->GetGlobalDataPointer();
 
   //


### PR DESCRIPTION
The word "the" often appears accidentally duplicated, both in regular and doxygen formatted comments.