### PR TITLE
STYLE: Replace SetSize/Index calls in tests with `region{ index, size }`

### DIFF
--- a/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
@@ -66,9 +66,7 @@ itkAbortProcessObjectTest(int, char *[])
   // fill in an image
   const ShortImage::IndexType index = { { 0, 0 } };
   const ShortImage::SizeType  size = { { 100, 100 } };
-  ShortImage::RegionType      region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType      region{ index, size };
   img->SetRegions(region);
   img->Allocate();
 
@@ -89,9 +87,7 @@ itkAbortProcessObjectTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  extractIndex = { { 0, 0 } };
   ShortImage::SizeType   extractSize = { { 99, 99 } };
-  ShortImage::RegionType extractRegion;
-  extractRegion.SetSize(extractSize);
-  extractRegion.SetIndex(extractIndex);
+  ShortImage::RegionType extractRegion{ extractIndex, extractSize };
   extract->SetExtractionRegion(extractRegion);
 
   itk::CStyleCommand::Pointer progressCmd = itk::CStyleCommand::New();

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -276,9 +276,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
 
     using ImageType = itk::Image<char, SpaceDimension>;
     auto                  image = ImageType::New();
-    ImageType::RegionType region;
-    region.SetIndex(startIndex);
-    region.SetSize(size);
+    ImageType::RegionType region{ startIndex, size };
 
     image->SetRegions(region);
     image->AllocateInitialized();

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -37,9 +37,7 @@ GetTestImage(int d1, int d2, int d3, int d4)
   itk::Index<4> origND;
   origND.Fill(0);
 
-  itk::ImageRegion<4> RegionND;
-  RegionND.SetSize(sizeND);
-  RegionND.SetIndex(origND);
+  itk::ImageRegion<4> RegionND{ origND, sizeND };
 
   auto imageND = TestImageType::New();
   imageND->SetRegions(RegionND);

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -32,9 +32,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestGetTestImage(int d1, int d2, int d3
   itk::Index<4> origND;
   origND.Fill(0);
 
-  itk::ImageRegion<4> RegionND;
-  RegionND.SetSize(sizeND);
-  RegionND.SetIndex(origND);
+  itk::ImageRegion<4> RegionND{ origND, sizeND };
 
   auto imageND = TImage::New();
   imageND->SetRegions(RegionND);

--- a/Modules/Core/Common/test/itkExtractImageTest.cxx
+++ b/Modules/Core/Common/test/itkExtractImageTest.cxx
@@ -110,9 +110,7 @@ itkExtractImageTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
-  ShortImage::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType region{ index, size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();
@@ -144,9 +142,7 @@ itkExtractImageTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  extractIndex = { { 0, 0 } };
   ShortImage::SizeType   extractSize = { { 8, 12 } };
-  ShortImage::RegionType extractRegion;
-  extractRegion.SetSize(extractSize);
-  extractRegion.SetIndex(extractIndex);
+  ShortImage::RegionType extractRegion{ extractIndex, extractSize };
   extract->SetExtractionRegion(extractRegion);
   extract->UpdateLargestPossibleRegion();
 

--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -80,9 +80,7 @@ itkImageAdaptorPipeLineTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   const float spacing[3] = { 1.0, 1.0, 1.0 };
 

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -69,9 +69,7 @@ itkImageAlgorithmCopyTest2(int, char *[])
   RegionType::SizeType size;
   size.Fill(64);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
 
   auto image1 = Short3DImageType::New();

--- a/Modules/Core/Common/test/itkImageIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorTest.cxx
@@ -62,9 +62,7 @@ itkImageIteratorTest(int, char *[])
   itk::Image<itk::Vector<unsigned short, 5>, ImageDimension>::IndexType regionEndIndex3D = { { 8, 15, 17 } };
 
 
-  itk::Image<itk::Vector<unsigned short, 5>, ImageDimension>::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  itk::Image<itk::Vector<unsigned short, 5>, ImageDimension>::RegionType region{ startIndex3D, imageSize3D };
   o3->SetRegions(region);
   o3->SetOrigin(origin3D);
   o3->SetSpacing(spacing3D);

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -46,9 +46,7 @@ public:
     typename ImageType::IndexType start;
     start.Fill(0);
 
-    typename ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+    typename ImageType::RegionType region{ start, size };
 
     m_Image->SetRegions(region);
     m_Image->Allocate();

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -38,9 +38,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   ImageType::IndexType start;
   start.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  ImageType::RegionType region{ start, size };
 
   myImage->SetRegions(region);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -44,9 +44,7 @@ itkImageLinearIteratorTest(int, char *[])
   ImageType::IndexType start0;
   start0.Fill(0);
 
-  ImageType::RegionType region0;
-  region0.SetIndex(start0);
-  region0.SetSize(size0);
+  ImageType::RegionType region0{ start0, size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();
@@ -156,9 +154,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 3;
     size[2] = 4;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     std::cout << "  IteratorType ior( myImage, region );" << std::endl;
     IteratorType ior(myImage, region);
@@ -237,9 +233,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     IteratorType bot(myImage, region);
 
@@ -285,9 +279,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     ConstIteratorType cbot(myImage, region);
 
@@ -333,9 +325,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     IteratorType cbot(myImage, region);
 
@@ -379,9 +369,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     ConstIteratorType cbot(myImage, region);
 
@@ -425,9 +413,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     std::cout << "    IteratorType cbot( myImage, region );" << std::endl;
     IteratorType cbot(myImage, region);
@@ -478,9 +464,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     std::cout << "    IteratorType cbot( myImage, region );" << std::endl;
     IteratorType cbot(myImage, region);
@@ -537,9 +521,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     ConstIteratorType cbot(myImage, region);
 
@@ -580,9 +562,7 @@ itkImageLinearIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     ConstIteratorType cbot(myImage, region);
 

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -46,9 +46,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
   ImageType::IndexType start0;
   start0.Fill(0);
 
-  ImageType::RegionType region0;
-  region0.SetIndex(start0);
-  region0.SetSize(size0);
+  ImageType::RegionType region0{ start0, size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();
@@ -170,9 +168,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     RandomConstIteratorType cbot(myImage, region);
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -46,9 +46,7 @@ itkImageRandomIteratorTest(int, char *[])
   ImageType::IndexType start0;
   start0.Fill(0);
 
-  ImageType::RegionType region0;
-  region0.SetIndex(start0);
-  region0.SetSize(size0);
+  ImageType::RegionType region0{ start0, size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();
@@ -220,9 +218,7 @@ itkImageRandomIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     RandomIteratorType cbot(myImage, region);
 
@@ -268,9 +264,7 @@ itkImageRandomIteratorTest(int, char *[])
     size[1] = 12;
     size[2] = 13;
 
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType region{ start, size };
 
     RandomConstIteratorType cbot(myImage, region);
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -55,9 +55,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
   ImageType::IndexType start;
   start.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  ImageType::RegionType region{ start, size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -49,9 +49,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   unsigned long        numberOfSamples = 10;
   ImageType::IndexType start0;
   start0.Fill(0);
-  ImageType::RegionType region0;
-  region0.SetIndex(start0);
-  region0.SetSize(size0);
+  ImageType::RegionType region0{ start0, size0 };
   myImage->SetRegions(region0);
   myImage->Allocate();
   // Make the priority image
@@ -62,9 +60,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   prioritySize[2] = 50;
   PriorityImageType::IndexType priorityStart;
   priorityStart.Fill(0);
-  PriorityImageType::RegionType priorityRegion;
-  priorityRegion.SetIndex(priorityStart);
-  priorityRegion.SetSize(prioritySize);
+  PriorityImageType::RegionType priorityRegion{ priorityStart, prioritySize };
   priorityImage->SetRegions(priorityRegion);
   priorityImage->Allocate();
   // we will make most of this image ones, with a small region of
@@ -86,10 +82,8 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   subsize[0] = 3;
   subsize[1] = 4;
   subsize[2] = 5;
-  PriorityImageType::RegionType subregion;
-  subregion.SetIndex(substart);
-  subregion.SetSize(subsize);
-  PriorityIteratorType subit(priorityImage, subregion);
+  PriorityImageType::RegionType subregion{ substart, subsize };
+  PriorityIteratorType          subit(priorityImage, subregion);
   subit.GoToBegin();
   while (!subit.IsAtEnd())
   {
@@ -241,10 +235,8 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
     size[0] = 11;
     size[1] = 12;
     size[2] = 13;
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
-    RandomIteratorType cbot(myImage, region);
+    ImageType::RegionType region{ start, size };
+    RandomIteratorType    cbot(myImage, region);
     cbot.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
     cbot.GoToBegin();
     while (!cbot.IsAtEnd())
@@ -280,9 +272,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
     size[0] = 11;
     size[1] = 12;
     size[2] = 13;
-    ImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    ImageType::RegionType   region{ start, size };
     RandomConstIteratorType cbot(myImage, region);
     cbot.SetNumberOfSamples(numberOfSamples);
     cbot.GoToBegin();

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
@@ -40,10 +40,8 @@ itkImageRandomNonRepeatingIteratorWithIndexTest2(int, char *[])
   size.Fill(N);
   ImageType::IndexType start;
   start.Fill(0);
-  ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
-  auto myImage = ImageType::New();
+  ImageType::RegionType region{ start, size };
+  auto                  myImage = ImageType::New();
   myImage->SetRegions(region);
   myImage->Allocate();
   using WalkType = std::vector<ImageType::IndexType>;

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -40,9 +40,7 @@ public:
     typename ImageType::IndexType start;
     start.Fill(0);
 
-    typename ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+    typename ImageType::RegionType region{ start, size };
 
     m_Image->SetRegions(region);
 

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -64,9 +64,7 @@ itkImageRegionIteratorTest(int, char *[])
   itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType regionEndIndex3D = { { 8, 15, 17 } };
 
 
-  itk::Image<itk::Vector<unsigned short, 5>, 3>::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  itk::Image<itk::Vector<unsigned short, 5>, 3>::RegionType region{ startIndex3D, imageSize3D };
   o3->SetLargestPossibleRegion(region);
   region.SetSize(bufferSize3D);
   region.SetIndex(bufferStartIndex3D);

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -69,9 +69,7 @@ itkImageReverseIteratorTest(int, char *[])
   ImageType::IndexType regionEndIndex3D = { { 8, 15, 17 } };
 
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  ImageType::RegionType region{ startIndex3D, imageSize3D };
   o3->SetLargestPossibleRegion(region);
   region.SetSize(bufferSize3D);
   region.SetIndex(bufferStartIndex3D);

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -65,9 +65,7 @@ itkImageScanlineIteratorTest1(int, char *[])
   ImageType::IndexType regionEndIndex3D = { { 8, 15, 17 } };
 
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  ImageType::RegionType region{ startIndex3D, imageSize3D };
   o3->SetLargestPossibleRegion(region);
   region.SetSize(bufferSize3D);
   region.SetIndex(bufferStartIndex3D);

--- a/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
@@ -43,9 +43,7 @@ itkImageSliceIteratorTest(int, char *[])
   ImageType::IndexType start;
   start.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  ImageType::RegionType region{ start, size };
 
   myImage->SetRegions(region);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -89,9 +89,7 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
   constexpr int dimLength = 3;
   size.Fill(dimLength);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   imageOfVectors->SetRegions(region);
   imageOfVectors->Allocate();

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -43,9 +43,7 @@ itkIteratorTests(int, char *[])
   ScalarImage::IndexType regionStartIndex3D = { { 5, 5, 5 } };
 
 
-  ScalarImage::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  ScalarImage::RegionType region{ startIndex3D, imageSize3D };
   o3->SetLargestPossibleRegion(region);
   region.SetSize(bufferSize3D);
   region.SetIndex(bufferStartIndex3D);

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -48,9 +48,7 @@ itkLineIteratorTest(int argc, char * argv[])
   ImageType::RegionType::SizeType size;
   size.Fill(200);
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   auto output = ImageType::New();
   output->SetRegions(region);

--- a/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
+++ b/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
@@ -99,9 +99,7 @@ itkMinimumMaximumImageCalculatorTest(int, char *[])
   // Set the region over which perform the computations
   itk::Size<3>                     regionSize = { { 4, 4, 4 } };
   itk::Index<3>                    idx = { { 0, 0, 0 } };
-  MinMaxCalculatorType::RegionType computationRegion;
-  computationRegion.SetSize(regionSize);
-  computationRegion.SetIndex(idx);
+  MinMaxCalculatorType::RegionType computationRegion{ idx, regionSize };
 
   calculator->SetRegion(computationRegion);
 

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -58,9 +58,7 @@ MakeImage(const int count, T pixel)
   size[0] = count;
   size[1] = count;
   size[2] = count;
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   testImage->SetRegions(region);
   testImage->Allocate();

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -42,10 +42,8 @@ itkOctreeTest(int, char *[])
   using ImageType = itk::Image<unsigned int, 3>;
   const ImageType::SizeType  imageSize = { { 4, 4, 4 } };
   const ImageType::IndexType imageIndex = { { 0, 0, 0 } };
-  ImageType::RegionType      region;
-  region.SetSize(imageSize);
-  region.SetIndex(imageIndex);
-  auto img = ImageType::New();
+  ImageType::RegionType      region{ imageIndex, imageSize };
+  auto                       img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
   srand(static_cast<unsigned int>(time(nullptr)));

--- a/Modules/Core/Common/test/itkPixelAccessTest.cxx
+++ b/Modules/Core/Common/test/itkPixelAccessTest.cxx
@@ -59,9 +59,7 @@ itkPixelAccessTest(int, char *[])
   itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType regionStartIndex3D = { { 5, 10, 12 } };
   itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType regionEndIndex3D = { { 8, 15, 17 } };
 
-  itk::Image<itk::Vector<unsigned short, 5>, 3>::RegionType region;
-  region.SetSize(imageSize3D);
-  region.SetIndex(startIndex3D);
+  itk::Image<itk::Vector<unsigned short, 5>, 3>::RegionType region{ startIndex3D, imageSize3D };
   o3->SetLargestPossibleRegion(region);
   region.SetSize(bufferSize3D);
   region.SetIndex(bufferStartIndex3D);

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
@@ -36,9 +36,7 @@ itkStreamingImageFilterTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 80, 122 } };
-  ShortImage::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType region{ index, size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
@@ -41,9 +41,7 @@ itkStreamingImageFilterTest2(int, char *[])
   // fill in an image
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 42, 64 } };
-  ShortImage::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType region{ index, size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -45,9 +45,7 @@ itkSymmetricSecondRankTensorImageReadTest(int argc, char * argv[])
   MatrixImageType::IndexType start;
   start.Fill(0);
 
-  MatrixImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  MatrixImageType::RegionType region{ start, size };
 
   matrixImage->SetRegions(region);
   matrixImage->Allocate();

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -43,9 +43,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
   TensorImageType::IndexType start;
   start.Fill(0);
 
-  TensorImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  TensorImageType::RegionType region{ start, size };
 
   tensorImageInput->SetRegions(region);
   tensorImageInput->Allocate();

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -55,9 +55,7 @@ itkGPUImageTest(int argc, char * argv[])
   ItkImage1f::SizeType size;
   size[0] = width;
   size[1] = height;
-  ItkImage1f::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ItkImage1f::RegionType region{ start, size };
 
   // create
   srcA = ItkImage1f::New();

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
@@ -65,9 +65,7 @@ itkImageAdaptorTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  myImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myImageType::RegionType region{ index, size };
 
   auto myImage = myImageType::New();
 

--- a/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
@@ -63,9 +63,7 @@ itkNthElementPixelAccessorTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  myImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myImageType::RegionType region{ index, size };
 
   auto myImage = myImageType::New();
 

--- a/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
@@ -64,9 +64,7 @@ itkRGBToVectorImageAdaptorTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   auto image = ImageType::New();
 

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -304,9 +304,7 @@ itkVectorImageTest(int, char * argv[])
       }
       start.Fill(0);
       size.Fill(50);
-      VariableLengthVectorImageType::RegionType region;
-      region.SetSize(size);
-      region.SetIndex(start);
+      VariableLengthVectorImageType::RegionType region{ start, size };
       image->SetRegions(region);
       image->Allocate();
       image->FillBuffer(f);
@@ -350,9 +348,7 @@ itkVectorImageTest(int, char * argv[])
       }
       start.Fill(0);
       size.Fill(50);
-      FixedArrayImageType::RegionType region;
-      region.SetSize(size);
-      region.SetIndex(start);
+      FixedArrayImageType::RegionType region{ start, size };
       image->SetRegions(region);
       image->Allocate();
       image->FillBuffer(f);
@@ -409,9 +405,7 @@ itkVectorImageTest(int, char * argv[])
       }
       start.Fill(0);
       size.Fill(50);
-      VectorImageType::RegionType region;
-      region.SetSize(size);
-      region.SetIndex(start);
+      VectorImageType::RegionType region{ start, size };
       vectorImage->SetVectorLength(VectorLength);
       vectorImage->SetRegions(region);
       vectorImage->Allocate();

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
@@ -51,9 +51,7 @@ itkVectorImageToImageAdaptorTest(int, char *[])
   start.Fill(0);
   size.Fill(50);
 
-  VectorImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  VectorImageType::RegionType region{ start, size };
   vectorImage->SetVectorLength(VectorLength);
   vectorImage->SetRegions(region);
   vectorImage->Allocate();

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -735,9 +735,7 @@ set2DInterpData(ImageType2D::Pointer imgPtr)
   ImageType2D::IndexType index;
   index.Fill(10);
 
-  ImageType2D::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType2D::RegionType region{ index, size };
 
   imgPtr->SetRegions(region);
   imgPtr->Allocate();

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -49,9 +49,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
   ImageType::SizeType size;
   size.Fill(3);
 
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ImageType::RegionType region{ start, size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -67,9 +67,7 @@ RunLinearInterpolateTest()
   constexpr int dimMaxLength = 3;
   size.Fill(dimMaxLength);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -64,9 +64,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
   SizeType size;
   size.Fill(3);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -83,9 +83,7 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   IndexType start;
   start.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   ImagePointerType image = ImageType::New();
   image->SetRegions(region);

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -70,9 +70,7 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   size[0] = 10;
   size[1] = 10;
 
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ImageType::RegionType region{ start, size };
 
   imageX->SetRegions(region);
   imageY->SetRegions(region);

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -87,9 +87,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
 
 
   ImageType::IndexType  index3D = { { 0, 0, 0 } };
-  ImageType::RegionType region3D;
-  region3D.SetSize(size);
-  region3D.SetIndex(index3D);
+  ImageType::RegionType region3D{ index3D, size };
 
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region3D);

--- a/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
@@ -69,9 +69,7 @@ itkWarpMeshFilterTest(int, char *[])
   size[1] = 25;
   size[2] = 25;
 
-  DisplacementFieldType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  DisplacementFieldType::RegionType region{ start, size };
 
   deformationField->SetRegions(region);
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -76,9 +76,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   constexpr unsigned int     index_offset = 6543;
   const ImageType::IndexType index = { { index_offset, index_offset, index_offset } };
 
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
   image->SetRegions(region);
   image->AllocateInitialized();
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -56,9 +56,7 @@ itkBinaryDilateImageFilterTest(int, char *[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -56,9 +56,7 @@ itkBinaryErodeImageFilterTest(int, char *[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -58,9 +58,7 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
@@ -56,9 +56,7 @@ itkFastIncrementalBinaryDilateImageFilterTest(int, char *[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -67,9 +67,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
     using ReferenceSizeType = ReferenceRegionType::SizeType;
     ReferenceSizeType   sizeReferenceImage = { { 4, 4, 4 } };
     ReferenceIndexType  indexReferenceImage = { { 0, 0, 0 } };
-    ReferenceRegionType regionReferenceImage;
-    regionReferenceImage.SetSize(sizeReferenceImage);
-    regionReferenceImage.SetIndex(indexReferenceImage);
+    ReferenceRegionType regionReferenceImage{ indexReferenceImage, sizeReferenceImage };
     referenceImage->SetRegions(regionReferenceImage);
     referenceImage->Allocate();
     referenceImage->FillBuffer(100);
@@ -97,9 +95,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
       auto               gradientImage = GradientImageType::New();
       GradientSizeType   sizeGradientImage = { { 4, 4, 4 } };
       GradientIndexType  indexGradientImage = { { 0, 0, 0 } };
-      GradientRegionType regionGradientImage;
-      regionGradientImage.SetSize(sizeGradientImage);
-      regionGradientImage.SetIndex(indexGradientImage);
+      GradientRegionType regionGradientImage{ indexGradientImage, sizeGradientImage };
       gradientImage->SetRegions(regionGradientImage);
       gradientImage->Allocate();
 

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
@@ -54,9 +54,7 @@ itkTensorFractionalAnisotropyImageFilterTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
@@ -54,9 +54,7 @@ itkTensorRelativeAnisotropyImageFilterTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -181,9 +181,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   ImportFilterType::IndexType start;
   start.Fill(0);
 
-  ImportFilterType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  ImportFilterType::RegionType region{ start, size };
 
   importFilter->SetRegion(region);
 

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -97,10 +97,8 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   inputDirection[2][1] = -1;
   inputDirection[2][2] = 0;
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  auto image = ImageType::New();
+  RegionType region{ index, size };
+  auto       image = ImageType::New();
   image->SetRegions(region);
   image->Allocate();
   image->SetSpacing(spacing);
@@ -141,9 +139,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   SpacingType outputSpacing;
   SizeType    outputSize;
   outputSize.Fill(24);
-  RegionType outputRegion;
-  outputRegion.SetSize(outputSize);
-  outputRegion.SetIndex(outputIndex);
+  RegionType outputRegion{ outputIndex, outputSize };
   outputSpacing[0] = 1.0;
   outputSpacing[1] = 2.0;
   outputSpacing[2] = 3.0;

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest.cxx
@@ -40,9 +40,7 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
   /* Allocate the 2D image */
   myImageType2D1::SizeType   size2D = { { 9, 9 } };
   myImageType2D1::IndexType  index2D = { { 0, 0 } };
-  myImageType2D1::RegionType region2D;
-  region2D.SetSize(size2D);
-  region2D.SetIndex(index2D);
+  myImageType2D1::RegionType region2D{ index2D, size2D };
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);
@@ -190,10 +188,8 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
   using ImageType3D = itk::Image<float, 3>;
   ImageType3D::SizeType   size3D = { { 200, 200, 200 } };
   ImageType3D::IndexType  index3D = { { 0, 0 } };
-  ImageType3D::RegionType region3D;
-  region3D.SetSize(size3D);
-  region3D.SetIndex(index3D);
-  auto inputImage3D = ImageType3D::New();
+  ImageType3D::RegionType region3D{ index3D, size3D };
+  auto                    inputImage3D = ImageType3D::New();
   inputImage3D->SetRegions(region3D);
   inputImage3D->Allocate();
   inputImage3D->FillBuffer(1);
@@ -207,9 +203,7 @@ itkDanielssonDistanceMapImageFilterTest(int, char *[])
     foregroundSize[i] = 5;
     foregroundIndex[i] = (size3D[i] / 2) - foregroundSize[i] / 2;
   }
-  ImageType3D::RegionType foregroundRegion;
-  foregroundRegion.SetSize(foregroundSize);
-  foregroundRegion.SetIndex(foregroundIndex);
+  ImageType3D::RegionType foregroundRegion{ foregroundIndex, foregroundSize };
 
   itk::ImageRegionIteratorWithIndex<ImageType3D> it3D(inputImage3D, foregroundRegion);
   for (it3D.GoToBegin(); !it3D.IsAtEnd(); ++it3D)

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -71,9 +71,7 @@ FastChamferDistanceImageFilterTest(unsigned int iPositive, unsigned int iNegativ
   size.Fill(32);
   typename ImageType::IndexType index;
   index.Fill(0);
-  typename ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename ImageType::RegionType region{ index, size };
 
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region);

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
@@ -40,9 +40,7 @@ itkReflectiveImageRegionIteratorTest(int, char *[])
   ImageType::IndexType start;
   start.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  ImageType::RegionType region{ start, size };
 
   myImage->SetRegions(region);
   myImage->Allocate();

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -58,9 +58,7 @@ test(int testIdx)
   myImageType2D1::IndexType index2D;
   index2D.Fill(0);
 
-  myImageType2D1::RegionType region2D;
-  region2D.SetSize(size2D);
-  region2D.SetIndex(index2D);
+  myImageType2D1::RegionType region2D{ index2D, size2D };
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest11.cxx
@@ -37,9 +37,7 @@ itkSignedDanielssonDistanceMapImageFilterTest11(int, char *[])
   /* Allocate the 2D image */
   myImageType2D1::SizeType   size2D = { { 5, 5 } };
   myImageType2D1::IndexType  index2D = { { 0, 0 } };
-  myImageType2D1::RegionType region2D;
-  region2D.SetSize(size2D);
-  region2D.SetIndex(index2D);
+  myImageType2D1::RegionType region2D{ index2D, size2D };
 
   auto inputImage2D = myImageType2D1::New();
   inputImage2D->SetRegions(region2D);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -154,9 +154,7 @@ itkFastMarchingTest(int argc, char * argv[])
     static_cast<typename FloatFMType::LevelSetImageType::IndexType::IndexValueType>(std::stoi(argv[5]));
   typename FloatFMType::LevelSetImageType::IndexType outputRegionIndex;
   outputRegionIndex.Fill(outputRegionIndexValue);
-  typename FloatFMType::OutputRegionType outputRegion;
-  outputRegion.SetSize(size);
-  outputRegion.SetIndex(outputRegionIndex);
+  typename FloatFMType::OutputRegionType outputRegion{ outputRegionIndex, size };
   marcher->SetOutputRegion(outputRegion);
   ITK_TEST_SET_GET_VALUE(outputRegion, marcher->GetOutputRegion());
 

--- a/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
@@ -67,9 +67,7 @@ itkAbsoluteValueDifferenceImageFilterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
@@ -67,9 +67,7 @@ itkSquaredDifferenceImageFilterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -56,9 +56,7 @@ itkJoinImageFilterTest(int, char *[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
@@ -45,11 +45,9 @@ itkJoinSeriesImageFilterTest(int, char *[])
   using OutputImageType = itk::Image<PixelType, 4>;
 
   // Expected result
-  OutputImageType::IndexType  expectedIndex = { { 1, 2, 0, 0 } };
-  OutputImageType::SizeType   expectedSize = { { 8, 5, 4, 1 } };
-  OutputImageType::RegionType expectedRegion;
-  expectedRegion.SetIndex(expectedIndex);
-  expectedRegion.SetSize(expectedSize);
+  OutputImageType::IndexType   expectedIndex = { { 1, 2, 0, 0 } };
+  OutputImageType::SizeType    expectedSize = { { 8, 5, 4, 1 } };
+  OutputImageType::RegionType  expectedRegion{ expectedIndex, expectedSize };
   OutputImageType::SpacingType expectedSpacing;
   expectedSpacing[0] = 1.1;
   expectedSpacing[1] = 1.2;
@@ -62,12 +60,10 @@ itkJoinSeriesImageFilterTest(int, char *[])
   expectedOrigin[3] = 0.0;
 
   // Create the input images
-  int                        numInputs = 4;
-  InputImageType::IndexType  index = { { 1, 2 } };
-  InputImageType::SizeType   size = { { 8, 5 } };
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  int                         numInputs = 4;
+  InputImageType::IndexType   index = { { 1, 2 } };
+  InputImageType::SizeType    size = { { 8, 5 } };
+  InputImageType::RegionType  region{ index, size };
   constexpr double            spacingValue = 1.3;
   InputImageType::SpacingType spacing;
   spacing[0] = 1.1;

--- a/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
@@ -64,9 +64,7 @@ itkGradientVectorFlowImageFilterTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -60,9 +60,7 @@ itkHessian3DToVesselnessMeasureImageFilterTest(int argc, char * argv[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
@@ -57,9 +57,7 @@ itkHessianRecursiveGaussianFilterTest(int argc, char * argv[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -43,9 +43,7 @@ public:
     typename ImageType::IndexType start;
     start.Fill(0);
 
-    typename ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+    typename ImageType::RegionType region{ start, size };
 
     m_Image->SetRegions(region);
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -67,9 +67,7 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   inputImage->SetRegions(region);
   inputImage->AllocateInitialized();

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -90,9 +90,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
   start[2] = 2;
 
   // Create one iterator for an internal region
-  myRegionType innerRegion;
-  innerRegion.SetSize(size);
-  innerRegion.SetIndex(start);
+  myRegionType   innerRegion{ start, size };
   myIteratorType itb(inputImage, innerRegion);
 
   // Initialize the content the internal region

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -62,9 +62,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -89,9 +89,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   start[2] = 2;
 
   // Create one iterator for an internal region
-  myRegionType innerRegion;
-  innerRegion.SetSize(size);
-  innerRegion.SetIndex(start);
+  myRegionType   innerRegion{ start, size };
   myIteratorType itb(inputImage, innerRegion);
 
   // Initialize the content the internal region

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -59,9 +59,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
@@ -52,9 +52,7 @@ itkGradientRecursiveGaussianFilterTest2(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -67,9 +67,7 @@ itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   my
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -34,9 +34,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
   // fill in an image
   InputImageType::IndexType  index = { { 100, 100 } };
   InputImageType::SizeType   size = { { 12, 20 } };
-  InputImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  InputImageType::RegionType region{ index, size };
   sourceImage->SetRegions(region);
   sourceImage->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
@@ -43,9 +43,7 @@ itkFlipImageFilterTest(int argc, char * argv[])
   // Define a small input image
   ImageType::IndexType  index = { { 10, 20, 30 } };
   ImageType::SizeType   size = { { 5, 4, 3 } };
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
 
   ImageType::SpacingType spacing;
   spacing[0] = 1.1;

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -28,10 +28,8 @@ CreateRandomImage()
 {
   const ImageType::SizeType  imageSize = { { 4, 4, 4 } };
   const ImageType::IndexType imageIndex = { { 0, 0, 0 } };
-  ImageType::RegionType      region;
-  region.SetSize(imageSize);
-  region.SetIndex(imageIndex);
-  auto img = ImageType::New();
+  ImageType::RegionType      region{ imageIndex, imageSize };
+  auto                       img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
   itk::ImageRegionIterator<ImageType> ri(img, region);

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -51,10 +51,8 @@ CreateAxialImage()
 {
   const ImageType::SizeType imageSize = { { 4, 4, 4 } };
   ImageType::IndexType      imageIndex = { { 0, 0, 0 } };
-  ImageType::RegionType     region;
-  region.SetSize(imageSize);
-  region.SetIndex(imageIndex);
-  auto img = ImageType::New();
+  ImageType::RegionType     region{ imageIndex, imageSize };
+  auto                      img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
 
@@ -103,10 +101,8 @@ CreateCoronalImage()
 {
   const ImageType::SizeType imageSize = { { 4, 4, 4 } };
   ImageType::IndexType      imageIndex = { { 0, 0, 0 } };
-  ImageType::RegionType     region;
-  region.SetSize(imageSize);
-  region.SetIndex(imageIndex);
-  auto img = ImageType::New();
+  ImageType::RegionType     region{ imageIndex, imageSize };
+  auto                      img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageAdaptorTest.cxx
@@ -67,9 +67,7 @@ itkOrientedImageAdaptorTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  myImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myImageType::RegionType region{ index, size };
 
   auto myImage = myImageType::New();
 

--- a/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
@@ -53,9 +53,7 @@ itkPermuteAxesImageFilterTest(int, char *[])
   // define a small input test
   ImageType::IndexType  index = { { 10, 20, 30, 40 } };
   ImageType::SizeType   size = { { 5, 4, 3, 2 } };
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
 
   double spacing[ImageDimension] = { 1.1, 1.2, 1.3, 1.4 };
   double origin[ImageDimension] = { 0.5, 0.4, 0.3, 0.2 };

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -46,9 +46,7 @@ itkResampleImageTest(int, char *[])
   ImagePointerType image = ImageType::New();
   ImageIndexType   index = { { 0, 0 } };
   ImageSizeType    size = { { 18, 12 } };
-  ImageRegionType  region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType  region{ index, size };
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
   image->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -54,9 +54,7 @@ itkResampleImageTest4(int argc, char * argv[])
   ImagePointerType image = ImageType::New();
   ImageIndexType   index = { { 0, 0 } };
   ImageSizeType    size = { { 64, 64 } };
-  ImageRegionType  region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType  region{ index, size };
   image->SetRegions(region);
   image->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -59,9 +59,7 @@ itkResampleImageTest5(int argc, char * argv[])
   ImagePointerType image = ImageType::New();
   ImageIndexType   index = { { 0, 0 } };
   ImageSizeType    size = { { 64, 64 } };
-  ImageRegionType  region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType  region{ index, size };
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
   image->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -62,9 +62,7 @@ itkResampleImageTest6(int argc, char * argv[])
   ImagePointerType image = ImageType::New();
   ImageIndexType   index = { { 0, 0 } };
   ImageSizeType    size = { { 64, 64 } };
-  ImageRegionType  region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType  region{ index, size };
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
   image->SetVectorLength(3);

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -51,9 +51,7 @@ itkResampleImageTest7(int, char *[])
   ImagePointerType image = ImageType::New();
   ImageIndexType   index = { { 0, 0 } };
   ImageSizeType    size = { { 64, 64 } };
-  ImageRegionType  region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType  region{ index, size };
   image->SetRegions(region);
   image->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -144,9 +144,7 @@ itkResampleImageTest8(int, char *[])
   InputImagePointerType inputImage = InputImageType::New();
   InputImageIndexType   inputIndex = { { 0, 0 } };
   InputImageSizeType    inputSize = { { 18, 12 } };
-  InputImageRegionType  inputRegion;
-  inputRegion.SetSize(inputSize);
-  inputRegion.SetIndex(inputIndex);
+  InputImageRegionType  inputRegion{ inputIndex, inputSize };
   inputImage->SetLargestPossibleRegion(inputRegion);
   inputImage->SetBufferedRegion(inputRegion);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -47,9 +47,7 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   InputImagePointerType image = InputImageType::New();
   ImageIndexType        index = { { 0, 0, 0 } };
   ImageSizeType         size = { { 13, 13, 9 } };
-  ImageRegionType       region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageRegionType       region{ index, size };
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
   image->SetAzimuthAngularSeparation(5.0 * 2.0 * itk::Math::pi / 360.0);

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
@@ -38,9 +38,7 @@ itkShrinkImageStreamingTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  index = { { 100, 100 } };
   ShortImage::SizeType   size = { { 8, 12 } };
-  ShortImage::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType region{ index, size };
   sourceImage->SetRegions(region);
   sourceImage->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -46,9 +46,7 @@ itkShrinkImageTest(int, char *[])
   // fill in an image
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
-  ShortImage::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ShortImage::RegionType region{ index, size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -48,10 +48,8 @@ MakeCheckerboard()
   ImageType::SpacingType spacing;
   spacing[0] = spacing[1] = spacing[2] = 1.0;
   ImageType::IndexType  index = { { 0, 0, 0 } };
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  ImageType::Pointer image;
+  ImageType::RegionType region{ index, size };
+  ImageType::Pointer    image;
   AllocateImageFromRegionAndSpacing(ImageType, image, region, spacing);
   image->FillBuffer(0.0);
   for (IteratorType it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
@@ -80,10 +78,8 @@ MakeDisplacementField()
   DisplacementFieldType::SpacingType    spacing;
   spacing[0] = spacing[1] = spacing[2] = 16.0 / static_cast<double>(TImageIndexSpaceSize);
   DisplacementFieldType::IndexType  index = { { 0, 0, 0 } };
-  DisplacementFieldType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  DisplacementFieldType::Pointer image;
+  DisplacementFieldType::RegionType region{ index, size };
+  DisplacementFieldType::Pointer    image;
   AllocateImageFromRegionAndSpacing(DisplacementFieldType, image, region, spacing);
   for (IteratorType it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
   {

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -172,9 +172,7 @@ itkZeroFluxNeumannPadImageFilterTest(int, char *[])
   // Fill in a test image
   ShortImage::IndexType  inputIndex = { { 0, 0 } };
   ShortImage::SizeType   inputSize = { { 8, 12 } };
-  ShortImage::RegionType inputRegion;
-  inputRegion.SetSize(inputSize);
-  inputRegion.SetIndex(inputIndex);
+  ShortImage::RegionType inputRegion{ inputIndex, inputSize };
   inputImage->SetLargestPossibleRegion(inputRegion);
   inputImage->SetBufferedRegion(inputRegion);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
@@ -72,9 +72,7 @@ itkAdaptImageFilterTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  myRGBImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myRGBImageType::RegionType region{ index, size };
 
   auto myImage = myRGBImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -67,9 +67,7 @@ itkAdaptImageFilterTest2(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  myVectorImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myVectorImageType::RegionType region{ index, size };
 
   auto myImage = myVectorImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -65,9 +65,7 @@ itkAddImageFilterFrameTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -109,9 +109,7 @@ itkEqualTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -70,9 +70,7 @@ itkGreaterEqualTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -69,9 +69,7 @@ itkGreaterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -81,9 +81,7 @@ itkImageAdaptorNthElementTest(int, char *[])
   start.Fill(0);
 
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   float spacing[3];
   spacing[0] = 1.0;

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -70,9 +70,7 @@ itkLessEqualTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -70,9 +70,7 @@ itkLessTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -57,9 +57,7 @@ itkMaskImageFilterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -59,9 +59,7 @@ itkMaskNegatedImageFilterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize the image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -38,9 +38,7 @@ InitializeImage(ImageType * image, const typename ImageType::PixelType & value)
   typename ImageType::IndexType start;
   start.Fill(0);
 
-  typename ImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  typename ImageType::RegionType region{ start, size };
 
   inputImage->SetRegions(region);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -70,9 +70,7 @@ itkNotEqualTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
@@ -68,9 +68,7 @@ itkNthElementPixelAccessorTest2(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  VectorImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  VectorImageType::RegionType region{ index, size };
 
   auto vectorImage = VectorImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
@@ -70,9 +70,7 @@ itkRGBToVectorAdaptImageFilterTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  RGBImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  RGBImageType::RegionType region{ index, size };
 
   auto myImage = RGBImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
@@ -64,9 +64,7 @@ itkVectorToRGBImageAdaptorTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   auto image = ImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -74,9 +74,7 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
@@ -61,9 +61,7 @@ itkChangeRegionLabelMapFilterTest1(int argc, char * argv[])
   ChangeType::SizeType size;
   size[0] = std::stoi(argv[5]);
   size[1] = std::stoi(argv[6]);
-  ChangeType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(idx);
+  ChangeType::RegionType region{ idx, size };
   change->SetRegion(region);
   itk::SimpleFilterWatcher watcher6(change, "filter");
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -57,9 +57,7 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -57,9 +57,7 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   start[0] = 0;
   start[1] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
@@ -65,9 +65,7 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   index[1] = 0;
   index[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  myRegionType region{ index, size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -61,9 +61,7 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
   ImageType::SizeType size;
   size[0] = 128;
   size[1] = 128;
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ImageType::RegionType region{ start, size };
   inputImage->SetRegions(region);
   double spacing[ImageType::ImageDimension];
   spacing[0] = 1.0;

--- a/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
@@ -106,9 +106,7 @@ itkOrthogonalSwath2DPathFilterTest(int, char *[])
   UCharImageType::SizeType size;
   size[0] = 128;
   size[1] = 128;
-  UCharImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  UCharImageType::RegionType region{ start, size };
   inputImage->SetRegions(region);
   double spacing[UCharImageType::ImageDimension];
   spacing[0] = 1.0;

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -52,9 +52,7 @@ itkPathFunctionsTest(int, char *[])
   ImageType::SizeType size;
   size[0] = 128;
   size[1] = 128;
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ImageType::RegionType region{ start, size };
   image->SetRegions(region);
   double spacing[ImageType::ImageDimension];
   spacing[0] = 1.0;

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -48,9 +48,7 @@ itkPathIteratorTest(int, char *[])
   ImageType::SizeType size;
   size[0] = 128;
   size[1] = 128;
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  ImageType::RegionType region{ start, size };
   image->SetRegions(region);
   double spacing[ImageType::ImageDimension];
   spacing[0] = 1.0;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
@@ -58,9 +58,7 @@ itkBinaryMask3DQuadEdgeMeshSourceTest(int, char *[])
   IndexType start;
   start.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   auto image = ImageType::New();
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
@@ -53,10 +53,8 @@ itkRecursiveGaussianImageFilterOnTensorsTest(int, char *[])
   size.Fill(9);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  auto inputImage = ImageType::New();
+  ImageType::RegionType region{ index, size };
+  auto                  inputImage = ImageType::New();
   inputImage->SetRegions(region);
   inputImage->Allocate();
   inputImage->FillBuffer(tensor0);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -51,10 +51,8 @@ itkRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   size.Fill(9);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
-  auto inputImage = ImageType::New();
+  ImageType::RegionType region{ index, size };
+  auto                  inputImage = ImageType::New();
   inputImage->SetRegions(region);
   inputImage->SetNumberOfComponentsPerPixel(NumberOfComponents);
   inputImage->Allocate();

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -61,9 +61,7 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     myIndexType start;
     start.Fill(0);
 
-    myRegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    myRegionType region{ start, size };
 
     // Initialize Image A
     inputImage->SetRegions(region);

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
@@ -59,9 +59,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
@@ -56,9 +56,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -54,9 +54,7 @@ itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   myIndexType start;
   start.Fill(0);
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
@@ -40,9 +40,7 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
   // Create an image with stripes to label
   InputImageType::IndexType  index = { { 0, 0 } };
   InputImageType::SizeType   size = { { 32, 32 } };
-  InputImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  InputImageType::RegionType region{ index, size };
 
   auto inputImage = InputImageType::New();
   inputImage->SetLargestPossibleRegion(region);

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -42,9 +42,7 @@ itkMatrixImageWriteReadTest(int argc, char * argv[])
   MatrixImageType::IndexType start;
   start.Fill(0);
 
-  MatrixImageType::RegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  MatrixImageType::RegionType region{ start, size };
 
   matrixImage1->SetRegions(region);
   matrixImage1->Allocate();

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -42,9 +42,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
   size.Fill(16);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);
   inputImage->Allocate();
   inputImage->FillBuffer(0);

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -64,9 +64,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   size.Fill(9);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);
   inputImage->Allocate();
   inputImage->FillBuffer(vector0);

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -323,9 +323,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 
   auto im = ImageType::New();
 
-  typename ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename ImageType::RegionType region{ index, size };
   im->SetRegions(region);
   im->SetSpacing(spacing);
   im->SetOrigin(origin);
@@ -589,9 +587,7 @@ MINCReadWriteTestVector(const char * fileName,
   auto im = ImageType::New();
 
   // itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion,spacing);
-  typename ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename ImageType::RegionType region{ index, size };
   im->SetRegions(region);
   im->SetSpacing(spacing);
   im->SetOrigin(origin);

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -40,10 +40,8 @@ itkNiftiWriteCoerceOrthogonalDirectionTest(int argc, char * argv[])
 
   ImageType::IndexType  startIndex = { { 0, 0 } };
   ImageType::SizeType   imageSize = { { 2, 2 } };
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(startIndex);
-  auto image1 = ImageType::New();
+  ImageType::RegionType region{ startIndex, imageSize };
+  auto                  image1 = ImageType::New();
   image1->SetRegions(region);
   image1->AllocateInitialized();
 

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -174,9 +174,7 @@ itkPNGImageIOTest(int argc, char * argv[])
   size3D.Fill(10);
   ImageType3D::IndexType start3D;
   start3D.Fill(0);
-  ImageType3D::RegionType region3D;
-  region3D.SetSize(size3D);
-  region3D.SetIndex(start3D);
+  ImageType3D::RegionType region3D{ start3D, size3D };
 
   volume->SetRegions(region3D);
   volume->Allocate();
@@ -220,9 +218,7 @@ itkPNGImageIOTest(int argc, char * argv[])
   size2D.Fill(10);
   ImageType2D::IndexType start2D;
   start2D.Fill(0);
-  ImageType2D::RegionType region2D;
-  region2D.SetSize(size2D);
-  region2D.SetIndex(start2D);
+  ImageType2D::RegionType region2D{ start2D, size2D };
 
   image->SetRegions(region2D);
   image->Allocate();
@@ -265,9 +261,7 @@ itkPNGImageIOTest(int argc, char * argv[])
   size1D.Fill(10);
   ImageType1D::IndexType start1D;
   start1D.Fill(0);
-  ImageType1D::RegionType region1D;
-  region1D.SetSize(size1D);
-  region1D.SetIndex(start1D);
+  ImageType1D::RegionType region1D{ start1D, size1D };
   line->SetRegions(region1D);
 
   line->Allocate();

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -54,9 +54,7 @@ ReadWriteTest(const std::string fileName, const bool isRealDisplacementField, co
     size.Fill(dimLength);
     typename FieldType::IndexType start;
     start.Fill(0);
-    typename FieldType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+    typename FieldType::RegionType region{ start, size };
     knownField->SetRegions(region);
 
     typename FieldType::SpacingType spacing;

--- a/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
@@ -54,9 +54,7 @@ itkFilterImageAddTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  myRegionType region;
-  region.SetIndex(start);
-  region.SetSize(size);
+  myRegionType region{ start, size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
@@ -168,9 +168,7 @@ itkDirectFourierReconstructionImageToImageFilterTest(int argc, char * argv[])
   size[1] = std::stoi(argv[15]);
   size[2] = std::stoi(argv[16]);
 
-  ROIFilterType::RegionType requestedRegion;
-  requestedRegion.SetIndex(start);
-  requestedRegion.SetSize(size);
+  ROIFilterType::RegionType requestedRegion{ start, size };
 
   ROIFilter->SetRegionOfInterest(requestedRegion);
 

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -130,9 +130,7 @@ itkImageFunctionTest(int, char *[])
   size[0] = 3;
   size[1] = 4;
   size[2] = 5;
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  RegionType region{ start, size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -63,9 +63,7 @@ class EigenAnalysis2DImageFilterTester
     myIndexType start;
     start.Fill(0);
 
-    myRegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+    myRegionType region{ start, size };
 
     inputImage->SetRegions(region);
     inputImage->Allocate();

--- a/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
@@ -269,9 +269,7 @@ itkFEMRobustSolverTest(int, char *[])
   InterpolationGridType::IndexType start;
   start[0] = 0;
   start[1] = 0;
-  InterpolationGridType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(start);
+  InterpolationGridType::RegionType region{ start, size };
   solver->SetRegion(region);
 
   InterpolationGridType::DirectionType direction;

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -128,9 +128,7 @@ itkNarrowBandImageFilterBaseTest(int argc, char * argv[])
 
   ImageType::SizeType   size = { { 64, 64 } };
   ImageType::IndexType  index = { { 0, 0 } };
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
 
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -53,9 +53,7 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   sz.Fill(35);
   IndexType idx;
   idx.Fill(0);
-  RegionType region;
-  region.SetSize(sz);
-  region.SetIndex(idx);
+  RegionType region{ idx, sz };
 
   inImage->SetRegions(region);
   inImage->AllocateInitialized();

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -79,9 +79,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   sz.Fill(25);
   IndexType idx;
   idx.Fill(0);
-  RegionType region;
-  region.SetSize(sz);
-  region.SetIndex(idx);
+  RegionType region{ idx, sz };
 
   inImage->SetRegions(region);
   inImage->AllocateInitialized();
@@ -92,9 +90,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   IndexType idxConstraint;
   idxConstraint[0] = 0;
   idxConstraint[1] = 5;
-  RegionType regionConstraint;
-  regionConstraint.SetSize(szConstraint);
-  regionConstraint.SetIndex(idxConstraint);
+  RegionType regionConstraint{ idxConstraint, szConstraint };
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);
@@ -164,9 +160,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   IndexType validStart;
   validStart[0] = 0;
   validStart[1] = 5;
-  RegionType validRegion;
-  validRegion.SetSize(validSz);
-  validRegion.SetIndex(validStart);
+  RegionType validRegion{ validStart, validSz };
 
   IteratorType it(inImage, region);
   it.GoToBegin();

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -114,9 +114,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   ImageType::IndexType index;
   index.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, size };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -55,9 +55,7 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   sz.Fill(regionSizeVal);
   IndexType idx;
   idx.Fill(0);
-  RegionType region;
-  region.SetSize(sz);
-  region.SetIndex(idx);
+  RegionType region{ idx, sz };
 
   inImage->SetRegions(region);
   inImage->AllocateInitialized();

--- a/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
@@ -270,9 +270,7 @@ itkCenteredTransformInitializerTest(int, char *[])
     index[1] = 0;
     index[2] = 0;
 
-    RegionType region;
-    region.SetSize(size);
-    region.SetIndex(index);
+    RegionType region{ index, size };
 
 
     auto fixedImage = FixedImageType::New();
@@ -337,13 +335,9 @@ itkCenteredTransformInitializerTest(int, char *[])
     movingIndex[1] = 20;
     movingIndex[2] = 30;
 
-    RegionType fixedRegion;
-    fixedRegion.SetSize(size);
-    fixedRegion.SetIndex(fixedIndex);
+    RegionType fixedRegion{ fixedIndex, size };
 
-    RegionType movingRegion;
-    movingRegion.SetSize(size);
-    movingRegion.SetIndex(movingIndex);
+    RegionType movingRegion{ movingIndex, size };
 
     using VersorType = itk::Versor<itk::SpacePrecisionType>;
     VersorType x;

--- a/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
@@ -78,9 +78,7 @@ itkCenteredVersorTransformInitializerTest(int, char *[])
   index[1] = 0;
   index[2] = 0;
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
 
   auto fixedImage = FixedImageType::New();

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -142,9 +142,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -149,9 +149,7 @@ itkImageRegistrationMethodTest_14(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -125,9 +125,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -131,9 +131,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -54,9 +54,7 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
 
   MovingImageType::SizeType   size = { { 16, 16 } };
   MovingImageType::IndexType  index = { { 0, 0 } };
-  MovingImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  MovingImageType::RegionType region{ index, size };
 
   auto imgMoving = MovingImageType::New();
   imgMoving->SetRegions(region);

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -61,9 +61,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
 
   typename MovingImageType::SizeType   size = { { 100, 100 } };
   typename MovingImageType::IndexType  index = { { 0, 0 } };
-  typename MovingImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename MovingImageType::RegionType region{ index, size };
 
   typename MovingImageType::SpacingType imgSpacing;
   imgSpacing[0] = 3.0;
@@ -462,9 +460,7 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
 
   typename MovingImageType::SizeType   size = { { 100, 100 } };
   typename MovingImageType::IndexType  index = { { 0, 0 } };
-  typename MovingImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename MovingImageType::RegionType region{ index, size };
 
   typename MovingImageType::SpacingType imgSpacing;
   imgSpacing[0] = 1.5;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -123,9 +123,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -121,9 +121,7 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 
   FixedImageType::SizeType   size = { { 100, 100, 40 } };
   FixedImageType::IndexType  index = { { 0, 0, 0 } };
-  FixedImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  FixedImageType::RegionType region{ index, size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -135,9 +135,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   // InputImageType::SizeType size = {{101,101,41}};
   InputImageType::SizeType   size = { { 128, 132, 48 } };
   InputImageType::IndexType  index = { { 0, 0, 0 } };
-  InputImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  InputImageType::RegionType region{ index, size };
 
   InputImageType::SpacingType spacing;
   spacing[0] = 0.5;

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -50,9 +50,7 @@ itkMutualInformationMetricTest(int, char *[])
 
   MovingImageType::SizeType   size = { { 100, 100 } };
   MovingImageType::IndexType  index = { { 0, 0 } };
-  MovingImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  MovingImageType::RegionType region{ index, size };
 
   auto imgMoving = MovingImageType::New();
   imgMoving->SetRegions(region);

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -97,9 +97,7 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   InputImageType::SizeType   size = { { 100, 100, 40 } };
   InputImageType::IndexType  index = { { 0, 0, 0 } };
-  InputImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  InputImageType::RegionType region{ index, size };
 
   auto imgTarget = InputImageType::New();
   imgTarget->SetRegions(region);

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -385,9 +385,7 @@ itkFEMFiniteDifferenceFunctionLoadTest(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto movingImage = InputImageType::New();
   auto fixedImage = InputImageType::New();

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -105,9 +105,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto movingImage = InputImageType::New();
   auto fixedImage = InputImageType::New();

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -106,9 +106,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto movingImage = InputImageType::New();
   auto fixedImage = InputImageType::New();

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -118,9 +118,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto movingImage = InputImageType::New();
   auto fixedImage = InputImageType::New();

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -137,9 +137,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -155,9 +155,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -132,9 +132,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -40,9 +40,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -274,9 +274,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
   RegionType::IndexType regionIndex;
   regionIndex.Fill(0);
 
-  RegionType region;
-  region.SetSize(regionSize);
-  region.SetIndex(regionIndex);
+  RegionType region{ regionIndex, regionSize };
 
   auto displacementField = FieldType::New();
   displacementField->SetOrigin(origin);

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -119,9 +119,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   typename RegionType::IndexType regionIndex;
   regionIndex.Fill(0);
 
-  RegionType region;
-  region.SetSize(regionSize);
-  region.SetIndex(regionIndex);
+  RegionType region{ regionIndex, regionSize };
 
   auto displacementField = FieldType::New();
   displacementField->SetOrigin(origin);
@@ -236,9 +234,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   // one that doesn't match the displacement field.
   typename RegionType::SizeType badSize;
   badSize.Fill(static_cast<itk::SizeValueType>(pointMax / 2.0));
-  RegionType badRegion;
-  badRegion.SetSize(badSize);
-  badRegion.SetIndex(regionIndex);
+  RegionType badRegion{ regionIndex, badSize };
   metric->SetVirtualDomain(spacing, origin, direction, badRegion);
   ITK_TRY_EXPECT_EXCEPTION(metric->Initialize());
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -386,11 +386,9 @@ itkImageToImageMetricv4Test(int, char ** const)
   using DimensionSizeType = unsigned int;
   constexpr DimensionSizeType imageSize = 4;
 
-  ImageToImageMetricv4TestImageType::SizeType   size = { { imageSize, imageSize } };
-  ImageToImageMetricv4TestImageType::IndexType  index = { { 0, 0 } };
-  ImageToImageMetricv4TestImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageToImageMetricv4TestImageType::SizeType    size = { { imageSize, imageSize } };
+  ImageToImageMetricv4TestImageType::IndexType   index = { { 0, 0 } };
+  ImageToImageMetricv4TestImageType::RegionType  region{ index, size };
   ImageToImageMetricv4TestImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageToImageMetricv4TestImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -40,9 +40,7 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -66,9 +66,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * const interpolator, const bo
   typename MovingImageType::SizeType   size = { { static_cast<SizeValueType>(imageSize),
                                                 static_cast<SizeValueType>(imageSize) } };
   typename MovingImageType::IndexType  index = { { 0, 0 } };
-  typename MovingImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename MovingImageType::RegionType region{ index, size };
 
   typename MovingImageType::SpacingType imgSpacing;
   imgSpacing[0] = 3.0;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -42,9 +42,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -38,9 +38,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType
   size.Fill(imageSize);
   typename ImageType::IndexType index;
   index.Fill(0);
-  typename ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  typename ImageType::RegionType  region{ index, size };
   typename ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   typename ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -43,9 +43,7 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -38,9 +38,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   size.Fill(imageSize);
   ImageType::IndexType index;
   index.Fill(0);
-  ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   ImageType::PointType origin;

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -213,9 +213,7 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
   size.Fill(imageSize);
   typename ImageType::IndexType virtualIndex;
   virtualIndex.Fill(0);
-  typename ImageType::RegionType region;
-  region.SetSize(size);
-  region.SetIndex(virtualIndex);
+  typename ImageType::RegionType  region{ virtualIndex, size };
   typename ImageType::SpacingType spacing;
   spacing.Fill(1.0);
   typename ImageType::PointType origin;

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -128,9 +128,7 @@ itkCurvatureRegistrationFilterTest(int, char *[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -127,9 +127,7 @@ itkDemonsRegistrationFilterTest(int, char *[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -139,9 +139,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -126,9 +126,7 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -142,9 +142,7 @@ itkLevelSetMotionRegistrationFilterTest(int argc, char * argv[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -173,9 +173,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   index.Fill(0);
   index[0] = 3;
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   ImageType::PointType origin;
   origin.Fill(0.0);

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -119,9 +119,7 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   IndexType index;
   index.Fill(0);
 
-  RegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  RegionType region{ index, size };
 
   auto moving = ImageType::New();
   auto fixed = ImageType::New();

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -244,9 +244,7 @@ test_regiongrowKLM1D()
   ImageType::IndexType index;
   index.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -830,9 +828,7 @@ test_regiongrowKLM2D()
   ImageType::IndexType index;
   index.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -1283,9 +1279,7 @@ test_regiongrowKLM3D()
   ImageType::IndexType index;
   index.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -1788,9 +1782,7 @@ test_regiongrowKLM4D()
   ImageType::IndexType index;
   index.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(index);
+  ImageType::RegionType region{ index, imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
@@ -66,9 +66,7 @@ itkCurvesLevelSetImageFilterTest(int, char *[])
   squareStart.Fill(20);
   ImageType::SizeType squareSize;
   squareSize.Fill(60);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
@@ -63,9 +63,7 @@ itkCurvesLevelSetImageFilterZeroSigmaTest(int, char *[])
   squareStart.Fill(20);
   ImageType::SizeType squareSize;
   squareSize.Fill(60);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -220,9 +220,7 @@ itkExtensionVelocitiesImageFilterTest(int, char *[])
   centerIndex.Fill(50 - 8);
   ImageType::SizeType centerSize;
   centerSize.Fill(17);
-  ImageType::RegionType centerRegion;
-  centerRegion.SetIndex(centerIndex);
-  centerRegion.SetSize(centerSize);
+  ImageType::RegionType centerRegion{ centerIndex, centerSize };
 
   iter = Iterator(difference->GetOutput(), centerRegion);
   iter.GoToBegin();

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
@@ -58,9 +58,7 @@ itkGeodesicActiveContourLevelSetImageFilterTest(int, char *[])
   squareStart.Fill(20);
   ImageType::SizeType squareSize;
   squareSize.Fill(60);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
@@ -60,9 +60,7 @@ itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest(int, char *[])
   squareStart.Fill(20);
   ImageType::SizeType squareSize;
   squareSize.Fill(60);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -117,9 +117,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   ImageType::SizeType rectSize;
   rectSize[0] = 80;
   rectSize[1] = 10;
-  ImageType::RegionType rectRegion;
-  rectRegion.SetIndex(rectStart);
-  rectRegion.SetSize(rectSize);
+  ImageType::RegionType rectRegion{ rectStart, rectSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, rectRegion);

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
@@ -121,9 +121,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2(int, char *[])
   ImageType::SizeType rectSize;
   rectSize[0] = 80;
   rectSize[1] = 10;
-  ImageType::RegionType rectRegion;
-  rectRegion.SetIndex(rectStart);
-  rectRegion.SetSize(rectSize);
+  ImageType::RegionType rectRegion{ rectStart, rectSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, rectRegion);

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
@@ -68,9 +68,7 @@ itkNarrowBandCurvesLevelSetImageFilterTest(int argc, char * argv[])
   squareStart.Fill(10);
   ImageType::SizeType squareSize;
   squareSize.Fill(30);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
@@ -64,9 +64,7 @@ itkShapeDetectionLevelSetImageFilterTest(int, char *[])
   squareStart.Fill(20);
   ImageType::SizeType squareSize;
   squareSize.Fill(60);
-  ImageType::RegionType squareRegion;
-  squareRegion.SetIndex(squareStart);
-  squareRegion.SetSize(squareSize);
+  ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;
   Iterator it(inputImage, squareRegion);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
@@ -87,9 +87,7 @@ itkLevelSetDenseImageTest(int, char *[])
   size[0] = 10;
   size[1] = 20;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   PixelType zeroValue = 0.;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -40,9 +40,7 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
   size[0] = 10;
   size[1] = 10;
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   ListPixelType l;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -51,9 +51,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -56,9 +56,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();
@@ -83,9 +81,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
     index[1] = 0;
     size.Fill(10);
 
-    InputImageType::RegionType region1;
-    region1.SetIndex(index);
-    region1.SetSize(size);
+    InputImageType::RegionType region1{ index, size };
 
     regionVector[i] = region1;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -68,9 +68,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -77,9 +77,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -80,9 +80,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -75,9 +75,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -74,9 +74,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -68,9 +68,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -74,9 +74,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -82,9 +82,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
@@ -57,9 +57,7 @@ itkMultiLevelSetChanAndVeseInternalTermTest(int, char *[])
   size[0] = 10;
   size[1] = 10;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   PixelType value = 0.;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -81,9 +81,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Input initialization
   auto input = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -40,9 +40,7 @@ itkMultiLevelSetDenseImageTest(int, char *[])
   size[0] = 10;
   size[1] = 10;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   PixelType value = 0.;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
@@ -66,9 +66,7 @@ itkMultiLevelSetEvolutionTest(int, char *[])
   size[0] = 10;
   size[1] = 10;
 
-  ImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  ImageType::RegionType region{ index, size };
 
   PixelType value = 0.;
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -82,9 +82,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Input initialization
   auto input = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -82,9 +82,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Input initialization
   auto input = InputImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -82,9 +82,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   InputImageType::IndexType index;
   index.Fill(0);
 
-  InputImageType::RegionType region;
-  region.SetIndex(index);
-  region.SetSize(size);
+  InputImageType::RegionType region{ index, size };
 
   // Input initialization
   auto input = InputImageType::New();

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -65,9 +65,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   ImageType::IndexType startIndex;
   startIndex.Fill(0);
 
-  ImageType::RegionType region;
-  region.SetSize(imageSize);
-  region.SetIndex(startIndex);
+  ImageType::RegionType region{ startIndex, imageSize };
 
 
   // set up the random number generator


### PR DESCRIPTION
Replaced code like:

    RegionType region;
    region.SetSize(size);
    region.SetIndex(index);

With the shorter equivalent, `RegionType region{ index, size };`

Using Notepad++, Replace in Files:

    Find what: ^( [ ]+)(\w.*Region[^ ]*)([ ]+)(\w+);\r\n\1\4\.SetSize\((\w+)\);\r\n\1\4\.SetIndex\((\w+)\);
    Replace with: $1$2$3$4{ $6, $5 };
    Find what: ^( [ ]+)(\w.*Region[^ ]*)([ ]+)(\w+);\r\n\1\4\.SetIndex\((\w+)\);\r\n\1\4\.SetSize\((\w+)\);
    Replace with: $1$2$3$4{ $5, $6 };
    Filters: itk*Test*.cxx
    [v] Match case
    (*) Regular expression