### PR TITLE
WparamReturn

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -31,11 +31,6 @@ namespace itk
  *
  * HexahedronCell represents a hexahedron, more precisely, a cuboid, for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \todo When reviewing this class, the documentation of the  template
  * parameters MUST be fixed.
  *

--- a/Modules/Core/Common/include/itkIsNumber.h
+++ b/Modules/Core/Common/include/itkIsNumber.h
@@ -28,7 +28,7 @@ namespace itk
 namespace mpl
 {
 /** Tells whether a type is a number.
- * \return \c TrueType for all kinds of numbers from \c short to `long long`,
+ * \c TrueType for all kinds of numbers from \c short to `long long`,
  * and from \c float to `long double`.
  * \ingroup MetaProgrammingLibrary
  * \ingroup ITKCommon

--- a/Modules/Core/Common/include/itkLineCell.h
+++ b/Modules/Core/Common/include/itkLineCell.h
@@ -32,11 +32,6 @@ namespace itk
  *
  * Template parameters for LineCell:
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
+++ b/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
@@ -99,7 +99,7 @@ struct OrC<false, false, false> : FalseType
 /** MPL \c OR operator on types.
  * \tparam TF1 First boolean type
  * \tparam TF2 Second boolean type
- * \tparam VF3 Third (optional) boolean type
+ * \tparam TF3 Third (optional) boolean type
  *
  * This \em overload automatically fetches \c TF1, \c TF2 and \c TF3 values.
  * However, beware, it won't work with standard C++ traits or boost traits.

--- a/Modules/Core/Common/include/itkPolyLineCell.h
+++ b/Modules/Core/Common/include/itkPolyLineCell.h
@@ -28,11 +28,6 @@ namespace itk
  *
  * Template parameters for PolyLineCell:
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkPolygonCell.h
+++ b/Modules/Core/Common/include/itkPolygonCell.h
@@ -41,10 +41,6 @@ namespace itk
  * PolygonCell represents a polygon for a Mesh.
  *  the points of the polygon can be dynamically changed.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
  *
  * \ingroup MeshObjects
  * \ingroup ITKCommon

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -82,7 +82,8 @@ ITK_ASSOCIATE(13, long double);
 /** Helper class to deduce, in C++98, the resulting type of an operation between two input types.
  * \tparam TA Input type 1
  * \tparam TB Input type 2
- * \return \c Type the resulting type compatible with \c TA and \c TB.
+ *
+ * \c Type the resulting type compatible with \c TA and \c TB.
  *
  * In order to support user defined type, specialize \c
  * itk::PromoteType<> in consequence. For instance, to support type promotion

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.h
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.h
@@ -28,11 +28,6 @@ namespace itk
 /** \class QuadraticEdgeCell
  *  \brief Represents a second order line segment for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.h
@@ -29,11 +29,6 @@ namespace itk
 /** \class QuadraticTriangleCell
  *  \brief Represents a second order triangular patch for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -29,11 +29,6 @@ namespace itk
 /** \class QuadrilateralCell
  *  \brief Represents a quadrilateral for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -29,10 +29,6 @@ namespace itk
 /** \class TetrahedronCell
  *  \brief TetrahedronCell represents a tetrahedron for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -113,7 +113,7 @@ public:
    * This policy, when used from \c VariableLengthVector::SetSize(), always
    * implies that the previous internal buffer will be reallocated. Even if
    * enough memory was available.
-   * \return true (always)
+   * Returns true (always)
    *
    * \sa \c itk::VariableLengthVector::SetSize
    * \sa \c NeverReallocate
@@ -138,8 +138,7 @@ public:
    *
    * The typical use case of this policy is to make sure a \c
    * VariableLengthVector is not a proxy object.
-   * \return false (always)
-   *
+   * Returns false (always)
    * \pre <tt>oldSize == newSize</tt>, checked by assertion
    *
    * \sa \c itk::VariableLengthVector::SetSize

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -29,11 +29,6 @@ namespace itk
 /** \class VertexCell
  *  \brief Represents a single vertex for a Mesh.
  *
- * \tparam TPixelType The type associated with a point, cell, or boundary
- * for use in storing its data.
- *
- * \tparam TCellTraits Type information of mesh containing cell.
- *
  * \ingroup MeshObjects
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/src/itkOctreeNode.cxx
+++ b/Modules/Core/Common/src/itkOctreeNode.cxx
@@ -85,7 +85,6 @@ OctreeNode::SetBranch(OctreeNodeBranch * NewBranch)
 
 /**
  * \brief Determines if the current node is colored
- * \param void
  * \return  bool true if this node is colored
  */
 bool


### PR DESCRIPTION
Contains the following fixes

- Remove parameters in documentation that are not in the class
- Remove \return when no return statement
- Remove \param when no parameter
- Fix small typo