### PR TITLE
STYLE: Remove `this->MakeOutput(0)` calls from constructors in Core

### DIFF
--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -39,11 +39,10 @@ namespace itk
 template <typename TOutputImage>
 ImageSource<TOutputImage>::ImageSource()
 {
-  // Create the output. We use static_cast<> here because we know the default
-  // output must be of type TOutputImage
-  const typename TOutputImage::Pointer output = static_cast<TOutputImage *>(this->MakeOutput(0).GetPointer());
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
-  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+
+  // Equivalent to SetNthOutput(0, MakeOutput(0)); in this case, calling MakeOutput is not necessary.
+  this->ProcessObject::SetNthOutput(0, TOutputImage::New());
 
   // Set the default behavior of an image source to NOT release its
   // output bulk data prior to GenerateData() in case that bulk data

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
@@ -27,11 +27,10 @@ template <typename TInputImage, typename TOutputMesh>
 ImageToMeshFilter<TInputImage, TOutputMesh>::ImageToMeshFilter()
 {
   this->ProcessObject::SetNumberOfRequiredInputs(1);
-
-  const OutputMeshPointer output = dynamic_cast<OutputMeshType *>(this->MakeOutput(0).GetPointer());
-
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
-  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+
+  // Equivalent to SetNthOutput(0, MakeOutput(0)); in this case, calling MakeOutput is not necessary.
+  this->ProcessObject::SetNthOutput(0, OutputMeshType::New());
 }
 
 /**

--- a/Modules/Core/Mesh/include/itkMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkMeshSource.hxx
@@ -26,12 +26,10 @@ template <typename TOutputMesh>
 MeshSource<TOutputMesh>::MeshSource()
 
 {
-  // Create the output. We use static_cast<> here because we know the default
-  // output must be of type TOutputMesh
-  const OutputMeshPointer output = static_cast<TOutputMesh *>(this->MakeOutput(0).GetPointer());
-
   this->ProcessObject::SetNumberOfRequiredOutputs(1);
-  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+
+  // Equivalent to SetNthOutput(0, MakeOutput(0)); in this case, calling MakeOutput is not necessary.
+  this->ProcessObject::SetNthOutput(0, TOutputMesh::New());
 }
 
 template <typename TOutputMesh>


### PR DESCRIPTION
In those cases, `MakeOutput(0)` just did `OutputType::New()` anyway. This commit avoids unnecessary casts and calls to virtual functions.

Following C++ Core Guidelines, February 15, 2024, "Don’t call virtual functions in constructors and destructors",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-ctor-virtual

----

Intended for _after_ the release of ITK v5.4.0