### PR TITLE
STYLE: Prefer c++17 [[maybe_unused]] attribute over (void)

### DIFF
--- a/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
@@ -21,15 +21,14 @@
 int
 main()
 {
-  fenv_t fenv;
+  [[maybe_unused]] fenv_t fenv;
 #if defined(ITK_CHECK_FENV_T_CONTROL)
-  (void)sizeof(fenv.__control);
+  [[maybe_unused]] const auto tempSize = sizeof(fenv.__control);
 #elif defined(ITK_CHECK_FENV_T_CONTROL_WORD)
-  (void)sizeof(fenv.__control_word);
+  [[maybe_unused]] const auto tempSize = sizeof(fenv.__control_word);
 #elif defined(ITK_CHECK_FENV_T_CW)
-  (void)sizeof(fenv.__cw);
+  [[maybe_unused]] const auto tempSize = sizeof(fenv.__cw);
 #else
-  (void)fenv;
 #  error \
     "Unknown fenv_t struct member test: Make sure to specify a compile definition of the form -DITK_CHECK_FENV_T_xxx"
 #endif

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -57,9 +57,8 @@ ExtractImageFilterCopyRegion(
   const typename BinaryUnsignedIntDispatch<T1, T2>::FirstLessThanSecondType & firstLessThanSecond,
   ImageRegion<T1> &                                                           destRegion,
   const ImageRegion<T2> &                                                     srcRegion,
-  const ImageRegion<T1> &                                                     totalInputExtractionRegion)
+  const ImageRegion<T1> &                                                     itkNotUsed(totalInputExtractionRegion))
 {
-  (void)totalInputExtractionRegion;
   ImageToImageFilterDefaultCopyRegion<T1, T2>(firstLessThanSecond, destRegion, srcRegion);
 }
 

--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -129,9 +129,9 @@ public:
    * pixel values in the outputRequestedRegion.
    */
   virtual RegionType
-  GetInputRequestedRegion(const RegionType & inputLargestPossibleRegion, const RegionType & outputRequestedRegion) const
+  GetInputRequestedRegion(const RegionType &                  inputLargestPossibleRegion,
+                          [[maybe_unused]] const RegionType & itkNotUsed(outputRequestedRegion)) const
   {
-    (void)outputRequestedRegion;
     return inputLargestPossibleRegion;
   }
 

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -218,12 +218,10 @@ public:
     {};
 
     // Factory registration, made thread-safe by "magic statics" (as introduced with C++11).
-    static const FactoryRegistration staticFactoryRegistration = [] {
+    [[maybe_unused]] static const FactoryRegistration staticFactoryRegistration = [] {
       RegisterFactoryInternal(TFactory::New());
       return FactoryRegistration{};
     }();
-
-    (void)staticFactoryRegistration;
   }
 
   /** Initialize the static members of ObjectFactoryBase. */

--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -25,11 +25,10 @@
 #ifndef itkSingletonMacro_h
 #define itkSingletonMacro_h
 
-#define itkInitGlobalsMacro(VarName)                       \
-  {                                                        \
-    static auto * staticGlobals = Get##VarName##Pointer(); \
-    (void)staticGlobals;                                   \
-  }                                                        \
+#define itkInitGlobalsMacro(VarName)                                        \
+  {                                                                         \
+    [[maybe_unused]] static auto * staticGlobals = Get##VarName##Pointer(); \
+  }                                                                         \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkGetGlobalDeclarationMacro(Type, VarName) static Type * Get##VarName##Pointer()

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -1030,9 +1030,8 @@ struct GetType
    * \note the default unspecialized behaviour returns the input number \c v.
    */
   static Type
-  Load(Type const & v, unsigned int idx)
+  Load(Type const & v, unsigned int itkNotUsed(idx))
   {
-    (void)idx;
     return v;
   }
 };
@@ -1049,9 +1048,8 @@ struct GetType
  */
 template <typename TExpr1, typename TExpr2>
 inline std::enable_if_t<mpl::And<mpl::IsArray<TExpr1>, mpl::IsArray<TExpr2>>::Value, unsigned int>
-GetSize(TExpr1 const & lhs, TExpr2 const & rhs)
+GetSize(TExpr1 const & lhs, [[maybe_unused]] TExpr2 const & rhs)
 {
-  (void)rhs;
   itkAssertInDebugAndIgnoreInReleaseMacro(lhs.Size() == rhs.Size());
   return lhs.Size();
 }

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -151,10 +151,8 @@ public:
   struct NeverReallocate : AllocateRootPolicy
   {
     bool
-    operator()(unsigned int newSize, unsigned int oldSize) const
+    operator()([[maybe_unused]] unsigned int newSize, [[maybe_unused]] unsigned int oldSize) const
     {
-      (void)newSize;
-      (void)oldSize;
       itkAssertInDebugAndIgnoreInReleaseMacro(newSize == oldSize &&
                                               "SetSize is expected to never change the VariableLengthVector size...");
       return true;

--- a/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
@@ -113,7 +113,7 @@ itkFloatingPointExceptionsAbortOrExit()
   }
 }
 
-void
+[[maybe_unused]] void
 itkFloatingPointExceptionsNotSupported()
 {
   std::cerr << "FloatingPointExceptions are not supported on this platform." << std::endl;

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -165,7 +165,6 @@ FloatingPointExceptions::Enable()
   sigaction(SIGFPE, &act, nullptr);
 #  endif
   FloatingPointExceptions::m_PimplGlobals->m_Enabled = true;
-  (void)itkFloatingPointExceptionsNotSupported; // avoid unused-function warning
 #else
   itkFloatingPointExceptionsNotSupported();
 #endif

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -348,7 +348,7 @@ using ITK_LOAD_FUNCTION = ObjectFactoryBase * (*)();
  * lower case for LibExtension values.
  */
 inline bool
-NameIsSharedLibrary(const char * name)
+NameIsSharedLibrary([[maybe_unused]] const char * name)
 {
 #ifdef ITK_DYNAMIC_LOADING
   std::string extension = itksys::DynamicLoader::LibExtension();
@@ -368,7 +368,6 @@ NameIsSharedLibrary(const char * name)
     return true;
   }
 #else // ITK_DYNAMIC_LOADING
-  (void)name;
   itkGenericExceptionMacro("ITK was not built with support for dynamic loading.");
 #endif
   return false;

--- a/Modules/Core/Common/test/itkBitCastGTest.cxx
+++ b/Modules/Core/Common/test/itkBitCastGTest.cxx
@@ -40,7 +40,6 @@ TEST(BitCast, ResultIsBitwiseEqualToArgument)
     Expect_return_value_is_bitwise_equal_to_function_argument<unsigned int>(i);
   }
 
-  int value;
-  (void)value;
+  [[maybe_unused]] int value;
   Expect_return_value_is_bitwise_equal_to_function_argument<intptr_t>(&value);
 }

--- a/Modules/Core/Common/test/itkCrossHelperTest.cxx
+++ b/Modules/Core/Common/test/itkCrossHelperTest.cxx
@@ -22,11 +22,8 @@
 
 
 int
-itkCrossHelperTest(int argc, char * argv[])
+itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  (void)argc;
-  (void)argv;
-
   constexpr unsigned int Dimension2D = 2;
   constexpr unsigned int Dimension3D = 3;
   constexpr unsigned int Dimension4D = 4;

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
@@ -89,7 +89,7 @@ public:
   PixelType
   ComputeUpdate(const NeighborhoodType & itkNotUsed(neighborhood),
                 void *                   itkNotUsed(globalData),
-                const FloatOffsetType &  itkNotUsed(offset = FloatOffsetType(0.0))) override
+                const FloatOffsetType &  itkNotUsed(offset) = FloatOffsetType(0.0)) override
   {
     PixelType pix{};
     return pix;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -216,10 +216,8 @@ public:
    * https://public.kitware.com/pipermail/insight-users/2005-April/012613.html
    */
   void
-  CopyInformation(const DataObject * data) override
-  {
-    (void)data;
-  }
+  CopyInformation(const DataObject * itkNotUsed(data)) override
+  {}
   void
   Graft(const DataObject * data) override;
 
@@ -235,25 +233,20 @@ public:
 #if !defined(ITK_WRAPPING_PARSER)
   /** overloaded method for backward compatibility */
   void
-  SetBoundaryAssignments(int dimension, BoundaryAssignmentsContainer * container)
-  {
-    (void)dimension;
-    (void)container;
-  }
+  SetBoundaryAssignments(int itkNotUsed(dimension), BoundaryAssignmentsContainer * itkNotUsed(container))
+  {}
 
   /** overloaded method for backward compatibility */
   BoundaryAssignmentsContainerPointer
-  GetBoundaryAssignments(int dimension)
+  GetBoundaryAssignments(int itkNotUsed(dimension))
   {
-    (void)dimension;
     return (nullptr);
   }
 
   /** overloaded method for backward compatibility */
   const BoundaryAssignmentsContainerPointer
-  GetBoundaryAssignments(int dimension) const
+  GetBoundaryAssignments(int itkNotUsed(dimension)) const
   {
-    (void)dimension;
     return (nullptr);
   }
 
@@ -261,66 +254,48 @@ public:
 
   /** overloaded method for backward compatibility */
   void
-  SetBoundaryAssignment(int                   dimension,
-                        CellIdentifier        cellId,
-                        CellFeatureIdentifier featureId,
-                        CellIdentifier        boundaryId)
-  {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
-    (void)boundaryId;
-  }
+  SetBoundaryAssignment(int                   itkNotUsed(dimension),
+                        CellIdentifier        itkNotUsed(cellId),
+                        CellFeatureIdentifier itkNotUsed(featureId),
+                        CellIdentifier        itkNotUsed(boundaryId))
+  {}
 
   /** overloaded method for backward compatibility */
   bool
-  GetBoundaryAssignment(int                   dimension,
-                        CellIdentifier        cellId,
-                        CellFeatureIdentifier featureId,
-                        CellIdentifier *      boundaryId) const
+  GetBoundaryAssignment(int                   itkNotUsed(dimension),
+                        CellIdentifier        itkNotUsed(cellId),
+                        CellFeatureIdentifier itkNotUsed(featureId),
+                        CellIdentifier *      itkNotUsed(boundaryId))
   {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
-    (void)boundaryId;
     return (false); // ALEX: is it the good way?
   }
 
   /** overloaded method for backward compatibility */
   bool
-  RemoveBoundaryAssignment(int dimension, CellIdentifier cellId, CellFeatureIdentifier featureId)
+  RemoveBoundaryAssignment(int                   itkNotUsed(dimension),
+                           CellIdentifier        itkNotUsed(cellId),
+                           CellFeatureIdentifier itkNotUsed(featureId))
   {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
     return (false); // ALEX: is it the good way?
   }
 
   /** overloaded method for backward compatibility */
   bool
-  GetCellBoundaryFeature(int                   dimension,
-                         CellIdentifier        cellId,
-                         CellFeatureIdentifier featureId,
-                         CellAutoPointer &     cellAP) const
+  GetCellBoundaryFeature(int                   itkNotUsed(dimension),
+                         CellIdentifier        itkNotUsed(cellId),
+                         CellFeatureIdentifier itkNotUsed(featureId),
+                         CellAutoPointer &     itkNotUsed(cellAP)) const
   {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
-    (void)cellAP;
     return (false);
   }
 
   /** overloaded method for backward compatibility */
   CellIdentifier
-  GetCellBoundaryFeatureNeighbors(int                        dimension,
-                                  CellIdentifier             cellId,
-                                  CellFeatureIdentifier      featureId,
-                                  std::set<CellIdentifier> * cellSet)
+  GetCellBoundaryFeatureNeighbors(int                        itkNotUsed(dimension),
+                                  CellIdentifier             itkNotUsed(cellId),
+                                  CellFeatureIdentifier      itkNotUsed(featureId),
+                                  std::set<CellIdentifier> * itkNotUsed(cellSet))
   {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
-    (void)cellSet;
     return CellIdentifier{};
   }
 
@@ -333,15 +308,11 @@ public:
 
   /** overloaded method for backward compatibility */
   bool
-  GetAssignedCellBoundaryIfOneExists(int                   dimension,
-                                     CellIdentifier        cellId,
-                                     CellFeatureIdentifier featureId,
-                                     CellAutoPointer &     cellAP) const
+  GetAssignedCellBoundaryIfOneExists(int                   itkNotUsed(dimension),
+                                     CellIdentifier        itkNotUsed(cellId),
+                                     CellFeatureIdentifier itkNotUsed(featureId),
+                                     CellAutoPointer &     itkNotUsed(cellAP)) const
   {
-    (void)dimension;
-    (void)cellId;
-    (void)featureId;
-    (void)cellAP;
     return (false); // ALEX: is it the good way?
   }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -337,10 +337,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::Splice(QEPrimal * a, QEPrimal * b) ->
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
 void
-QuadEdgeMesh<TPixel, VDimension, TTraits>::SetCell(CellIdentifier cId, CellAutoPointer & cell)
+QuadEdgeMesh<TPixel, VDimension, TTraits>::SetCell(CellIdentifier itkNotUsed(cId), CellAutoPointer & cell)
 {
-  (void)cId;
-
   // NOTE ALEX: should add some checking to be sure everything went fine
   EdgeCellType *    qe;
   PolygonCellType * pe;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -202,9 +202,8 @@ protected:
    *  to the "topological metric" i.e. all edges have unit length.
    */
   virtual CoordRepType
-  GetCost(QEType * edge)
+  GetCost(QEType * itkNotUsed(edge))
   {
-    (void)edge;
     return (1);
   }
 
@@ -271,14 +270,10 @@ public:
 
 public:
   /** Object creation methods. */
-  QuadEdgeMeshConstFrontIterator(const MeshType * mesh = (MeshType *)0,
-                                 bool             start = true,
-                                 QEType *         seed = (QEType *)nullptr)
-  {
-    (void)mesh;
-    (void)start;
-    (void)seed;
-  }
+  QuadEdgeMeshConstFrontIterator(const MeshType * itkNotUsed(mesh) = (MeshType *)0,
+                                 bool             itkNotUsed(start) = true,
+                                 QEType *         itkNotUsed(seed) = (QEType *)nullptr)
+  {}
 
   /** \todo do we need here a    : Superclass( mesh, start, seed ) { } */
   ~QuadEdgeMeshConstFrontIterator() override = default;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
@@ -135,14 +135,11 @@ QuadEdgeMeshLineCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension)
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
 bool
-QuadEdgeMeshLineCell<TCellInterface>::GetBoundaryFeature(int                   dimension,
-                                                         CellFeatureIdentifier cellId,
-                                                         CellAutoPointer &     cell)
+QuadEdgeMeshLineCell<TCellInterface>::GetBoundaryFeature(int                   itkNotUsed(dimension),
+                                                         CellFeatureIdentifier itkNotUsed(cellId),
+                                                         CellAutoPointer &     itkNotUsed(cell))
 {
   // TODO : FIXME
-  (void)dimension;
-  (void)cellId;
-  (void)cell;
   return (false);
 }
 
@@ -173,9 +170,8 @@ QuadEdgeMeshLineCell<TCellInterface>::InternalSetPointIds(PointIdInternalConstIt
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
 void
-QuadEdgeMeshLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConstIterator last)
+QuadEdgeMeshLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first, PointIdConstIterator itkNotUsed(last))
 {
-  (void)last;
   this->GetQEGeom()->SetOrigin(*first);
   ++first;
   this->GetQEGeom()->SetDestination(*first);
@@ -185,9 +181,8 @@ QuadEdgeMeshLineCell<TCellInterface>::SetPointIds(PointIdConstIterator first, Po
 template <typename TCellInterface>
 void
 QuadEdgeMeshLineCell<TCellInterface>::InternalSetPointIds(PointIdInternalConstIterator first,
-                                                          PointIdInternalConstIterator last)
+                                                          PointIdInternalConstIterator itkNotUsed(last))
 {
-  (void)last;
   this->GetQEGeom()->SetOrigin(*first);
   ++first;
   this->GetQEGeom()->SetDestination(*first);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
@@ -160,14 +160,11 @@ QuadEdgeMeshPolygonCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimensi
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
 bool
-QuadEdgeMeshPolygonCell<TCellInterface>::GetBoundaryFeature(int                   dimension,
-                                                            CellFeatureIdentifier cellId,
-                                                            CellAutoPointer &     cell)
+QuadEdgeMeshPolygonCell<TCellInterface>::GetBoundaryFeature(int                   itkNotUsed(dimension),
+                                                            CellFeatureIdentifier itkNotUsed(cellId),
+                                                            CellAutoPointer &     itkNotUsed(cell))
 {
   /// \todo
-  (void)dimension;
-  (void)cellId;
-  (void)cell;
   return (false);
 }
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -49,11 +49,8 @@ class CustomQELineVisitor
 {
 public:
   void
-  Visit(unsigned long cellId, QELineCellType * t)
-  {
-    (void)cellId;
-    (void)t;
-  }
+  Visit(unsigned long itkNotUsed(cellId), QELineCellType * itkNotUsed(t))
+  {}
   virtual ~CustomQELineVisitor() = default;
 };
 
@@ -61,11 +58,8 @@ class CustomQEPolyVisitor
 {
 public:
   void
-  Visit(unsigned long cellId, QEPolygonCellType * t)
-  {
-    (void)cellId;
-    (void)t;
-  }
+  Visit(unsigned long itkNotUsed(cellId), QEPolygonCellType * itkNotUsed(t))
+  {}
   virtual ~CustomQEPolyVisitor() = default;
 };
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
@@ -74,7 +74,7 @@ itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest(int, char *[])
   std::cout << "OK" << std::endl;
 #endif
 
-  (void)createCenterVertex->GetNameOfClass();
+  [[maybe_unused]] const std::string name_of_class = createCenterVertex->GetNameOfClass();
 
   createCenterVertex->SetInput(mesh);
 #ifndef NDEBUG

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorsTestHelper.h"
+#include "itkTestingMacros.h"
 
 int
 itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest(int, char *[])
@@ -73,8 +74,8 @@ itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest(int, char *[])
   }
   std::cout << "OK" << std::endl;
 #endif
-
-  [[maybe_unused]] const std::string name_of_class = createCenterVertex->GetNameOfClass();
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorCreateCenterVertexFunction"),
+                        std::string_view(createCenterVertex->GetNameOfClass()));
 
   createCenterVertex->SetInput(mesh);
 #ifndef NDEBUG

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
@@ -22,11 +22,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int argc, char * argv[])
+itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  (void)argc;
-  (void)argv;
-
   using MeshType = itk::QuadEdgeMesh<double, 3>;
   using MeshPointer = MeshType::Pointer;
   using QEType = MeshType::QEType;

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -135,8 +135,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input
@@ -235,8 +233,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input
@@ -337,8 +333,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input
@@ -471,8 +465,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input
@@ -570,8 +562,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input
@@ -672,8 +662,6 @@ public:
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     // don't add FFTW_WISDOM_ONLY if the plan rigor is FFTW_ESTIMATE
     // because FFTW_ESTIMATE guarantee to not destroy the input

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -124,13 +124,13 @@ public:
   }
 
   static PlanType
-  Plan_dft_c2r(int           rank,
-               const int *   n,
-               ComplexType * in,
-               PixelType *   out,
-               unsigned int  flags,
-               int           threads = 1,
-               bool          canDestroyInput = false)
+  Plan_dft_c2r(int                  rank,
+               const int *          n,
+               ComplexType *        in,
+               PixelType *          out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1,
+               bool                 canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
@@ -223,13 +223,13 @@ public:
   }
 
   static PlanType
-  Plan_dft_r2c(int           rank,
-               const int *   n,
-               PixelType *   in,
-               ComplexType * out,
-               unsigned int  flags,
-               int           threads = 1,
-               bool          canDestroyInput = false)
+  Plan_dft_r2c(int                  rank,
+               const int *          n,
+               PixelType *          in,
+               ComplexType *        out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1,
+               bool                 canDestroyInput = false)
   {
     //
 #  ifndef ITK_USE_CUFFTW
@@ -325,14 +325,14 @@ public:
   }
 
   static PlanType
-  Plan_dft(int           rank,
-           const int *   n,
-           ComplexType * in,
-           ComplexType * out,
-           int           sign,
-           unsigned int  flags,
-           int           threads = 1,
-           bool          canDestroyInput = false)
+  Plan_dft(int                  rank,
+           const int *          n,
+           ComplexType *        in,
+           ComplexType *        out,
+           int                  sign,
+           unsigned int         flags,
+           [[maybe_unused]] int threads = 1,
+           bool                 canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
@@ -460,13 +460,13 @@ public:
   }
 
   static PlanType
-  Plan_dft_c2r(int           rank,
-               const int *   n,
-               ComplexType * in,
-               PixelType *   out,
-               unsigned int  flags,
-               int           threads = 1,
-               bool          canDestroyInput = false)
+  Plan_dft_c2r(int                  rank,
+               const int *          n,
+               ComplexType *        in,
+               PixelType *          out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1,
+               bool                 canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
@@ -559,13 +559,13 @@ public:
   }
 
   static PlanType
-  Plan_dft_r2c(int           rank,
-               const int *   n,
-               PixelType *   in,
-               ComplexType * out,
-               unsigned int  flags,
-               int           threads = 1,
-               bool          canDestroyInput = false)
+  Plan_dft_r2c(int                  rank,
+               const int *          n,
+               PixelType *          in,
+               ComplexType *        out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1,
+               bool                 canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
@@ -660,14 +660,14 @@ public:
   }
 
   static PlanType
-  Plan_dft(int           rank,
-           const int *   n,
-           ComplexType * in,
-           ComplexType * out,
-           int           sign,
-           unsigned int  flags,
-           int           threads = 1,
-           bool          canDestroyInput = false)
+  Plan_dft(int                  rank,
+           const int *          n,
+           ComplexType *        in,
+           ComplexType *        out,
+           int                  sign,
+           unsigned int         flags,
+           [[maybe_unused]] int threads = 1,
+           bool                 canDestroyInput = false)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());

--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -62,110 +62,129 @@ public:
   using Self = ComplexToComplexProxy<float>;
 
   static PlanType
-  Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_c2r_1d(n, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_2d(int                  nx,
+                  int                  ny,
+                  ComplexType *        in,
+                  PixelType *          out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_c2r_2d(nx, ny, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_3d(int                  nx,
+                  int                  ny,
+                  int                  nz,
+                  ComplexType *        in,
+                  PixelType *          out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_c2r_3d(nx, ny, nz, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r(int                  rank,
+               const int *          n,
+               ComplexType *        in,
+               PixelType *          out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_c2r(rank, n, in, out, flags);
     return plan;
   }
 
   static PlanType
-  Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_r2c_1d(n, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_2d(int                  nx,
+                  int                  ny,
+                  PixelType *          in,
+                  ComplexType *        out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_r2c_2d(nx, ny, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_3d(int                  nx,
+                  int                  ny,
+                  int                  nz,
+                  PixelType *          in,
+                  ComplexType *        out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_r2c_3d(nx, ny, nz, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c(int                  rank,
+               const int *          n,
+               PixelType *          in,
+               ComplexType *        out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_r2c(rank, n, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
+  Plan_dft_1d(const int            n,
+              ComplexType *        in,
+              ComplexType *        out,
+              int                  sign,
+              unsigned int         flags,
+              [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftwf_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftwf_plan_dft_1d(n, in, out, sign, flags);
     return plan;
@@ -198,113 +217,132 @@ public:
   using Self = ComplexToComplexProxy<double>;
 
   static PlanType
-  Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_1d(int n, ComplexType * in, PixelType * out, unsigned int flags, [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_c2r_1d(n, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r_2d(int nx, int ny, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_2d(int                  nx,
+                  int                  ny,
+                  ComplexType *        in,
+                  PixelType *          out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_c2r_2d(nx, ny, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r_3d(int nx, int ny, int nz, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r_3d(int                  nx,
+                  int                  ny,
+                  int                  nz,
+                  ComplexType *        in,
+                  PixelType *          out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_c2r_3d(nx, ny, nz, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_c2r(int rank, const int * n, ComplexType * in, PixelType * out, unsigned int flags, int threads = 1)
+  Plan_dft_c2r(int                  rank,
+               const int *          n,
+               ComplexType *        in,
+               PixelType *          out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_c2r(rank, n, in, out, flags);
     return plan;
   }
 
   static PlanType
-  Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_1d(int n, PixelType * in, ComplexType * out, unsigned int flags, [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_r2c_1d(n, in, out, flags);
     return plan;
   }
 
   static PlanType
-  Plan_dft_r2c_2d(int nx, int ny, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_2d(int                  nx,
+                  int                  ny,
+                  PixelType *          in,
+                  ComplexType *        out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_r2c_2d(nx, ny, in, out, flags);
     return plan;
   }
 
   static PlanType
-  Plan_dft_r2c_3d(int nx, int ny, int nz, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c_3d(int                  nx,
+                  int                  ny,
+                  int                  nz,
+                  PixelType *          in,
+                  ComplexType *        out,
+                  unsigned int         flags,
+                  [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_r2c_3d(nx, ny, nz, in, out, flags);
     return plan;
   }
 
   static PlanType
-  Plan_dft_r2c(int rank, const int * n, PixelType * in, ComplexType * out, unsigned int flags, int threads = 1)
+  Plan_dft_r2c(int                  rank,
+               const int *          n,
+               PixelType *          in,
+               ComplexType *        out,
+               unsigned int         flags,
+               [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_r2c(rank, n, in, out, flags);
     return plan;
   }
   static PlanType
-  Plan_dft_1d(const int n, ComplexType * in, ComplexType * out, int sign, unsigned int flags, int threads = 1)
+  Plan_dft_1d(const int            n,
+              ComplexType *        in,
+              ComplexType *        out,
+              int                  sign,
+              unsigned int         flags,
+              [[maybe_unused]] int threads = 1)
   {
 #  ifndef ITK_USE_CUFFTW
     const std::lock_guard<FFTWGlobalConfiguration::MutexType> lockGuard(FFTWGlobalConfiguration::GetLockMutex());
     fftw_plan_with_nthreads(threads);
-#  else
-    (void)threads;
 #  endif
     PlanType plan = fftw_plan_dft_1d(n, in, out, sign, flags);
     return plan;

--- a/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
@@ -107,8 +107,7 @@ itkFFTPadImageFilterTest(int argc, char * argv[])
   // Ensure we can build with a different output image type.
   using OutputImageType = itk::Image<double, Dimension>;
   using FFTPadWithOutputType = itk::FFTPadImageFilter<ImageType, OutputImageType>;
-  auto fftPadWithOutput = FFTPadWithOutputType::New();
-  (void)fftPadWithOutput;
+  [[maybe_unused]] auto fftPadWithOutput = FFTPadWithOutputType::New();
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
@@ -28,7 +28,7 @@
 // dimensions are taken from the array.The data types used are float and
 // double.
 int
-itkFFTWF_FFTTest(int argc, char * argv[])
+itkFFTWF_FFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageCF1 = itk::Image<std::complex<float>, 1>;
@@ -55,9 +55,6 @@ itkFFTWF_FFTTest(int argc, char * argv[])
   std::cout << "WisdomCacheBase " << itk::FFTWGlobalConfiguration::GetWisdomCacheBase() << std::endl;
   std::cout << "WisdomeFile     " << itk::FFTWGlobalConfiguration::GetWisdomFileDefaultBaseName() << std::endl;
 #  endif
-  // Avoid unused parameter warnings.
-  (void)argc;
-  (void)argv;
 
   unsigned int SizeOfDimensions1[] = { 4, 4, 4 };
   unsigned int SizeOfDimensions2[] = { 3, 5, 4 };

--- a/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
@@ -26,7 +26,7 @@
 // template argument and the size of these dimensions are taken from
 // the array.The data types used are float and double.
 int
-itkFFTWF_RealFFTTest(int argc, char * argv[])
+itkFFTWF_RealFFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageCF1 = itk::Image<std::complex<float>, 1>;
@@ -53,9 +53,6 @@ itkFFTWF_RealFFTTest(int argc, char * argv[])
   std::cout << "WisdomCacheBase " << itk::FFTWGlobalConfiguration::GetWisdomCacheBase() << std::endl;
   std::cout << "WisdomeFile     " << itk::FFTWGlobalConfiguration::GetWisdomFileDefaultBaseName() << std::endl;
 #  endif
-  // Avoid unused parameter warnings.
-  (void)argc;
-  (void)argv;
 
   unsigned int SizeOfDimensions1[] = { 4, 4, 4 };
   unsigned int SizeOfDimensions2[] = { 3, 5, 4 };

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
@@ -27,7 +27,7 @@
 // of these dimensions are taken from the array.The data types used are float
 // and double.
 int
-itkVnlFFTWF_FFTTest(int argc, char * argv[])
+itkVnlFFTWF_FFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageF2 = itk::Image<float, 2>;
@@ -47,9 +47,6 @@ itkVnlFFTWF_FFTTest(int argc, char * argv[])
   std::cout << "WisdomCacheBase " << itk::FFTWGlobalConfiguration::GetWisdomCacheBase() << std::endl;
   std::cout << "WisdomeFile     " << itk::FFTWGlobalConfiguration::GetWisdomFileDefaultBaseName() << std::endl;
 #  endif
-  // Avoid unused parameter warnings.
-  (void)argc;
-  (void)argv;
 
   unsigned int SizeOfDimensions1[] = { 4, 4, 4 };
   unsigned int SizeOfDimensions2[] = { 3, 5, 4 };

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
@@ -27,7 +27,7 @@
 // template argument and the size of these dimensions are taken from
 // the array. The data types used are float and double.
 int
-itkVnlFFTWF_RealFFTTest(int argc, char * argv[])
+itkVnlFFTWF_RealFFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageF2 = itk::Image<float, 2>;
@@ -47,9 +47,6 @@ itkVnlFFTWF_RealFFTTest(int argc, char * argv[])
   std::cout << "WisdomCacheBase " << itk::FFTWGlobalConfiguration::GetWisdomCacheBase() << std::endl;
   std::cout << "WisdomeFile     " << itk::FFTWGlobalConfiguration::GetWisdomFileDefaultBaseName() << std::endl;
 #  endif
-  // Avoid unused parameter warnings.
-  (void)argc;
-  (void)argv;
 
   unsigned int SizeOfDimensions1[] = { 4, 4, 4 };
   unsigned int SizeOfDimensions2[] = { 3, 5, 4 };

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -264,12 +264,10 @@ FastMarchingImageFilterBase<TInput, TOutput>::GetInternalNodesUsed(OutputImageTy
 
 template <typename TInput, typename TOutput>
 double
-FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *            oImage,
+FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *            itkNotUsed(oImage),
                                                     const NodeType &             iNode,
                                                     InternalNodeStructureArray & iNeighbors) const
 {
-  (void)oImage;
-
   // Sort the local list
   std::sort(iNeighbors.Begin(), iNeighbors.End());
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -376,7 +376,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::ComputeUpdate(const OutputV
 template <typename TInput, typename TOutput>
 bool
 FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UnfoldTriangle(OutputMeshType *                  oMesh,
-                                                                    const OutputPointIdentifierType & iId,
+                                                                    const OutputPointIdentifierType & itkNotUsed(iId),
                                                                     const OutputPointType &           iP,
                                                                     const OutputPointIdentifierType & iId1,
                                                                     const OutputPointType &           iP1,
@@ -388,8 +388,6 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UnfoldTriangle(OutputMeshTy
                                                                     OutputVectorRealType &            oDot2,
                                                                     OutputPointIdentifierType &       oId) const
 {
-  (void)iId;
-
   OutputVectorType     Edge1 = iP1 - iP;
   OutputVectorRealType Norm1 = Edge1.GetNorm();
 
@@ -569,11 +567,9 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::UnfoldTriangle(OutputMeshTy
 
 template <typename TInput, typename TOutput>
 bool
-FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::CheckTopology(OutputMeshType * oMesh, const NodeType & iNode)
+FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::CheckTopology(OutputMeshType * itkNotUsed(oMesh),
+                                                                   const NodeType & itkNotUsed(iNode))
 {
-  (void)oMesh;
-  (void)iNode;
-
   return true;
 }
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -190,9 +190,7 @@ itkFastMarchingBaseTest(int argc, char * argv[])
 
 
     using OutputImageType = ImageFastMarching::OutputDomainType;
-    OutputImageType::Pointer output = fmm->GetOutput();
-
-    (void)output;
+    [[maybe_unused]] OutputImageType::Pointer output = fmm->GetOutput();
   }
   else if (useMeshVsImage == 1)
   {
@@ -208,9 +206,7 @@ itkFastMarchingBaseTest(int argc, char * argv[])
 
 
     using OutputMeshType = MeshFastMarching::OutputDomainType;
-    OutputMeshType::Pointer output = fmm->GetOutput();
-
-    (void)output;
+    [[maybe_unused]] OutputMeshType::Pointer output = fmm->GetOutput();
   }
 
   // Test streaming enumeration for FastMarchingTraitsEnums::TopologyCheck elements

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -273,10 +273,10 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::JoinVertexFailed(
 
 template <typename TInput, typename TOutput, typename TCriterion>
 void
-EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::DeletePoint(const OutputPointIdentifier & iIdToBeDeleted,
-                                                                           const OutputPointIdentifier & iRemaining)
+EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::DeletePoint(
+  const OutputPointIdentifier & iIdToBeDeleted,
+  const OutputPointIdentifier & itkNotUsed(iRemaining))
 {
-  (void)iRemaining;
   this->GetOutput()->DeletePoint(iIdToBeDeleted);
 }
 

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -241,13 +241,12 @@ private:
 class I18nIfstream : public std::istream
 {
 public:
-  I18nIfstream(const char * str, std::ios_base::openmode mode = std::ios_base::in)
+  I18nIfstream(const char * str, std::ios_base::openmode itkNotused(mode) = std::ios_base::in)
     : std::istream(0)
     , m_fd(I18nOpenForReading(str))
     , m_buf(m_fd)
   {
     ///\todo better handle mode flag
-    (void)mode;
     this->rdbuf(&m_buf);
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
@@ -21,7 +21,7 @@
 
 
 int
-itkImageFileReaderTest1(int itkNotUsed(argc), char * argv[])
+itkImageFileReaderTest1(int argc, char * argv[])
 {
 
   using ImageNDType = itk::Image<short, 2>;

--- a/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
@@ -23,7 +23,7 @@
 int
 itkImageFileReaderTest1(int argc, char * argv[])
 {
-
+  ITK_TEST_EXPECT_TRUE(argc == 1);
   using ImageNDType = itk::Image<short, 2>;
   using ReaderType = itk::ImageFileReader<ImageNDType>;
 

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -38,7 +38,7 @@ struct itk_jpeg_error_mgr
 
 extern "C"
 {
-  METHODDEF(void) itk_jpeg_error_exit(j_common_ptr cinfo)
+  METHODDEF(void) itk_jpeg_error_exit([[maybe_unused]] j_common_ptr cinfo)
   {
     /* cinfo->err really points to an itk_jpeg_error_mgr struct, so coerce pointer
      */
@@ -58,8 +58,6 @@ extern "C"
     char buffer[JMSG_LENGTH_MAX + 1];
     (*cinfo->err->format_message)(cinfo, buffer);
     printf("%s\n", buffer);
-#else
-    (void)cinfo;
 #endif
   }
 }

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -34,8 +34,6 @@ extern "C"
   void
   MINCIOFreeTmpDimHandle(unsigned int size, midimhandle_t * ptr)
   {
-    int          error = 0;
-    unsigned int x = 0;
     if (!ptr)
     {
       /*
@@ -46,16 +44,14 @@ extern "C"
 #endif
       return;
     }
-    for (; x < size; ++x)
+    for (unsigned int x = 0; x < size; ++x)
     {
-      error = mifree_dimension_handle(ptr[x]);
+      [[maybe_unused]] int error = mifree_dimension_handle(ptr[x]);
 #ifndef NDEBUG
       if (error != MI_NOERROR)
       {
         printf("MINCIOFreeTmpDimHandle: mifree_dimension_handle(ptr[%u]) returned %d", x, error);
       }
-#else
-      (void)error;
 #endif
     }
   }

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
@@ -73,7 +73,7 @@ TransformFactoryBase::RegisterDefaultTransforms()
   // make sure that the factory instance has
   // been created. All normal paths to this method
   // already do this but this makes certain sure it's done
-  (void)TransformFactoryBase::GetFactory();
+  [[maybe_unused]] auto currentFactory = TransformFactoryBase::GetFactory();
 
   if (!TransformFactoryBasePrivate::DefaultTransformsRegistered)
   {

--- a/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
@@ -20,11 +20,8 @@
 #include <iostream>
 
 int
-itkTriangleHelperTest(int argc, char * argv[])
+itkTriangleHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  (void)argc;
-  (void)argv;
-
   constexpr unsigned int Dimension = 3;
   using CoordRepType = double;
   using PointType = itk::Point<CoordRepType, Dimension>;

--- a/Modules/Nonunit/Review/test/itkTimeAndMemoryProbeTest.cxx
+++ b/Modules/Nonunit/Review/test/itkTimeAndMemoryProbeTest.cxx
@@ -21,11 +21,8 @@
 #include <iostream>
 
 int
-itkTimeAndMemoryProbeTest(int argc, char * argv[])
+itkTimeAndMemoryProbeTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-  (void)argc;
-  (void)argv;
-
   itk::TimeProbe                 timeProbe;
   itk::MemoryProbesCollectorBase memoryProbes;
 

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -72,8 +72,7 @@ CovarianceSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType index
 
   if (index == 1)
   {
-    MeasurementVectorRealType mean;
-    (void)mean; // for complainty pants : valgrind
+    [[maybe_unused]] MeasurementVectorRealType mean;
     NumericTraits<MeasurementVectorRealType>::SetLength(mean, this->GetMeasurementVectorSize());
     // NumericTraits::SetLength also initializes array to zero
     auto decoratedMean = MeasurementVectorDecoratedType::New();

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -54,8 +54,7 @@ template <typename TSample>
 auto
 MeanSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
-  MeasurementVectorRealType mean;
-  (void)mean; // for complainty pants : valgrind
+  [[maybe_unused]] MeasurementVectorRealType mean;
   NumericTraits<MeasurementVectorRealType>::SetLength(mean, this->GetMeasurementVectorSize());
   // NumericTraits::SetLength also initializes array to zero
   auto decoratedMean = MeasurementVectorDecoratedType::New();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -75,8 +75,9 @@ public:
 
 template <unsigned int TDimension>
 int
-PerformBSplineSyNImageRegistration(int itkNotUsed(argc), char * argv[])
+PerformBSplineSyNImageRegistration(int argc, char * argv[])
 {
+  ITK_TEST_EXPECT_TRUE(argc == 4);
   const unsigned int ImageDimension = TDimension;
 
   using PixelType = double;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -120,7 +120,7 @@ template <unsigned int TDimension>
 int
 PerformCompositeImageRegistration(int argc, char * argv[])
 {
-  if (argc != 4)
+  if (argc != 5)
   {
     std::cout << "ERROR: incorrect number of arguments" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -118,8 +118,13 @@ public:
 
 template <unsigned int TDimension>
 int
-PerformCompositeImageRegistration(int itkNotUsed(argc), char * argv[])
+PerformCompositeImageRegistration(int argc, char * argv[])
 {
+  if (argc != 4)
+  {
+    std::cout << "ERROR: incorrect number of arguments" << std::endl;
+    return EXIT_FAILURE;
+  }
   const unsigned int ImageDimension = TDimension;
 
   using PixelType = double;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
@@ -77,8 +77,9 @@ public:
 
 template <unsigned int TDimension>
 int
-ImageRegistration(int itkNotUsed(argc), char * argv[])
+ImageRegistration(int argc, char * argv[])
 {
+  ITK_TEST_EXPECT_TRUE(argc == 4);
   const unsigned int ImageDimension = TDimension;
 
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -109,8 +109,13 @@ public:
 
 template <unsigned int TDimension>
 int
-PerformDisplacementFieldImageRegistration(int itkNotUsed(argc), char * argv[])
+PerformDisplacementFieldImageRegistration(int argc, char * argv[])
 {
+  if (argc != 4)
+  {
+    std::cout << "ERROR: incorrect number of arguments" << std::endl;
+    return EXIT_FAILURE;
+  }
   const unsigned int ImageDimension = TDimension;
 
   using PixelType = double;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -111,7 +111,7 @@ template <unsigned int TDimension>
 int
 PerformDisplacementFieldImageRegistration(int argc, char * argv[])
 {
-  if (argc != 4)
+  if (argc != 5)
   {
     std::cout << "ERROR: incorrect number of arguments" << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
The use of (void)varname was a mechanism to silence compiler warnings prior to universal language support in c++17 for the [[maybe_unused]] attribute specifier.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
