### PR TITLE
STYLE: Use `ITK_TEST_EXPECT_EQUAL` to compare class names in QEMesh

### DIFF
--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
@@ -19,6 +19,7 @@
 #include "itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorsTestHelper.h"
+#include "itkTestingMacros.h"
 
 int
 itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int argc, char * argv[])
@@ -82,13 +83,8 @@ itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int argc, char * argv[])
   }
   std::cout << "OK" << std::endl;
 
-  const std::string className = deleteCenterVertex->GetNameOfClass();
-  const std::string requiredClassName{ "QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction" };
-  if (className != requiredClassName)
-  {
-    std::cout << className << " != " << requiredClassName << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction",
+                        (const std::string)deleteCenterVertex->GetNameOfClass());
 
   deleteCenterVertex->SetInput(mesh);
   std::cout << "     "

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
@@ -83,13 +83,9 @@ itkQuadEdgeMeshEulerOperatorJoinFacetTest(int, char *[])
   std::cout << "OK" << std::endl;
 #endif
 
-  const std::string className = joinFacet->GetNameOfClass();
-  const std::string requiredClassName{ "QuadEdgeMeshEulerOperatorJoinFacetFunction" };
-  if (className != requiredClassName)
-  {
-    std::cout << className << " != " << requiredClassName << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorJoinFacetFunction",
+                        (const std::string)joinFacet->GetNameOfClass());
+
   joinFacet->SetInput(mesh);
 
 #ifndef NDEBUG

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -210,13 +210,8 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
   std::cout << "OK" << std::endl;
 #endif
 
-  const std::string className = joinVertex->GetNameOfClass();
-  const std::string requiredClassName{ "QuadEdgeMeshEulerOperatorJoinVertexFunction" };
-  if (className != requiredClassName)
-  {
-    std::cout << className << " != " << requiredClassName << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorJoinVertexFunction",
+                        (const std::string)joinVertex->GetNameOfClass());
 
   joinVertex->SetInput(mesh);
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorsTestHelper.h"
+#include "itkTestingMacros.h"
 
 int
 itkQuadEdgeMeshEulerOperatorSplitEdgeTest(int, char *[])
@@ -48,13 +49,9 @@ itkQuadEdgeMeshEulerOperatorSplitEdgeTest(int, char *[])
   }
   std::cout << "OK" << std::endl;
 
-  const std::string className = splitEdge->GetNameOfClass();
-  const std::string requiredClassName{ "QuadEdgeMeshEulerOperatorSplitEdgeFunction" };
-  if (className != requiredClassName)
-  {
-    std::cout << className << " != " << requiredClassName << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorSplitEdgeFunction",
+                        (const std::string)splitEdge->GetNameOfClass());
+
   splitEdge->SetInput(mesh);
   std::cout << "     "
             << "Test No QE Input";

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
@@ -19,6 +19,7 @@
 #include "itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorsTestHelper.h"
+#include "itkTestingMacros.h"
 
 int
 itkQuadEdgeMeshEulerOperatorSplitVertexTest(int, char *[])
@@ -51,13 +52,8 @@ itkQuadEdgeMeshEulerOperatorSplitVertexTest(int, char *[])
   }
   std::cout << "OK" << std::endl;
 
-  const std::string className = splitVertex->GetNameOfClass();
-  const std::string requiredClassName{ "QuadEdgeMeshEulerOperatorSplitVertexFunction" };
-  if (className != requiredClassName)
-  {
-    std::cout << className << " != " << requiredClassName << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorSplitVertexFunction",
+                        (const std::string)splitVertex->GetNameOfClass());
 
   splitVertex->SetInput(mesh);
   std::cout << "     "


### PR DESCRIPTION
Prefer using `ITK_TEST_EXPECT_EQUAL` to compare class names in `QuadEdgeMesh` tests.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- 