### PR TITLE
ENH: Optionally limit an ImageMask to a specific pixel value

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -33,9 +33,10 @@ namespace itk
  * Image Registration Metrics.
  *
  * \note The bounding box of an image mask is defined in such a way that
- * any point whose nearest pixel has a non-zero value is inside the
- * bounding box. When all the pixels of an image are zero, the bounding box
- * of the image mask is empty, and its bounds are all zero.
+ * any point whose nearest pixel has a non-zero value (or matches the
+ * specified mask value) is inside the bounding box. When all the pixels of
+ * an image are zero, the bounding box of the image mask is empty, and
+ * its bounds are all zero.
  *
  * \sa ImageSpatialObject SpatialObject CompositeSpatialObject
  * \ingroup ITKSpatialObjects
@@ -74,13 +75,25 @@ public:
 
   /** Test whether a point is inside the object.
    *
-   * A point is inside the image mask when the value of its nearest pixel is non-zero.
+   * A point is inside the image mask when the value of its nearest pixel is
+   * non-zero or matches the Mask_Value value.
    *
    * For computational speed purposes, it is faster if the method does not  check the name of the class and the
    * current depth.
    */
   bool
   IsInsideInObjectSpace(const PointType & point) const override;
+
+  /** Specify the value in the mask image that defines the object.
+   * You must also call SetUseMaskValue(true) to enable the use
+   * of the mask value, otherwise the value is ignored and any
+   * non-zero value in the mask is used to define the object. */
+  itkSetMacro(MaskValue, PixelType);
+  itkGetConstReferenceMacro(MaskValue, PixelType);
+
+  itkBooleanMacro(UseMaskValue);
+  itkSetMacro(UseMaskValue, bool);
+  itkGetConstReferenceMacro(UseMaskValue, bool);
 
   /* Avoid hiding the overload that supports depth and name arguments */
   using Superclass::IsInsideInObjectSpace;
@@ -118,6 +131,10 @@ protected:
 
   typename LightObject::Pointer
   InternalClone() const override;
+
+private:
+  bool      m_UseMaskValue{};
+  PixelType m_MaskValue{};
 };
 } // end of namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -18,6 +18,7 @@
 #ifndef itkImageMaskSpatialObject_h
 #define itkImageMaskSpatialObject_h
 
+#include "itkNumericTraits.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageSliceConstIteratorWithIndex.h"
 
@@ -133,8 +134,8 @@ protected:
   InternalClone() const override;
 
 private:
-  bool      m_UseMaskValue{};
-  PixelType m_MaskValue{};
+  bool      m_UseMaskValue{ false };
+  PixelType m_MaskValue{ NumericTraits<PixelType>::OneValue() };
 };
 } // end of namespace itk
 

--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ITKSpatialObjectsTests
     itkImageMaskSpatialObjectTest2.cxx
     itkImageMaskSpatialObjectTest3.cxx
     itkImageMaskSpatialObjectTest4.cxx
+    itkImageMaskSpatialObjectTest5.cxx
     itkBlobSpatialObjectTest.cxx
     itkContourSpatialObjectTest.cxx
     itkSurfaceSpatialObjectTest.cxx
@@ -91,6 +92,12 @@ itk_add_test(
   COMMAND
   ITKSpatialObjectsTestDriver
   itkImageMaskSpatialObjectTest4)
+itk_add_test(
+  NAME
+  itkImageMaskSpatialObjectTest5
+  COMMAND
+  ITKSpatialObjectsTestDriver
+  itkImageMaskSpatialObjectTest5)
 itk_add_test(
   NAME
   itkBlobSpatialObjectTest

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
@@ -1,0 +1,143 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+// Disable warning for long symbol names in this file only
+
+/*
+ * This is a test file for the itkImageMaskSpatialObject class.
+ * The supported pixel types does not include itkRGBPixel, itkRGBAPixel, etc...
+ * So far it only allows to manage images of simple types like unsigned short,
+ * unsigned int, or itk::Vector<...>.
+ */
+
+
+#include "itkImageRegionIterator.h"
+
+#include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
+
+
+int
+itkImageMaskSpatialObjectTest5(int, char *[])
+{
+  constexpr unsigned int VDimension = 3;
+
+  using ImageMaskSpatialObject = itk::ImageMaskSpatialObject<VDimension>;
+  using PixelType = ImageMaskSpatialObject::PixelType;
+  using ImageType = ImageMaskSpatialObject::ImageType;
+  using Iterator = itk::ImageRegionIterator<ImageType>;
+
+  auto                  image = ImageType::New();
+  ImageType::SizeType   size = { { 50, 50, 50 } };
+  ImageType::IndexType  index = { { 0, 0, 0 } };
+  ImageType::RegionType region;
+
+  region.SetSize(size);
+  region.SetIndex(index);
+
+  image->SetRegions(region);
+  image->AllocateInitialized();
+
+  ImageType::RegionType insideRegion;
+  ImageType::SizeType   insideSize = { { 30, 30, 30 } };
+  ImageType::IndexType  insideIndex = { { 10, 10, 10 } };
+  insideRegion.SetSize(insideSize);
+  insideRegion.SetIndex(insideIndex);
+
+
+  Iterator it(image, insideRegion);
+  it.GoToBegin();
+
+  while (!it.IsAtEnd())
+  {
+    it.Set(itk::NumericTraits<PixelType>::max());
+    ++it;
+  }
+
+  auto maskSO = ImageMaskSpatialObject::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(maskSO, ImageMaskSpatialObject, ImageSpatialObject);
+
+
+  maskSO->SetImage(image);
+  maskSO->Update();
+
+  Iterator itr(image, region);
+  itr.GoToBegin();
+  while (!itr.IsAtEnd())
+  {
+    const ImageType::IndexType constIndex = itr.GetIndex();
+    const bool                 reference = insideRegion.IsInside(constIndex);
+    ImageType::PointType       point;
+    image->TransformIndexToPhysicalPoint(constIndex, point);
+    const bool test = maskSO->IsInsideInWorldSpace(point);
+    if (test != reference)
+    {
+      std::cerr << "Error in the evaluation of IsInside() - Part 1 " << std::endl;
+      std::cerr << "Index failed = " << constIndex << std::endl;
+      std::cerr << "   Mask " << test << " != " << reference << std::endl;
+      return EXIT_FAILURE;
+    }
+    ++itr;
+  }
+
+  // Repeat test using a mask value
+  maskSO->SetMaskValue(itk::NumericTraits<PixelType>::max());
+  maskSO->SetUseMaskValue(true);
+  itr.GoToBegin();
+  while (!itr.IsAtEnd())
+  {
+    const ImageType::IndexType constIndex = itr.GetIndex();
+    const bool                 reference = insideRegion.IsInside(constIndex);
+    ImageType::PointType       point;
+    image->TransformIndexToPhysicalPoint(constIndex, point);
+    const bool test = maskSO->IsInsideInWorldSpace(point);
+    if (test != reference)
+    {
+      std::cerr << "Error in the evaluation of IsInside() - Part 2" << std::endl;
+      std::cerr << "Index failed = " << constIndex << std::endl;
+      std::cerr << "   Mask " << test << " != " << reference << std::endl;
+      return EXIT_FAILURE;
+    }
+    ++itr;
+  }
+
+  // The following should result in all IsInsideInWorldSpace calls
+  // returning false
+  maskSO->SetMaskValue(itk::NumericTraits<PixelType>::OneValue());
+  maskSO->SetUseMaskValue(true);
+  itr.GoToBegin();
+  while (!itr.IsAtEnd())
+  {
+    const ImageType::IndexType constIndex = itr.GetIndex();
+    const bool                 reference = insideRegion.IsInside(constIndex);
+    ImageType::PointType       point;
+    image->TransformIndexToPhysicalPoint(constIndex, point);
+    const bool test = maskSO->IsInsideInWorldSpace(point);
+    if (test == true)
+    {
+      std::cerr << "Error in the evaluation of IsInside() - Part 3" << std::endl;
+      std::cerr << "Index failed = " << constIndex << std::endl;
+      std::cerr << "   Mask " << test << " != " << reference << std::endl;
+      return EXIT_FAILURE;
+    }
+    ++itr;
+  }
+
+  std::cout << "Test finished" << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Nominally an ImageMaskSpatialObject considers any non-zero pixel to indicate that the object is present at that point.

With this change, it is possible to specify a MaskValue and to enable the use of that MaskValue (via the UseMaskValue functions) so that a specific pixel value is needed to indicate the presence of that object.

This is particularly useful when a single mask image defines multiple
objects via different values.   That single image can be assigned
to multiple ImageMaskSpatialObjects, each using a different MaskValue.  This reduces memory requirements, etc.

A new set of tests were added to confirm proper function.

Default behaviour is unchanged.
