### PR TITLE
COMP: Fix zero as null pointer constant

### DIFF
--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -129,12 +129,34 @@ TEST(SmartPointer, EmptyAndNull)
   cptr = nullptr;
   EXPECT_TRUE(cptr.IsNull());
 
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#  endif
+#endif
   // NOLINTNEXTLINE(modernize-use-nullptr)
   ptr = NULL; // Do not change NULL, null, Null in this file. This file intentionally contains usage of legacy NULL
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic pop
+#  endif
+#endif
   EXPECT_TRUE(ptr.IsNull());
 
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#  endif
+#endif
   // NOLINTNEXTLINE(modernize-use-nullptr)
   cptr = NULL; // Do not change NULL, null, Null in this file. This file intentionally contains usage of legacy NULL
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic pop
+#  endif
+#endif
   EXPECT_TRUE(cptr.IsNull());
 
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -32,7 +32,7 @@
   using FrontIterator = QuadEdgeMeshFrontIterator<MeshTypeArg, QEPrimalType>;                                         \
   using ConstFrontIterator = QuadEdgeMeshConstFrontIterator<MeshTypeArg, QEPrimalType>;                               \
                                                                                                                       \
-  virtual FrontIterator BeginFront(QEPrimalType * seed = (QEPrimalType *)0)                                           \
+  virtual FrontIterator BeginFront(QEPrimalType * seed = (QEPrimalType *)nullptr)                                     \
   {                                                                                                                   \
     return (FrontIterator(this, true, seed));                                                                         \
   }                                                                                                                   \


### PR DESCRIPTION
This is to fix Wzero-as-null-pointer-constant warnings by either warning suppression or nullptr usage
