### PR TITLE
BUG: Missing modality tag when reading meta-image format.

### DIFF
--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -23,6 +23,7 @@
 #include "itkMath.h"
 #include "itkSingleton.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "metaImageUtils.h"
 
 namespace itk
 {
@@ -404,6 +405,12 @@ MetaImageIO::ReadImageInformation()
 
   std::string classname(this->GetNameOfClass());
   EncapsulateMetaData<std::string>(thisMetaDict, ITK_InputFilterName, classname);
+
+  // metaImage has a Modality tag which is not stored as part of its
+  // metadata dictionary
+  std::string modality;
+  MET_ImageModalityToString(m_MetaImage.Modality(), modality);
+  EncapsulateMetaData<std::string>(thisMetaDict, "Modality", modality);
   //
   // save the metadatadictionary in the MetaImage header.
   // NOTE: The MetaIO library only supports typeless strings as metadata

--- a/Modules/IO/Meta/test/itkMetaImageIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest.cxx
@@ -90,6 +90,9 @@ itkMetaImageIOTest(int argc, char * argv[])
   myImage::Pointer image = reader->GetOutput();
   image->Print(std::cout);
 
+  // MetaImage is expected to have a modality tag
+  image->GetMetaDataDictionary().Get("Modality");
+
   myImage::RegionType region = image->GetLargestPossibleRegion();
   std::cout << "region " << region;
 


### PR DESCRIPTION
The modality of a meta image is not stored as part of the metadata dictionary and was not copied into the ITK metadata dictionary. This change addresses the issue.
