### PR TITLE
BUG: Fix SpatialObjectProperties.GetTag*Value() to return values in python

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -115,8 +115,24 @@ public:
 
   bool
   GetTagScalarValue(const std::string & tag, double & value) const;
+  double
+  GetTagScalarValue(const std::string & tag) const
+  {
+    double value = 0;
+    this->GetTagScalarValue(tag, value);
+    return value;
+  }
+
   bool
   GetTagStringValue(const std::string & tag, std::string & value) const;
+  std::string
+  GetTagStringValue(const std::string & tag) const
+  {
+    std::string value = "";
+    this->GetTagStringValue(tag, value);
+    return value;
+  }
+
 
   std::map<std::string, double> &
   GetTagScalarDictionary();


### PR DESCRIPTION
The dictionary used by SpatialObjectProperties is queried using functions that return the dictionary value in a variable that is passed by reference: https://itk.org/Doxygen/html/classitk_1_1SpatialObjectProperty.html#aff2b1c659a8e77bdb6afeef0bab037fb

    bool itk::SpatialObjectProperty::GetTagScalarValue ( const std::string & tag, double & value ) const

This function is not correctly wrapped by SWIG, and cannot be used from within python.

Here is a snippet of code that demonstrates the issue:

    In [1]: import itk
    In [2]: so = itk.TubeSpatialObject[3].New()
    In [3]: so.GetProperty().SetTagScalarValue("foo",1) In [4]: ret = 0.0
    In [5]: so.GetProperty().GetTagScalarValue("foo",ret)
    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call last)
    Cell In[5], line 1
    ----> 1 so.GetProperty().GetTagScalarValue("foo",ret)
    TypeError: in method 'itkSpatialObjectProperty_GetTagScalarValue', argument 3 of type 'double &'

This commit simply creates two new version of the problematic functions, that differ only by arguments passed and returned values.  The new functions are also more consistent with ITK's standard Get function format:

    double itk::SpatialObjectProperty::GetTagScalarValue(const std::string & tag) const

    std::string itk::SpatialObjectProperty::GetTagStringValue(const std::string & tag) const
