### PR TITLE
COMP: Add type aliases of ptrdiff_t and size_t to the `itk` namespace

### DIFF
--- a/Modules/Core/Common/include/itkIntTypes.h
+++ b/Modules/Core/Common/include/itkIntTypes.h
@@ -58,6 +58,9 @@ using std::uintmax_t;
 using std::intptr_t;
 using std::uintptr_t;
 
+using std::size_t;
+using std::ptrdiff_t;
+
 
 #if defined(ITK_USE_64BITS_IDS) && ((ULLONG_MAX != ULONG_MAX) || (LLONG_MAX != LONG_MAX))
 


### PR DESCRIPTION
Officially, we may not assume that `ptrdiff_t` and `size_t` are defined in the global namespace.

----

Motivation: Both `ptrdiff_t` and `size_t` are already commonly being used inside the `itk` namespace, without specifying their `std` namespace:

https://github.com/InsightSoftwareConsortium/ITK/blob/487da6d086b341808147c71e8dd1eb1f57371ea6/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h#L64

https://github.com/InsightSoftwareConsortium/ITK/blob/487da6d086b341808147c71e8dd1eb1f57371ea6/Modules/Video/IO/src/itkFileListVideoIO.cxx#L64

It just compiles, so far! However, compilers may become more picky, as those types are not guaranteed to remain available in the global namespace. 