### PR TITLE
COMP: Fix python wrapping build state to match python version

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -391,8 +391,9 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
   if(ITK_WRAP_PYTHON_VERSION VERSION_GREATER_EQUAL 3.11)
     set(use_python_limited_api_default 1)
   endif()
-  set(ITK_USE_PYTHON_LIMITED_API ${use_python_limited_api_default} CACHE BOOL "Use Python's limited API for Python minor version compatibility.")
+  set(ITK_USE_PYTHON_LIMITED_API ${use_python_limited_api_default} CACHE BOOL "Use Python's limited API for Python minor version compatibility." FORCE)
   mark_as_advanced(ITK_USE_PYTHON_LIMITED_API)
+  unset(use_python_limited_api_default)
 
   # build all the c++ files from this module in a common lib
   if(NOT TARGET ${lib})


### PR DESCRIPTION
If initially configured with python >= 3.11 before selecting a python version <3.11 as the python environment, then the state of the ITK_USE_PYTHON_LIMITED_API was incorrectly cached to retain the compiler settings desired for building with the original 3.11 python version.

Py_buffer is only included as part of the limited
Python API in 3.11 or greater versions.

Compilation would fail due to building with
-DPy_LIMITED_API to restrict the Python interfaces available.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

