### PR TITLE
WIP: Add static member, `itk::Image::CreateInitialized(const RegionType &)`

### DIFF
--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -189,6 +189,16 @@ public:
   void
   Allocate(bool initializePixels = false) override;
 
+  /** Creates an image with the specified region. Allocates its pixel buffer, zero-initializing its pixels. */
+  static Pointer
+  CreateInitialized(const RegionType & region)
+  {
+    const auto image = Image::New();
+    image->SetRegions(region);
+    image->AllocateInitialized();
+    return image;
+  }
+
   /** Restore the data object to its initial state. This means releasing
    * memory. */
   void

--- a/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
@@ -195,11 +195,9 @@ itkAdaptorComparisonTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  auto scalar_image = ScalarImageType::New();
-  auto vector_image = VectorImageType::New();
+  auto scalar_image = ScalarImageType::CreateInitialized(region);
 
-  scalar_image->SetRegions(region);
-  scalar_image->AllocateInitialized();
+  auto vector_image = VectorImageType::New();
 
   vector_image->SetRegions(region);
   vector_image->Allocate();

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -275,13 +275,11 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     auto kernel = KernelType::New();
 
     using ImageType = itk::Image<char, SpaceDimension>;
-    auto                  image = ImageType::New();
     ImageType::RegionType region;
     region.SetIndex(startIndex);
     region.SetSize(size);
 
-    image->SetRegions(region);
-    image->AllocateInitialized();
+    auto image = ImageType::CreateInitialized(region);
 
     using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType  iter(image, image->GetBufferedRegion());

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -248,11 +248,9 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
   using OffsetType = itk::Offset<ImageDimension>;
 
   // Create a "dummy" image.
-  const auto image = ImageType::New();
-  SizeType   imageSize;
+  SizeType imageSize;
   imageSize.Fill(1);
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(imageSize);
 
   // Create a radius, (just) large enough for all offsets activated below here.
   SizeType radius;

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -79,14 +79,8 @@ itkImageAlgorithmCopyTest2(int, char *[])
   image1->Allocate();
   image1->FillBuffer(13);
 
-  auto image2 = Short3DImageType::New();
-  image2->SetRegions(region);
-  image2->AllocateInitialized();
-
-
-  auto image3 = Float3DImageType::New();
-  image3->SetRegions(region);
-  image3->AllocateInitialized();
+  auto image2 = Short3DImageType::CreateInitialized(region);
+  auto image3 = Float3DImageType::CreateInitialized(region);
 
   std::cout << "Copying two images of same type" << std::endl;
   itk::ImageAlgorithm::Copy(image1.GetPointer(), image2.GetPointer(), region, region);

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -41,9 +41,7 @@ itkImageDuplicatorTest(int, char *[])
   {
     /** Create an image image */
     std::cout << "Creating simulated image: ";
-    auto m_Image = ImageType::New();
-    m_Image->SetRegions(region);
-    m_Image->AllocateInitialized();
+    auto m_Image = ImageType::CreateInitialized(region);
 
     itk::ImageRegionIterator<ImageType> it(m_Image, region);
     it.GoToBegin();

--- a/Modules/Core/Common/test/itkImageGTest.cxx
+++ b/Modules/Core/Common/test/itkImageGTest.cxx
@@ -83,11 +83,7 @@ void
 Expect_allocated_initialized_image_equal_to_itself()
 {
   using SizeType = typename TImage::SizeType;
-
-  const auto image = TImage::New();
-  image->SetRegions(SizeType::Filled(2));
-  image->AllocateInitialized();
-
+  const auto image = TImage::CreateInitialized(SizeType::Filled(2));
   Expect_equal_to_itself(*image);
 }
 
@@ -98,13 +94,8 @@ Expect_unequal_when_sizes_differ()
 {
   using SizeType = typename TImage::SizeType;
 
-  const auto image1 = TImage::New();
-  image1->SetRegions(SizeType::Filled(2));
-  image1->AllocateInitialized();
-
-  const auto image2 = TImage::New();
-  image2->SetRegions(SizeType::Filled(3));
-  image2->AllocateInitialized();
+  const auto image1 = TImage::CreateInitialized(SizeType::Filled(2));
+  const auto image2 = TImage::CreateInitialized(SizeType::Filled(3));
 
   Expect_unequal(*image1, *image2);
 }

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -43,8 +43,6 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto image = ImageType::New();
-
   ImageType::SizeType size;
 
   size[0] = 1000;
@@ -59,8 +57,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   using RandomIteratorType = itk::ImageRandomIteratorWithIndex<ImageType>;
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -628,13 +628,10 @@ TEST(ImageRegionRange, ThrowsInReleaseWhenIterationRegionIsOutsideBufferedRegion
   using SizeType = ImageType::SizeType;
   using RegionType = ImageType::RegionType;
 
-  const auto image = ImageType::New();
-
   const IndexType imageIndex{ { -1, -2 } };
   const SizeType  imageSize{ { 3, 4 } };
 
-  image->SetRegions(RegionType{ imageIndex, imageSize });
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized({ imageIndex, imageSize });
 
   Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
     *image, RegionType{ imageIndex, imageSize + SizeType::Filled(1) });

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -52,9 +52,7 @@ itkLineIteratorTest(int argc, char * argv[])
   region.SetIndex(index);
   region.SetSize(size);
 
-  auto output = ImageType::New();
-  output->SetRegions(region);
-  output->AllocateInitialized();
+  auto output = ImageType::CreateInitialized(region);
 
   // First test: empty line
   IndexType startIndex;

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -1004,9 +1004,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsArbitraryBufferedRegionIndex)
 
   const ImageType::RegionType bufferedRegion{ arbitraryIndex, imageSize };
 
-  const auto image = ImageType::New();
-  image->SetRegions(bufferedRegion);
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(bufferedRegion);
 
   // Set a 'magic value' at the begin of the buffered region.
   const ImageType::PixelType   magicPixelValue = 42;

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -64,9 +64,7 @@ DoConvolution(typename ImageType::Pointer inputImage, unsigned long int directio
 
   NeighborhoodIteratorType it(radius, inputImage, inputImage->GetRequestedRegion());
 
-  auto outputImage = ImageType::New();
-  outputImage->SetRegions(inputImage->GetRequestedRegion());
-  outputImage->AllocateInitialized();
+  auto outputImage = ImageType::CreateInitialized(inputImage->GetRequestedRegion());
 
   IteratorType                             out(outputImage, inputImage->GetRequestedRegion());
   itk::NeighborhoodInnerProduct<ImageType> innerProduct;

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -70,9 +70,7 @@ itkGPUImageTest(int argc, char * argv[])
   srcB->Allocate();
   srcB->FillBuffer(3.0f);
 
-  dest = ItkImage1f::New();
-  dest->SetRegions(region);
-  dest->AllocateInitialized();
+  dest = ItkImage1f::CreateInitialized(region);
 
   // check pixel value
   ItkImage1f::IndexType idx;

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -29,7 +29,6 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
 
   using FloatImage = itk::Image<float, 3>;
 
-  auto                   image = FloatImage::New();
   FloatImage::RegionType region;
   FloatImage::SizeType   size;
   size.Fill(64);
@@ -39,8 +38,7 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
   region.SetIndex(index);
   region.SetSize(size);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = FloatImage::CreateInitialized(region);
 
   for (unsigned int i = 0; i < FloatImage::ImageDimension; ++i)
   {

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -29,7 +29,6 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   using GFunctionType = itk::GaussianBlurImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                  image = ImageType::New();
   ImageType::SizeType   size;
   ImageType::IndexType  start;
   ImageType::RegionType region;
@@ -41,8 +40,7 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -29,7 +29,6 @@ TestGaussianDerivativeImageFunction()
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
   typename ImageType::SizeType   size;
   typename ImageType::IndexType  start;
   typename ImageType::RegionType region;
@@ -41,8 +40,7 @@ TestGaussianDerivativeImageFunction()
   region.SetIndex(start);
   region.SetSize(size);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -56,9 +56,7 @@ template <typename TImage>
 void
 Expect_EvaluateAtIndex_returns_zero_when_all_pixels_are_zero(const typename TImage::SizeType & imageSize)
 {
-  const auto image = TImage::New();
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
+  const auto image = TImage::CreateInitialized(imageSize);
 
   const auto imageFunction = itk::SumOfSquaresImageFunction<TImage>::New();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -49,10 +49,7 @@ void
 Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero(
   const itk::ImageRegion<VImageDimension> & imageRegion)
 {
-  const auto image = itk::Image<TPixel, VImageDimension>::New();
-
-  image->SetRegions(imageRegion);
-  image->AllocateInitialized();
+  const auto image = itk::Image<TPixel, VImageDimension>::CreateInitialized(imageRegion);
 
   EXPECT_EQ(ComputeAxisAlignedBoundingBoxRegionInImageGridSpace(*image).GetSize(), itk::Size<VImageDimension>{});
 }
@@ -84,10 +81,7 @@ void
 Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel(
   const itk::ImageRegion<VImageDimension> & imageRegion)
 {
-  const auto image = itk::Image<TPixel, VImageDimension>::New();
-
-  image->SetRegions(imageRegion);
-  image->AllocateInitialized();
+  const auto image = itk::Image<TPixel, VImageDimension>::CreateInitialized(imageRegion);
 
   const itk::ImageRegionIndexRange<VImageDimension> indexRange{ imageRegion };
 
@@ -246,9 +240,7 @@ TEST(ImageMaskSpatialObject, IsInsideSingleNonZeroPixel)
   using PointType = ImageType::PointType;
 
   // Create an image filled with zero valued pixels.
-  const auto image = ImageType::New();
-  image->SetRegions(SizeType::Filled(8));
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(SizeType::Filled(8));
 
   constexpr itk::IndexValueType indexValue{ 4 };
   image->SetPixel({ { indexValue, indexValue } }, 1);
@@ -273,9 +265,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
   using PointType = ImageType::PointType;
 
   // Create an image filled with zero valued pixels.
-  const auto image = ImageType::New();
-  image->SetRegions(SizeType::Filled(10));
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(SizeType::Filled(10));
 
   // Set the value of a pixel to non-zero.
   constexpr itk::IndexValueType indexValue{ 8 };
@@ -312,9 +302,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
 TEST(ImageMaskSpatialObject, CornerPointIsNotInsideMaskOfZeroValues)
 {
   // Create a mask image, and fill the image with zero vales.
-  const auto image = itk::Image<unsigned char>::New();
-  image->SetRegions(itk::Size<>{ { 2, 2 } });
-  image->AllocateInitialized();
+  const auto image = itk::Image<unsigned char>::CreateInitialized(itk::Size<>{ { 2, 2 } });
 
   const auto imageMaskSpatialObject = itk::ImageMaskSpatialObject<2>::New();
   imageMaskSpatialObject->SetImage(image);
@@ -332,9 +320,7 @@ TEST(ImageMaskSpatialObject, IsInsideInWorldSpaceOverloads)
   using PointType = MaskImageType::PointType;
 
   // Create a mask image.
-  const auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(itk::Size<imageDimension>::Filled(2));
-  maskImage->AllocateInitialized();
+  const auto maskImage = MaskImageType::CreateInitialized(itk::Size<imageDimension>::Filled(2));
   maskImage->SetPixel({}, MaskPixelType{ 1 });
   maskImage->SetSpacing(itk::MakeFilled<MaskImageType::SpacingType>(0.5));
 
@@ -368,9 +354,8 @@ TEST(ImageMaskSpatialObject, StoresRegionsFromMaskImage)
       using SizeType = MaskImageType::SizeType;
 
       // Create a mask image.
-      const auto maskImage = MaskImageType::New();
-      maskImage->SetRegions(RegionType{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
-      maskImage->AllocateInitialized();
+      const auto maskImage =
+        MaskImageType::CreateInitialized({ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
 
       const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
       imageMaskSpatialObject->SetImage(maskImage);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -41,7 +41,6 @@ itkImageMaskSpatialObjectTest(int, char *[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  auto                  image = ImageType::New();
   ImageType::SizeType   size = { { 50, 50, 50 } };
   ImageType::IndexType  index = { { 0, 0, 0 } };
   ImageType::RegionType region;
@@ -49,8 +48,7 @@ itkImageMaskSpatialObjectTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::RegionType insideRegion;
   ImageType::SizeType   insideSize = { { 30, 30, 30 } };

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -51,7 +51,15 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   // Also explicitly uses nonzero origin, non identity scales
   // to fully test the commonly encountered cases from the real world
 
-  auto image = ImageType::New();
+  const ImageType::SizeType size = { { 50, 50, 50 } };
+
+  constexpr unsigned int     index_offset = 6543;
+  const ImageType::IndexType index = { { index_offset, index_offset, index_offset } };
+
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(index);
+  auto image = ImageType::CreateInitialized(region);
 
   // Set the direction for a non-oriented image
   // to better test the frequently encountered case
@@ -61,8 +69,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   const ImageType::DirectionType direction = tfm->GetMatrix();
   image->SetDirection(direction);
 
-  const ImageType::SizeType size = { { 50, 50, 50 } };
-  ImageType::PointType      origin;
+  ImageType::PointType origin;
   origin[0] = 1.51;
   origin[1] = 2.10;
   origin[2] = -300;
@@ -73,14 +80,6 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   spacing[1] = 0.7;
   spacing[2] = 1.1;
   image->SetSpacing(spacing);
-  constexpr unsigned int     index_offset = 6543;
-  const ImageType::IndexType index = { { index_offset, index_offset, index_offset } };
-
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  image->SetRegions(region);
-  image->AllocateInitialized();
 
   ImageType::RegionType  insideRegion;
   constexpr unsigned int INSIDE_SIZE = 30;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -42,8 +42,18 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   using PixelType = ImageMaskSpatialObjectType::PixelType;
   using ImageType = itk::Image<PixelType, VDimension>;
 
-  auto                 image = ImageType::New();
-  ImageType::SizeType  size = { { 5, 5, 5 } };
+  ImageType::SizeType size = { { 5, 5, 5 } };
+
+  ImageType::IndexType index;
+  index.Fill(0);
+
+  ImageType::RegionType region;
+
+  region.SetSize(size);
+  region.SetIndex(index);
+
+  auto image = ImageType::CreateInitialized(region);
+
   ImageType::PointType origin;
   origin.Fill(0);
   image->SetOrigin(origin);
@@ -52,22 +62,12 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   spacing.Fill(1);
   image->SetSpacing(spacing);
 
-  ImageType::IndexType index;
-  index.Fill(0);
-
   ImageType::DirectionType direction;
   direction.Fill(0.0);
   direction[0][1] = 1;
   direction[1][0] = 1;
   direction[2][2] = 1;
   image->SetDirection(direction);
-
-  ImageType::RegionType region;
-
-  region.SetSize(size);
-  region.SetIndex(index);
-  image->SetRegions(region);
-  image->AllocateInitialized();
 
   auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
   imageMaskSpatialObject->SetImage(image);

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -37,8 +37,6 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
 
   auto filter = FilterType::New();
 
-  auto inputImage = InputImageType::New();
-
   InputImageType::SizeType size;
   size[0] = 20;
   size[1] = 20;
@@ -47,8 +45,7 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
   InputImageType::RegionType region;
   region.SetSize(size);
 
-  inputImage->SetRegions(region);
-  inputImage->AllocateInitialized();
+  auto inputImage = InputImageType::CreateInitialized(region);
 
   InputImageType::DirectionType direction;
   direction[0][0] = 1.0;

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
@@ -43,9 +43,7 @@ itkConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 
   // Set up delta function image.
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto                  deltaFunctionImage = ImageType::New();
-  deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->AllocateInitialized();
+  auto                  deltaFunctionImage = ImageType::CreateInitialized(region);
 
   // Set the middle pixel (rounded up) to 1.
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -54,9 +54,7 @@ itkFFTConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 
   // Set up delta function image
   ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto                  deltaFunctionImage = ImageType::New();
-  deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->AllocateInitialized();
+  auto                  deltaFunctionImage = ImageType::CreateInitialized(region);
 
   // Set the middle pixel (rounded up) to 1
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
@@ -44,9 +44,7 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
   region2D.SetSize(size2D);
   region2D.SetIndex(index2D);
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   // Set pixel (4,4) with the value 1
   // and pixel (1,6) with the value 2

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -62,9 +62,7 @@ test(int testIdx)
   region2D.SetSize(size2D);
   region2D.SetIndex(index2D);
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   if (!testIdx)
   {

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
@@ -41,9 +41,7 @@ itkSignedDanielssonDistanceMapImageFilterTest11(int, char *[])
   region2D.SetSize(size2D);
   region2D.SetIndex(index2D);
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   /* Set pixel (4,4) with the value 1
    * The SignedDanielsson Distance is performed for each pixel with a value > 0

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -55,12 +55,10 @@ Test_GetCircles_should_return_empty_list_when_NumberOfCircles_is_set_to_zero()
   using ImageType = itk::Image<PixelType>;
 
   // Create an image that has at least one circle.
-  const auto                image = ImageType::New();
   const ImageType::SizeType size = { { 64, 64 } };
-  image->SetRegions(size);
-  image->AllocateInitialized();
-  const unsigned int center[] = { 16, 16 };
-  constexpr double   radius = 7.0;
+  const auto                image = ImageType::CreateInitialized(size);
+  const unsigned int        center[] = { 16, 16 };
+  constexpr double          radius = 7.0;
   CreateCircle<ImageType>(image, center, radius);
 
   using FilterType = itk::HoughTransform2DCirclesImageFilter<PixelType, PixelType, PixelType>;
@@ -256,12 +254,10 @@ Test_Center_IsInside_SpatialObject_from_GetCircles()
 {
   using PixelType = unsigned int;
   using ImageType = itk::Image<PixelType>;
-  const auto                image = ImageType::New();
   const ImageType::SizeType imageSize = { { 16, 32 } };
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
-  const double center[] = { 6.0, 9.0 };
-  const double radius = 1.0;
+  const auto                image = ImageType::CreateInitialized(imageSize);
+  const double              center[] = { 6.0, 9.0 };
+  const double              radius = 1.0;
   CreateCircle<ImageType>(image, center, radius);
 
   using FilterType = itk::HoughTransform2DCirclesImageFilter<PixelType, unsigned int, double>;
@@ -312,8 +308,6 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // Create a black image
-  auto image = ImageType::New();
-
   ImageType::RegionType region;
 
   ImageType::SizeType size;
@@ -325,8 +319,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Create 3 circles
   constexpr unsigned int circles = 3;
@@ -352,9 +345,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   }
 
   // Allocate Hough Space image (accumulator)
-  auto m_HoughSpaceImage = ImageType::New();
-  m_HoughSpaceImage->SetRegions(region);
-  m_HoughSpaceImage->AllocateInitialized();
+  auto m_HoughSpaceImage = ImageType::CreateInitialized(region);
 
   // Apply gradient filter to the input image
   using CastingFilterType = itk::CastImageFilter<ImageType, HoughImageType>;

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -47,10 +47,8 @@ Test_GetLines_should_return_empty_list_when_input_image_is_entirely_black()
   using FilterType = itk::HoughTransform2DLinesImageFilter<PixelType, double>;
 
   // Create a black input image for the filter.
-  const auto                image = ImageType::New();
   const ImageType::SizeType size = { { 32, 32 } };
-  image->SetRegions(size);
-  image->AllocateInitialized();
+  const auto                image = ImageType::CreateInitialized(size);
 
   const auto filter = FilterType::New();
   filter->SetInput(image);
@@ -73,15 +71,13 @@ Test_GetLines_should_return_empty_list_when_NumberOfLines_is_set_to_zero()
   using ImageType = itk::Image<PixelType>;
 
   // Create an image.
-  const auto image = ImageType::New();
   enum
   {
     sizeX = 32,
     sizeY = 32
   };
   const ImageType::SizeType size = { { sizeX, sizeY } };
-  image->SetRegions(size);
-  image->AllocateInitialized();
+  const auto                image = ImageType::CreateInitialized(size);
 
   // Place some line segment in the image.
   for (itk::IndexValueType x = 1; x < (sizeX - 1); ++x)
@@ -136,8 +132,6 @@ itkHoughTransform2DLinesImageTest(int, char *[])
 
 
   // Create a line image with one line
-  auto image = ImageType::New();
-
   ImageType::RegionType region;
 
   ImageType::SizeType size;
@@ -149,8 +143,7 @@ itkHoughTransform2DLinesImageTest(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Create a line
   constexpr unsigned int lines = 1;

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -46,19 +46,13 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
 
   // create a mask the size of the input file
   using MaskImageType = itk::Image<unsigned char, Dimension>;
-  auto                      mask1 = MaskImageType::New();
-  auto                      mask2 = MaskImageType::New();
   MaskImageType::RegionType region;
   MaskImageType::SizeType   size;
   MaskImageType::IndexType  index;
 
   region = input->GetOutput()->GetBufferedRegion();
-  mask1->SetRegions(region);
-  mask1->AllocateInitialized();
-
-  mask2->SetRegions(region);
-  mask2->AllocateInitialized();
-
+  auto mask1 = MaskImageType::CreateInitialized(region);
+  auto mask2 = MaskImageType::CreateInitialized(region);
 
   size = region.GetSize();
   index = region.GetIndex();

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -59,8 +59,6 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   using mySizeType = itk::Size<myDimension>;
   using myRegionType = itk::ImageRegion<myDimension>;
 
-  auto inputImage = myImageType::New();
-
   mySizeType size;
   size.Fill(8);
 
@@ -71,8 +69,7 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  inputImage->SetRegions(region);
-  inputImage->AllocateInitialized();
+  auto inputImage = myImageType::CreateInitialized(region);
 
   // Set the metadata for the image
   myImageType::PointType     origin;

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -165,13 +165,11 @@ itkSliceBySliceImageFilterTest(int argc, char * argv[])
   // spacing. We are setting the input image to have a non-zero
   // starting index.
   //
-  auto image = ImageType::New();
-  {
+  auto image = ImageType::CreateInitialized([&reader] {
     ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
     region.SetIndex(0, 10);
-    image->SetRegions(region);
-    image->AllocateInitialized();
-  }
+    return region;
+  }());
 
   ImageType::SpacingType spacing;
   ImageType::PointType   origin;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
@@ -33,7 +33,6 @@ itkImageFileWriterTest2(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageNDType>;
   using ReaderType = itk::ImageFileReader<ImageNDType>;
 
-  auto                    image = ImageNDType::New();
   ImageNDType::RegionType region;
   ImageNDType::IndexType  index;
   ImageNDType::SizeType   size;
@@ -47,8 +46,7 @@ itkImageFileWriterTest2(int argc, char * argv[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageNDType::CreateInitialized(region);
 
   image->TransformIndexToPhysicalPoint(index, originalPoint);
   std::cout << "Original Starting Index: " << index << std::endl;

--- a/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
@@ -43,14 +43,7 @@ struct ITKWriteImageFunctionTest : public ::testing::Test
   ImageType::Pointer
   MakeImage()
   {
-    auto image = ImageType::New();
-
-    RegionType region(SizeType{ { 3, 2 } });
-
-    image->SetRegions(region);
-
-    image->AllocateInitialized();
-    return image;
+    return ImageType::CreateInitialized(SizeType{ 3, 2 });
   }
 };
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -36,8 +36,6 @@ itkJPEGImageIOTest2(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-
   ImageType::RegionType region;
   ImageType::IndexType  start;
   ImageType::SizeType   size;
@@ -51,8 +49,7 @@ itkJPEGImageIOTest2(int argc, char * argv[])
   region.SetSize(size);
   region.SetIndex(start);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::SpacingType spacing;
 

--- a/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
@@ -53,9 +53,7 @@ itkNiftiLargeImageRegionReadTest(int argc, char * argv[])
   region.SetSize(size);
 
   {
-    auto image = ImageType::New();
-    image->SetRegions(region);
-    image->AllocateInitialized();
+    auto image = ImageType::CreateInitialized(region);
     itk::WriteImage(image, fname);
   }
 

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -43,9 +43,7 @@ itkNiftiWriteCoerceOrthogonalDirectionTest(int argc, char * argv[])
   ImageType::RegionType region;
   region.SetSize(imageSize);
   region.SetIndex(startIndex);
-  auto image1 = ImageType::New();
-  image1->SetRegions(region);
-  image1->AllocateInitialized();
+  auto image1 = ImageType::CreateInitialized(region);
 
   ImageType::DirectionType mat1;
   mat1.SetIdentity();

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
@@ -36,8 +36,6 @@ itkTIFFImageIOTest2(int argc, char * argv[])
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-
   ImageType::RegionType region;
   ImageType::IndexType  start;
   ImageType::SizeType   size;
@@ -51,8 +49,7 @@ itkTIFFImageIOTest2(int argc, char * argv[])
   region.SetSize(size);
   region.SetIndex(start);
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::SpacingType spacing;
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -79,9 +79,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * 
   }
   std::cout << std::endl;
 
-  auto visitedImage = ImageType::New();
-  visitedImage->SetRegions(region);
-  visitedImage->AllocateInitialized();
+  auto visitedImage = ImageType::CreateInitialized(region);
 
   for (; !shapedFloodIt.IsAtEnd(); ++shapedFloodIt)
   {

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
@@ -49,9 +49,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2(int, char *[])
     region.SetIndex(0, 0);
     region.SetIndex(1, 0);
 
-    auto inputImage = ImageType::New();
-    inputImage->SetRegions(region);
-    inputImage->AllocateInitialized();
+    auto inputImage = ImageType::CreateInitialized(region);
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
@@ -51,9 +51,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3(int, char *[])
     region.SetIndex(1, 0);
     region.SetIndex(2, 0);
 
-    auto inputImage = ImageType::New();
-    inputImage->SetRegions(region);
-    inputImage->AllocateInitialized();
+    auto inputImage = ImageType::CreateInitialized(region);
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -48,7 +48,6 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   using SamplerType = itk::Statistics::GaussianRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
   using WriterType = itk::ImageFileWriter<FloatImage>;
 
-  auto     inImage = FloatImage::New();
   SizeType sz;
   sz.Fill(35);
   IndexType idx;
@@ -57,8 +56,7 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   region.SetSize(sz);
   region.SetIndex(idx);
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = FloatImage::CreateInitialized(region);
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -63,7 +63,6 @@ CreateImage()
 static MaskImageType::Pointer
 CreateMaskImage()
 {
-  auto                     image = MaskImageType::New();
   MaskImageType::IndexType start;
   MaskImageType::SizeType  size;
 
@@ -71,8 +70,7 @@ CreateMaskImage()
   size.Fill(10);
 
   MaskImageType::RegionType region(start, size);
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto                      image = MaskImageType::CreateInitialized(region);
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
@@ -100,8 +98,6 @@ CreateMaskImage()
 static MaskImageType::Pointer
 CreateLargerMaskImage()
 {
-  auto image = MaskImageType::New();
-
   MaskImageType::IndexType start;
   MaskImageType::SizeType  size;
 
@@ -112,9 +108,7 @@ CreateLargerMaskImage()
   size[1] = 17;
 
   MaskImageType::RegionType region(start, size);
-  image->SetRegions(region);
-  image->AllocateInitialized();
-  return image;
+  return MaskImageType::CreateInitialized(region);
 }
 
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -59,9 +59,7 @@ itkImageToListSampleFilterTest2(int, char *[])
     ++it;
   }
 
-  auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(region);
-  maskImage->AllocateInitialized();
+  auto                     maskImage = MaskImageType::CreateInitialized(region);
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -67,9 +67,7 @@ itkImageToListSampleFilterTest3(int, char *[])
     ++it;
   }
 
-  auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(region);
-  maskImage->AllocateInitialized();
+  auto maskImage = MaskImageType::CreateInitialized(region);
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -74,7 +74,6 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   using SamplerType = itk::Statistics::SpatialNeighborSubsampler<AdaptorType, RegionType>;
   using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
 
-  auto     inImage = ImageType::New();
   SizeType sz;
   sz.Fill(25);
   IndexType idx;
@@ -83,8 +82,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   region.SetSize(sz);
   region.SetIndex(idx);
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = ImageType::CreateInitialized(region);
 
   SizeType szConstraint;
   szConstraint[0] = 23;

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -49,7 +49,6 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   using SamplerType = itk::Statistics::UniformRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
   using WriterType = itk::ImageFileWriter<FloatImage>;
 
-  auto                          inImage = FloatImage::New();
   typename SizeType::value_type regionSizeVal = 35;
   SizeType                      sz;
   sz.Fill(regionSizeVal);
@@ -59,8 +58,7 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   region.SetSize(sz);
   region.SetIndex(idx);
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = FloatImage::CreateInitialized(region);
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -65,10 +65,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   fixedImageSize.Fill(128);
 
   // Create fixed image
-  auto fixedImage = FixedImageType::New();
-  fixedImage->SetRegions(fixedImageSize);
-  fixedImage->AllocateInitialized();
-  fixedImage->Update();
+  auto fixedImage = FixedImageType::CreateInitialized(fixedImageSize);
 
   FixedImageIteratorType fixedIt(fixedImage, fixedImage->GetBufferedRegion());
   for (fixedIt.GoToBegin(); !fixedIt.IsAtEnd(); ++fixedIt)
@@ -84,9 +81,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   movingImageSize.Fill(128);
 
   // Create moving image
-  auto movingImage = MovingImageType::New();
-  movingImage->SetRegions(movingImageSize);
-  movingImage->AllocateInitialized();
+  auto movingImage = MovingImageType::CreateInitialized(movingImageSize);
   movingImage->Update();
 
   MovingImageIteratorType movingIt(movingImage, movingImage->GetBufferedRegion());
@@ -160,14 +155,8 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   //
   metric->ComputeGradient();
 
-  auto xGradImage = GradientImageType::New();
-  xGradImage->SetRegions(movingImageSize);
-  xGradImage->AllocateInitialized();
-  xGradImage->Update();
-
-  auto yGradImage = GradientImageType::New();
-  yGradImage->SetRegions(movingImageSize);
-  yGradImage->AllocateInitialized();
+  auto xGradImage = GradientImageType::CreateInitialized(movingImageSize);
+  auto yGradImage = GradientImageType::CreateInitialized(movingImageSize);
   yGradImage->Update();
 
   GradientImageIteratorType xGradIt(xGradImage, xGradImage->GetBufferedRegion());

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -253,12 +253,10 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
 
   /* Now remap the labels - background first followed by brain */
   using LabelImageType = KMeansFilterType::OutputImageType;
-  auto kmeansLabelImage = LabelImageType::New();
-  kmeansLabelImage->SetRegions(maskReader->GetOutput()->GetLargestPossibleRegion());
+  auto kmeansLabelImage = LabelImageType::CreateInitialized(maskReader->GetOutput()->GetLargestPossibleRegion());
   kmeansLabelImage->SetSpacing(maskReader->GetOutput()->GetSpacing());
   kmeansLabelImage->SetDirection(maskReader->GetOutput()->GetDirection());
   kmeansLabelImage->SetOrigin(maskReader->GetOutput()->GetOrigin());
-  kmeansLabelImage->AllocateInitialized();
 
   using LabelMapStatisticsFilterType = itk::LabelStatisticsImageFilter<LabelImageType, LabelImageType>;
   auto statisticsNonBrainFilter = LabelMapStatisticsFilterType::New();

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -38,9 +38,7 @@ CreateTestImageA()
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-  image->SetRegions(ImageType::RegionType(itk::MakeSize(2u, 2u, 2u)));
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(itk::MakeSize(2u, 2u, 2u));
 
   for (size_t i = 0; i < 8; ++i)
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -137,11 +137,9 @@ TEST(RelabelComponentImageFilter, big_zero)
   using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto                           image = ImageType::New();
   typename ImageType::RegionType region;
   region.SetSize({ { 512, 512, 512 } });
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   auto filter = itk::RelabelComponentImageFilter<ImageType, ImageType>::New();
   filter->SetInput(image);

--- a/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
@@ -42,8 +42,6 @@ itkBinaryMaskToNarrowBandPointSetFilterTest(int argc, char * argv[])
   //
   //  Initialize an image with a white square in a black background
   //
-  auto binaryMask = BinaryMaskImageType::New();
-
   BinaryMaskImageType::SizeType   size;
   BinaryMaskImageType::IndexType  index;
   BinaryMaskImageType::RegionType region;
@@ -57,8 +55,7 @@ itkBinaryMaskToNarrowBandPointSetFilterTest(int argc, char * argv[])
   region.SetIndex(index);
   region.SetSize(size);
 
-  binaryMask->SetRegions(region);
-  binaryMask->AllocateInitialized();
+  auto binaryMask = BinaryMaskImageType::CreateInitialized(region);
 
   size[0] = 60;
   size[1] = 60;

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
@@ -51,9 +51,7 @@ itkWatershedImageFilterTest(int, char *[])
   image2D->SetRegions(region);
   image2D->Allocate();
 
-  auto longimage2D = LongImageType2D::New();
-  longimage2D->SetRegions(region);
-  longimage2D->AllocateInitialized();
+  auto longimage2D = LongImageType2D::CreateInitialized(region);
 
   itk::ImageRegionIterator<ImageType2D> it2D(image2D, image2D->GetRequestedRegion());
 


### PR DESCRIPTION
`itk::Image::CreateInitialized` aims to simplify creating an image with an allocated buffer of zero-initialized pixels.

Replaced more than sixty cases of code like:

```cpp
    auto image = ImageType::New();
    image->SetRegions(region);
    image->AllocateInitialized();
```
with the following single statement:

```cpp
    auto image = ImageType::CreateInitialized(region);
```

in ITK test files (`"itk*Test*.cxx"`).
