### PR TITLE
ENH: Fix workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
          fetch-depth: 0
     - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
       with:
         error-message: 'Code is inconsistent with ITK Coding Style. Add the *action:ApplyClangFormat* PR label to correct.'

--- a/.github/workflows/spell-check-comments.yml
+++ b/.github/workflows/spell-check-comments.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 


### PR DESCRIPTION
Fix format linter and spell check workflow actions warnings linked to `Node.js`: bump `actions/checkout` to `v4` and `actions/setup-python` to v5.

Fixes:
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20:
actions/checkout@v3, actions/setup-python@v4.
For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITK/actions/runs/8655098674

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
