### PR TITLE
Use unique_ptr for the "pimpl pointers" of GiplImageIO and MINCImageIO

### DIFF
--- a/Modules/IO/GIPL/include/itkGiplImageIO.h
+++ b/Modules/IO/GIPL/include/itkGiplImageIO.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include "itkImageIOBase.h"
 #include <cstdio>
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -100,7 +101,7 @@ private:
   std::ofstream m_Ofstream{};
   bool          m_IsCompressed{};
 
-  GiplImageIOInternals * m_Internal{};
+  const std::unique_ptr<GiplImageIOInternals> m_Internal;
 };
 } // end namespace itk
 

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -73,9 +73,8 @@ public:
 #define GIPL_MAGIC_NUMBER2 0x2ae389b8
 
 GiplImageIO::GiplImageIO()
+  : m_Internal(std::make_unique<GiplImageIOInternals>())
 {
-  m_Internal = new GiplImageIOInternals;
-  m_Internal->m_GzFile = nullptr;
   m_ByteOrder = IOByteOrderEnum::BigEndian;
   m_IsCompressed = false;
 }
@@ -94,7 +93,6 @@ GiplImageIO::~GiplImageIO()
   {
     m_Ifstream.close();
   }
-  delete m_Internal;
 }
 
 bool

--- a/Modules/IO/MINC/include/itkMINCImageIO.h
+++ b/Modules/IO/MINC/include/itkMINCImageIO.h
@@ -32,6 +32,7 @@
 #include "itkMatrix.h"
 
 #include "ITKIOMINCExport.h"
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -146,7 +147,7 @@ protected:
   CloseVolume();
 
 private:
-  MINCImageIOPImpl * m_MINCPImpl{};
+  const std::unique_ptr<MINCImageIOPImpl> m_MINCPImpl;
 
   MatrixType m_DirectionCosines{};
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -238,17 +238,8 @@ MINCImageIO::CloseVolume()
 }
 
 MINCImageIO::MINCImageIO()
-  : m_MINCPImpl(new MINCImageIOPImpl)
+  : m_MINCPImpl(std::make_unique<MINCImageIOPImpl>())
 {
-  m_MINCPImpl->m_NDims = 0;
-  m_MINCPImpl->m_DimensionName = nullptr;
-  m_MINCPImpl->m_DimensionSize = nullptr;
-  m_MINCPImpl->m_DimensionStart = nullptr;
-  m_MINCPImpl->m_DimensionStep = nullptr;
-  m_MINCPImpl->m_MincFileDims = nullptr;
-  m_MINCPImpl->m_MincApparentDims = nullptr;
-  m_MINCPImpl->m_Volume = nullptr;
-
   for (auto & dimensionIndex : m_MINCPImpl->m_DimensionIndices)
   {
     dimensionIndex = -1;
@@ -285,7 +276,6 @@ MINCImageIO::MINCImageIO()
 MINCImageIO::~MINCImageIO()
 {
   this->CloseVolume();
-  delete m_MINCPImpl;
 }
 
 void
@@ -295,7 +285,7 @@ MINCImageIO::PrintSelf(std::ostream & os, Indent indent) const
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MINCPImpl: " << m_MINCPImpl << std::endl;
+  os << indent << "MINCPImpl: " << m_MINCPImpl.get() << std::endl;
   os << indent << "DirectionCosines: " << m_DirectionCosines << std::endl;
 }
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -164,7 +164,7 @@ MINCImageIO::Read(void * buffer)
       return;
   }
 
-  if (miget_real_value_hyperslab(this->m_MINCPImpl->m_Volume, volume_data_type, start.get(), count.get(), buffer) < 0)
+  if (miget_real_value_hyperslab(m_MINCPImpl->m_Volume, volume_data_type, start.get(), count.get(), buffer) < 0)
   {
     itkExceptionMacro(" Can not get real value hyperslab!!\n");
   }
@@ -173,28 +173,28 @@ MINCImageIO::Read(void * buffer)
 void
 MINCImageIO::CleanupDimensions()
 {
-  if (this->m_MINCPImpl->m_DimensionName)
+  if (m_MINCPImpl->m_DimensionName)
   {
-    for (int i = 0; i < this->m_MINCPImpl->m_NDims; ++i)
+    for (int i = 0; i < m_MINCPImpl->m_NDims; ++i)
     {
-      mifree_name(this->m_MINCPImpl->m_DimensionName[i]);
-      this->m_MINCPImpl->m_DimensionName[i] = nullptr;
+      mifree_name(m_MINCPImpl->m_DimensionName[i]);
+      m_MINCPImpl->m_DimensionName[i] = nullptr;
     }
   }
 
-  delete[] this->m_MINCPImpl->m_DimensionName;
-  delete[] this->m_MINCPImpl->m_DimensionSize;
-  delete[] this->m_MINCPImpl->m_DimensionStart;
-  delete[] this->m_MINCPImpl->m_DimensionStep;
-  delete[] this->m_MINCPImpl->m_MincFileDims;
-  delete[] this->m_MINCPImpl->m_MincApparentDims;
+  delete[] m_MINCPImpl->m_DimensionName;
+  delete[] m_MINCPImpl->m_DimensionSize;
+  delete[] m_MINCPImpl->m_DimensionStart;
+  delete[] m_MINCPImpl->m_DimensionStep;
+  delete[] m_MINCPImpl->m_MincFileDims;
+  delete[] m_MINCPImpl->m_MincApparentDims;
 
-  this->m_MINCPImpl->m_DimensionName = nullptr;
-  this->m_MINCPImpl->m_DimensionSize = nullptr;
-  this->m_MINCPImpl->m_DimensionStart = nullptr;
-  this->m_MINCPImpl->m_DimensionStep = nullptr;
-  this->m_MINCPImpl->m_MincFileDims = nullptr;
-  this->m_MINCPImpl->m_MincApparentDims = nullptr;
+  m_MINCPImpl->m_DimensionName = nullptr;
+  m_MINCPImpl->m_DimensionSize = nullptr;
+  m_MINCPImpl->m_DimensionStart = nullptr;
+  m_MINCPImpl->m_DimensionStep = nullptr;
+  m_MINCPImpl->m_MincFileDims = nullptr;
+  m_MINCPImpl->m_MincApparentDims = nullptr;
 }
 
 void
@@ -202,24 +202,24 @@ MINCImageIO::AllocateDimensions(int nDims)
 {
   this->CleanupDimensions();
 
-  this->m_MINCPImpl->m_NDims = nDims;
+  m_MINCPImpl->m_NDims = nDims;
 
-  this->m_MINCPImpl->m_DimensionName = new char *[this->m_MINCPImpl->m_NDims];
-  this->m_MINCPImpl->m_DimensionSize = new misize_t[this->m_MINCPImpl->m_NDims];
-  this->m_MINCPImpl->m_DimensionStart = new double[this->m_MINCPImpl->m_NDims];
-  this->m_MINCPImpl->m_DimensionStep = new double[this->m_MINCPImpl->m_NDims];
-  this->m_MINCPImpl->m_MincFileDims = new midimhandle_t[this->m_MINCPImpl->m_NDims];
-  this->m_MINCPImpl->m_MincApparentDims = new midimhandle_t[this->m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_DimensionName = new char *[m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_DimensionSize = new misize_t[m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_DimensionStart = new double[m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_DimensionStep = new double[m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_MincFileDims = new midimhandle_t[m_MINCPImpl->m_NDims];
+  m_MINCPImpl->m_MincApparentDims = new midimhandle_t[m_MINCPImpl->m_NDims];
 
-  for (int i = 0; i < this->m_MINCPImpl->m_NDims; ++i)
+  for (int i = 0; i < m_MINCPImpl->m_NDims; ++i)
   {
-    this->m_MINCPImpl->m_DimensionName[i] = nullptr;
-    this->m_MINCPImpl->m_DimensionSize[i] = 0;
-    this->m_MINCPImpl->m_DimensionStart[i] = 0.0;
-    this->m_MINCPImpl->m_DimensionStep[i] = 0.0;
+    m_MINCPImpl->m_DimensionName[i] = nullptr;
+    m_MINCPImpl->m_DimensionSize[i] = 0;
+    m_MINCPImpl->m_DimensionStart[i] = 0.0;
+    m_MINCPImpl->m_DimensionStep[i] = 0.0;
   }
 
-  for (auto & dimensionIndex : this->m_MINCPImpl->m_DimensionIndices)
+  for (auto & dimensionIndex : m_MINCPImpl->m_DimensionIndices)
   {
     dimensionIndex = -1;
   }
@@ -230,26 +230,26 @@ MINCImageIO::CloseVolume()
 {
   this->CleanupDimensions();
 
-  if (this->m_MINCPImpl->m_Volume)
+  if (m_MINCPImpl->m_Volume)
   {
-    miclose_volume(this->m_MINCPImpl->m_Volume);
+    miclose_volume(m_MINCPImpl->m_Volume);
   }
-  this->m_MINCPImpl->m_Volume = nullptr;
+  m_MINCPImpl->m_Volume = nullptr;
 }
 
 MINCImageIO::MINCImageIO()
   : m_MINCPImpl(new MINCImageIOPImpl)
 {
-  this->m_MINCPImpl->m_NDims = 0;
-  this->m_MINCPImpl->m_DimensionName = nullptr;
-  this->m_MINCPImpl->m_DimensionSize = nullptr;
-  this->m_MINCPImpl->m_DimensionStart = nullptr;
-  this->m_MINCPImpl->m_DimensionStep = nullptr;
-  this->m_MINCPImpl->m_MincFileDims = nullptr;
-  this->m_MINCPImpl->m_MincApparentDims = nullptr;
-  this->m_MINCPImpl->m_Volume = nullptr;
+  m_MINCPImpl->m_NDims = 0;
+  m_MINCPImpl->m_DimensionName = nullptr;
+  m_MINCPImpl->m_DimensionSize = nullptr;
+  m_MINCPImpl->m_DimensionStart = nullptr;
+  m_MINCPImpl->m_DimensionStep = nullptr;
+  m_MINCPImpl->m_MincFileDims = nullptr;
+  m_MINCPImpl->m_MincApparentDims = nullptr;
+  m_MINCPImpl->m_Volume = nullptr;
 
-  for (auto & dimensionIndex : this->m_MINCPImpl->m_DimensionIndices)
+  for (auto & dimensionIndex : m_MINCPImpl->m_DimensionIndices)
   {
     dimensionIndex = -1;
   }
@@ -278,8 +278,8 @@ MINCImageIO::MINCImageIO()
   this->Self::SetMaximumCompressionLevel(9);
   this->Self::SetCompressionLevel(4); // Range 0-9; 0 = no file compression, 9 =
                                       // maximum file compression
-  this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
-  this->m_MINCPImpl->m_Volume_class = MI_CLASS_REAL;
+  m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
+  m_MINCPImpl->m_Volume_class = MI_CLASS_REAL;
 }
 
 MINCImageIO::~MINCImageIO()
@@ -306,7 +306,7 @@ MINCImageIO::ReadImageInformation()
 
   this->CloseVolume();
   // call to minc2.0 function to open the file
-  if (miopen_volume(m_FileName.c_str(), MI2_OPEN_READ, &this->m_MINCPImpl->m_Volume) < 0)
+  if (miopen_volume(m_FileName.c_str(), MI2_OPEN_READ, &m_MINCPImpl->m_Volume) < 0)
   {
     // Error opening the volume
     itkExceptionMacro("Could not open file \"" << m_FileName.c_str() << "\".");
@@ -315,7 +315,7 @@ MINCImageIO::ReadImageInformation()
   // find out how many dimensions are there regularly sampled
   // dimensions only
   int ndims;
-  if (miget_volume_dimension_count(this->m_MINCPImpl->m_Volume, MI_DIMCLASS_ANY, MI_DIMATTR_ALL, &ndims) < 0)
+  if (miget_volume_dimension_count(m_MINCPImpl->m_Volume, MI_DIMCLASS_ANY, MI_DIMATTR_ALL, &ndims) < 0)
   {
     itkDebugMacro("Could not get the number of dimensions in the volume!");
     return;
@@ -324,62 +324,61 @@ MINCImageIO::ReadImageInformation()
 
   // get dimension handles in FILE ORDER (i.e, the order as they are
   // submitted to file)
-  if (miget_volume_dimensions(this->m_MINCPImpl->m_Volume,
+  if (miget_volume_dimensions(m_MINCPImpl->m_Volume,
                               MI_DIMCLASS_ANY,
                               MI_DIMATTR_ALL,
                               MI_DIMORDER_FILE,
-                              this->m_MINCPImpl->m_NDims,
-                              this->m_MINCPImpl->m_MincFileDims) < 0)
+                              m_MINCPImpl->m_NDims,
+                              m_MINCPImpl->m_MincFileDims) < 0)
   {
     itkExceptionMacro("Could not get dimension handles!");
   }
 
-  for (int i = 0; i < this->m_MINCPImpl->m_NDims; ++i)
+  for (int i = 0; i < m_MINCPImpl->m_NDims; ++i)
   {
     char *       name;
     double       _sep;
     const char * _sign = "+";
-    if (miget_dimension_name(this->m_MINCPImpl->m_MincFileDims[i], &name) < 0)
+    if (miget_dimension_name(m_MINCPImpl->m_MincFileDims[i], &name) < 0)
     {
       // Error getting dimension name
       itkExceptionMacro("Could not get dimension name!");
     }
 
-    if (miget_dimension_separation(this->m_MINCPImpl->m_MincFileDims[i], MI_ORDER_FILE, &_sep) == MI_NOERROR &&
-        _sep < 0)
+    if (miget_dimension_separation(m_MINCPImpl->m_MincFileDims[i], MI_ORDER_FILE, &_sep) == MI_NOERROR && _sep < 0)
       _sign = "-";
 
-    this->m_MINCPImpl->m_DimensionName[i] = name;
+    m_MINCPImpl->m_DimensionName[i] = name;
     if (!strcmp(name, MIxspace) || !strcmp(name, MIxfrequency)) // this is X space
     {
-      this->m_MINCPImpl->m_DimensionIndices[1] = i;
+      m_MINCPImpl->m_DimensionIndices[1] = i;
       dimension_order += _sign;
       dimension_order += "X";
     }
     else if (!strcmp(name, MIyspace) || !strcmp(name, MIyfrequency)) // this is Y
                                                                      // space
     {
-      this->m_MINCPImpl->m_DimensionIndices[2] = i;
+      m_MINCPImpl->m_DimensionIndices[2] = i;
       dimension_order += _sign;
       dimension_order += "Y";
     }
     else if (!strcmp(name, MIzspace) || !strcmp(name, MIzfrequency)) // this is Z
                                                                      // space
     {
-      this->m_MINCPImpl->m_DimensionIndices[3] = i;
+      m_MINCPImpl->m_DimensionIndices[3] = i;
       dimension_order += _sign;
       dimension_order += "Z";
     }
     else if (!strcmp(name, MIvector_dimension)) // this is vector space
     {
-      this->m_MINCPImpl->m_DimensionIndices[0] = i;
+      m_MINCPImpl->m_DimensionIndices[0] = i;
       dimension_order += "+"; // vector dimension is always positive
       dimension_order += "V";
     }
     else if (!strcmp(name, MItime) || !strcmp(name, MItfrequency)) // this is time
                                                                    // space
     {
-      this->m_MINCPImpl->m_DimensionIndices[4] = i;
+      m_MINCPImpl->m_DimensionIndices[4] = i;
       dimension_order += _sign;
       dimension_order += "T";
     }
@@ -390,31 +389,26 @@ MINCImageIO::ReadImageInformation()
   }
 
   // fill the DimensionSize by calling the following MINC2.0 function
-  if (miget_dimension_sizes(
-        this->m_MINCPImpl->m_MincFileDims, this->m_MINCPImpl->m_NDims, this->m_MINCPImpl->m_DimensionSize) < 0)
+  if (miget_dimension_sizes(m_MINCPImpl->m_MincFileDims, m_MINCPImpl->m_NDims, m_MINCPImpl->m_DimensionSize) < 0)
   {
     // Error getting dimension sizes
     itkExceptionMacro("Could not get dimension sizes!");
   }
 
-  if (miget_dimension_separations(this->m_MINCPImpl->m_MincFileDims,
-                                  MI_ORDER_FILE,
-                                  this->m_MINCPImpl->m_NDims,
-                                  this->m_MINCPImpl->m_DimensionStep) < 0)
+  if (miget_dimension_separations(
+        m_MINCPImpl->m_MincFileDims, MI_ORDER_FILE, m_MINCPImpl->m_NDims, m_MINCPImpl->m_DimensionStep) < 0)
   {
     itkExceptionMacro(" Could not dimension sizes");
   }
 
-  if (miget_dimension_starts(this->m_MINCPImpl->m_MincFileDims,
-                             MI_ORDER_FILE,
-                             this->m_MINCPImpl->m_NDims,
-                             this->m_MINCPImpl->m_DimensionStart) < 0)
+  if (miget_dimension_starts(
+        m_MINCPImpl->m_MincFileDims, MI_ORDER_FILE, m_MINCPImpl->m_NDims, m_MINCPImpl->m_DimensionStart) < 0)
   {
     itkExceptionMacro(" Could not dimension sizes");
   }
 
   mitype_t volume_data_type;
-  if (miget_data_type(this->m_MINCPImpl->m_Volume, &volume_data_type) < 0)
+  if (miget_data_type(m_MINCPImpl->m_Volume, &volume_data_type) < 0)
   {
     itkExceptionMacro(" Can not get volume data type!!\n");
   }
@@ -423,7 +417,7 @@ MINCImageIO::ReadImageInformation()
   miboolean_t slice_scaling_flag = 0;
   miboolean_t global_scaling_flag = 0;
 
-  if (miget_slice_scaling_flag(this->m_MINCPImpl->m_Volume, &slice_scaling_flag) < 0)
+  if (miget_slice_scaling_flag(m_MINCPImpl->m_Volume, &slice_scaling_flag) < 0)
   {
     itkExceptionMacro(" Can not get slice scaling flag!!\n");
   }
@@ -431,7 +425,7 @@ MINCImageIO::ReadImageInformation()
   // voxel valid range
   double valid_min, valid_max;
   // get the voxel valid range
-  if (miget_volume_valid_range(this->m_MINCPImpl->m_Volume, &valid_max, &valid_min) < 0)
+  if (miget_volume_valid_range(m_MINCPImpl->m_Volume, &valid_max, &valid_min) < 0)
   {
     itkExceptionMacro(" Can not get volume valid range!!\n");
   }
@@ -440,7 +434,7 @@ MINCImageIO::ReadImageInformation()
   double volume_min = 0.0, volume_max = 1.0;
   if (!slice_scaling_flag)
   {
-    if (miget_volume_range(this->m_MINCPImpl->m_Volume, &volume_max, &volume_min) < 0)
+    if (miget_volume_range(m_MINCPImpl->m_Volume, &volume_max, &volume_min) < 0)
     {
       itkExceptionMacro(" Can not get volume range!!\n");
     }
@@ -454,7 +448,7 @@ MINCImageIO::ReadImageInformation()
   // extract direction cosines
   for (int i = 1; i < 4; ++i)
   {
-    if (this->m_MINCPImpl->m_DimensionIndices[i] != -1) // this dimension is present
+    if (m_MINCPImpl->m_DimensionIndices[i] != -1) // this dimension is present
     {
       ++spatial_dimension_count;
     }
@@ -465,7 +459,7 @@ MINCImageIO::ReadImageInformation()
     itkExceptionMacro(" minc files without spatial dimensions are not supported!");
   }
 
-  if (this->m_MINCPImpl->m_DimensionIndices[0] != -1 && this->m_MINCPImpl->m_DimensionIndices[4] != -1)
+  if (m_MINCPImpl->m_DimensionIndices[0] != -1 && m_MINCPImpl->m_DimensionIndices[4] != -1)
   {
     itkExceptionMacro(" 4D minc files vector dimension are not supported currently");
   }
@@ -487,23 +481,23 @@ MINCImageIO::ReadImageInformation()
   // minc api uses inverse order of dimensions , fastest varying are last
   for (int i = 3; i > 0; i--)
   {
-    if (this->m_MINCPImpl->m_DimensionIndices[i] != -1)
+    if (m_MINCPImpl->m_DimensionIndices[i] != -1)
     {
       // MINC2: bad design!
-      // micopy_dimension(hdim[this->m_MINCPImpl->m_DimensionIndices[i]],&apparent_dimension_order[usable_dimensions]);
-      this->m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
-        this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[i]];
+      // micopy_dimension(hdim[m_MINCPImpl->m_DimensionIndices[i]],&apparent_dimension_order[usable_dimensions]);
+      m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
+        m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[i]];
       // always use positive
-      miset_dimension_apparent_voxel_order(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_POSITIVE);
+      miset_dimension_apparent_voxel_order(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_POSITIVE);
       misize_t _sz;
-      miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
+      miget_dimension_size(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
 
       std::vector<double> _dir(3);
       double              _sep, _start;
 
-      miget_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_sep);
-      miget_dimension_cosines(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_dir[0]);
-      miget_dimension_start(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_start);
+      miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_sep);
+      miget_dimension_cosines(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_dir[0]);
+      miget_dimension_start(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_start);
 
       for (int j = 0; j < 3; ++j)
       {
@@ -521,35 +515,34 @@ MINCImageIO::ReadImageInformation()
     }
   }
 
-  if (this->m_MINCPImpl->m_DimensionIndices[0] != -1) // have vector dimension
+  if (m_MINCPImpl->m_DimensionIndices[0] != -1) // have vector dimension
   {
-    // micopy_dimension(this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[0]],&apparent_dimension_order[usable_dimensions]);
-    this->m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
-      this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[0]];
+    // micopy_dimension(m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[0]],&apparent_dimension_order[usable_dimensions]);
+    m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
+      m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[0]];
     // always use positive, vector dimension does not supposed to have notion of positive step size, so leaving as is
-    // miset_dimension_apparent_voxel_order(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions],MI_POSITIVE);
+    // miset_dimension_apparent_voxel_order(m_MINCPImpl->m_MincApparentDims[usable_dimensions],MI_POSITIVE);
     misize_t _sz;
-    miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
+    miget_dimension_size(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
     numberOfComponents = _sz;
     ++usable_dimensions;
   }
 
-  if (this->m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
+  if (m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
   {
-    // micopy_dimension(hdim[this->m_MINCPImpl->m_DimensionIndices[4]],&apparent_dimension_order[usable_dimensions]);
-    this->m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
-      this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[4]];
+    // micopy_dimension(hdim[m_MINCPImpl->m_DimensionIndices[4]],&apparent_dimension_order[usable_dimensions]);
+    m_MINCPImpl->m_MincApparentDims[usable_dimensions] =
+      m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]];
     // always use positive
-    miset_dimension_apparent_voxel_order(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_POSITIVE);
+    miset_dimension_apparent_voxel_order(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_POSITIVE);
     misize_t _sz;
-    miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
+    miget_dimension_size(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
     numberOfComponents = _sz;
     ++usable_dimensions;
   }
 
   // Set apparent dimension order to the MINC2 api
-  if (miset_apparent_dimension_order(
-        this->m_MINCPImpl->m_Volume, usable_dimensions, this->m_MINCPImpl->m_MincApparentDims) < 0)
+  if (miset_apparent_dimension_order(m_MINCPImpl->m_Volume, usable_dimensions, m_MINCPImpl->m_MincApparentDims) < 0)
   {
     itkExceptionMacro(" Can't set apparent dimension order!");
   }
@@ -563,7 +556,7 @@ MINCImageIO::ReadImageInformation()
 
   miclass_t volume_data_class;
 
-  if (miget_data_class(this->m_MINCPImpl->m_Volume, &volume_data_class) < 0)
+  if (miget_data_class(m_MINCPImpl->m_Volume, &volume_data_class) < 0)
   {
     itkExceptionMacro(" Could not get data class");
   }
@@ -692,25 +685,24 @@ MINCImageIO::ReadImageInformation()
 
   // store history
   size_t minc_history_length = 0;
-  if (miget_attr_length(this->m_MINCPImpl->m_Volume, "", "history", &minc_history_length) == MI_NOERROR)
+  if (miget_attr_length(m_MINCPImpl->m_Volume, "", "history", &minc_history_length) == MI_NOERROR)
   {
     const auto minc_history = make_unique_for_overwrite<char[]>(minc_history_length + 1);
     if (miget_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", minc_history_length + 1, minc_history.get()) ==
+          m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", minc_history_length + 1, minc_history.get()) ==
         MI_NOERROR)
     {
       EncapsulateMetaData<std::string>(thisDic, "history", std::string(minc_history.get()));
     }
   }
 
-  if (this->m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
+  if (m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
   {
     // store time dimension start and step in metadata for preservation
     double _sep, _start;
     miget_dimension_separation(
-      this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_sep);
-    miget_dimension_start(
-      this->m_MINCPImpl->m_MincFileDims[this->m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_start);
+      m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_sep);
+    miget_dimension_start(m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_start);
     EncapsulateMetaData<double>(thisDic, "tstart", _start);
     EncapsulateMetaData<double>(thisDic, "tstep", _sep);
   }
@@ -766,19 +758,19 @@ MINCImageIO::ReadImageInformation()
   // at least it is not used anywhere
   milisthandle_t grplist;
 
-  if ((milist_start(this->m_MINCPImpl->m_Volume, "", 0, &grplist)) == MI_NOERROR)
+  if ((milist_start(m_MINCPImpl->m_Volume, "", 0, &grplist)) == MI_NOERROR)
   {
     char           group_name[256];
     milisthandle_t attlist;
 
     while (milist_grp_next(grplist, group_name, sizeof(group_name)) == MI_NOERROR)
     {
-      if ((milist_start(this->m_MINCPImpl->m_Volume, group_name, 1, &attlist)) == MI_NOERROR)
+      if ((milist_start(m_MINCPImpl->m_Volume, group_name, 1, &attlist)) == MI_NOERROR)
       {
         char attribute[256];
 
         while (milist_attr_next(
-                 this->m_MINCPImpl->m_Volume, attlist, group_name, sizeof(group_name), attribute, sizeof(attribute)) ==
+                 m_MINCPImpl->m_Volume, attlist, group_name, sizeof(group_name), attribute, sizeof(attribute)) ==
                MI_NOERROR)
         {
           mitype_t    att_data_type;
@@ -789,8 +781,8 @@ MINCImageIO::ReadImageInformation()
           entry_key += ":";
           entry_key += attribute;
 
-          if (miget_attr_type(this->m_MINCPImpl->m_Volume, group_name, attribute, &att_data_type) == MI_NOERROR &&
-              miget_attr_length(this->m_MINCPImpl->m_Volume, group_name, attribute, &att_length) == MI_NOERROR)
+          if (miget_attr_type(m_MINCPImpl->m_Volume, group_name, attribute, &att_data_type) == MI_NOERROR &&
+              miget_attr_length(m_MINCPImpl->m_Volume, group_name, attribute, &att_length) == MI_NOERROR)
           {
             switch (att_data_type)
             {
@@ -798,7 +790,7 @@ MINCImageIO::ReadImageInformation()
               {
                 const auto tmp = make_unique_for_overwrite<char[]>(att_length + 1);
                 if (miget_attr_values(
-                      this->m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length + 1, tmp.get()) ==
+                      m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length + 1, tmp.get()) ==
                     MI_NOERROR)
                 {
                   EncapsulateMetaData<std::string>(thisDic, entry_key, std::string(tmp.get()));
@@ -808,12 +800,9 @@ MINCImageIO::ReadImageInformation()
               case MI_TYPE_FLOAT:
               {
                 Array<float> tmp(att_length);
-                if (miget_attr_values(this->m_MINCPImpl->m_Volume,
-                                      att_data_type,
-                                      group_name,
-                                      attribute,
-                                      att_length,
-                                      tmp.data_block()) == MI_NOERROR)
+                if (miget_attr_values(
+                      m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length, tmp.data_block()) ==
+                    MI_NOERROR)
                 {
                   if (att_length == 1)
                   {
@@ -833,12 +822,9 @@ MINCImageIO::ReadImageInformation()
               case MI_TYPE_DOUBLE:
               {
                 Array<double> tmp(att_length);
-                if (miget_attr_values(this->m_MINCPImpl->m_Volume,
-                                      att_data_type,
-                                      group_name,
-                                      attribute,
-                                      att_length,
-                                      tmp.data_block()) == MI_NOERROR)
+                if (miget_attr_values(
+                      m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length, tmp.data_block()) ==
+                    MI_NOERROR)
                 {
                   if (att_length == 1)
                   {
@@ -854,12 +840,9 @@ MINCImageIO::ReadImageInformation()
               case MI_TYPE_INT:
               {
                 Array<int> tmp(att_length);
-                if (miget_attr_values(this->m_MINCPImpl->m_Volume,
-                                      att_data_type,
-                                      group_name,
-                                      attribute,
-                                      att_length,
-                                      tmp.data_block()) == MI_NOERROR)
+                if (miget_attr_values(
+                      m_MINCPImpl->m_Volume, att_data_type, group_name, attribute, att_length, tmp.data_block()) ==
+                    MI_NOERROR)
                 {
                   if (att_length == 1)
                   {
@@ -924,23 +907,21 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMCLASS_TIME,
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        nComp,
-                       &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
+                       &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
 
     if (!ExposeMetaData<double>(thisDic, "tstart", tstart))
     {
       tstart = 0.0;
     }
 
-    miset_dimension_start(this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1],
-                          tstart);
+    miset_dimension_start(m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1], tstart);
 
     if (!ExposeMetaData<double>(thisDic, "tstep", tstep))
     {
       tstep = 1.0;
     }
 
-    miset_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1],
-                               tstep);
+    miset_dimension_separation(m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1], tstep);
 
     ++minc_dimensions;
   }
@@ -950,7 +931,7 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMCLASS_RECORD,
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        nComp,
-                       &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
+                       &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
     ++minc_dimensions;
   }
 
@@ -958,7 +939,7 @@ MINCImageIO::WriteImageInformation()
                      MI_DIMCLASS_SPATIAL,
                      MI_DIMATTR_REGULARLY_SAMPLED,
                      this->GetDimensions(0),
-                     &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
+                     &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
   ++minc_dimensions;
 
   if (nDims > 1)
@@ -967,7 +948,7 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMCLASS_SPATIAL,
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        this->GetDimensions(1),
-                       &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
+                       &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
     ++minc_dimensions;
   }
 
@@ -977,13 +958,13 @@ MINCImageIO::WriteImageInformation()
                        MI_DIMCLASS_SPATIAL,
                        MI_DIMATTR_REGULARLY_SAMPLED,
                        this->GetDimensions(2),
-                       &this->m_MINCPImpl->m_MincApparentDims[this->m_MINCPImpl->m_NDims - minc_dimensions - 1]);
+                       &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
     ++minc_dimensions;
   }
 
   if (nDims > 3)
   {
-    MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+    MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
     itkExceptionMacro("Unfortunately, only up to 3D volume are supported now.");
   }
 
@@ -1019,40 +1000,40 @@ MINCImageIO::WriteImageInformation()
         dir_cos[k] = 0.0;
       }
     }
-    miset_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], this->GetSpacing(i));
-    miset_dimension_start(this->m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], origin[i]);
-    miset_dimension_cosines(this->m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], dir_cos);
+    miset_dimension_separation(m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], this->GetSpacing(i));
+    miset_dimension_start(m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], origin[i]);
+    miset_dimension_cosines(m_MINCPImpl->m_MincApparentDims[minc_dimensions - j - 1], dir_cos);
   }
 
   // TODO: fix this to appropriate
-  this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
-  this->m_MINCPImpl->m_Volume_class = MI_CLASS_REAL;
+  m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
+  m_MINCPImpl->m_Volume_class = MI_CLASS_REAL;
 
   switch (this->GetComponentType())
   {
     case IOComponentEnum::UCHAR:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
     case IOComponentEnum::CHAR:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
     case IOComponentEnum::USHORT:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_USHORT;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_USHORT;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
     case IOComponentEnum::SHORT:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_SHORT;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_SHORT;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
     case IOComponentEnum::UINT:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_UINT;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_UINT;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
     case IOComponentEnum::INT:
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_INT;
-      // this->m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_INT;
+      // m_MINCPImpl->m_Volume_class=MI_CLASS_INT;
       break;
       //     case IOComponentEnum::ULONG://TODO: make sure we are cross-platform here!
       //       volume_data_type=MI_TYPE_ULONG;
@@ -1061,13 +1042,13 @@ MINCImageIO::WriteImageInformation()
       //       volume_data_type=MI_TYPE_LONG;
       //       break;
     case IOComponentEnum::FLOAT: // TODO: make sure we are cross-platform here!
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
       break;
     case IOComponentEnum::DOUBLE: // TODO: make sure we are cross-platform here!
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_DOUBLE;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_DOUBLE;
       break;
     default:
-      MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+      MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
       itkExceptionMacro("Could read datatype " << this->GetComponentType());
   }
 
@@ -1079,22 +1060,22 @@ MINCImageIO::WriteImageInformation()
   {
     if (storage_data_type == typeid(char).name())
     {
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
     }
     else if (storage_data_type == typeid(unsigned char).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
     else if (storage_data_type == typeid(short).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_SHORT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_SHORT;
     else if (storage_data_type == typeid(unsigned short).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_USHORT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_USHORT;
     else if (storage_data_type == typeid(int).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_INT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_INT;
     else if (storage_data_type == typeid(unsigned int).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_UINT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_UINT;
     else if (storage_data_type == typeid(float).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;
     else if (storage_data_type == typeid(double).name())
-      this->m_MINCPImpl->m_Volume_type = MI_TYPE_DOUBLE;
+      m_MINCPImpl->m_Volume_type = MI_TYPE_DOUBLE;
   }
   // now let's create the same dimension order and positive/negative step size as
   // in original image
@@ -1122,7 +1103,7 @@ MINCImageIO::WriteImageInformation()
             }
             else
             {
-              j = this->m_MINCPImpl->m_NDims - 1;
+              j = m_MINCPImpl->m_NDims - 1;
             }
             break;
           case 't':
@@ -1134,20 +1115,20 @@ MINCImageIO::WriteImageInformation()
             }
             else
             {
-              j = this->m_MINCPImpl->m_NDims - 1;
+              j = m_MINCPImpl->m_NDims - 1;
             }
             break;
           case 'x':
           case 'X':
-            j = this->m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0));
+            j = m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0));
             break;
           case 'y':
           case 'Y':
-            j = this->m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0) + 1);
+            j = m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0) + 1);
             break;
           case 'z':
           case 'Z':
-            j = this->m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0) + 2);
+            j = m_MINCPImpl->m_NDims - 1 - ((nComp > 1 ? 1 : 0) + 2);
             break;
           default:
             itkDebugMacro("Dimension order is incorrect " << dimension_order.c_str());
@@ -1165,20 +1146,20 @@ MINCImageIO::WriteImageInformation()
             double   _sep, _start;
             misize_t _sz;
 
-            miget_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_sep);
-            miget_dimension_start(this->m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_start);
-            miget_dimension_size(this->m_MINCPImpl->m_MincApparentDims[j], &_sz);
+            miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_sep);
+            miget_dimension_start(m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_start);
+            miget_dimension_size(m_MINCPImpl->m_MincApparentDims[j], &_sz);
 
             _start = _start + (_sz - 1) * _sep;
             _sep = -_sep;
 
-            miset_dimension_separation(this->m_MINCPImpl->m_MincApparentDims[j], _sep);
-            miset_dimension_start(this->m_MINCPImpl->m_MincApparentDims[j], _start);
+            miset_dimension_separation(m_MINCPImpl->m_MincApparentDims[j], _sep);
+            miset_dimension_start(m_MINCPImpl->m_MincApparentDims[j], _start);
 
-            miset_dimension_apparent_voxel_order(this->m_MINCPImpl->m_MincApparentDims[j], MI_POSITIVE);
+            miset_dimension_apparent_voxel_order(m_MINCPImpl->m_MincApparentDims[j], MI_POSITIVE);
           }
           // Hmmm.... what are we going to get in the end?
-          this->m_MINCPImpl->m_MincFileDims[i] = this->m_MINCPImpl->m_MincApparentDims[j];
+          m_MINCPImpl->m_MincFileDims[i] = m_MINCPImpl->m_MincApparentDims[j];
         }
       }
     }
@@ -1192,14 +1173,14 @@ MINCImageIO::WriteImageInformation()
   {
     for (unsigned int i = 0; i < minc_dimensions; ++i)
     {
-      this->m_MINCPImpl->m_MincFileDims[i] = this->m_MINCPImpl->m_MincApparentDims[i];
+      m_MINCPImpl->m_MincFileDims[i] = m_MINCPImpl->m_MincApparentDims[i];
     }
   }
 
   mivolumeprops_t hprops;
   if (minew_volume_props(&hprops) < 0)
   {
-    MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+    MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
     itkExceptionMacro("Could not allocate MINC properties");
   }
 
@@ -1207,14 +1188,14 @@ MINCImageIO::WriteImageInformation()
   {
     if (miset_props_compression_type(hprops, MI_COMPRESS_ZLIB) < 0)
     {
-      MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+      MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
       mifree_volume_props(hprops);
       itkExceptionMacro("Could not set MINC compression");
     }
 
     if (miset_props_zlib_compression(hprops, this->GetCompressionLevel()) < 0)
     {
-      MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+      MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
       mifree_volume_props(hprops);
       itkExceptionMacro("Could not set MINC compression level");
     }
@@ -1223,7 +1204,7 @@ MINCImageIO::WriteImageInformation()
   {
     if (miset_props_compression_type(hprops, MI_COMPRESS_NONE) < 0)
     {
-      MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+      MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
       mifree_volume_props(hprops);
       itkExceptionMacro("Could not set MINC compression");
     }
@@ -1231,43 +1212,42 @@ MINCImageIO::WriteImageInformation()
 
   if (micreate_volume(m_FileName.c_str(),
                       minc_dimensions,
-                      this->m_MINCPImpl->m_MincFileDims,
-                      this->m_MINCPImpl->m_Volume_type,
-                      this->m_MINCPImpl->m_Volume_class,
+                      m_MINCPImpl->m_MincFileDims,
+                      m_MINCPImpl->m_Volume_type,
+                      m_MINCPImpl->m_Volume_class,
                       hprops,
-                      &this->m_MINCPImpl->m_Volume) < 0)
+                      &m_MINCPImpl->m_Volume) < 0)
   {
     // Error opening the volume
-    MINCIOFreeTmpDimHandle(minc_dimensions, this->m_MINCPImpl->m_MincApparentDims);
+    MINCIOFreeTmpDimHandle(minc_dimensions, m_MINCPImpl->m_MincApparentDims);
     mifree_volume_props(hprops);
     itkExceptionMacro("Could not open file \"" << m_FileName.c_str() << "\".");
   }
 
-  if (micreate_volume_image(this->m_MINCPImpl->m_Volume) < 0)
+  if (micreate_volume_image(m_MINCPImpl->m_Volume) < 0)
   {
     // Error opening the volume
     mifree_volume_props(hprops);
     itkExceptionMacro("Could not create image in  file \"" << m_FileName.c_str() << "\".");
   }
 
-  if (miset_apparent_dimension_order(
-        this->m_MINCPImpl->m_Volume, minc_dimensions, this->m_MINCPImpl->m_MincApparentDims) < 0)
+  if (miset_apparent_dimension_order(m_MINCPImpl->m_Volume, minc_dimensions, m_MINCPImpl->m_MincApparentDims) < 0)
   {
     mifree_volume_props(hprops);
     itkExceptionMacro(" Can't set apparent dimension order!");
   }
 
-  if (miset_slice_scaling_flag(this->m_MINCPImpl->m_Volume, 0) < 0)
+  if (miset_slice_scaling_flag(m_MINCPImpl->m_Volume, 0) < 0)
   {
     mifree_volume_props(hprops);
     itkExceptionMacro("Could not set slice scaling flag");
   }
 
   double valid_min, valid_max;
-  miget_volume_valid_range(this->m_MINCPImpl->m_Volume, &valid_max, &valid_min);
+  miget_volume_valid_range(m_MINCPImpl->m_Volume, &valid_max, &valid_min);
 
   // by default valid range will be equal to range, to avoid scaling
-  miset_volume_range(this->m_MINCPImpl->m_Volume, valid_max, valid_min);
+  miset_volume_range(m_MINCPImpl->m_Volume, valid_max, valid_min);
 
   for (MetaDataDictionary::ConstIterator it = thisDic.Begin(); it != thisDic.End(); ++it)
   {
@@ -1292,40 +1272,38 @@ MINCImageIO::WriteImageInformation()
       {
         const std::string & tmp = dynamic_cast<MetaDataObject<std::string> *>(bs)->GetMetaDataObjectValue();
         miset_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, var.c_str(), att.c_str(), tmp.length() + 1, tmp.c_str());
+          m_MINCPImpl->m_Volume, MI_TYPE_STRING, var.c_str(), att.c_str(), tmp.length() + 1, tmp.c_str());
       }
       else if (!strcmp(tname, typeid(Array<double>).name()))
       {
         const Array<double> & tmp = dynamic_cast<MetaDataObject<Array<double>> *>(bs)->GetMetaDataObjectValue();
         miset_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_DOUBLE, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
+          m_MINCPImpl->m_Volume, MI_TYPE_DOUBLE, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
       }
       else if (!strcmp(tname, typeid(Array<float>).name()))
       {
         const Array<float> & tmp = dynamic_cast<MetaDataObject<Array<float>> *>(bs)->GetMetaDataObjectValue();
-        miset_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_FLOAT, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
+        miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_FLOAT, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
       }
       else if (!strcmp(tname, typeid(Array<int>).name()))
       {
         const Array<int> & tmp = dynamic_cast<MetaDataObject<Array<int>> *>(bs)->GetMetaDataObjectValue();
-        miset_attr_values(
-          this->m_MINCPImpl->m_Volume, MI_TYPE_INT, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
+        miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_INT, var.c_str(), att.c_str(), tmp.Size(), tmp.data_block());
       }
       else if (!strcmp(tname, typeid(double).name()))
       {
         double tmp = dynamic_cast<MetaDataObject<double> *>(bs)->GetMetaDataObjectValue();
-        miset_attr_values(this->m_MINCPImpl->m_Volume, MI_TYPE_DOUBLE, var.c_str(), att.c_str(), 1, &tmp);
+        miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_DOUBLE, var.c_str(), att.c_str(), 1, &tmp);
       }
       else if (!strcmp(tname, typeid(float).name()))
       {
         float tmp = dynamic_cast<MetaDataObject<float> *>(bs)->GetMetaDataObjectValue();
-        miset_attr_values(this->m_MINCPImpl->m_Volume, MI_TYPE_FLOAT, var.c_str(), att.c_str(), 1, &tmp);
+        miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_FLOAT, var.c_str(), att.c_str(), 1, &tmp);
       }
       else if (!strcmp(tname, typeid(int).name()))
       {
         int tmp = dynamic_cast<MetaDataObject<int> *>(bs)->GetMetaDataObjectValue();
-        miset_attr_values(this->m_MINCPImpl->m_Volume, MI_TYPE_INT, var.c_str(), att.c_str(), 1, &tmp);
+        miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_INT, var.c_str(), att.c_str(), 1, &tmp);
       }
       else
       {
@@ -1335,7 +1313,7 @@ MINCImageIO::WriteImageInformation()
     else if (it->first == "history")
     {
       const std::string & tmp = dynamic_cast<MetaDataObject<std::string> *>(bs)->GetMetaDataObjectValue();
-      miset_attr_values(this->m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", tmp.length() + 1, tmp.c_str());
+      miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_STRING, "", "history", tmp.length() + 1, tmp.c_str());
     }
     else
     { // else we have an attribute without variable name, most likely
@@ -1448,10 +1426,10 @@ MINCImageIO::Write(const void * buffer)
   this->WriteImageInformation();
 
   // by default valid range will be equal to range, to avoid scaling
-  if (volume_data_type == this->m_MINCPImpl->m_Volume_type)
+  if (volume_data_type == m_MINCPImpl->m_Volume_type)
   {
-    miset_volume_valid_range(this->m_MINCPImpl->m_Volume, buffer_max, buffer_min);
-    miset_volume_range(this->m_MINCPImpl->m_Volume, buffer_max, buffer_min);
+    miset_volume_valid_range(m_MINCPImpl->m_Volume, buffer_max, buffer_min);
+    miset_volume_range(m_MINCPImpl->m_Volume, buffer_max, buffer_min);
   }
   else // we are using scaling
   {
@@ -1460,20 +1438,20 @@ MINCImageIO::Write(const void * buffer)
     // but it's ok since it matches float
     if (this->GetComponentType() == IOComponentEnum::FLOAT)
     {
-      if (this->m_MINCPImpl->m_Volume_type == MI_TYPE_INT)
+      if (m_MINCPImpl->m_Volume_type == MI_TYPE_INT)
       {
-        miset_volume_valid_range(this->m_MINCPImpl->m_Volume, INT_MAX / 2, INT_MIN / 2);
+        miset_volume_valid_range(m_MINCPImpl->m_Volume, INT_MAX / 2, INT_MIN / 2);
       }
-      else if (this->m_MINCPImpl->m_Volume_type == MI_TYPE_UINT)
+      else if (m_MINCPImpl->m_Volume_type == MI_TYPE_UINT)
       {
-        miset_volume_valid_range(this->m_MINCPImpl->m_Volume, UINT_MAX / 2, 0);
+        miset_volume_valid_range(m_MINCPImpl->m_Volume, UINT_MAX / 2, 0);
       }
     }
-    miset_volume_range(this->m_MINCPImpl->m_Volume, buffer_max, buffer_min);
+    miset_volume_range(m_MINCPImpl->m_Volume, buffer_max, buffer_min);
   }
 
   if (miset_real_value_hyperslab(
-        this->m_MINCPImpl->m_Volume, volume_data_type, start.get(), count.get(), const_cast<void *>(buffer)) < 0)
+        m_MINCPImpl->m_Volume, volume_data_type, start.get(), count.get(), const_cast<void *>(buffer)) < 0)
   {
     itkExceptionMacro(" Can not set real value hyperslab!!\n");
   }


### PR DESCRIPTION
Both "pimpl-like" pointers were already `private` anyway.

- Following C++ Core Guidelines, ["Use unique_ptr or shared_ptr to avoid forgetting to delete objects created using new"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-smart)
- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4539

@thewtex This PR obviously does not affect the public API. It just aims to make the code more secure, by removing two more cases of manual memory management. Would it still be in time for ITK 5.4.0?