### PR TITLE
BUG: Fix removal of '-' from patientId

### DIFF
--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -272,7 +272,7 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
 
   // patient id
   std::string tmpId(buffer.get() + VOff(84, 88), 13);
-  (void)std::remove(tmpId.begin(), tmpId.end(), '-');
+  tmpId.erase(std::remove(tmpId.begin(), tmpId.end(), '-'), tmpId.end());
   strncpy(curImage->patientId, tmpId.c_str(), sizeof(curImage->patientId) - 1);
   curImage->patientId[sizeof(curImage->patientId) - 1] = '\0';
 


### PR DESCRIPTION
The use of std::remove was not correctly implemented. After removing '-' from the string and shuffling items forward into the space, the remaining items
in the string need to be explicitly erased.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
