### PR TITLE
ENH: Update Montage remote module

### DIFF
--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG 53f0970fe3ed9a257c8e7f1e6b1ab547840f8fa8
+  GIT_TAG 19591429076a87c61ab369ba63fc0961ddaf4890
   )


### PR DESCRIPTION
**git shortlog v0.8.1..v0.8.2**

Dženan Zukić (15):
      ENH: Require less components to be built for examples
      COMP: Fix compile error of MontageImageCompareCommand
      COMP: Fix discarding return value warning introduced by ITK 5.4
      STYLE: Replace SFINAE selection by constexpr if
      BUG: erase confidence together with the translation candidate
      COMP: Update minimum CMake version from 3.10.2 to 3.16.3
      BUG: Avoid appearance of NaN values
      STYLE: Use trailing return type instead of typename + dependent type
      COMP: Fix HyperSphereImageSource class name in type macro (was Image)
      ENH: Update CI action
      ENH: Compute and expose per-tile registration reliability
      ENH: Update CI for ITK 5.4 RC 04
      ENH: Switch to SciKit build core
      ENH: Use updated remote module action which includes notebook fix
      Merge pull request #225 from dzenanz/master

Jon Haitz Legarreta Gorroño (1):
      Merge pull request #224 from dzenanz/master

Tom Birdsong (5):
      BUG: Update `TileMergeImageFilter` signature in example script
      Merge pull request #215 from InsightSoftwareConsortium/example-patch
      ENH: Port montage notebook example
      ENH: Add CI notebook testing
      Merge pull request #217 from InsightSoftwareConsortium/notebook-tests


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
