### PR TITLE
COMP: Fix for gcc13.2 compiler test failures

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
@@ -209,13 +209,9 @@ public:
 
   // DUMB: this only search within the level of the current DataSet
   bool FindDataElement(const Tag &t) const {
-    const DataElement r(t);
-    //ConstIterator it = DES.find(r);
-    if( DES.find(r) != DES.end() )
-      {
-      return true;
-      }
-    return false;
+    const auto it = GetDataElement(t);
+    // Return if tag is found
+    return it != GetDEEnd();
     }
 
   // WARNING:


### PR DESCRIPTION
Three tests fail in ITK for Release and RelWithDebInfo builds on Ubuntu 24.04 with GCC 13.2:
  itkGDCMLegacyMultiFrameTest (Failed)
  itkGDCMImageReadWriteTest_MultiFrameMRIZSpacing (Failed)
  itkGDCM_ComplianceTest_singlebit (Failed)

(Note: Debug builds do not fail these tests)

The initial review of the code did not indicate a problem, but it looks like perhaps an over-optimization that removes variables and causes the incorrect behavior to occur.

The function "FindDataElement" had duplicate code from "GetDataElement" so made "FindDataElement" use the "GetDataElement" working function.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
