### PR TITLE
COMP: Fix macro spelling in `itkOpenCVImageBridgeRGBTest.cxx`

### DIFF
--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -153,7 +153,7 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
   auto reader = ReaderType::New();
   reader->SetFileName(argv1);
 
-  ITK_TRY_EXPECT_NO_EXCEPTIION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   typename ImageType::Pointer baselineImage = reader->GetOutput();


### PR DESCRIPTION
Fix `ITK_TRY_EXPECT_NO_EXCEPTION` macro spelling in `itkOpenCVImageBridgeRGBTest.cxx`.

Fixes:
```
Error when building the ITK-5.4rc02:
C:\lib\ITK-5.4rc02\Modules\Video\BridgeOpenCV\test\itkOpenCVImageBridgeRGBTest.cxx(156,3):
error C3861: ITK_TRY_EXPECT_NO_EXCEPTIION
identifier not found
```

Fixes #4550.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)