### PR TITLE
COMP: Use default copy, move for construc, assign `RealTimeStamp`

### DIFF
--- a/Modules/Core/Common/include/itkRealTimeStamp.h
+++ b/Modules/Core/Common/include/itkRealTimeStamp.h
@@ -55,6 +55,13 @@ public:
   /** Destructor */
   ~RealTimeStamp();
 
+  RealTimeStamp(const RealTimeStamp &) = default;
+  RealTimeStamp &
+  operator=(const RealTimeStamp &) = default;
+  RealTimeStamp(RealTimeStamp &&) = default;
+  RealTimeStamp &
+  operator=(RealTimeStamp &&) = default;
+
   /** Native type used to represent the time in different time units. */
   using TimeRepresentationType = RealTimeInterval::TimeRepresentationType;
 


### PR DESCRIPTION
Use the compiler-proved default implementations for `itk::RealTimeStamp` copy constructor, copy assignment, move constructor, and move assignment functions.

As noted in [1], the C++ standard deprecated the implicit generation of copy and assignment operators.

Fixes:
```
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkRealTimeStamp.h:56:3:
 warning: definition of implicit copy assignment operator for 'RealTimeStamp' is deprecated because it has a user-declared destructor [-Wdeprecated]
  ~RealTimeStamp();
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkDataObject.h:452:3:
 note: in implicit copy assignment operator for 'itk::RealTimeStamp' first required here
  itkSetMacro(RealTimeStamp, RealTimeStamp);
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:992:22:
 note: expanded from macro 'itkSetMacro'
      this->m_##name = std::move(_arg);                        \
                     ^
[CTest: warning suppressed] 1 warning generated.
```

And other similar warnings stemming from `itk::RealTimeStamp` that have been appearing consistently in some macOS site builds in the dashboard: https://open.cdash.org/viewBuildError.php?type=1&buildid=9579479

[1] https://learn.microsoft.com/bs-latn-ba/cpp/error-messages/compiler-warnings/c5267?view=msvc-150#remarks

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)