### PR TITLE
COMP:  Ubuntu2404 fixes issue 4607

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -152,7 +152,6 @@ StatementMacros:
   - ITK_GCC_SUPPRESS_Wformat_nonliteral
   - CLANG_PRAGMA_PUSH
   - CLANG_PRAGMA_POP
-  - CLANG_SUPPRESS_Wcpp14_extensions
   - INTEL_PRAGMA_WARN_PUSH
   - INTEL_PRAGMA_WARN_POP
   - INTEL_SUPPRESS_warning_1292

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -119,11 +119,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(m_OutputImageRegion);
 
   // Set the output spacing and origin
-  const ImageBase<InputImageDimension> * phyData;
-
-  phyData = dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
-
-  if (phyData)
+  if (this->GetInput())
   {
     // Copy what we can from the image from spacing and origin of the input
     // This logic needs to be augmented with logic that select which

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -62,7 +62,6 @@ ExtractImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputImageReg
                 "InputImageDimension must be greater than OutputImageDimension");
   m_ExtractionRegion = extractRegion;
 
-  unsigned int        nonzeroSizeCount = 0;
   InputImageSizeType  inputSize = extractRegion.GetSize();
   OutputImageSizeType outputSize;
   outputSize.Fill(0);
@@ -73,12 +72,16 @@ ExtractImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputImageReg
    * check to see if the number of non-zero entries in the extraction region
    * matches the number of dimensions in the output image.
    */
+  unsigned int nonzeroSizeCount = 0;
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     if (inputSize[i])
     {
-      outputSize[nonzeroSizeCount] = inputSize[i];
-      outputIndex[nonzeroSizeCount] = extractRegion.GetIndex()[i];
+      if (nonzeroSizeCount < OutputImageDimension)
+      {
+        outputSize[nonzeroSizeCount] = inputSize[i];
+        outputIndex[nonzeroSizeCount] = extractRegion.GetIndex()[i];
+      }
       ++nonzeroSizeCount;
     }
   }

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -120,15 +120,16 @@ namespace itk
 #if defined(__clang__) && defined(__has_warning)
 #  define CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
 #  define CLANG_PRAGMA_POP ITK_PRAGMA(clang diagnostic pop)
-#  if __has_warning("-Wc++14-extensions")
-#    define CLANG_SUPPRESS_Wcpp14_extensions ITK_PRAGMA(clang diagnostic ignored "-Wc++14-extensions")
-#  else
-#    define CLANG_SUPPRESS_Wcpp14_extensions
-#  endif
 #else
 #  define CLANG_PRAGMA_PUSH
 #  define CLANG_PRAGMA_POP
-#  define CLANG_SUPPRESS_Wcpp14_extensions
+#endif
+
+#if !defined(ITK_LEGACY_REMOVE)
+// Issue warning if deprecated preprocessor flag is used.
+#  define CLANG_SUPPRESS_Wcpp14_extensions                                                                \
+    [[deprecated("Remove deprecated CLANG_SUPPRESS_Wcpp14_extensions c++14 warning suppression")]] void * \
+      CLANG_SUPPRESS_Wcpp14_extensions = nullptr;
 #endif
 
 // Intel compiler convenience macros

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -238,8 +238,6 @@ ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 INTEL_PRAGMA_WARN_PUSH
 INTEL_SUPPRESS_warning_1292
-CLANG_PRAGMA_PUSH
-CLANG_SUPPRESS_Wcpp14_extensions
   // clang-format on
 #  ifdef ITK_LEGACY_SILENT
   struct ThreadInfoStruct
@@ -247,7 +245,6 @@ CLANG_SUPPRESS_Wcpp14_extensions
   struct [[deprecated("Use WorkUnitInfo, ThreadInfoStruct is deprecated since ITK 5.0")]] ThreadInfoStruct
 #  endif
     // clang-format off
-CLANG_PRAGMA_POP
 INTEL_PRAGMA_WARN_POP
   // clang-format on
   {

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -136,7 +136,7 @@ public:
   SizeValueType
   GetRadius(DimensionValueType n) const
   {
-    return m_Radius[n];
+    return m_Radius.at(n);
   }
 
   /** Returns the size (total length) of the neighborhood along
@@ -144,7 +144,7 @@ public:
   SizeValueType
   GetSize(DimensionValueType n) const
   {
-    return m_Size[n];
+    return m_Size.at(n);
   }
 
   /** Returns the size (total length of sides) of the neighborhood. */

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -93,6 +93,11 @@ public:
   void
   SetDirection(const unsigned long direction)
   {
+    if (direction >= VDimension)
+    {
+      itkExceptionMacro(<< " Can not set direction " << direction << " greater than dimensionality of neighborhood "
+                        << VDimension);
+    }
     m_Direction = direction;
   }
 

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -366,11 +366,14 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdReverseCopy)
   itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   const unsigned int numberOfNeighborhoodPixels = 3;
+  ASSERT_EQ(numberOfNeighborhoodPixels, range.size());
 
   const std::vector<PixelType> stdVector(range.begin(), range.end());
-  std::vector<PixelType>       reversedStdVector1(numberOfNeighborhoodPixels);
-  std::vector<PixelType>       reversedStdVector2(numberOfNeighborhoodPixels);
-  std::vector<PixelType>       reversedStdVector3(numberOfNeighborhoodPixels);
+  ASSERT_EQ(stdVector.size(), numberOfNeighborhoodPixels);
+
+  std::vector<PixelType> reversedStdVector1(numberOfNeighborhoodPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfNeighborhoodPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfNeighborhoodPixels);
 
   // Checks bidirectionality of the ShapedImageNeighborhoodRange iterators!
   std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
@@ -911,12 +914,15 @@ TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
     itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
-  const unsigned int numberOfNeighborhoodPixels = 3;
+  constexpr unsigned int numberOfNeighborhoodPixels = 3;
+  ASSERT_EQ(numberOfNeighborhoodPixels, range.size());
 
   const std::vector<PixelType> stdVector(range.begin(), range.end());
-  std::vector<PixelType>       reversedStdVector1(numberOfNeighborhoodPixels);
-  std::vector<PixelType>       reversedStdVector2(numberOfNeighborhoodPixels);
-  std::vector<PixelType>       reversedStdVector3(numberOfNeighborhoodPixels);
+  ASSERT_EQ(stdVector.size(), numberOfNeighborhoodPixels);
+
+  std::vector<PixelType> reversedStdVector1(numberOfNeighborhoodPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfNeighborhoodPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfNeighborhoodPixels);
 
   std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
 

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -350,7 +350,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdVectorConstructor)
 // second argument of std::reverse (which requires bidirectional iterators).
 TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdReverseCopy)
 {
-  using PixelType = unsigned char;
+  using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType>;
   enum
   {
@@ -900,7 +900,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsSubscript)
 
 TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
 {
-  using PixelType = unsigned char;
+  using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType>;
   using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
   enum

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -458,11 +458,13 @@ TEST(ShapedImageNeighborhoodRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
     itk::GenerateRectangularImageNeighborhoodOffsets(radius);
-  RangeType range{ *image, location, offsets };
+  RangeType           range{ *image, location, offsets };
+  constexpr PixelType reference_value = 42;
 
   for (const PixelType pixel : range)
   {
-    EXPECT_NE(pixel, 42);
+    // Initially not set to reference value
+    EXPECT_NE(pixel, reference_value);
   }
 
   // Note: instead of 'iterator::reference', you may also type 'auto&&', but
@@ -474,12 +476,12 @@ TEST(ShapedImageNeighborhoodRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
   // https://bugs.llvm.org/show_bug.cgi?id=37392
   for (RangeType::iterator::reference pixel : range)
   {
-    pixel = 42;
+    pixel = reference_value;
   }
 
   for (const PixelType pixel : range)
   {
-    EXPECT_EQ(pixel, 42);
+    EXPECT_EQ(pixel, reference_value);
   }
 }
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
@@ -42,7 +42,7 @@ itkQuadEdgeMeshEulerOperatorSplitEdgeTest(int, char *[])
   auto splitEdge = SplitEdge::New();
   std::cout << "     "
             << "Test No Mesh Input";
-  if (splitEdge->Evaluate((QEType *)1))
+  if (splitEdge->Evaluate((QEType *)0))
   {
     std::cout << "FAILED." << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -157,7 +157,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Befor
   srad.Fill(typename RadiusType::SizeValueType{});
   for (unsigned int i = 0, j = 0; i < ImageDimension; ++i)
   {
-    if (j != static_cast<unsigned int>(m_SliceDimension))
+    if (j != static_cast<unsigned int>(m_SliceDimension) && (j < (ImageDimension - 1)))
     {
       srad[j] = m_ContourThickness[i];
       ++j;

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -56,7 +56,7 @@ public:
   inline TOutput
   operator()(const TInput & x) const
   {
-    TOutput eigenValues;
+    TOutput eigenValues{};
 
     m_Calculator.ComputeEigenValues(x, eigenValues);
     return eigenValues;


### PR DESCRIPTION
##

Fixes for 100's of warnings presented by the gcc 13.2 compiler under the upcoming Ubuntu 24.04  LTS release.

This does not fix all of the issues, but is for comparison against the master branch build 

https://open.cdash.org/builds/9565813

## Additional information
Related to issue #4607 

These new compiler warnings are due to increased default security settings in Ubuntu 24.04.

https://ubuntu.com/blog/whats-new-in-security-for-ubuntu-24-04-lts#:~:text=Overall%2C%20the%20vast%20range%20of,most%20secure%20release%20to%20date.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
