### PR TITLE
COMP: Only support SWIG slice workaround for Python >= 3.2

### DIFF
--- a/Wrapping/Generators/Python/module_ext.i.in
+++ b/Wrapping/Generators/Python/module_ext.i.in
@@ -4,13 +4,8 @@
 // Needs to be investigated
 #include <iostream>
 
-#if PY_VERSION_HEX >= 0x03020000
-# define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
-# define SWIGPY_SLICEOBJECT PyObject
-#else
-# define SWIGPY_SLICE_ARG(obj) ((PySliceObject*) (obj))
-# define SWIGPY_SLICEOBJECT PySliceObject
-#endif
+#define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
+#define SWIGPY_SLICEOBJECT PyObject
 %}
 
 @ITK_WRAP_PYTHON_SWIG_EXT@


### PR DESCRIPTION
We now only support Python 3.8+.
