### PR TITLE
ENH: Bump ITK's CMake version to 6.0.0

### DIFF
--- a/CMake/itkVersion.cmake
+++ b/CMake/itkVersion.cmake
@@ -1,4 +1,4 @@
 # ITK version number components.
-set(ITK_VERSION_MAJOR "5")
-set(ITK_VERSION_MINOR "4")
+set(ITK_VERSION_MAJOR "6")
+set(ITK_VERSION_MINOR "0")
 set(ITK_VERSION_PATCH "0")


### PR DESCRIPTION
Following the process outlined in the Release documentation.

Clarify for developers and for users that they are working with the
in-progress ITK 6 development code.
