### PR TITLE
STYLE: Replace `(const std::string)` casts with C++17 `std::string_view`

### DIFF
--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
@@ -83,8 +83,8 @@ itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int argc, char * argv[])
   }
   std::cout << "OK" << std::endl;
 
-  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction",
-                        (const std::string)deleteCenterVertex->GetNameOfClass());
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction"),
+                        std::string_view(deleteCenterVertex->GetNameOfClass()));
 
   deleteCenterVertex->SetInput(mesh);
   std::cout << "     "

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
@@ -83,8 +83,8 @@ itkQuadEdgeMeshEulerOperatorJoinFacetTest(int, char *[])
   std::cout << "OK" << std::endl;
 #endif
 
-  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorJoinFacetFunction",
-                        (const std::string)joinFacet->GetNameOfClass());
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorJoinFacetFunction"),
+                        std::string_view(joinFacet->GetNameOfClass()));
 
   joinFacet->SetInput(mesh);
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -210,8 +210,8 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
   std::cout << "OK" << std::endl;
 #endif
 
-  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorJoinVertexFunction",
-                        (const std::string)joinVertex->GetNameOfClass());
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorJoinVertexFunction"),
+                        std::string_view(joinVertex->GetNameOfClass()));
 
   joinVertex->SetInput(mesh);
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
@@ -49,8 +49,8 @@ itkQuadEdgeMeshEulerOperatorSplitEdgeTest(int, char *[])
   }
   std::cout << "OK" << std::endl;
 
-  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorSplitEdgeFunction",
-                        (const std::string)splitEdge->GetNameOfClass());
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorSplitEdgeFunction"),
+                        std::string_view(splitEdge->GetNameOfClass()));
 
   splitEdge->SetInput(mesh);
   std::cout << "     "

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
@@ -52,8 +52,8 @@ itkQuadEdgeMeshEulerOperatorSplitVertexTest(int, char *[])
   }
   std::cout << "OK" << std::endl;
 
-  ITK_TEST_EXPECT_EQUAL((const std::string) "QuadEdgeMeshEulerOperatorSplitVertexFunction",
-                        (const std::string)splitVertex->GetNameOfClass());
+  ITK_TEST_EXPECT_EQUAL(std::string_view("QuadEdgeMeshEulerOperatorSplitVertexFunction"),
+                        std::string_view(splitVertex->GetNameOfClass()));
 
   splitVertex->SetInput(mesh);
   std::cout << "     "


### PR DESCRIPTION
Prevented potential static analysis warnings, like Clang-Tidy:

> C-style casts are discouraged; use static_cast [google-readability-casting]

And JetBrains ReSharper:

> C-style cast is used instead of a C++ cast

Note that `std::string_view` is more lightweight than `std::string`.

- Follow-up to pull request #4583