### PR TITLE
COMP: Add GDCM system version check for SetSecondaryCaptureImagePlaneModule

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -280,8 +280,12 @@ GDCMImageIO::Read(void * pointer)
   inputFileStream.close();
 
   itkAssertInDebugAndIgnoreInReleaseMacro(gdcm::ImageHelper::GetForceRescaleInterceptSlope());
+// Only available in newer versions
+#if (!defined(ITK_USE_SYSTEM_GDCM) || \
+     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || GDCM_MAJOR_VERSION > 3))
   // Secondary capture image orientation patient and image position patient support
   itkAssertInDebugAndIgnoreInReleaseMacro(gdcm::ImageHelper::GetSecondaryCaptureImagePlaneModule());
+#endif
   gdcm::ImageReader reader;
   reader.SetFileName(m_FileName.c_str());
   if (!reader.Read())
@@ -450,8 +454,12 @@ GDCMImageIO::InternalReadImageInformation()
 
   // In general this should be relatively safe to assume
   gdcm::ImageHelper::SetForceRescaleInterceptSlope(true);
+// Only available in newer versions
+#if (!defined(ITK_USE_SYSTEM_GDCM) || \
+     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || GDCM_MAJOR_VERSION > 3))
   // Secondary capture image orientation patient and image position patient support
   gdcm::ImageHelper::SetSecondaryCaptureImagePlaneModule(true);
+#endif
 
   gdcm::ImageReader reader;
   reader.SetFileName(m_FileName.c_str());


### PR DESCRIPTION
This has not been released in GDCM, yet. Avoid build errors for a system
GDCM. There will be a difference in behavior, which will be flagged with
failing tests.

Co-authored-by: Mihail Isakov <mihail.isakov@gmail.com>
