### PR TITLE
STYLE: Allocate local GaussianOperator objects (`oper`) on the stack

### DIFF
--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -61,11 +61,10 @@ itkNeighborhoodOperatorImageFunctionTest(int, char *[])
 
   function->SetInputImage(image);
 
-  auto * oper = new NeighborhoodOperatorType;
-  oper->CreateToRadius(3);
+  NeighborhoodOperatorType oper;
+  oper.CreateToRadius(3);
 
-  function->SetOperator(*oper);
-  delete oper;
+  function->SetOperator(oper);
 
   itk::Index<3> index;
   index.Fill(25);

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -501,7 +501,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
   using OutputPixelType = typename TOutputImage::PixelType;
   using OperatorType = GaussianOperator<OutputPixelType, ImageDimension>;
 
-  auto * oper = new OperatorType;
+  OperatorType oper;
 
   typename TInputImage::SizeType radius;
 
@@ -510,13 +510,12 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
 
   for (idim = 0; idim < TInputImage::ImageDimension; ++idim)
   {
-    oper->SetDirection(idim);
-    oper->SetVariance(itk::Math::sqr(0.5 * static_cast<float>(m_Schedule[refLevel][idim])));
-    oper->SetMaximumError(m_MaximumError);
-    oper->CreateDirectional();
-    radius[idim] = oper->GetRadius()[idim];
+    oper.SetDirection(idim);
+    oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(m_Schedule[refLevel][idim])));
+    oper.SetMaximumError(m_MaximumError);
+    oper.CreateDirectional();
+    radius[idim] = oper.GetRadius()[idim];
   }
-  delete oper;
 
   inputRequestedRegion.PadByRadius(radius);
 

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -231,8 +231,8 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   using OutputPixelType = typename TOutputImage::PixelType;
   using OperatorType = GaussianOperator<OutputPixelType, ImageDimension>;
 
-  auto * oper = new OperatorType;
-  oper->SetMaximumError(this->GetMaximumError());
+  OperatorType oper;
+  oper.SetMaximumError(this->GetMaximumError());
 
   using SizeType = typename OutputImageType::SizeType;
   using IndexType = typename OutputImageType::IndexType;
@@ -265,10 +265,10 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
       // take into account smoothing component
       if (factors[idim] > 1)
       {
-        oper->SetDirection(idim);
-        oper->SetVariance(itk::Math::sqr(0.5 * static_cast<float>(factors[idim])));
-        oper->CreateDirectional();
-        radius[idim] = oper->GetRadius()[idim];
+        oper.SetDirection(idim);
+        oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(factors[idim])));
+        oper.CreateDirectional();
+        radius[idim] = oper.GetRadius()[idim];
       }
       else
       {
@@ -298,10 +298,10 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
       // take into account smoothing component
       if (factors[idim] > 1)
       {
-        oper->SetDirection(idim);
-        oper->SetVariance(itk::Math::sqr(0.5 * static_cast<float>(factors[idim])));
-        oper->CreateDirectional();
-        radius[idim] = oper->GetRadius()[idim];
+        oper.SetDirection(idim);
+        oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(factors[idim])));
+        oper.CreateDirectional();
+        radius[idim] = oper.GetRadius()[idim];
       }
       else
       {
@@ -328,9 +328,6 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
 
     this->GetOutput(ilevel)->SetRequestedRegion(requestedRegion);
   }
-
-  // clean up
-  delete oper;
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -369,7 +366,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
   using OutputPixelType = typename TOutputImage::PixelType;
   using OperatorType = GaussianOperator<OutputPixelType, ImageDimension>;
 
-  auto * oper = new OperatorType;
+  OperatorType oper;
 
   typename TInputImage::SizeType radius;
 
@@ -378,17 +375,16 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
 
   for (idim = 0; idim < TInputImage::ImageDimension; ++idim)
   {
-    oper->SetDirection(idim);
-    oper->SetVariance(itk::Math::sqr(0.5 * static_cast<float>(this->GetSchedule()[refLevel][idim])));
-    oper->SetMaximumError(this->GetMaximumError());
-    oper->CreateDirectional();
-    radius[idim] = oper->GetRadius()[idim];
+    oper.SetDirection(idim);
+    oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(this->GetSchedule()[refLevel][idim])));
+    oper.SetMaximumError(this->GetMaximumError());
+    oper.CreateDirectional();
+    radius[idim] = oper.GetRadius()[idim];
     if (this->GetSchedule()[refLevel][idim] <= 1)
     {
       radius[idim] = 0;
     }
   }
-  delete oper;
 
   inputRequestedRegion.PadByRadius(radius);
 

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -302,8 +302,8 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   using OperatorType = GaussianOperator<ScalarType, ImageDimension>;
   using SmootherType = VectorNeighborhoodOperatorImageFilter<DisplacementFieldType, DisplacementFieldType>;
 
-  auto * oper = new OperatorType;
-  auto   smoother = SmootherType::New();
+  OperatorType oper;
+  auto         smoother = SmootherType::New();
 
   using PixelContainerPointer = typename DisplacementFieldType::PixelContainerPointer;
   PixelContainerPointer swapPtr;
@@ -314,15 +314,15 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     // smooth along this dimension
-    oper->SetDirection(j);
+    oper.SetDirection(j);
     double variance = itk::Math::sqr(m_StandardDeviations[j]);
-    oper->SetVariance(variance);
-    oper->SetMaximumError(m_MaximumError);
-    oper->SetMaximumKernelWidth(m_MaximumKernelWidth);
-    oper->CreateDirectional();
+    oper.SetVariance(variance);
+    oper.SetMaximumError(m_MaximumError);
+    oper.SetMaximumKernelWidth(m_MaximumKernelWidth);
+    oper.CreateDirectional();
 
     // todo: make sure we only smooth within the buffered region
-    smoother->SetOperator(*oper);
+    smoother->SetOperator(oper);
     smoother->SetInput(field);
     smoother->Update();
 
@@ -339,8 +339,6 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   // graft the output back to this filter
   m_TempField->SetPixelContainer(field->GetPixelContainer());
   this->GraftOutput(smoother->GetOutput());
-
-  delete oper;
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>


### PR DESCRIPTION
Following C++ Core Guidelines, ["Prefer scoped objects, don’t heap-allocate unnecessarily"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily)