### PR TITLE
BUG: Use unique filenames for Nifti tests

### DIFF
--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -37,7 +37,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftisform2DirectionDefNiiGzTest.nii.gz
   DATA{${ITK_DATA_ROOT}/Input/itkNiftisform2DirectionDef.nii.gz})
 
 itk_add_test(
@@ -46,7 +46,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedHdrTest.nii.gz
   itkNiftiIOBigEndianCompressed.hdr
   DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.hdr})
 itk_add_test(
@@ -55,7 +55,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgTest.nii.gz
   itkNiftiIOBigEndianCompressed.img
   DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.img})
 itk_add_test(
@@ -64,7 +64,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgGz.nii.gz
   itkNiftiIOBigEndianCompressed.img.gz
   DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.img.gz})
 itk_add_test(
@@ -73,7 +73,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianTest.nii.gz
   itkNiftiIOBigEndian
   DATA{${ITK_DATA_ROOT}/Input/BigEndian.hdr,BigEndian.mhd,BigEndian.img})
 itk_add_test(
@@ -82,7 +82,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianCompressedTest.nii.gz
   itkNiftiImageIOTest
   DATA{${ITK_DATA_ROOT}/Input/LittleEndianCompressed.hdr,LittleEndianCompressed.img.gz})
 itk_add_test(
@@ -91,7 +91,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianCompressedTest.nii.gz
   itkNiftiIOLittleEndian
   DATA{${ITK_DATA_ROOT}/Input/LittleEndian.hdr,LittleEndian.mhd,LittleEndian.img})
 itk_add_test(
@@ -100,7 +100,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest
-  ${ITK_TEST_OUTPUT_DIR})
+  ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOInternalTestsTest.nii.gz)
 itk_add_test(
   NAME
   itkNiftiIOShouldFail
@@ -252,7 +252,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest14
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check.nii
   DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
   DATA{Input/xyzt_units_test_scl.nii.gz}
   )
@@ -263,7 +263,7 @@ itk_add_test(
   COMMAND
   ITKIONIFTITestDriver
   itkNiftiImageIOTest14
-  ${ITK_TEST_OUTPUT_DIR}
+  ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check2.nii
   DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
   DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
   )

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -103,14 +103,16 @@ itkNiftiImageIOTest(int argc, char * argv[])
   itk::ObjectFactoryBase::UnRegisterAllFactories();
   itk::NiftiImageIOFactory::RegisterOneFactory();
   int rval = 0;
-  //
-  // first argument is passing in the writable directory to do all testing
-  if (argc > 1)
+  if (argc < 2)
   {
-    char * testdir = *++argv;
-    --argc;
-    itksys::SystemTools::ChangeDirectory(testdir);
+    std::cerr << "testFileName required." << std::endl;
+    return EXIT_FAILURE;
   }
+  //
+  // first argument is the test filepath to do all testing
+  const char * testFileName = *++argv;
+  --argc;
+
   std::string prefix = "";
   if (argc > 1)
   {
@@ -158,74 +160,74 @@ itkNiftiImageIOTest(int argc, char * argv[])
   else // This is the mechanism for doing internal testing of all data types.
   {
     int cur_return;
-    cur_return = MakeNiftiImage<char>();
+    cur_return = MakeNiftiImage<char>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type char" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<unsigned char>();
+    cur_return = MakeNiftiImage<unsigned char>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type unsigned char" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<short>();
+    cur_return = MakeNiftiImage<short>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type short" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<unsigned short>();
+    cur_return = MakeNiftiImage<unsigned short>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type unsigned short" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<int>();
+    cur_return = MakeNiftiImage<int>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type int" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<unsigned int>();
+    cur_return = MakeNiftiImage<unsigned int>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type unsigned int" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<long>();
+    cur_return = MakeNiftiImage<long>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type long" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<unsigned long>();
+    cur_return = MakeNiftiImage<unsigned long>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type unsigned long" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<long long>();
+    cur_return = MakeNiftiImage<long long>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type long long" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<unsigned long long>();
+    cur_return = MakeNiftiImage<unsigned long long>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type unsigned long long" << std::endl;
       rval += cur_return;
     }
-    cur_return = MakeNiftiImage<float>();
+    cur_return = MakeNiftiImage<float>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type float" << std::endl;
       rval += cur_return;
     }
     // awaiting a double precision byte swapper
-    cur_return = MakeNiftiImage<double>();
+    cur_return = MakeNiftiImage<double>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type double" << std::endl;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -61,10 +61,9 @@ PreFillDirection();
 
 template <typename T>
 int
-MakeNiftiImage()
+MakeNiftiImage(const char * filename)
 {
   using ImageType = itk::Image<T, 3>;
-  const char * filename = "test.nii";
   // Allocate Images
   enum
   {

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
@@ -32,19 +32,18 @@ itkNiftiImageIOTest14(int argc, char * argv[])
   // images should have the same size, spacing, and origin, but may have different units
   if (argc != 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " test_dir ref_image test_image" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " output_test_fn ref_image test_image" << std::endl;
     return EXIT_FAILURE;
   }
 
-  // first arg is output dir
-  char * test_dir = argv[1];
-  itksys::SystemTools::ChangeDirectory(test_dir);
+  // first arg is the output test filename
+  const char * output_test_fn = argv[1];
 
-  // second arg is reference image in mm and sec
-  char * ref_image_fn = argv[2];
+  // second arg is the reference image in mm and sec
+  const char * ref_image_fn = argv[2];
 
   // third arg is the test image in different units
-  char * test_image_fn = argv[3];
+  const char * test_image_fn = argv[3];
 
   constexpr unsigned int Dimension = 4;
 
@@ -89,8 +88,6 @@ itkNiftiImageIOTest14(int argc, char * argv[])
       return EXIT_FAILURE;
     }
   }
-
-  const std::string output_test_fn = std::string(test_dir) + "/xyzt_units_output_check.nii";
 
   // set the origin of time to a non-zero value
   auto newOrigin = ImageType::PointType();
@@ -161,8 +158,6 @@ itkNiftiImageIOTest14(int argc, char * argv[])
     std::cerr << "Exception caught while reading image back in" << std::endl;
     throw;
   }
-
-  itk::IOTestHelper::Remove(output_test_fn.c_str());
 
   if (metadataHasCorrectXYZTTUnits && metadataHasCorrectToffset && imageHasCorrectTimeOrigin)
   {


### PR DESCRIPTION
When the tests are run in parallel they can try to write to or remove
the same file from different processes, causing intermittent failures.

Also add `const` where it is missing.

Also use full paths as tests inputs, instead of changing directories,
which is more explicit.
