### PR TITLE
ENH: allow calling RemoveObserver() from a const itkObject

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -201,7 +201,7 @@ public:
 
   /** Remove the observer with this tag value. */
   void
-  RemoveObserver(unsigned long tag);
+  RemoveObserver(unsigned long tag) const;
 
   /** Remove all observers . */
   void

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -493,7 +493,7 @@ Object::GetCommand(unsigned long tag)
 }
 
 void
-Object::RemoveObserver(unsigned long tag)
+Object::RemoveObserver(unsigned long tag) const
 {
   if (this->m_SubjectImplementation)
   {


### PR DESCRIPTION
Exposes a const version of `RemoveObserver() API` just like the already existing `AddObserver()` API [here](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/src/itkObject.cxx#L467) . 

Helps with application architecture when building observer design pattern with itkObject as subject.

@mentions: @thewtex - I apologize for mentioning you without any sort of prior discussion. I'm a new contributor, and would be very grateful for some feedback on this PR!

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Thanks for reviewing this change!