### PR TITLE
BUG: Move InputSpaceName, OutputSpaceName from Transform to Transform…

### DIFF
--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -115,20 +115,6 @@ public:
     return VOutputDimension;
   }
 
-
-  /* For storing the  name of InputSpace */
-  itkSetMacro(InputSpaceName, std::string);
-  itkGetConstReferenceMacro(InputSpaceName, std::string);
-
-  /** For storing the  name of InputSpace/OutputSpace.
-
-  InputSpaceName, OutputSpaceName provide identifiers for the world spaces
-  that the transform applied to and the direction of the spatial transformation.
-  The direction of the transform goes from the input space to output space.
-  Typical values include the names of an atlas or a dataset. */
-  itkSetMacro(OutputSpaceName, std::string);
-  itkGetConstReferenceMacro(OutputSpaceName, std::string);
-
   /** Type of the input parameters. */
   using typename Superclass::FixedParametersType;
   using typename Superclass::FixedParametersValueType;
@@ -617,9 +603,6 @@ protected:
   }
 
 private:
-  std::string m_InputSpaceName{};
-  std::string m_OutputSpaceName{};
-
   template <typename TType>
   static std::string
   GetTransformTypeAsString(TType *)

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -90,6 +90,19 @@ public:
    *  therefore we use here a large capacity integer. */
   using NumberOfParametersType = IdentifierType;
 
+  /* For storing the  name of InputSpace */
+  itkSetMacro(InputSpaceName, std::string);
+  itkGetConstReferenceMacro(InputSpaceName, std::string);
+
+  /** For storing the  name of InputSpace/OutputSpace.
+
+  InputSpaceName, OutputSpaceName provide identifiers for the world spaces
+  that the transform applied to and the direction of the spatial transformation.
+  The direction of the transform goes from the input space to output space.
+  Typical values include the names of an atlas or a dataset. */
+  itkSetMacro(OutputSpaceName, std::string);
+  itkGetConstReferenceMacro(OutputSpaceName, std::string);
+
   /** Return the number of parameters that completely define the Transform  */
   virtual NumberOfParametersType
   GetNumberOfParameters() const = 0;
@@ -178,6 +191,10 @@ protected:
   TransformBaseTemplate() = default;
   ~TransformBaseTemplate() override = default;
 #endif
+
+private:
+  std::string m_InputSpaceName{};
+  std::string m_OutputSpaceName{};
 };
 
 /** This helps to meet backward compatibility */

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -317,6 +317,12 @@ public:
     transform->SetOutputSpaceName("test_outputspace");
     ITK_TEST_EXPECT_EQUAL(std::string("test_outputspace"), transform->GetOutputSpaceName());
 
+    transform->itk::TransformBase::SetInputSpaceName("test_inputspace");
+    ITK_TEST_EXPECT_EQUAL(std::string("test_inputspace"), transform->itk::TransformBase::GetInputSpaceName());
+
+    transform->itk::TransformBase::SetOutputSpaceName("test_outputspace");
+    ITK_TEST_EXPECT_EQUAL(std::string("test_outputspace"), transform->itk::TransformBase::GetOutputSpaceName());
+
     // Test streaming enumeration for TransformBaseTemplateEnums::TransformCategory elements
     const std::set<itk::TransformBaseTemplateEnums::TransformCategory> allTransformCategory{
       itk::TransformBaseTemplateEnums::TransformCategory::UnknownTransformCategory,

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -241,6 +241,8 @@ oneTest(const std::string goodname, const std::string badname, const bool useCom
     while (lit != list->end())
     {
       (*lit)->Print(std::cout);
+      std::cout << "Input space name: " << (*lit)->GetInputSpaceName() << std::endl;
+      std::cout << "Output space name: " << (*lit)->GetOutputSpaceName() << std::endl;
       ++lit;
     }
   }


### PR DESCRIPTION
…Base

These were added to support features of the OME-Zarr transform proposals. However, they need to be available in itk::TransformBase instead of itk::Transform for access in TransformIO classes.