### PR TITLE
WIP: COMP: Revert "COMP: GCC 13 CastXML vector include workaround"

### DIFF
--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -21,17 +21,8 @@
 
 #include <iostream>
 #include <iterator>
-
-// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112467
-#if defined(ITK_WRAPPING_PARSER) && defined(__GNUC__) && !defined(__clang__)
-#  define __clang__
-#  define ITK_CASTXML_GCC_VECTOR_WORKAROUND
-#endif
 #include <vector>
-#if defined(ITK_CASTXML_GCC_VECTOR_WORKAROUND)
-#  undef __clang__
-#  undef ITK_CASTXML_GCC_VECTOR_WORKAROUND
-#endif
+
 
 namespace itk
 {


### PR DESCRIPTION
This reverts commit ad6c58223df6399b1281724192a41589a8214457.

Addressed in CastXML 3d27ce9b90b2dfa125e3de99716c6c5832b4d6de.
