### PR TITLE
ENH: Bump SWIG to 2024-03-26-master

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -130,7 +130,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of image and Buffer.");
     PyBuffer_Release(&pyBuffer);
-    Py_DECREF(shapeseq);
+    SWIG_Py_DECREF(shapeseq);
     return nullptr;
   }
 
@@ -169,7 +169,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   output->SetPixelContainer(importer);
   output->SetNumberOfComponentsPerPixel(numberOfComponents);
 
-  Py_DECREF(shapeseq);
+  SWIG_Py_DECREF(shapeseq);
   PyBuffer_Release(&pyBuffer);
 
   return output;

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/itkPCAShapeSignedDistanceFunction.wrap
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/itkPCAShapeSignedDistanceFunction.wrap
@@ -8,6 +8,7 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
   # `double` because of OptimizerParameters is hardcoded as templated
   # over `double` in parent class `ShapeSignedDistanceFunction`.
   foreach(t ${types})
+    string(APPEND ITK_WRAP_PYTHON_SWIG_EXT "DECL_PYTHON_STD_VEC_RAW_TO_SMARTPTR_TYPEMAP(itkImage${ITKM_${t}}${d}, itkImage${ITKM_${t}}${d}_Pointer)\n")
     itk_wrap_template("${ITKM_D}${d}${ITKM_I${t}${d}}" "${ITKT_D},${d},${ITKT_I${t}${d}}")
   endforeach()
 endforeach()

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -274,7 +274,7 @@ macro(
   add_custom_command(
     OUTPUT ${cpp_file} ${python_file}
     COMMAND
-      ${swig_command} -c++ -python -O -features autodoc=2 -doxygen -Werror
+      ${swig_command} -c++ -python -fastdispatch -fvirtual -features autodoc=2 -doxygen -Werror
       -w302 # Identifier 'name' redefined (ignored)
       -w303 # %extend defined for an undeclared class 'name' (to avoid warning about customization in pyBase.i)
       -w312 # Unnamed nested class not currently supported (ignored)
@@ -406,7 +406,7 @@ macro(itk_end_wrap_submodule_python group_name)
     PyImport_AddModule(\"itk._${base_name}Python\");
     PyObject * ${base_name}Module = PyInit__${base_name}Python();
     PyDict_SetItemString(sysModules, \"itk._${base_name}Python\", ${base_name}Module);
-    Py_DECREF( ${base_name}Module);
+    SWIG_Py_DECREF( ${base_name}Module);
     }
 ")
 

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -274,7 +274,7 @@ macro(
   add_custom_command(
     OUTPUT ${cpp_file} ${python_file}
     COMMAND
-      ${swig_command} -c++ -python -O -features autodoc=2 -py3 -doxygen -Werror
+      ${swig_command} -c++ -python -O -features autodoc=2 -doxygen -Werror
       -w302 # Identifier 'name' redefined (ignored)
       -w303 # %extend defined for an undeclared class 'name' (to avoid warning about customization in pyBase.i)
       -w312 # Unnamed nested class not currently supported (ignored)

--- a/Wrapping/Generators/Python/PyBase/CMakeLists.txt
+++ b/Wrapping/Generators/Python/PyBase/CMakeLists.txt
@@ -56,16 +56,6 @@ add_python_config_template(
   "ios_base"
   "")
 add_python_config_template(
-  "ios_base_sync_with_stdio"
-  "std::ios_base_sync_with_stdio"
-  "ios_base_sync_with_stdio"
-  "")
-add_python_config_template(
-  "ios_base_xalloc"
-  "std::ios_base_xalloc"
-  "ios_base_xalloc"
-  "")
-add_python_config_template(
   "iostream"
   "std::iostream"
   "iostream"

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -867,11 +867,11 @@ str = str
                     } else if (PyFloat_Check(o)) {
                         itks[i] = (type)PyFloat_AsDouble(o);
                     } else {
-                        Py_DECREF(o);
+                        SWIG_Py_DECREF(o);
                         PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int or float");
                         return NULL;
                     }
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                 }
                 $1 = &itks;
             }else if (PyInt_Check($input)) {
@@ -915,11 +915,11 @@ str = str
                     } else if (PyFloat_Check(o)) {
                         itks[i] = (type)PyFloat_AsDouble(o);
                     } else {
-                        Py_DECREF(o);
+                        SWIG_Py_DECREF(o);
                         PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int or float");
                         return NULL;
                     }
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                 }
                 $1 = itks;
             }else if (PyInt_Check($input)) {
@@ -991,11 +991,11 @@ str = str
                 } else if (PyFloat_Check(o)) {
                     itks[i] = (value_type)PyFloat_AsDouble(o);
                 } else {
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                     PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int or float");
                     return NULL;
                 }
-                Py_DECREF(o);
+                SWIG_Py_DECREF(o);
             }
             $1 = &itks;
         }
@@ -1024,11 +1024,11 @@ str = str
                 } else if (PyFloat_Check(o)) {
                     itks[i] = (value_type)PyFloat_AsDouble(o);
                 } else {
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                     PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int or float");
                     return NULL;
                 }
-                Py_DECREF(o);
+                SWIG_Py_DECREF(o);
             }
             $1 = itks;
         }
@@ -1078,11 +1078,11 @@ str = str
                     if (PyInt_Check(o) || PyLong_Check(o)) {
                         itks[i] = PyInt_AsLong(o);
                     } else {
-                        Py_DECREF(o);
+                        SWIG_Py_DECREF(o);
                         PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int (or long)");
                         return NULL;
                     }
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                 }
                 $1 = &itks;
             }else if (PyInt_Check($input) || PyLong_Check($input)) {
@@ -1119,11 +1119,11 @@ str = str
                     if (PyInt_Check(o) || PyLong_Check(o)) {
                         itks[i] = PyInt_AsLong(o);
                     } else {
-                        Py_DECREF(o);
+                        SWIG_Py_DECREF(o);
                         PyErr_SetString(PyExc_ValueError,"Expecting a sequence of int (or long)");
                         return NULL;
                     }
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                 }
                 $1 = itks;
             }else if (PyInt_Check($input) || PyLong_Check($input)) {
@@ -1208,11 +1208,11 @@ str = str
                     if(SWIG_ConvertPtr(o,(void **)(&raw_ptr),$descriptor(swig_name *), 0) == 0) {
                         vec_smartptr.push_back(raw_ptr);
                     } else {
-                        Py_DECREF(o);
+                        SWIG_Py_DECREF(o);
                         PyErr_SetString(PyExc_ValueError,"Expecting a sequence of raw pointers (" #swig_name ")." );
                         SWIG_fail;
                     }
-                    Py_DECREF(o);
+                    SWIG_Py_DECREF(o);
                 }
                 $1 = vec_smartptr;
             }

--- a/Wrapping/Generators/Python/PyUtils/itkPyImageFilter.hxx
+++ b/Wrapping/Generators/Python/PyUtils/itkPyImageFilter.hxx
@@ -32,12 +32,12 @@ PyImageFilter<TInputImage, TOutputImage>::~PyImageFilter()
 {
   if (this->m_GenerateDataCallable)
   {
-    Py_DECREF(this->m_GenerateDataCallable);
+    SWIG_Py_DECREF(this->m_GenerateDataCallable);
   }
   this->m_GenerateDataCallable = nullptr;
   if (this->m_GenerateInputRequestedRegionCallable)
   {
-    Py_DECREF(this->m_GenerateInputRequestedRegionCallable);
+    SWIG_Py_DECREF(this->m_GenerateInputRequestedRegionCallable);
   }
   this->m_GenerateInputRequestedRegionCallable = nullptr;
 }
@@ -51,7 +51,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateData(PyObject * o)
     if (this->m_GenerateDataCallable)
     {
       // get rid of our reference
-      Py_DECREF(this->m_GenerateDataCallable);
+      SWIG_Py_DECREF(this->m_GenerateDataCallable);
     }
 
     // store the new object
@@ -62,7 +62,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateData(PyObject * o)
     {
       // take out reference (so that the calling code doesn't
       // have to keep a binding to the callable around)
-      Py_INCREF(this->m_GenerateDataCallable);
+      SWIG_Py_INCREF(this->m_GenerateDataCallable);
     }
   }
 }
@@ -77,7 +77,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateOutputInformation(PyObjec
     if (this->m_GenerateOutputInformationCallable)
     {
       // get rid of our reference
-      Py_DECREF(this->m_GenerateOutputInformationCallable);
+      SWIG_Py_DECREF(this->m_GenerateOutputInformationCallable);
     }
 
     // store the new object
@@ -88,7 +88,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateOutputInformation(PyObjec
     {
       // take out reference (so that the calling code doesn't
       // have to keep a binding to the callable around)
-      Py_INCREF(this->m_GenerateOutputInformationCallable);
+      SWIG_Py_INCREF(this->m_GenerateOutputInformationCallable);
     }
   }
 }
@@ -103,7 +103,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyEnlargeOutputRequestedRegion(PyOb
     if (this->m_EnlargeOutputRequestedRegionCallable)
     {
       // get rid of our reference
-      Py_DECREF(this->m_EnlargeOutputRequestedRegionCallable);
+      SWIG_Py_DECREF(this->m_EnlargeOutputRequestedRegionCallable);
     }
 
     // store the new object
@@ -114,7 +114,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyEnlargeOutputRequestedRegion(PyOb
     {
       // take out reference (so that the calling code doesn't
       // have to keep a binding to the callable around)
-      Py_INCREF(this->m_EnlargeOutputRequestedRegionCallable);
+      SWIG_Py_INCREF(this->m_EnlargeOutputRequestedRegionCallable);
     }
   }
 }
@@ -129,7 +129,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateInputRequestedRegion(PyOb
     if (this->m_GenerateInputRequestedRegionCallable)
     {
       // get rid of our reference
-      Py_DECREF(this->m_GenerateInputRequestedRegionCallable);
+      SWIG_Py_DECREF(this->m_GenerateInputRequestedRegionCallable);
     }
 
     // store the new object
@@ -140,7 +140,7 @@ PyImageFilter<TInputImage, TOutputImage>::SetPyGenerateInputRequestedRegion(PyOb
     {
       // take out reference (so that the calling code doesn't
       // have to keep a binding to the callable around)
-      Py_INCREF(this->m_GenerateInputRequestedRegionCallable);
+      SWIG_Py_INCREF(this->m_GenerateInputRequestedRegionCallable);
     }
   }
 }
@@ -159,11 +159,11 @@ PyImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
     PyObject * args = PyTuple_Pack(1, this->m_Self);
     result = PyObject_Call(this->m_GenerateOutputInformationCallable, args, (PyObject *)NULL);
-    Py_DECREF(args);
+    SWIG_Py_DECREF(args);
 
     if (result)
     {
-      Py_DECREF(result);
+      SWIG_Py_DECREF(result);
     }
     else
     {
@@ -191,12 +191,12 @@ PyImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObjec
     PyObject * pyDataObject = PyObject_CallMethod(this->m_Self, "GetOutput", (const char *)NULL);
     PyObject * args = PyTuple_Pack(2, this->m_Self, pyDataObject);
     PyObject * result = PyObject_Call(this->m_EnlargeOutputRequestedRegionCallable, args, (PyObject *)NULL);
-    Py_DECREF(args);
-    Py_DECREF(pyDataObject);
+    SWIG_Py_DECREF(args);
+    SWIG_Py_DECREF(pyDataObject);
 
     if (result)
     {
-      Py_DECREF(result);
+      SWIG_Py_DECREF(result);
     }
     else
     {
@@ -224,11 +224,11 @@ PyImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
     PyObject * args = PyTuple_Pack(1, this->m_Self);
     result = PyObject_Call(this->m_GenerateInputRequestedRegionCallable, args, (PyObject *)NULL);
-    Py_DECREF(args);
+    SWIG_Py_DECREF(args);
 
     if (result)
     {
-      Py_DECREF(result);
+      SWIG_Py_DECREF(result);
     }
     else
     {
@@ -261,11 +261,11 @@ PyImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     PyObject * args = PyTuple_Pack(1, this->m_Self);
     result = PyObject_Call(this->m_GenerateDataCallable, args, (PyObject *)NULL);
-    Py_DECREF(args);
+    SWIG_Py_DECREF(args);
 
     if (result)
     {
-      Py_DECREF(result);
+      SWIG_Py_DECREF(result);
     }
     else
     {

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 
 option(ITK_USE_SYSTEM_SWIG "Use system swig. If OFF, swig is built as an external project." OFF)
 mark_as_advanced(ITK_USE_SYSTEM_SWIG)
-
 # Minimal swig version
 if(WIN32)
   set(swig_version_min 4.2.0)
@@ -21,14 +20,23 @@ if(WIN32)
       "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
   )
   set(swigwin_cid "bafybeibljxzip2irc3q3w5qlh2ae5ns27xpi7mo6iskxni45dcmwtk2x6a")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
   set(swig_version_min 4.2.0)
   set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_cmake_version 4.3.0)
-  set(swiglinux_hash
-      "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
-  )
-  set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
+  if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(swiglinux_hash
+        "9a3cfa330235ac78799c7401299506db5ea7459314b781bf27f2db8ddb582508ec5b15c2fa96fc241d5b832c4f702cd9ef043a61e37a574cac7ca78e4aba8f78"
+    )
+    set(swiglinux_cid "bafybeiaa2xv7oxnvaz6qupdaykgwakldrmahk54n2pp2z2ianuvq57uvmy")
+    set(swiglinux_arch "arm64")
+  else()
+    set(swiglinux_hash
+        "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
+    )
+    set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
+    set(swiglinux_arch "amd64")
+  endif()
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_version_min 4.2.0)
   set(ITK_SWIG_VERSION 2024-03-26-master)
@@ -55,8 +63,8 @@ endif()
 
 if(WIN32)
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${ITK_SWIG_VERSION}/bin/swig")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig")
 else()
@@ -118,7 +126,7 @@ else()
         BUILD_COMMAND ""
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
       set(SWIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}/bin)
-    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
       # If we are building ITK
       if(ITK_BINARY_DIR)
         itk_download_attempt_check(SWIG)
@@ -126,16 +134,16 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
-            "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
-            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
-            "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
+            "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
+            "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
         URL_HASH SHA512=${swiglinux_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
       set(SWIG_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
+          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
           CACHE FILEPATH "swig directory.")
     elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
       # If we are building ITK

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -29,6 +29,14 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR ST
       "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
   )
   set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+  set(swig_version_min 4.2.0)
+  set(ITK_SWIG_VERSION 2024-03-26-master)
+  set(swig_cmake_version 4.3.0)
+  set(swigmacos_hash
+      "96eec93fd9e1df35813f8cc194a8811c8c84f265284c1515ec81aa7e696aee2c952f426e5155c011c163376e76245f5d7f479525f0d1ea8396524629ed6b8aec"
+  )
+  set(swigmacos_cid "bafybeialov6ur5q2yli4mtclrvqoirk2nsteum3vgnswjypquwejwomxnm")
 else()
   set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_version_min 4.2.0)
@@ -40,6 +48,8 @@ if(WIN32)
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${ITK_SWIG_VERSION}/bin/swig")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${ITK_SWIG_VERSION}/bin/swig")
 else()
   # follow the standard EP_PREFIX locations
   set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
@@ -117,6 +127,25 @@ else()
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
       set(SWIG_DIR
           ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
+          CACHE FILEPATH "swig directory.")
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+      # If we are building ITK
+      if(ITK_BINARY_DIR)
+        itk_download_attempt_check(SWIG)
+      endif()
+      ExternalProject_Add(
+        swig
+        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
+            "https://dweb.link/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
+            "https://w3s.link/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
+        URL_HASH SHA512=${swigmacos_hash}
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${SWIG_VERSION}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND "" ${download_extract_timestamp_flag})
+      set(SWIG_DIR
+          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
           CACHE FILEPATH "swig directory.")
     else()
       # build swig as an external project

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -11,18 +11,21 @@ endif()
 
 option(ITK_USE_SYSTEM_SWIG "Use system swig. If OFF, swig is built as an external project." OFF)
 mark_as_advanced(ITK_USE_SYSTEM_SWIG)
+
 # Minimal swig version
+set(swig_version_min 4.2.0)
+# Version used in vendored binary or source build configured in this file.
+set(ITK_SWIG_VERSION 2024-03-26-master)
+
 if(WIN32)
-  set(swig_version_min 4.2.0)
-  set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_cmake_version 4.3.0)
   set(swigwin_hash
       "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
   )
   set(swigwin_cid "bafybeibljxzip2irc3q3w5qlh2ae5ns27xpi7mo6iskxni45dcmwtk2x6a")
+
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
-  set(swig_version_min 4.2.0)
-  set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_cmake_version 4.3.0)
   if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
     set(swiglinux_hash
@@ -37,9 +40,9 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR S
     set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
     set(swiglinux_arch "amd64")
   endif()
+
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-  set(swig_version_min 4.2.0)
-  set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_cmake_version 4.3.0)
   if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
     set(swigmacos_hash
@@ -54,20 +57,14 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
     set(swigmacos_cid "bafybeifkl5wfscum7pnsjdmwhshrv5v6srilinkrftunq5g4gqzgqmyqf4")
     set(swigmacos_arch "amd64")
   endif()
-else()
-  set(ITK_SWIG_VERSION 2024-03-26-master)
-  set(swig_version_min 4.2.0)
-  set(swig_hash "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9")
-  set(swig_cid "bafybeib56uexrqtccgzxjgmlammjii5ntwush4732kbkr6okbtjhzcmvia")
-endif()
 
-if(WIN32)
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig")
 else()
+  # Build from source
+
+  set(swig_hash "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9")
+  set(swig_cid "bafybeib56uexrqtccgzxjgmlammjii5ntwush4732kbkr6okbtjhzcmvia")
+
   # follow the standard EP_PREFIX locations
   set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
   set(swig_source_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig)

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -29,14 +29,23 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR ST
       "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
   )
   set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_version_min 4.2.0)
   set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_cmake_version 4.3.0)
-  set(swigmacos_hash
+  if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+    set(swigmacos_hash
       "96eec93fd9e1df35813f8cc194a8811c8c84f265284c1515ec81aa7e696aee2c952f426e5155c011c163376e76245f5d7f479525f0d1ea8396524629ed6b8aec"
-  )
-  set(swigmacos_cid "bafybeialov6ur5q2yli4mtclrvqoirk2nsteum3vgnswjypquwejwomxnm")
+    )
+    set(swigmacos_cid "bafybeialov6ur5q2yli4mtclrvqoirk2nsteum3vgnswjypquwejwomxnm")
+    set(swigmacos_arch "arm64")
+  else()
+    set(swigmacos_hash
+      "169760d2a34c2a95a907e80d93c1dc7ebc33a7dd34eb7ed7a9841866db3e25f7d7e93bf49ea28db01843aca5c2c6712756c1f01f6531d6ee027dc6eb293d95d7"
+    )
+    set(swigmacos_cid "bafybeifkl5wfscum7pnsjdmwhshrv5v6srilinkrftunq5g4gqzgqmyqf4")
+    set(swigmacos_arch "amd64")
+  endif()
 else()
   set(ITK_SWIG_VERSION 2024-03-26-master)
   set(swig_version_min 4.2.0)
@@ -48,8 +57,8 @@ if(WIN32)
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${ITK_SWIG_VERSION}/bin/swig")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${ITK_SWIG_VERSION}/bin/swig")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig")
 else()
   # follow the standard EP_PREFIX locations
   set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
@@ -128,7 +137,7 @@ else()
       set(SWIG_DIR
           ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
           CACHE FILEPATH "swig directory.")
-    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
       # If we are building ITK
       if(ITK_BINARY_DIR)
         itk_download_attempt_check(SWIG)
@@ -136,16 +145,16 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
-            "https://dweb.link/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
-            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
-            "https://w3s.link/ipfs/${swigmacos_cid}/swigmacos-arm64-${SWIG_VERSION}.zip"
+            "https://dweb.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
+            "https://w3s.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
         URL_HASH SHA512=${swigmacos_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${SWIG_VERSION}
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
       set(SWIG_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-arm64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
+          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
           CACHE FILEPATH "swig directory.")
     else()
       # build swig as an external project

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -14,34 +14,33 @@ mark_as_advanced(ITK_USE_SYSTEM_SWIG)
 
 # Minimal swig version
 if(WIN32)
-  set(swig_version_min 4.0.2)
-  set(ITK_SWIG_VERSION 4.0.2)
+  set(swig_version_min 4.2.0)
+  set(ITK_SWIG_VERSION 2024-03-26-master)
+  set(swig_cmake_version 4.3.0)
   set(swigwin_hash
-      "b8f105f9b9db6acc1f6e3741990915b533cd1bc206eb9645fd6836457fd30789b7229d2e3219d8e35f2390605ade0fbca493ae162ec3b4bc4e428b57155db03d"
+      "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
   )
-  set(swigwin_cid "bafybeifxmwvuck7gda6inwgl24cslv4m34uv3dgedvv2b62ctpbwz6sfoy")
+  set(swigwin_cid "bafybeibljxzip2irc3q3w5qlh2ae5ns27xpi7mo6iskxni45dcmwtk2x6a")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(swig_version_min 4.0.2)
-  set(ITK_SWIG_VERSION 4.0.2)
+  set(swig_version_min 4.2.0)
+  set(ITK_SWIG_VERSION 2024-03-26-master)
+  set(swig_cmake_version 4.3.0)
   set(swiglinux_hash
-      "811a96b1223ef062e93c82d9848d74ae4b9dd42edeb2b32292aaa0be357ebabc2c2ba71ec5ee3fda83fb892e9b21266a249469aa66c23e2339dbd07bb48ad6c6"
+      "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
   )
-  set(swiglinux_cid "bafybeihacajysw4jwrfkffuzvnlv4ees4eqoydl7ftw2o2nmciru6wky6e")
+  set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
 else()
-  set(ITK_SWIG_VERSION 4.0.2)
-  set(swig_version_min 4.0.2)
-  set(swig_hash
-      "05e7da70ce6d9a733b96c0bcfa3c1b82765bd859f48c74759bbf4bb1467acb1809caa310cba5e2b3280cd704fca249eaa0624821dffae1d2a75097c7f55d14ed"
-  )
-  set(swig_cid "bafybeihguuzirrzzfkwzln42dbq34fare5cnlmpigvyfqitiw3rshwsjie")
+  set(ITK_SWIG_VERSION 2024-03-26-master)
+  set(swig_version_min 4.2.0)
+  set(swig_hash "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9")
+  set(swig_cid "bafybeib56uexrqtccgzxjgmlammjii5ntwush4732kbkr6okbtjhzcmvia")
 endif()
 
 if(WIN32)
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${ITK_SWIG_VERSION}/swig.exe")
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${ITK_SWIG_VERSION}/bin/swig")
+  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${ITK_SWIG_VERSION}/bin/swig")
 else()
-
   # follow the standard EP_PREFIX locations
   set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
   set(swig_source_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig)
@@ -91,15 +90,15 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigwin_hash}/download"
-            "https://dweb.link/ipfs/${swigwin_cid}/swigwin-4.0.2.zip"
-            "https://itk.mypinata.cloud/ipfs/${swigwin_cid}/swigwin-4.0.2.zip"
-            "https://w3s.link/ipfs/${swigwin_cid}/swigwin-4.0.2.zip"
+            "https://dweb.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
+            "https://w3s.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
         URL_HASH SHA512=${swigwin_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_VERSION}
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
-      set(SWIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_VERSION})
+      set(SWIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}/bin)
     elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
       # If we are building ITK
       if(ITK_BINARY_DIR)
@@ -108,94 +107,55 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
-            "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-4.0.2.tar.gz"
-            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-4.0.2.tar.gz"
-            "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-4.0.2.tar.gz"
+            "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
+            "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-amd64-${SWIG_VERSION}.zip"
         URL_HASH SHA512=${swiglinux_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${SWIG_VERSION}
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND "" ${download_extract_timestamp_flag})
       set(SWIG_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${SWIG_VERSION}/share/swig/${SWIG_VERSION}
+          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-amd64-${SWIG_VERSION}/share/swig/${swig_cmake_version}
           CACHE FILEPATH "swig directory.")
     else()
-      # From PCRE configure
-      # Some influential environment variables:
-      #  CC          C compiler command
-      #  CFLAGS      C compiler flags
-      #  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
-      #              nonstandard directory <lib dir>
-      #  LIBS        libraries to pass to the linker, e.g. -l<library>
-      #  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
-      #              you have headers in a nonstandard directory <include dir>
-      #  CXX         C++ compiler command
-      #  CXXFLAGS    C++ compiler flags
-      #  CPP         C preprocessor
-      #  CXXCPP      C++ preprocessor
-
       # build swig as an external project
 
       # If we are building ITK
       if(ITK_BINARY_DIR)
         itk_download_attempt_check(PCRE)
       endif()
-      set(pcre_env)
+      set(compiler_information)
       if(NOT CMAKE_CROSSCOMPILING)
-        set(pcre_env
-            env
-            "AR=${CMAKE_AR}"
-            "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
-            "CFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE} -w"
-            "LDFLAGS=$ENV{LDFLAGS}"
-            "LIBS=$ENV{LIBS}"
-            "CPPFLAGS=$ENV{CPPFLAGS}"
-            "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
-            "CXXFLAGS=${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} -w"
-            "CPP=$ENV{CPP}"
-            "CXXPP=$ENV{CXXPP}")
-        if(APPLE)
-          # If building on OS X, the compiler must know what version of the OS X SDK to use
-          # without SDKROOT set, configuring PCRE fails.  The deployment target is set to
-          # ensure the built library is compatible with the correct OS X version.  This may
-          # not be strictly necessary for configure, but the compiler determines which
-          # header files to use based on both of these settings.  Adding it for safety.
-          set(pcre_env ${pcre_env} "SDKROOT=${CMAKE_OSX_SYSROOT}"
-                       "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
-        endif()
-      endif()
-      set(extra_external_project_commands)
-      if(APPLE)
-        # If building on OS X, we have to set the SDKROOT and DEPOLYMENT_TARGET environment variables
-        # so that XCode's compilers know which version of the OS X SDK to use.
-        list(
-          APPEND
-          extra_external_project_commands
-          BUILD_COMMAND
-          env
-          "SDKROOT=${CMAKE_OSX_SYSROOT}"
-          "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
-          make
-          INSTALL_COMMAND
-          env
-          "SDKROOT=${CMAKE_OSX_SYSROOT}"
-          "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
-          make
-          install)
+        set(CMAKE_CXX_COMPILER_LAUNCHER_FLAG -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER})
+        set(CMAKE_C_COMPILER_LAUNCHER_FLAG -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER})
+        set(compiler_information
+            -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+            ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
+            "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w"
+            -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+            ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
+            "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w")
       endif()
       set(pcre_hash
-          "abac4c4f9df9e61d7d7761a9c50843882611752e1df0842a54318f358c28f5953025eba2d78997d21ee690756b56cc9f1c04a5ed591dd60654cc78ba16d9ecfb"
+          "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
       )
-      set(pcre_cid "bafybeibat55kr3wwfytqx5qser3jhej67fek4wpeypdy5ybxfa3zjbvx3a")
+      set(pcre_cid "bafybeicnpyjts3vq4lpdfhktr5qioq4qdifmtjkbemyyqpkayxjsqtwz74")
       ExternalProject_Add(
         PCRE
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
-            "https://dweb.link/ipfs/${pcre_cid}/pcre-8.44.tar.gz"
-            "https://itk.pinata.cloud/ipfs/${pcre_cid}/pcre-8.44.tar.gz"
-            "https://w3s.link/ipfs/${pcre_cid}/pcre-8.44.tar.gz"
+            "https://dweb.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+            "https://itk.pinata.cloud/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+            "https://w3s.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
         URL_HASH SHA512=${pcre_hash}
-        CONFIGURE_COMMAND ${pcre_env} ../PCRE/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/PCRE --enable-shared=no
-                          ${extra_external_project_commands} ${download_extract_timestamp_flag})
+        CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+        CMAKE_CACHE_ARGS
+          ${compiler_information}
+          -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/PCRE2
+        ${download_extract_timestamp_flag}
+        )
 
       # swig uses bison find it by cmake and pass it down
       find_package(BISON)
@@ -204,90 +164,9 @@ else()
           CACHE STRING "Flags used by bison")
       mark_as_advanced(BISON_FLAGS)
 
-      # From SWIG configure
-      # Some influential environment variables:
-      #  CC          C compiler command
-      #  CFLAGS      C compiler flags
-      #  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
-      #              nonstandard directory <lib dir>
-      #  LIBS        libraries to pass to the linker, e.g. -l<library>
-      #  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
-      #              you have headers in a nonstandard directory <include dir>
-      #  CXX         C++ compiler command
-      #  CXXFLAGS    C++ compiler flags
-      #  CPP         C preprocessor
-      #  PCRE_CONFIG config script used for pcre
-      #  PCRE_CFLAGS CFLAGS used for pcre
-      #  PCRE_LIBS   LIBS used for pcre
-      #  YACC        The `Yet Another C Compiler' implementation to use. Defaults to
-      #              the first program found out of: `bison -y', `byacc', `yacc'.
-      #  YFLAGS      The list of arguments that will be passed by default to $YACC.
-      #              This script will default YFLAGS to the empty string to avoid a
-      #              default value of `-d' given by some make applications.
-
       # If we are building ITK
       if(ITK_BINARY_DIR)
         itk_download_attempt_check(SWIG)
-      endif()
-      # Swig configure step
-      # Run in a CMake script because it will be flagged as a false-positive
-      # warning when executed with CTEST_USE_LAUNCHERS
-      set(swig_env)
-      if(NOT CMAKE_CROSSCOMPILING)
-        set(swig_env
-            "
-set(ENV{CC} \"${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}\")
-set(ENV{CFLAGS} \"${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE} -w\")
-set(ENV{LDFLAGS} \"$ENV{LDFLAGS}\")
-set(ENV{LIBS} \"$ENV{LIBS}\")
-set(ENV{CPPFLAGS} \"$ENV{CPPFLAGS}\")
-set(ENV{CXX} \"${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}\")
-set(ENV{CXXFLAGS} \"${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} -w\")
-set(ENV{CPP} \"$ENV{CPP}\")
-set(ENV{YACC} \"${BISON_EXECUTABLE}\")
-set(ENV{YFLAGS} \"${BISON_FLAGS}\")
-")
-      endif()
-      set(_swig_configure_script ${CMAKE_CURRENT_BINARY_DIR}/swig_configure_step.cmake)
-      file(
-        WRITE ${_swig_configure_script}
-        "
-      ${swig_env}
-execute_process(COMMAND ../swig/configure
-        \"--prefix=${CMAKE_CURRENT_BINARY_DIR}/swig\"
-        \"--with-pcre-prefix=${CMAKE_CURRENT_BINARY_DIR}/PCRE\"
-  WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build\"
-  RESULT_VARIABLE result
-  OUTPUT_VARIABLE output
-  ERROR_VARIABLE error
-  )
-
-set(output_file \"${CMAKE_CURRENT_BINARY_DIR}/swig_configure_output.txt\")
-file(WRITE \${output_file} \${output})
-
-set(error_file \"${CMAKE_CURRENT_BINARY_DIR}/swig_configure_error.txt\")
-file(WRITE \${error_file} \${error})
-
-if(NOT \${result} EQUAL 0)
-  message(STATUS \"Swig configure errors detected - See below.\n\${output}\n\${error}\")
-  message(FATAL_ERROR \"Swig configure error. See \${output_file} and \${error_file}\")
-endif()
-
-message(STATUS \"Swig configure successfully completed.\")
-")
-      set(extra_swig_configure_env)
-      if(APPLE)
-        # If building on OS X, the compiler must know what version of the OS X SDK to use
-        # without SDKROOT set, configuring swig fails.  The deployment target is set to
-        # ensure the built library is compatible with the correct OS X version.  This may
-        # not be strictly necessary for configure, but the compiler determines which
-        # header files to use based on both of these settings.  Adding it for safety.
-        list(
-          APPEND
-          extra_swig_configure_env
-          env
-          "SDKROOT=${CMAKE_OSX_SYSROOT}"
-          "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
 
       ExternalProject_Add(
@@ -297,9 +176,15 @@ message(STATUS \"Swig configure successfully completed.\")
             "https://itk.pinata.cloud/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
             "https://w3s.link/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
         URL_HASH SHA512=${swig_hash}
-        CONFIGURE_COMMAND ${extra_swig_configure_env} ${CMAKE_COMMAND} -P "${_swig_configure_script}"
-                          ${extra_external_project_commands}
-        DEPENDS PCRE ${download_extract_timestamp_flag})
+        CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+        CMAKE_CACHE_ARGS
+          ${compiler_information}
+          -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+          -DPCRE2_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/PCRE2
+        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/swig
+        DEPENDS PCRE ${download_extract_timestamp_flag}
+        )
     endif()
 
     set(SWIG_DIR

--- a/Wrapping/TypedefMacros.cmake
+++ b/Wrapping/TypedefMacros.cmake
@@ -721,20 +721,6 @@ macro(itk_wrap_simple_type wrap_class swig_name)
       "${cpp_name}< ${template_params} > ")
   endif()
 
-  if("${cpp_name}" STREQUAL "itk::PCAShapeSignedDistanceFunction"
-     AND NOT
-         "${swig_name}"
-         MATCHES
-         "Pointer$")
-
-    set(import_text "%include ${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/python/itkImage_ext.i\n")
-    string(FIND ${ITK_WRAP_PYTHON_SWIG_EXT} ${import_text} pos)
-    if(${pos} EQUAL -1)
-      string(PREPEND ITK_WRAP_PYTHON_SWIG_EXT "${import_text}")
-    endif()
-    unset(import_text)
-  endif()
-
   if("${cpp_name}" STREQUAL "itk::Index")
     add_python_seq_typemap("${swig_name}" "${template_params}")
   endif()


### PR DESCRIPTION
- Supports more modern C++
- More Pythonic interfaces, e.g. Python Iterator Protocol
- Python Limited ABI

There were duplicate definition errors due to double inclusion of

  %template(vectoritkImageXX, std::vector< itkImageXX >)

via itkImage_ext.i in PCAShapeSignedDistanceFunction. Remove
itkImage_ext.i from the latter but still provide the required typemaps
by adding DECL_PYTHON_STD_VEC_RAW_TO_SMARTPTR_TYPEMAP in
itkPCAShapeSignedDistanceFunction.wrap.

Remove -py3 because it is no longer supported (the default).

Remove "ios_base*" config templates because they are no longer emitted.

Bump PCRE. SWIG and PCRE are now built via CMake instead of autotools.

Closes https://github.com/InsightSoftwareConsortium/ITK/issues/4536
Closes https://github.com/InsightSoftwareConsortium/ITK/issues/3364
Closes https://github.com/InsightSoftwareConsortium/ITK/issues/3955