### PR TITLE
DOC: Remove commented-out `GetAllCounts` method declaration

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -381,9 +381,6 @@ public:
   SizeValueType
   GetVolume(LabelPixelType label) const;
 
-  /** Return the number of pixels for all labels. */
-  // std::vector< SizeValueType > GetAllCounts() const;
-
   /** Return the computed integrated pixel intensity for a label. */
   RealType
   GetIntegratedIntensity(LabelPixelType label) const;


### PR DESCRIPTION
Its docstring spills into the next method's doxygen docstring. The method itself lacked an implementation, commented out or otherwise.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Updated API documentation (or API not changed)
