### PR TITLE
COMP: GCC 13 CastXML vector include workaround

### DIFF
--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -21,8 +21,17 @@
 
 #include <iostream>
 #include <iterator>
-#include <vector>
 
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112467
+#if defined(ITK_WRAPPING_PARSER) && defined(__GNUC__) && !defined(__clang__)
+#  define __clang__
+#  define ITK_CASTXML_GCC_VECTOR_WORKAROUND
+#endif
+#include <vector>
+#if defined(ITK_CASTXML_GCC_VECTOR_WORKAROUND)
+#  undef __clang__
+#  undef ITK_CASTXML_GCC_VECTOR_WORKAROUND
+#endif
 
 namespace itk
 {


### PR DESCRIPTION
Addresses:

```
FAILED: Wrapping/castxml_inputs/itkImageSource.xml /home/matt/bin/ITK-Wrap-Release/Wrapping/castxml_inputs/itkImageSource.xml
cd /home/matt/bin/ITK-Wrap-Release/Wrapping/Modules/ITKCommon && /home/matt/bin/ITK-Wrap-Release/Wrapping/Generators/CastXML/castxml/bin/castxml -o /home/matt/bin/ITK-Wrap-Release/Wrapping/castxml_inputs/itkImageSource.xml --castxml-gccxml --castxml-start _wrapping_ --castxml-cc-gnu "(" /usr/bin/c++ -Wall -Wcast-align -Wdisabled-optimization -Wextra -Wformat=2 -Winvalid-pch -Wno-format-nonliteral -Wpointer-arith -Wshadow -Wunused -Wwrite-strings -Wno-strict-overflow -Wno-deprecated -Wno-invalid-offsetof -Woverloaded-virtual -Wctad-maybe-unsupported -Wstrict-null-sentinel -fno-sized-deallocation -msse2 -fno-sized-deallocation -msse2 -std=c++17 ")" -w -c @/home/matt/bin/ITK-Wrap-Release/Wrapping/castxml_inputs/.castxml.inc /home/matt/bin/ITK-Wrap-Release/Wrapping/castxml_inputs/itkImageSource.cxx
In file included from /home/matt/bin/ITK-Wrap-Release/Wrapping/castxml_inputs/itkImageSource.cxx:1:
In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkCommand.h:21:
In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkObject.h:31:
In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkLightObject.h:21:
In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkMacro.h:51:
In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkPrintHelper.h:24:
In file included from /usr/include/c++/13/vector:67:
/usr/include/c++/13/bits/stl_bvector.h:190:35: error: expected string literal as argument of '__assume__' attribute
  190 |       __attribute__ ((__assume__ (__ofst < unsigned(_S_word_bit))));
      |                                   ^
```

See also:

  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112467
