### PR TITLE
WIP (Not ready): Add `GradientImageFilter::OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType>)`

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -147,7 +147,7 @@ public:
 
   /** Allows to change the default boundary condition */
   void
-  OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType> boundaryCondition);
+  OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType> && boundaryCondition);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -100,6 +100,9 @@ public:
   using CovariantVectorType = CovariantVector<OutputValueType, Self::OutputImageDimension>;
   using OutputImageRegionType = typename OutputImageType::RegionType;
 
+  /** Helper typedef for the parameter type of OverrideBoundaryCondition. */
+  using BoundaryConditionType = ImageBoundaryCondition<TInputImage>;
+
   /** GradientImageFilter needs a larger input requested region than
    * the output requested region.  As such, GradientImageFilter needs
    * to provide an implementation for GenerateInputRequestedRegion()
@@ -140,7 +143,7 @@ public:
 
   /** Allows to change the default boundary condition */
   void
-  OverrideBoundaryCondition(ImageBoundaryCondition<TInputImage> * boundaryCondition);
+  OverrideBoundaryCondition(BoundaryConditionType * boundaryCondition);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -228,7 +231,7 @@ private:
   bool m_UseImageDirection{ true };
 
   // allow setting the m_BoundaryCondition
-  std::unique_ptr<ImageBoundaryCondition<TInputImage, TInputImage>> m_BoundaryCondition{
+  std::unique_ptr<BoundaryConditionType> m_BoundaryCondition{
     std::make_unique<ZeroFluxNeumannBoundaryCondition<TInputImage>>()
   };
 };

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -141,9 +141,12 @@ public:
   }
 #endif
 
-  /** Allows to change the default boundary condition */
-  void
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** Allows to change the default boundary condition
+   * \note This filter takes ownership of the specified boundary condition object. */
+  [[deprecated("Deprecated in favor of `OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType>)`.")]] void
   OverrideBoundaryCondition(BoundaryConditionType * boundaryCondition);
+#endif
 
   /** Allows to change the default boundary condition */
   void

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -145,6 +145,10 @@ public:
   void
   OverrideBoundaryCondition(BoundaryConditionType * boundaryCondition);
 
+  /** Allows to change the default boundary condition */
+  void
+  OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType> boundaryCondition);
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputValueType>));

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -227,7 +227,7 @@ private:
   // when computing the derivatives.
   bool m_UseImageDirection{ true };
 
-  // allow setting the the m_BoundaryCondition
+  // allow setting the m_BoundaryCondition
   std::unique_ptr<ImageBoundaryCondition<TInputImage, TInputImage>> m_BoundaryCondition{
     std::make_unique<ZeroFluxNeumannBoundaryCondition<TInputImage>>()
   };

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -48,7 +48,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
 void
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>::OverrideBoundaryCondition(
-  std::unique_ptr<BoundaryConditionType> boundaryCondition)
+  std::unique_ptr<BoundaryConditionType> && boundaryCondition)
 {
   m_BoundaryCondition = std::move(boundaryCondition);
 }

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -45,6 +45,14 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>
   m_BoundaryCondition.reset(boundaryCondition);
 }
 
+template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
+void
+GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>::OverrideBoundaryCondition(
+  std::unique_ptr<BoundaryConditionType> boundaryCondition)
+{
+  m_BoundaryCondition = std::move(boundaryCondition);
+}
+
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>
 void
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputImageType>::GenerateInputRequestedRegion()

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -37,6 +37,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   this->ThreaderUpdateProgressOff();
 }
 
+#ifndef ITK_FUTURE_LEGACY_REMOVE
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
 void
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>::OverrideBoundaryCondition(
@@ -44,6 +45,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>
 {
   m_BoundaryCondition.reset(boundaryCondition);
 }
+#endif
 
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
 void

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -40,7 +40,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValue, typename TOutputImage>
 void
 GradientImageFilter<TInputImage, TOperatorValueType, TOutputValue, TOutputImage>::OverrideBoundaryCondition(
-  ImageBoundaryCondition<TInputImage> * boundaryCondition)
+  BoundaryConditionType * boundaryCondition)
 {
   m_BoundaryCondition.reset(boundaryCondition);
 }

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
@@ -89,7 +89,7 @@ itkGradientImageFilterTest(int argc, char * argv[])
 
   using PeriodicBoundaryType = itk::PeriodicBoundaryCondition<InputImageType2>;
   // Test the OverrideBoundaryCondition setting;
-  filter2->OverrideBoundaryCondition(new PeriodicBoundaryType);
+  filter2->OverrideBoundaryCondition(std::make_unique<PeriodicBoundaryType>());
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter2, GradientImageFilter, ImageToImageFilter);
 


### PR DESCRIPTION
Deprecated the old `GradientImageFilter` member function `OverrideBoundaryCondition(BoundaryConditionType *)` in favor of `OverrideBoundaryCondition(std::unique_ptr<BoundaryConditionType>)`.

Aims to make it more clear that the filter takes the ownership of the specified `BoundaryCondition` object.

Triggered by a comment from Bradley Lowekamp (@blowekamp) at https://github.com/InsightSoftwareConsortium/ITK/pull/4512#discussion_r1523141237