### PR TITLE
Default copy and move of iterators, using `ITK_DEFAULT_COPY_AND_MOVE`

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -60,6 +60,8 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ConstNeighborhoodIteratorWithOnlyIndex : public Neighborhood<char, TImage::ImageDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ConstNeighborhoodIteratorWithOnlyIndex);
+
   /** Type used to refer to space dimensions */
   using DimensionValueType = unsigned int;
 
@@ -94,16 +96,9 @@ public:
   /** Virtual destructor */
   ~ConstNeighborhoodIteratorWithOnlyIndex() override = default;
 
-  /** Copy constructor */
-  ConstNeighborhoodIteratorWithOnlyIndex(const ConstNeighborhoodIteratorWithOnlyIndex &);
-
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
   ConstNeighborhoodIteratorWithOnlyIndex(const SizeType & radius, const ImageType * ptr, const RegionType & region);
-
-  /** Assignment operator */
-  Self &
-  operator=(const Self & orig);
 
   /** Standard itk print method */
   void

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -128,29 +128,6 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() co
 
 
 template <typename TImage>
-ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex(const Self & orig)
-  : Neighborhood<DummyNeighborhoodPixelType, Dimension>(orig)
-{
-  m_Bound = orig.m_Bound;
-  m_BeginIndex = orig.m_BeginIndex;
-  m_ConstImage = orig.m_ConstImage;
-  m_EndIndex = orig.m_EndIndex;
-  m_Loop = orig.m_Loop;
-  m_Region = orig.m_Region;
-
-  m_NeedToUseBoundaryCondition = orig.m_NeedToUseBoundaryCondition;
-  for (DimensionValueType i = 0; i < Dimension; ++i)
-  {
-    m_InBounds[i] = orig.m_InBounds[i];
-  }
-  m_IsInBoundsValid = orig.m_IsInBoundsValid;
-  m_IsInBounds = orig.m_IsInBounds;
-
-  m_InnerBoundsLow = orig.m_InnerBoundsLow;
-  m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
-}
-
-template <typename TImage>
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex(const SizeType &   radius,
                                                                                        const ImageType *  ptr,
                                                                                        const RegionType & region)
@@ -233,36 +210,6 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::Initialize(const SizeType &   ra
 
   m_IsInBoundsValid = false;
   m_IsInBounds = false;
-}
-
-template <typename TImage>
-ConstNeighborhoodIteratorWithOnlyIndex<TImage> &
-ConstNeighborhoodIteratorWithOnlyIndex<TImage>::operator=(const Self & orig)
-{
-  if (this != &orig)
-  {
-    Superclass::operator=(orig);
-
-    m_Bound = orig.m_Bound;
-    m_ConstImage = orig.m_ConstImage;
-    m_EndIndex = orig.m_EndIndex;
-    m_Loop = orig.m_Loop;
-    m_Region = orig.m_Region;
-    m_BeginIndex = orig.m_BeginIndex;
-
-    m_NeedToUseBoundaryCondition = orig.m_NeedToUseBoundaryCondition;
-
-    m_InnerBoundsLow = orig.m_InnerBoundsLow;
-    m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
-
-    for (DimensionValueType i = 0; i < Dimension; ++i)
-    {
-      m_InBounds[i] = orig.m_InBounds[i];
-    }
-    m_IsInBoundsValid = orig.m_IsInBoundsValid;
-    m_IsInBounds = orig.m_IsInBounds;
-  }
-  return *this;
 }
 
 template <typename TImage>

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -95,6 +95,8 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageConstIteratorWithOnlyIndex
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ImageConstIteratorWithOnlyIndex);
+
   /** Standard class type aliases. */
   using Self = ImageConstIteratorWithOnlyIndex;
 
@@ -126,21 +128,12 @@ public:
    * provide a copy constructor. */
   ImageConstIteratorWithOnlyIndex() = default;
 
-  /** Copy Constructor. The copy constructor is provided to make sure the
-   * handle to the image is properly reference counted. */
-  ImageConstIteratorWithOnlyIndex(const Self & it);
-
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
   ImageConstIteratorWithOnlyIndex(const TImage * ptr, const RegionType & region);
 
   /** Default Destructor. */
   virtual ~ImageConstIteratorWithOnlyIndex() = default;
-
-  /** operator= is provided to make sure the handle to the image is properly
-   * reference counted. */
-  Self &
-  operator=(const Self & it);
 
   /** Get the dimension (size) of the index. */
   static unsigned int

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -25,24 +25,6 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const Self & it)
-{
-  m_Image = it.m_Image; // copy the smart pointer
-
-  m_PositionIndex = it.m_PositionIndex;
-  m_BeginIndex = it.m_BeginIndex;
-  m_EndIndex = it.m_EndIndex;
-  m_Region = it.m_Region;
-
-  std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
-
-  m_Remaining = it.m_Remaining;
-}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
 ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const TImage * ptr, const RegionType & region)
 {
   m_Image = ptr;
@@ -66,29 +48,6 @@ ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const T
   }
 
   GoToBegin();
-}
-
-//----------------------------------------------------------------------
-//    Assignment Operator
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageConstIteratorWithOnlyIndex<TImage> &
-ImageConstIteratorWithOnlyIndex<TImage>::operator=(const Self & it)
-{
-  if (this != *it)
-  {
-    m_Image = it.m_Image; // copy the smart pointer
-
-    m_BeginIndex = it.m_BeginIndex;
-    m_EndIndex = it.m_EndIndex;
-    m_PositionIndex = it.m_PositionIndex;
-    m_Region = it.m_Region;
-
-    std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
-
-    m_Remaining = it.m_Remaining;
-  }
-  return *this;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/Common/include/itkImageIterator.h
+++ b/Modules/Core/Common/include/itkImageIterator.h
@@ -65,6 +65,8 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageIterator : public ImageConstIterator<TImage>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ImageIterator);
+
   /** Standard class type aliases. */
   using Self = ImageIterator;
 
@@ -96,18 +98,9 @@ public:
   /** Default Destructor */
   ~ImageIterator() override = default;
 
-  /** Copy Constructor. The copy constructor is provided to make sure the
-   * handle to the image is properly reference counted. */
-  ImageIterator(const Self & it);
-
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
   ImageIterator(TImage * ptr, const RegionType & region);
-
-  /** operator= is provided to make sure the handle to the image is properly
-   * reference counted. */
-  Self &
-  operator=(const Self & it);
 
   /** Set the pixel value */
   void

--- a/Modules/Core/Common/include/itkImageIterator.hxx
+++ b/Modules/Core/Common/include/itkImageIterator.hxx
@@ -26,14 +26,6 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageIterator<TImage>::ImageIterator(const Self & it)
-  : ImageConstIterator<TImage>(it)
-{}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
 ImageIterator<TImage>::ImageIterator(TImage * ptr, const RegionType & region)
   : ImageConstIterator<TImage>(ptr, region)
 {}
@@ -52,17 +44,6 @@ ImageIterator<TImage>::ImageIterator(const ImageConstIterator<TImage> & it)
 template <typename TImage>
 ImageIterator<TImage> &
 ImageIterator<TImage>::operator=(const ImageConstIterator<TImage> & it)
-{
-  this->ImageConstIterator<TImage>::operator=(it);
-  return *this;
-}
-
-//----------------------------------------------------------------------
-//    Assignment Operator
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageIterator<TImage> &
-ImageIterator<TImage>::operator=(const Self & it)
 {
   this->ImageConstIterator<TImage>::operator=(it);
   return *this;

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.h
@@ -68,6 +68,8 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ImageIteratorWithIndex);
+
   /** Standard class type aliases. */
   using Self = ImageIteratorWithIndex;
 
@@ -99,18 +101,9 @@ public:
   /** Default Destructor */
   ~ImageIteratorWithIndex() override = default;
 
-  /** Copy Constructor. The copy constructor is provided to make sure the
-   * handle to the image is properly reference counted. */
-  ImageIteratorWithIndex(const Self & it);
-
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
   ImageIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** operator= is provided to make sure the handle to the image is properly
-   * reference counted. */
-  Self &
-  operator=(const Self & it);
 
   /** Set the pixel value */
   void

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.hxx
@@ -26,14 +26,6 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageIteratorWithIndex<TImage>::ImageIteratorWithIndex(const Self & it)
-  : ImageConstIteratorWithIndex<TImage>(it)
-{}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
 ImageIteratorWithIndex<TImage>::ImageIteratorWithIndex(TImage * ptr, const RegionType & region)
   : ImageConstIteratorWithIndex<TImage>(ptr, region)
 {}
@@ -52,17 +44,6 @@ ImageIteratorWithIndex<TImage>::ImageIteratorWithIndex(const ImageConstIteratorW
 template <typename TImage>
 ImageIteratorWithIndex<TImage> &
 ImageIteratorWithIndex<TImage>::operator=(const ImageConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-
-//----------------------------------------------------------------------
-//    Assignment Operator
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageIteratorWithIndex<TImage> &
-ImageIteratorWithIndex<TImage>::operator=(const Self & it)
 {
   this->ImageConstIteratorWithIndex<TImage>::operator=(it);
   return *this;


### PR DESCRIPTION
Replaced hand-written copy-constructors and assignment operators of four iterators with the equivalent `ITK_DEFAULT_COPY_AND_MOVE` macro calls.

----

- Follow-up to pull request #4652 