### PR TITLE
STYLE: Call `SetNthOutput(i, MakeOutput(i))` in a `for` loop

### DIFF
--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -30,16 +30,14 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::DanielssonDistanceMapImageFilter()
 {
-  this->SetNumberOfRequiredOutputs(3);
+  constexpr unsigned int numberOfRequiredOutputs{ 3 };
+  this->SetNumberOfRequiredOutputs(numberOfRequiredOutputs);
 
-  // distance map
-  this->SetNthOutput(0, this->MakeOutput(0));
-
-  // voronoi map
-  this->SetNthOutput(1, this->MakeOutput(1));
-
-  // distance vectors
-  this->SetNthOutput(2, this->MakeOutput(2));
+  // distance map, voronoi map, distance vectors
+  for (unsigned int i{}; i < numberOfRequiredOutputs; ++i)
+  {
+    ProcessObject::SetNthOutput(i, Self::MakeOutput(i));
+  }
 
   m_SquaredDistance = false;
   m_InputIsBinary = false;

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -32,16 +32,14 @@ template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::
   SignedDanielssonDistanceMapImageFilter()
 {
-  this->SetNumberOfRequiredOutputs(3);
+  constexpr unsigned int numberOfRequiredOutputs{ 3 };
+  this->SetNumberOfRequiredOutputs(numberOfRequiredOutputs);
 
-  // distance map
-  this->SetNthOutput(0, static_cast<OutputImageType *>(this->MakeOutput(0).GetPointer()));
-
-  // voronoi map
-  this->SetNthOutput(1, static_cast<VoronoiImageType *>(this->MakeOutput(1).GetPointer()));
-
-  // distance vectors
-  this->SetNthOutput(2, static_cast<VectorImageType *>(this->MakeOutput(2).GetPointer()));
+  // distance map, voronoi map, distance vectors
+  for (unsigned int i{}; i < numberOfRequiredOutputs; ++i)
+  {
+    ProcessObject::SetNthOutput(i, Self::MakeOutput(i));
+  }
 
   // Default values
   this->m_SquaredDistance = false; // Should we remove this ?

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -27,11 +27,13 @@ namespace itk
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::EigenAnalysis2DImageFilter()
 {
+  constexpr unsigned int numberOfRequiredOutputs{ 3 };
   this->SetNumberOfRequiredInputs(3);
-  this->SetNumberOfRequiredOutputs(3);
-  this->SetNthOutput(0, this->MakeOutput(0));
-  this->SetNthOutput(1, this->MakeOutput(1));
-  this->SetNthOutput(2, this->MakeOutput(2));
+  this->SetNumberOfRequiredOutputs(numberOfRequiredOutputs);
+  for (unsigned int i{}; i < numberOfRequiredOutputs; ++i)
+  {
+    ProcessObject::SetNthOutput(i, Self::MakeOutput(i));
+  }
   static_assert(EigenVectorType::Dimension == 2, "Error: PixelType of EigenVector Image must have exactly 2 elements!");
 }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1354,13 +1354,16 @@ Segmenter<TInputImage>::Segmenter()
   m_SortEdgeLists = true;
   m_Connectivity.direction = nullptr;
   m_Connectivity.index = nullptr;
-  typename OutputImageType::Pointer  img = static_cast<OutputImageType *>(this->MakeOutput(0).GetPointer());
-  typename SegmentTableType::Pointer st = static_cast<SegmentTableType *>(this->MakeOutput(1).GetPointer());
-  typename BoundaryType::Pointer     bd = static_cast<BoundaryType *>(this->MakeOutput(2).GetPointer());
-  this->SetNumberOfRequiredOutputs(3);
-  this->ProcessObject::SetNthOutput(0, img.GetPointer());
-  this->ProcessObject::SetNthOutput(1, st.GetPointer());
-  this->ProcessObject::SetNthOutput(2, bd.GetPointer());
+
+  constexpr unsigned int numberOfRequiredOutputs{ 3 };
+  this->SetNumberOfRequiredOutputs(numberOfRequiredOutputs);
+
+  // OutputImage, SegmentTable, Boundary
+  for (unsigned int i{}; i < numberOfRequiredOutputs; ++i)
+  {
+    ProcessObject::SetNthOutput(i, Self::MakeOutput(i));
+  }
+
 
   // Allocate memory for connectivity
   m_Connectivity.size = 2 * ImageDimension;


### PR DESCRIPTION
Reduced duplicate code by replacing manual `SetNthOutput(i, MakeOutput(i))` calls for i = 0, 1, 2 with the corresponding `for` loops.