### PR TITLE
`Array2D`, `CompensatedSummation`, `Versor`: remove hand-written copy-constructor and assignment

### DIFF
--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -58,7 +58,7 @@ public:
   Array2D(unsigned int numberOfRows, unsigned int numberOfCols, const TValue & initialValue);
 
   /** Copy-constructor. */
-  Array2D(const Self & array);
+  Array2D(const Self &) = default;
 
   /** Move-constructor.
    * \note This move-constructor is `noexcept`, even while the move-constructor of its base class (`vnl_matrix`) is not
@@ -74,7 +74,7 @@ public:
 
   /** Copy-assignment operator. */
   Self &
-  operator=(const Self & array);
+  operator=(const Self &) = default;
 
   /** Move-assignment operator.
    * \note This move-assignment operator is `noexcept`, even while the move-assignment operator of its base class

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -38,19 +38,6 @@ Array2D<TValue>::Array2D(const VnlMatrixType & matrix)
 {}
 
 template <typename TValue>
-Array2D<TValue>::Array2D(const Self & array)
-  : vnl_matrix<TValue>(array)
-{}
-
-template <typename TValue>
-Array2D<TValue> &
-Array2D<TValue>::operator=(const Self & array)
-{
-  this->VnlMatrixType::operator=(array);
-  return *this;
-}
-
-template <typename TValue>
 Array2D<TValue> &
 Array2D<TValue>::operator=(const VnlMatrixType & matrix)
 {

--- a/Modules/Core/Common/include/itkCompensatedSummation.h
+++ b/Modules/Core/Common/include/itkCompensatedSummation.h
@@ -80,10 +80,10 @@ public:
   CompensatedSummation(FloatType value);
 
   /** Copy constructor. */
-  CompensatedSummation(const Self & rhs);
+  CompensatedSummation(const Self &) = default;
   /** Assignment operator. */
   Self &
-  operator=(const Self & rhs);
+  operator=(const Self &) = default;
 
   /** Add an element to the sum. */
   void

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -65,25 +65,6 @@ CompensatedSummation<TFloat>::CompensatedSummation(const TFloat value)
 {}
 
 template <typename TFloat>
-CompensatedSummation<TFloat>::CompensatedSummation(const Self & rhs)
-{
-  this->m_Sum = rhs.m_Sum;
-  this->m_Compensation = rhs.m_Compensation;
-}
-
-template <typename TFloat>
-auto
-CompensatedSummation<TFloat>::operator=(const Self & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    this->m_Sum = rhs.m_Sum;
-    this->m_Compensation = rhs.m_Compensation;
-  }
-  return *this;
-}
-
-template <typename TFloat>
 void
 CompensatedSummation<TFloat>::AddElement(const FloatType & element)
 {

--- a/Modules/Core/Common/include/itkVersor.h
+++ b/Modules/Core/Common/include/itkVersor.h
@@ -37,6 +37,8 @@ namespace itk
  * versor. For this reason, addition is not defined in this class, even
  * though it is a valid operation between quaternions.
  *
+ * \note Its special member functions are implicitly defaulted, following the C++ "Rule of Zero".
+ *
  * \ingroup Geometry
  * \ingroup DataRepresentation
  *
@@ -107,17 +109,6 @@ public:
    */
   void
   Set(T x, T y, T z, T w);
-
-  /** Default constructor creates a null versor
-   * (representing 0 degrees  rotation). */
-  Versor() = default;
-
-  /** Copy constructor.  */
-  Versor(const Self & v);
-
-  /** Assignment operator =.  Copy the versor argument. */
-  Self &
-  operator=(const Self & v);
 
   /** Composition operator *=.  Compose the current versor
    * with the operand and store the result in the current

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -25,26 +25,6 @@
 namespace itk
 {
 template <typename T>
-Versor<T>::Versor(const Self & v)
-{
-  m_X = v.m_X;
-  m_Y = v.m_Y;
-  m_Z = v.m_Z;
-  m_W = v.m_W;
-}
-
-template <typename T>
-Versor<T> &
-Versor<T>::operator=(const Self & v)
-{
-  m_X = v.m_X;
-  m_Y = v.m_Y;
-  m_Z = v.m_Z;
-  m_W = v.m_W;
-  return *this;
-}
-
-template <typename T>
 void
 Versor<T>::SetIdentity()
 {


### PR DESCRIPTION
- Replaced the hand-written copy-constructor and copy-assignment of `Array2D` and `CompensatedSummation` with `= default`.
- Simply removed them from `Versor`, following the "Rule of Zero"

The hand-written copy-constructors were found with regular expression `^(\w+)<.+>::\1\(const Self`