### PR TITLE
COMP: Fix the WDocumentation warnings for enum class.

### DIFF
--- a/Modules/Core/Common/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/Common/ITKKWStyleOverwrite.txt
@@ -33,3 +33,14 @@ itkMultiThreaderBase.h Comments Disable
 itkSingleton\.cxx Namespace Disable
 itkExceptionObject\.h IfNDefDefine Disable
 itkConceptChecking\.h Template Disable
+itkCommonEnums\.h Comments Disable
+itkExtractImageFilter\.h Comments Disable
+itkFloatingPointExceptions\.h Comments Disable
+itkFrustumSpatialFunction\.h Comments Disable
+itkGaussianDerivativeOperator\.h Comments Disable
+itkLoggerBase\.h Comments Disable
+itkLoggerThreadWrapper\.h Comments Disable
+itkMultiThreaderBase\.h Comments Disable
+itkObjectStore\.h Comments Disable
+itkSpatialOrientation\.h Comments Disable
+itkSymmetricEigenAnalysis\.h Comments Disable

--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -40,7 +40,6 @@ class CommonEnums
 public:
   // Used in Input/Output for Images/Mesh/Transform types
   /**
-   * \class IOPixel
    * \ingroup ITKCommon
    * Enums used to manipulate the point/cell pixel type. The pixel type provides
    * context for automatic data conversions (for instance, RGB to
@@ -67,7 +66,6 @@ public:
   };
 
   /**
-   * \class IOComponent
    * \ingroup ITKCommon
    * Enums used to manipulate the component type. The component type
    * refers to the actual storage class associated with either a
@@ -92,7 +90,6 @@ public:
   };
 
   /**
-   * \class IOFile
    * \ingroup ITKCommon
    * Enums used to specify write style: whether binary or ASCII. Some
    * subclasses use this, some ignore it.
@@ -108,7 +105,6 @@ public:
   };
 
   /**
-   * \class IOFileMode
    * \ingroup ITKCommon
    * Mode in which the files is intended to be used
    */
@@ -119,7 +115,6 @@ public:
   };
 
   /**
-   * \class IOByteOrder
    * \ingroup ITKCommon
    * Enums used to specify byte order; whether Big Endian or Little Endian.
    * Some subclasses use this, some ignore it.
@@ -132,7 +127,6 @@ public:
   };
 
   /**
-   * \class CellGeometry
    * \ingroup ITKCommon
    * Enums used to specify cell type */
   enum class CellGeometry : uint8_t
@@ -190,7 +184,7 @@ extern ITKCommon_EXPORT std::ostream &
 class MeshEnums
 {
 public:
-  /** \class MeshClassCellsAllocationMethod
+  /**
    * \ingroup ITKCommon
    * Enum defining the possible methods used to allocate memory for
    * the Cells */
@@ -212,7 +206,6 @@ class OctreeEnums
 {
 public:
   /**
-   * \class Octree
    * \ingroup ITKCommon
    * The enumeration to define the planar orientation of the octree
    */
@@ -223,8 +216,7 @@ public:
     CORONAL_PLANE,   ///< The plane is Coronal
     TRANSVERSE_PLANE ///< The plane is Transverse
   };
-  /***
-   * \class LeafIdentifier
+  /**
    * \ingroup ITKCommon
    */
   enum class LeafIdentifier : uint8_t
@@ -251,7 +243,7 @@ extern ITKCommon_EXPORT std::ostream &
 class ObjectEnums
 {
 public:
-  /** \class RegionEnum
+  /**
    * \ingroup ITKCommon
    * Enums used to describe the extent types. */
   enum class RegionEnum : uint8_t
@@ -270,10 +262,9 @@ extern ITKCommon_EXPORT std::ostream &
 class ObjectFactoryEnums
 {
 public:
-  /** \class InsertionPosition
-   *  \ingroup ITKCommon
-   *  Position at which the new factory will be registered in the
-   *  internal factory container.
+  /** \ingroup ITKCommon
+   * Position at which the new factory will be registered in the
+   * internal factory container.
    */
   enum class InsertionPosition : uint8_t
   {

--- a/Modules/Core/Common/include/itkExtractImageFilter.h
+++ b/Modules/Core/Common/include/itkExtractImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
 class ExtractImageFilterEnums
 {
 public:
-  /** \class DirectionCollapseStrategy
+  /**
    * \ingroup ITKCommon
    * Strategy to be used to collapse physical space dimensions
    */

--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -30,7 +30,7 @@ namespace itk
 class FloatingPointExceptionsEnums
 {
 public:
-  /** \class ExceptionAction
+  /**
    * \ingroup ITKCommon
    * defines what should happen when exceptions occur */
   enum class ExceptionAction : uint8_t

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.h
@@ -32,7 +32,7 @@ namespace itk
 class FrustumSpatialFunctionEnums
 {
 public:
-  /** \class RotationPlane
+  /**
    *  \ingroup ITKCommon
    */
   enum class RotationPlane : uint8_t

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -35,7 +35,6 @@ class GaussianDerivativeOperatorEnums
 {
 public:
   /**
-   * \class InterpolationMode
    * \ingroup ITKCommon
    * Interpolation modes
    */

--- a/Modules/Core/Common/include/itkLoggerBase.h
+++ b/Modules/Core/Common/include/itkLoggerBase.h
@@ -35,7 +35,7 @@ namespace itk
 class LoggerBaseEnums
 {
 public:
-  /** \class PriorityLevel
+  /**
    *  \ingroup ITKCommon
    * Definition of types of messages. These codes will be used to regulate
    * the level of detail of messages reported to the final outputs
@@ -51,7 +51,7 @@ public:
     NOTSET
   };
 
-  /** \class TimeStampFormat
+  /**
    * \ingroup ITKCommon
    * Select the type of format for reporting time stamps */
   enum class TimeStampFormat : uint8_t

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.h
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.h
@@ -37,7 +37,7 @@ namespace itk
 class LoggerThreadWrapperEnums
 {
 public:
-  /** \class Operation
+  /**
    * \ingroup ITKCommon
    * Definition of types of operations for LoggerThreadWrapper.
    */

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -53,7 +53,7 @@ namespace itk
 class MultiThreaderBaseEnums
 {
 public:
-  /** \class Threader
+  /**
    * \ingroup ITKCommon
    * Currently supported types of multi-threader implementations.
    * Last will change with additional implementations.
@@ -68,7 +68,7 @@ public:
     Unknown = -1
   };
 
-  /** \class ThreadExitCode
+  /**
    * \ingroup ITKCommon
    */
   enum class ThreadExitCode : uint8_t

--- a/Modules/Core/Common/include/itkObjectStore.h
+++ b/Modules/Core/Common/include/itkObjectStore.h
@@ -34,7 +34,7 @@ namespace itk
 class ObjectStoreEnums
 {
 public:
-  /** \class GrowthStrategy
+  /**
    * \ingroup ITKCommon
    * Type of memory allocation strategy */
   enum class GrowthStrategy : uint8_t

--- a/Modules/Core/Common/include/itkSpatialOrientation.h
+++ b/Modules/Core/Common/include/itkSpatialOrientation.h
@@ -46,7 +46,7 @@ namespace itk
 class SpatialOrientationEnums
 {
 public:
-  /** \class CoordinateTerms
+  /**
    *
    * Coordinate orientation codes have a place-value organization such that
    * an ImageDimension-al sequence of subcodes says both which varies fastest
@@ -70,7 +70,7 @@ public:
                                   // ITK_COORDINATE_Future=17
   };
 
-  /** \class CoordinateMajornessTerms
+  /**
    *
    * These code place values have to be far enough apart to
    * separate the CoordinateTerms above.
@@ -92,7 +92,7 @@ public:
     ITK_COORDINATE_TertiaryMinor = 16
   };
 
-  /** \class CoordinateMajornessTerms
+  /**
    *
    * Adding time IN GENERAL would make these 8 x 6 = 48 triples into 16
    * x 24 = 384 4-tuples.

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -119,7 +119,7 @@ permuteColumnsWithSortIndices(QMatrix & eigenVectors, const std::vector<int> & i
 class SymmetricEigenAnalysisEnums
 {
 public:
-  /** \class EigenValueOrder
+  /**
    * \ingroup ITKCommon
    * Order of eigen values
    * OrderByValue:      lambda_1 < lambda_2 < ....

--- a/Modules/Core/QuadEdgeMesh/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/QuadEdgeMesh/ITKKWStyleOverwrite.txt
@@ -1,0 +1,5 @@
+itkQuadEdgeMeshEulerOperatorFlipEdgeFunction\.h Comments Disable
+itkGeometricalQuadEdgeTest1.cxx Namespace Disable
+itkQuadEdgeMeshBasicLayerTest.cxx Namespace Disable
+itkQuadEdgeMeshCellInterfaceTest.cxx Namespace Disable
+itkQuadEdgeMeshPointTest1.cxx Namespace Disable

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.h
@@ -32,7 +32,7 @@ namespace itk
 class QuadEdgeMeshEulerOperatorFlipEdgeFunctionEnums
 {
 public:
-  /*** \class EdgeStatusType
+  /**
    * \ingroup ITKQuadEdgeMesh
    * Status of edge
    */

--- a/Modules/Core/SpatialObjects/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/SpatialObjects/ITKKWStyleOverwrite.txt
@@ -1,0 +1,3 @@
+itkContourSpatialObject\.h Comments Disable
+itkDTITubeSpatialObjectPoint\.h Comments Disable
+itkSpatialObjectToImageFilterTest.cxx Namespace Disable

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -34,7 +34,7 @@ namespace itk
 class ContourSpatialObjectEnums
 {
 public:
-  /*** \class InterpolationMethodEnum
+  /**
    * \ingroup ITKSpatialObjects
    * Hold interpolation method type
    */

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -32,10 +32,10 @@ class DTITubeSpatialObjectPointEnums
 {
 public:
   /**
-* \class DTITubeSpatialObjectPointField
-* \ingroup ITKSpatialObjects
-* If you add a type here you need to modify the TranslateEnumToChar
-to translate the enum to a string */
+  *
+  * \ingroup ITKSpatialObjects
+  * If you add a type here you need to modify the TranslateEnumToChar
+  to translate the enum to a string */
   enum class DTITubeSpatialObjectPointField : uint8_t
   {
     FA = 0,

--- a/Modules/Core/TestKernel/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/TestKernel/ITKKWStyleOverwrite.txt
@@ -1,3 +1,6 @@
 test/.*\.cxx Namespace Disable
 itkTestingMacros\.h Namespace Disable
 itkFilterWatcher\.h Namespace Disable
+itkTestingExtractSliceImageFilter\.h Comments Disable
+itkTestingHashImageFilter\.h Comments Disable
+itkComplexToComplexFFTImageFilter\.h Comments Disable

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
@@ -34,7 +34,6 @@ class ExtractSliceImageFilterEnums
 {
 public:
   /**
-   * \class TestExtractSliceImageFilterCollapseStrategy
    * \ingroup ITKTestKernel
    */
   enum class TestExtractSliceImageFilterCollapseStrategy : uint8_t

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
@@ -33,7 +33,7 @@ namespace Testing
 class HashImageFilterEnums
 {
 public:
-  /** \class HashFunction
+  /**
    * \ingroup ITKTestKernel
    * Describes the hash function
    */

--- a/Modules/Core/Transform/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/Transform/ITKKWStyleOverwrite.txt
@@ -1,1 +1,2 @@
 test/.*\.cxx Namespace Disable
+itkTransformBase\.h Comments Disable

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -39,7 +39,7 @@ namespace itk
 class TransformBaseTemplateEnums
 {
 public:
-  /** \class TransformCategory
+  /**
    * \ingroup ITKTransform
    * */
   enum class TransformCategory : uint8_t

--- a/Modules/Filtering/Convolution/ITKKWStyleOverwrite.txt
+++ b/Modules/Filtering/Convolution/ITKKWStyleOverwrite.txt
@@ -1,0 +1,1 @@
+itkConvolutionImageFilterBase\.h Comments Disable

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -32,7 +32,6 @@ class ConvolutionImageFilterBaseEnums
 {
 public:
   /**
-   * \class ConvolutionImageFilterOutputRegion
    * \ingroup ITKConvolution
    * Output region mode type enumeration
    */

--- a/Modules/Filtering/FFT/ITKKWStyleOverwrite.txt
+++ b/Modules/Filtering/FFT/ITKKWStyleOverwrite.txt
@@ -8,3 +8,4 @@ itkVnlForwardFFTImageFilter.h IfNDefDefine Disable
 itkVnlHalfHermitianToRealInverseFFTImageFilter.h IfNDefDefine Disable
 itkVnlInverseFFTImageFilter.h IfNDefDefine Disable
 itkVnlRealToHalfHermitianForwardFFTImageFilter.h IfNDefDefine Disable
+itkComplexToComplexFFTImageFilter.h Comments Disable

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
@@ -34,7 +34,6 @@ class ComplexToComplexFFTImageFilterEnums
 {
 public:
   /**
-   * \class TransformDirection
    * \ingroup ITKFFT
    * \ingroup FourierTransform
    * */

--- a/Modules/IO/ImageBase/ITKKWStyleOverwrite.txt
+++ b/Modules/IO/ImageBase/ITKKWStyleOverwrite.txt
@@ -1,2 +1,3 @@
 itkConvertPixelBuffer\.hxx Namespace Disable
 test/itkWriteImageFunctionGTest.cxx Namespace Disable
+itkIOCommon\.h Comments Disable

--- a/Modules/IO/ImageBase/include/itkIOCommon.h
+++ b/Modules/IO/ImageBase/include/itkIOCommon.h
@@ -33,7 +33,7 @@ namespace itk
 class IOCommonEnums
 {
 public:
-  /** \class AtomicPixel
+  /**
    * \ingroup IOFilters
    * \ingroup ITKIOImageBase
    * enumerated constants for the different data types

--- a/Modules/IO/NIFTI/ITKKWStyleOverwrite.txt
+++ b/Modules/IO/NIFTI/ITKKWStyleOverwrite.txt
@@ -1,0 +1,1 @@
+itkNiftiImageIO\.h Comments Disable

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -35,7 +35,7 @@ namespace itk
 class NiftiImageIOEnums
 {
 public:
-  /** \class Analyze75Flavor
+  /**
    * \ingroup ITKIONIFTI
    * Enum used to define the way to treat legacy Analyze75 files.
    */

--- a/Modules/Numerics/Statistics/ITKKWStyleOverwrite.txt
+++ b/Modules/Numerics/Statistics/ITKKWStyleOverwrite.txt
@@ -1,3 +1,6 @@
 test/.*\.cxx Namespace Disable
 test/itkMeasurementVectorTraitsTest\.cxx Operator Disable
 itkStatisticsTypesTest\.cxx Typedefs Disable
+itkExpectationMaximizationMixtureModelEstimator\.h Comments Disable
+itkHistogramToRunLengthFeaturesFilter\.h Comments Disable
+itkHistogramToTextureFeaturesFilter\.h Comments Disable

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -34,7 +34,7 @@ namespace Statistics
 class ExpectationMaximizationMixtureModelEstimatorEnums
 {
 public:
-  /** \class TERMINATION_CODE
+  /**
    * \ingroup ITKStatistics
    * Termination status after running optimization */
   enum class TERMINATION_CODE : uint8_t

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
@@ -35,7 +35,6 @@ class HistogramToRunLengthFeaturesFilterEnums
 {
 public:
   /**
-   * \class RunLengthFeature
    * \ingroup ITKStatistics
    * Run-length feature types.
    */

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
@@ -35,7 +35,6 @@ class HistogramToTextureFeaturesFilterEnums
 {
 public:
   /**
-   * \class TextureFeature
    * \ingroup ITKStatistics
    * Texture feature types
    */


### PR DESCRIPTION
Used with clang

Replaced \class Doxygen annotations with \enum to avoid warnings
