### PR TITLE
ENH: Default to allow ITK_MACROEND_NOOP_STATEMENT

### DIFF
--- a/Documentation/docs/releases/5.1.md
+++ b/Documentation/docs/releases/5.1.md
@@ -138,7 +138,7 @@ In addition to the many other pixel types supported, the `itk` binary Python pac
 
 ITK has adopted a [*.clang-format*](https://github.com/InsightSoftwareConsortium/ITK/blob/master/.clang-format) coding style configuration file so a consistent coding style can automatically be applied to C++ code with the [`clang-format`](https://releases.llvm.org/download.html) binary. A consistent coding style is critical for readability and collaborative development.
 
-`clang-format` has been applied to the entire codebase. The Whitesmiths style of brace indentation, previously part of the [ITK Coding Style Guidelines](https://itk.org/ItkSoftwareGuide.pdf), is not supported by clang-format, so it has been replaced by a brace style consistent with VTK's current style.
+`clang-format` has been applied to the entire code base. The Whitesmiths style of brace indentation, previously part of the [ITK Coding Style Guidelines](https://itk.org/ItkSoftwareGuide.pdf), is not supported by clang-format, so it has been replaced by a brace style consistent with VTK's current style.
 
 A Git commit hook will automatically apply `clang-format` to changed C++ code.
 

--- a/Documentation/docs/scientific_ecosystem/itk_ecosystem.md
+++ b/Documentation/docs/scientific_ecosystem/itk_ecosystem.md
@@ -1,6 +1,6 @@
 # ITK ecosystem
 
-Together with the core ITK codebase, a number of other projects and
+Together with the core ITK code base, a number of other projects and
 frameworks are maintained allowing to leverage the power of ITK beyond
 its natural boundaries:
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -82,7 +82,7 @@ namespace itk
 
 /* NOTE:  The ITK_MACROEND_NOOP_STATEMENT is used at the end
  * of ITK supported macros to ensure that when the macro
- * is used in the codebase that the line must have ';' after
+ * is used in the code base that the line must have ';' after
  * the macro is used. This makes formatting visually similar
  * to functions, and greatly improves the clang-format
  * behaviors for indentation.  This also assists

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -68,29 +68,28 @@ namespace itk
 #define itkNotUsed(x)
 
 // clang-format off
-
 /** The `static_assert(true, "")`  idiom is commonly employed for
  *  C++11 or greater to ensure that it is compile-time only
  *  check that can not be part of the binary file.
- *  This allows a macro to be used anywhere that a statement
- *  is expected, and to enforce consistent use of ; after
- *  a macro. The static_assert is a constexpr that can be used
- *  in places where raw statements (i.e. 'do{} while(0)') are
+ *
+ *  The ITK_NOOP_STATEMENT idiom allows a macro to be used anywhere
+ *  that a statement is expected, and to enforce consistent use of
+ *  ';' after a macro. The static_assert is a constexpr that can be
+ *  used in places where raw statements (i.e. 'do{} while(0)') are
  *  not allowed (i.e. after class member function definitions).
  *  */
 #define ITK_NOOP_STATEMENT static_assert(true, "")
 
-
-#if defined(ITK_FUTURE_LEGACY_REMOVE)
-
-#  define ITK_MACROEND_NOOP_STATEMENT ITK_NOOP_STATEMENT
-#else
-/* NOTE:  The ITK_MACROEND_NOOP_STATEMENT must be defined to nothing
- * in order to maintain backwards compatibility with earlier macro
- * uses that may or may not have ';' after the macro is used. */
-/* Purposefully empty */
-#  define ITK_MACROEND_NOOP_STATEMENT
-#endif
+/* NOTE:  The ITK_MACROEND_NOOP_STATEMENT is used at the end
+ * of ITK supported macros to ensure that when the macro
+ * is used in the codebase that the line must have ';' after
+ * the macro is used. This makes formatting visually similar
+ * to functions, and greatly improves the clang-format
+ * behaviors for indentation.  This also assists
+ * modern IDE's and removes 1000's of warnings about
+ * unused statements or unnecessary ';' when macros are
+ * used. */
+#define ITK_MACROEND_NOOP_STATEMENT ITK_NOOP_STATEMENT
 // clang-format on
 
 // Define ITK_PRAGMA macro.

--- a/Modules/Remote/Deprecated/NeuralNetworks.remote.cmake
+++ b/Modules/Remote/Deprecated/NeuralNetworks.remote.cmake
@@ -36,7 +36,7 @@
 #-- ### Please document here any justification for the criteria above
 #       This outdated code is not recommended for use. It is not optimized or rigourously tested
 #       This module has not received updates or testing for many many years
-#       Core developers should *NOT* expend energy or resources keeping this codebase consistent with ITK
+#       Core developers should *NOT* expend energy or resources keeping this code base consistent with ITK
 
 if(NOT ITK_LEGACY_REMOVE
    AND ITKV4_COMPATIBILITY

--- a/Utilities/ITKv5Preparation/CheckForOutdatedDefines.sh
+++ b/Utilities/ITKv5Preparation/CheckForOutdatedDefines.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # \author Hans J. Johnson
 #
-# This script simply checks a codebase for pre-processor
+# This script simply checks a code base for pre-processor
 # macros that have been deprecated since ITKv5.
 #
 # This is intended to assist developers with


### PR DESCRIPTION
The ITK_MACROEND_NOOP_STATEMENT is always supported in compilers, 
and allows macros to be used with
semi-colons without warnings or clang-format
inconsistencies.

related to #4699 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

NOTE: Does require ';' at the end of ITK macros when used.  This greatly simplifies meeting the clang-format desired formatting behaviors in the code base.