### PR TITLE
COMP: Suppress `-Wformat-nonliteral` warning in diff tensor example

### DIFF
--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -250,14 +250,15 @@ main(int argc, char * argv[])
       if (DiffusionVectors->ElementAt(i).two_norm() <=
           0.0) // this is a reference image
       {
-        std::string fn("ReferenceImage%d.mhd");
-        snprintf(filename, sizeof(filename), fn.c_str(), referenceImageIndex);
+        snprintf(filename,
+                 sizeof(filename),
+                 "ReferenceImage%d.mhd",
+                 referenceImageIndex);
         ++referenceImageIndex;
       }
       else
       {
-        std::string fn("Gradient%d.mhd");
-        snprintf(filename, sizeof(filename), fn.c_str(), i);
+        snprintf(filename, sizeof(filename), "Gradient%d.mhd", i);
       }
       gradientWriter->SetFileName(filename);
       gradientWriter->Update();


### PR DESCRIPTION
Suppress `-Wformat-nonliteral` warning in diffusion tensor reconstruction image filter example.

Fixes:
```
[CTest: warning matched]
 /Users/builder/externalExamples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx:254:46:
 warning: format string is not a string literal [-Wformat-nonliteral]
        snprintf(filename, sizeof(filename), fn.c_str(), referenceImageIndex);
                                             ^~~~~~~~~~
[CTest: warning matched]
 /Users/builder/externalExamples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx:260:46:
 warning: format string is not a string literal [-Wformat-nonliteral]
        snprintf(filename, sizeof(filename), fn.c_str(), i);
                                             ^~~~~~~~~~
[CTest: warning suppressed] 2 warnings generated.
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=9582771

Left behind in commit 001a1a7.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)