### PR TITLE
Add constexpr to IndexRange, and let BSplineInterpolationWeightFunction make use of it

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -115,17 +115,6 @@ public:
 protected:
   BSplineInterpolationWeightFunction() = default;
   ~BSplineInterpolationWeightFunction() override = default;
-
-private:
-  /** Lookup table type. */
-  using TableType = FixedArray<IndexType, NumberOfWeights>;
-
-  /** Table mapping linear offset to indices. */
-  const TableType m_OffsetToIndexTable{ [] {
-    TableType     table;
-    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(SupportSize).cbegin(), NumberOfWeights, table.begin());
-    return table;
-  }() };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -47,6 +47,18 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
   WeightsType &               weights,
   IndexType &                 startIndex) const
 {
+  static constexpr auto offsetToIndexTable = [] {
+    FixedArray<IndexType, NumberOfWeights> table{};
+    auto                                   indexIterator = ZeroBasedIndexRange<SpaceDimension>(SupportSize).cbegin();
+
+    for (size_t i{}; i < NumberOfWeights; ++i)
+    {
+      table[i] = *indexIterator;
+      ++indexIterator;
+    }
+    return table;
+  }();
+
   unsigned int j, k;
 
   // Find the starting index of the support region
@@ -77,7 +89,7 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
 
     for (j = 0; j < SpaceDimension; ++j)
     {
-      weights[k] *= weights1D[j][m_OffsetToIndexTable[k][j]];
+      weights[k] *= weights1D[j][offsetToIndexTable[k][j]];
     }
   }
 }

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -101,15 +101,15 @@ public:
 
 
     /**  Returns a reference to the current index. */
-    reference operator*() const noexcept { return m_Index; }
+    constexpr reference operator*() const noexcept { return m_Index; }
 
 
     /**  Returns a pointer to the current index. */
-    pointer operator->() const noexcept { return &(**this); }
+    constexpr pointer operator->() const noexcept { return &(**this); }
 
 
     /** Prefix increment ('++it'). */
-    const_iterator &
+    constexpr const_iterator &
     operator++() noexcept
     {
       for (unsigned int i = 0; i < (VDimension - 1); ++i)
@@ -132,7 +132,7 @@ public:
 
     /** Postfix increment ('it++').
      * \note Usually prefix increment ('++it') is preferable. */
-    const_iterator
+    constexpr const_iterator
     operator++(int) noexcept
     {
       auto result = *this;
@@ -142,7 +142,7 @@ public:
 
 
     /** Prefix decrement ('--it'). */
-    const_iterator &
+    constexpr const_iterator &
     operator--() noexcept
     {
       for (unsigned int i = 0; i < (VDimension - 1); ++i)
@@ -164,7 +164,7 @@ public:
 
     /** Postfix increment ('it--').
      * \note  Usually prefix increment ('--it') is preferable. */
-    const_iterator
+    constexpr const_iterator
     operator--(int) noexcept
     {
       auto result = *this;
@@ -195,7 +195,7 @@ public:
 
 
     /** Returns (it1 < it2) for iterators it1 and it2. */
-    friend bool
+    friend constexpr bool
     operator<(const const_iterator & lhs, const const_iterator & rhs) noexcept
     {
       for (unsigned int i = VDimension; i > 0; --i)
@@ -216,7 +216,7 @@ public:
 
 
     /** Returns (it1 > it2) for iterators it1 and it2. */
-    friend bool
+    friend constexpr bool
     operator>(const const_iterator & lhs, const const_iterator & rhs) noexcept
     {
       // Implemented just like the corresponding std::rel_ops operator.
@@ -225,7 +225,7 @@ public:
 
 
     /** Returns (it1 <= it2) for iterators it1 and it2. */
-    friend bool
+    friend constexpr bool
     operator<=(const const_iterator & lhs, const const_iterator & rhs) noexcept
     {
       // Implemented just like the corresponding std::rel_ops operator.
@@ -234,7 +234,7 @@ public:
 
 
     /** Returns (it1 >= it2) for iterators it1 and it2. */
-    friend bool
+    friend constexpr bool
     operator>=(const const_iterator & lhs, const const_iterator & rhs) noexcept
     {
       // Implemented just like the corresponding std::rel_ops operator.
@@ -261,7 +261,9 @@ public:
     using MinIndexType = std::conditional_t<VBeginAtZero, ZeroIndex, IndexType>;
 
     // Private constructor, only used by friend class IndexRange.
-    const_iterator(const IndexType & index, const MinIndexType & minIndex, const IndexType & maxIndex) noexcept
+    constexpr const_iterator(const IndexType &    index,
+                             const MinIndexType & minIndex,
+                             const IndexType &    maxIndex) noexcept
       : // Note: Use parentheses instead of curly braces to initialize data members,
         // to avoid AppleClang 6.0.0.6000056 compilation error, "no viable conversion..."
       m_Index(index)
@@ -296,7 +298,7 @@ public:
 
   /** Constructs a range of indices for the specified grid size.
    */
-  explicit IndexRange(const SizeType & gridSize)
+  constexpr explicit IndexRange(const SizeType & gridSize)
     : // Note: Use parentheses instead of curly braces to initialize data members,
       // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
     m_MinIndex()
@@ -326,14 +328,14 @@ public:
 
 
   /** Returns an iterator to the first index. */
-  iterator
+  constexpr iterator
   begin() const noexcept
   {
     return iterator(m_MinIndex, m_MinIndex, m_MaxIndex);
   }
 
   /** Returns an 'end iterator' for this range. */
-  iterator
+  constexpr iterator
   end() const noexcept
   {
     IndexType index = m_MinIndex;
@@ -343,14 +345,14 @@ public:
 
   /** Returns a const iterator to the first index.
    * Provides only read-only access to the index data. */
-  const_iterator
+  constexpr const_iterator
   cbegin() const noexcept
   {
     return this->begin();
   }
 
   /** Returns a const 'end iterator' for this range. */
-  const_iterator
+  constexpr const_iterator
   cend() const noexcept
   {
     return this->end();
@@ -386,7 +388,7 @@ public:
 
 
   /** Returns the size of the range, that is the number of indices. */
-  size_t
+  constexpr size_t
   size() const noexcept
   {
     size_t result = 1;
@@ -400,7 +402,7 @@ public:
 
 
   /** Tells whether the range is empty. */
-  bool
+  constexpr bool
   empty() const noexcept
   {
     // When an IndexRange is empty, each index value of m_MaxIndex is less than the corresponding
@@ -414,7 +416,7 @@ public:
 private:
   using MinIndexType = typename iterator::MinIndexType;
 
-  static IndexType
+  static constexpr IndexType
   CalculateMaxIndex(const MinIndexType & minIndex, const SizeType & size)
   {
     const bool sizeHasZeroValue = [&size] {
@@ -431,7 +433,8 @@ private:
     // Treat any size that has a zero value equally.
     const SizeType normalizedSize = sizeHasZeroValue ? SizeType{ { 0 } } : size;
 
-    IndexType index;
+    // The `index` is initialized (`{}`), just to support C++17 constexpr.
+    IndexType index{};
 
     for (unsigned int i = 0; i < VDimension; ++i)
     {

--- a/Modules/Core/Common/test/itkIndexRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexRangeGTest.cxx
@@ -91,11 +91,11 @@ template <unsigned int VDimension>
 void
 ExpectRangeIsEmptyWhenRegionSizeIsZero()
 {
-  const itk::Size<VDimension> zeroSize{ { 0 } };
+  static constexpr itk::Size<VDimension> zeroSize{ { 0 } };
 
   // Test when both the region index and the region size are zero:
-  EXPECT_TRUE(ZeroBasedIndexRange<VDimension>{ zeroSize }.empty());
-  EXPECT_TRUE(ImageRegionIndexRange<VDimension>{ zeroSize }.empty());
+  static_assert(ZeroBasedIndexRange<VDimension>{ zeroSize }.empty());
+  static_assert(ImageRegionIndexRange<VDimension>{ zeroSize }.empty());
 
   // Now do the test for an arbitrary (random) region index:
   const itk::Index<VDimension>       randomRegionIndex = GenerateRandomIndex<VDimension>();
@@ -143,12 +143,12 @@ TEST(IndexRange, EquivalentBeginOrEndIteratorsCompareEqual)
 {
   using RangeType = IndexRange<2, true>;
 
-  RangeType range(RangeType::SizeType{ { 1, 2 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 1, 2 } });
 
-  const RangeType::iterator       begin = range.begin();
-  const RangeType::iterator       end = range.end();
-  const RangeType::const_iterator cbegin = range.cbegin();
-  const RangeType::const_iterator cend = range.cend();
+  static constexpr RangeType::iterator       begin = range.begin();
+  static constexpr RangeType::iterator       end = range.end();
+  static constexpr RangeType::const_iterator cbegin = range.cbegin();
+  static constexpr RangeType::const_iterator cend = range.cend();
 
   // An iterator object compares equal to itself:
   EXPECT_EQ(begin, begin);
@@ -175,10 +175,9 @@ TEST(IndexRange, EquivalentBeginOrEndIteratorsCompareEqual)
 TEST(IndexRange, BeginAndEndDoNotCompareEqualWhenSizeIsGreaterThanZero)
 {
   using RangeType = IndexRange<2, true>;
-  RangeType range(RangeType::SizeType{ { 1, 2 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 1, 2 } });
 
-  EXPECT_TRUE(!range.empty());
-  EXPECT_FALSE(range.empty());
+  static_assert(!range.empty());
 
   EXPECT_FALSE(range.begin() == range.end());
   EXPECT_NE(range.begin(), range.end());
@@ -190,7 +189,7 @@ TEST(IndexRange, BeginAndEndDoNotCompareEqualWhenSizeIsGreaterThanZero)
 TEST(IndexRange, IteratorsCanBePassedToStdVectorConstructor)
 {
   using RangeType = IndexRange<2, true>;
-  RangeType range(RangeType::SizeType{ { 1, 2 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 1, 2 } });
 
   // Easily store all indices of an IndexRange in an std::vector:
   const std::vector<RangeType::IndexType> stdVector(range.begin(), range.end());
@@ -206,9 +205,9 @@ TEST(IndexRange, IteratorsCanBePassedToStdReverseCopy)
 {
   using RangeType = IndexRange<2, true>;
   using IndexType = RangeType::IndexType;
-  RangeType range(RangeType::SizeType{ { 2, 3 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 2, 3 } });
 
-  const unsigned int numberOfIndices = range.size();
+  static constexpr unsigned int numberOfIndices = range.size();
 
   const std::vector<IndexType> stdVector(range.begin(), range.end());
   std::vector<IndexType>       reversedStdVector1(numberOfIndices);
@@ -237,7 +236,7 @@ TEST(IndexRange, IteratorsCanBePassedToStdForEach)
 {
   using RangeType = IndexRange<2, true>;
   using IndexType = RangeType::IndexType;
-  RangeType range(RangeType::SizeType{ { 2, 3 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 2, 3 } });
 
   std::for_each(range.begin(), range.end(), [](const IndexType index) { EXPECT_TRUE(index >= IndexType()); });
 }
@@ -249,7 +248,7 @@ TEST(IndexRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
 {
   using RangeType = IndexRange<2, true>;
   using IndexType = RangeType::IndexType;
-  RangeType range(RangeType::SizeType{ { 2, 3 } });
+  static constexpr RangeType range(RangeType::SizeType{ { 2, 3 } });
 
   for (auto && index : range)
   {
@@ -266,14 +265,14 @@ TEST(IndexRange, SupportsImageRegion)
   using IndexType = ImageRegionIndexRangeType::IndexType;
   using RegionType = itk::ImageRegion<Dimension>;
 
-  const RegionType::SizeType  size = { { 2, 3 } };
-  const RegionType::IndexType regionIndex = { { 4, 5 } };
-  const RegionType            imageRegion{ regionIndex, size };
+  static constexpr RegionType::SizeType  size = { { 2, 3 } };
+  static constexpr RegionType::IndexType regionIndex = { { 4, 5 } };
+  const RegionType                       imageRegion{ regionIndex, size };
 
   // Default index range, beginning at [0, 0].
-  const ZeroBasedIndexRange<Dimension> indexRange(size);
-  const auto                           beginOfIndexRange = indexRange.cbegin();
-  const auto                           endOfIndexRange = indexRange.cend();
+  static constexpr ZeroBasedIndexRange<Dimension> indexRange(size);
+  static constexpr auto                           beginOfIndexRange = indexRange.cbegin();
+  static constexpr auto                           endOfIndexRange = indexRange.cend();
 
   const ImageRegionIndexRangeType imageRegionIndexRange(imageRegion);
 


### PR DESCRIPTION
- Added constexpr to many IndexRange functions
- Estimated the OffsetToIndexTable of BSplineInterpolationWeightFunction at compile-time