### PR TITLE
ENH: Allow SpatialObject Readers/Writers to use new MetaIO format

### DIFF
--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
@@ -63,6 +63,12 @@ public:
   void
   Update();
 
+  /** Set the version of MetaIO to use */
+  void
+  SetMetaIOVersion(unsigned int ver);
+  unsigned int
+  GetMetaIOVersion(void) const;
+
   /** Set the filename  */
   itkSetStringMacro(FileName);
 

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
@@ -43,6 +43,20 @@ SpatialObjectReader<VDimension, PixelType, TMeshTraits>::Update()
   }
 }
 
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+void
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::SetMetaIOVersion(unsigned int ver)
+{
+  m_MetaToSpatialConverter->SetMetaIOVersion(ver);
+}
+
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+unsigned int
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::GetMetaIOVersion(void) const
+{
+  return m_MetaToSpatialConverter->GetMetaIOVersion();
+}
+
 /** Add a converter for a new MetaObject/SpatialObject type */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -81,6 +81,16 @@ public:
   itkGetConstMacro(BinaryPoints, bool);
   itkBooleanMacro(BinaryPoints);
 
+  /** Set the version of MetaIO to use.
+   *    Version 0 cannot accurately represented ImageSpatialObjects.
+   *    Version 1 fixes bugs in Version 0, but introduces new tag-value
+   *      pairs that might throw warnings on older readers. */
+
+  void
+  SetMetaIOVersion(unsigned int ver);
+  unsigned int
+  GetMetaIOVersion(void) const;
+
   void
   SetTransformPrecision(unsigned int precision);
 

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
@@ -31,6 +31,20 @@ SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SpatialObjectWriter()
   m_MetaToSpatialConverter = MetaSceneConverterType::New();
 }
 
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+void
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SetMetaIOVersion(unsigned int ver)
+{
+  m_MetaToSpatialConverter->SetMetaIOVersion(ver);
+}
+
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+unsigned int
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::GetMetaIOVersion(void) const
+{
+  return m_MetaToSpatialConverter->GetMetaIOVersion();
+}
+
 /** Set the precision at which the transform should be written */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void


### PR DESCRIPTION
Updates to MetaIO allow for the specification of the file format to write and how to interpret files that are read.  Two versions are supported:
- Version 0 [default]: is not able to completely/accurately represent a spatialobject scene containing images.  For images, the image transform and its parent-object transfer were mixed / mishandled.
- Version 1: fixes the errors of version 0, but it introduces additional tag-value pairs (e.g., ElementDirection) that will throw warnings if read by previous MetaIO code/applications.

If you are using SpatialObjects, we strongly recommend specifying SetMetaIOVersion(1) for the SpatialObject Readers and Writers before calling Update().

This commit is dependent on PR https://github.com/InsightSoftwareConsortium/ITK/pull/4739 and PR https://github.com/InsightSoftwareConsortium/ITK/pull/4742