### PR TITLE
COMP: UnaryFunctorImageFilter RLEImage support on Apple Clang

### DIFF
--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
@@ -85,8 +85,8 @@ UnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGe
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageScanlineConstIterator inputIt(inputPtr, inputRegionForThread);
-  ImageScanlineIterator      outputIt(outputPtr, outputRegionForThread);
+  ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
+  ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
   inputIt.GoToBegin();
   outputIt.GoToBegin();


### PR DESCRIPTION
With:

❯ c++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

Addresses:

```
/Users/matt.mccormick/src/RLETest/RLEIteratorTest.cxx:15:35: error: no viable constructor or deduction guide for deduction of template arguments of 'ImageScanlineConstIterator'
  itk::ImageScanlineConstIterator it2(constRLE, constRLE->GetLargestPossibleRegion());
                                  ^
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:106:3: note: candidate template ignored: substitution failure [with TImage = itk::RLEImage<short>]: cannot reference member of primary template because deduced class template specialization 'ImageScanlineConstIterator<itk::RLEImage<short, 3, unsigned short>>' is instantiated from a partial specialization
  ImageScanlineConstIterator(const TImage * ptr, const RegionType & region)
  ^                                                    ~~~~~~~~~~
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:267:1: note: candidate template ignored: could not match 'SmartPointer<TImage>' against 'const itk::RLEImage<short, 3> *'
ImageScanlineConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
^
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:119:3: note: candidate function template not viable: requires single argument 'it', but 2 arguments were provided
  ImageScanlineConstIterator(const ImageIterator<TImage> & it)
  ^
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:135:3: note: candidate function template not viable: requires single argument 'it', but 2 arguments were provided
  ImageScanlineConstIterator(const ImageConstIterator<TImage> & it)
  ^
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:64:27: note: candidate function template not viable: requires 1 argument, but 2 were provided
class ITK_TEMPLATE_EXPORT ImageScanlineConstIterator : public ImageConstIterator<TImage>
                          ^
/Users/matt.mccormick/src/ITK/Modules/Core/Common/include/itkImageScanlineConstIterator.h:97:3: note: candidate function template not viable: requires 0 arguments, but 2 were provided
  ImageScanlineConstIterator()
  ^
```

Closes #4537.
