### PR TITLE
COMP: Update GDCM system version check for SetSecondaryCaptureImagePlaneModule

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -281,8 +281,9 @@ GDCMImageIO::Read(void * pointer)
 
   itkAssertInDebugAndIgnoreInReleaseMacro(gdcm::ImageHelper::GetForceRescaleInterceptSlope());
 // Only available in newer versions
-#if (!defined(ITK_USE_SYSTEM_GDCM) || \
-     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || GDCM_MAJOR_VERSION > 3))
+#if (!defined(ITK_USE_SYSTEM_GDCM) ||                                                    \
+     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || \
+      (GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION > 0) || GDCM_MAJOR_VERSION > 3))
   // Secondary capture image orientation patient and image position patient support
   itkAssertInDebugAndIgnoreInReleaseMacro(gdcm::ImageHelper::GetSecondaryCaptureImagePlaneModule());
 #endif
@@ -455,8 +456,9 @@ GDCMImageIO::InternalReadImageInformation()
   // In general this should be relatively safe to assume
   gdcm::ImageHelper::SetForceRescaleInterceptSlope(true);
 // Only available in newer versions
-#if (!defined(ITK_USE_SYSTEM_GDCM) || \
-     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || GDCM_MAJOR_VERSION > 3))
+#if (!defined(ITK_USE_SYSTEM_GDCM) ||                                                    \
+     ((GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION > 23) || \
+      (GDCM_MAJOR_VERSION == 3 && GDCM_MINOR_VERSION > 0) || GDCM_MAJOR_VERSION > 3))
   // Secondary capture image orientation patient and image position patient support
   gdcm::ImageHelper::SetSecondaryCaptureImagePlaneModule(true);
 #endif


### PR DESCRIPTION
Follow up https://github.com/InsightSoftwareConsortium/ITK/pull/4601
GDCM master branch is currently at version **3.1.0**.
Updated check to include versions 3.1+.

P.S.
Maybe GDCM will change its approach in the future and not insist on `SecondaryCaptureImagePlaneModule=true` for _reading_ at all.  ImagePlaneModule for SC is a part of the standard now. But it is still there. The variable could be useful for _writing_ in the future.

