### PR TITLE
STYLE: Use unique_ptr for MRIBiasEnergyFunction m_InternalEnergyFunction

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -29,6 +29,9 @@
 #include "itkOnePlusOneEvolutionaryOptimizer.h"
 #include "itkImageRegionIterator.h"
 
+#include <memory> // For unique_ptr.
+
+
 namespace itk
 {
 /**
@@ -154,7 +157,7 @@ protected:
   MRIBiasEnergyFunction();
 
   /** Destructor. */
-  ~MRIBiasEnergyFunction() override;
+  ~MRIBiasEnergyFunction() override = default;
 
 private:
   /** Bias field object pointer. */
@@ -170,7 +173,7 @@ private:
   ImageRegionType m_Region{};
 
   /** Internal energy function object pointer. */
-  InternalEnergyFunction * m_InternalEnergyFunction{};
+  std::unique_ptr<InternalEnergyFunction> m_InternalEnergyFunction;
 
   /** Sampling factors */
   SamplingFactorType m_SamplingFactor{};

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -39,14 +39,7 @@ void
 MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::InitializeDistributions(Array<double> classMeans,
                                                                                Array<double> classSigmas)
 {
-  m_InternalEnergyFunction = new InternalEnergyFunction(classMeans, classSigmas);
-}
-
-template <typename TImage, typename TImageMask, typename TBiasField>
-MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::~MRIBiasEnergyFunction()
-{
-  delete m_InternalEnergyFunction;
-  m_InternalEnergyFunction = nullptr;
+  m_InternalEnergyFunction = std::make_unique<InternalEnergyFunction>(classMeans, classSigmas);
 }
 
 template <typename TImage, typename TImageMask, typename TBiasField>


### PR DESCRIPTION
Following C++ Core Guidelines, ["Use unique_ptr or shared_ptr to avoid forgetting to delete objects created using new"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-smart)

Also defaulted the destructor of `MRIBiasEnergyFunction`.