### PR TITLE
COMP: Test NumPy pre-releases (NumPy 2.0 RC) in CI

### DIFF
--- a/.github/workflows/macos-arm.yml
+++ b/.github/workflows/macos-arm.yml
@@ -101,7 +101,7 @@ jobs:
               run: |
                 set -x
                 python3 -m pip install ninja
-                python3 -m pip install numpy
+                python3 -m pip install --upgrade --pre numpy
 
             - name: Download dashboard script and testing data
               run: |

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -50,7 +50,8 @@ jobs:
 
     - bash: |
         set -x
-        python3 -m pip install ninja numpy>=1.20 typing-extensions
+        python3 -m pip install ninja typing-extensions
+        python3 -m pip install --upgrade --pre numpy
         python3 -m pip install --upgrade setuptools
         python3 -m pip install lxml scikit-ci-addons dask distributed
       displayName: 'Install dependencies'


### PR DESCRIPTION
Added to the macOS, Linux Python CI builds.

Re: #4700
