### PR TITLE
BUG: Make dict_from_transform more consistent with other dict representations

### DIFF
--- a/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
+++ b/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
@@ -35,16 +35,13 @@ transforms_to_test = [
 
 keys_to_test1 = [
     "name",
-    "parametersValueType",
-    "transformType",
-    "inputDimension",
-    "outputDimension",
     "inputSpaceName",
     "outputSpaceName",
     "numberOfParameters",
     "numberOfFixedParameters",
 ]
 keys_to_test2 = ["parameters", "fixedParameters"]
+keys_to_test3 = ["transformParameterization", "parametersValueType", "inputDimension", "outputDimension"]
 
 transform_object_list = []
 for i, transform_type in enumerate(transforms_to_test):
@@ -60,6 +57,8 @@ for i, transform_type in enumerate(transforms_to_test):
     # Test all the parameters
     for k in keys_to_test2:
         assert np.array_equal(serialize_deserialize[k], transform[k])
+    for k in keys_to_test3:
+        assert serialize_deserialize["transformType"][k], transform["transformType"][k]
     transform_object_list.append(transform)
 
 print("Individual Transforms Test Done")
@@ -92,6 +91,9 @@ for i in range(len(transforms_to_test)):
     # Test all the parameter arrays
     for k in keys_to_test2:
         assert np.array_equal(transform_obj[k], transform_object_list[i][k])
+
+    for k in keys_to_test3:
+        assert transform_object_list[i]["transformType"][k], transform["transformType"][k]
 
 
 # Test for transformation using de-serialized BSpline Transform

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -430,7 +430,7 @@ str = str
                 Return keys related to the transform's metadata.
                 These keys are used in the dictionary resulting from dict(transform).
                 """
-                result = ['name', 'inputDimension', 'outputDimension', 'inputSpaceName', 'outputSpaceName', 'numberOfParameters', 'numberOfFixedParameters', 'parameters', 'fixedParameters']
+                result = ['transformType', 'name', 'inputSpaceName', 'outputSpaceName', 'numberOfParameters', 'numberOfFixedParameters', 'parameters', 'fixedParameters']
                 return result
 
             def __getitem__(self, key):
@@ -438,7 +438,7 @@ str = str
                 import itk
                 if isinstance(key, str):
                     state = itk.dict_from_transform(self)
-                    return state[0][key]
+                    return state[key]
 
             def __setitem__(self, key, value):
                 if isinstance(key, str):
@@ -474,7 +474,6 @@ str = str
             def __setstate__(self, state):
                 """Set object state, necessary for serialization with pickle."""
                 import itk
-                import numpy as np
                 deserialized = itk.transform_from_dict(state)
                 self.__dict__['this'] = deserialized
             %}

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -343,6 +343,11 @@ assert np.allclose(parameters, baseline_parameters)
 parameters = np.asarray(transforms[0].GetParameters())
 assert np.allclose(parameters, np.array(baseline_additional_transform_params))
 
+transform_dict = itk.dict_from_transform(transforms[0])
+transform_back = itk.transform_from_dict(transform_dict)
+transform_dict = itk.dict_from_transform(transforms)
+transform_back = itk.transform_from_dict(transform_dict)
+
 # pipeline, auto_pipeline and templated class are tested in other files
 
 # BridgeNumPy


### PR DESCRIPTION
Encapsulate the "transformParameterization", "parametersValueType",
"inputDimension", "outputDimension", which are static, into a
"transformType" member, similar to "imageType", "meshType" for Images,
Meshes. "transformParameterization" is the string name of the ITK transform
class, less the trailing "Transform".

Example serialization:

```py
{
    'transformType': {'transformParameterization': 'Translation', 'parametersValueType': 'float64', 'inputDimension': 3, 'outputDimension': 3},
    'name': '',
    'inputSpaceName': '',
    'outputSpaceName': '',
    'parameters': array([3., 2., 8.]),
    'fixedParameters': array([], dtype=float64),
    'numberOfParameters': 3,
    'numberOfFixedParameters': 0
}
```

```py
[
    {
        'transformType': {'transformParameterization': 'Translation', 'parametersValueType': 'float64', 'inputDimension': 3, 'outputDimension': 3},
        'name': '',
        'inputSpaceName': '',
        'outputSpaceName': '',
        'parameters': array([3., 2., 8.]),
        'fixedParameters': array([], dtype=float64),
        'numberOfParameters': 3,
        'numberOfFixedParameters': 0
    },
    {
        'transformType': {'transformParameterization': 'Affine', 'parametersValueType': 'float64', 'inputDimension': 3, 'outputDimension': 3},
        'name': '',
        'inputSpaceName': '',
        'outputSpaceName': '',
        'parameters': array([  0.6563149 ,   0.58065837,  -0.48175367,  -0.74079868,
         0.37486398,  -0.55739959,  -0.14306664,   0.72271215,
         0.67617978, -66.        ,  69.        ,  32.        ]),
        'fixedParameters': array([0., 0., 0.]),
        'numberOfParameters': 12,
        'numberOfFixedParameters': 3
    }
]
```

Remove unused numpy import in __setstate__.

Support both a list of transforms and a single transform in
dict_from_transform.

Add more smoke tests in extras.py.
