### PR TITLE
BUG: Add bufferedRegion to dict_from_image representation

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -20,7 +20,7 @@
             if source:
                 source.UpdateLargestPossibleRegion()
 
-        itksize = image.GetLargestPossibleRegion().GetSize()
+        itksize = image.GetBufferedRegion().GetSize()
         dim     = len(itksize)
         shape   = [int(itksize[idx]) for idx in range(dim)]
 

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -224,6 +224,14 @@ image_back = itk.image_from_dict(image_dict)
 diff = itk.comparison_image_filter(image.astype(itk.F), image_back.astype(itk.F))
 assert np.sum(diff) == 0
 
+
+largest_region = itk.ImageRegion[2]([0, 0], [1024, 1024])
+image.SetLargestPossibleRegion(largest_region)
+image_dict = itk.dict_from_image(image)
+image_back = itk.image_from_dict(image_dict)
+diff = itk.comparison_image_filter(image.astype(itk.F), image_back.astype(itk.F))
+assert np.sum(diff) == 0
+
 mesh_dict = itk.dict_from_mesh(mesh)
 mesh_back = itk.mesh_from_dict(mesh_dict)
 


### PR DESCRIPTION
Optional specification of the BufferedRegion, which is a subset of the
LargestPossibleRegion. Addresses #4267.

The LargestPossibleRegion's Index is assumed to be trivial (zeros).

Also update the NumPy bridge to correctly use the BufferedRegion instead
of the LargestPossibleRegion for the array shape.
