### PR TITLE
COMP: -Wextra-semi new fix proposed

### DIFF
--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -39,7 +39,8 @@
     {                                                                                                          \
       v->VisitFromCell(cellid, this);                                                                          \
     }                                                                                                          \
-  }
+  }                                                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
 
 // Define a macro for the common type alias required by the
 // classes deriving form CellInterface (included).

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -696,7 +696,7 @@ OutputWindowDisplayDebugText(const char *);
   struct newtype : public oldtype                                         \
   {                                                                       \
     char _StructPadding[mincachesize - (sizeof(oldtype) % mincachesize)]; \
-  };
+  }
 
 //
 // itkAlignedTypedef is a macro which creates a new type to make a

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -27,7 +27,8 @@
   static constexpr ValueType min(ValueType) { return std::numeric_limits<ValueType>::min(); } \
   static constexpr ValueType max(ValueType) { return std::numeric_limits<ValueType>::max(); } \
   static constexpr ValueType min() { return std::numeric_limits<ValueType>::min(); }          \
-  static constexpr ValueType max() { return std::numeric_limits<ValueType>::max(); }
+  static constexpr ValueType max() { return std::numeric_limits<ValueType>::max(); }          \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #include <limits> // for std::numeric_limits
 #include <complex>

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -204,7 +204,8 @@ public:
     MakeFilled<GENERIC_ARRAY<T, D>>(NumericTraits<T>::Zero);                            \
   template <>                                                                           \
   ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::One =  \
-    MakeFilled<GENERIC_ARRAY<T, D>>(NumericTraits<T>::One);
+    MakeFilled<GENERIC_ARRAY<T, D>>(NumericTraits<T>::One);                             \
+  ITK_MACROEND_NOOP_STATEMENT
 
 //
 // List here the array dimension specializations of these static

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -899,7 +899,7 @@ protected:
   progressFixedToFloat(uint32_t fixed)
   {
     return static_cast<double>(fixed) / static_cast<double>(std::numeric_limits<uint32_t>::max());
-  };
+  }
 
   /**
    * Internal method convert floating point progress [0.0, 1.0] to internal integer representation. Values outside the
@@ -918,7 +918,7 @@ protected:
     }
     double temp = static_cast<double>(f) * std::numeric_limits<uint32_t>::max();
     return static_cast<uint32_t>(temp);
-  };
+  }
 
 
   /** Sets the required number of outputs, and creates each of them by MakeOutput. */

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -60,7 +60,7 @@ struct Identity
   struct SizeToType<VTypeEnum, TA, TB>  \
   {                                     \
     using Type = Typed;                 \
-  };
+  }
 
 ITK_ASSOCIATE(1, TA);
 ITK_ASSOCIATE(2, TB);

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -38,7 +38,7 @@ const TValueType *
 GetPointerToMatrixData(const vnl_matrix_fixed<TValueType, VRows, VColumns> & inputMatrix)
 {
   return inputMatrix.data_block();
-};
+}
 template <typename TValueType>
 const TValueType *
 GetPointerToMatrixData(const vnl_matrix<TValueType> & inputMatrix)
@@ -51,7 +51,7 @@ const TValueType *
 GetPointerToMatrixData(const itk::Matrix<TValueType, VRows, VColumns> & inputMatrix)
 {
   return inputMatrix.GetVnlMatrix().data_block();
-};
+}
 
 /** Sort input to be ordered by magnitude, and returns container with the
  * permutations required for the sorting.

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -244,7 +244,7 @@ public:
       m_Pos += n;
       m_Iter += n;
       return *this;
-    };
+    }
 
     /** Get the index into the VectorContainer associated with this iterator.
      */
@@ -335,7 +335,7 @@ public:
       m_Pos += n;
       m_Iter += n;
       return *this;
-    };
+    }
 
     difference_type
     operator-(const ConstIterator & r) const

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -302,14 +302,14 @@ private:
 
   /** Methods have empty implementations */
   void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const override{};
+  SetFixedParametersGridSizeFromTransformDomainInformation() const override{}
   void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const override{};
+  SetFixedParametersGridOriginFromTransformDomainInformation() const override{}
   void
   SetFixedParametersGridSpacingFromTransformDomainInformation() const override
   {}
   void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const override{};
+  SetFixedParametersGridDirectionFromTransformDomainInformation() const override{}
 
   /** Check if a continuous index is inside the valid region. */
   bool

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -154,7 +154,7 @@ protected:
   /** Default superclass implementation ensures that input images
    * occupy same physical space. This is not needed for this filter. */
   void
-  VerifyInputInformation() const override{};
+  VerifyInputInformation() const override{}
 
 private:
   bool m_Normalize{ false };

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -166,7 +166,7 @@ public:
 
   /** Trigger the computation of the displacement field by integrating the velocity field. */
   virtual void
-  IntegrateVelocityField(){};
+  IntegrateVelocityField(){}
 
   /**
    * Set the lower time bound defining the integration domain of the transform.

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -48,7 +48,7 @@ class NullImageToImageFilterDriver
 {
 public:
   NullImageToImageFilterDriver()
-    : m_Filter(nullptr){};
+    : m_Filter(nullptr){}
 
   using ImageSizeType = typename TInputImage::SizeType;
   using InputPixelType = typename TInputImage::PixelType;

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -239,7 +239,7 @@ public:
   SetActualXDimensionIsOdd(bool value)
   {
     this->m_ActualXDimensionIsOdd = value;
-  };
+  }
   itkGetMacro(ActualXDimensionIsOdd, bool);
   itkBooleanMacro(ActualXDimensionIsOdd);
 

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -169,7 +169,7 @@ public:
   {
     m_Threshold = 1e-5 * NumericTraits<TDenominator>::OneValue();
     m_Constant = TOutput{};
-  };
+  }
 
   ~DivideOrZeroOut() = default;
 

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -37,7 +37,7 @@
 #include <string>
 #include <list>
 /** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility()); */
-#define IPLSetMacroDeclaration(name, type) virtual void Set##name(const type _arg);
+#define IPLSetMacroDeclaration(name, type) virtual void Set##name(const type _arg)
 
 #define IPLSetMacroDefinition(class, name, type) \
   void class ::Set##name(const type _arg)        \
@@ -49,14 +49,15 @@
       this->m_##name = _arg;                     \
     }                                            \
     ITK_GCC_PRAGMA_POP                           \
-  }
+  }                                              \
+  ITK_MACROEND_NOOP_STATEMENT
 
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility()); */
-#define IPLGetMacroDeclaration(name, type) virtual type Get##name();
+#define IPLGetMacroDeclaration(name, type) virtual type Get##name()
 
-#define IPLGetMacroDefinition(class, name, type) \
-  type class ::Get##name() { return this->m_##name; }
-
+#define IPLGetMacroDefinition(class, name, type)      \
+  type class ::Get##name() { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
 namespace itk
 {
 /**

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -522,24 +522,24 @@ private:
   void SetMinimumConvergenceValue(PrecisionType) override
   {
     itkWarningMacro("Not supported. Please use LBFGS specific convergence methods.");
-  };
+  }
   void SetConvergenceWindowSize(SizeValueType) override
   {
     itkWarningMacro("Not supported. Please use LBFGS specific convergence methods.");
-  };
+  }
   const PrecisionType &
   GetConvergenceValue() const override
   {
     itkWarningMacro("Not supported. Please use LBFGS specific convergence methods.");
     static PrecisionType value{};
     return value;
-  };
+  }
 
   void
   AdvanceOneStep() override
   {
     itkWarningMacro("LBFGS2Optimizerv4Template does not implement single step advance");
-  };
+  }
 };
 
 

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
@@ -107,7 +107,7 @@ public:
 
   /** Initialize the transform using the specified fixed parameters */
   void
-  AdaptTransformParameters() override{};
+  AdaptTransformParameters() override{}
 
 protected:
   TransformParametersAdaptor() = default;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -418,13 +418,13 @@ protected:
   RequiresMovingPointsLocator() const
   {
     return true;
-  };
+  }
 
   virtual bool
   RequiresFixedPointsLocator() const
   {
     return true;
-  };
+  }
 
   /**
    * Function to be defined in the appropriate derived classes.  Calculates

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -210,7 +210,7 @@ private:
                                      const PixelType & pixel) const override
   {
     return this->GetLocalNeighborhoodValue(point, pixel);
-  };
+  }
 
   LocalDerivativeType
   GetLocalNeighborhoodDerivativeWithIndex(const PointIdentifier &,
@@ -218,7 +218,7 @@ private:
                                           const PixelType & pixel) const override
   {
     return this->GetLocalNeighborhoodDerivative(point, pixel);
-  };
+  }
 
   void
   GetLocalNeighborhoodValueAndDerivativeWithIndex(const PointIdentifier &,
@@ -228,7 +228,7 @@ private:
                                                   const PixelType &     pixel) const override
   {
     this->GetLocalNeighborhoodValueAndDerivative(point, measure, derivative, pixel);
-  };
+  }
 };
 } // end namespace itk
 


### PR DESCRIPTION
Decided to remove semicolon from struct and not from where the function-like macro is used. Is this a fix that is acceptable? Can we proceed with similar fixes?
