### PR TITLE
COMP: Fix implicit copy constructor definition deprecation warnings

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -52,6 +52,13 @@ public:
 
   /** Has to have empty throw(). */
   ~ImageFileReaderException() noexcept override;
+
+  ImageFileReaderException(const ImageFileReaderException &) = default;
+  ImageFileReaderException(ImageFileReaderException &&) = default;
+  ImageFileReaderException &
+  operator=(const ImageFileReaderException &) = default;
+  ImageFileReaderException &
+  operator=(ImageFileReaderException &&) = default;
 };
 } // namespace itk
 #endif // itkImageFileReaderException_h

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -55,6 +55,13 @@ public:
 
   /** Has to have empty throw(). */
   ~ImageFileWriterException() noexcept override;
+
+  ImageFileWriterException(const ImageFileWriterException &) = default;
+  ImageFileWriterException(ImageFileWriterException &&) = default;
+  ImageFileWriterException &
+  operator=(const ImageFileWriterException &) = default;
+  ImageFileWriterException &
+  operator=(ImageFileWriterException &&) = default;
 };
 
 /** \class ImageFileWriter

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -49,6 +49,13 @@ public:
                           unsigned int        line,
                           const char *        message = "Error in IO",
                           const char *        loc = "Unknown");
+
+  MeshFileReaderException(const MeshFileReaderException &) = default;
+  MeshFileReaderException(MeshFileReaderException &&) = default;
+  MeshFileReaderException &
+  operator=(const MeshFileReaderException &) = default;
+  MeshFileReaderException &
+  operator=(MeshFileReaderException &&) = default;
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -49,6 +49,13 @@ public:
                           unsigned int        line,
                           const char *        message = "Error in IO",
                           const char *        loc = "Unknown");
+
+  MeshFileWriterException(const MeshFileWriterException &) = default;
+  MeshFileWriterException(MeshFileWriterException &&) = default;
+  MeshFileWriterException &
+  operator=(const MeshFileWriterException &) = default;
+  MeshFileWriterException &
+  operator=(MeshFileWriterException &&) = default;
 };
 } // end namespace itk
 


### PR DESCRIPTION
Fix implicit copy constructor definition deprecation warnings in image/mesh file reader exception classes by using explicitly the compiler-provided default implementation (together with the assignment
assignment and move semantics).

Fixes:
```
[CTest: warning matched]
 /Users/builder/externalModules/IO/ImageBase/include/itkImageFileReaderException.h:54:3:
 warning: definition of implicit copy constructor for 'ImageFileReaderException' is deprecated because it has a user-declared destructor [-Wdeprecated]
  ~ImageFileReaderException() noexcept override;
  ^
```

and
```
[CTest: warning matched]
 /Users/builder/externalModules/IO/ImageBase/include/itkImageFileWriter.h:57:3:
 warning: definition of implicit copy constructor for 'ImageFileWriterException' is deprecated because it has a user-declared destructor [-Wdeprecated]
  ~ImageFileWriterException() noexcept override;
  ^
```

and
```
[CTest: warning matched]
 /Users/builder/externalModules/IO/MeshBase/include/itkMeshFileReaderException.h:36:3:
 warning: definition of implicit copy constructor for 'MeshFileReaderException' is deprecated because it has a user-declared destructor [-Wdeprecated]
  ~MeshFileReaderException() noexcept override;
  ^
```

and
```
[CTest: warning matched]
 /Users/builder/externalModules/IO/MeshBase/include/itkMeshFileWriterException.h:36:3:
 warning: definition of implicit copy constructor for 'MeshFileWriterException' is deprecated because it has a user-declared destructor [-Wdeprecated]
  ~MeshFileWriterException() noexcept override;
  ^
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=9587875

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)