### PR TITLE
STYLE: Revert C++14 workaround when using the constexpr `SupportSize`

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -123,11 +123,7 @@ private:
   /** Table mapping linear offset to indices. */
   const TableType m_OffsetToIndexTable{ [] {
     TableType     table;
-    // Note: Copied the constexpr value `SupportSize` to a local variable, to prevent a GCC
-    // (Ubuntu 7.5.0-3ubuntu1~18.04) link error, "undefined reference to `SupportSize`", and Clang
-    // (Mac10.13-AppleClang-dbg-x86_64-static) "Undefined symbols for architecture x86_64".
-    const auto    supportSize = SupportSize;
-    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(supportSize).cbegin(), NumberOfWeights, table.begin());
+    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(SupportSize).cbegin(), NumberOfWeights, table.begin());
     return table;
   }() };
 };

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -500,8 +500,7 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Tran
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
   // For each dimension, correlate coefficient with weights
-  constexpr SizeType supportSize = WeightsFunctionType::SupportSize;
-  const RegionType   supportRegion(supportIndex, supportSize);
+  const RegionType supportRegion(supportIndex, WeightsFunctionType::SupportSize);
 
   outputPoint.Fill(ScalarType{});
 


### PR DESCRIPTION
C++17 allows using a static constexpr member variable like `SupportSize`, without being "redeclared". The workaround of copying `SupportSize` into a local variable is no longer necessary.

Reverts pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2742 commit 27e4815bb816c2cebe3abd0b9aca85afda8101c6
"COMP: Copy BSplineInterpolationWeightFunction::SupportSize within lambda"