### PR TITLE
COMP: Numerical computation precision limit in resampling

### DIFF
--- a/Examples/Filtering/test/CMakeLists.txt
+++ b/Examples/Filtering/test/CMakeLists.txt
@@ -565,6 +565,10 @@ itk_add_test(
   ResampleImageFilter9Test
   COMMAND
   ${ITK_TEST_DRIVER}
+  # Coordinate computations for nearest neighbor are computed at the limits of numerical precision for this image
+  # during resampling.  arm64 and x86_64 compute input continuous index coordinates as 105.39999999999999 vs 105.4
+  # which requires a slight tolerance acceptance in the comparisons
+  --compareRadiusTolerance 1
   --compare
   DATA{${BASELINE}/ResampleImageFilter9TestPixelCentered.png,:}
   ${TEMP}/ResampleImageFilter9TestNearestPixelCentered.png


### PR DESCRIPTION
Coordinate computations for nearest neighbor are computed at the limits of numerical precision for this image during resampling.  arm64 and x86_64 compute input continuous index coordinates as 105.39999999999999 vs 105.4 which requires a slight tolerance acceptance in the comparisons

Add --compareRadiusTolerance 1 to test validation.

![image](https://github.com/InsightSoftwareConsortium/ITK/assets/313970/38160ff9-23e3-47e4-829b-a880c2b0ec2a)


https://open.cdash.org/tests/1506666894



## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

