### PR TITLE
Wmissing variable declaration

### DIFF
--- a/Examples/RegistrationITKv4/DeformableRegistration17.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration17.cxx
@@ -101,9 +101,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "itkResampleImageFilter.h"
 #include "itkDisplacementFieldTransform.h"
 
-
+namespace
+{
 unsigned int RmsCounter = 0;
 double       MaxRmsE[4] = { 0.8, 0.75, 0.4, 0.2 };
+} // namespace
 
 //  The following section of code implements a Command observer
 //  that will monitor the evolution of the registration process.

--- a/Modules/Core/Common/test/itkMultithreadingTest.cxx
+++ b/Modules/Core/Common/test/itkMultithreadingTest.cxx
@@ -21,8 +21,11 @@
 #include "itkConfigure.h"
 #include <mutex>
 
+namespace
+{
 std::shared_ptr<std::mutex> sharedMutex;
 bool                        debugPrint = false;
+} // namespace
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 execute(void * ptr)

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -38,9 +38,12 @@
 #include "itkTestingComparisonImageFilter.h"
 #include "itkTestingHashImageFilter.h"
 
+namespace
+{
 RegressionTestParameters  regressionTestParameters;
 std::vector<HashPairType> hashTestList;
 RedirectOutputParameters  redirectOutputParameters;
+} // namespace
 
 RegressionTestParameters &
 GetRegressionTestParameters()

--- a/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
@@ -55,15 +55,16 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _bottom_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 7.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 8)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType bottom_left(_bottom_left, _bottom_left + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType bottom_left(_bottom_left, _bottom_left + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_bottom_left[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_bottom_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 8),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 7.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_bottom_left(_rev_bottom_left, _rev_bottom_left + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_bottom_left(_rev_bottom_left,
+                                                                                       _rev_bottom_left + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col4[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col4[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 6),
@@ -74,9 +75,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col4[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col4(_row2_col4, _row2_col4 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col4(_row2_col4, _row2_col4 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col4[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col4[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 5),
@@ -87,9 +88,10 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col4[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col4(_rev_row2_col4, _rev_row2_col4 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col4(_rev_row2_col4,
+                                                                                     _rev_row2_col4 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col3[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(6.5, 6),
@@ -100,9 +102,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col3(_row2_col3, _row2_col3 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col3(_row2_col3, _row2_col3 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col3[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8, 5.5),
@@ -113,9 +115,10 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8, 6.5),
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col3(_rev_row2_col3, _rev_row2_col3 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col3(_rev_row2_col3,
+                                                                                     _rev_row2_col3 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col2[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(4.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(4, 5.5),
@@ -126,9 +129,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col2(_row2_col2, _row2_col2 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col2(_row2_col2, _row2_col2 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col2[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5.5, 5),
@@ -139,9 +142,10 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(4.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col2(_rev_row2_col2, _rev_row2_col2 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col2(_rev_row2_col2,
+                                                                                     _rev_row2_col2 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col1[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 5),
@@ -152,9 +156,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row2_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col1(_row2_col1, _row2_col1 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row2_col1(_row2_col1, _row2_col1 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col1[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 5.5),
@@ -165,29 +169,30 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row2_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col1(_rev_row2_col1, _rev_row2_col1 + 9);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row2_col1(_rev_row2_col1,
+                                                                                     _rev_row2_col1 + 9);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_middle[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_middle[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_middle(_row1_col4_middle,
-                                                                                 _row1_col4_middle + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_middle(_row1_col4_middle,
+                                                                                        _row1_col4_middle + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_middle[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_middle[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_middle(_rev_row1_col4_middle,
-                                                                                     _rev_row1_col4_middle + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_middle(_rev_row1_col4_middle,
+                                                                                            _rev_row1_col4_middle + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col2[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(4, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(3.5, 3),
@@ -196,9 +201,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col2(_row1_col2, _row1_col2 + 7);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col2(_row1_col2, _row1_col2 + 7);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col2[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 2.5),
@@ -207,65 +212,69 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col2[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(4, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(5, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col2(_rev_row1_col2, _rev_row1_col2 + 7);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col2(_rev_row1_col2,
+                                                                                     _rev_row1_col2 + 7);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col1[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col1(_row1_col1, _row1_col1 + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col1(_row1_col1, _row1_col1 + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col1[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col1(_rev_row1_col1, _rev_row1_col1 + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col1(_rev_row1_col1,
+                                                                                     _rev_row1_col1 + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_right[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_right[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 2.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_right(_row1_col4_right, _row1_col4_right + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_right(_row1_col4_right,
+                                                                                       _row1_col4_right + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_right[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_right[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 2.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_right(_rev_row1_col4_right,
-                                                                                    _rev_row1_col4_right + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_right(_rev_row1_col4_right,
+                                                                                           _rev_row1_col4_right + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_left[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 2.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_left(_row1_col4_left, _row1_col4_left + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_left(_row1_col4_left,
+                                                                                      _row1_col4_left + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_left[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 2.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(8.5, 2),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 2.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_left(_rev_row1_col4_left,
-                                                                                   _rev_row1_col4_left + 5);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_left(_rev_row1_col4_left,
+                                                                                          _rev_row1_col4_left + 5);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col3[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(6.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(6.5, 2),
@@ -274,9 +283,9 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col3(_row1_col3, _row1_col3 + 7);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col3(_row1_col3, _row1_col3 + 7);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col3[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7.5, 2),
@@ -285,52 +294,54 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col3[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(6.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(7, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col3(_rev_row1_col3, _rev_row1_col3 + 7);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col3(_rev_row1_col3,
+                                                                                     _rev_row1_col3 + 7);
 
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_right[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_right[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(12, 0.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 0)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_right(_top_right, _top_right + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_right(_top_right, _top_right + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_right[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_right[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11.5, 0),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(12, 0.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_right(_rev_top_right, _rev_top_right + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_right(_rev_top_right,
+                                                                                     _rev_top_right + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_left[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 0),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 0.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 1),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 1.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_left(_top_left, _top_left + 4);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_left(_top_left, _top_left + 4);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_left[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_left[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 1),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 0.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 0)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_left(_rev_top_left, _rev_top_left + 4);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_left(_rev_top_left, _rev_top_left + 4);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_left_cropped[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _top_left_cropped[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 1),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 1.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_left_cropped(_top_left_cropped,
-                                                                                 _top_left_cropped + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType top_left_cropped(_top_left_cropped,
+                                                                                        _top_left_cropped + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_left_cropped[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_top_left_cropped[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 1.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 1)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_left_cropped(_rev_top_left_cropped,
-                                                                                     _rev_top_left_cropped + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_top_left_cropped(_rev_top_left_cropped,
+                                                                                            _rev_top_left_cropped + 2);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_all[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_all[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9, 2.5),
@@ -345,9 +356,10 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _row1_col4_all[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_all(_row1_col4_all, _row1_col4_all + 13);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType row1_col4_all(_row1_col4_all,
+                                                                                     _row1_col4_all + 13);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_all[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_all[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(11, 2.5),
@@ -362,24 +374,25 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _rev_row1_col4_all[]
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(9.5, 3),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(10, 3.5)
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_all(_rev_row1_col4_all,
-                                                                                  _rev_row1_col4_all + 13);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType rev_row1_col4_all(_rev_row1_col4_all,
+                                                                                         _rev_row1_col4_all + 13);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edco[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edco[] = {
   top_left,         top_right, row1_col3, row1_col4_left, row1_col4_right, row1_col1,   row1_col2,
   row1_col4_middle, row2_col1, row2_col2, row2_col3,      row2_col4,       bottom_left, bottom_right
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_clockwise_outputs(_edco,
-                                                                                                        _edco + 14);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_clockwise_outputs(_edco,
+                                                                                                               _edco +
+                                                                                                                 14);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edcco[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edcco[] = {
   rev_top_left,  rev_top_right, rev_row1_col3,        rev_row1_col4_left, rev_row1_col4_right,
   rev_row1_col1, rev_row1_col2, rev_row1_col4_middle, rev_row2_col1,      rev_row2_col2,
   rev_row2_col3, rev_row2_col4, rev_bottom_left,      rev_bottom_right
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_counterclockwise_outputs(_edcco,
-                                                                                                               _edcco +
-                                                                                                                 14);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_counterclockwise_outputs(
+  _edcco,
+  _edcco + 14);
 
 itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _ecco[] = { top_left,      top_right,   row1_col3,
                                                                             row1_col4_all, row1_col1,   row1_col2,
@@ -387,15 +400,15 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _ecco[] = { top_
                                                                             row2_col4,     bottom_left, bottom_right };
 itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_connected_clockwise_outputs(_ecco, _ecco + 12);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edcro[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListType _edcro[] = {
   top_left_cropped, row1_col3, row1_col4_left, row1_col4_right, row1_col1, row1_col2,
   row1_col4_middle, row2_col1, row2_col2,      row2_col3,       row2_col4
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_clockwise_cropped_outputs(_edcro,
-                                                                                                                _edcro +
-                                                                                                                  11);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconnected_clockwise_cropped_outputs(
+  _edcro,
+  _edcro + 11);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels0[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels0[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 7.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 7.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 7.5),
@@ -420,7 +433,7 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels0[] = {
 };
 itkContourExtractor2DImageFilterTestNamespace::MyVertexListType labels0(_labels0, _labels0 + 21);
 
-itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels1[] = {
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels1[] = {
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 6),
   itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 5),
@@ -437,7 +450,8 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexListType labels[]{
   labels0,
   labels1,
 };
-itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_values_as_labels_outputs(labels, labels + 2);
+static itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_values_as_labels_outputs(labels,
+                                                                                                         labels + 2);
 /*--------------------------------------------------------------------------*/
 
 void

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -48,7 +48,10 @@ PSOTest2();
 int
 PSOTest3();
 
+namespace
+{
 bool verboseFlag = false;
+}
 
 /**
  * The particle swarm optimizer is a stochastic algorithm. Consequentially, we run

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -19,7 +19,10 @@
 #include "itkPowellOptimizerv4.h"
 #include "itkTestingMacros.h"
 
+namespace
+{
 int POWELL_CALLS_TO_GET_VALUE = 0;
+}
 
 /**
  *  The objective function is the quadratic form:

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
@@ -20,7 +20,6 @@
 #include "itkListSample.h"
 
 constexpr unsigned int MeasurementVectorSize = 3;
-unsigned int           counter = 0;
 
 using MeasurementVectorType = itk::FixedArray<float, MeasurementVectorSize>;
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
@@ -20,7 +20,6 @@
 #include "itkListSample.h"
 
 constexpr unsigned int MeasurementVectorSize2 = 3;
-unsigned int           counter2 = 0;
 
 using MeasurementVectorType2 = itk::Array<float>;
 

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -194,7 +194,7 @@ protected:
  * Static list of CallRecord items representing the stack trace of
  * calls to GenerateData and TemporalStreamingGenerateData
  */
-std::vector<CallRecord> m_CallStack;
+static std::vector<CallRecord> m_CallStack;
 
 /**
  * \class DummyTemporalDataObject


### PR DESCRIPTION
 COMP: Fix missing declarations of unused variables.

This is to fix the -Wmissing-variable-declarations warning of clang.

This is simply related that the variable in question is not used in the file

---------------------------------------------------------------------------

 COMP: Fix missing variables declaration (static)

This is a fix about -Wmissing-variable-declarations warning of clang

This is about the static case. A lot of variables were marked as warning due to non declaration. The static keyword was added when it makes sense that the variable is used internally.