### PR TITLE
COMP: Use default copy and move construct and assign in `itk::Region`

### DIFF
--- a/Modules/Core/Common/include/itkRegion.h
+++ b/Modules/Core/Common/include/itkRegion.h
@@ -90,6 +90,13 @@ public:
   Region() = default;
   virtual ~Region() = default;
 
+  Region(const Region &) = default;
+  Region &
+  operator=(const Region &) = default;
+  Region(Region &&) = default;
+  Region &
+  operator=(Region &&) = default;
+
 protected:
   /** Methods invoked by Print() to print information about the object
    * including superclasses. Typically not called by the user (use Print()


### PR DESCRIPTION
Use the compiler-proved default implementations for `itk::Region` copy constructor, copy assignment, move constructor, and move assignment functions.

As noted in [1], the C++ standard deprecated the implicit generation of copy and assignment operators.

Fixes:
```
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkRegion.h:91:11:
 warning: definition of implicit copy assignment operator for 'Region' is deprecated because it has a user-declared destructor [-Wdeprecated]
  virtual ~Region() = default;
          ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImageIORegion.h:117:30:
 note: in implicit copy assignment operator for 'itk::Region' first required here
  operator=(Self &&) = default;
                             ^
[CTest: warning matched] /Users/builder/externalModules/IO/ImageBase/include/itkImageIOBase.h:228:3:
 note: in implicit move assignment operator for 'itk::ImageIORegion' first required here
  itkSetMacro(IORegion, ImageIORegion);
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:992:22:
 note: expanded from macro 'itkSetMacro'
      this->m_##name = std::move(_arg);                        \
                     ^
```

And other similar warnings stemming from `itk::Region` that have been appearing consistently in some macOS site builds in the dashboard: https://open.cdash.org/viewBuildError.php?type=1&buildid=9579479

[1] https://learn.microsoft.com/bs-latn-ba/cpp/error-messages/compiler-warnings/c5267?view=msvc-150#remarks

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)