### PR TITLE
Add helper function, `Transform::InvertTransform`, simplifying `GetInverseTransform()`

### DIFF
--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -259,9 +259,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
@@ -170,9 +170,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 CenteredAffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 } // namespace itk

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
@@ -194,9 +194,7 @@ template <typename TParametersValueType>
 auto
 CenteredEuler3DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 // Print self

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
@@ -199,9 +199,7 @@ template <typename TParametersValueType>
 auto
 CenteredRigid2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
@@ -214,13 +214,7 @@ template <typename TParametersValueType>
 auto
 CenteredSimilarity2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  if (this->GetInverse(inv))
-  {
-    return inv.GetPointer();
-  }
-  return nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -446,17 +446,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 CompositeTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  /* This method can't be defined in Superclass because of the call to New() */
-  Pointer inverseTransform = New();
-
-  if (this->GetInverse(inverseTransform))
-  {
-    return inverseTransform.GetPointer();
-  }
-  else
-  {
-    return nullptr;
-  }
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkEuler2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler2DTransform.hxx
@@ -65,9 +65,7 @@ template <typename TParametersValueType>
 auto
 Euler2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 // Create and return an inverse transformation

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -463,9 +463,7 @@ auto
 MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetInverseTransform() const
   -> InverseTransformBasePointer
 {
-  auto inv = InverseTransformType::New();
-
-  return GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -154,9 +154,7 @@ template <typename TParametersValueType>
 auto
 Rigid2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -144,9 +144,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 ScalableAffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -185,13 +185,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 ScaleTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  if (this->GetInverse(inv))
-  {
-    return inv.GetPointer();
-  }
-  return nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -260,13 +260,7 @@ template <typename TParametersValueType>
 auto
 Similarity2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  if (this->GetInverse(inv))
-  {
-    return inv.GetPointer();
-  }
-  return nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -606,6 +606,16 @@ protected:
   PreservationOfPrincipalDirectionDiffusionTensor3DReorientation(const InputDiffusionTensor3DType &,
                                                                  const InverseJacobianPositionType &) const;
 
+  /** Returns the inverse of the specified transform. Returns null if it cannot invert the transform. Helper function
+   * for the implementation of `GetInverseTransform()` in derived transform classes. */
+  template <typename TTransform>
+  static InverseTransformBasePointer
+  InvertTransform(const TTransform & transform)
+  {
+    const auto inverse = TTransform::New();
+    return transform.GetInverse(inverse) ? inverse.GetPointer() : nullptr;
+  }
+
 private:
   std::string m_InputSpaceName{};
   std::string m_OutputSpaceName{};

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -171,9 +171,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 TranslationTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inv = New();
-
-  return GetInverse(inv) ? inv.GetPointer() : nullptr;
+  return Superclass::InvertTransform(*this);
 }
 
 

--- a/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
@@ -124,8 +124,7 @@ public:
   InverseTransformBasePointer
   GetInverseTransform() const override
   {
-    Pointer inv = New();
-    return this->GetInverse(inv) ? inv.GetPointer() : nullptr;
+    return Superclass::InvertTransform(*this);
   }
 
 protected:

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -93,15 +93,7 @@ auto
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const
   -> InverseTransformBasePointer
 {
-  Pointer inverseTransform = New();
-  if (this->GetInverse(inverseTransform))
-  {
-    return inverseTransform.GetPointer();
-  }
-  else
-  {
-    return nullptr;
-  }
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -125,16 +125,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inverseTransform = New();
-
-  if (this->GetInverse(inverseTransform))
-  {
-    return inverseTransform.GetPointer();
-  }
-  else
-  {
-    return nullptr;
-  }
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -90,15 +90,7 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 VelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
-  Pointer inverseTransform = New();
-  if (this->GetInverse(inverseTransform))
-  {
-    return inverseTransform.GetPointer();
-  }
-  else
-  {
-    return nullptr;
-  }
+  return Superclass::InvertTransform(*this);
 }
 
 template <typename TParametersValueType, unsigned int VDimension>


### PR DESCRIPTION
- Added a static, protected helper function, `Transform::InvertTransform`
- Let derived `GetInverseTransform()` member functions just call `Transform::InvertTransform`

Aims to simplify the code, and reduce code duplication.


