### PR TITLE
COMP: Fix Unitialized scenarios

### DIFF
--- a/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
@@ -93,7 +93,7 @@ itkLabelStatisticsImageFilterTest(int argc, char * argv[])
   using RegionType = FilterType::RegionType;
   using LabelPixelType = FilterType::LabelPixelType;
 
-  LabelPixelType labelValue;
+  LabelPixelType labelValue = 0.0;
 
   std::cout << "There are " << numberOfLabels << " labels" << std::endl;
   std::cout << "There are " << numberOfObjects << " objects" << std::endl;

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -189,6 +189,16 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
         {
           pointIsValid =
             this->m_ANTSAssociate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
+
+          if (pointIsValid)
+          {
+            sumFixed2 += fixedImageValue * fixedImageValue;
+            sumMoving2 += movingImageValue * movingImageValue;
+            sumFixed += fixedImageValue;
+            sumMoving += movingImageValue;
+            sumFixedMoving += fixedImageValue * movingImageValue;
+            count += NumericTraits<LocalRealType>::OneValue();
+          }
         }
       }
       catch (const ExceptionObject & exc)
@@ -197,17 +207,6 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
         std::string msg("Caught exception: \n");
         msg += exc.what();
         throw ExceptionObject(__FILE__, __LINE__, msg);
-      }
-
-
-      if (pointIsValid)
-      {
-        sumFixed2 += fixedImageValue * fixedImageValue;
-        sumMoving2 += movingImageValue * movingImageValue;
-        sumFixed += fixedImageValue;
-        sumMoving += movingImageValue;
-        sumFixedMoving += fixedImageValue * movingImageValue;
-        count += NumericTraits<LocalRealType>::OneValue();
       }
     } // for indct
 
@@ -273,6 +272,16 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       {
         pointIsValid =
           this->m_ANTSAssociate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
+
+        if (pointIsValid)
+        {
+          sumFixed2 += fixedImageValue * fixedImageValue;
+          sumMoving2 += movingImageValue * movingImageValue;
+          sumFixed += fixedImageValue;
+          sumMoving += movingImageValue;
+          sumFixedMoving += fixedImageValue * movingImageValue;
+          count += NumericTraits<LocalRealType>::OneValue();
+        }
       }
     }
     catch (const ExceptionObject & exc)
@@ -281,15 +290,6 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       std::string msg("Caught exception: \n");
       msg += exc.what();
       throw ExceptionObject(__FILE__, __LINE__, msg);
-    }
-    if (pointIsValid)
-    {
-      sumFixed2 += fixedImageValue * fixedImageValue;
-      sumMoving2 += movingImageValue * movingImageValue;
-      sumFixed += fixedImageValue;
-      sumMoving += movingImageValue;
-      sumFixedMoving += fixedImageValue * movingImageValue;
-      count += NumericTraits<LocalRealType>::OneValue();
     }
   }
   scanMem.QsumFixed2.push_back(sumFixed2);
@@ -466,6 +466,27 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
           this->m_ANTSAssociate->ComputeMovingImageGradientAtPoint(mappedMovingPoint, movingImageGradient);
         }
       }
+      if (pointIsValid)
+      {
+        scanMem.fixedA = fixedImageValue - fixedMean;
+        scanMem.movingA = movingImageValue - movingMean;
+        scanMem.sFixedMoving = sFixedMoving;
+        scanMem.sFixedFixed = sFixedFixed;
+        scanMem.sMovingMoving = sMovingMoving;
+
+        if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesFixed())
+        {
+          scanMem.fixedImageGradient = fixedImageGradient;
+        }
+        if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesMoving())
+        {
+          scanMem.movingImageGradient = movingImageGradient;
+        }
+
+        scanMem.mappedFixedPoint = mappedFixedPoint;
+        scanMem.mappedMovingPoint = mappedMovingPoint;
+        scanMem.virtualPoint = virtualPoint;
+      }
     }
   }
   catch (const ExceptionObject & exc)
@@ -476,27 +497,6 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
     throw ExceptionObject(__FILE__, __LINE__, msg);
   }
 
-  if (pointIsValid)
-  {
-    scanMem.fixedA = fixedImageValue - fixedMean;
-    scanMem.movingA = movingImageValue - movingMean;
-    scanMem.sFixedMoving = sFixedMoving;
-    scanMem.sFixedFixed = sFixedFixed;
-    scanMem.sMovingMoving = sMovingMoving;
-
-    if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesFixed())
-    {
-      scanMem.fixedImageGradient = fixedImageGradient;
-    }
-    if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesMoving())
-    {
-      scanMem.movingImageGradient = movingImageGradient;
-    }
-
-    scanMem.mappedFixedPoint = mappedFixedPoint;
-    scanMem.mappedMovingPoint = mappedMovingPoint;
-    scanMem.virtualPoint = virtualPoint;
-  }
 
   return pointIsValid;
 }

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -73,6 +73,26 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
     {
       pointIsValid =
         this->m_Associate->TransformAndEvaluateMovingPoint(virtualPoint, mappedMovingPoint, movingImageValue);
+
+      /** Add the paired intensity points to the joint histogram */
+      if (pointIsValid)
+      {
+        JointPDFPointType jointPDFpoint;
+        this->m_Associate->ComputeJointPDFPoint(fixedImageValue, movingImageValue, jointPDFpoint);
+        const auto jointPDFIndex =
+          m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->TransformPhysicalPointToIndex(jointPDFpoint);
+        if (this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetBufferedRegion().IsInside(
+              jointPDFIndex))
+        {
+          typename JointHistogramType::PixelType jointHistogramPixel;
+          jointHistogramPixel =
+            this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetPixel(jointPDFIndex);
+          ++jointHistogramPixel;
+          this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->SetPixel(jointPDFIndex,
+                                                                                        jointHistogramPixel);
+          this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogramCount++;
+        }
+      }
     }
   }
   catch (const ExceptionObject & exc)
@@ -82,25 +102,6 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
     msg += exc.what();
     ExceptionObject err(__FILE__, __LINE__, msg);
     throw err;
-  }
-
-  /** Add the paired intensity points to the joint histogram */
-  if (pointIsValid)
-  {
-    JointPDFPointType jointPDFpoint;
-    this->m_Associate->ComputeJointPDFPoint(fixedImageValue, movingImageValue, jointPDFpoint);
-    const auto jointPDFIndex =
-      m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->TransformPhysicalPointToIndex(jointPDFpoint);
-    if (this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetBufferedRegion().IsInside(
-          jointPDFIndex))
-    {
-      typename JointHistogramType::PixelType jointHistogramPixel;
-      jointHistogramPixel =
-        this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetPixel(jointPDFIndex);
-      ++jointHistogramPixel;
-      this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->SetPixel(jointPDFIndex, jointHistogramPixel);
-      this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogramCount++;
-    }
   }
 }
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -1265,7 +1265,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
   typename FiniteDifferenceFunctionType::Pointer         df = this->GetDifferenceFunction();
   typename FiniteDifferenceFunctionType::FloatOffsetType offset;
   ValueType                                              norm_grad_phi_squared, dx_forward, dx_backward;
-  ValueType                                              centerValue, forwardValue, backwardValue;
+  ValueType                                              centerValue = 0.0, forwardValue, backwardValue;
   ValueType                                              MIN_NORM = 1.0e-6;
   if (this->GetUseImageSpacing())
   {


### PR DESCRIPTION
This is to fix the -Wconditional-uninitialized warning from clang. The compiler produces this warning in the following scenarios.

1. Variable is declared. Used inside a try clause and processed after the try/catch clause.
2. Variable is declared and used inside a if statement

For scenario 1, for itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxxTo, the compiler complains about movingImageValue. This variable is declared and used inside the try clause. After the try clause, it is used. The compiler doesn't seem to catch that it is used in the try clause. To fix scenario 1, the code after the try/catch clause is brought inside the try statement. The two blocks depend on pointIsValid which is used inside the if statements. Hence, everything is found inside the try and the compiler doesn't complain about uninitialized while respecting the logic of the if statements and respecting the catch clause.

To fix scenario 2, the variable will be set to 0.0 which seems to be the easiest fix. Since the variable is processed inside if statements, setting to 0.0 is the easiest fix to solve the uninitialized problem.
