### PR TITLE
WIP: Use std filesystem path

### DIFF
--- a/Modules/Core/Common/include/itkPathType.h
+++ b/Modules/Core/Common/include/itkPathType.h
@@ -1,0 +1,29 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkPathType_h
+#define itkPathType_h
+
+#include <filesystem>
+
+namespace itk
+{
+using PathType = std::filesystem::path;
+}
+
+#endif

--- a/Modules/IO/ImageBase/include/itkImageFileReader.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.h
@@ -20,7 +20,6 @@
 #include "itkImageFileReaderException.h"
 
 #include "ITKIOImageBaseExport.h"
-
 #include "itkImageIOBase.h"
 #include "itkImageSource.h"
 #include "itkMacro.h"

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -20,6 +20,7 @@
 #include "ITKIOImageBaseExport.h"
 
 #include "itkIOConfigure.h"
+#include "itkPathType.h"
 
 #include "itkLightProcessObject.h"
 #include "itkIndent.h"
@@ -89,8 +90,38 @@ public:
   itkOverrideGetNameOfClassMacro(ImageIOBase);
 
   /** Set/Get the name of the file to be read. */
-  itkSetStringMacro(FileName);
-  itkGetStringMacro(FileName);
+  virtual void
+  SetFilePath(const PathType & filepath)
+  {
+    if (m_FilePath != filepath)
+    {
+      m_FilePath = filepath;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+      m_NonConstFileName = filepath.string();
+#endif
+      this->Modified();
+    }
+  }
+  itkGetConstReferenceMacro(FilePath, PathType);
+
+  /** Set/Get the name of the file to be read as a c-string or string. */
+  virtual void
+  SetFileName(const char * filename)
+  {
+    this->SetFilePath(PathType(filename));
+  }
+  virtual void
+  SetFileName(const std::string & filename)
+  {
+    this->SetFilePath(PathType(filename));
+  }
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  virtual const char *
+  GetFileName() const
+  {
+    return this->m_FileName.c_str();
+  }
+#endif
 
   /** Types for managing image size and image index components. */
   using IndexValueType = itk::IndexValueType;
@@ -710,8 +741,14 @@ protected:
   /** Does the ImageIOBase object have enough info to be of use? */
   bool m_Initialized{};
 
+private:
+  std::string m_NonConstFileName{};
+
+protected:
+#ifndef ITK_FUTURE_LEGACY_REMOVE
   /** Filename to read */
-  std::string m_FileName{};
+  const std::string & m_FileName{ m_NonConstFileName };
+#endif
 
   /** Stores the number of components per pixel. This will be 1 for
    * grayscale images, 3 for RGBPixel images, and 4 for RGBPixelA images. */
@@ -893,6 +930,9 @@ private:
 
   ArrayOfExtensionsType m_SupportedReadExtensions{};
   ArrayOfExtensionsType m_SupportedWriteExtensions{};
+
+
+  PathType m_FilePath{};
 };
 
 /** Utility function for writing RAW bytes */

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -35,7 +35,8 @@ void
 ImageIOBase::Reset(const bool)
 {
   m_Initialized = false;
-  m_FileName = "";
+  m_FilePath = PathType{};
+  m_NonConstFileName = "";
   m_NumberOfComponents = 1;
   for (unsigned int i = 0; i < m_NumberOfDimensions; ++i)
   {
@@ -1159,7 +1160,8 @@ ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FileName: " << m_FileName << std::endl;
+  os << indent << "FileName: " << this->GetFileName() << std::endl;
+  os << indent << "PathName: " << this->GetFilePath() << std::endl;
   os << indent << "IOFileEnum: " << this->GetFileTypeAsString(m_FileType) << std::endl;
   os << indent << "IOByteOrderEnum: " << this->GetByteOrderAsString(m_ByteOrder) << std::endl;
   os << indent << "IORegion: " << std::endl;


### PR DESCRIPTION
 Add std::filesystem::path to ImageIOBase for eventual wchar support for paths.

This proposes an approach to remove direct access to m_FileName, with the eventual end goal to use GetFilePath and "legacy" GetFileName methods.
    
    Add Set/Get FilePath member functions to ImageIOBase, with the future
    plan to replace the m_FileName member variable with these access
    member functions. The m_FileName is directly access by derived ImageIO
    classes.
    
    The m_FileName is now "constant" to disallow derived classes from
    directly writing to the variable.  The SetFilePath method updates the
    legacy const m_FileName to maintain compatibility.
