### PR TITLE
STYLE: Add `constexpr` to `if (Dimension ...)` statements

### DIFF
--- a/Modules/Core/Common/include/itkCrossHelper.h
+++ b/Modules/Core/Common/include/itkCrossHelper.h
@@ -51,13 +51,13 @@ public:
   {
     VectorType oCross;
 
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       oCross[0] = iU[1] * iV[2] - iV[1] * iU[2];
       oCross[1] = iV[0] * iU[2] - iU[0] * iV[2];
       oCross[2] = iU[0] * iV[1] - iV[0] * iU[1];
 
-      if (Dimension > 3)
+      if constexpr (Dimension > 3)
       {
         for (unsigned int dim = 3; dim < Dimension; ++dim)
         {

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -521,7 +521,7 @@ operator<<(std::ostream & os, const Index<VDimension> & obj)
   {
     os << obj[i] << ", ";
   }
-  if (VDimension >= 1)
+  if constexpr (VDimension >= 1)
   {
     os << obj[VDimension - 1];
   }

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -464,7 +464,7 @@ operator<<(std::ostream & os, const Offset<VDimension> & ind)
   {
     os << ind[i] << ", ";
   }
-  if (VDimension >= 1)
+  if constexpr (VDimension >= 1)
   {
     os << ind[VDimension - 1];
   }

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -263,7 +263,7 @@ std::ostream &
 operator<<(std::ostream & os, const Point<T, TPointDimension> & vct)
 {
   os << '[';
-  if (TPointDimension == 1)
+  if constexpr (TPointDimension == 1)
   {
     os << vct[0];
   }

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -435,7 +435,7 @@ operator<<(std::ostream & os, const Size<VDimension> & obj)
   {
     os << obj[i] << ", ";
   }
-  if (VDimension >= 1)
+  if constexpr (VDimension >= 1)
   {
     os << obj[VDimension - 1];
   }

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -28,43 +28,46 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
 {
   this->InitializeToZero();
 
-  // Note that this code is only good for 2d and 3d operators.  Places the
-  // coefficients in the exact center of the neighborhood
-  const unsigned int center = this->GetCenterNeighborhoodIndex();
-
-  if (VDimension == 3)
+  if constexpr (VDimension == 2 || VDimension == 3)
   {
-    unsigned int coeff_index = 0;
-    for (int z = -1; z <= 1; ++z)
+    // Note that this code is only good for 2d and 3d operators.  Places the
+    // coefficients in the exact center of the neighborhood
+    const unsigned int center = this->GetCenterNeighborhoodIndex();
+
+    if constexpr (VDimension == 3)
     {
+      unsigned int coeff_index = 0;
+      for (int z = -1; z <= 1; ++z)
+      {
+        for (int y = -1; y <= 1; ++y)
+        {
+          for (int x = -1; x <= 1; ++x)
+          {
+            const int pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
+
+            this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
+
+            ++coeff_index;
+          }
+        }
+      }
+    }
+    else // So now VDimension == 2
+    {
+      unsigned int coeff_index = 0;
       for (int y = -1; y <= 1; ++y)
       {
         for (int x = -1; x <= 1; ++x)
         {
-          const int pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
-
+          const int pos = center + y * this->GetStride(1) + x * this->GetStride(0);
+          // Note, The following line copies the double precision
+          // coefficients of SobelOperator to the pixel type
+          // of the neighborhood operator which may not support
+          // negative numbers, or floating point numbers.
           this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
 
           ++coeff_index;
         }
-      }
-    }
-  }
-  else if (VDimension == 2)
-  {
-    unsigned int coeff_index = 0;
-    for (int y = -1; y <= 1; ++y)
-    {
-      for (int x = -1; x <= 1; ++x)
-      {
-        const int pos = center + y * this->GetStride(1) + x * this->GetStride(0);
-        // Note, The following line copies the double precision
-        // coefficients of SobelOperator to the pixel type
-        // of the neighborhood operator which may not support
-        // negative numbers, or floating point numbers.
-        this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
-
-        ++coeff_index;
       }
     }
   }

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -167,7 +167,7 @@ std::ostream &
 operator<<(std::ostream & os, const Vector<T, TVectorDimension> & vct)
 {
   os << '[';
-  if (TVectorDimension == 1)
+  if constexpr (TVectorDimension == 1)
   {
     os << vct[0];
   }

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -133,7 +133,7 @@ NeighborhoodAlgorithmTest()
   region.SetIndex(ind);
 
   size.Fill(5);
-  if (VDimension > 1)
+  if constexpr (VDimension > 1)
   {
     size[VDimension - 1] = 1;
   }
@@ -184,7 +184,7 @@ NeighborhoodAlgorithmTest()
     return false;
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     ind[0] = 0;
     ind[1] = 249;

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -864,7 +864,7 @@ itkVectorImageTest(int, char * argv[])
         failed = true;
       }
 
-      if (Dimension == 3)
+      if constexpr (Dimension == 3)
       {
 
         //

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -114,7 +114,7 @@ MetaBlobConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
     Blob->GetPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     Blob->PointDim("x y red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -172,11 +172,11 @@ MetaContourConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     contourMO->GetControlPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     contourMO->ControlPointDim("id x y xp yp v1 v2 r g b a");
   }
-  else if (VDimension == 3)
+  else if constexpr (VDimension == 3)
   {
     contourMO->ControlPointDim("id x y z xp yp zp v1 v2 v3 r gn be a");
   }
@@ -201,11 +201,11 @@ MetaContourConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     contourMO->GetInterpolatedPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     contourMO->InterpolatedPointDim("id x y r g b a");
   }
-  else if (VDimension == 3)
+  else if constexpr (VDimension == 3)
   {
     contourMO->InterpolatedPointDim("id x y z r g b a");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -278,7 +278,7 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     {
       pnt->AddField("v1x", it->GetNormal1InObjectSpace()[0]);
       pnt->AddField("v1y", it->GetNormal1InObjectSpace()[1]);
-      if (VDimension == 3)
+      if constexpr (VDimension == 3)
       {
         pnt->AddField("v1z", it->GetNormal1InObjectSpace()[2]);
       }
@@ -288,7 +288,7 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     {
       pnt->AddField("v2x", it->GetNormal2InObjectSpace()[0]);
       pnt->AddField("v2y", it->GetNormal2InObjectSpace()[1]);
-      if (VDimension == 3)
+      if constexpr (VDimension == 3)
       {
         pnt->AddField("v2z", it->GetNormal2InObjectSpace()[2]);
       }
@@ -298,7 +298,7 @@ MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     {
       pnt->AddField("tx", it->GetTangentInObjectSpace()[0]);
       pnt->AddField("ty", it->GetTangentInObjectSpace()[1]);
-      if (VDimension == 3)
+      if constexpr (VDimension == 3)
       {
         pnt->AddField("tz", it->GetTangentInObjectSpace()[2]);
       }

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -112,7 +112,7 @@ MetaLandmarkConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObject
     landmarkMO->GetPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     landmarkMO->PointDim("x y red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -134,11 +134,11 @@ MetaLineConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType
     lineMO->GetPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     lineMO->PointDim("x y v1x v1y v2x v2y red green blue alpha");
   }
-  else if (VDimension == 3)
+  else if constexpr (VDimension == 3)
   {
     lineMO->PointDim("x y z v1x v1y v1z v2x v2y v2z red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -123,11 +123,11 @@ MetaSurfaceConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectT
     surfaceMO->GetPoints().push_back(pnt);
   }
 
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     surfaceMO->PointDim("x y v1 v2 red green blue alpha");
   }
-  else if (VDimension == 3)
+  else if constexpr (VDimension == 3)
   {
     surfaceMO->PointDim("x y z v1 v2 v3 red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -194,7 +194,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
       PointType v2 = this->m_Points[identifier[1]].GetPositionInObjectSpace();
       PointType v3 = this->m_Points[identifier[2]].GetPositionInObjectSpace();
 
-      if (TDimension == 3)
+      if constexpr (TDimension == 3)
       {
         double coa = -(v1[1] * (v2[2] - v3[2]) + v2[1] * (v3[2] - v1[2]) + v3[1] * (v1[2] - v2[2]));
         double cob = -(v1[2] * (v2[0] - v3[0]) + v2[2] * (v3[0] - v1[0]) + v3[2] * (v1[0] - v2[0]));

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -427,7 +427,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()
 
     // Compute the normal
     CovariantVectorType n1;
-    if (TDimension == 2)
+    if constexpr (TDimension == 2)
     {
       // The normal to the tangent in 2D is the orthogonal direction to the tangent.
       n1[0] = t[1];
@@ -447,7 +447,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()
       ((TubePointType *)(this->GetPoint(it1)))->SetNormal1InObjectSpace(n1);
       prevN1 = n1;
     }
-    else if (TDimension == 3)
+    else if constexpr (TDimension == 3)
     {
       // The normal to the tangent in 3D is the cross product of adjacent tangent directions.
       n1[0] = t[1] * t2[2] - t[2] * t2[1];

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -192,7 +192,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::MRIBiasFiel
 {
   m_NormalVariateGenerator->Initialize(time(nullptr));
 
-  if (ImageDimension == 3)
+  if constexpr (ImageDimension == 3)
   {
     m_UsingInterSliceIntensityCorrection = true;
     m_SlicingDirection = 2;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -35,7 +35,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField,
   this->m_NumberOfTimePoints = 0;
   this->SetNumberOfRequiredInputs(1);
 
-  if (InputImageDimension - 1 != OutputImageDimension)
+  if constexpr (InputImageDimension - 1 != OutputImageDimension)
   {
     itkExceptionMacro("The time-varying velocity field (input) should have "
                       << "dimensionality of 1 greater than the deformation field (output). ");

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -570,13 +570,13 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
   // Initialize indices if this->m_TopologyCheck is activated
   if (this->m_TopologyCheck != Superclass::TopologyCheckEnum::Nothing)
   {
-    if (ImageDimension == 2)
+    if constexpr (ImageDimension == 2)
     {
       InitializeIndices2D();
     }
     else
     {
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       {
         InitializeIndices3D();
       }
@@ -596,7 +596,7 @@ bool
 FastMarchingImageFilterBase<TInput, TOutput>::DoesVoxelChangeViolateWellComposedness(const NodeType & idx) const
 {
   bool isChangeWellComposed = false;
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     isChangeWellComposed = this->IsChangeWellComposed2D(idx);
   }

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
@@ -36,7 +36,7 @@ GPUScalarAnisotropicDiffusionFunction<TImage>::GPUScalarAnisotropicDiffusionFunc
   // load GPU kernel
   std::ostringstream defines;
 
-  if (ImageDimension > 3 || ImageDimension < 1)
+  if constexpr (ImageDimension > 3 || ImageDimension < 1)
   {
     itkExceptionMacro("GPUScalarAnisotropicDiffusionFunction supports 1/2/3D image.");
   }

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
@@ -67,7 +67,7 @@ runGPUMeanImageFilterTest(const std::string & inFile, const std::string & outFil
   typename InputImageType::SizeType indexRadius;
   indexRadius[0] = 2; // radius along x
   indexRadius[1] = 2; // radius along y
-  if (VImageDimension > 2)
+  if constexpr (VImageDimension > 2)
   {
     indexRadius[2] = 2; // radius along z
   }

--- a/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
@@ -71,7 +71,7 @@ runGPUImageFilterTest(const std::string & inFile, const std::string & outFile)
   typename InputImageType::SizeType indexRadius;
   indexRadius[0] = 2; // radius along x
   indexRadius[1] = 2; // radius along y
-  if (VImageDimension > 2)
+  if constexpr (VImageDimension > 2)
   {
     indexRadius[2] = 2; // radius along z
   }

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -176,7 +176,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
 
   // Create a chain of filters
-  if (ImageDimension == 1)
+  if constexpr (ImageDimension == 1)
   {
     // Use just a single filter
     SingleFilterPointer singleFilter = SingleFilterType::New();
@@ -212,7 +212,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     // Middle filters convolves from real to real
     std::vector<IntermediateFilterPointer> intermediateFilters;
-    if (ImageDimension > 2)
+    if constexpr (ImageDimension > 2)
     {
       const unsigned int max_dim = ImageDimension - 1;
       for (unsigned int i = 1; i != max_dim; ++i)
@@ -239,7 +239,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
     LastFilterPointer lastFilter = LastFilterType::New();
     lastFilter->SetOperator(oper[ImageDimension - 1]);
     lastFilter->ReleaseDataFlagOn();
-    if (ImageDimension > 2)
+    if constexpr (ImageDimension > 2)
     {
       const unsigned int temp_dim = ImageDimension - 3;
       lastFilter->SetInput(intermediateFilters[temp_dim]->GetOutput());

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -217,7 +217,7 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Because the output of last filter in the mini-pipeline is not
   // pipelined the data must be manually released
-  if (ImageDimension > 1)
+  if constexpr (ImageDimension > 1)
   {
     m_SmoothingFilters[ImageDimension - 2]->GetOutput()->ReleaseData();
   }

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -33,7 +33,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursi
 
   static_assert(ImageDimension > 0, "Images shall have one dimension at least");
   const unsigned int imageDimensionMinus1 = ImageDimension - 1;
-  if (ImageDimension > 1)
+  if constexpr (ImageDimension > 1)
   {
     m_SmoothingFilters.resize(imageDimensionMinus1);
 
@@ -54,7 +54,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursi
   m_DerivativeFilter->InPlaceOff();
   m_DerivativeFilter->SetInput(this->GetInput());
 
-  if (ImageDimension > 1)
+  if constexpr (ImageDimension > 1)
   {
     m_SmoothingFilters[0]->SetInput(m_DerivativeFilter->GetOutput());
     for (unsigned int i = 1; i != imageDimensionMinus1; ++i)
@@ -174,7 +174,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   static_assert(ImageDimension > 0, "Images shall have one dimension at least");
   const unsigned int imageDimensionMinus1 = ImageDimension - 1;
-  if (ImageDimension > 1)
+  if constexpr (ImageDimension > 1)
   {
     for (unsigned int i = 0; i != imageDimensionMinus1; ++i)
     {
@@ -231,7 +231,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
       GaussianFilterPointer lastFilter;
 
-      if (ImageDimension > 1)
+      if constexpr (ImageDimension > 1)
       {
         const auto imageDimensionMinus2 = static_cast<unsigned int>(ImageDimension - 2);
         lastFilter = m_SmoothingFilters[imageDimensionMinus2];
@@ -247,7 +247,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       m_ImageAdaptor->SelectNthElement(nc * ImageDimension + dim);
 
       typename RealImageType::Pointer derivativeImage;
-      if (ImageDimension > 1)
+      if constexpr (ImageDimension > 1)
       {
         derivativeImage = lastFilter->GetOutput();
       }
@@ -276,7 +276,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
 
   // manually release memory in last filter in the mini-pipeline
-  if (ImageDimension > 1)
+  if constexpr (ImageDimension > 1)
   {
     int temp_dim = static_cast<int>(ImageDimension) - 2;
     m_SmoothingFilters[temp_dim]->GetOutput()->ReleaseData();

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -216,7 +216,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
 
     if (m_UsePrincipleComponents)
     {
-      if (ImageDimension == 3)
+      if constexpr (ImageDimension == 3)
       { // Use the specialized eigensolve which can be threaded
         while (!bit.IsAtEnd())
         {

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
@@ -51,7 +51,7 @@ PadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent i
 
   os << indent << "Output Pad Lower Bounds: [";
 
-  if (ImageDimension >= 1)
+  if constexpr (ImageDimension >= 1)
   {
     os << m_PadLowerBound[0];
   }
@@ -62,7 +62,7 @@ PadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent i
   os << ']' << std::endl;
 
   os << indent << "Output Pad Upper Bounds: [";
-  if (ImageDimension >= 1)
+  if constexpr (ImageDimension >= 1)
   {
     os << m_PadUpperBound[0];
   }

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -81,7 +81,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
     Transform<TTransformPrecisionType, Self::OutputImageDimension, Self::OutputImageDimension>;
   typename IdentityTransformType::Pointer defaultTransform =
     IdentityTransform<TTransformPrecisionType, OutputImageDimension>::New();
-  if (InputImageDimension == OutputImageDimension)
+  if constexpr (InputImageDimension == OutputImageDimension)
   {
     using DecoratorType = DataObjectDecorator<IdentityTransformType>;
     auto decoratedInput = DecoratorType::New();
@@ -597,7 +597,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   GenerateOutputInformation()
 {
   // Call the superclass' implementation of this method
-  if (InputImageDimension == OutputImageDimension)
+  if constexpr (InputImageDimension == OutputImageDimension)
   {
     Superclass::GenerateOutputInformation();
   }

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -32,7 +32,7 @@ itkGaborImageSourceTestHelper(char * outputFilename, bool calculcateImaginaryPar
   using GaborSourceType = itk::GaborImageSource<ImageType>;
   auto gaborImage = GaborSourceType::New();
 
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     typename ImageType::SizeType size;
     size.Fill(64 * 4);
@@ -40,7 +40,7 @@ itkGaborImageSourceTestHelper(char * outputFilename, bool calculcateImaginaryPar
   }
 
   typename GaborSourceType::ArrayType sigma;
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     sigma[0] = 2.0;
     sigma[1] = 5.0;

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -345,7 +345,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   double elongation = 0;
   double flatness = 0;
-  if (ImageDimension < 2)
+  if constexpr (ImageDimension < 2)
   {
     elongation = 1;
     flatness = 1;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -266,7 +266,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
       principalAxes[ImageDimension - 1][i] *= std::real(det);
     }
 
-    if (ImageDimension < 2)
+    if constexpr (ImageDimension < 2)
     {
       elongation = 1;
       flatness = 1;

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -333,7 +333,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 
   mat.SetIdentity();
 
-  if (VDimension == 3)
+  if constexpr (VDimension == 3)
   { // there are problems with 4D direction cosines!
     // 30deg rotation
     mat[1][1] = mat[0][0] = 0.866025403784439;
@@ -598,7 +598,7 @@ MINCReadWriteTestVector(const char * fileName,
 
   mat.SetIdentity();
 
-  if (VDimension == 3)
+  if constexpr (VDimension == 3)
   { // there are problems with 4D direction cosines!
     // 30deg rotation
     mat[1][1] = mat[0][0] = 0.866025403784439;

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -291,7 +291,7 @@ public:
 protected:
   MINCTransformAdapter()
   {
-    if (VInputDimension != 3 || VOutputDimension != 3)
+    if constexpr (VInputDimension != 3 || VOutputDimension != 3)
     {
       itkExceptionMacro("MINC transform is currently implemented only for 3D to 3D.");
     }

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -54,11 +54,11 @@ vnl_matrix<double> inline CalculateRotationMatrix(const vnl_symmetric_eigensyste
   // can fix this by making one of them negative.  Make the last
   // eigenvector (with smallest eigenvalue) negative.
   float matrixDet;
-  if (VDimension == 2)
+  if constexpr (VDimension == 2)
   {
     matrixDet = vnl_det(rotationMatrix[0], rotationMatrix[1]);
   }
-  else if (VDimension == 3)
+  else if constexpr (VDimension == 3)
   {
     matrixDet = vnl_det(rotationMatrix[0], rotationMatrix[1], rotationMatrix[2]);
   }

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -166,7 +166,7 @@ LabelGeometryImageFilterTest(std::string labelImageName,
 
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[0];
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[1];
-    if (VDimension == 3)
+    if constexpr (VDimension == 3)
     {
       matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[2];
     }
@@ -176,7 +176,7 @@ LabelGeometryImageFilterTest(std::string labelImageName,
     }
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[0];
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[1];
-    if (VDimension == 3)
+    if constexpr (VDimension == 3)
     {
       matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[2];
     }

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -621,7 +621,7 @@ ImageMetricLoad<TMoving, TFixed>::GetPolynomialFitToMetric(VectorType Gpos, Vect
     tindex[k] = static_cast<long>(Gpos[k] + 0.5) - static_cast<long>(regionRadius[k]) / 2;
   }
 
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     double measure[3][3];
     for (int row = -1; row < 2; ++row)
@@ -670,7 +670,7 @@ ImageMetricLoad<TMoving, TFixed>::GetPolynomialFitToMetric(VectorType Gpos, Vect
       }
     }
   }
-  else if (ImageDimension == 3)
+  else if constexpr (ImageDimension == 3)
   {
     double measure3D[3][3][3];
     for (int row = -1; row < 2; ++row)

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -171,11 +171,11 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
     return;
   }
 
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     this->Generate2DQuadrilateralMesh();
   }
-  else if (ImageDimension == 3)
+  else if constexpr (ImageDimension == 3)
   {
     this->Generate3DHexahedralMesh();
   }

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -348,7 +348,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   }
 
   // Sanity check
-  if (ImageDimension != 3)
+  if constexpr (ImageDimension != 3)
   {
     itkExceptionMacro("Transform is VersorRigid3DTransform and Fixed image dimension is not 3");
   }
@@ -480,7 +480,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   }
 
   // Sanity check for dimension.
-  if (ImageDimension != 3)
+  if constexpr (ImageDimension != 3)
   {
     itkExceptionMacro("Transform is Similiarity3DTransform and Fixed image dimension is not 3");
   }
@@ -628,7 +628,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     itkExceptionMacro("Rigid2DTransformType Expected but transform is " << this->m_Transform->GetNameOfClass());
   }
   // Sanity check.
-  if (ImageDimension != 2)
+  if constexpr (ImageDimension != 2)
   {
     itkExceptionMacro("Transform is Rigid2DTransform and Fixed image dimension is not 2");
   }

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -658,7 +658,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::InterpolateVectorF
   Sol.set_size(ImageDimension);
   Gpt.set_size(ImageDimension);
 
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     Element::ConstPointer eltp;
     for (; !fieldIter.IsAtEnd(); ++fieldIter)
@@ -697,7 +697,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::InterpolateVectorF
     }
   }
 
-  if (ImageDimension == 3)
+  if constexpr (ImageDimension == 3)
   {
     // FIXME SHOULD BE 2.0 over meshpixperelt
     rstep = 1.25 / (static_cast<double>(m_MeshPixelsPerElementAtEachResolution[m_CurrentLevel]));

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -132,7 +132,7 @@ CreateMesh(InputImageType * image, unsigned int elementWidth = 1)
   meshFilter->SetInput(image);
   meshFilter->SetPixelsPerElement(pixelsPerElement);
   auto material = MaterialType::New();
-  if (ImageDimension == 2)
+  if constexpr (ImageDimension == 2)
   {
     auto element = Element2DType::New();
     element->SetMaterial(material);

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -49,7 +49,7 @@ itkEuclideanDistancePointSetMetricTestRun()
     PointType fixedPoint;
     fixedPoint[0] = pointSetRadius * std::cos(theta);
     fixedPoint[1] = pointSetRadius * std::sin(theta);
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = pointSetRadius * std::sin(theta);
     }
@@ -58,7 +58,7 @@ itkEuclideanDistancePointSetMetricTestRun()
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }
@@ -136,7 +136,7 @@ itkEuclideanDistancePointSetMetricTestRun()
       moving_str1 << sourcePoint[d] << ' ';
       moving_str2 << targetPoint[d] << ' ';
     }
-    if (Dimension < 3)
+    if constexpr (Dimension < 3)
     {
       moving_str1 << "0 ";
       moving_str2 << "0 ";

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -61,7 +61,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   fixedPoint[0] = pointMax / 2.0;
   fixedPoint[1] = pointMax / 2.0;
   fixedPoints->SetPoint(4, fixedPoint);
-  if (Dimension == 3)
+  if constexpr (Dimension == 3)
   {
     fixedPoint[0] = pointMax / 2.0;
     fixedPoint[1] = pointMax / 2.0;
@@ -80,7 +80,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
     fixedPoint = fixedPoints->GetPoint(n);
     movingPoint[0] = fixedPoint[0] + (n + 1) * 0.5;
     movingPoint[1] = fixedPoint[1] - (n + 2) * 0.5;
-    if (Dimension == 3)
+    if constexpr (Dimension == 3)
     {
       movingPoint[2] = fixedPoint[2] + (n + 3) * 0.5;
     }

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -57,7 +57,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
   fixedPoint[0] = 0.0;
   fixedPoint[1] = pointMax;
   fixedPoints->SetPoint(2, fixedPoint);
-  if (Dimension == 3)
+  if constexpr (Dimension == 3)
   {
     fixedPoint[0] = 0.0;
     fixedPoint[1] = 0.0;
@@ -86,7 +86,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
       movingPoint[0] = fixedPoint[0] + 0.25;
       movingPoint[1] = fixedPoint[1];
     }
-    if (Dimension == 3)
+    if constexpr (Dimension == 3)
     {
       movingPoint[2] = fixedPoint[2] + 0.75;
     }
@@ -178,7 +178,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
     {
       derivativeTest[0] = derivativeTest[0] + tempDerivative[0];
       derivativeTest[1] = derivativeTest[1] + tempDerivative[1];
-      if (Dimension == 3)
+      if constexpr (Dimension == 3)
       {
         derivativeTest[2] = derivativeTest[2] + tempDerivative[2];
       }

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricRegistrationTest.cxx
@@ -115,7 +115,7 @@ itkExpectationBasedPointSetMetricRegistrationTest(int argc, char * argv[])
     float     radius = 100.0;
     fixedPoint[0] = radius * std::cos(theta);
     fixedPoint[1] = radius * std::sin(theta);
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = radius * std::sin(theta);
     }
@@ -124,7 +124,7 @@ itkExpectationBasedPointSetMetricRegistrationTest(int argc, char * argv[])
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -50,7 +50,7 @@ itkExpectationBasedPointSetMetricTestRun()
     float     radius = 100.0;
     fixedPoint[0] = radius * std::cos(theta);
     fixedPoint[1] = radius * std::sin(theta);
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = radius * std::sin(theta);
     }
@@ -59,7 +59,7 @@ itkExpectationBasedPointSetMetricTestRun()
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }
@@ -148,7 +148,7 @@ itkExpectationBasedPointSetMetricTestRun()
       moving_str1 << sourcePoint[d] << ' ';
       moving_str2 << targetPoint[d] << ' ';
     }
-    if (Dimension < 3)
+    if constexpr (Dimension < 3)
     {
       moving_str1 << "0 ";
       moving_str2 << "0 ";

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -52,7 +52,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
   // Create two simple images
   itk::SizeValueType   ImageSize = 100;
   itk::OffsetValueType boundary = 6;
-  if (Dimension == 3)
+  if constexpr (Dimension == 3)
   {
     ImageSize = 60;
     boundary = 4;

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
@@ -119,7 +119,7 @@ itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest(int argc, char * arg
     float     radius = 100.0;
     fixedPoint[0] = radius * std::cos(theta);
     fixedPoint[1] = radius * std::sin(theta);
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = radius * std::sin(theta);
     }
@@ -128,7 +128,7 @@ itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest(int argc, char * arg
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -60,7 +60,7 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
     // simplistic point set test:
     //    fixedPoint[0] = 1;
     //    fixedPoint[1] = 1;
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = radius * std::sin(theta);
       //      fixedPoint[2] = 1;
@@ -70,7 +70,7 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }
@@ -88,8 +88,6 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
 
   unsigned int numberOfAlphaValues = 6;
   float        alphaValues[] = { 1.0f, 1.2f, 1.4f, 1.6f, 1.8f, 2.0f };
-  float        metricValues2D[] = { 0.143842f, -0.0129571f, -0.00105768f, -0.000115118f, -1.40956e-05f, -1.84099e-06f };
-  float metricValues3D[] = { 0.175588f, -0.0086854f, -0.000475248f, -3.46729e-05f, -2.84585e-06f, -2.49151e-07f };
 
   unsigned int evaluationKNeighborhood = 50;
   auto         useAnisotropicCovariances = false;
@@ -153,15 +151,21 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
       }
     }
 
-    if (Dimension == 2)
+    if constexpr (Dimension == 2)
     {
+      static constexpr float metricValues2D[] = { 0.143842f,     -0.0129571f,   -0.00105768f,
+                                                  -0.000115118f, -1.40956e-05f, -1.84099e-06f };
+
       if (itk::Math::abs(value - metricValues2D[i]) > 0.01)
       {
         std::cerr << "calculated value is different than expected." << std::endl;
       }
     }
-    else if (Dimension == 3)
+    else if constexpr (Dimension == 3)
     {
+      static constexpr float metricValues3D[] = { 0.175588f,     -0.0086854f,   -0.000475248f,
+                                                  -3.46729e-05f, -2.84585e-06f, -2.49151e-07f };
+
       if (itk::Math::abs(value - metricValues3D[i]) > 0.01)
       {
         std::cerr << "calculated value is different than expected." << std::endl;
@@ -205,7 +209,7 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
         moving_str1 << sourcePoint[d] << ' ';
         moving_str2 << targetPoint[d] << ' ';
       }
-      if (Dimension < 3)
+      if constexpr (Dimension < 3)
       {
         moving_str1 << "0 ";
         moving_str2 << "0 ";

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -59,7 +59,7 @@ itkLabeledPointSetMetricTestRun()
     PointType fixedPoint;
     fixedPoint[0] = pointSetRadius * std::cos(theta);
     fixedPoint[1] = pointSetRadius * std::sin(theta);
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       fixedPoint[2] = pointSetRadius * std::sin(theta);
     }
@@ -69,7 +69,7 @@ itkLabeledPointSetMetricTestRun()
     PointType movingPoint;
     movingPoint[0] = fixedPoint[0] + offset[0];
     movingPoint[1] = fixedPoint[1] + offset[1];
-    if (Dimension > 2)
+    if constexpr (Dimension > 2)
     {
       movingPoint[2] = fixedPoint[2] + offset[2];
     }
@@ -158,7 +158,7 @@ itkLabeledPointSetMetricTestRun()
       moving_str1 << sourcePoint[d] << ' ';
       moving_str2 << targetPoint[d] << ' ';
     }
-    if (Dimension < 3)
+    if constexpr (Dimension < 3)
     {
       moving_str1 << "0 ";
       moving_str2 << "0 ";

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -34,11 +34,11 @@ LevelSetFunction<TImageType>::ComputeCurvatureTerm(const NeighborhoodType & neig
   }
   else
   {
-    if (ImageDimension == 3)
+    if constexpr (ImageDimension == 3)
     {
       return this->Compute3DMinimalCurvature(neighborhood, offset, gd);
     }
-    else if (ImageDimension == 2)
+    else if constexpr (ImageDimension == 2)
     {
       return this->ComputeMeanCurvature(neighborhood, offset, gd);
     }


### PR DESCRIPTION
Made it clearer that the condition of these `if` statements can be evaluated at compile-time.

----

Cases found by the regular expression ` if \(\w*Dimension `. Manually checked if the conditions could really be evaluated at compile-time.