### PR TITLE
-Wextra-semi

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -155,6 +155,7 @@ StatementMacros:
   - INTEL_PRAGMA_WARN_PUSH
   - INTEL_PRAGMA_WARN_POP
   - INTEL_SUPPRESS_warning_1292
+  - itkBooleanMacro
 TabWidth:        2
 UseTab:          Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -156,6 +156,12 @@ StatementMacros:
   - INTEL_PRAGMA_WARN_POP
   - INTEL_SUPPRESS_warning_1292
   - itkBooleanMacro
+  - itkQEDefineFrontIteratorMethodsMacro
+  - itkQEAccessorsMacro
+  - itkCellVisitMacro
+  - itkNUMERIC_TRAITS_MIN_MAX_MACRO
+  - itkTemplateFloatingToIntegerMacro
+  - itkPadStruct
 TabWidth:        2
 UseTab:          Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -163,6 +163,8 @@ StatementMacros:
   - itkTemplateFloatingToIntegerMacro
   - itkPadStruct
   - itkLegacyMacro
+  - IPLSetMacroDeclaration
+  - IPLGetMacroDeclaration
 TabWidth:        2
 UseTab:          Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -162,6 +162,7 @@ StatementMacros:
   - itkNUMERIC_TRAITS_MIN_MAX_MACRO
   - itkTemplateFloatingToIntegerMacro
   - itkPadStruct
+  - itkLegacyMacro
 TabWidth:        2
 UseTab:          Never
 ...

--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.h
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.h
@@ -136,7 +136,7 @@ public:
    */
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
 
 protected:
   VectorCentralDifferenceImageFunction();

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
@@ -118,7 +118,7 @@ public:
    * set to false for the opposite direction. */
   itkGetConstMacro(Polarity, bool);
   itkSetMacro(Polarity, bool);
-  itkBooleanMacro(Polarity);
+  itkBooleanMacro(Polarity)
 
 protected:
   ConicShellInteriorExteriorSpatialFunction() = default;

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -351,7 +351,7 @@ public:
   }
 
   itkGetConstReferenceMacro(ReleaseDataFlag, bool);
-  itkBooleanMacro(ReleaseDataFlag);
+  itkBooleanMacro(ReleaseDataFlag)
 
   /** Turn on/off a flag to control whether every object releases its data
    * after being used by a filter. Being a global flag, it controls the

--- a/Modules/Core/Common/include/itkFileOutputWindow.h
+++ b/Modules/Core/Common/include/itkFileOutputWindow.h
@@ -69,7 +69,7 @@ public:
   /** Set/Get the buffer flushing mode */
   itkSetMacro(Flush, bool);
   itkGetConstMacro(Flush, bool);
-  itkBooleanMacro(Flush);
+  itkBooleanMacro(Flush)
 
   /** Setting append will cause the log file to be
    * opened in append mode.  Otherwise, if the log file exists,
@@ -77,7 +77,7 @@ public:
    * is created. */
   itkSetMacro(Append, bool);
   itkGetConstMacro(Append, bool);
-  itkBooleanMacro(Append);
+  itkBooleanMacro(Append)
 
 protected:
   FileOutputWindow();

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -136,7 +136,7 @@ public:
   {
     return m_NormalizeAcrossScale;
   }
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set/Get the variance of the Gaussian kernel.
    *

--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -64,7 +64,8 @@ public:
 
 protected:
   GaussianKernelFunction()
-    : m_Factor(TRealValueType{ 1.0 } / std::sqrt(TRealValueType{ 2.0 * itk::Math::pi })){};
+    : m_Factor(TRealValueType{ 1.0 } / std::sqrt(TRealValueType{ 2.0 * itk::Math::pi }))
+  {}
   ~GaussianKernelFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.h
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.h
@@ -78,7 +78,7 @@ public:
   /** Set/Get whether or not to normalize the Gaussian. Default is false. */
   itkSetMacro(Normalized, bool);
   itkGetConstMacro(Normalized, bool);
-  itkBooleanMacro(Normalized);
+  itkBooleanMacro(Normalized)
 
   /** Set/Get the standard deviation in each direction. */
   itkSetMacro(Sigma, ArrayType);

--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -154,7 +154,7 @@ public:
                    InterpolationWeightType *) override;
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::HEXAHEDRON_CELL);
+  itkCellVisitMacro(CellGeometryEnum::HEXAHEDRON_CELL)
 
 protected:
   /** Store the number of points needed for a hexahedron. */

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -397,7 +397,7 @@ protected:
    * thus enabling custom region splitting methods. */
   itkGetConstMacro(DynamicMultiThreading, bool);
   itkSetMacro(DynamicMultiThreading, bool);
-  itkBooleanMacro(DynamicMultiThreading);
+  itkBooleanMacro(DynamicMultiThreading)
 
   bool m_DynamicMultiThreading{};
 };

--- a/Modules/Core/Common/include/itkImportImageContainer.h
+++ b/Modules/Core/Common/include/itkImportImageContainer.h
@@ -149,7 +149,7 @@ public:
    *  \warning Improper use of these methods will result in memory leaks */
   itkSetMacro(ContainerManageMemory, bool);
   itkGetConstMacro(ContainerManageMemory, bool);
-  itkBooleanMacro(ContainerManageMemory);
+  itkBooleanMacro(ContainerManageMemory)
 
 protected:
   ImportImageContainer() = default;

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.h
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.h
@@ -112,7 +112,7 @@ public:
    * image type match. */
   itkSetMacro(InPlace, bool);
   itkGetConstMacro(InPlace, bool);
-  itkBooleanMacro(InPlace);
+  itkBooleanMacro(InPlace)
 
   /** Can the filter run in place? To do so, the filter's first input
    * and output must have the same dimension and pixel type. This

--- a/Modules/Core/Common/include/itkLightProcessObject.h
+++ b/Modules/Core/Common/include/itkLightProcessObject.h
@@ -95,7 +95,7 @@ public:
   itkGetConstReferenceMacro(AbortGenerateData, bool);
 
   /** Turn on and off the AbortGenerateData flag. */
-  itkBooleanMacro(AbortGenerateData);
+  itkBooleanMacro(AbortGenerateData)
 
   /** Set the execution progress of a process object. The progress is
    * a floating number between (0,1), 0 meaning no progress; 1 meaning

--- a/Modules/Core/Common/include/itkLineCell.h
+++ b/Modules/Core/Common/include/itkLineCell.h
@@ -111,7 +111,7 @@ public:
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::LINE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::LINE_CELL)
 
   LineCell() = default;
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -647,7 +647,8 @@ OutputWindowDisplayDebugText(const char *);
 //
 // See below for what to do for the method definition.
 #if defined(ITK_LEGACY_REMOVE)
-#  define itkLegacyMacro(method) /* no ';' */
+#  define itkLegacyMacro(method) \
+    static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 #else
 #  if defined(ITK_LEGACY_SILENT) || defined(ITK_LEGACY_TEST)
 //   Provide legacy methods with no warnings.

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -204,7 +204,7 @@ itkTemplateFloatingToIntegerMacro(Floor);
  *  the default one (or at least that it is always restored to the
  *  default one).
  */
-itkTemplateFloatingToIntegerMacro(Ceil);
+itkTemplateFloatingToIntegerMacro(Ceil)
 
 #undef itkTemplateFloatingToIntegerMacro
 

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -393,7 +393,7 @@ public:
   static constexpr char ITKCommon_EXPORT Zero = 0;
   static constexpr char ITKCommon_EXPORT One = 1;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
 
   static constexpr char
   NonpositiveMin()
@@ -621,7 +621,7 @@ public:
   static constexpr unsigned char ITKCommon_EXPORT Zero = 0;
   static constexpr unsigned char ITKCommon_EXPORT One = 1;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
 
   static constexpr unsigned char
   NonpositiveMin()
@@ -724,7 +724,7 @@ public:
   static constexpr short ITKCommon_EXPORT Zero = 0;
   static constexpr short ITKCommon_EXPORT One = 1;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr short
   NonpositiveMin()
   {
@@ -827,7 +827,7 @@ public:
   static constexpr unsigned short ITKCommon_EXPORT Zero = 0;
   static constexpr unsigned short ITKCommon_EXPORT One = 1;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr unsigned short
   NonpositiveMin()
   {
@@ -929,7 +929,7 @@ public:
   static constexpr int ITKCommon_EXPORT Zero = 0;
   static constexpr int ITKCommon_EXPORT One = 1;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr int
   NonpositiveMin()
   {
@@ -1154,7 +1154,7 @@ public:
   static constexpr long ITKCommon_EXPORT Zero = 0L;
   static constexpr long ITKCommon_EXPORT One = 1L;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr long
   NonpositiveMin()
   {
@@ -1257,7 +1257,7 @@ public:
   static constexpr unsigned long ITKCommon_EXPORT Zero = 0UL;
   static constexpr unsigned long ITKCommon_EXPORT One = 1UL;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr unsigned long
   NonpositiveMin()
   {
@@ -1361,7 +1361,7 @@ public:
   static constexpr float ITKCommon_EXPORT Zero = 0.0f;
   static constexpr float ITKCommon_EXPORT One = 1.0f;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr float
   NonpositiveMin()
   {
@@ -1464,7 +1464,7 @@ public:
   static constexpr double ITKCommon_EXPORT Zero = 0.0;
   static constexpr double ITKCommon_EXPORT One = 1.0;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr double
   NonpositiveMin()
   {
@@ -1575,7 +1575,7 @@ public:
   static constexpr long double ITKCommon_EXPORT Zero = 0.0;
   static constexpr long double ITKCommon_EXPORT One = 1.0;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr long double
   NonpositiveMin()
   {
@@ -1679,7 +1679,7 @@ public:
   static constexpr ValueType ITKCommon_EXPORT Zero = 0LL;
   static constexpr ValueType ITKCommon_EXPORT One = 1LL;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr ValueType
   NonpositiveMin()
   {
@@ -1782,7 +1782,7 @@ public:
   static constexpr ValueType ITKCommon_EXPORT Zero = 0ULL;
   static constexpr ValueType ITKCommon_EXPORT One = 1ULL;
 
-  itkNUMERIC_TRAITS_MIN_MAX_MACRO();
+  itkNUMERIC_TRAITS_MIN_MAX_MACRO()
   static constexpr ValueType
   NonpositiveMin()
   {

--- a/Modules/Core/Common/include/itkOutputWindow.h
+++ b/Modules/Core/Common/include/itkOutputWindow.h
@@ -123,7 +123,7 @@ public:
    * messages. */
   itkSetMacro(PromptUser, bool);
   itkGetConstMacro(PromptUser, bool);
-  itkBooleanMacro(PromptUser);
+  itkBooleanMacro(PromptUser)
 
 protected:
   OutputWindow();

--- a/Modules/Core/Common/include/itkPolyLineCell.h
+++ b/Modules/Core/Common/include/itkPolyLineCell.h
@@ -115,7 +115,7 @@ public:
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::POLYLINE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::POLYLINE_CELL)
 
   void
   InitializePoints(PointIdentifier numberOfPoints)

--- a/Modules/Core/Common/include/itkPolygonCell.h
+++ b/Modules/Core/Common/include/itkPolygonCell.h
@@ -77,7 +77,7 @@ public:
   using EdgeInfoDQ = std::deque<EdgeInfo>;
 
   /** Need to add POLYGON_CELL into CellInterface. */
-  itkCellVisitMacro(CellGeometryEnum::POLYGON_CELL);
+  itkCellVisitMacro(CellGeometryEnum::POLYGON_CELL)
 
   /** Implement the standard CellInterface. */
   CellGeometryEnum

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -299,7 +299,7 @@ public:
   itkGetConstReferenceMacro(AbortGenerateData, bool);
 
   /** \brief Turn on and off the AbortGenerateData flag. */
-  itkBooleanMacro(AbortGenerateData);
+  itkBooleanMacro(AbortGenerateData)
 
   /** \deprecated
    * Set the execution progress of a process object. The progress is
@@ -488,7 +488,7 @@ public:
    * utilization. Default value is on. */
   itkSetMacro(ReleaseDataBeforeUpdateFlag, bool);
   itkGetConstReferenceMacro(ReleaseDataBeforeUpdateFlag, bool);
-  itkBooleanMacro(ReleaseDataBeforeUpdateFlag);
+  itkBooleanMacro(ReleaseDataBeforeUpdateFlag)
 
   /** Get/Set the number of work units to create when executing. */
   itkSetClampMacro(NumberOfWorkUnits, ThreadIdType, 1, ITK_MAX_THREADS);
@@ -893,7 +893,7 @@ protected:
    * updated in derived filters.
    */
   itkGetConstMacro(ThreaderUpdateProgress, bool);
-  itkBooleanMacro(ThreaderUpdateProgress);
+  itkBooleanMacro(ThreaderUpdateProgress)
   virtual void
   SetThreaderUpdateProgress(bool arg);
 

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -495,9 +495,15 @@ public:
   itkGetConstReferenceMacro(NumberOfWorkUnits, ThreadIdType);
 
 #if !defined(ITK_LEGACY_REMOVE) || defined(ITKV4_COMPATIBILITY)
-  itkLegacyMacro(void SetNumberOfThreads(ThreadIdType count)) { this->SetNumberOfWorkUnits(count); }
+  itkLegacyMacro(void SetNumberOfThreads(ThreadIdType count))
+  {
+    this->SetNumberOfWorkUnits(count);
+  }
 
-  itkLegacyMacro(ThreadIdType GetNumberOfThreads() const) { return this->GetNumberOfWorkUnits(); }
+  itkLegacyMacro(ThreadIdType GetNumberOfThreads() const)
+  {
+    return this->GetNumberOfWorkUnits();
+  }
 #endif // !ITK_LEGACY_REMOVE
 
   /** Return the multithreader used by this class. */
@@ -905,7 +911,7 @@ protected:
   progressFixedToFloat(uint32_t fixed)
   {
     return static_cast<double>(fixed) / static_cast<double>(std::numeric_limits<uint32_t>::max());
-  };
+  }
 
   /**
    * Internal method convert floating point progress [0.0, 1.0] to internal integer representation. Values outside the
@@ -924,7 +930,7 @@ protected:
     }
     double temp = static_cast<double>(f) * std::numeric_limits<uint32_t>::max();
     return static_cast<uint32_t>(temp);
-  };
+  }
 
   /** These ivars are made protected so filters like itkStreamingImageFilter
    * can access them directly. */

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -62,20 +62,20 @@ struct Identity
     using Type = Typed;                 \
   };
 
-ITK_ASSOCIATE(1, TA);
-ITK_ASSOCIATE(2, TB);
+ITK_ASSOCIATE(1, TA)
+ITK_ASSOCIATE(2, TB)
 
-ITK_ASSOCIATE(3, short);
-ITK_ASSOCIATE(4, unsigned short);
-ITK_ASSOCIATE(5, int);
-ITK_ASSOCIATE(6, unsigned int);
-ITK_ASSOCIATE(7, long);
-ITK_ASSOCIATE(8, unsigned long);
-ITK_ASSOCIATE(9, long long);
-ITK_ASSOCIATE(10, unsigned long long);
-ITK_ASSOCIATE(11, float);
-ITK_ASSOCIATE(12, double);
-ITK_ASSOCIATE(13, long double);
+ITK_ASSOCIATE(3, short)
+ITK_ASSOCIATE(4, unsigned short)
+ITK_ASSOCIATE(5, int)
+ITK_ASSOCIATE(6, unsigned int)
+ITK_ASSOCIATE(7, long)
+ITK_ASSOCIATE(8, unsigned long)
+ITK_ASSOCIATE(9, long long)
+ITK_ASSOCIATE(10, unsigned long long)
+ITK_ASSOCIATE(11, float)
+ITK_ASSOCIATE(12, double)
+ITK_ASSOCIATE(13, long double)
 #undef ITK_ASSOCIATE
 } // namespace Details
 

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.h
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.h
@@ -106,7 +106,7 @@ public:
   GetVertex(CellFeatureIdentifier, VertexAutoPointer &);
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::QUADRATIC_EDGE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::QUADRATIC_EDGE_CELL)
 
   QuadraticEdgeCell() = default;
 

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.h
@@ -119,7 +119,7 @@ public:
   GetEdge(CellFeatureIdentifier, EdgeAutoPointer &);
 
   /** Cell visitor interface. */
-  itkCellVisitMacro(CellGeometryEnum::QUADRATIC_TRIANGLE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::QUADRATIC_TRIANGLE_CELL)
 
   /** Given the parametric coordinates of a point in the cell
    *  determine the value of its Shape Functions

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -130,7 +130,7 @@ public:
                    InterpolationWeightType * weight) override;
 
   /** Visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::QUADRILATERAL_CELL);
+  itkCellVisitMacro(CellGeometryEnum::QUADRILATERAL_CELL)
 
   /** Constructor and destructor */
   QuadrilateralCell() = default;

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -141,9 +141,9 @@ public:
   // This was observed in at least gcc 4.8 and 5.4.0, and
   // AppleClang 7.0.2 and 8.0.0. Probably others too.
   // "= default" doesn't gain us much, so just don't use it here.
-  ~QuadrilateralCell() override{};
+  ~QuadrilateralCell() override {}
 #else
-  ~QuadrilateralCell() override = default;
+  ~QuadrilateralCell() override = default
 #endif
 
 protected:

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -239,7 +239,7 @@ public:
   bool
   GetFullyConnected() const;
 
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   virtual const SeedsContainerType &
   GetSeeds() const

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -165,7 +165,7 @@ public:
   GetFace(CellFeatureIdentifier, FaceAutoPointer &);
 
   /** Visitor interface. */
-  itkCellVisitMacro(CellGeometryEnum::TETRAHEDRON_CELL);
+  itkCellVisitMacro(CellGeometryEnum::TETRAHEDRON_CELL)
 
   bool
   EvaluatePosition(CoordRepType *,

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -188,9 +188,9 @@ public:
   // This was observed in at least gcc 4.8 and 5.4.0, and
   // AppleClang 7.0.2 and 8.0.0. Probably others too.
   // "= default" doesn't gain us much, so just don't use it here.
-  ~TriangleCell() override{};
+  ~TriangleCell() override {}
 #else
-  ~TriangleCell() override = default;
+  ~TriangleCell() override = default
 #endif
 
 protected:

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -165,7 +165,7 @@ public:
                    InterpolationWeightType *) override;
 
   /** Cell visitor interface. */
-  itkCellVisitMacro(CellGeometryEnum::TRIANGLE_CELL);
+  itkCellVisitMacro(CellGeometryEnum::TRIANGLE_CELL)
 
   /** Compute Area to a TriangleCell given a PointsContainer. */
   CoordRepType

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -244,7 +244,7 @@ public:
       m_Pos += n;
       m_Iter += n;
       return *this;
-    };
+    }
 
     /** Get the index into the VectorContainer associated with this iterator.
      */
@@ -335,7 +335,7 @@ public:
       m_Pos += n;
       m_Iter += n;
       return *this;
-    };
+    }
 
     difference_type
     operator-(const ConstIterator & r) const

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -125,7 +125,7 @@ public:
   GetPointId();
 
   /** Cell visitor interface */
-  itkCellVisitMacro(CellGeometryEnum::VERTEX_CELL);
+  itkCellVisitMacro(CellGeometryEnum::VERTEX_CELL)
 
   /** Evaluate the position of a given point */
   bool

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -189,7 +189,7 @@ public:
   /** Use the image spacing information in calculations. Use this option if you
    *  want derivatives in physical space. Default is UseImageSpacingOn. */
   itkSetMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
   itkGetConstReferenceMacro(UseImageSpacing, bool);
 
   /** Set/Get the maximum error allowed in the solution.  This may not be
@@ -206,7 +206,7 @@ public:
       SetStateToUninitialized() */
   itkSetMacro(ManualReinitialization, bool);
   itkGetConstReferenceMacro(ManualReinitialization, bool);
-  itkBooleanMacro(ManualReinitialization);
+  itkBooleanMacro(ManualReinitialization)
 
   itkSetMacro(IsInitialized, bool);
   itkGetMacro(IsInitialized, bool);

--- a/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
@@ -73,7 +73,7 @@ public:
   // macro to set if GPU is used
   itkSetMacro(GPUEnabled, bool);
   itkGetConstMacro(GPUEnabled, bool);
-  itkBooleanMacro(GPUEnabled);
+  itkBooleanMacro(GPUEnabled)
 
   void
   GenerateData() override;

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -302,7 +302,7 @@ public:
    */
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
 
   SizeType
   GetRadius() const override

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
@@ -201,7 +201,7 @@ public:
    */
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
 
 protected:
   CentralDifferenceImageFunction();

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
@@ -157,7 +157,7 @@ public:
    */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 protected:
   GaussianBlurImageFunction();

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
@@ -123,7 +123,7 @@ public:
       this->RecomputeGaussianKernel();
     }
   }
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
   itkGetMacro(UseImageSpacing, bool);
 
   /** The variance for the discrete Gaussian kernel. Sets the variance

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.h
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.h
@@ -96,7 +96,7 @@ public:
    * an operator=(). Default value = true */
   itkSetMacro(ComputeIndices, bool);
   itkGetConstMacro(ComputeIndices, bool);
-  itkBooleanMacro(ComputeIndices);
+  itkBooleanMacro(ComputeIndices)
 
 protected:
   ImageToParametricSpaceFilter();

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -103,7 +103,7 @@ public:
   inline itkQEDefineIteratorGeomMethodsMacro(InvDnext);
 
   /** QE macros. */
-  itkQEAccessorsMacro(Superclass, Self, DualType);
+  itkQEAccessorsMacro(Superclass, Self, DualType)
 
 public:
   GeometricalQuadEdge();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -169,7 +169,7 @@ public:
 
 #if !defined(ITK_WRAPPING_PARSER)
   /** FrontIterator definitions */
-  itkQEDefineFrontIteratorMethodsMacro(Self);
+  itkQEDefineFrontIteratorMethodsMacro(Self)
 #endif
 
 public:

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -174,7 +174,7 @@ public:
   /** Get if the contour is closed. */
   itkGetConstMacro(IsClosed, bool);
 
-  itkBooleanMacro(IsClosed);
+  itkBooleanMacro(IsClosed)
 
   /** Get the axis-normal orientation of the contour */
   int

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -92,7 +92,7 @@ public:
   itkSetMacro(MaskValue, PixelType);
   itkGetConstReferenceMacro(MaskValue, PixelType);
 
-  itkBooleanMacro(UseMaskValue);
+  itkBooleanMacro(UseMaskValue)
   itkSetMacro(UseMaskValue, bool);
   itkGetConstReferenceMacro(UseMaskValue, bool);
 

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -76,7 +76,7 @@ public:
    */
   itkSetMacro(WriteImagesInSeparateFile, bool);
   itkGetConstMacro(WriteImagesInSeparateFile, bool);
-  itkBooleanMacro(WriteImagesInSeparateFile);
+  itkBooleanMacro(WriteImagesInSeparateFile)
 
 protected:
   MetaConverterBase() = default;

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -86,7 +86,7 @@ public:
   /** Set if the points should be saved in binary/ASCII */
   itkSetMacro(BinaryPoints, bool);
   itkGetConstMacro(BinaryPoints, bool);
-  itkBooleanMacro(BinaryPoints);
+  itkBooleanMacro(BinaryPoints)
 
   /** set/get the precision for writing out numbers as plain text */
   itkSetMacro(TransformPrecision, unsigned int);
@@ -95,7 +95,7 @@ public:
   /** Set if the images should be written in different files */
   itkSetMacro(WriteImagesInSeparateFile, bool);
   itkGetConstMacro(WriteImagesInSeparateFile, bool);
-  itkBooleanMacro(WriteImagesInSeparateFile);
+  itkBooleanMacro(WriteImagesInSeparateFile)
 
   /** add new SpatialObject/MetaObject converters at runtime
    *

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -77,7 +77,7 @@ public:
   /** Get if the contour is closed */
   itkGetConstMacro(IsClosed, bool);
 
-  itkBooleanMacro(IsClosed);
+  itkBooleanMacro(IsClosed)
 
   /** Method returns area of polygon described by points */
   double

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -184,7 +184,7 @@ public:
    *  the ValueAtInWorldSpace() function instead of IsInsideInWorldSpace() */
   itkSetMacro(UseObjectValue, bool);
   itkGetConstMacro(UseObjectValue, bool);
-  itkBooleanMacro(UseObjectValue);
+  itkBooleanMacro(UseObjectValue)
 
 protected:
   SpatialObjectToImageFilter();

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -77,7 +77,7 @@ public:
   /** Set the type of tube end-type: false = flat, true = rounded */
   itkSetMacro(EndRounded, bool);
   itkGetConstMacro(EndRounded, bool);
-  itkBooleanMacro(EndRounded);
+  itkBooleanMacro(EndRounded)
 
   /** Compute the tangents and normals of the centerline of the tube. */
   bool
@@ -108,7 +108,7 @@ public:
    *  tube network in the scene */
   itkGetConstMacro(Root, bool);
 
-  itkBooleanMacro(Root);
+  itkBooleanMacro(Root)
 
   /** Test whether a point is inside the object: returns true if the point is inside the tube, false otherwise.
    *

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
@@ -101,7 +101,7 @@ public:
    */
   itkSetMacro(ClearPipelineOnGenerateOutputInformation, bool);
   itkGetMacro(ClearPipelineOnGenerateOutputInformation, bool);
-  itkBooleanMacro(ClearPipelineOnGenerateOutputInformation);
+  itkBooleanMacro(ClearPipelineOnGenerateOutputInformation)
 
 
   /** This a meta verify method to check expected pipeline execution

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
@@ -76,7 +76,7 @@ public:
    */
   itkSetMacro(VerifyInputInformation, bool);
   itkGetConstMacro(VerifyInputInformation, bool);
-  itkBooleanMacro(VerifyInputInformation);
+  itkBooleanMacro(VerifyInputInformation)
 
   /** Set/Get the maximum distance away to look for a matching pixel.
       Default is 0. */
@@ -93,7 +93,7 @@ public:
    *    Default = false */
   itkSetMacro(IgnoreBoundaryPixels, bool);
   itkGetConstMacro(IgnoreBoundaryPixels, bool);
-  itkBooleanMacro(IgnoreBoundaryPixels);
+  itkBooleanMacro(IgnoreBoundaryPixels)
 
   /** Get statistical attributes for those pixels which exceed the
    * tolerance and radius parameters */

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -302,14 +302,17 @@ private:
 
   /** Methods have empty implementations */
   void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const override{};
+  SetFixedParametersGridSizeFromTransformDomainInformation() const override
+  {}
   void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const override{};
+  SetFixedParametersGridOriginFromTransformDomainInformation() const override
+  {}
   void
   SetFixedParametersGridSpacingFromTransformDomainInformation() const override
   {}
   void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const override{};
+  SetFixedParametersGridDirectionFromTransformDomainInformation() const override
+  {}
 
   /** Check if a continuous index is inside the valid region. */
   bool

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -595,9 +595,9 @@ protected:
   // This was observed in at least gcc 4.8 and 5.4.0, and
   // AppleClang 7.0.2 and 8.0.0. Probably others too.
   // "= default" doesn't gain us much, so just don't use it here.
-  ~Transform() override{};
+  ~Transform() override {}
 #else
-  ~Transform() override = default;
+  ~Transform() override = default
 #endif
   mutable ParametersType      m_Parameters{};
   mutable FixedParametersType m_FixedParameters{};

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -172,8 +172,8 @@ protected:
   // This was observed in at least gcc 4.8 and 5.4.0, and
   // AppleClang 7.0.2 and 8.0.0. Probably others too.
   // "= default" doesn't gain us much, so just don't use it here.
-  TransformBaseTemplate(){};
-  ~TransformBaseTemplate() override{};
+  TransformBaseTemplate() {}
+  ~TransformBaseTemplate() override {}
 #else
   TransformBaseTemplate() = default;
   ~TransformBaseTemplate() override = default;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -327,7 +327,7 @@ public:
    * internally uses log intensity values for every calculation. */
   itkSetMacro(BiasFieldMultiplicative, bool);
   itkGetConstMacro(BiasFieldMultiplicative, bool);
-  itkBooleanMacro(BiasFieldMultiplicative);
+  itkBooleanMacro(BiasFieldMultiplicative)
 
 #if defined(ITK_LEGACY_REMOVE)
   /** If the bias field is multiplicative, it returns true. */
@@ -344,7 +344,7 @@ public:
    * input images). */
   itkSetMacro(UsingInterSliceIntensityCorrection, bool);
   itkGetConstMacro(UsingInterSliceIntensityCorrection, bool);
-  itkBooleanMacro(UsingInterSliceIntensityCorrection);
+  itkBooleanMacro(UsingInterSliceIntensityCorrection)
 
   /** Set/Get the slab correction flag. If the flag is true, inter-slice
    * intensity correction and bias field correction will be performed slab by
@@ -353,7 +353,7 @@ public:
    * should be buffered. */
   itkSetMacro(UsingSlabIdentification, bool);
   itkGetConstMacro(UsingSlabIdentification, bool);
-  itkBooleanMacro(UsingSlabIdentification);
+  itkBooleanMacro(UsingSlabIdentification)
 
   itkSetMacro(SlabBackgroundMinimumThreshold, InputImagePixelType);
   itkGetConstReferenceMacro(SlabBackgroundMinimumThreshold, InputImagePixelType);
@@ -371,13 +371,13 @@ public:
    * is true). */
   itkSetMacro(UsingBiasFieldCorrection, bool);
   itkGetConstMacro(UsingBiasFieldCorrection, bool);
-  itkBooleanMacro(UsingBiasFieldCorrection);
+  itkBooleanMacro(UsingBiasFieldCorrection)
 
   /** Set/Get the flag. If the flag is true, the output image (corrected image)
    * will be created when this filter is updated (default value is true). */
   itkSetMacro(GeneratingOutput, bool);
   itkGetConstMacro(GeneratingOutput, bool);
-  itkBooleanMacro(GeneratingOutput);
+  itkBooleanMacro(GeneratingOutput)
 
   /** Sets the direction of slicing.
    * 0 - x axis, 1 - y axis, 2 - z axis */

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -184,7 +184,7 @@ public:
    * Defaults to false. */
   itkSetMacro(UseMaskLabel, bool);
   itkGetConstMacro(UseMaskLabel, bool);
-  itkBooleanMacro(UseMaskLabel);
+  itkBooleanMacro(UseMaskLabel)
 
   /**
    * Set confidence image function.  If a confidence image is specified,

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
@@ -92,7 +92,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 protected:
   BinaryClosingByReconstructionImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
@@ -97,7 +97,7 @@ public:
    * and remove it once the closing is done */
   itkSetMacro(SafeBorder, bool);
   itkGetConstReferenceMacro(SafeBorder, bool);
-  itkBooleanMacro(SafeBorder);
+  itkBooleanMacro(SafeBorder)
 
 protected:
   BinaryMorphologicalClosingImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
@@ -175,7 +175,7 @@ public:
    */
   itkSetMacro(BoundaryToForeground, bool);
   itkGetConstReferenceMacro(BoundaryToForeground, bool);
-  itkBooleanMacro(BoundaryToForeground);
+  itkBooleanMacro(BoundaryToForeground)
 
   /** Set kernel (structuring element). */
   void

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
@@ -97,7 +97,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 protected:
   BinaryOpeningByReconstructionImageFilter();

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -191,7 +191,7 @@ public:
    * these values can be set in the colormap manually. */
   itkSetMacro(UseInputImageExtremaForScaling, bool);
   itkGetConstMacro(UseInputImageExtremaForScaling, bool);
-  itkBooleanMacro(UseInputImageExtremaForScaling);
+  itkBooleanMacro(UseInputImageExtremaForScaling)
 
 protected:
   ScalarToRGBColormapImageFilter();

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -154,7 +154,8 @@ protected:
   /** Default superclass implementation ensures that input images
    * occupy same physical space. This is not needed for this filter. */
   void
-  VerifyInputInformation() ITKv5_CONST override{};
+  VerifyInputInformation() ITKv5_CONST override
+  {}
 
 private:
   bool m_Normalize{ false };

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -107,7 +107,7 @@ public:
    * components. Defaults to off. */
   itkSetMacro(Normalize, bool);
   itkGetConstMacro(Normalize, bool);
-  itkBooleanMacro(Normalize);
+  itkBooleanMacro(Normalize)
 
   /** Reverse compatibility for enumerations */
   using OutputRegionModeEnum = ConvolutionImageFilterBaseEnums::ConvolutionImageFilterOutputRegion;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -258,7 +258,7 @@ public:
    *  Defaults to false.
    */
   itkSetMacro(KernelBandwidthEstimation, bool);
-  itkBooleanMacro(KernelBandwidthEstimation);
+  itkBooleanMacro(KernelBandwidthEstimation)
   itkGetConstMacro(KernelBandwidthEstimation, bool);
 
   /** Set/Get the update frequency for the kernel bandwidth estimation.
@@ -285,7 +285,7 @@ public:
    * Defaults to false.
    */
   itkSetMacro(AlwaysTreatComponentsAsEuclidean, bool);
-  itkBooleanMacro(AlwaysTreatComponentsAsEuclidean);
+  itkBooleanMacro(AlwaysTreatComponentsAsEuclidean)
   itkGetConstMacro(AlwaysTreatComponentsAsEuclidean, bool);
 
   /** Set the state of the filter to INITIALIZED. */
@@ -308,7 +308,7 @@ public:
    * SetStateToUninitialized(). */
   itkSetMacro(ManualReinitialization, bool);
   itkGetConstReferenceMacro(ManualReinitialization, bool);
-  itkBooleanMacro(ManualReinitialization);
+  itkBooleanMacro(ManualReinitialization)
 
 protected:
   PatchBasedDenoisingBaseImageFilter();

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -143,7 +143,7 @@ public:
    *  weights provided via the SetPatchWeights method.
    */
   itkSetMacro(UseSmoothDiscPatchWeights, bool);
-  itkBooleanMacro(UseSmoothDiscPatchWeights);
+  itkBooleanMacro(UseSmoothDiscPatchWeights)
   itkGetConstMacro(UseSmoothDiscPatchWeights, bool);
 
   /** Set/Get initial kernel bandwidth estimate.
@@ -164,7 +164,7 @@ public:
   /** Set/Get flag indicating whether conditional derivatives should be used
     estimating sigma. */
   itkSetMacro(ComputeConditionalDerivatives, bool);
-  itkBooleanMacro(ComputeConditionalDerivatives);
+  itkBooleanMacro(ComputeConditionalDerivatives)
   itkGetConstMacro(ComputeConditionalDerivatives, bool);
 
   /** Set/Get flag indicating whether the fast algorithm for tensor computations should be used.
@@ -181,7 +181,7 @@ public:
    *  performance.
    */
   itkSetMacro(UseFastTensorComputations, bool);
-  itkBooleanMacro(UseFastTensorComputations);
+  itkBooleanMacro(UseFastTensorComputations)
   itkGetConstMacro(UseFastTensorComputations, bool);
 
   /** Maximum number of Newton-Raphson iterations for sigma update. */

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -173,7 +173,7 @@ public:
   /**
    * Enforce stationary boundaries.  Important for diffeomorphic transforms.
    */
-  itkBooleanMacro(EnforceStationaryBoundary);
+  itkBooleanMacro(EnforceStationaryBoundary)
   itkSetMacro(EnforceStationaryBoundary, bool);
   itkGetConstMacro(EnforceStationaryBoundary, bool);
 

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -154,7 +154,7 @@ public:
   // Set/get compute number of exp. integration steps automatically
   itkSetMacro(CalculateNumberOfIntegrationStepsAutomatically, bool);
   itkGetConstMacro(CalculateNumberOfIntegrationStepsAutomatically, bool);
-  itkBooleanMacro(CalculateNumberOfIntegrationStepsAutomatically);
+  itkBooleanMacro(CalculateNumberOfIntegrationStepsAutomatically)
 
   /**
    * Set the lower time bound defining the integration domain of the transform.

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -179,7 +179,7 @@ public:
   void
   SetUseImageSpacing(bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Set the derivative weights according to the spacing of the input image

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
@@ -201,7 +201,7 @@ public:
   /* Use input field to define the B-spline domain. */
   itkSetMacro(UseInputFieldToDefineTheBSplineDomain, bool);
   itkGetConstMacro(UseInputFieldToDefineTheBSplineDomain, bool);
-  itkBooleanMacro(UseInputFieldToDefineTheBSplineDomain);
+  itkBooleanMacro(UseInputFieldToDefineTheBSplineDomain)
 
   /**
    * Set the spline order defining the bias field estimate.  Default = 3.
@@ -265,14 +265,14 @@ public:
   /**
    * Estimate the inverse field instead of the forward field.  Default = false.
    */
-  itkBooleanMacro(EstimateInverse);
+  itkBooleanMacro(EstimateInverse)
   itkSetMacro(EstimateInverse, bool);
   itkGetConstMacro(EstimateInverse, bool);
 
   /**
    * Enforce stationary boundary conditions.  Default = false.
    */
-  itkBooleanMacro(EnforceStationaryBoundary);
+  itkBooleanMacro(EnforceStationaryBoundary)
   itkSetMacro(EnforceStationaryBoundary, bool);
   itkGetConstMacro(EnforceStationaryBoundary, bool);
 

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
@@ -97,7 +97,7 @@ public:
    * MaximumNumberOfIterations ) */
   itkSetMacro(AutomaticNumberOfIterations, bool);
   itkGetConstMacro(AutomaticNumberOfIterations, bool);
-  itkBooleanMacro(AutomaticNumberOfIterations);
+  itkBooleanMacro(AutomaticNumberOfIterations)
 
   /** If ComputeInverse is on, the filter will compute the exponential
    * of the opposite (minus) of the input vector field. The output displacement
@@ -106,7 +106,7 @@ public:
    * each other. */
   itkSetMacro(ComputeInverse, bool);
   itkGetConstMacro(ComputeInverse, bool);
-  itkBooleanMacro(ComputeInverse);
+  itkBooleanMacro(ComputeInverse)
 
   /** Image dimension. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -139,7 +139,7 @@ public:
   /* Should we force the boundary to have zero displacement? */
   itkSetMacro(EnforceBoundaryCondition, bool);
   itkGetMacro(EnforceBoundaryCondition, bool);
-  itkBooleanMacro(EnforceBoundaryCondition);
+  itkBooleanMacro(EnforceBoundaryCondition)
 
 protected:
   /** Constructor */

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
@@ -154,7 +154,7 @@ public:
    */
   itkSetMacro(TimeBoundsAsRates, bool);
   itkGetConstMacro(TimeBoundsAsRates, bool);
-  itkBooleanMacro(TimeBoundsAsRates);
+  itkBooleanMacro(TimeBoundsAsRates)
 
 protected:
   TimeVaryingVelocityFieldIntegrationImageFilter();

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
@@ -147,7 +147,7 @@ public:
   /** Turn on/off whether a specified reference image should be used to define
    *  the output information. */
   itkSetMacro(UseReferenceImage, bool);
-  itkBooleanMacro(UseReferenceImage);
+  itkBooleanMacro(UseReferenceImage)
   itkGetConstMacro(UseReferenceImage, bool);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -166,7 +166,8 @@ public:
 
   /** Trigger the computation of the displacement field by integrating the velocity field. */
   virtual void
-  IntegrateVelocityField(){};
+  IntegrateVelocityField()
+  {}
 
   /**
    * Set the lower time bound defining the integration domain of the transform.

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
@@ -121,7 +121,7 @@ public:
   /** Set/Get if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
@@ -127,7 +127,7 @@ public:
   /** Set if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
@@ -129,7 +129,7 @@ public:
   /** Set/Get if the distance should be squared. */
   itkSetMacro(SquaredDistance, bool);
   itkGetConstReferenceMacro(SquaredDistance, bool);
-  itkBooleanMacro(SquaredDistance);
+  itkBooleanMacro(SquaredDistance)
 
   /** Set/Get if the input is binary. If this variable is set, each
    * nonzero pixel in the input image will be given a unique numeric
@@ -138,12 +138,12 @@ public:
    * different nonzero pixels, then you need not set this.  */
   itkSetMacro(InputIsBinary, bool);
   itkGetConstReferenceMacro(InputIsBinary, bool);
-  itkBooleanMacro(InputIsBinary);
+  itkBooleanMacro(InputIsBinary)
 
   /** Set/Get if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstReferenceMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Get Voronoi Map
    * This map shows for each pixel what object is closest to it.

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
@@ -128,7 +128,7 @@ public:
   /** Set/Get if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Return the computed directed Hausdorff distance. */
   itkGetConstMacro(DirectedHausdorffDistance, RealType);

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
@@ -120,7 +120,7 @@ public:
    * off. */
   itkSetMacro(NarrowBanding, bool);
   itkGetConstMacro(NarrowBanding, bool);
-  itkBooleanMacro(NarrowBanding);
+  itkBooleanMacro(NarrowBanding)
 
   /** Set/Get the narrowband. */
   void

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -159,7 +159,7 @@ public:
   itkGetConstReferenceMacro(SquaredDistance, bool);
 
   /** Set On/Off if the distance is squared. */
-  itkBooleanMacro(SquaredDistance);
+  itkBooleanMacro(SquaredDistance)
 
   /** Set if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
@@ -168,7 +168,7 @@ public:
   itkGetConstReferenceMacro(UseImageSpacing, bool);
 
   /** Set On/Off whether spacing is used. */
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set if the inside represents positive values in the signed distance
    *  map. By convention ON pixels are treated as inside pixels.           */
@@ -181,7 +181,7 @@ public:
   /** Set if the inside represents positive values in the signed distance
    * map. By convention ON pixels are treated as inside pixels. Default is
    * true.                             */
-  itkBooleanMacro(InsideIsPositive);
+  itkBooleanMacro(InsideIsPositive)
 
   /** Get Voronoi Map
    * This map shows for each pixel what object is closest to it.

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
@@ -122,7 +122,7 @@ public:
   itkGetConstReferenceMacro(SquaredDistance, bool);
 
   /** Set On/Off if the distance is squared. */
-  itkBooleanMacro(SquaredDistance);
+  itkBooleanMacro(SquaredDistance)
 
   /** Set if the inside represents positive values in the signed distance
    *  map. By convention ON pixels are treated as inside pixels.*/
@@ -135,7 +135,7 @@ public:
   /** Set if the inside represents positive values in the signed distance
    * map. By convention ON pixels are treated as inside pixels. Default is
    * true.                             */
-  itkBooleanMacro(InsideIsPositive);
+  itkBooleanMacro(InsideIsPositive)
 
   /** Set if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
@@ -144,7 +144,7 @@ public:
   itkGetConstReferenceMacro(UseImageSpacing, bool);
 
   /** Set On/Off whether spacing is used. */
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /**
    * Set the background value which defines the object.  Usually this

--- a/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.h
@@ -86,7 +86,7 @@ public:
    * of the dimensions has an odd size. */
   itkSetMacro(Inverse, bool);
   itkGetConstReferenceMacro(Inverse, bool);
-  itkBooleanMacro(Inverse);
+  itkBooleanMacro(Inverse)
 
 protected:
   FFTShiftImageFilter();

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
@@ -85,7 +85,7 @@ public:
 
   /** Was the original truncated dimension size odd? */
   itkSetGetDecoratedInputMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
   /* Return the preferred greatest prime factor supported for the input image
    * size. Defaults to 2 as many implementations work only for sizes that are

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.h
@@ -80,7 +80,7 @@ public:
 
   /** Was the original truncated dimension size in the x-dimension odd? */
   itkSetGetDecoratedInputMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
 protected:
   HalfToFullHermitianImageFilter();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
@@ -228,7 +228,7 @@ public:
 
   /** Get the Collect Points flag. */
   itkGetConstReferenceMacro(CollectPoints, bool);
-  itkBooleanMacro(CollectPoints);
+  itkBooleanMacro(CollectPoints)
 
 protected:
   /** \brief Constructor */

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -334,7 +334,7 @@ public:
 
   /** Get the Const Collect Points flag. */
   itkGetConstReferenceMacro(CollectPoints, bool);
-  itkBooleanMacro(CollectPoints);
+  itkBooleanMacro(CollectPoints)
 
   /** Get the container of Processed Points. If the CollectPoints flag
    * is set, the algorithm collects a container of all processed nodes.
@@ -372,7 +372,7 @@ public:
   itkGetConstReferenceMacro(OutputOrigin, OutputPointType);
   itkSetMacro(OverrideOutputInformation, bool);
   itkGetConstReferenceMacro(OverrideOutputInformation, bool);
-  itkBooleanMacro(OverrideOutputInformation);
+  itkBooleanMacro(OverrideOutputInformation)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
@@ -157,7 +157,7 @@ public:
   itkGetConstReferenceMacro(OutputOrigin, OutputPointType);
   itkSetMacro(OverrideOutputInformation, bool);
   itkGetConstReferenceMacro(OverrideOutputInformation, bool);
-  itkBooleanMacro(OverrideOutputInformation);
+  itkBooleanMacro(OverrideOutputInformation)
 
 protected:
   FastMarchingImageFilterBase();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
@@ -108,7 +108,7 @@ public:
 
   itkSetMacro(IsForbiddenImageBinaryMask, bool);
   itkGetConstMacro(IsForbiddenImageBinaryMask, bool);
-  itkBooleanMacro(IsForbiddenImageBinaryMask);
+  itkBooleanMacro(IsForbiddenImageBinaryMask)
 
   /** \brief Get resulting Alive Points container*/
   NodePairContainerType *

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -181,7 +181,7 @@ public:
 
   /** Get the GenerateGradientImage flag. */
   itkGetConstReferenceMacro(GenerateGradientImage, bool);
-  itkBooleanMacro(GenerateGradientImage);
+  itkBooleanMacro(GenerateGradientImage)
 
   /** Set how long (in terms of arrival times) after targets are reached the
    * front must stop.  This is useful to ensure that the level set of target

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
@@ -151,7 +151,7 @@ public:
    * sigma. When automatic is "off", the kernel size is whatever is
    * specified by the user.
    * \sa SetRadius() */
-  itkBooleanMacro(AutomaticKernelSize);
+  itkBooleanMacro(AutomaticKernelSize)
   itkGetConstMacro(AutomaticKernelSize, bool);
   itkSetMacro(AutomaticKernelSize, bool);
 

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
@@ -98,7 +98,7 @@ public:
    * in isotropic voxel space. Default is On. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Use the image spacing information in calculations. Use this option if you

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
@@ -169,14 +169,14 @@ public:
       image in its calculations. Default is ImageSpacingOn. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set/Get the flag for calculating scale-space normalized derivatives.
    * Normalized derivatives are obtained multiplying by the scale
    * parameter t. */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
@@ -124,7 +124,7 @@ public:
   void
   SetNormalizeAcrossScale(bool normalize);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** HessianRecursiveGaussianImageFilter needs all of the input to produce an
    * output. Therefore, HessianRecursiveGaussianImageFilter needs to provide

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -108,7 +108,7 @@ public:
     absolute eigenvalue */
   itkSetMacro(ScaleObjectnessMeasure, bool);
   itkGetConstMacro(ScaleObjectnessMeasure, bool);
-  itkBooleanMacro(ScaleObjectnessMeasure);
+  itkBooleanMacro(ScaleObjectnessMeasure)
 
   /** Set/Get the dimensionality of the object (0: points (blobs),
    * 1: lines (vessels), 2: planes (plate-like structures), 3: hyper-planes.
@@ -120,7 +120,7 @@ public:
     false. Default is "On" (equivalent to vesselness). */
   itkSetMacro(BrightObject, bool);
   itkGetConstMacro(BrightObject, bool);
-  itkBooleanMacro(BrightObject);
+  itkBooleanMacro(BrightObject)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
@@ -106,7 +106,7 @@ public:
   /** Enable/Disable using the image spacing information in
    *  calculations. Use this option if you  want derivatives in
    *  physical space. Default  is UseImageSpacingOn. */
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set/Get whether or not the filter will use the spacing of the input
       image in its calculations */

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
@@ -86,7 +86,7 @@ public:
 
   /** Set/Get whether or not the filter will use the spacing information of the input image in its calculations. Use
    * this option if derivatives are required in physical space. */
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
 

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
@@ -127,7 +127,7 @@ public:
   /** enable/disable tensor computations */
   itkSetMacro(ComputeStructureTensors, bool);
   itkGetMacro(ComputeStructureTensors, bool);
-  itkBooleanMacro(ComputeStructureTensors);
+  itkBooleanMacro(ComputeStructureTensors)
 
   /** set fraction of eligible points to select */
   itkSetClampMacro(SelectFraction, double, 0, 1);

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
@@ -157,7 +157,7 @@ public:
    */
   itkSetMacro(NonNegativeHessianBasedMeasure, bool);
   itkGetConstMacro(NonNegativeHessianBasedMeasure, bool);
-  itkBooleanMacro(NonNegativeHessianBasedMeasure);
+  itkBooleanMacro(NonNegativeHessianBasedMeasure)
 
   using SigmaStepMethodEnum = MultiScaleHessianBasedMeasureImageFilterEnums::SigmaStepMethod;
 #if !defined(ITK_LEGACY_REMOVE)
@@ -193,13 +193,13 @@ public:
    *  each pixel for the best vesselness response */
   itkSetMacro(GenerateScalesOutput, bool);
   itkGetConstMacro(GenerateScalesOutput, bool);
-  itkBooleanMacro(GenerateScalesOutput);
+  itkBooleanMacro(GenerateScalesOutput)
 
   /** Methods to turn on/off flag to generate an image with hessian values at
    *  each pixel for the best vesselness response */
   itkSetMacro(GenerateHessianOutput, bool);
   itkGetConstMacro(GenerateHessianOutput, bool);
-  itkBooleanMacro(GenerateHessianOutput);
+  itkBooleanMacro(GenerateHessianOutput)
 
   /** This is overloaded to create the Scales and Hessian output images */
   using DataObjectPointerArraySizeType = ProcessObject::DataObjectPointerArraySizeType;

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -138,7 +138,7 @@ public:
    * range of output type. Default: On. */
   itkSetMacro(Clamp, bool);
   itkGetConstMacro(Clamp, bool);
-  itkBooleanMacro(Clamp);
+  itkBooleanMacro(Clamp)
 
 protected:
   UnsharpMaskImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -132,7 +132,7 @@ public:
   itkGetConstReferenceMacro(UseDefaultValue, bool);
 
   /** Turn on and off the UseDefaultValue flag. */
-  itkBooleanMacro(UseDefaultValue);
+  itkBooleanMacro(UseDefaultValue)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -48,7 +48,8 @@ class NullImageToImageFilterDriver
 {
 public:
   NullImageToImageFilterDriver()
-    : m_Filter(nullptr){};
+    : m_Filter(nullptr)
+  {}
 
   using ImageSizeType = typename TInputImage::SizeType;
   using InputPixelType = typename TInputImage::PixelType;

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -125,18 +125,18 @@ public:
    * independent of m_PassBand */
   itkSetMacro(PassLowFrequencyThreshold, bool);
   itkGetConstReferenceMacro(PassLowFrequencyThreshold, bool);
-  itkBooleanMacro(PassLowFrequencyThreshold);
+  itkBooleanMacro(PassLowFrequencyThreshold)
 
   /** The pixel values that correspond to m_HighFrequencyThreshold are passed to the output image,
    * independent of m_PassBand */
   itkSetMacro(PassHighFrequencyThreshold, bool);
   itkGetConstReferenceMacro(PassHighFrequencyThreshold, bool);
-  itkBooleanMacro(PassHighFrequencyThreshold);
+  itkBooleanMacro(PassHighFrequencyThreshold)
 
   /** True: the band is a PassBand. False: StopBand **/
   itkSetMacro(PassBand, bool);
   itkGetConstReferenceMacro(PassBand, bool);
-  itkBooleanMacro(PassBand);
+  itkBooleanMacro(PassBand)
 
   /**
    * Utility method equivalent to:
@@ -166,19 +166,19 @@ public:
    * the frequency vector. */
   itkSetMacro(RadialBand, bool);
   itkGetConstReferenceMacro(RadialBand, bool);
-  itkBooleanMacro(RadialBand);
+  itkBooleanMacro(RadialBand)
 
   /** Control if negative frequencies with absolute value equal to low frequency threshold are passing.
    * Only effective when RadialBand is false **/
   itkSetMacro(PassNegativeLowFrequencyThreshold, bool);
   itkGetConstReferenceMacro(PassNegativeLowFrequencyThreshold, bool);
-  itkBooleanMacro(PassNegativeLowFrequencyThreshold);
+  itkBooleanMacro(PassNegativeLowFrequencyThreshold)
 
   /** Control if negative frequencies with absolute value equal to high frequency threshold are passing.
    * Only effective when RadialBand is false **/
   itkSetMacro(PassNegativeHighFrequencyThreshold, bool);
   itkGetConstReferenceMacro(PassNegativeHighFrequencyThreshold, bool);
-  itkBooleanMacro(PassNegativeHighFrequencyThreshold);
+  itkBooleanMacro(PassNegativeHighFrequencyThreshold)
 
 
 protected:

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -265,7 +265,7 @@ public:
     this->m_ActualXDimensionIsOdd = value;
   };
   itkGetMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
 private:
   /** Calculate Nyquist frequency index (m_LargestPositiveFrequencyIndex), Min/Max indices from LargestPossibleRegion.

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -263,7 +263,7 @@ public:
   SetActualXDimensionIsOdd(bool value)
   {
     this->m_ActualXDimensionIsOdd = value;
-  };
+  }
   itkGetMacro(ActualXDimensionIsOdd, bool);
   itkBooleanMacro(ActualXDimensionIsOdd)
 

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -279,7 +279,7 @@ public:
     this->m_FrequencySpacing[0] = 1.0 / (this->m_Image->GetSpacing()[0] * size_estimated);
   }
   itkGetMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
 private:
   /** Calculate Nyquist frequency index (m_LargestPositiveFrequencyIndex), Min/Max indices from LargestPossibleRegion.

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -241,7 +241,7 @@ public:
     this->m_ActualXDimensionIsOdd = value;
   };
   itkGetMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
 private:
   /** Calculate m_ZeroFrequencyIndex, and frequency spacing/origin.

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -239,7 +239,7 @@ public:
   SetActualXDimensionIsOdd(bool value)
   {
     this->m_ActualXDimensionIsOdd = value;
-  };
+  }
   itkGetMacro(ActualXDimensionIsOdd, bool);
   itkBooleanMacro(ActualXDimensionIsOdd)
 

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -102,7 +102,7 @@ public:
    * image was odd. **/
   itkSetMacro(ActualXDimensionIsOdd, bool);
   itkGetConstReferenceMacro(ActualXDimensionIsOdd, bool);
-  itkBooleanMacro(ActualXDimensionIsOdd);
+  itkBooleanMacro(ActualXDimensionIsOdd)
 
   /** Returns factor with which the current frequency should be multiplied. */
   using ConstRefFunctionType = double(const FrequencyIteratorType &);

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -116,7 +116,7 @@ public:
    * voxel space. Default is On. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Use the image spacing information in calculations. Use this option if you
@@ -161,7 +161,7 @@ public:
    */
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
 
 protected:
   GradientImageFilter();

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
@@ -92,7 +92,7 @@ public:
    * compute the gradient in isotropic voxel space. Default is On. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Use the image spacing information in calculations. Use this option if you

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
@@ -123,7 +123,7 @@ public:
   void
   SetNormalizeAcrossScale(bool normalize);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   void
   SetNumberOfWorkUnits(ThreadIdType nb) override;

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -169,7 +169,7 @@ public:
    */
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -202,7 +202,7 @@ public:
   void
   SetUseImageSpacing(bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Set the derivative weights according to the spacing of the input image
@@ -250,7 +250,7 @@ public:
       derivatives squared.  Default is UsePrincipleComponents = true. */
   itkSetMacro(UsePrincipleComponents, bool);
   itkGetConstMacro(UsePrincipleComponents, bool);
-  itkBooleanMacro(UsePrincipleComponents);
+  itkBooleanMacro(UsePrincipleComponents)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** \deprecated Use VectorGradientMagnitudeImageFilter::UsePrincipleComponentsOn instead. */

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -276,7 +276,7 @@ public:
    * describe the continuous B-spline object. */
   itkSetMacro(GenerateOutputImage, bool);
   itkGetConstReferenceMacro(GenerateOutputImage, bool);
-  itkBooleanMacro(GenerateOutputImage);
+  itkBooleanMacro(GenerateOutputImage)
 
   /** Get the control point lattice produced by the fitting process. */
   PointDataImagePointer

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
@@ -113,7 +113,7 @@ public:
   itkGetModifiableObjectMacro(ReferenceImage, TInputImage);
 
   itkSetMacro(UseReferenceImage, bool);
-  itkBooleanMacro(UseReferenceImage);
+  itkBooleanMacro(UseReferenceImage)
   itkGetConstMacro(UseReferenceImage, bool);
 
   /** Specify a new data spacing explicitly.  The default is to
@@ -174,7 +174,7 @@ public:
    *      OutputSpacing. */
 
   itkSetMacro(ChangeSpacing, bool);
-  itkBooleanMacro(ChangeSpacing);
+  itkBooleanMacro(ChangeSpacing)
   itkGetConstMacro(ChangeSpacing, bool);
 
   /** Change the Origin of the output image. If false, the output
@@ -184,7 +184,7 @@ public:
    *      OutputOrigin. */
 
   itkSetMacro(ChangeOrigin, bool);
-  itkBooleanMacro(ChangeOrigin);
+  itkBooleanMacro(ChangeOrigin)
   itkGetConstMacro(ChangeOrigin, bool);
 
   /** Change the direction of the output image. If false, the output
@@ -194,20 +194,20 @@ public:
    *  OutputDirection. */
 
   itkSetMacro(ChangeDirection, bool);
-  itkBooleanMacro(ChangeDirection);
+  itkBooleanMacro(ChangeDirection)
   itkGetConstMacro(ChangeDirection, bool);
 
   /** Change the BufferedRegion of the output image. */
 
   itkSetMacro(ChangeRegion, bool);
-  itkBooleanMacro(ChangeRegion);
+  itkBooleanMacro(ChangeRegion)
   itkGetConstMacro(ChangeRegion, bool);
 
   /** Set the Origin of the output so that image coordinate (0,0,0)
    * lies at the Center of the Image.  This will override
    * SetOutputOrigin. */
   itkSetMacro(CenterImage, bool);
-  itkBooleanMacro(CenterImage);
+  itkBooleanMacro(CenterImage)
   itkGetConstMacro(CenterImage, bool);
 
   /** Apply changes to the output image information. */

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
@@ -91,7 +91,7 @@ public:
   /** Controls how the output origin is computed. If FlipAboutOrigin is
    * "On", the flip will occur about the origin of the axis, otherwise,
    * the flip will occur about the center of the axis. Default is "On". */
-  itkBooleanMacro(FlipAboutOrigin);
+  itkBooleanMacro(FlipAboutOrigin)
   itkGetConstMacro(FlipAboutOrigin, bool);
   itkSetMacro(FlipAboutOrigin, bool);
 

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
@@ -208,7 +208,7 @@ public:
    * SetGivenCoordinateOrientation method to establish the
    * orientation. For compatibility with the original API, the default value
    * is Off. */
-  itkBooleanMacro(UseImageDirection);
+  itkBooleanMacro(UseImageDirection)
   itkGetConstMacro(UseImageDirection, bool);
   itkSetMacro(UseImageDirection, bool);
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -267,7 +267,7 @@ public:
   /** Turn on/off whether a specified reference image should be used to define
    *  the output information. */
   itkSetMacro(UseReferenceImage, bool);
-  itkBooleanMacro(UseReferenceImage);
+  itkBooleanMacro(UseReferenceImage)
   itkGetConstMacro(UseReferenceImage, bool);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -170,7 +170,7 @@ public:
   {
     m_Threshold = 1e-5 * NumericTraits<TDenominator>::OneValue();
     m_Constant = TOutput{};
-  };
+  }
 
   ~DivideOrZeroOut() = default;
 

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -145,7 +145,7 @@ public:
    * used. */
   itkSetMacro(ThresholdAtMeanIntensity, bool);
   itkGetConstMacro(ThresholdAtMeanIntensity, bool);
-  itkBooleanMacro(ThresholdAtMeanIntensity);
+  itkBooleanMacro(ThresholdAtMeanIntensity)
 
   /** Set/Get if the reference histogram is regenerated from
    * the supplied ReferenceImage (true) or supplied directly
@@ -158,7 +158,7 @@ public:
    */
   itkSetMacro(GenerateReferenceHistogramFromImage, bool);
   itkGetConstMacro(GenerateReferenceHistogramFromImage, bool);
-  itkBooleanMacro(GenerateReferenceHistogramFromImage);
+  itkBooleanMacro(GenerateReferenceHistogramFromImage)
 
   /** This filter requires all of the input to be in the buffer. */
   void

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
@@ -107,7 +107,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the background value used to mark the pixels not on the border of the

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
@@ -108,7 +108,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the background value used to identify the objects and mark the

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
@@ -94,7 +94,7 @@ public:
    * part. Default is false. */
   itkSetMacro(CalculateImaginaryPart, bool);
   itkGetConstReferenceMacro(CalculateImaginaryPart, bool);
-  itkBooleanMacro(CalculateImaginaryPart);
+  itkBooleanMacro(CalculateImaginaryPart)
 
 protected:
   GaborImageSource();

--- a/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
@@ -98,7 +98,7 @@ public:
    * complex part. Default is false. */
   itkSetMacro(CalculateImaginaryPart, bool);
   itkGetConstMacro(CalculateImaginaryPart, bool);
-  itkBooleanMacro(CalculateImaginaryPart);
+  itkBooleanMacro(CalculateImaginaryPart)
 
 protected:
   GaborKernelFunction()

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
@@ -103,7 +103,7 @@ public:
   /** Set/Get whether or not to normalize the Gaussian. Default is false. */
   itkSetMacro(Normalized, bool);
   itkGetConstReferenceMacro(Normalized, bool);
-  itkBooleanMacro(Normalized);
+  itkBooleanMacro(Normalized)
 
   /** Set/Get the standard deviation in each direction. */
   itkSetMacro(Sigma, ArrayType);

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
@@ -71,7 +71,7 @@ public:
   itkOverrideGetNameOfClassMacro(GenerateImageSource);
 
   itkSetMacro(UseReferenceImage, bool);
-  itkBooleanMacro(UseReferenceImage);
+  itkBooleanMacro(UseReferenceImage)
   itkGetConstMacro(UseReferenceImage, bool);
 
   /**

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
@@ -104,7 +104,7 @@ public:
    * value is false. */
   itkSetMacro(Average, bool);
   itkGetConstMacro(Average, bool);
-  itkBooleanMacro(Average);
+  itkBooleanMacro(Average)
 
 protected:
   AccumulateImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -135,7 +135,7 @@ public:
     }
   }
   itkGetConstMacro(UseLookupTable, bool);
-  itkBooleanMacro(UseLookupTable);
+  itkBooleanMacro(UseLookupTable)
 #endif
 
   void

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -279,7 +279,7 @@ public:
   // macros for Histogram enables
   itkSetMacro(UseHistograms, bool);
   itkGetConstMacro(UseHistograms, bool);
-  itkBooleanMacro(UseHistograms);
+  itkBooleanMacro(UseHistograms)
 
 
   virtual const ValidLabelValuesContainerType &

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
@@ -91,7 +91,7 @@ public:
    */
   itkSetMacro(ReverseOrdering, bool);
   itkGetConstReferenceMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the number of objects to keep

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
@@ -100,7 +100,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
 protected:
   AttributeOpeningLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
@@ -92,7 +92,7 @@ public:
    */
   itkSetMacro(ReverseOrdering, bool);
   itkGetConstReferenceMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
 protected:
   AttributeRelabelLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
@@ -115,7 +115,7 @@ public:
    */
   itkGetConstMacro(Exclude, bool);
   itkSetMacro(Exclude, bool);
-  itkBooleanMacro(Exclude);
+  itkBooleanMacro(Exclude)
 
   /** Clear the attribute set, and add the attribute passed in parameter */
   void

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
@@ -97,7 +97,7 @@ public:
    */
   itkSetMacro(ReverseOrdering, bool);
   itkGetConstReferenceMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
 protected:
   AttributeUniqueLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
@@ -84,7 +84,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
@@ -84,7 +84,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
@@ -119,7 +119,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   // only set after completion
   itkGetConstReferenceMacro(NumberOfObjects, SizeValueType);

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
@@ -106,7 +106,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -136,7 +136,7 @@ public:
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
-  itkBooleanMacro(ComputeFeretDiameter);
+  itkBooleanMacro(ComputeFeretDiameter)
 
   /**
    * Set/Get whether the perimeter should be computed or not.
@@ -144,7 +144,7 @@ public:
    */
   itkSetMacro(ComputePerimeter, bool);
   itkGetConstReferenceMacro(ComputePerimeter, bool);
-  itkBooleanMacro(ComputePerimeter);
+  itkBooleanMacro(ComputePerimeter)
 
   /**
    * Set/Get whether the oriented bounding box should be
@@ -153,7 +153,7 @@ public:
    */
   itkSetMacro(ComputeOrientedBoundingBox, bool);
   itkGetConstReferenceMacro(ComputeOrientedBoundingBox, bool);
-  itkBooleanMacro(ComputeOrientedBoundingBox);
+  itkBooleanMacro(ComputeOrientedBoundingBox)
 
 protected:
   BinaryImageToShapeLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
@@ -92,7 +92,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -122,7 +122,7 @@ public:
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
-  itkBooleanMacro(ComputeFeretDiameter);
+  itkBooleanMacro(ComputeFeretDiameter)
 
   /**
    * Set/Get whether the perimeter should be computed or not. The default value
@@ -130,7 +130,7 @@ public:
    */
   itkSetMacro(ComputePerimeter, bool);
   itkGetConstReferenceMacro(ComputePerimeter, bool);
-  itkBooleanMacro(ComputePerimeter);
+  itkBooleanMacro(ComputePerimeter)
 
   /** Set the feature image */
   void
@@ -169,7 +169,7 @@ public:
    */
   itkSetMacro(ComputeHistogram, bool);
   itkGetConstReferenceMacro(ComputeHistogram, bool);
-  itkBooleanMacro(ComputeHistogram);
+  itkBooleanMacro(ComputeHistogram)
 
   /**
    * Set/Get the number of bins in the histogram. Note that the histogram is used

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
@@ -103,7 +103,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
@@ -103,7 +103,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
@@ -97,7 +97,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -134,7 +134,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to keep. The default

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
@@ -97,7 +97,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -135,7 +135,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove.

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
@@ -100,7 +100,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -137,7 +137,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to keep. The default

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
@@ -104,7 +104,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -142,7 +142,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove.

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
@@ -125,7 +125,7 @@ public:
    * effect when the input and output image type match. */
   itkSetMacro(InPlace, bool);
   itkGetMacro(InPlace, bool);
-  itkBooleanMacro(InPlace);
+  itkBooleanMacro(InPlace)
 
   /** Can the filter run in place? To do so, the filter's first input
    * and output must have the same dimension and pixel type. This

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
@@ -108,7 +108,7 @@ public:
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
-  itkBooleanMacro(ComputeFeretDiameter);
+  itkBooleanMacro(ComputeFeretDiameter)
 
   /**
    * Set/Get whether the perimeter should be computed or not.
@@ -116,7 +116,7 @@ public:
    */
   itkSetMacro(ComputePerimeter, bool);
   itkGetConstReferenceMacro(ComputePerimeter, bool);
-  itkBooleanMacro(ComputePerimeter);
+  itkBooleanMacro(ComputePerimeter)
 
   /**
    * Set/Get whether the oriented bounding box should be
@@ -125,7 +125,7 @@ public:
    */
   itkSetMacro(ComputeOrientedBoundingBox, bool);
   itkGetConstReferenceMacro(ComputeOrientedBoundingBox, bool);
-  itkBooleanMacro(ComputeOrientedBoundingBox);
+  itkBooleanMacro(ComputeOrientedBoundingBox)
 
 
 protected:

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
@@ -106,7 +106,7 @@ public:
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
-  itkBooleanMacro(ComputeFeretDiameter);
+  itkBooleanMacro(ComputeFeretDiameter)
 
   /**
    * Set/Get whether the perimeter should be computed or not. The default value
@@ -114,7 +114,7 @@ public:
    */
   itkSetMacro(ComputePerimeter, bool);
   itkGetConstReferenceMacro(ComputePerimeter, bool);
-  itkBooleanMacro(ComputePerimeter);
+  itkBooleanMacro(ComputePerimeter)
 
   /** Set the feature image */
   void
@@ -153,7 +153,7 @@ public:
    */
   itkSetMacro(ComputeHistogram, bool);
   itkGetConstReferenceMacro(ComputeHistogram, bool);
-  itkBooleanMacro(ComputeHistogram);
+  itkBooleanMacro(ComputeHistogram)
 
   /**
    * Set/Get the number of bins in the histogram. Note that the histogram is used

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
@@ -133,14 +133,14 @@ public:
    */
   itkSetMacro(Negated, bool);
   itkGetConstReferenceMacro(Negated, bool);
-  itkBooleanMacro(Negated);
+  itkBooleanMacro(Negated)
 
   /**
    * Set/Get whether the image size should be adjusted to the masked image or not.
    */
   itkSetMacro(Crop, bool);
   itkGetConstReferenceMacro(Crop, bool);
-  itkBooleanMacro(Crop);
+  itkBooleanMacro(Crop)
 
   /**
    * Set/Get the border added to the mask before the crop. The default is 0 on

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
@@ -119,7 +119,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to keep. The default

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
@@ -116,7 +116,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove. The default

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
@@ -118,7 +118,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to keep. The default

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
@@ -119,7 +119,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove. The default

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.h
@@ -164,7 +164,7 @@ public:
    */
   itkSetMacro(KeepLabels, bool);
   itkGetMacro(KeepLabels, bool);
-  itkBooleanMacro(KeepLabels);
+  itkBooleanMacro(KeepLabels)
 
   /** If PadSize is not zero, the image produce for each object will be padded.
    * The default value is 1 on all the dimensions.
@@ -178,7 +178,7 @@ public:
    */
   itkSetMacro(ConstrainPaddingToImage, bool);
   itkGetMacro(ConstrainPaddingToImage, bool);
-  itkBooleanMacro(ConstrainPaddingToImage);
+  itkBooleanMacro(ConstrainPaddingToImage)
 
   /** Set/Get whether the internal image produced by OutputFilter should be interpreted
    * as a binary image in which the filter have to search for connected components. If
@@ -187,7 +187,7 @@ public:
    */
   itkSetMacro(BinaryInternalOutput, bool);
   itkGetMacro(BinaryInternalOutput, bool);
-  itkBooleanMacro(BinaryInternalOutput);
+  itkBooleanMacro(BinaryInternalOutput)
 
   /** The foreground value used internally to represent the object in the image passed to
    * InputFilter, and to read the data produced by OutputFilter, if BinaryInternalOutput

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
@@ -89,7 +89,7 @@ public:
    */
   itkSetMacro(ReverseOrdering, bool);
   itkGetConstReferenceMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the number of objects to keep

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -105,7 +105,7 @@ public:
    */
   itkSetMacro(ComputeFeretDiameter, bool);
   itkGetConstReferenceMacro(ComputeFeretDiameter, bool);
-  itkBooleanMacro(ComputeFeretDiameter);
+  itkBooleanMacro(ComputeFeretDiameter)
 
   /**
    * Set/Get whether the perimeter should be computed or not.
@@ -113,7 +113,7 @@ public:
    */
   itkSetMacro(ComputePerimeter, bool);
   itkGetConstReferenceMacro(ComputePerimeter, bool);
-  itkBooleanMacro(ComputePerimeter);
+  itkBooleanMacro(ComputePerimeter)
 
   /**
    * Set/Get whether the oriented bounding box should be
@@ -122,7 +122,7 @@ public:
    */
   itkSetMacro(ComputeOrientedBoundingBox, bool);
   itkGetConstReferenceMacro(ComputeOrientedBoundingBox, bool);
-  itkBooleanMacro(ComputeOrientedBoundingBox);
+  itkBooleanMacro(ComputeOrientedBoundingBox)
 
   /** Set the label image */
   void

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
@@ -101,7 +101,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove.

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
@@ -108,7 +108,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use. Default is "Size".

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -91,7 +91,7 @@ public:
    */
   itkSetMacro(ReverseOrdering, bool);
   itkGetConstReferenceMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use.

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
@@ -90,7 +90,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use to select the object to remove. The default

--- a/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
@@ -87,7 +87,7 @@ public:
 
   itkSetMacro(ChangeBackgroundValue, bool);
   itkGetConstMacro(ChangeBackgroundValue, bool);
-  itkBooleanMacro(ChangeBackgroundValue);
+  itkBooleanMacro(ChangeBackgroundValue)
 
 protected:
   ShiftScaleLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -123,7 +123,7 @@ public:
    */
   itkSetMacro(ComputeHistogram, bool);
   itkGetConstReferenceMacro(ComputeHistogram, bool);
-  itkBooleanMacro(ComputeHistogram);
+  itkBooleanMacro(ComputeHistogram)
 
   /**
    * Set/Get the number of bins in the histogram. Note that the histogram is used

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
@@ -111,7 +111,7 @@ public:
    */
   itkGetConstMacro(ReverseOrdering, bool);
   itkSetMacro(ReverseOrdering, bool);
-  itkBooleanMacro(ReverseOrdering);
+  itkBooleanMacro(ReverseOrdering)
 
   /**
    * Set/Get the attribute to use. Default is "Mean".

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
@@ -93,7 +93,7 @@ public:
    * and remove it once the closing is done */
   itkSetMacro(SafeBorder, bool);
   itkGetConstReferenceMacro(SafeBorder, bool);
-  itkBooleanMacro(SafeBorder);
+  itkBooleanMacro(SafeBorder)
 
   /** Set/Get the backend filter class. */
   itkSetMacro(Algorithm, AlgorithmEnum);
@@ -101,7 +101,7 @@ public:
 
   itkSetMacro(ForceAlgorithm, bool);
   itkGetConstReferenceMacro(ForceAlgorithm, bool);
-  itkBooleanMacro(ForceAlgorithm);
+  itkBooleanMacro(ForceAlgorithm)
 
 protected:
   BlackTopHatImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
@@ -100,7 +100,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get whether the original intensities of the image retained for
@@ -108,7 +108,7 @@ public:
    * the output pixel contrast will be reduced. */
   itkSetMacro(PreserveIntensities, bool);
   itkGetConstReferenceMacro(PreserveIntensities, bool);
-  itkBooleanMacro(PreserveIntensities);
+  itkBooleanMacro(PreserveIntensities)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
@@ -114,7 +114,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -212,7 +212,7 @@ public:
   {
     m_RadiusIsParametric = flag;
   }
-  itkBooleanMacro(RadiusIsParametric);
+  itkBooleanMacro(RadiusIsParametric)
 
   /** Create a FlatStructureElement from a bool
    *  image. Image must be odd in all dimensions.*/

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
@@ -88,7 +88,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
@@ -89,7 +89,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
@@ -94,7 +94,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
@@ -123,7 +123,7 @@ public:
    * to "reconstruction by dilation". Default is off. */
   itkSetMacro(RunOneIteration, bool);
   itkGetConstMacro(RunOneIteration, bool);
-  itkBooleanMacro(RunOneIteration);
+  itkBooleanMacro(RunOneIteration)
 
   /** Get the number of iterations used to produce the current
    * output. */
@@ -137,7 +137,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
@@ -124,7 +124,7 @@ public:
    * to "reconstruction by erosion". Default is off. */
   itkSetMacro(RunOneIteration, bool);
   itkGetConstMacro(RunOneIteration, bool);
-  itkBooleanMacro(RunOneIteration);
+  itkBooleanMacro(RunOneIteration)
 
   /** Get the number of iterations used to produce the current
    * output. */
@@ -138,7 +138,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
@@ -108,7 +108,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
@@ -126,7 +126,7 @@ public:
    * and remove it once the closing is done */
   itkSetMacro(SafeBorder, bool);
   itkGetConstReferenceMacro(SafeBorder, bool);
-  itkBooleanMacro(SafeBorder);
+  itkBooleanMacro(SafeBorder)
 
 protected:
   GrayscaleMorphologicalClosingImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -125,7 +125,7 @@ public:
    * and remove it once the closing is done */
   itkSetMacro(SafeBorder, bool);
   itkGetConstReferenceMacro(SafeBorder, bool);
-  itkBooleanMacro(SafeBorder);
+  itkBooleanMacro(SafeBorder)
 
 protected:
   GrayscaleMorphologicalOpeningImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
@@ -90,7 +90,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
@@ -90,7 +90,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
@@ -102,7 +102,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
@@ -100,7 +100,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.h
@@ -143,7 +143,7 @@ public:
   SetGenerateOutputMask(bool);
 
   itkGetConstMacro(GenerateOutputMask, bool);
-  itkBooleanMacro(GenerateOutputMask);
+  itkBooleanMacro(GenerateOutputMask)
 
   /** ConfigureHistogram can be used to configure the histogram. The default version just does nothing. */
   virtual void

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
@@ -102,7 +102,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get whether the original intensities of the image retained for
@@ -110,7 +110,7 @@ public:
    * the output pixel contrast will be reduced. */
   itkSetMacro(PreserveIntensities, bool);
   itkGetConstReferenceMacro(PreserveIntensities, bool);
-  itkBooleanMacro(PreserveIntensities);
+  itkBooleanMacro(PreserveIntensities)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.h
@@ -120,7 +120,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Perform a padding of the image internally to increase the performance
@@ -129,7 +129,7 @@ public:
    */
   itkSetMacro(UseInternalCopy, bool);
   itkGetConstReferenceMacro(UseInternalCopy, bool);
-  itkBooleanMacro(UseInternalCopy);
+  itkBooleanMacro(UseInternalCopy)
 
 protected:
   ReconstructionImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
@@ -92,7 +92,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the value in the output image to consider as "foreground".
@@ -114,7 +114,7 @@ public:
    */
   itkSetMacro(FlatIsMaxima, bool);
   itkGetConstMacro(FlatIsMaxima, bool);
-  itkBooleanMacro(FlatIsMaxima);
+  itkBooleanMacro(FlatIsMaxima)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
@@ -90,7 +90,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the value in the output image to consider as "foreground".
@@ -112,7 +112,7 @@ public:
    */
   itkSetMacro(FlatIsMinima, bool);
   itkGetConstMacro(FlatIsMinima, bool);
-  itkBooleanMacro(FlatIsMinima);
+  itkBooleanMacro(FlatIsMinima)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
@@ -116,7 +116,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the value used to mark all pixels which are not extrema.

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
@@ -91,7 +91,7 @@ public:
    * and remove it once the closing is done */
   itkSetMacro(SafeBorder, bool);
   itkGetConstReferenceMacro(SafeBorder, bool);
-  itkBooleanMacro(SafeBorder);
+  itkBooleanMacro(SafeBorder)
 
   /** Set/Get the backend filter class. */
   itkSetMacro(Algorithm, AlgorithmEnum);
@@ -99,7 +99,7 @@ public:
 
   itkSetMacro(ForceAlgorithm, bool);
   itkGetConstReferenceMacro(ForceAlgorithm, bool);
-  itkBooleanMacro(ForceAlgorithm);
+  itkBooleanMacro(ForceAlgorithm)
 
 protected:
   WhiteTopHatImageFilter();

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -157,19 +157,19 @@ public:
    * gradient. (See class documentation.) */
   itkSetMacro(ReverseContourOrientation, bool);
   itkGetConstReferenceMacro(ReverseContourOrientation, bool);
-  itkBooleanMacro(ReverseContourOrientation);
+  itkBooleanMacro(ReverseContourOrientation)
 
   /** Control whether high- or low-valued pixels are vertex-connected.
    * Default is for low-valued pixels to be vertex-connected.
    * (See class documentation.) */
   itkSetMacro(VertexConnectHighPixels, bool);
   itkGetConstReferenceMacro(VertexConnectHighPixels, bool);
-  itkBooleanMacro(VertexConnectHighPixels);
+  itkBooleanMacro(VertexConnectHighPixels)
 
   /** Return contours for all distinct labels */
   itkSetMacro(LabelContours, bool);
   itkGetConstReferenceMacro(LabelContours, bool);
-  itkBooleanMacro(LabelContours);
+  itkBooleanMacro(LabelContours)
 
   /** Control whether the largest possible input region is used, or if a
    * custom requested region is to be used. */

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
@@ -66,7 +66,7 @@ public:
   /** Set/Get the direction in which to reflect the data. Default is "Off". */
   itkSetMacro(MaximallyConnected, bool);
   itkGetConstMacro(MaximallyConnected, bool);
-  itkBooleanMacro(MaximallyConnected);
+  itkBooleanMacro(MaximallyConnected)
 
 protected:
   PathToChainCodePathFilter();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -66,7 +66,7 @@ public:
     this->m_MeasureBound = bound;
   }
 
-  itkBooleanMacro(TopologicalChange);
+  itkBooleanMacro(TopologicalChange)
   itkGetConstMacro(TopologicalChange, bool);
   itkSetMacro(TopologicalChange, bool);
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
@@ -100,7 +100,7 @@ public:
   itkGetConstMacro(NumberOfIterations, unsigned int);
 
   /** Set/Get if DelaunayConformingQuadEdgeMeshFilter is used at the end of each iterations */
-  itkBooleanMacro(DelaunayConforming);
+  itkBooleanMacro(DelaunayConforming)
   itkSetMacro(DelaunayConforming, bool);
   itkGetConstMacro(DelaunayConforming, bool);
 

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -281,7 +281,7 @@ public:
    * in voxel units. Default is On. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Use the image spacing information in calculations. Use this option if you

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -178,7 +178,7 @@ public:
      */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set/Get the Order of the Gaussian to convolve with.
       \li ZeroOrder is equivalent to convolving with a Gaussian.  This

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -129,7 +129,7 @@ public:
   void
   SetNormalizeAcrossScale(bool normalize);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set the number of work units to create. */
   void

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -159,14 +159,14 @@ public:
    * Default is true for all but char types */
   itkSetMacro(AutoMinimumMaximum, bool);
   itkGetConstMacro(AutoMinimumMaximum, bool);
-  itkBooleanMacro(AutoMinimumMaximum);
+  itkBooleanMacro(AutoMinimumMaximum)
 
   /** Do you want the output to be masked by the mask used in
    * histogram construction. Only relevant if masking is in
    * use. Default is true. */
   itkSetMacro(MaskOutput, bool);
   itkGetConstMacro(MaskOutput, bool);
-  itkBooleanMacro(MaskOutput);
+  itkBooleanMacro(MaskOutput)
 
   /** The value in the mask image, if used, indicating voxels that
   should be included. Default is the max of pixel type, as in the

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.h
@@ -83,7 +83,7 @@ public:
   peaks is used. Default is "On". */
   itkSetMacro(UseInterMode, bool);
   itkGetConstMacro(UseInterMode, bool);
-  itkBooleanMacro(UseInterMode);
+  itkBooleanMacro(UseInterMode)
 
 protected:
   IntermodesThresholdCalculator()

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -101,7 +101,7 @@ public:
      peaks is used. */
   itkSetMacro(UseInterMode, bool);
   itkGetConstReferenceMacro(UseInterMode, bool);
-  itkBooleanMacro(UseInterMode);
+  itkBooleanMacro(UseInterMode)
 
   /** Image related type alias. */
   static constexpr unsigned int InputImageDimension = InputImageType::ImageDimension;

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
@@ -92,7 +92,7 @@ public:
   /** Set/Get the use of valley emphasis. Default is false. */
   itkSetMacro(ValleyEmphasis, bool);
   itkGetConstReferenceMacro(ValleyEmphasis, bool);
-  itkBooleanMacro(ValleyEmphasis);
+  itkBooleanMacro(ValleyEmphasis)
 
   /** Should the threshold value be mid-point of the bin or the maximum?
    * Default is to return bin maximum. */

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -115,13 +115,13 @@ public:
   /** Set/Get the use of valley emphasis. Default is false. */
   itkSetMacro(ValleyEmphasis, bool);
   itkGetConstReferenceMacro(ValleyEmphasis, bool);
-  itkBooleanMacro(ValleyEmphasis);
+  itkBooleanMacro(ValleyEmphasis)
 
   /** Should the threshold value be mid-point of the bin or the maximum?
    * Default is to return bin maximum. */
   itkSetMacro(ReturnBinMidpoint, bool);
   itkGetConstReferenceMacro(ReturnBinMidpoint, bool);
-  itkBooleanMacro(ReturnBinMidpoint);
+  itkBooleanMacro(ReturnBinMidpoint)
 
   /** Get the computed threshold. */
   const ThresholdVectorType &

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
@@ -67,7 +67,7 @@ public:
    * Default is to return bin maximum. */
   itkSetMacro(ReturnBinMidpoint, bool);
   itkGetConstReferenceMacro(ReturnBinMidpoint, bool);
-  itkBooleanMacro(ReturnBinMidpoint);
+  itkBooleanMacro(ReturnBinMidpoint)
 
   /** for backward compatibility. Update() should be preferred. */
   void

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -104,7 +104,7 @@ public:
    * Default is to return bin maximum. */
   itkSetMacro(ReturnBinMidpoint, bool);
   itkGetConstReferenceMacro(ReturnBinMidpoint, bool);
-  itkBooleanMacro(ReturnBinMidpoint);
+  itkBooleanMacro(ReturnBinMidpoint)
 
 protected:
   OtsuThresholdImageFilter() { this->SetCalculator(CalculatorType::New()); }

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
@@ -71,8 +71,8 @@ public:
   /** Set macros */
   itkSetMacro(HasColumnHeaders, bool);
   itkSetMacro(HasRowHeaders, bool);
-  itkBooleanMacro(HasColumnHeaders);
-  itkBooleanMacro(HasRowHeaders);
+  itkBooleanMacro(HasColumnHeaders)
+  itkBooleanMacro(HasRowHeaders)
 
   /** Get macros for Column and Row headers. */
   itkGetConstMacro(HasColumnHeaders, bool);

--- a/Modules/IO/CSV/include/itkCSVFileReaderBase.h
+++ b/Modules/IO/CSV/include/itkCSVFileReaderBase.h
@@ -117,9 +117,9 @@ public:
   /** Boolean macros for setting HasRowHeaders, HasColumnHeaders and
    *  UseStringDelimiterCharacter. They can conveniently be set by appending
    *  On() or Off() to each of the variable names. */
-  itkBooleanMacro(HasRowHeaders);
-  itkBooleanMacro(HasColumnHeaders);
-  itkBooleanMacro(UseStringDelimiterCharacter);
+  itkBooleanMacro(HasRowHeaders)
+  itkBooleanMacro(HasColumnHeaders)
+  itkBooleanMacro(UseStringDelimiterCharacter)
 
   /** Counts the number of rows and columns in a file and prepares the file
    * for iterative reading using the GetNextField() method. */

--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -134,7 +134,7 @@ public:
   /** Recursively parse the input directory */
   itkSetMacro(Recursive, bool);
   itkGetConstMacro(Recursive, bool);
-  itkBooleanMacro(Recursive);
+  itkBooleanMacro(Recursive)
 
   /** Use additional series information such as ProtocolName
    *   and SeriesName to identify when a single SeriesUID contains
@@ -171,7 +171,7 @@ public:
    */
   itkSetMacro(LoadSequences, bool);
   itkGetConstMacro(LoadSequences, bool);
-  itkBooleanMacro(LoadSequences);
+  itkBooleanMacro(LoadSequences)
 
   /** Parse any private tags in the DICOM file. Defaults to false
    * to skip private tags. This makes loading DICOM files faster when
@@ -179,7 +179,7 @@ public:
    */
   itkSetMacro(LoadPrivateTags, bool);
   itkGetConstMacro(LoadPrivateTags, bool);
-  itkBooleanMacro(LoadPrivateTags);
+  itkBooleanMacro(LoadPrivateTags)
 
 protected:
   DCMTKSeriesFileNames();

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -178,19 +178,19 @@ public:
   /** Preserve the original DICOM UIDs of the input files. */
   itkSetMacro(KeepOriginalUID, bool);
   itkGetConstMacro(KeepOriginalUID, bool);
-  itkBooleanMacro(KeepOriginalUID);
+  itkBooleanMacro(KeepOriginalUID)
 
   /** Parse and load any private tags in the DICOM file. Loading DICOM
    * files is faster when private tags are not needed. Default is false. */
   itkSetMacro(LoadPrivateTags, bool);
   itkGetConstMacro(LoadPrivateTags, bool);
-  itkBooleanMacro(LoadPrivateTags);
+  itkBooleanMacro(LoadPrivateTags)
 
   /** Convert Y'CbCr (YBR_FULL, YBR_FULL_422) to RGB. Default is true,
    * not required for YBR_RCT and YBR_ICT. */
   itkSetMacro(ReadYBRtoRGB, bool);
   itkGetConstMacro(ReadYBRtoRGB, bool);
-  itkBooleanMacro(ReadYBRtoRGB);
+  itkBooleanMacro(ReadYBRtoRGB)
 
 #if defined(ITKIO_DEPRECATED_GDCM1_API)
   /** Convenience methods to query patient information and scanner

--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -141,7 +141,7 @@ public:
    * Must be set before the call to SetInputDirectory(). */
   itkSetMacro(Recursive, bool);
   itkGetConstMacro(Recursive, bool);
-  itkBooleanMacro(Recursive);
+  itkBooleanMacro(Recursive)
 
   /** Use additional series information such as ProtocolName
    *   and SeriesName to identify when a single SeriesUID contains
@@ -175,7 +175,7 @@ public:
    */
   itkSetMacro(LoadSequences, bool);
   itkGetConstMacro(LoadSequences, bool);
-  itkBooleanMacro(LoadSequences);
+  itkBooleanMacro(LoadSequences)
 
   /** Parse any private tags in the DICOM file. Defaults to false
    * to skip private tags. This makes loading DICOM files faster when
@@ -183,7 +183,7 @@ public:
    */
   itkSetMacro(LoadPrivateTags, bool);
   itkGetConstMacro(LoadPrivateTags, bool);
-  itkBooleanMacro(LoadPrivateTags);
+  itkBooleanMacro(LoadPrivateTags)
 
 protected:
   GDCMSeriesFileNames();

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -93,21 +93,15 @@ public:
 
   virtual ~IPLFileSortInfo();
 
-  IPLSetMacroDeclaration(ImageFileName, std::string);
-  IPLGetMacroDeclaration(ImageFileName, std::string);
-  IPLSetMacroDeclaration(SliceLocation, float);
-  IPLGetMacroDeclaration(SliceLocation, float);
-  IPLSetMacroDeclaration(SliceOffset, int);
-  IPLGetMacroDeclaration(SliceOffset, int);
-  IPLSetMacroDeclaration(EchoNumber, int);
-  IPLGetMacroDeclaration(EchoNumber, int);
-  IPLSetMacroDeclaration(ImageNumber, int);
-  IPLGetMacroDeclaration(ImageNumber, int);
-  IPLSetMacroDeclaration(Data, void *);
-  IPLGetMacroDeclaration(Data, const void *);
+  IPLSetMacroDeclaration(ImageFileName, std::string)
+  IPLGetMacroDeclaration(ImageFileName, std::string) IPLSetMacroDeclaration(SliceLocation, float)
+  IPLGetMacroDeclaration(SliceLocation, float) IPLSetMacroDeclaration(SliceOffset, int)
+  IPLGetMacroDeclaration(SliceOffset, int) IPLSetMacroDeclaration(EchoNumber, int)
+  IPLGetMacroDeclaration(EchoNumber, int) IPLSetMacroDeclaration(ImageNumber, int)
+  IPLGetMacroDeclaration(ImageNumber, int) IPLSetMacroDeclaration(Data, void *)
+  IPLGetMacroDeclaration(Data, const void *)
 
-private:
-  std::string  m_ImageFileName{};
+    private : std::string m_ImageFileName{};
   float        m_SliceLocation{};
   int          m_SliceOffset{};
   int          m_EchoNumber{};

--- a/Modules/IO/ImageBase/include/itkImageFileReader.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.h
@@ -116,7 +116,7 @@ public:
   /** Set the stream On or Off */
   itkSetMacro(UseStreaming, bool);
   itkGetConstReferenceMacro(UseStreaming, bool);
-  itkBooleanMacro(UseStreaming);
+  itkBooleanMacro(UseStreaming)
 
 protected:
   ImageFileReader();

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -201,7 +201,7 @@ public:
   /** Set the compression On or Off */
   itkSetMacro(UseCompression, bool);
   itkGetConstReferenceMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
   /** Set the compression level. \sa ImageIOBase for details.
    * Set to a negative number to use ImageIO's default compression level. */
@@ -216,7 +216,7 @@ public:
    *  the ImageIO object. */
   itkSetMacro(UseInputMetaDataDictionary, bool);
   itkGetConstReferenceMacro(UseInputMetaDataDictionary, bool);
-  itkBooleanMacro(UseInputMetaDataDictionary);
+  itkBooleanMacro(UseInputMetaDataDictionary)
 
 protected:
   ImageFileWriter() = default;

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -258,7 +258,7 @@ public:
   /** Set/Get a boolean to use the compression or not. */
   itkSetMacro(UseCompression, bool);
   itkGetConstMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
   /** \brief Set/Get a compression level hint
    *
@@ -286,12 +286,12 @@ public:
   /** Set/Get a boolean to use streaming while reading or not. */
   itkSetMacro(UseStreamedReading, bool);
   itkGetConstMacro(UseStreamedReading, bool);
-  itkBooleanMacro(UseStreamedReading);
+  itkBooleanMacro(UseStreamedReading)
 
   /** Set/Get a boolean to use streaming while writing or not. */
   itkSetMacro(UseStreamedWriting, bool);
   itkGetConstMacro(UseStreamedWriting, bool);
-  itkBooleanMacro(UseStreamedWriting);
+  itkBooleanMacro(UseStreamedWriting)
 
   /** Set/Get a boolean to perform RGB palette expansion.
    * If true, palette image is read as RGB,
@@ -299,13 +299,13 @@ public:
    * A RGB image is always read as RGB.*/
   itkSetMacro(ExpandRGBPalette, bool);
   itkGetConstMacro(ExpandRGBPalette, bool);
-  itkBooleanMacro(ExpandRGBPalette);
+  itkBooleanMacro(ExpandRGBPalette)
 
   /** Set/Get a boolean to include a color palette while writing
    * the image file. Applies only for scalar Pixels*/
   itkSetMacro(WritePalette, bool);
   itkGetConstMacro(WritePalette, bool);
-  itkBooleanMacro(WritePalette);
+  itkBooleanMacro(WritePalette)
 
   /** Determine whether a palletized image file has been read as a scalar image
    *  plus a color palette.

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -118,13 +118,13 @@ public:
    * from last to first */
   itkSetMacro(ReverseOrder, bool);
   itkGetConstMacro(ReverseOrder, bool);
-  itkBooleanMacro(ReverseOrder);
+  itkBooleanMacro(ReverseOrder)
 
   /** Do we want to force orthogonal direction cosines? On by default.
    * Turning it off enables proper reading of DICOM series with gantry tilt. */
   itkSetMacro(ForceOrthogonalDirection, bool);
   itkGetConstMacro(ForceOrthogonalDirection, bool);
-  itkBooleanMacro(ForceOrthogonalDirection);
+  itkBooleanMacro(ForceOrthogonalDirection)
 
   /** Set/Get the ImageIO helper class. By default, the
    * ImageSeriesReader uses the factory mechanism of the
@@ -144,7 +144,7 @@ public:
    */
   itkSetMacro(MetaDataDictionaryArrayUpdate, bool);
   itkGetConstMacro(MetaDataDictionaryArrayUpdate, bool);
-  itkBooleanMacro(MetaDataDictionaryArrayUpdate);
+  itkBooleanMacro(MetaDataDictionaryArrayUpdate)
 
   /** Prepare the allocation of the output image during the first back
    * propagation of the pipeline. */
@@ -167,7 +167,7 @@ public:
   /** Set the stream On or Off */
   itkSetMacro(UseStreaming, bool);
   itkGetConstReferenceMacro(UseStreaming, bool);
-  itkBooleanMacro(UseStreaming);
+  itkBooleanMacro(UseStreaming)
 
   /** Set the relative threshold for issuing warnings about non-uniform sampling */
   itkSetMacro(SpacingWarningRelThreshold, double);

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -208,7 +208,7 @@ public:
   /** Set the compression On or Off */
   itkSetMacro(UseCompression, bool);
   itkGetConstReferenceMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
 protected:
   ImageSeriesWriter();

--- a/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
@@ -103,7 +103,7 @@ public:
    * submatch alphabetically. */
   itkSetMacro(NumericSort, bool);
   itkGetConstMacro(NumericSort, bool);
-  itkBooleanMacro(NumericSort);
+  itkBooleanMacro(NumericSort)
 
   /** Returns a vector containing the series' file names. The file
    * names are sorted by the sub expression selected by the SubMatch id. */

--- a/Modules/IO/JPEG/include/itkJPEGImageIO.h
+++ b/Modules/IO/JPEG/include/itkJPEGImageIO.h
@@ -67,12 +67,12 @@ public:
   /**  */
   itkSetMacro(Progressive, bool);
   itkGetConstMacro(Progressive, bool);
-  itkBooleanMacro(Progressive);
+  itkBooleanMacro(Progressive)
 
   /** Convert to RGB if out_color_space is CMYK, default is true */
   itkSetMacro(CMYKtoRGB, bool);
   itkGetConstMacro(CMYKtoRGB, bool);
-  itkBooleanMacro(CMYKtoRGB);
+  itkBooleanMacro(CMYKtoRGB)
 
   /*-------- This part of the interface deals with reading data. ------ */
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -139,7 +139,7 @@ public:
   /** Set the compression On or Off */
   itkSetMacro(UseCompression, bool);
   itkGetConstReferenceMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
 protected:
   MeshFileWriter();

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -459,16 +459,16 @@ public:
   itkGetConstMacro(CellBufferSize, SizeValueType);
   itkSetMacro(UpdatePoints, bool);
   itkGetConstMacro(UpdatePoints, bool);
-  itkBooleanMacro(UpdatePoints);
+  itkBooleanMacro(UpdatePoints)
   itkSetMacro(UpdateCells, bool);
   itkGetConstMacro(UpdateCells, bool);
-  itkBooleanMacro(UpdateCells);
+  itkBooleanMacro(UpdateCells)
   itkSetMacro(UpdatePointData, bool);
   itkGetConstMacro(UpdatePointData, bool);
-  itkBooleanMacro(UpdatePointData);
+  itkBooleanMacro(UpdatePointData)
   itkSetMacro(UpdateCellData, bool);
   itkGetConstMacro(UpdateCellData, bool);
-  itkBooleanMacro(UpdateCellData);
+  itkBooleanMacro(UpdateCellData)
 
   unsigned int
   GetComponentSize(IOComponentEnum componentType) const;
@@ -527,7 +527,7 @@ public:
   /** Set/Get a boolean to use the compression or not. */
   itkSetMacro(UseCompression, bool);
   itkGetConstMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
   /** Convenience method returns the IOFileEnum as a string. This can be
    * used for writing output files. */

--- a/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
+++ b/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
@@ -63,7 +63,7 @@ public:
 
   itkGetConstMacro(ReadPointData, bool);
   itkSetMacro(ReadPointData, bool);
-  itkBooleanMacro(ReadPointData);
+  itkBooleanMacro(ReadPointData)
 
   void
   SetDirection(const DirectionType & direction);

--- a/Modules/IO/Meta/include/itkMetaArrayWriter.h
+++ b/Modules/IO/Meta/include/itkMetaArrayWriter.h
@@ -56,7 +56,7 @@ public:
    *  If set to On, data will be stored in the file in binary format; if set
    *  to Off, data will be stored in ascii format.
    *  Default is Off. */
-  itkBooleanMacro(Binary);
+  itkBooleanMacro(Binary)
   itkSetMacro(Binary, bool);
   itkGetConstMacro(Binary, bool);
 

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -198,7 +198,7 @@ public:
    */
   itkSetMacro(ConvertRASVectors, bool);
   itkGetConstMacro(ConvertRASVectors, bool);
-  itkBooleanMacro(ConvertRASVectors);
+  itkBooleanMacro(ConvertRASVectors)
 
   /** Enable conversion of vector coordinates between RAS coordinate system (in NIFTI file) and
    * LPS (ITK convention) when reading or writing a "displacement vector" file (intent code: 1006).
@@ -217,12 +217,12 @@ public:
    */
   itkSetMacro(ConvertRASDisplacementVectors, bool);
   itkGetConstMacro(ConvertRASDisplacementVectors, bool);
-  itkBooleanMacro(ConvertRASDisplacementVectors);
+  itkBooleanMacro(ConvertRASDisplacementVectors)
 
   /** Allow to read nifti files with non-orthogonal sform*/
   itkSetMacro(SFORM_Permissive, bool);
   itkGetConstMacro(SFORM_Permissive, bool);
-  itkBooleanMacro(SFORM_Permissive);
+  itkBooleanMacro(SFORM_Permissive)
 
 protected:
   NiftiImageIO();

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -79,7 +79,7 @@ public:
 
   itkSetMacro(BinaryPoints, bool);
   itkGetConstMacro(BinaryPoints, bool);
-  itkBooleanMacro(BinaryPoints);
+  itkBooleanMacro(BinaryPoints)
 
   void
   SetTransformPrecision(unsigned int precision);
@@ -90,7 +90,7 @@ public:
   /** Set/Get if the images should be written in a different file */
   itkSetMacro(WriteImagesInSeparateFile, bool);
   itkGetConstMacro(WriteImagesInSeparateFile, bool);
-  itkBooleanMacro(WriteImagesInSeparateFile);
+  itkBooleanMacro(WriteImagesInSeparateFile)
 
   /** Add a converter for a new MetaObject/SpatialObject type */
   void

--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.h
@@ -83,12 +83,12 @@ public:
   /** Set/Get the write mode (append/overwrite) for the filter. */
   itkSetMacro(AppendMode, bool);
   itkGetConstMacro(AppendMode, bool);
-  itkBooleanMacro(AppendMode);
+  itkBooleanMacro(AppendMode)
 
   /** Set/Get a boolean to use the compression or not. */
   itkSetMacro(UseCompression, bool);
   itkGetConstMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
   /** Set/Get the input transform to write */
   void

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -127,12 +127,12 @@ public:
   /** Set the writer to append to the specified file */
   itkSetMacro(AppendMode, bool);
   itkGetConstMacro(AppendMode, bool);
-  itkBooleanMacro(AppendMode);
+  itkBooleanMacro(AppendMode)
 
   /** Set/Get a boolean to use the compression or not. */
   itkSetMacro(UseCompression, bool);
   itkGetConstMacro(UseCompression, bool);
-  itkBooleanMacro(UseCompression);
+  itkBooleanMacro(UseCompression)
 
   /** The transform type has a string representation used when reading
    * and writing transform files.  In the case where a double-precision

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -90,7 +90,7 @@ public:
    */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstReferenceMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 protected:
   AreaClosingImageFilter() { m_UseImageSpacing = true; }

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -92,7 +92,7 @@ public:
    */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstReferenceMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
 protected:
   AreaOpeningImageFilter() { m_UseImageSpacing = true; }

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -114,7 +114,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get the threshold value used to select the connected components.

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.h
@@ -169,12 +169,12 @@ public:
    * parameter t. */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set/Get the flag for using image spacing when calculating derivatives. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set/Get a limit for growth of the kernel. Small maximum error values with
    *  large variances will yield very large kernel sizes. This value can be

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
@@ -156,12 +156,12 @@ public:
    * parameter t. */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set/Get the flag for using image spacing when calculating derivatives. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set/Get a limit for growth of the kernel. Small maximum error values with
    *  large variances will yield very large kernel sizes. This value can be

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.h
@@ -156,12 +156,12 @@ public:
    * parameter t. */
   itkSetMacro(NormalizeAcrossScale, bool);
   itkGetConstMacro(NormalizeAcrossScale, bool);
-  itkBooleanMacro(NormalizeAcrossScale);
+  itkBooleanMacro(NormalizeAcrossScale)
 
   /** Set/Get the flag for using image spacing when calculating derivatives. */
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   /** Set/Get a limit for growth of the kernel. Small maximum error values with
    *  large variances will yield very large kernel sizes. This value can be

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -253,7 +253,7 @@ public:
 
   // Macros for enabling the calculation of additional features.
   itkGetMacro(CalculatePixelIndices, bool);
-  itkBooleanMacro(CalculatePixelIndices);
+  itkBooleanMacro(CalculatePixelIndices)
   void SetCalculatePixelIndices(const bool value)
   {
     // CalculateOrientedBoundingBox, CalculateOrientedLabelImage, and
@@ -279,7 +279,7 @@ public:
   }
 
   itkGetMacro(CalculateOrientedBoundingBox, bool);
-  itkBooleanMacro(CalculateOrientedBoundingBox);
+  itkBooleanMacro(CalculateOrientedBoundingBox)
   void SetCalculateOrientedBoundingBox(const bool value)
   {
     if (this->m_CalculateOrientedBoundingBox != value)
@@ -297,7 +297,7 @@ public:
   }
 
   itkGetMacro(CalculateOrientedLabelRegions, bool);
-  itkBooleanMacro(CalculateOrientedLabelRegions);
+  itkBooleanMacro(CalculateOrientedLabelRegions)
   void SetCalculateOrientedLabelRegions(const bool value)
   {
     if (this->m_CalculateOrientedLabelRegions != value)
@@ -315,7 +315,7 @@ public:
   }
 
   itkGetMacro(CalculateOrientedIntensityRegions, bool);
-  itkBooleanMacro(CalculateOrientedIntensityRegions);
+  itkBooleanMacro(CalculateOrientedIntensityRegions)
   void SetCalculateOrientedIntensityRegions(const bool value)
   {
     if (this->m_CalculateOrientedIntensityRegions != value)

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -263,7 +263,7 @@ public:
   /** Use the image spacing information in calculations. Use this option if you
    *  want derivatives in physical space. Default is UseImageSpacingOn. */
   itkSetMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
   itkGetConstReferenceMacro(UseImageSpacing, bool);
 
   /** Set/Get the maximum error allowed in the solution.  This may not be
@@ -279,13 +279,13 @@ public:
   /** Set/Get the state of the filter. */
   itkSetMacro(InitializedState, bool);
   itkGetConstReferenceMacro(InitializedState, bool);
-  itkBooleanMacro(InitializedState);
+  itkBooleanMacro(InitializedState)
 
   /** Require the filter to be manually reinitialized (by calling
       SetInitializedStateOff() */
   itkSetMacro(ManualReinitialization, bool);
   itkGetConstReferenceMacro(ManualReinitialization, bool);
-  itkBooleanMacro(ManualReinitialization);
+  itkBooleanMacro(ManualReinitialization)
 
   /** Set the number of elapsed iterations of the filter. */
   itkSetMacro(ElapsedIterations, unsigned int);

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
@@ -289,7 +289,7 @@ public:
    *  applications may not use this value and can safely turn the flag off. */
   itkSetMacro(InterpolateSurfaceLocation, bool);
   itkGetConstMacro(InterpolateSurfaceLocation, bool);
-  itkBooleanMacro(InterpolateSurfaceLocation);
+  itkBooleanMacro(InterpolateSurfaceLocation)
 
   void
   SetFunctionCount(const IdCellType & n)

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.h
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.h
@@ -100,7 +100,7 @@ public:
   void
   SetUseImageSpacing(bool);
   itkGetConstMacro(UseImageSpacing, bool);
-  itkBooleanMacro(UseImageSpacing);
+  itkBooleanMacro(UseImageSpacing)
 
   using WeightsType = FixedArray<double, ImageDimension>;
 

--- a/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
@@ -112,7 +112,7 @@ public:
    * simplex as [x0[0], x0[1], ..., x0[i]+InitialSimplexDelta[i], ...,
    * x0[d-1]]. */
   itkSetMacro(AutomaticInitialSimplex, bool);
-  itkBooleanMacro(AutomaticInitialSimplex);
+  itkBooleanMacro(AutomaticInitialSimplex)
   itkGetConstMacro(AutomaticInitialSimplex, bool);
 
   /** Set/Get the mode that determines if we want to use multiple runs of the
@@ -122,7 +122,7 @@ public:
    * that from the previous iteration.
    */
   itkSetMacro(OptimizeWithRestarts, bool);
-  itkBooleanMacro(OptimizeWithRestarts);
+  itkBooleanMacro(OptimizeWithRestarts)
   itkGetConstMacro(OptimizeWithRestarts, bool);
 
   /** Set/Get the deltas that are used to define the initial simplex

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
@@ -72,7 +72,7 @@ public:
   itkGetMacro(DifferenceTolerance, double);
   itkSetMacro(Verbose, bool);
   itkGetMacro(Verbose, bool);
-  itkBooleanMacro(Verbose);
+  itkBooleanMacro(Verbose)
   itkGetMacro(ComputedMean, double);
   itkGetMacro(ComputedStandardDeviation, double);
   itkGetMacro(UpperAsymptote, double);

--- a/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
@@ -92,7 +92,7 @@ public:
   /** Convert gradient to a unit length vector */
   itkSetMacro(UseUnitLengthGradient, bool);
   itkGetConstMacro(UseUnitLengthGradient, bool);
-  itkBooleanMacro(UseUnitLengthGradient);
+  itkBooleanMacro(UseUnitLengthGradient)
 
   /** Start optimization. */
   void

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -100,7 +100,7 @@ public:
   /** Methods to configure the cost function. */
   itkGetConstReferenceMacro(Maximize, bool);
   itkSetMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   bool
   GetMinimize() const
   {

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -112,7 +112,7 @@ public:
   SetTrace(bool flag);
 
   itkGetMacro(Trace, bool);
-  itkBooleanMacro(Trace);
+  itkBooleanMacro(Trace)
 
   /** Set the lower bound value for each variable. */
   virtual void

--- a/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
@@ -125,7 +125,7 @@ public:
   SetTrace(bool flag);
 
   itkGetMacro(Trace, bool);
-  itkBooleanMacro(Trace);
+  itkBooleanMacro(Trace)
 
   /** Set/Get the maximum number of function evaluations allowed. */
   virtual void

--- a/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
@@ -92,7 +92,7 @@ public:
 
   /** Set if the Optimizer should Maximize the metric */
   itkSetMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   itkGetConstReferenceMacro(Maximize, bool);
 
   bool

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -93,7 +93,7 @@ public:
    * convergence.*/
   itkSetMacro(InitializeNormalDistribution, bool);
   itkGetMacro(InitializeNormalDistribution, bool);
-  itkBooleanMacro(InitializeNormalDistribution);
+  itkBooleanMacro(InitializeNormalDistribution)
 
   /**
    * Specify the initial swarm. Useful for evaluating PSO variants. If the
@@ -112,7 +112,7 @@ public:
    */
   itkSetMacro(PrintSwarm, bool);
   itkGetMacro(PrintSwarm, bool);
-  itkBooleanMacro(PrintSwarm);
+  itkBooleanMacro(PrintSwarm)
 
   /** Start optimization. */
   void
@@ -184,7 +184,7 @@ public:
    * generator. Default is Off. */
   itkSetMacro(UseSeed, bool);
   itkGetMacro(UseSeed, bool);
-  itkBooleanMacro(UseSeed);
+  itkBooleanMacro(UseSeed)
 
   /** Get the function value for the current position.
    *  NOTE: This value is only valid during and after the execution of the

--- a/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
@@ -82,7 +82,7 @@ public:
 
   /** Set if the Optimizer should Maximize the metric */
   itkSetMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   itkGetConstReferenceMacro(Maximize, bool);
 
   /** Set/Get maximum iteration limit. */

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -86,7 +86,7 @@ public:
   /** Specify whether to minimize or maximize the cost function. */
   itkSetMacro(Maximize, bool);
   itkGetConstReferenceMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   bool
   GetMinimize() const
   {

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -191,7 +191,7 @@ public:
   /** Methods to configure the cost function. */
   itkGetConstMacro(Maximize, bool);
   itkSetMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   bool
   GetMinimize() const
   {

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
@@ -70,7 +70,7 @@ public:
    * -1.0. */
   itkGetConstReferenceMacro(Maximize, bool);
   itkSetMacro(Maximize, bool);
-  itkBooleanMacro(Maximize);
+  itkBooleanMacro(Maximize)
   bool
   GetMinimize() const
   {

--- a/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
@@ -100,7 +100,7 @@ public:
    * simplex as [x0[0], x0[1], ..., x0[i]+InitialSimplexDelta[i], ...,
    * x0[d-1]]. */
   itkSetMacro(AutomaticInitialSimplex, bool);
-  itkBooleanMacro(AutomaticInitialSimplex);
+  itkBooleanMacro(AutomaticInitialSimplex)
   itkGetConstMacro(AutomaticInitialSimplex, bool);
 
   /** Set/Get the mode that determines if we want to use multiple runs of the
@@ -110,7 +110,7 @@ public:
    * that from the previous iteration.
    */
   itkSetMacro(OptimizeWithRestarts, bool);
-  itkBooleanMacro(OptimizeWithRestarts);
+  itkBooleanMacro(OptimizeWithRestarts)
   itkGetConstMacro(OptimizeWithRestarts, bool);
 
   /** Set/Get the deltas that are used to define the initial simplex

--- a/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
@@ -128,7 +128,7 @@ public:
    */
   itkSetMacro(PrintParameters, bool);
   itkGetMacro(PrintParameters, bool);
-  itkBooleanMacro(PrintParameters);
+  itkBooleanMacro(PrintParameters)
 
 
 protected:

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
@@ -131,7 +131,7 @@ public:
    */
   itkSetMacro(DoEstimateLearningRateAtEachIteration, bool);
   itkGetConstReferenceMacro(DoEstimateLearningRateAtEachIteration, bool);
-  itkBooleanMacro(DoEstimateLearningRateAtEachIteration);
+  itkBooleanMacro(DoEstimateLearningRateAtEachIteration)
 
   /** Option to use ScalesEstimator for learning rate estimation
    * only *once*, during first iteration. The estimation overrides the
@@ -142,7 +142,7 @@ public:
    */
   itkSetMacro(DoEstimateLearningRateOnce, bool);
   itkGetConstReferenceMacro(DoEstimateLearningRateOnce, bool);
-  itkBooleanMacro(DoEstimateLearningRateOnce);
+  itkBooleanMacro(DoEstimateLearningRateOnce)
 
   /** Minimum convergence value for convergence checking.
    *  The convergence checker calculates convergence value by fitting to
@@ -183,7 +183,7 @@ public:
    */
   itkSetMacro(ReturnBestParametersAndValue, bool);
   itkGetConstReferenceMacro(ReturnBestParametersAndValue, bool);
-  itkBooleanMacro(ReturnBestParametersAndValue);
+  itkBooleanMacro(ReturnBestParametersAndValue)
 
   /** Start and run the optimization. */
   void

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -459,7 +459,7 @@ public:
    */
   itkSetMacro(EstimateScalesAtEachIteration, bool);
   itkGetConstReferenceMacro(EstimateScalesAtEachIteration, bool);
-  itkBooleanMacro(EstimateScalesAtEachIteration);
+  itkBooleanMacro(EstimateScalesAtEachIteration)
 
 protected:
   LBFGS2Optimizerv4Template();

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
@@ -119,7 +119,7 @@ public:
   SetTrace(bool flag);
 
   itkGetConstMacro(Trace, bool);
-  itkBooleanMacro(Trace);
+  itkBooleanMacro(Trace)
 
   /** Set/Get the maximum number of function evaluations allowed. */
   virtual void

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -214,7 +214,7 @@ public:
    */
   itkSetMacro(DoEstimateScales, bool);
   itkGetConstReferenceMacro(DoEstimateScales, bool);
-  itkBooleanMacro(DoEstimateScales);
+  itkBooleanMacro(DoEstimateScales)
 
   /** Set the number of work units to use when threading.
    * The default is the global default number of work units

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
@@ -160,7 +160,7 @@ public:
 
   itkGetConstReferenceMacro(CatchGetValueException, bool);
   itkSetMacro(CatchGetValueException, bool);
-  itkBooleanMacro(CatchGetValueException);
+  itkBooleanMacro(CatchGetValueException)
 
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
@@ -126,7 +126,7 @@ public:
 
   itkGetConstReferenceMacro(CatchGetValueException, bool);
   itkSetMacro(CatchGetValueException, bool);
-  itkBooleanMacro(CatchGetValueException);
+  itkBooleanMacro(CatchGetValueException)
 
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -158,7 +158,7 @@ public:
    */
   itkSetMacro(TransformForward, bool);
   itkGetConstMacro(TransformForward, bool);
-  itkBooleanMacro(TransformForward);
+  itkBooleanMacro(TransformForward)
 
   /** Get/Set a point set for virtual domain sampling. */
 #ifndef ITK_FUTURE_LEGACY_REMOVE

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -159,7 +159,7 @@ public:
   /** Set/Get whether the bins at the edges of the histogram extend to +/- infinity. */
   itkGetConstMacro(ClipBinsAtEnds, bool);
   itkSetMacro(ClipBinsAtEnds, bool);
-  itkBooleanMacro(ClipBinsAtEnds);
+  itkBooleanMacro(ClipBinsAtEnds)
 
   /** Returns true if the given index is out of bound meaning one of index
    * is not between [0, last index] */

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
@@ -119,7 +119,7 @@ public:
    * minimum and maximum of the histogram are going to be computed
    * automatically from the values of the sample */
   itkSetGetDecoratedInputMacro(AutoMinimumMaximum, bool);
-  itkBooleanMacro(AutoMinimumMaximum);
+  itkBooleanMacro(AutoMinimumMaximum)
 
   /** Method that facilitates the use of this filter in the internal
    * pipeline of another filter. */

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -135,7 +135,7 @@ public:
   itkGetConstMacro(UseImageRegion, bool);
 
   /** Convenience methods to turn on/off the UseImageRegion flag */
-  itkBooleanMacro(UseImageRegion);
+  itkBooleanMacro(UseImageRegion)
 
 
   /** returns the number of measurement vectors in this container */

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -177,7 +177,7 @@ public:
   /** Method to set UsePixelContainer flag */
   itkSetMacro(UsePixelContainer, bool);
   itkGetConstMacro(UsePixelContainer, bool);
-  itkBooleanMacro(UsePixelContainer);
+  itkBooleanMacro(UsePixelContainer)
 
   //  void PrintSelf(std::ostream& os, Indent indent) const override;
 

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -156,7 +156,7 @@ public:
 
   itkSetMacro(UseClusterLabels, bool);
   itkGetConstMacro(UseClusterLabels, bool);
-  itkBooleanMacro(UseClusterLabels);
+  itkBooleanMacro(UseClusterLabels)
 
 protected:
   KdTreeBasedKmeansEstimator();

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
@@ -158,7 +158,7 @@ public:
     total frequency). Normalization is off by default. */
   itkSetMacro(Normalize, bool);
   itkGetConstMacro(Normalize, bool);
-  itkBooleanMacro(Normalize);
+  itkBooleanMacro(Normalize)
 
   /** Method to set/get the image */
   using Superclass::SetInput;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -211,7 +211,7 @@ public:
 
   itkGetConstMacro(FastCalculations, bool);
   itkSetMacro(FastCalculations, bool);
-  itkBooleanMacro(FastCalculations);
+  itkBooleanMacro(FastCalculations)
 
 protected:
   ScalarImageToTextureFeaturesFilter();

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -85,7 +85,7 @@ public:
    */
   itkSetMacro(CanSelectQuery, bool);
   itkGetConstReferenceMacro(CanSelectQuery, bool);
-  itkBooleanMacro(CanSelectQuery);
+  itkBooleanMacro(CanSelectQuery)
 
   /** Provide an interface to set the seed.
    *  The seed value will be used by subclasses where appropriate.

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -112,7 +112,7 @@ public:
     }
   }
 
-  itkBooleanMacro(UseClockForSeed);
+  itkBooleanMacro(UseClockForSeed)
   itkGetConstMacro(UseClockForSeed, bool);
 
   virtual void

--- a/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
@@ -88,7 +88,7 @@ public:
    * initial rotation that will align them. */
   itkSetMacro(ComputeRotation, bool);
   itkGetMacro(ComputeRotation, bool);
-  itkBooleanMacro(ComputeRotation);
+  itkBooleanMacro(ComputeRotation)
 
 protected:
   CenteredVersorTransformInitializer();

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
@@ -113,7 +113,7 @@ public:
    *  of distances^4 instead of the sum of distances^2. Default is false. */
   itkSetMacro(ComputeSquaredDistance, bool);
   itkGetConstMacro(ComputeSquaredDistance, bool);
-  itkBooleanMacro(ComputeSquaredDistance);
+  itkBooleanMacro(ComputeSquaredDistance)
 
 protected:
   EuclideanDistancePointMetric();

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -215,7 +215,7 @@ public:
   /** Set/Get gradient computation. */
   itkSetMacro(ComputeGradient, bool);
   itkGetConstReferenceMacro(ComputeGradient, bool);
-  itkBooleanMacro(ComputeGradient);
+  itkBooleanMacro(ComputeGradient)
 
   /** Computes the gradient image and assigns it to m_GradientImage */
   virtual void
@@ -338,7 +338,7 @@ public:
    * preserve backward compatibility with previous versions of ITK. */
   itkSetMacro(UseCachingOfBSplineWeights, bool);
   itkGetConstReferenceMacro(UseCachingOfBSplineWeights, bool);
-  itkBooleanMacro(UseCachingOfBSplineWeights);
+  itkBooleanMacro(UseCachingOfBSplineWeights)
 
   using MultiThreaderType = MultiThreaderBase;
   /** Get the Threader. */

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
@@ -120,7 +120,7 @@ public:
    * (ComplementOn). When using an optimizer that minimizes
    * metric values use ComplementOn(). */
   itkSetMacro(Complement, bool);
-  itkBooleanMacro(Complement);
+  itkBooleanMacro(Complement)
   itkGetConstMacro(Complement, bool);
 
 protected:

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -121,7 +121,7 @@ public:
    * or mismatches. The default is to measure matches
    * (MeasureMatchesOn). */
   itkSetMacro(MeasureMatches, bool);
-  itkBooleanMacro(MeasureMatches);
+  itkBooleanMacro(MeasureMatches)
   itkGetConstMacro(MeasureMatches, bool);
 
   /** Return the multithreader used by this class. */

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -218,7 +218,7 @@ public:
    * number of parameters, such as, BSplineTransforms. */
   itkSetMacro(UseExplicitPDFDerivatives, bool);
   itkGetConstReferenceMacro(UseExplicitPDFDerivatives, bool);
-  itkBooleanMacro(UseExplicitPDFDerivatives);
+  itkBooleanMacro(UseExplicitPDFDerivatives)
 
   /** The marginal PDFs are stored as std::vector. */
   using PDFValueType = double; // NOTE:  floating point precision is not as stable.  Double precision proves faster and

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -358,7 +358,7 @@ private:
   };
 
 #if !defined(ITK_WRAPPING_PARSER)
-  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, MMIMetricPerThreadStruct, PaddedMMIMetricPerThreadStruct);
+  itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, MMIMetricPerThreadStruct, PaddedMMIMetricPerThreadStruct)
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT, PaddedMMIMetricPerThreadStruct, AlignedMMIMetricPerThreadStruct);
   // Due to a bug in older version of Visual Studio where std::vector resize
   // uses a value instead of a const reference, this must be a pointer.

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
@@ -211,7 +211,7 @@ public:
 
   itkSetMacro(UseShrinkImageFilter, bool);
   itkGetConstMacro(UseShrinkImageFilter, bool);
-  itkBooleanMacro(UseShrinkImageFilter);
+  itkBooleanMacro(UseShrinkImageFilter)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.h
@@ -97,7 +97,7 @@ public:
    * Default value is false. */
   itkSetMacro(SubtractMean, bool);
   itkGetConstReferenceMacro(SubtractMean, bool);
-  itkBooleanMacro(SubtractMean);
+  itkBooleanMacro(SubtractMean)
 
 protected:
   NormalizedCorrelationImageToImageMetric();

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
@@ -99,7 +99,7 @@ public:
    * Default value is false. */
   itkSetMacro(SubtractMean, bool);
   itkGetConstReferenceMacro(SubtractMean, bool);
-  itkBooleanMacro(SubtractMean);
+  itkBooleanMacro(SubtractMean)
 
 protected:
   NormalizedCorrelationPointSetToImageMetric();

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
@@ -107,7 +107,8 @@ public:
 
   /** Initialize the transform using the specified fixed parameters */
   void
-  AdaptTransformParameters() override{};
+  AdaptTransformParameters() override
+  {}
 
 protected:
   TransformParametersAdaptor() = default;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -400,14 +400,14 @@ public:
    */
   itkSetMacro(UseLandmarks, bool);
   itkGetMacro(UseLandmarks, bool);
-  itkBooleanMacro(UseLandmarks);
+  itkBooleanMacro(UseLandmarks)
 
   /**
    * Get/Set Use of the mass matrix in FEM solution. This should be true.
    */
   itkSetMacro(UseMassMatrix, bool);
   itkGetMacro(UseMassMatrix, bool);
-  itkBooleanMacro(UseMassMatrix);
+  itkBooleanMacro(UseMassMatrix)
 
   /**
    * Get/Set the energy below which we decide the solution has converged.
@@ -471,7 +471,7 @@ public:
    */
   itkSetMacro(UseNormalizedGradient, bool);
   itkGetMacro(UseNormalizedGradient, bool);
-  itkBooleanMacro(UseNormalizedGradient);
+  itkBooleanMacro(UseNormalizedGradient)
 
   /**
    * Get/Set the number of iterations before regridding is employed.
@@ -553,7 +553,7 @@ public:
    */
   itkSetMacro(CreateMeshFromImage, bool);
   itkGetMacro(CreateMeshFromImage, bool);
-  itkBooleanMacro(CreateMeshFromImage);
+  itkBooleanMacro(CreateMeshFromImage)
 
   /** Set the interpolator function. */
   itkSetObjectMacro(Interpolator, InterpolatorType);

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -454,13 +454,13 @@ public:
   /** Set/Get flag to use a domain sampling point set */
   itkSetMacro(UseSampledPointSet, bool);
   itkGetConstReferenceMacro(UseSampledPointSet, bool);
-  itkBooleanMacro(UseSampledPointSet);
+  itkBooleanMacro(UseSampledPointSet)
 
   /** Set/Get flag to indicate of the VirtualSampledPointSet is set
    * over the FixedSampledPointSet*/
   itkSetMacro(UseVirtualSampledPointSet, bool);
   itkGetConstReferenceMacro(UseVirtualSampledPointSet, bool);
-  itkBooleanMacro(UseVirtualSampledPointSet);
+  itkBooleanMacro(UseVirtualSampledPointSet)
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** UseFixedSampledPointSet is deprecated and has been replaced
@@ -488,12 +488,12 @@ public:
    * for fixed image. */
   itkSetMacro(UseFixedImageGradientFilter, bool);
   itkGetConstReferenceMacro(UseFixedImageGradientFilter, bool);
-  itkBooleanMacro(UseFixedImageGradientFilter);
+  itkBooleanMacro(UseFixedImageGradientFilter)
 
   /** Set/Get gradient computation via an image filter. */
   itkSetMacro(UseMovingImageGradientFilter, bool);
   itkGetConstReferenceMacro(UseMovingImageGradientFilter, bool);
-  itkBooleanMacro(UseMovingImageGradientFilter);
+  itkBooleanMacro(UseMovingImageGradientFilter)
 
   /** Get number of work units to used in the most recent
    * evaluation.  Only valid after GetValueAndDerivative() or
@@ -571,7 +571,7 @@ public:
    * of this truncation are highly dependent on the derivative magnitudes. */
   itkSetMacro(UseFloatingPointCorrection, bool);
   itkGetConstReferenceMacro(UseFloatingPointCorrection, bool);
-  itkBooleanMacro(UseFloatingPointCorrection);
+  itkBooleanMacro(UseFloatingPointCorrection)
 
   /** Set/Get the floating point resolution used optionally by the derivatives.
    * If this is set, for example to 1e5, then the derivative will have precision up to 5

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -189,7 +189,7 @@ protected:
   };
   itkPadStruct(ITK_CACHE_LINE_ALIGNMENT,
                GetValueAndDerivativePerThreadStruct,
-               PaddedGetValueAndDerivativePerThreadStruct);
+               PaddedGetValueAndDerivativePerThreadStruct)
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,
                     PaddedGetValueAndDerivativePerThreadStruct,
                     AlignedGetValueAndDerivativePerThreadStruct);

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -176,7 +176,7 @@ public:
    * Get/set whether or not anisotropic covariances are determined for each
    * Gaussian.  Default = false.
    */
-  itkBooleanMacro(UseAnisotropicCovariances);
+  itkBooleanMacro(UseAnisotropicCovariances)
 
   /**
    * Set the size of the covariance neighborhood used to construct the

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -141,7 +141,7 @@ public:
    * Normalize covariance by the sum of the weights of the nearest neighbors.
    * Default = true.
    */
-  itkBooleanMacro(Normalize);
+  itkBooleanMacro(Normalize)
 
   /**
    * Construct covariances using the local neighborhood point set structure.
@@ -162,7 +162,7 @@ public:
    * Otherwise, the Gaussian for each point is characterized by the value
    * of m_RegularizationSigma.  Default = true.
    */
-  itkBooleanMacro(UseAnisotropicCovariances);
+  itkBooleanMacro(UseAnisotropicCovariances)
 
   /** Set the input point set */
   void

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -418,13 +418,13 @@ protected:
   RequiresMovingPointsLocator() const
   {
     return true;
-  };
+  }
 
   virtual bool
   RequiresFixedPointsLocator() const
   {
     return true;
-  };
+  }
 
   /**
    * Function to be defined in the appropriate derived classes.  Calculates

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -305,14 +305,14 @@ public:
    */
   itkSetMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms, bool);
   itkGetConstMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms, bool);
-  itkBooleanMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms);
+  itkBooleanMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms)
 
   /**
    *
    */
   itkSetMacro(CalculateValueAndDerivativeInTangentSpace, bool);
   itkGetConstMacro(CalculateValueAndDerivativeInTangentSpace, bool);
-  itkBooleanMacro(CalculateValueAndDerivativeInTangentSpace);
+  itkBooleanMacro(CalculateValueAndDerivativeInTangentSpace)
 
 protected:
   PointSetToPointSetMetricWithIndexv4();

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -210,7 +210,7 @@ private:
                                      const PixelType & pixel) const override
   {
     return this->GetLocalNeighborhoodValue(point, pixel);
-  };
+  }
 
   LocalDerivativeType
   GetLocalNeighborhoodDerivativeWithIndex(const PointIdentifier &,
@@ -218,7 +218,7 @@ private:
                                           const PixelType & pixel) const override
   {
     return this->GetLocalNeighborhoodDerivative(point, pixel);
-  };
+  }
 
   void
   GetLocalNeighborhoodValueAndDerivativeWithIndex(const PointIdentifier &,
@@ -228,7 +228,7 @@ private:
                                                   const PixelType &     pixel) const override
   {
     this->GetLocalNeighborhoodValueAndDerivative(point, measure, derivative, pixel);
-  };
+  }
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
@@ -112,7 +112,7 @@ public:
    * for computing the displacement field updates. */
   itkSetMacro(UseMovingImageGradient, bool);
   itkGetConstMacro(UseMovingImageGradient, bool);
-  itkBooleanMacro(UseMovingImageGradient);
+  itkBooleanMacro(UseMovingImageGradient)
 
   /** Set/Get the threshold below which the absolute difference of
    * intensity yields a match. When the intensities match between a

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -139,7 +139,7 @@ public:
    *  s <- s o (Id + u) instead of s <- s o exp(u) */
   itkSetMacro(UseFirstOrderExp, bool);
   itkGetConstMacro(UseFirstOrderExp, bool);
-  itkBooleanMacro(UseFirstOrderExp);
+  itkBooleanMacro(UseFirstOrderExp)
 
   /** Set/Get the threshold below which the absolute difference of
    * intensity yields a match. When the intensities match between a

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
@@ -155,7 +155,7 @@ public:
    * deviations are specified with SetStandardDeviations() */
   itkSetMacro(SmoothDisplacementField, bool);
   itkGetConstMacro(SmoothDisplacementField, bool);
-  itkBooleanMacro(SmoothDisplacementField);
+  itkBooleanMacro(SmoothDisplacementField)
 
   using StandardDeviationsType = FixedArray<double, ImageDimension>;
 
@@ -177,7 +177,7 @@ public:
    * deviations are specified with SetUpdateFieldStandardDeviations() */
   itkSetMacro(SmoothUpdateField, bool);
   itkGetConstMacro(SmoothUpdateField, bool);
-  itkBooleanMacro(SmoothUpdateField);
+  itkBooleanMacro(SmoothUpdateField)
 
   /** Set the Gaussian smoothing standard deviations for the update
    * field. The values are set with respect to pixel coordinates. */

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
@@ -431,7 +431,7 @@ public:
    */
   itkSetMacro(SmoothingSigmasAreSpecifiedInPhysicalUnits, bool);
   itkGetConstMacro(SmoothingSigmasAreSpecifiedInPhysicalUnits, bool);
-  itkBooleanMacro(SmoothingSigmasAreSpecifiedInPhysicalUnits);
+  itkBooleanMacro(SmoothingSigmasAreSpecifiedInPhysicalUnits)
 
   /** Make a DataObject of the correct type to be used as the specified output. */
   using DataObjectPointerArraySizeType = ProcessObject::DataObjectPointerArraySizeType;
@@ -480,14 +480,14 @@ public:
    */
   itkSetMacro(InPlace, bool);
   itkGetConstMacro(InPlace, bool);
-  itkBooleanMacro(InPlace);
+  itkBooleanMacro(InPlace)
 
   /**
    * Initialize the current linear transform to be optimized with the center of the
    * previous transform in the queue.  This provides a much better initialization than
    * the default origin.
    */
-  itkBooleanMacro(InitializeCenterOfLinearOutputTransform);
+  itkBooleanMacro(InitializeCenterOfLinearOutputTransform)
   itkSetMacro(InitializeCenterOfLinearOutputTransform, bool);
   itkGetConstMacro(InitializeCenterOfLinearOutputTransform, bool);
 

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -135,7 +135,7 @@ public:
    * only for display. The default value is false. */
   itkSetMacro(UseNonContiguousLabels, bool);
   itkGetConstReferenceMacro(UseNonContiguousLabels, bool);
-  itkBooleanMacro(UseNonContiguousLabels);
+  itkBooleanMacro(UseNonContiguousLabels)
 
   /** Set Region method to constrain classification to a certain region */
   void

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -131,7 +131,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /** Type used as identifier of the different component labels. */
   using LabelType = IdentifierType;

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -175,7 +175,7 @@ public:
    * If false, initial order of labels is kept. */
   itkSetMacro(SortByObjectSize, bool);
   itkGetConstMacro(SortByObjectSize, bool);
-  itkBooleanMacro(SortByObjectSize);
+  itkBooleanMacro(SortByObjectSize)
 
   /** Get the size of each object in pixels. This information is only
    * valid after the filter has executed.  Size of the background is

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
@@ -145,11 +145,11 @@ public:
 
   itkSetMacro(ApplyConnectivity, bool);
   itkGetConstMacro(ApplyConnectivity, bool);
-  itkBooleanMacro(ApplyConnectivity);
+  itkBooleanMacro(ApplyConnectivity)
 
   itkSetMacro(StopOnTargets, bool);
   itkGetConstMacro(StopOnTargets, bool);
-  itkBooleanMacro(StopOnTargets);
+  itkBooleanMacro(StopOnTargets)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
@@ -108,7 +108,7 @@ public:
 
   /** Get the narrowbanding flag. */
   itkGetConstMacro(NarrowBanding, bool);
-  itkBooleanMacro(NarrowBanding);
+  itkBooleanMacro(NarrowBanding)
 
   /** Set/Get the input narrowband. A narrowband is represented as
    * a VectorContainer of LevelSetNodes. */

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -269,7 +269,7 @@ public:
    * set. */
   itkSetMacro(ReverseExpansionDirection, bool);
   itkGetConstMacro(ReverseExpansionDirection, bool);
-  itkBooleanMacro(ReverseExpansionDirection);
+  itkBooleanMacro(ReverseExpansionDirection)
 
   /** Combined scaling of the propagation and advection speed
       terms. You should use either this -or- Get/SetPropagationScaling and

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
@@ -91,7 +91,7 @@ public:
    * off. */
   itkSetMacro(NarrowBanding, bool);
   itkGetConstMacro(NarrowBanding, bool);
-  itkBooleanMacro(NarrowBanding);
+  itkBooleanMacro(NarrowBanding)
 
   /** Set/Get the input narrow bandwidth. The default value is 12. */
   itkSetClampMacro(InputNarrowBandwidth, double, 0.0, NumericTraits<double>::max());

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -316,7 +316,7 @@ public:
    * set. */
   itkSetMacro(ReverseExpansionDirection, bool);
   itkGetConstMacro(ReverseExpansionDirection, bool);
-  itkBooleanMacro(ReverseExpansionDirection);
+  itkBooleanMacro(ReverseExpansionDirection)
 
   /** Turn On/Off automatic generation of Speed and Advection terms when Update
       is called.  If set to Off, the Speed and Advection images must be set
@@ -325,7 +325,7 @@ public:
       to updating the filter. */
   itkSetMacro(AutoGenerateSpeedAdvection, bool);
   itkGetConstMacro(AutoGenerateSpeedAdvection, bool);
-  itkBooleanMacro(AutoGenerateSpeedAdvection);
+  itkBooleanMacro(AutoGenerateSpeedAdvection)
 
   /** Combined scaling of the propagation and advection speed
       terms. You should use either this -or- Get/SetPropagationScaling and

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -215,7 +215,7 @@ public:
   itkSetMacro(NormalProcessConductance, ValueType);
   itkSetMacro(NormalProcessUnsharpFlag, bool);
   itkGetConstReferenceMacro(NormalProcessUnsharpFlag, bool);
-  itkBooleanMacro(NormalProcessUnsharpFlag);
+  itkBooleanMacro(NormalProcessUnsharpFlag)
   itkSetMacro(NormalProcessUnsharpWeight, ValueType);
   itkGetConstReferenceMacro(NormalProcessUnsharpWeight, ValueType);
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
@@ -97,7 +97,7 @@ public:
 
   itkSetMacro(UseCurvatureImage, bool);
   itkGetMacro(UseCurvatureImage, bool);
-  itkBooleanMacro(UseCurvatureImage);
+  itkBooleanMacro(UseCurvatureImage)
 
   /** Neighborhood radius type */
   using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<InputImageType>;

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
@@ -192,7 +192,7 @@ public:
   /** Set/Get whether to find an upper threshold (separating two dark
    * regions) or a lower threshold (separating two bright regions). */
   itkSetMacro(FindUpperThreshold, bool);
-  itkBooleanMacro(FindUpperThreshold);
+  itkBooleanMacro(FindUpperThreshold)
   itkGetConstReferenceMacro(FindUpperThreshold, bool);
 
   /** Get the flag that tells whether the algorithm failed to find a

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -137,7 +137,7 @@ public:
    */
   itkSetMacro(InitializationPerturbation, bool);
   itkGetMacro(InitializationPerturbation, bool);
-  itkBooleanMacro(InitializationPerturbation);
+  itkBooleanMacro(InitializationPerturbation)
 
 
   /** \brief Post processing step to enforce superpixel morphology.
@@ -149,7 +149,7 @@ public:
    */
   itkSetMacro(EnforceConnectivity, bool);
   itkGetMacro(EnforceConnectivity, bool);
-  itkBooleanMacro(EnforceConnectivity);
+  itkBooleanMacro(EnforceConnectivity)
 
 
   /** \brief Get the current average cluster residual.

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -141,7 +141,7 @@ public:
       sessions. The setting of OutputBoundary determines the type of output. */
   itkSetMacro(InteractiveSegmentation, bool);
   itkGetConstMacro(InteractiveSegmentation, bool);
-  itkBooleanMacro(InteractiveSegmentation);
+  itkBooleanMacro(InteractiveSegmentation)
 
   /** Set/Get the mean deviation. */
   itkSetMacro(MeanDeviation, double);

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
@@ -150,7 +150,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get whether the watershed pixel must be marked or not. Default
@@ -159,7 +159,7 @@ public:
    */
   itkSetMacro(MarkWatershedLine, bool);
   itkGetConstReferenceMacro(MarkWatershedLine, bool);
-  itkBooleanMacro(MarkWatershedLine);
+  itkBooleanMacro(MarkWatershedLine)
 
 protected:
   MorphologicalWatershedFromMarkersImageFilter();

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
@@ -93,7 +93,7 @@ public:
    */
   itkSetMacro(FullyConnected, bool);
   itkGetConstReferenceMacro(FullyConnected, bool);
-  itkBooleanMacro(FullyConnected);
+  itkBooleanMacro(FullyConnected)
 
   /**
    * Set/Get whether the watershed pixel must be marked or not. Default
@@ -102,7 +102,7 @@ public:
    */
   itkSetMacro(MarkWatershedLine, bool);
   itkGetConstReferenceMacro(MarkWatershedLine, bool);
-  itkBooleanMacro(MarkWatershedLine);
+  itkBooleanMacro(MarkWatershedLine)
 
   /**
    */

--- a/Modules/Video/IO/include/itkVideoFileReader.h
+++ b/Modules/Video/IO/include/itkVideoFileReader.h
@@ -84,7 +84,7 @@ public:
    * frame for the largest possible temporal region */
   itkSetMacro(IFrameSafe, bool);
   itkGetMacro(IFrameSafe, bool);
-  itkBooleanMacro(IFrameSafe);
+  itkBooleanMacro(IFrameSafe)
 
   /** Set up the output information */
   void


### PR DESCRIPTION
This is part 2 of if the following changes regarding the -Wextra-semi (semi = semicolon) warning of clang can be done throughout the repository. https://github.com/InsightSoftwareConsortium/ITK/pull/4679 

COMP: Remove ; from itkBooleanMacro

COMP: Remove ; from other itk macros 

COMP: Updated itkLegacyMacro Definition. We decided to change the definition of itkLegacyMacro to not have two ; if the if defined(ITK_LEGACY_REMOVE) branch is hit.

COMP: Remove ITK_ASSOCIATE ; or struct;
    Should we remove the semicolon from the struct or from ITK_ASSOCIATE?

COMP: Remove ; to function cases 

COMP: Remove cases with ; to override cases 

COMP: Remove ; IPL cases 

