### PR TITLE
COMP: Fix ununsed code ( if(false) )

### DIFF
--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -156,6 +156,7 @@ itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, char * 
   std::cout << argc << std::endl;
   unsigned int numberOfIterations = 10;
   unsigned int numberOfDisplacementIterations = 10;
+  bool         useScalesEstimator = true;
   if (argc >= 5)
   {
     numberOfIterations = std::stoi(argv[4]);
@@ -163,6 +164,10 @@ itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, char * 
   if (argc >= 6)
   {
     numberOfDisplacementIterations = std::stoi(argv[5]);
+  }
+  if (argc >= 7)
+  {
+    useScalesEstimator = std::stoi(argv[6]);
   }
   std::cout << " iterations " << numberOfIterations << " displacementIterations " << numberOfDisplacementIterations
             << std::endl;
@@ -313,7 +318,7 @@ itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, char * 
   RegistrationParameterScalesFromShiftType::ScalesType displacementScales(
     displacementTransform->GetNumberOfLocalParameters());
   displacementScales.Fill(1);
-  if (false)
+  if (!useScalesEstimator)
   {
     optimizer->SetScales(displacementScales);
   }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -57,6 +57,7 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   std::cout << argc << std::endl;
   unsigned int numberOfIterations = 2;
   unsigned int numberOfDisplacementIterations = 2;
+  bool         useScalesEstimator = true;
   if (argc >= 5)
   {
     numberOfIterations = std::stoi(argv[4]);
@@ -64,6 +65,10 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   if (argc >= 6)
   {
     numberOfDisplacementIterations = std::stoi(argv[5]);
+  }
+  if (argc >= 7)
+  {
+    useScalesEstimator = std::stoi(argv[6]);
   }
   std::cout << " iterations " << numberOfIterations << " displacementIterations " << numberOfDisplacementIterations
             << std::endl;
@@ -204,7 +209,7 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   RegistrationParameterScalesFromShiftType::ScalesType displacementScales(
     displacementTransform->GetNumberOfLocalParameters());
   displacementScales.Fill(1);
-  if (false)
+  if (!useScalesEstimator)
   {
     optimizer->SetScales(displacementScales);
   }
@@ -212,6 +217,7 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   {
     optimizer->SetScalesEstimator(shiftScaleEstimator);
   }
+
   optimizer->SetMetric(metric);
   optimizer->SetNumberOfIterations(numberOfDisplacementIterations);
   try

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -59,6 +59,7 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   std::cout << argc << std::endl;
   unsigned int numberOfAffineIterations = 2;
   unsigned int numberOfDisplacementIterations = 2;
+  bool         useScalesEstimator = true;
   if (argc >= 5)
   {
     numberOfAffineIterations = std::stoi(argv[4]);
@@ -66,6 +67,10 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   if (argc >= 6)
   {
     numberOfDisplacementIterations = std::stoi(argv[5]);
+  }
+  if (argc >= 7)
+  {
+    useScalesEstimator = std::stoi(argv[6]);
   }
   std::cout << " affine iterations " << numberOfAffineIterations << " displacementIterations "
             << numberOfDisplacementIterations << std::endl;
@@ -218,7 +223,8 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   RegistrationParameterScalesFromShiftType::ScalesType displacementScales(
     displacementTransform->GetNumberOfLocalParameters());
   displacementScales.Fill(1);
-  if (false)
+
+  if (!useScalesEstimator)
   {
     optimizer->SetScales(displacementScales);
   }
@@ -226,6 +232,7 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   {
     optimizer->SetScalesEstimator(shiftScaleEstimator);
   }
+
   optimizer->SetMetric(metric);
   optimizer->SetNumberOfIterations(numberOfDisplacementIterations);
   try

--- a/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
@@ -57,9 +57,14 @@ itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char * argv[])
 
   std::cout << argc << std::endl;
   unsigned int numberOfIterations = 10;
+  bool         useSubSampling = true;
   if (argc >= 5)
   {
     numberOfIterations = std::stoi(argv[4]);
+  }
+  if (argc >= 6)
+  {
+    useSubSampling = std::stoi(argv[5]);
   }
   std::cout << " iterations " << numberOfIterations << std::endl;
 
@@ -113,7 +118,7 @@ itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   metric->SetNumberOfHistogramBins(20);
   auto metric2 = MetricType2::New();
 
-  if (false)
+  if (!useSubSampling)
   {
     std::cout << "Dense sampling." << std::endl;
     metric->SetUseSampledPointSet(false);
@@ -142,7 +147,6 @@ itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char * argv[])
     metric2->SetUseSampledPointSet(true);
     std::cout << "Testing metric with point set..." << std::endl;
   }
-
   metric->SetFixedImage(fixedImage);
   metric->SetMovingImage(movingImage);
   metric->SetFixedTransform(identityTransform);


### PR DESCRIPTION
This is a comment to fix the -Wunreachable-code warning generated by clang.

This fix simply removes if (false) clauses. An investigation was done to see why these clause exist. This change was done 10 years ago. The clauses at that time were if(0).