### PR TITLE
Add `ITK_DEFAULT_COPY_AND_MOVE` and replace "manually" defaulted copy and move member function declarations

### DIFF
--- a/.github/workflows/itk_dict.txt
+++ b/.github/workflows/itk_dict.txt
@@ -224,6 +224,7 @@ Vkept
 Vox
 Wachowiak
 Wanlin
+Wdeprecated
 Wi
 Wtautological
 Xu

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -405,6 +405,20 @@ namespace itk
 #endif
 
 
+/** Explicitly "defaults" the copy constructor, copy assignment operator, move constructor, and move assignment operator
+of the specified class. Especially meant to address compiler warnings like:
+ - "warning: definition of implicit copy assignment operator for '<TypeName>' is deprecated because it has a
+user-declared destructor [-Wdeprecated]" (Mac10.13-AppleClang)
+ - "warning C5267: definition of implicit copy constructor for '<TypeName>' is deprecated because it has a user-provided
+destructor." (Visual Studio 2022/MSVC)
+  Intended to be used in the public section of a class. */
+#define ITK_DEFAULT_COPY_AND_MOVE(TypeName)         \
+  TypeName(const TypeName &) = default;             \
+  TypeName & operator=(const TypeName &) = default; \
+  TypeName(TypeName &&) = default;                  \
+  TypeName & operator=(TypeName &&) = default
+
+
 // When ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR is defined, ITK uses
 // the ability for operator!= to be rewritten automatically in terms of
 // operator==, as introduced with C++20. This macro is experimental. It may be

--- a/Modules/Core/Common/include/itkRealTimeStamp.h
+++ b/Modules/Core/Common/include/itkRealTimeStamp.h
@@ -45,6 +45,8 @@ namespace itk
 class ITKCommon_EXPORT RealTimeStamp
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(RealTimeStamp);
+
   using Self = RealTimeStamp;
 
   friend class RealTimeClock;
@@ -54,13 +56,6 @@ public:
 
   /** Destructor */
   ~RealTimeStamp();
-
-  RealTimeStamp(const RealTimeStamp &) = default;
-  RealTimeStamp &
-  operator=(const RealTimeStamp &) = default;
-  RealTimeStamp(RealTimeStamp &&) = default;
-  RealTimeStamp &
-  operator=(RealTimeStamp &&) = default;
 
   /** Native type used to represent the time in different time units. */
   using TimeRepresentationType = RealTimeInterval::TimeRepresentationType;

--- a/Modules/Core/Common/include/itkRegion.h
+++ b/Modules/Core/Common/include/itkRegion.h
@@ -65,6 +65,8 @@ namespace itk
 class ITKCommon_EXPORT Region
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(Region);
+
   /** Standard class type aliases. */
   using Self = Region;
 
@@ -89,13 +91,6 @@ public:
 
   Region() = default;
   virtual ~Region() = default;
-
-  Region(const Region &) = default;
-  Region &
-  operator=(const Region &) = default;
-  Region(Region &&) = default;
-  Region &
-  operator=(Region &&) = default;
 
 protected:
   /** Methods invoked by Print() to print information about the object

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -31,6 +31,8 @@ namespace itk
 class ITKIOImageBase_EXPORT ImageFileReaderException : public ExceptionObject
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ImageFileReaderException);
+
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageFileReaderException);
 
@@ -52,13 +54,6 @@ public:
 
   /** Has to have empty throw(). */
   ~ImageFileReaderException() noexcept override;
-
-  ImageFileReaderException(const ImageFileReaderException &) = default;
-  ImageFileReaderException(ImageFileReaderException &&) = default;
-  ImageFileReaderException &
-  operator=(const ImageFileReaderException &) = default;
-  ImageFileReaderException &
-  operator=(ImageFileReaderException &&) = default;
 };
 } // namespace itk
 #endif // itkImageFileReaderException_h

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -34,6 +34,8 @@ namespace itk
 class ITKIOImageBase_EXPORT ImageFileWriterException : public ExceptionObject
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ImageFileWriterException);
+
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageFileWriterException);
 
@@ -55,13 +57,6 @@ public:
 
   /** Has to have empty throw(). */
   ~ImageFileWriterException() noexcept override;
-
-  ImageFileWriterException(const ImageFileWriterException &) = default;
-  ImageFileWriterException(ImageFileWriterException &&) = default;
-  ImageFileWriterException &
-  operator=(const ImageFileWriterException &) = default;
-  ImageFileWriterException &
-  operator=(ImageFileWriterException &&) = default;
 };
 
 /** \class ImageFileWriter

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -32,6 +32,8 @@ namespace itk
 class ITKIOMeshBase_EXPORT MeshFileReaderException : public ExceptionObject
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(MeshFileReaderException);
+
   /** Has to have empty throw(). */
   ~MeshFileReaderException() noexcept override;
 
@@ -49,13 +51,6 @@ public:
                           unsigned int        line,
                           const char *        message = "Error in IO",
                           const char *        loc = "Unknown");
-
-  MeshFileReaderException(const MeshFileReaderException &) = default;
-  MeshFileReaderException(MeshFileReaderException &&) = default;
-  MeshFileReaderException &
-  operator=(const MeshFileReaderException &) = default;
-  MeshFileReaderException &
-  operator=(MeshFileReaderException &&) = default;
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -32,6 +32,8 @@ namespace itk
 class ITKIOMeshBase_EXPORT MeshFileWriterException : public ExceptionObject
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(MeshFileWriterException);
+
   /** Has to have empty throw(). */
   ~MeshFileWriterException() noexcept override;
 
@@ -49,13 +51,6 @@ public:
                           unsigned int        line,
                           const char *        message = "Error in IO",
                           const char *        loc = "Unknown");
-
-  MeshFileWriterException(const MeshFileWriterException &) = default;
-  MeshFileWriterException(MeshFileWriterException &&) = default;
-  MeshFileWriterException &
-  operator=(const MeshFileWriterException &) = default;
-  MeshFileWriterException &
-  operator=(MeshFileWriterException &&) = default;
 };
 } // end namespace itk
 


### PR DESCRIPTION
Aims to address issue #4645 "Defaulting copy constructor, copy assignment, move constructor, and move
assignment functions", reported by Jon Haitz Legarreta Gorroño (@jhlegarreta).