### PR TITLE
COMP: Use the c++ 17 common [[fallthrough]] attribute

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -264,20 +264,10 @@ namespace itk
 #  define itkExposeEnumValue(name) static_cast<int>(name)
 #endif
 
-// Use "ITK_FALLTHROUGH;" to annotate deliberate fall-through in switches,
-// use it analogously to "break;".  The trailing semi-colon is required.
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-#  if (__GNUC__ >= 7)
-#    define ITK_FALLTHROUGH __attribute__((fallthrough))
-#  endif
-#elif defined(__has_warning)
-#  if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
-#    define ITK_FALLTHROUGH [[clang::fallthrough]]
-#  endif
-#endif
-
-#ifndef ITK_FALLTHROUGH
-#  define ITK_FALLTHROUGH ((void)0)
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
+#  define ITK_FALLTHROUGH [[fallthrough]]
+#else
+#  define ITK_FALLTHROUGH static_assert(false, "ERROR: ITK_FALLTHROUGH must be replaced with [[fallthrough]]")
 #endif
 
 /** Define two object creation methods.  The first method, New(),

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -36,10 +36,10 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::FastChamferDistanceIm
     // Note the fall through the cases to set all the components
     case 3:
       m_Weights[--dim] = 1.65849;
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 2:
       m_Weights[--dim] = 1.34065;
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 1:
       m_Weights[--dim] = 0.92644;
       break;

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -560,19 +560,19 @@ Bruker2dseqImageIO::Read(void * buffer)
   switch (this->m_ComponentType)
   {
     case IOComponentEnum::CHAR:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::UCHAR:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::SHORT:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::USHORT:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::INT:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::UINT:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::LONG:
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case IOComponentEnum::ULONG:
       itkExceptionMacro("Must have float pixels to rescale");
     case IOComponentEnum::FLOAT:

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1345,35 +1345,35 @@ NiftiImageIO::ReadImageInformation()
       this->SetDimensions(6, this->m_NiftiImage->nw);
       // NOTE: Scaling is not defined in this dimension
       this->SetSpacing(6, ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->dw) : this->m_NiftiImage->dw);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 6:
       this->SetDimensions(5, this->m_NiftiImage->nv);
       // NOTE: Scaling is not defined in this dimension
       this->SetSpacing(5, ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->dv) : this->m_NiftiImage->dv);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 5:
       this->SetDimensions(4, this->m_NiftiImage->nu);
       // NOTE: Scaling is not defined in this dimension
       this->SetSpacing(4, ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->du) : this->m_NiftiImage->du);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 4:
       this->SetDimensions(3, this->m_NiftiImage->nt);
       this->SetSpacing(3,
                        ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->dt * timingscale)
                                               : this->m_NiftiImage->dt * timingscale);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 3:
       this->SetDimensions(2, this->m_NiftiImage->nz);
       this->SetSpacing(2,
                        ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->dz * spacingscale)
                                               : this->m_NiftiImage->dz * spacingscale);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 2:
       this->SetDimensions(1, this->m_NiftiImage->ny);
       this->SetSpacing(1,
                        ignore_negative_pixdim ? itk::Math::abs(this->m_NiftiImage->dy * spacingscale)
                                               : this->m_NiftiImage->dy * spacingscale);
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 1:
       this->SetDimensions(0, this->m_NiftiImage->nx);
       this->SetSpacing(0,
@@ -1523,32 +1523,32 @@ NiftiImageIO::WriteImageInformation()
       this->m_NiftiImage->dim[7] = this->m_NiftiImage->nw = static_cast<int>(this->GetDimensions(6));
       this->m_NiftiImage->pixdim[7] = this->m_NiftiImage->dw = static_cast<float>(this->GetSpacing(6));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[7];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 6:
       this->m_NiftiImage->dim[6] = this->m_NiftiImage->nv = this->GetDimensions(5);
       this->m_NiftiImage->pixdim[6] = this->m_NiftiImage->dv = static_cast<float>(this->GetSpacing(5));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[6];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 5:
       this->m_NiftiImage->dim[5] = this->m_NiftiImage->nu = this->GetDimensions(4);
       this->m_NiftiImage->pixdim[5] = this->m_NiftiImage->du = static_cast<float>(this->GetSpacing(4));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[5];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 4:
       this->m_NiftiImage->dim[4] = this->m_NiftiImage->nt = this->GetDimensions(3);
       this->m_NiftiImage->pixdim[4] = this->m_NiftiImage->dt = static_cast<float>(this->GetSpacing(3));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[4];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 3:
       this->m_NiftiImage->dim[3] = this->m_NiftiImage->nz = this->GetDimensions(2);
       this->m_NiftiImage->pixdim[3] = this->m_NiftiImage->dz = static_cast<float>(this->GetSpacing(2));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[3];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 2:
       this->m_NiftiImage->dim[2] = this->m_NiftiImage->ny = this->GetDimensions(1);
       this->m_NiftiImage->pixdim[2] = this->m_NiftiImage->dy = static_cast<float>(this->GetSpacing(1));
       this->m_NiftiImage->nvox *= this->m_NiftiImage->dim[2];
-      ITK_FALLTHROUGH;
+      [[fallthrough]];
     case 1:
       this->m_NiftiImage->dim[1] = this->m_NiftiImage->nx = this->GetDimensions(0);
       this->m_NiftiImage->pixdim[1] = this->m_NiftiImage->dx = static_cast<float>(this->GetSpacing(0));


### PR DESCRIPTION
[[fallthrough]](C++17)	indicates that the fall through from the previous case label is intentional and should not be diagnosed by a compiler that warns on fall-through (attribute specifier)

Remove complicated #ifdef macro logic to enforce compiler specific behaviors.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
