### PR TITLE
DOC: Add See Also entries for alternatives to LabelGeometryImageFilter

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -66,6 +66,9 @@ namespace itk
  *  by Padfield D., Miller J
  *  https://www.insight-journal.org/browse/publication/301
  *
+ * \sa LabelStatisticsImageFilter
+ * \sa LabelImageToShapeLabelMapFilter
+ *
  * \ingroup ITKReview
  *
  * \sphinx


### PR DESCRIPTION
This filter is buggy, and sometimes produces wrong results. Follow-up to: #4530.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Updated API documentation (or API not changed)
