### PR TITLE
ENH: Finalize ITKv5 const function API change

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -9,6 +9,8 @@ Require modern C++ language feature use
 ---------------------------------------
 Many backward compatible/ forward enabling compiler features are now required to be used.
 
+Replace `ITKv5_CONST` with `const`
+
 Remove support for ITKv4 interfaces
 -----------------------------------
 

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -158,7 +158,7 @@ protected:
   {}
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   void
   BeforeStreamedGenerateData() override

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -167,7 +167,7 @@ ImageSink<TInputImage>::GenerateNthInputRequestedRegion(unsigned int inputReques
 
 template <typename TInputImage>
 void
-ImageSink<TInputImage>::VerifyInputInformation() ITKv5_CONST
+ImageSink<TInputImage>::VerifyInputInformation() const
 {
   using ImageBaseType = const ImageBase<InputImageDimension>;
 

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -244,7 +244,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   /** What is the input requested region that is required to produce
    * the output requested region? The base assumption for image

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -145,7 +145,7 @@ ImageToImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
 
 template <typename TInputImage, typename TOutputImage>
 void
-ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
 
   using ImageBaseType = const ImageBase<InputImageDimension>;

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1376,11 +1376,11 @@ compilers.
 #  define ITK_ITERATOR_FINAL
 #endif
 
-#if defined(ITKV4_COMPATIBILITY)
-// A macro for methods which are const in ITKv5, but not in ITKv4
-#  define ITKv5_CONST
+#if defined(ITK_LEGACY_REMOVE)
+// A macro for methods which are const in ITKv5 and ITKv6 require const for functions
+#  define ITKv5_CONST static_assert(false, "ERROR: ITKv5_CONST must be replaced with 'const'")
 #else
-// A macro for methods which are const in ITKv5, but not in ITKv4
+// A macro for methods which are const in after ITKv4
 #  define ITKv5_CONST const
 #endif
 

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -782,7 +782,7 @@ protected:
    *
    */
   virtual void
-  VerifyPreconditions() ITKv5_CONST;
+  VerifyPreconditions() const;
 
   /** \brief Verifies that the inputs meta-data is consistent and valid
    * for continued execution of the pipeline, throws an exception if
@@ -795,7 +795,7 @@ protected:
    *
    */
   virtual void
-  VerifyInputInformation() ITKv5_CONST;
+  VerifyInputInformation() const;
 
   /** What is the input requested region that is required to produce the
    * output requested region? By default, the largest possible region is

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1327,7 +1327,7 @@ ProcessObject::PropagateResetPipeline()
 
 
 void
-ProcessObject::VerifyPreconditions() ITKv5_CONST
+ProcessObject::VerifyPreconditions() const
 {
   /**
    * Make sure that all the required named inputs are there and non null
@@ -1356,7 +1356,7 @@ ProcessObject::VerifyPreconditions() ITKv5_CONST
 
 
 void
-ProcessObject::VerifyInputInformation() ITKv5_CONST
+ProcessObject::VerifyInputInformation() const
 {}
 
 

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
@@ -135,7 +135,7 @@ protected:
   AfterThreadedGenerateData() override;
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   OutputPixelType m_DifferenceThreshold{};
 

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -265,7 +265,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::AfterThreadedGenerateData()
 
 template <typename TInputImage, typename TOutputImage>
 void
-ComparisonImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+ComparisonImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
   if (m_VerifyInputInformation)
   {

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -155,7 +155,7 @@ protected:
   GenerateOutputInformation() override;
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   void
   GenerateData() override;

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
@@ -36,7 +36,7 @@ TransformGeometryImageFilter<TInputImage, TOutputImage>::TransformGeometryImageF
 
 template <typename TInputImage, typename TOutputImage>
 void
-TransformGeometryImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+TransformGeometryImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -154,7 +154,7 @@ protected:
   /** Default superclass implementation ensures that input images
    * occupy same physical space. This is not needed for this filter. */
   void
-  VerifyInputInformation() ITKv5_CONST override{};
+  VerifyInputInformation() const override{};
 
 private:
   bool m_Normalize{ false };

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -248,7 +248,7 @@ protected:
 
   /** Overlap the VerifyInputInformation method */
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   /** Standard pipeline method.*/
   void

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -600,7 +600,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>::VerifyInputInformation() ITKv5_CONST
+MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>::VerifyInputInformation() const
 {
   // Call the superclass' implementation of this method.
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -312,7 +312,7 @@ protected:
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /** Enables backwards compatibility for enum values */
   using GradientImageTypeEnumeration = DiffusionTensor3DReconstructionImageFilterEnums::GradientImageFormat;

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -642,7 +642,7 @@ void
 DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
                                            TGradientImagePixelType,
                                            TTensorPixelType,
-                                           TMaskImageType>::VerifyPreconditions() ITKv5_CONST
+                                           TMaskImageType>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -246,7 +246,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   virtual void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   void
   Initialize(LevelSetImageType *) override;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -60,7 +60,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::os
 
 template <typename TLevelSet, typename TSpeedImage>
 void
-FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::VerifyPreconditions() ITKv5_CONST
+FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -104,7 +104,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   /** Overrides GenerateOutputInformation() in order to produce
    * an image which has a different information than the first input.

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -34,7 +34,7 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::JoinSeriesImageFilter()
 
 template <typename TInputImage, typename TOutputImage>
 void
-JoinSeriesImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+JoinSeriesImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -135,7 +135,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -40,7 +40,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::HessianToObjec
 
 template <typename TInputImage, typename TOutputImage>
 void
-HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
   if (m_ObjectDimension >= ImageDimension)

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -107,7 +107,7 @@ public:
 
   /** Verifies the preconditions of this filter. */
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /** Method for evaluating the implicit function over the image. */
   void

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -65,8 +65,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
 
 template <typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType>
 void
-HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPixelType>::VerifyPreconditions()
-  ITKv5_CONST
+HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPixelType>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -155,7 +155,7 @@ protected:
   GenerateInputRequestedRegion() override;
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
   void
   GenerateData() override;
 

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
@@ -56,7 +56,7 @@ UnsharpMaskImageFilter<TInputImage, TOutputImage, TInternalPrecision>::GenerateI
 
 template <typename TInputImage, typename TOutputImage, typename TInternalPrecision>
 void
-UnsharpMaskImageFilter<TInputImage, TOutputImage, TInternalPrecision>::VerifyPreconditions() ITKv5_CONST
+UnsharpMaskImageFilter<TInputImage, TOutputImage, TInternalPrecision>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
   if (m_Threshold < 0.0)

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -188,7 +188,7 @@ protected:
 
   /* Checks the logic of FrequencyThresholds. */
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /* This is the box functor, which implements the filter's behavior. */
   void

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -111,7 +111,7 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::SetFrequencyThresholds
 
 template <typename TImageType, typename TFrequencyIterator>
 void
-FrequencyBandImageFilter<TImageType, TFrequencyIterator>::VerifyPreconditions() ITKv5_CONST
+FrequencyBandImageFilter<TImageType, TFrequencyIterator>::VerifyPreconditions() const
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
@@ -235,7 +235,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
 private:

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
@@ -113,7 +113,7 @@ protected:
   GenerateOutputInformation() override;
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
 private:
   SizeType m_UpperBoundaryCropSize{};

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -58,7 +58,7 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
 template <typename TInputImage, typename TOutputImage>
 void
-CropImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+CropImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
   Superclass::VerifyInputInformation();
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -179,7 +179,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
 private:

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
@@ -167,11 +167,11 @@ public:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   bool
   CanRunInPlace() const override;

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -78,7 +78,7 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::GenerateInputRequeste
 
 template <typename TInputImage, typename TSourceImage, typename TOutputImage>
 void
-PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -185,7 +185,7 @@ public:
   /* See superclass for doxygen. This method adds the additional check
    * that the output space is set */
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /** Get/Set the coordinate transformation.
    * Set the coordinate transform to use for resampling.  Note that this must
@@ -288,7 +288,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
   /** ResampleImageFilter produces an image which is a different size

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -102,7 +102,7 @@ template <typename TInputImage,
           typename TTransformPrecisionType>
 void
 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
-  VerifyPreconditions() ITKv5_CONST
+  VerifyPreconditions() const
 {
   this->Superclass::VerifyPreconditions();
   const ReferenceImageBaseType * const referenceImage = this->GetReferenceImage();

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
@@ -166,7 +166,7 @@ protected:
   ~SliceBySliceImageFilter() override = default;
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   void
   GenerateData() override;

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -54,7 +54,7 @@ SliceBySliceImageFilter<TInputImage,
                         TInputFilter,
                         TOutputFilter,
                         TInternalInputImageType,
-                        TInternalOutputImageType>::VerifyInputInformation() ITKv5_CONST
+                        TInternalOutputImageType>::VerifyInputInformation() const
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
@@ -154,7 +154,7 @@ protected:
 
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
 private:
   IndexType m_Start{};

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -302,7 +302,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
 template <class TInputImage, class TOutputImage>
 void
-SliceImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+SliceImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -148,7 +148,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
 private:
   typename TileImageType::Pointer m_TileImage{};

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -356,7 +356,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
 template <typename TInputImage, typename TOutputImage>
 void
-TileImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+TileImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
 
   // Do not call superclass's VerifyInputInformation method.

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -251,7 +251,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
 
   /** This function should be in an interpolator but none of the ITK
    * interpolators at this point handle edge conditions properly

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -100,7 +100,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::SetOutputParamet
 
 template <typename TInputImage, typename TOutputImage, typename TDisplacementField>
 void
-WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::VerifyInputInformation() ITKv5_CONST
+WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::VerifyInputInformation() const
 {
   if (ImageDimension != GetDisplacementField()->GetNumberOfComponentsPerPixel())
   {

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -98,7 +98,7 @@ protected:
   ~DivideImageFilter() override = default;
 
   void
-  VerifyPreconditions() ITKv5_CONST override
+  VerifyPreconditions() const override
   {
     Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -204,11 +204,11 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
   /** Compute min, max and mean of an image. */
   void

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -110,7 +110,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
 
 template <typename TInputImage, typename TOutputImage, typename THistogramMeasurement>
 void
-HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::VerifyPreconditions() ITKv5_CONST
+HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::VerifyPreconditions() const
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -217,7 +217,7 @@ protected:
   /* See superclass for doxygen. This method adds the additional check
    * that sigma is greater than zero. */
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
 private:
   /** Compute the N coefficients in the recursive filter. */

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -323,7 +323,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::ComputeRemainingCoeffic
 
 template <typename TInputImage, typename TOutputImage>
 void
-RecursiveGaussianImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+RecursiveGaussianImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() const
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -201,7 +201,7 @@ protected:
   GenerateData() override;
 
   void
-  VerifyPreconditions() ITKv5_CONST override
+  VerifyPreconditions() const override
   {
     Superclass::VerifyPreconditions();
     if (m_Calculator.IsNull())

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -118,7 +118,7 @@ protected:
   ~IntermodesThresholdImageFilter() override = default;
 
   void
-  VerifyPreconditions() ITKv5_CONST override
+  VerifyPreconditions() const override
   {
     Superclass::VerifyPreconditions();
     if (dynamic_cast<const CalculatorType *>(Superclass::GetCalculator()) == nullptr)

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -119,7 +119,7 @@ protected:
   }
 
   void
-  VerifyPreconditions() ITKv5_CONST override
+  VerifyPreconditions() const override
   {
     Superclass::VerifyPreconditions();
     if (dynamic_cast<const CalculatorType *>(Superclass::GetCalculator()) == nullptr)

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
@@ -144,7 +144,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
 private:

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -283,7 +283,7 @@ protected:
    * \sa ProcessObject::VerifyInputInformation
    */
   void
-  VerifyInputInformation() ITKv5_CONST override
+  VerifyInputInformation() const override
   {}
 
 private:

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -167,7 +167,7 @@ protected:
   /* See superclass for doxygen. This methods additionally checks that
    * the number of means is not 0. */
   void
-  VerifyPreconditions() ITKv5_CONST override;
+  VerifyPreconditions() const override;
 
 private:
   using MeansContainer = std::vector<RealPixelType>;

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -42,7 +42,7 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::SetImageRegion(const Im
 
 template <typename TInputImage, typename TOutputImage>
 void
-ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() const
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
@@ -141,7 +141,7 @@ protected:
   EnlargeOutputRequestedRegion(DataObject * output) override;
 
   void
-  VerifyInputInformation() ITKv5_CONST override;
+  VerifyInputInformation() const override;
   void
   GenerateData() override;
 };

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -61,7 +61,7 @@ IsolatedWatershedImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedR
 
 template <typename TInputImage, typename TOutputImage>
 void
-IsolatedWatershedImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+IsolatedWatershedImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 {
   Superclass::VerifyInputInformation();
 


### PR DESCRIPTION
The non-const API variants are no longer supported at compile-time.
    
    Replace 'ITKv5_CONST' with 'const'.
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

