### PR TITLE
COMP: remove suppression of -Winconsistent-missing-override

### DIFF
--- a/Modules/Numerics/Statistics/include/itkSubsample.h
+++ b/Modules/Numerics/Statistics/include/itkSubsample.h
@@ -75,27 +75,12 @@ public:
    * object */
   using InstanceIdentifierHolder = std::vector<InstanceIdentifier>;
 
-// Disable clang warning false positive.
-// <https://llvm.org/bugs/show_bug.cgi?id=22582>
-#if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Winconsistent-missing-override")
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#  endif
-#endif
-
   /** Get the Id Holder */
   const InstanceIdentifierHolder &
   GetIdHolder() const
   {
     return this->m_IdHolder;
   }
-
-#if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Winconsistent-missing-override")
-#    pragma clang diagnostic pop
-#  endif
-#endif
 
   /** Plug in the actual sample data */
   void


### PR DESCRIPTION
I tested with AppleClang 10, the oldest AppleClang submitting to cdash, and this false positive seems to have been fixed long ago.
