### PR TITLE
PERF: Avoid redundant searches for a data element in a `gdcm::DataSet`

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -647,9 +647,8 @@ GDCMImageIO::InternalReadImageInformation()
     {
       std::vector<double> sp;
       gdcm::Tag           spacingTag(0x0028, 0x0030);
-      if (ds.FindDataElement(spacingTag) && !ds.GetDataElement(spacingTag).IsEmpty())
+      if (const gdcm::DataElement & de = ds.GetDataElement(spacingTag); !de.IsEmpty())
       {
-        gdcm::DataElement                            de = ds.GetDataElement(spacingTag);
         std::stringstream                            m_Ss;
         gdcm::Element<gdcm::VR::DS, gdcm::VM::VM1_n> m_El;
         const gdcm::ByteValue *                      bv = de.GetByteValue();


### PR DESCRIPTION
The original code requested `gdcm::DataSet` to search for one and the same data element three times in a row, by calling both FindDataElement and GetDataElement for the very same tag. With this commit, the search is only performed once.

Issue found by Mihail Isakov (@issakomi):
https://github.com/InsightSoftwareConsortium/ITK/pull/4636#discussion_r1593789757

----

For the record, the redundant searches appear introduced with commit 168c457e840c3ca9e7c0b6d4df4a25252a5ddc7a, June 5, 2014: https://github.com/InsightSoftwareConsortium/ITK/blob/168c457e840c3ca9e7c0b6d4df4a25252a5ddc7a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx#L384-L387
