### PR TITLE
Wdeprecated

### DIFF
--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -171,7 +171,7 @@ public:
    * example usage:
    * using OutputImageType = typename ImageType::template Rebind< float >::Type;
    *
-   * \deprecated Use RebindImageType instead
+   * Deprecated: Use RebindImageType instead
    */
   template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
   struct Rebind

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -110,7 +110,7 @@ public:
   /** Constructor to initialize entire vector to one value.
    * \warning Not intended to convert a scalar value into
    * a Vector filled with that value.
-   * \deprecated */
+   * Deprecated */
   Vector(const ValueType & r);
 #else
   /** Constructor to initialize entire vector to one value,

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -181,7 +181,7 @@ public:
      \endcode
    *
    * \sa Image::Rebind
-   * \deprecated Use template alias RebindImageType instead
+   * Deprecated: Use template alias RebindImageType instead
    */
   template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
   struct Rebind

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -132,7 +132,7 @@ public:
    * example usage:
    * using OutputImageType = typename ImageAdaptorType::template Rebind< float >::Type;
    *
-   * \deprecated Use RebindImageType instead
+   * Deprecated: Use RebindImageType instead
    */
   template <typename UPixelType, unsigned int UImageDimension = TImage::ImageDimension>
   struct Rebind

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -494,7 +494,7 @@ public:
   }
 
 protected:
-  /** \deprecated Use GetInverse for public API instead.
+  /** Deprecated: Use GetInverse for public API instead.
    * Method will eventually be made a protected member function */
   const InverseMatrixType &
   GetInverseMatrix() const;

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -31,7 +31,7 @@ namespace Functor
 {
 /** \class Cast
  *
- *  \deprecated This functor is no longer used by the CastImageFilter.
+ * Deprecated: This functor is no longer used by the CastImageFilter.
  * \ingroup ITKImageFilterBase
  */
 


### PR DESCRIPTION
Added ITK_DEPRECATED when \deprecated is used in a comment. They must both come together. Applied to structs, classes and functions