### PR TITLE
PERF: Make `ImageRegion` trivially copyable (LEGACY_REMOVE)

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -36,11 +36,11 @@
 #include <type_traits> // For conditional and integral_constant.
 #include <utility>     // For tuple_element and tuple_size.
 
-// Macro added to each `ImageRegion` member function that overrides a virtual member function of `Region`. In the
-// future, `ImageRegion` will no longer inherit from `Region`, so then those `ImageRegion` member functions will no
-// longer override.
-#ifdef ITK_FUTURE_LEGACY_REMOVE
-#  define itkRegionOverrideMacro // nothing (in the future)
+// Macro added to each `ImageRegion` member function that overrides a virtual member function of `Region`, when legacy
+// support is enabled. Without legacy support, `ImageRegion` will no longer inherit from `Region`, so then those
+// `ImageRegion` member functions will no longer override.
+#ifdef ITK_LEGACY_REMOVE
+#  define itkRegionOverrideMacro // nothing
 #else
 #  define itkRegionOverrideMacro override
 #endif
@@ -78,8 +78,8 @@ class ITK_TEMPLATE_EXPORT ImageBase;
  */
 template <unsigned int VImageDimension>
 class ITK_TEMPLATE_EXPORT ImageRegion final
-#ifndef ITK_FUTURE_LEGACY_REMOVE
-  // This inheritance is to be removed in the future.
+#ifndef ITK_LEGACY_REMOVE
+  // This inheritance is only there when legacy support is enabled.
   : public Region
 #endif
 {
@@ -87,7 +87,7 @@ public:
   /** Standard class type aliases. */
   using Self = ImageRegion;
 
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_LEGACY_REMOVE
   using Superclass = Region;
 #endif
 

--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -32,11 +32,13 @@ CheckTrivialCopyabilityOfImageRegion()
 {
   constexpr bool isImageRegionTriviallyCopyable{ std::is_trivially_copyable_v<itk::ImageRegion<VDimension>> };
 
-#ifdef ITK_FUTURE_LEGACY_REMOVE
-  static_assert(isImageRegionTriviallyCopyable, "In the future, ImageRegion<VDimension> should be trivially copyable.");
+#ifdef ITK_LEGACY_REMOVE
+  static_assert(isImageRegionTriviallyCopyable,
+                "When legacy support is removed, ImageRegion<VDimension> should be trivially copyable.");
   return isImageRegionTriviallyCopyable;
 #else
-  static_assert(!isImageRegionTriviallyCopyable, "ImageRegion<VDimension> should *not* be trivially copyable.");
+  static_assert(!isImageRegionTriviallyCopyable,
+                "When legacy support is enabled, ImageRegion<VDimension> should *not* be trivially copyable.");
   return !isImageRegionTriviallyCopyable;
 #endif
 }


### PR DESCRIPTION
Replaced `ITK_FUTURE_LEGACY_REMOVE` with `ITK_LEGACY_REMOVE`, regarding its inheritance from `itk::Region`.

A run-time performance improvement of more than 25% on default-constructing and destructing a sequence of `ImageRegion` objects was observed.

- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4344 commit 1f3bbb658698556ff0d437c4effb9c1e42acc7c2