### PR TITLE
COMP: macOS-11 Azure CI environment EOL

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -31,7 +31,8 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: macos-11
+    # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    vmImage: macos-13
   steps:
     - checkout: self
       clean: true

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -31,7 +31,8 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: macos-11
+    # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    vmImage: macos-13
   steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
The macOS-11 environment is deprecated and scheduled to be removed on June 28th, 2024.

https://learn.microsoft.com/en-us/azure/devops/release-notes/features-timeline-released

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
