### PR TITLE
DOC: Start ITK 6 migration guide

### DIFF
--- a/Documentation/docs/migration_guides/index.md
+++ b/Documentation/docs/migration_guides/index.md
@@ -6,5 +6,6 @@ These migration guides explain how to update major versions of ITK, whic may con
 :hidden:
 :maxdepth: 3
 
+itk_6_migration_guide
 itk_5_migration_guide
 ```

--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -1,0 +1,23 @@
+ITK v6 Migration Guide
+======================
+
+This guide documents the changes required to migrate a code base
+which uses ITK v5 to use ITK v6. The migration guide for transition
+from v4 to v5 can be found [here](./itk_5_migration_guide.md).
+
+Legacy code removed
+-------------------
+
+Most code that was marked as legacy in ITK 5 has been removed, with exceptions
+made on an as-needed basis. External code which previously required
+`ITK_LEGACY_REMOVE` CMake option to be `OFF` in order to build will now fail
+to compile. Before starting migration to v6 (as explained in this guide),
+migration to v5 should be finished. Dependent code should build and pass tests
+with `ITK_LEGACY_REMOVE` turned `ON` when compiling against
+[ITK 5](https://github.com/InsightSoftwareConsortium/ITK/releases/tag/v5.4.0).
+
+Most code which was marked as `ITK_FUTURE_LEGACY_REMOVE` has been now
+re-flagged as `ITK_LEGACY_REMOVE`. There have been some other
+deprecations and API changes. The new behavior is activated by setting
+`ITK_LEGACY_REMOVE` to `ON`. By default, compatibility with v5 is retained
+(`ITK_LEGACY_REMOVE=OFF`).


### PR DESCRIPTION
This document provides information for developers on how to migrate from
ITK 5 to ITK 6. It contains information on what backwards-incompatible
changes were made, such as the removal of deprecated code, why they made,
and how to migrate old code no the new code.

Developers making backwards-incompatible changes for ITK 6 should add
entries to this document as the changes are made.

The ITK 6 migration guide is similar to the ITK 5 migration guide with the
following modifications:

- The current and previous migration guide are now developed on GitHub
  and published to the ITK Sphinx Documentation.
- We now have the consistent and simpler ITK_LEGACY_REMOVE and
  ITK_FUTURE_LEGACY_REMOVE options without the additional
  *_COMPATIBILITY option.
- We have "most" instead of "all" ITK_LEGACY_REMOVE,
  ITK_FUTURE_LEGACY_REMOVE to allow for exceptions on an as-needed basis
  to prevent forcing deprecations that may be premature in terms of
  their removal-cost-benefit or the availability of migration
  options.
