### PR TITLE
COMP: Remove use of itkDebugMacro in static method

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -123,7 +123,6 @@ isNoPreambleDicom(std::ifstream & file) // NOTE: Similar function is in itkGDCMI
     }
   } while (groupNo == 2);
 
-  itkDebugMacro(<< "No DICOM magic number found, but the file appears to be DICOM without a preamble.");
   return true;
 }
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -188,8 +188,6 @@ readNoPreambleDicom(std::ifstream & file) // NOTE: This file is duplicated in it
     }
   } while (groupNo == 2);
 
-  itkDebugMacro(<< "No DICOM magic number found, but the file appears to be DICOM without a preamble.");
-
   return true;
 }
 


### PR DESCRIPTION
To address:

```
/Users/builder/externalModules/IO/GDCM/src/itkGDCMImageIO.cxx:191:3: error: invalid use of 'this' outside of a non-static member function
  itkDebugMacro(<< "No DICOM magic number found, but the file appears to be DICOM without a preamble.");
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:504:11: note: expanded from macro 'itkDebugMacro'
      if (this->GetDebug() && ::itk::Object::GetGlobalWarningDisplay())        \
          ^
/Users/builder/externalModules/IO/GDCM/src/itkGDCMImageIO.cxx:191:3: error: invalid use of 'this' outside of a non-static member function
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:508:19: note: expanded from macro 'itkDebugMacro'
               << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
                  ^
/Users/builder/externalModules/IO/GDCM/src/itkGDCMImageIO.cxx:191:3: error: invalid use of 'this' outside of a non-static member function
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:508:53: note: expanded from macro 'itkDebugMacro'
               << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
                                                    ^
3 errors generated.
```

Re: https://open.cdash.org/viewBuildError.php?buildid=9495220
