### PR TITLE
COMP: restored old spelling of CLANG_SUPPRESS_Wfloat_equal

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -118,12 +118,18 @@ namespace itk
 
 // For Clang only (and not GCC):
 #if defined(__clang__) && defined(__has_warning)
-#  define CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
-#  define CLANG_PRAGMA_POP ITK_PRAGMA(clang diagnostic pop)
+#  define ITK_CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
+#  define ITK_CLANG_PRAGMA_POP ITK_PRAGMA(clang diagnostic pop)
 #else
-#  define CLANG_PRAGMA_PUSH
-#  define CLANG_PRAGMA_POP
+#  define ITK_CLANG_PRAGMA_PUSH
+#  define ITK_CLANG_PRAGMA_POP
 #endif
+
+// These were not intended as public API, but some code was nevertheless using them.
+// Support the pre ITK 5.4 spelling for compatibility.
+#define CLANG_PRAGMA_PUSH ITK_CLANG_PRAGMA_PUSH
+#define CLANG_PRAGMA_POP ITK_CLANG_PRAGMA_POP
+#define CLANG_SUPPRESS_Wfloat_equal ITK_GCC_SUPPRESS_Wfloat_equal
 
 #if !defined(ITK_LEGACY_REMOVE)
 // Issue warning if deprecated preprocessor flag is used.


### PR DESCRIPTION
Brought back #define CLANG_SUPPRESS_Wfloat_equal for compatibility with third party code using this as public API.

While here, also prefixed some other defines with ITK to indicate they are from ITK.
