### PR TITLE
BUG: Wrap SymmetricEigenAnalysisImageFilter with CovariantVector Image output

### DIFF
--- a/Modules/Core/Common/wrapping/itkImageToImageFilterB.wrap
+++ b/Modules/Core/Common/wrapping/itkImageToImageFilterB.wrap
@@ -1,3 +1,4 @@
+itk_wrap_include("itkSymmetricSecondRankTensor.h")
 itk_wrap_include("itkPhasedArray3DSpecialCoordinatesImage.h")
 itk_wrap_class("itk::ImageToImageFilter" POINTER)
 
@@ -115,4 +116,11 @@ foreach(t3 ${WRAP_ITK_COMPLEX_REAL})
     "itk::PhasedArray3DSpecialCoordinatesImage<  ${ITKT_${t3}} >, itk::PhasedArray3DSpecialCoordinatesImage<  ${ITKT_${t3}} >"
   )
 endforeach()
+
+# SymmetricSecondRankTensor
+# SymmetricEigenAnalysisImageFilter
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  itk_wrap_template("${ITKM_ISSRT${ITKM_D}${d}${d}}I${ITKM_CV${ITKM_D}${d}}${d}" "${ITKT_ISSRT${ITKM_D}${d}${d}}, itk::Image< ${ITKT_CV${ITKM_D}${d}}, ${d} >")
+endforeach()
+
 itk_end_wrap_class()

--- a/Modules/Core/Common/wrapping/itkInPlaceImageFilterB.wrap
+++ b/Modules/Core/Common/wrapping/itkInPlaceImageFilterB.wrap
@@ -1,4 +1,5 @@
 itk_wrap_include("itkPhasedArray3DSpecialCoordinatesImage.h")
+itk_wrap_include("itkSymmetricSecondRankTensor.h")
 itk_wrap_class("itk::InPlaceImageFilter" POINTER)
 # VectorImage <-> scalar
 unique(to_types "UC;${WRAP_ITK_SCALAR}")
@@ -47,6 +48,12 @@ foreach(t ${WRAP_ITK_SCALAR})
     itk_wrap_template("I${ITKM_${t}}3PA3DSCI${ITKM_${ut}}"
                       "itk::Image< ${ITKT_${t}}, 3 >, itk::PhasedArray3DSpecialCoordinatesImage< ${ITKT_${ut}} >")
   endforeach()
+endforeach()
+
+# SymmetricSecondRankTensor
+# SymmetricEigenAnalysisImageFilter
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  itk_wrap_template("${ITKM_ISSRT${ITKM_D}${d}${d}}I${ITKM_CV${ITKM_D}${d}}${d}" "${ITKT_ISSRT${ITKM_D}${d}${d}}, itk::Image< ${ITKT_CV${ITKM_D}${d}}, ${d} >")
 endforeach()
 
 itk_end_wrap_class()

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -209,7 +209,7 @@ extern ITKImageIntensity_EXPORT std::ostream &
  *
  * \ingroup ITKImageIntensity
  */
-template <typename TInputImage, typename TOutputImage = TInputImage>
+template <typename TInputImage, typename TOutputImage>
 class SymmetricEigenAnalysisImageFilter
   : public UnaryFunctorImageFilter<
       TInputImage,

--- a/Modules/Filtering/ImageIntensity/wrapping/itkSymmetricEigenAnalysisImageFilter.wrap
+++ b/Modules/Filtering/ImageIntensity/wrapping/itkSymmetricEigenAnalysisImageFilter.wrap
@@ -4,8 +4,8 @@ itk_wrap_include("itkSymmetricSecondRankTensor.h")
 
 itk_wrap_simple_class("itk::SymmetricEigenAnalysisEnums")
 
-itk_wrap_class("itk::SymmetricEigenAnalysisImageFilter" POINTER_WITH_2_SUPERCLASSES)
+itk_wrap_class("itk::SymmetricEigenAnalysisImageFilter" POINTER_WITH_SUPERCLASS)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
-  itk_wrap_template("${ITKM_ISSRT${ITKM_D}${d}${d}}" "${ITKT_ISSRT${ITKM_D}${d}${d}}")
+  itk_wrap_template("${ITKM_ISSRT${ITKM_D}${d}${d}}I${ITKM_CV${ITKM_D}${d}}${d}" "${ITKT_ISSRT${ITKM_D}${d}${d}}, itk::Image< ${ITKT_CV${ITKM_D}${d}}, ${d} >")
 endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
The default template parameter output, an Image of
SymmetricSecondRankTensor, is not correct or valid. The output of this
filter is an image of eigenvectors. Wrap with an Image of
CovariantVector along with base classes. Also remove the invalid default
template parameter output.

Closes #4520
