### PR TITLE
ENH: Fix macOS ARM workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/macos-arm.yml
+++ b/.github/workflows/macos-arm.yml
@@ -38,7 +38,7 @@ jobs:
                 clean: true
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
 
@@ -93,7 +93,7 @@ jobs:
                 clean: true
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
 


### PR DESCRIPTION
Fix macOS ARM workflow actions warnings linked to `Node.js`: bump `actions/setup-python` to v5.

Fixes:
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20:
actions/setup-python@v4.
For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITK/actions/runs/8676305102

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)