### PR TITLE
COMP: Bump KWStyle to silence boost predefined-identifier warning

### DIFF
--- a/Utilities/KWStyle/BuildKWStyle.cmake
+++ b/Utilities/KWStyle/BuildKWStyle.cmake
@@ -23,7 +23,7 @@ if(NOT TARGET KWStyle)
   ExternalProject_Add(
     KWStyle
     GIT_REPOSITORY "https://github.com/Kitware/KWStyle.git"
-    GIT_TAG d2cba46b3c63b5a7b6453052e85c593c48c0dffd
+    GIT_TAG a3b775739de472b778cd5157c68cd527dca4749b
     UPDATE_COMMAND ""
     DOWNLOAD_DIR ${KWStyle_SOURCE_DIR}
     SOURCE_DIR ${KWStyle_SOURCE_DIR}


### PR DESCRIPTION
To address:

```
:
/home/matt/src/KWStyle/Utilities/boost/throw_exception.hpp:233:105: warning: predefined identifier is only valid inside function [-Wpredefined-identifier-outside-function]
template<class E> BOOST_NORETURN void throw_with_location( E && e, boost::source_location const & loc = BOOST_CURRENT_LOCATION )
                                                                                                        ^
/home/matt/src/KWStyle/Utilities/boost/assert/source_location.hpp:104:79: note: expanded from macro 'BOOST_CURRENT_LOCATION'
                                                                              ^
/home/matt/src/KWStyle/Utilities/boost/current_function.hpp:37:33: note: expanded from macro 'BOOST_CURRENT_FUNCTION'
```
