### PR TITLE
BUG: Provide an API for SpatialObjectProperties that works with python

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -55,6 +55,12 @@ public:
     m_Color = color;
   }
 
+  ColorType
+  Color()
+  {
+    return m_Color;
+  }
+
   ColorType &
   GetColor()
   {
@@ -74,21 +80,41 @@ public:
   SetRed(double r);
   double
   GetRed() const;
+  double
+  Red() const
+  {
+    return GetRed();
+  }
 
   void
   SetGreen(double g);
   double
   GetGreen() const;
+  double
+  Green() const
+  {
+    return GetGreen();
+  }
 
   void
   SetBlue(double b);
   double
   GetBlue() const;
+  double
+  Blue() const
+  {
+    return GetBlue();
+  }
 
   void
   SetAlpha(double a);
   double
   GetAlpha() const;
+  double
+  Alpha() const
+  {
+    return GetAlpha();
+  }
 
   void
   SetName(const std::string & name)
@@ -108,24 +134,59 @@ public:
     return m_Name;
   }
 
+  std::string
+  Name() const
+  {
+    return m_Name;
+  }
+
   void
   SetTagScalarValue(const std::string & tag, double value);
+
   void
   SetTagStringValue(const std::string & tag, const std::string & value);
 
   bool
   GetTagScalarValue(const std::string & tag, double & value) const;
+  double
+  TagScalarValue(const std::string & tag) const
+  {
+    double value = 0;
+    this->GetTagScalarValue(tag, value);
+    return value;
+  }
+
   bool
   GetTagStringValue(const std::string & tag, std::string & value) const;
+  std::string
+  TagStringValue(const std::string & tag) const
+  {
+    std::string value = "";
+    this->GetTagStringValue(tag, value);
+    return value;
+  }
 
   std::map<std::string, double> &
   GetTagScalarDictionary();
   const std::map<std::string, double> &
   GetTagScalarDictionary() const;
+
+  std::map<std::string, double>
+  ScalarDictionary() const
+  {
+    return m_ScalarDictionary;
+  }
+
   std::map<std::string, std::string> &
   GetTagStringDictionary();
   const std::map<std::string, std::string> &
   GetTagStringDictionary() const;
+
+  std::map<std::string, std::string>
+  StringDictionary() const
+  {
+    return m_StringDictionary;
+  }
 
   void
   SetTagScalarDictionary(const std::map<std::string, double> & dict);


### PR DESCRIPTION
The dictionary used by SpatialObjectProperties is queried using a function that returns the dictionary value in a variable that is passed by reference: https://itk.org/Doxygen/html/classitk_1_1SpatialObjectProperty.html#aff2b1c659a8e77bdb6afeef0bab037fb

    bool itk::SpatialObjectProperty::GetTagScalarValue ( const std::string & tag, double & value ) const

This function is not correctly wrapped by SWIG, and cannot be used from within python.

Here is a snippet of code that demonstrates the issue:

    In [1]: import itk
    In [2]: so = itk.TubeSpatialObject[3].New()
    In [3]: so.GetProperty().SetTagScalarValue("foo",1) In [4]: ret = 0.0
    In [5]: so.GetProperty().GetTagScalarValue("foo",ret) 
    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call last)
    Cell In[5], line 1
    ----> 1 so.GetProperty().GetTagScalarValue("foo",ret)
    TypeError: in method 'itkSpatialObjectProperty_GetTagScalarValue', argument 3 of type 'double &'

This commit adds new functions that can be correctly wrapped.  Old functions are unmodified to preserve backward compatibility.
