### PR TITLE
 `FUTURE_LEGACY_REMOVE` BoundaryConditionPointerType, replace with `BoundaryConditionType *`

### DIFF
--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -93,8 +93,8 @@ public:
   using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<TInputImage>;
 
   /** Set/get the boundary condition. */
-  itkSetMacro(BoundaryCondition, BoundaryConditionPointerType);
-  itkGetConstMacro(BoundaryCondition, BoundaryConditionPointerType);
+  itkSetMacro(BoundaryCondition, BoundaryConditionType *);
+  itkGetConstMacro(BoundaryCondition, BoundaryConditionType *);
 
   /** Set/get the image kernel. */
   itkSetInputMacro(KernelImage, KernelImageType);
@@ -157,7 +157,7 @@ private:
   bool m_Normalize{ false };
 
   DefaultBoundaryConditionType m_DefaultBoundaryCondition{};
-  BoundaryConditionPointerType m_BoundaryCondition{};
+  BoundaryConditionType *      m_BoundaryCondition{};
 
   OutputRegionModeEnum m_OutputRegionMode{ ConvolutionImageFilterBaseEnums::ConvolutionImageFilterOutputRegion::SAME };
 };

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -89,7 +89,10 @@ public:
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage>;
-  using BoundaryConditionPointerType = BoundaryConditionType *;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using BoundaryConditionPointerType [[deprecated("Please just use `BoundaryConditionType *` instead!")]] =
+    BoundaryConditionType *;
+#endif
   using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<TInputImage>;
 
   /** Set/get the boundary condition. */

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
@@ -107,7 +107,6 @@ public:
 
   /** Typedef to describe the boundary condition. */
   using typename Superclass::BoundaryConditionType;
-  using typename Superclass::BoundaryConditionPointerType;
 
   itkSetMacro(SizeGreatestPrimeFactor, SizeValueType);
   itkGetMacro(SizeGreatestPrimeFactor, SizeValueType);

--- a/Modules/Filtering/FFT/include/itkFFTPadImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTPadImageFilter.h
@@ -95,7 +95,6 @@ public:
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage, TOutputImage>;
-  using BoundaryConditionPointerType = BoundaryConditionType *;
   using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>;
 
 protected:

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
@@ -77,7 +77,6 @@ public:
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage, TOutputImage>;
-  using BoundaryConditionPointerType = BoundaryConditionType *;
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(PadImageFilter);

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
@@ -86,8 +86,8 @@ public:
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Set/get the boundary condition. */
-  itkSetMacro(BoundaryCondition, BoundaryConditionPointerType);
-  itkGetConstMacro(BoundaryCondition, BoundaryConditionPointerType);
+  itkSetMacro(BoundaryCondition, BoundaryConditionType *);
+  itkGetConstMacro(BoundaryCondition, BoundaryConditionType *);
 
 protected:
   PadImageFilterBase();
@@ -110,10 +110,10 @@ protected:
 
   /** Method for subclasses to set the boundary condition. */
   void
-  InternalSetBoundaryCondition(const BoundaryConditionPointerType boundaryCondition);
+  InternalSetBoundaryCondition(BoundaryConditionType * const boundaryCondition);
 
 private:
-  BoundaryConditionPointerType m_BoundaryCondition{};
+  BoundaryConditionType * m_BoundaryCondition{};
 };
 
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
@@ -77,7 +77,10 @@ public:
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage, TOutputImage>;
-  using BoundaryConditionPointerType = BoundaryConditionType *;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using BoundaryConditionPointerType [[deprecated("Please just use `BoundaryConditionType *` instead!")]] =
+    BoundaryConditionType *;
+#endif
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(PadImageFilterBase);

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
@@ -128,7 +128,7 @@ PadImageFilterBase<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 template <typename TInputImage, typename TOutputImage>
 void
 PadImageFilterBase<TInputImage, TOutputImage>::InternalSetBoundaryCondition(
-  const BoundaryConditionPointerType boundaryCondition)
+  BoundaryConditionType * const boundaryCondition)
 {
   m_BoundaryCondition = boundaryCondition;
 }


### PR DESCRIPTION
`BoundaryConditionPointerType` is just a type alias for  `BoundaryConditionType *`. It appears much clearer to directly use `BoundaryConditionType *`, to explicitly make clear when using a _raw_ pointer, rather than a _smart_ pointer.
