### PR TITLE
BUG: Fix Py_LIMITED_API minor version spec

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -435,7 +435,7 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
 
     # Python Limited API / Stable ABI
     if (ITK_USE_PYTHON_LIMITED_API)
-      target_compile_definitions(${lib} PUBLIC -DPy_LIMITED_API=0x03110000)
+      target_compile_definitions(${lib} PUBLIC -DPy_LIMITED_API=0x030b0000)
     endif()
     # Link the modules together
     target_link_libraries(${lib} LINK_PUBLIC ${WRAPPER_LIBRARY_LINK_LIBRARIES})


### PR DESCRIPTION
This is in hex, we want 11 in decimal.

Ref:

  https://docs.python.org/3/c-api/apiabiversion.html#c.PY_VERSION_HEX
