### PR TITLE
ENH: Update SpatialObjects for MetaIO v1

### DIFF
--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -58,7 +58,7 @@ public:
   Array2D(unsigned int numberOfRows, unsigned int numberOfCols, const TValue & initialValue);
 
   /** Copy-constructor. */
-  Array2D(const Self & array);
+  Array2D(const Self &) = default;
 
   /** Move-constructor.
    * \note This move-constructor is `noexcept`, even while the move-constructor of its base class (`vnl_matrix`) is not
@@ -74,7 +74,7 @@ public:
 
   /** Copy-assignment operator. */
   Self &
-  operator=(const Self & array);
+  operator=(const Self &) = default;
 
   /** Move-assignment operator.
    * \note This move-assignment operator is `noexcept`, even while the move-assignment operator of its base class

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -38,19 +38,6 @@ Array2D<TValue>::Array2D(const VnlMatrixType & matrix)
 {}
 
 template <typename TValue>
-Array2D<TValue>::Array2D(const Self & array)
-  : vnl_matrix<TValue>(array)
-{}
-
-template <typename TValue>
-Array2D<TValue> &
-Array2D<TValue>::operator=(const Self & array)
-{
-  this->VnlMatrixType::operator=(array);
-  return *this;
-}
-
-template <typename TValue>
 Array2D<TValue> &
 Array2D<TValue>::operator=(const VnlMatrixType & matrix)
 {

--- a/Modules/Core/Common/include/itkCompensatedSummation.h
+++ b/Modules/Core/Common/include/itkCompensatedSummation.h
@@ -80,10 +80,10 @@ public:
   CompensatedSummation(FloatType value);
 
   /** Copy constructor. */
-  CompensatedSummation(const Self & rhs);
+  CompensatedSummation(const Self &) = default;
   /** Assignment operator. */
   Self &
-  operator=(const Self & rhs);
+  operator=(const Self &) = default;
 
   /** Add an element to the sum. */
   void

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -65,25 +65,6 @@ CompensatedSummation<TFloat>::CompensatedSummation(const TFloat value)
 {}
 
 template <typename TFloat>
-CompensatedSummation<TFloat>::CompensatedSummation(const Self & rhs)
-{
-  this->m_Sum = rhs.m_Sum;
-  this->m_Compensation = rhs.m_Compensation;
-}
-
-template <typename TFloat>
-auto
-CompensatedSummation<TFloat>::operator=(const Self & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    this->m_Sum = rhs.m_Sum;
-    this->m_Compensation = rhs.m_Compensation;
-  }
-  return *this;
-}
-
-template <typename TFloat>
 void
 CompensatedSummation<TFloat>::AddElement(const FloatType & element)
 {

--- a/Modules/Core/Common/include/itkVersor.h
+++ b/Modules/Core/Common/include/itkVersor.h
@@ -37,6 +37,8 @@ namespace itk
  * versor. For this reason, addition is not defined in this class, even
  * though it is a valid operation between quaternions.
  *
+ * \note Its special member functions are implicitly defaulted, following the C++ "Rule of Zero".
+ *
  * \ingroup Geometry
  * \ingroup DataRepresentation
  *
@@ -107,17 +109,6 @@ public:
    */
   void
   Set(T x, T y, T z, T w);
-
-  /** Default constructor creates a null versor
-   * (representing 0 degrees  rotation). */
-  Versor() = default;
-
-  /** Copy constructor.  */
-  Versor(const Self & v);
-
-  /** Assignment operator =.  Copy the versor argument. */
-  Self &
-  operator=(const Self & v);
 
   /** Composition operator *=.  Compose the current versor
    * with the operand and store the result in the current

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -25,26 +25,6 @@
 namespace itk
 {
 template <typename T>
-Versor<T>::Versor(const Self & v)
-{
-  m_X = v.m_X;
-  m_Y = v.m_Y;
-  m_Z = v.m_Z;
-  m_W = v.m_W;
-}
-
-template <typename T>
-Versor<T> &
-Versor<T>::operator=(const Self & v)
-{
-  m_X = v.m_X;
-  m_Y = v.m_Y;
-  m_Z = v.m_Z;
-  m_W = v.m_W;
-  return *this;
-}
-
-template <typename T>
 void
 Versor<T>::SetIdentity()
 {

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -38,11 +38,6 @@ ArrowSpatialObject<TDimension>::Clear()
 {
   Superclass::Clear();
 
-  this->GetProperty().SetRed(1);
-  this->GetProperty().SetGreen(0);
-  this->GetProperty().SetBlue(0);
-  this->GetProperty().SetAlpha(1);
-
   m_DirectionInObjectSpace.Fill(0);
   m_DirectionInObjectSpace[0] = 1; // along the x direction by default
   m_PositionInObjectSpace.Fill(0);

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -41,6 +41,8 @@ MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType *
   }
   ArrowSpatialObjectPointer arrowSO = ArrowSpatialObjectType::New();
 
+  this->MetaObjectToSpatialObjectBase(mo, arrowSO);
+
   float lengthInObjectSpace = metaArrow->Length();
   arrowSO->SetLengthInObjectSpace(lengthInObjectSpace);
 
@@ -53,17 +55,19 @@ MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType *
     positionInObjectSpace[i] = metaPosition[i];
     directionInObjectSpace[i] = metaDirection[i];
   }
-  arrowSO->SetPositionInObjectSpace(positionInObjectSpace);
+  if (mo->APIVersion() == 1)
+  {
+    // if not using new API, then the position is already stored as Offset.
+    // Really not certain how to handle the old case since it produced a bug...with
+    //    position being stored in the Offset and the Position!  But then the WorldPosition
+    //    would compose offset with position, which would be wrong...   It really never
+    //    worked correctly...
+    arrowSO->SetPositionInObjectSpace(positionInObjectSpace);
+  }
+
+  std::cout << directionInObjectSpace << std::endl;
   arrowSO->SetDirectionInObjectSpace(directionInObjectSpace);
 
-  // convert the other fields
-  arrowSO->GetProperty().SetName(metaArrow->Name());
-  arrowSO->SetId(metaArrow->ID());
-  arrowSO->SetParentId(metaArrow->ParentID());
-  arrowSO->GetProperty().SetRed(metaArrow->Color()[0]);
-  arrowSO->GetProperty().SetGreen(metaArrow->Color()[1]);
-  arrowSO->GetProperty().SetBlue(metaArrow->Color()[2]);
-  arrowSO->GetProperty().SetAlpha(metaArrow->Color()[3]);
   arrowSO->Update();
 
   return arrowSO.GetPointer();
@@ -81,13 +85,13 @@ MetaArrowConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectTyp
   }
 
   auto * mo = new MetaArrow(VDimension);
+  mo->APIVersion(1);
+  mo->FileFormatVersion(1);
+
+  this->SpatialObjectToMetaObjectBase(spatialObject, mo);
 
   float metaLength = arrowSO->GetLengthInObjectSpace();
-
-  if (arrowSO->GetParent())
-  {
-    mo->ParentID(arrowSO->GetParent()->GetId());
-  }
+  mo->Length(metaLength);
 
   // convert position and direction
   double                                 metaPosition[VDimension];
@@ -101,15 +105,6 @@ MetaArrowConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectTyp
   }
   mo->Position(metaPosition);
   mo->Direction(metaDirection);
-
-  // convert the rest of the parameters
-  mo->Length(metaLength);
-  mo->ID(arrowSO->GetId());
-
-  mo->Color(arrowSO->GetProperty().GetRed(),
-            arrowSO->GetProperty().GetGreen(),
-            arrowSO->GetProperty().GetBlue(),
-            arrowSO->GetProperty().GetAlpha());
 
   return mo;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -53,7 +53,11 @@ public:
 
   using SpatialObjectType = SpatialObject<VDimension>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
   using MetaObjectType = MetaObject;
+
+  itkSetMacro(MetaIOVersion, unsigned int);
+  itkGetConstMacro(MetaIOVersion, unsigned int);
 
   /** Read a MetaIO file, return a SpatialObject */
   virtual SpatialObjectPointer
@@ -62,6 +66,12 @@ public:
   /** Write a MetaIO file based on this SpatialObject */
   virtual bool
   WriteMeta(const SpatialObjectType * spatialObject, const char * name);
+
+  void
+  MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer spatialObject);
+
+  void
+  SpatialObjectToMetaObjectBase(SpatialObjectConstPointer spatialObject, MetaObjectType * mo);
 
   /** Convert the MetaObject to Spatial Object */
   virtual SpatialObjectPointer
@@ -88,7 +98,8 @@ protected:
 
 
 private:
-  bool m_WriteImagesInSeparateFile{ false };
+  bool         m_WriteImagesInSeparateFile{ false };
+  unsigned int m_MetaIOVersion{ 0 };
 };
 
 } // namespace itk

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -24,14 +24,82 @@ namespace itk
 {
 
 template <unsigned int VDimension>
+void
+MetaConverterBase<VDimension>::MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer rval)
+{
+  rval->SetId(mo->ID());
+  rval->SetParentId(mo->ParentID());
+  SpatialObject<VDimension>::TransformType::Pointer    tfm = SpatialObject<VDimension>::TransformType::New();
+  SpatialObject<VDimension>::TransformType::OffsetType off;
+  SpatialObject<VDimension>::TransformType::MatrixType mat;
+  SpatialObject<VDimension>::TransformType::CenterType cen;
+  for (int i = 0; i < VDimension; ++i)
+  {
+    off[i] = mo->Offset()[i];
+    for (int j = 0; j < VDimension; ++j)
+    {
+      mat[i][j] = mo->TransformMatrix()[i * VDimension + j];
+    }
+    cen[i] = mo->CenterOfRotation()[i];
+  }
+  tfm->SetCenter(cen);
+  tfm->SetMatrix(mat);
+  tfm->SetOffset(off);
+  rval->SetObjectToParentTransform(tfm);
+  rval->GetProperty().SetName(mo->Name());
+  rval->GetProperty().SetRed(mo->Color()[0]);
+  rval->GetProperty().SetGreen(mo->Color()[1]);
+  rval->GetProperty().SetBlue(mo->Color()[2]);
+  rval->GetProperty().SetAlpha(mo->Color()[3]);
+}
+
+template <unsigned int VDimension>
+void
+MetaConverterBase<VDimension>::SpatialObjectToMetaObjectBase(SpatialObjectConstPointer spatialObject,
+                                                             MetaObjectType *          mo)
+{
+  mo->APIVersion(m_MetaIOVersion);
+
+  mo->ID(spatialObject->GetId());
+  if (spatialObject->GetParent())
+  {
+    mo->ParentID(spatialObject->GetParent()->GetId());
+    SpatialObject<VDimension>::TransformType::ConstPointer tfm = spatialObject->GetObjectToParentTransform();
+    double                                                 mo_off[10];
+    double                                                 mo_mat[100];
+    double                                                 mo_cen[10];
+    for (int i = 0; i < VDimension; ++i)
+    {
+      mo_off[i] = tfm->GetOffset()[i];
+      for (int j = 0; j < VDimension; ++j)
+      {
+        mo_mat[i * VDimension + j] = tfm->GetMatrix()[i][j];
+      }
+      mo_cen[i] = tfm->GetCenter()[i];
+    }
+    mo->CenterOfRotation(mo_cen);
+    mo->TransformMatrix(mo_mat);
+    mo->Offset(mo_off);
+  }
+  mo->Name(spatialObject->GetProperty().GetName().c_str());
+  mo->Color(spatialObject->GetProperty().GetRed(),
+            spatialObject->GetProperty().GetGreen(),
+            spatialObject->GetProperty().GetBlue(),
+            spatialObject->GetProperty().GetAlpha());
+}
+
+template <unsigned int VDimension>
 auto
 MetaConverterBase<VDimension>::ReadMeta(const char * name) -> SpatialObjectPointer
 {
   SpatialObjectPointer rval;
   MetaObjectType *     mo = this->CreateMetaObject();
 
+  mo->APIVersion(m_MetaIOVersion);
   mo->Read(name);
+
   rval = this->MetaObjectToSpatialObject(mo);
+
   delete mo;
   return rval;
 }
@@ -41,7 +109,11 @@ bool
 MetaConverterBase<VDimension>::WriteMeta(const SpatialObjectType * spatialObject, const char * name)
 {
   MetaObject * mo = this->SpatialObjectToMetaObject(spatialObject);
+
+  mo->APIVersion(m_MetaIOVersion);
+  mo->FileFormatVersion(m_MetaIOVersion);
   mo->Write(name);
+
   delete mo;
   return true;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -69,6 +69,15 @@ public:
   using MetaConverterPointer = typename MetaConverterBaseType::Pointer;
   using ConverterMapType = std::map<std::string, MetaConverterPointer>;
 
+  /** Choose the API and FileFormat version for MetaIO.
+   *    Version 0 (default) is not able to fully / accurately represent
+   *       a SpatialObject scene (image transform and parent-object
+   *       transforms are intermingled.
+   *    Version 1 fixes the bugs in Version 0, but introduces new
+   *       tag-value pairs that won't be processed by older readers/apps. */
+  itkSetMacro(MetaIOVersion, unsigned int);
+  itkGetConstMacro(MetaIOVersion, unsigned int);
+
   /** Read a MetaFile and create a Scene SpatialObject. */
   SpatialObjectPointer
   ReadMeta(const std::string & name);
@@ -151,15 +160,12 @@ private:
   void
   SetTransform(SpatialObjectType * so, const MetaObject * meta);
 
-  double m_Orientation[100]{};
-  double m_Position[10]{};
-  double m_CenterOfRotation[10]{};
-
   MetaEvent *      m_Event{};
   bool             m_BinaryPoints{};
   bool             m_WriteImagesInSeparateFile{};
   unsigned int     m_TransformPrecision{};
   ConverterMapType m_ConverterMap{};
+  unsigned int     m_MetaIOVersion{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -105,6 +105,7 @@ itkMetaArrowConverterTest(int argc, char * argv[])
 
   // set up itkArrow
   auto itkArrow = SpatialObjectType::New();
+  itkArrow->SetId(0);
   itkArrow->SetDirectionInObjectSpace(direction);
   itkArrow->SetPositionInObjectSpace(position);
   itkArrow->SetLengthInObjectSpace(length);
@@ -120,6 +121,7 @@ itkMetaArrowConverterTest(int argc, char * argv[])
 
   // set up metaArrow
   auto * metaArrow = new MetaArrow(Dimensions);
+  metaArrow->ID(2);
   metaArrow->Length(static_cast<float>(length));
   metaArrow->Position((const double *)mPosition);
   metaArrow->Direction((const double *)mDirection);
@@ -353,6 +355,8 @@ itkMetaArrowConverterTest(int argc, char * argv[])
       itk::Math::abs(reLoadDirectionNorm[2] - directionNorm[2]) > precisionLimit)
   {
     std::cout << "Didn't read direction properly [FAILED]" << std::endl;
+    std::cout << "  Direction: " << reLoadDirectionNorm << std::endl;
+    std::cout << "    vs: " << directionNorm << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << "[PASSED]  Reading: direction" << std::endl;

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/CMakeLists.txt
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/CMakeLists.txt
@@ -122,15 +122,14 @@ else ()
     ${sources}
     ${headers}
   )
+  if (METAIO_FOR_ITK)
+    target_link_libraries(${METAIO_TARGET} PUBLIC
+      itksys
+    )
+  endif (METAIO_FOR_ITK)
 endif ()
 
 include_regular_expression("^.*$")
-
-# Need nsl to resolve gethostbyname on SunOS-5.8
-# and socket also
-if(CMAKE_SYSTEM MATCHES "SunOS.*")
-  target_link_libraries(${METAIO_TARGET} PRIVATE socket nsl)
-endif()
 
 target_link_libraries(${METAIO_TARGET} PUBLIC
   ${METAIO_LIBXML2_LIBRARIES}

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/localMetaConfiguration.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/localMetaConfiguration.h
@@ -21,26 +21,30 @@
 
 #include "metaIOConfig.h"
 
-#if defined(METAIO_FOR_ITK) || !defined(METAIO_FOR_VTK)
+#if defined(METAIO_FOR_ITK)
 // ITK
 
 #  define METAIO_USE_NAMESPACE 0
 #  define METAIO_NAMESPACE ITKMetaIO
+#  define METAIO_STREAM itksys
 
-#  include "itk_zlib.h"
+#  include <itksys/FStream.hxx>
+#  include <itk_zlib.h>
 
 #  include <iostream>
 #  include <fstream>
 
 #  define METAIO_EXPORT
 
-#else
+#elif defined(METAIO_FOR_VTK)
 // VTK
 
 #  define METAIO_USE_NAMESPACE 1
 #  define METAIO_NAMESPACE vtkmetaio
+#  define METAIO_STREAM vtksys
 
-#  include "vtk_zlib.h"
+#  include <vtksys/FStream.hxx>
+#  include <vtk_zlib.h>
 
 #  include <iostream>
 #  include <fstream>
@@ -57,5 +61,18 @@
 #    define METAIO_EXPORT
 #  endif
 
-// end VTK/ITK
+#else
+// Independent of ITK and VTK
+
+#  define METAIO_USE_NAMESPACE 0
+#  define METAIO_NAMESPACE metaio
+#  define METAIO_STREAM std
+
+#  include "itk_zlib.h"
+
+#  include <iostream>
+#  include <fstream>
+
+#  define METAIO_EXPORT
+
 #endif

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.cxx
@@ -552,13 +552,9 @@ MetaArray::CanRead(const char * _headerName) const
   }
 
   // Now check the file content
-  std::ifstream inputStream;
+  METAIO_STREAM::ifstream inputStream;
 
-#ifdef __sgi
-  inputStream.open(_headerName, std::ios::in);
-#else
   inputStream.open(_headerName, std::ios::in | std::ios::binary);
-#endif
 
   if (!inputStream.rdbuf()->is_open())
   {
@@ -581,13 +577,9 @@ MetaArray::Read(const char * _headerName, bool _readElements, void * _elementDat
     m_FileName = _headerName;
   }
 
-  auto * tmpStream = new std::ifstream;
+  auto * tmpStream = new METAIO_STREAM::ifstream;
 
-#ifdef __sgi
-  tmpStream->open(m_FileName, std::ios::in);
-#else
-  tmpStream->open(m_FileName, std::ios::in | std::ios::binary);
-#endif
+  tmpStream->open(m_FileName.c_str(), std::ios::in | std::ios::binary);
 
   if (!tmpStream->rdbuf()->is_open())
   {
@@ -612,7 +604,7 @@ MetaArray::Read(const char * _headerName, bool _readElements, void * _elementDat
 
 
 bool
-MetaArray::CanReadStream(std::ifstream * _stream) const
+MetaArray::CanReadStream(METAIO_STREAM::ifstream * _stream) const
 {
   if (!strncmp(MET_ReadForm(*_stream).c_str(), "Array", 5))
   {
@@ -622,7 +614,7 @@ MetaArray::CanReadStream(std::ifstream * _stream) const
 }
 
 bool
-MetaArray::ReadStream(std::ifstream * _stream, bool _readElements, void * _elementDataBuffer, bool _autoFreeElementData)
+MetaArray::ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements, void * _elementDataBuffer, bool _autoFreeElementData)
 {
   META_DEBUG_PRINT( "MetaArray: ReadStream" );
 
@@ -671,13 +663,9 @@ MetaArray::ReadStream(std::ifstream * _stream, bool _readElements, void * _eleme
       {
         fName = m_ElementDataFileName;
       }
-      auto * readStreamTemp = new std::ifstream;
+      auto * readStreamTemp = new METAIO_STREAM::ifstream;
 
-#ifdef __sgi
-      readStreamTemp->open(fName, std::ios::in);
-#else
-      readStreamTemp->open(fName, std::ios::binary | std::ios::in);
-#endif
+      readStreamTemp->open(fName.c_str(), std::ios::binary | std::ios::in);
       if (!readStreamTemp->rdbuf()->is_open())
       {
         std::cout << "MetaArray: Read: Cannot open data file" << '\n';
@@ -756,19 +744,9 @@ MetaArray::Write(const char * _headName, const char * _dataName, bool _writeElem
     }
   }
 
-  auto * tmpWriteStream = new std::ofstream;
+  auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
-// Some older sgi compilers have a error in the ofstream constructor
-// that requires a file to exist for output
-#ifdef __sgi
-  {
-    std::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  tmpWriteStream->open(m_FileName, std::ios::out);
-#else
-  tmpWriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  tmpWriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!tmpWriteStream->rdbuf()->is_open())
   {
@@ -795,7 +773,7 @@ MetaArray::Write(const char * _headName, const char * _dataName, bool _writeElem
 }
 
 bool
-MetaArray::WriteStream(std::ofstream * _stream, bool _writeElements, const void * _constElementData)
+MetaArray::WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements, const void * _constElementData)
 {
   if (m_WriteStream != nullptr)
   {
@@ -989,7 +967,7 @@ MetaArray::M_Read()
 }
 
 bool
-MetaArray::M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuantity)
+MetaArray::M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, int _dataQuantity)
 {
   META_DEBUG_PRINT( "MetaArray: M_ReadElements" );
 
@@ -1044,10 +1022,10 @@ MetaArray::M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuant
 }
 
 bool
-MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
+MetaArray::M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
 {
   bool            localData;
-  std::ofstream * tmpWriteStream;
+  METAIO_STREAM::ofstream * tmpWriteStream;
   if (m_ElementDataFileName == "LOCAL")
   {
     localData = true;
@@ -1056,7 +1034,7 @@ MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
   else
   {
     localData = false;
-    tmpWriteStream = new std::ofstream;
+    tmpWriteStream = new METAIO_STREAM::ofstream;
 
     std::string dataFileName;
     std::string pathName;
@@ -1070,17 +1048,7 @@ MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
       dataFileName = m_ElementDataFileName;
     }
 
-// Some older sgi compilers have a error in the ofstream constructor
-// that requires a file to exist for output
-#ifdef __sgi
-    {
-      std::ofstream tFile(dataFileName, std::ios::out);
-      tFile.close();
-    }
-    tmpWriteStream->open(dataFileName, std::ios::out);
-#else
-    tmpWriteStream->open(dataFileName, std::ios::binary | std::ios::out);
-#endif
+    tmpWriteStream->open(dataFileName.c_str(), std::ios::binary | std::ios::out);
   }
 
   if (!m_BinaryData)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.h
@@ -159,10 +159,10 @@ public:
        bool         _autoFreeElementData = false);
 
   virtual bool
-  CanReadStream(std::ifstream * _stream) const;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) const;
 
   virtual bool
-  ReadStream(std::ifstream * _stream,
+  ReadStream(METAIO_STREAM::ifstream * _stream,
              bool            _readElements = true,
              void *          _elementDataBuffer = nullptr,
              bool            _autoFreeElementData = false);
@@ -174,7 +174,7 @@ public:
         const void * _constElementData = nullptr);
 
   virtual bool
-  WriteStream(std::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
+  WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
 
   // PROTECTED
 protected:
@@ -205,10 +205,10 @@ protected:
   M_Read() override;
 
   bool
-  M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuantity);
+  M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, int _dataQuantity);
 
   bool
-  M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 };
 
 #  if (METAIO_USE_NAMESPACE)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.cxx
@@ -50,7 +50,7 @@ MetaArrow::MetaArrow(unsigned int dim)
 {
   META_DEBUG_PRINT( "MetaArrow()" );
   MetaArrow::Clear();
-  m_NDims = dim;
+  MetaObject::InitializeEssential(dim);
 }
 
 //
@@ -64,11 +64,17 @@ void
 MetaArrow::PrintInfo() const
 {
   MetaObject::PrintInfo();
-  std::cout << "Length = " << M_Length << '\n';
+  std::cout << "Length = " << m_Length << '\n';
+  std::cout << "Position = ";
+  for (int i = 0; i < m_NDims; i++)
+  {
+    std::cout << m_Position[i] << " ";
+  }
+  std::cout << '\n';
   std::cout << "Direction = ";
   for (int i = 0; i < m_NDims; i++)
   {
-    std::cout << M_Direction[i] << " ";
+    std::cout << m_Direction[i] << " ";
   }
   std::cout << '\n';
 }
@@ -91,11 +97,16 @@ MetaArrow::CopyInfo(const MetaObject * _object)
     }
     if (arrow)
     {
-      M_Length = arrow->Length();
+      m_Length = arrow->Length();
       const double * direction = arrow->Direction();
       for (int i = 0; i < m_NDims; i++)
       {
-        M_Direction[i] = direction[i];
+        m_Direction[i] = direction[i];
+      }
+      const double * position = arrow->Position();
+      for (int i = 0; i < m_NDims; i++)
+      {
+        m_Position[i] = position[i];
       }
     }
   }
@@ -105,13 +116,13 @@ MetaArrow::CopyInfo(const MetaObject * _object)
 void
 MetaArrow::Length(float length)
 {
-  M_Length = length;
+  m_Length = length;
 }
 
 float
 MetaArrow::Length() const
 {
-  return M_Length;
+  return m_Length;
 }
 
 void
@@ -119,14 +130,69 @@ MetaArrow::Direction(const double * direction)
 {
   for (int i = 0; i < m_NDims; i++)
   {
-    M_Direction[i] = direction[i];
+    m_Direction[i] = direction[i];
   }
 }
 
 const double *
 MetaArrow::Direction() const
 {
-  return M_Direction;
+  return m_Direction;
+}
+
+const double *
+MetaArrow::Position() const
+{
+  if (m_APIVersion == 1)
+  {
+    return m_Position;
+  }
+  else
+  {
+    return MetaObject::Position();
+  }
+}
+
+double
+MetaArrow::Position(int _i) const
+{
+  if (m_APIVersion == 1)
+  {
+    return m_Position[_i];
+  }
+  else
+  {
+    return MetaObject::Position(_i);
+  }
+}
+
+void
+MetaArrow::Position(const double * position)
+{
+  if (m_APIVersion == 1)
+  {
+    for (int i = 0; i < m_NDims; i++)
+    {
+      m_Position[i] = position[i];
+    }
+  }
+  else
+  {
+    MetaObject::Position(position);
+  }
+}
+
+void
+MetaArrow::Position(int _i, double value)
+{
+  if (m_APIVersion == 1)
+  {
+    m_Position[_i] = value;
+  }
+  else
+  {
+    MetaObject::Position(_i, value);
+  }
 }
 
 /** Clear Arrow information */
@@ -138,11 +204,13 @@ MetaArrow::Clear()
 
   strcpy(m_ObjectTypeName, "Arrow");
 
-  M_Length = 1;
+  m_Length = 1;
 
   // zero out direction then set to (1,0,0)
-  memset(M_Direction, 0, 10 * sizeof(double));
-  M_Direction[0] = 1.0;
+  memset(m_Direction, 0, 10 * sizeof(double));
+  m_Direction[0] = 1.0;
+
+  memset(m_Position, 0, 10 * sizeof(double));
 }
 
 /** Set Read fields */
@@ -163,6 +231,10 @@ MetaArrow::M_SetupReadFields()
   int nDimsRecordNumber = MET_GetFieldRecordNumber("NDims", &m_Fields);
 
   mF = new MET_FieldRecordType;
+  MET_InitReadField(mF, "Position", MET_DOUBLE_ARRAY, false, nDimsRecordNumber);
+  m_Fields.push_back(mF);
+
+  mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "Direction", MET_DOUBLE_ARRAY, true, nDimsRecordNumber);
   mF->terminateRead = true;
   m_Fields.push_back(mF);
@@ -176,14 +248,20 @@ MetaArrow::M_SetupWriteFields()
   MET_FieldRecordType * mF;
 
   mF = new MET_FieldRecordType;
-  MET_InitWriteField(mF, "Length", MET_FLOAT, M_Length);
+  MET_InitWriteField(mF, "Length", MET_FLOAT, m_Length);
   m_Fields.push_back(mF);
+
+  if (m_APIVersion == 1)
+  {
+    mF = new MET_FieldRecordType;
+    MET_InitWriteField(mF, "Position", MET_DOUBLE_ARRAY, static_cast<size_t>(m_NDims), m_Position);
+    m_Fields.push_back(mF);
+  }
 
   mF = new MET_FieldRecordType;
-  MET_InitWriteField(mF, "Direction", MET_DOUBLE_ARRAY, static_cast<size_t>(m_NDims), M_Direction);
+  MET_InitWriteField(mF, "Direction", MET_DOUBLE_ARRAY, static_cast<size_t>(m_NDims), m_Direction);
   m_Fields.push_back(mF);
 }
-
 
 bool
 MetaArrow::M_Read()
@@ -198,20 +276,57 @@ MetaArrow::M_Read()
 
   META_DEBUG_PRINT( "MetaArrow: M_Read: Parsing Header" );
 
-  MET_FieldRecordType * mF_length;
-  mF_length = MET_GetFieldRecord("Length", &m_Fields);
-  if (mF_length->defined)
+  MET_FieldRecordType * mF;
+  mF = MET_GetFieldRecord("Length", &m_Fields);
+  if (mF && mF->defined)
   {
-    M_Length = static_cast<float>(mF_length->value[0]);
+    m_Length = static_cast<float>(mF->value[0]);
   }
 
-  MET_FieldRecordType * mF_direction;
-  mF_direction = MET_GetFieldRecord("Direction", &m_Fields);
-  if (mF_direction->defined)
+  mF = MET_GetFieldRecord("Position", &m_Fields);
+  if (mF && mF->defined)
+  {
+    if (m_APIVersion == 1)
+    {
+      for (int i = 0; i < m_NDims; i++)
+      {
+        m_Position[i] = mF->value[i];
+      }
+      if (m_FileFormatVersion == 0)
+      {
+        for (int i = 0; i < m_NDims; i++)
+        {
+          m_Offset[i] = 0;
+        }
+      }
+    }
+  }
+  else
+  {
+    if (m_FileFormatVersion == 1)
+    {
+      std::cout << "MetaArrow: M_Read: Position not found" << '\n';
+      return false;
+    }
+    else // Old file format
+    {
+      if (m_APIVersion == 1) // new API - move offset to position
+      {
+        for (int i = 0; i < m_NDims; i++)
+        {
+          m_Position[i] = m_Offset[i];
+          m_Offset[i] = 0;
+        }
+      }
+    }
+  }
+
+  mF = MET_GetFieldRecord("Direction", &m_Fields);
+  if (mF && mF->defined)
   {
     for (int i = 0; i < m_NDims; i++)
     {
-      M_Direction[i] = mF_direction->value[i];
+      m_Direction[i] = mF->value[i];
     }
   }
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.h
@@ -85,6 +85,15 @@ public:
   const double *
   Direction() const;
 
+  const double *
+  Position() const override;
+  double
+  Position(int _i) const override;
+  void
+  Position(const double * position) override;
+  void
+  Position(int _i, double _value) override;
+
 
   // PROTECTED
 protected:
@@ -97,9 +106,11 @@ protected:
   bool
   M_Read() override;
 
-  float M_Length{1.0}; // default 1.0
+  float m_Length{1.0}; // default 1.0
 
-  double M_Direction[10]{};
+  double m_Direction[10]{};
+
+  double m_Position[10]{};
 };
 
 #  if (METAIO_USE_NAMESPACE)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaBlob.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaBlob.cxx
@@ -245,20 +245,20 @@ MetaBlob::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("NPoints", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NPoints = static_cast<size_t>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("ElementType", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     MET_StringToType(reinterpret_cast<char *>(mF->value), &m_ElementType);
   }
 
 
   mF = MET_GetFieldRecord("PointDim", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     strcpy(m_PointDim, reinterpret_cast<char *>(mF->value));
   }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.cxx
@@ -1363,7 +1363,7 @@ MetaCommand::ExportGAD(bool dynamic)
   std::string filename = m_Name;
   filename += ".gad.xml";
 
-  std::ofstream file;
+  METAIO_STREAM::ofstream file;
 #ifdef __sgi
   file.open(filename.c_str(), std::ios::out);
 #else

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaContour.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaContour.cxx
@@ -338,7 +338,7 @@ MetaContour::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("Closed", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     if (mF->value[0] != 0.0)
     {
@@ -347,7 +347,7 @@ MetaContour::M_Read()
   }
 
   mF = MET_GetFieldRecord("DisplayOrientation", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     if (mF->value[0] != 0.0)
     {
@@ -356,7 +356,7 @@ MetaContour::M_Read()
   }
 
   mF = MET_GetFieldRecord("PinToSlice", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     if (mF->value[0] != 0.0)
     {
@@ -365,13 +365,13 @@ MetaContour::M_Read()
   }
 
   mF = MET_GetFieldRecord("NControlPoints", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NControlPoints = static_cast<int>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("ControlPointDim", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     strcpy(m_ControlPointDim, reinterpret_cast<char *>(mF->value));
   }
@@ -690,7 +690,7 @@ MetaContour::M_Read()
       delete[] v;
 
       char c = ' ';
-      while ((c != '\n') && (!m_ReadStream->eof()))
+      while ((c != '\n') && (c != -1) && (!m_ReadStream->eof()))
       {
         c = static_cast<char>(m_ReadStream->get()); // to avoid unrecognize charactere
       }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaEllipse.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaEllipse.cxx
@@ -188,7 +188,7 @@ MetaEllipse::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("Radius", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     for (int i = 0; i < m_NDims; i++)
     {

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
@@ -546,12 +546,8 @@ MetaForm::Read(const char * _fileName)
 
   std::cout << "Read FileName = _" << m_FileName << "_" << '\n';
 
-  auto * tmpReadStream = new std::ifstream;
-#ifdef __sgi
-  tmpReadStream->open(m_FileName, std::ios::in);
-#else
-  tmpReadStream->open(m_FileName, std::ios::binary | std::ios::in);
-#endif
+  auto * tmpReadStream = new METAIO_STREAM::ifstream;
+  tmpReadStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
   if (!tmpReadStream->rdbuf()->is_open())
   {
@@ -576,7 +572,7 @@ MetaForm::Read(const char * _fileName)
 }
 
 bool
-MetaForm::CanReadStream(std::ifstream * _stream)
+MetaForm::CanReadStream(METAIO_STREAM::ifstream * _stream)
 {
   if (_stream)
   {
@@ -589,7 +585,7 @@ MetaForm::CanReadStream(std::ifstream * _stream)
 }
 
 bool
-MetaForm::ReadStream(std::ifstream * _stream)
+MetaForm::ReadStream(METAIO_STREAM::ifstream * _stream)
 {
   META_DEBUG_PRINT( "MetaForm: ReadStream" );
 
@@ -623,18 +619,9 @@ MetaForm::Write(const char * _fileName)
 
   std::cout << "Write FileName = _" << m_FileName << "_" << '\n';
 
-  auto * tmpWriteStream = new std::ofstream;
+  auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
-#ifdef __sgi
-  {
-    // Create the file. This is required on some older sgi's
-    std::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  tmpWriteStream->open(m_FileName, std::ios::out);
-#else
-  tmpWriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  tmpWriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!tmpWriteStream->rdbuf()->is_open())
   {
@@ -653,7 +640,7 @@ MetaForm::Write(const char * _fileName)
 }
 
 bool
-MetaForm::WriteStream(std::ofstream * _stream)
+MetaForm::WriteStream(METAIO_STREAM::ofstream * _stream)
 {
   M_SetupWriteFields();
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.h
@@ -159,23 +159,23 @@ public:
   Read(const char * _fileName = nullptr);
 
   static bool
-  CanReadStream(std::ifstream * _stream) ;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) ;
 
   bool
-  ReadStream(std::ifstream * _stream);
+  ReadStream(METAIO_STREAM::ifstream * _stream);
 
   bool
   Write(const char * _fileName = nullptr);
 
   bool
-  WriteStream(std::ofstream * _stream);
+  WriteStream(METAIO_STREAM::ofstream * _stream);
 
   // PROTECTED
 protected:
   typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-  std::ifstream * m_ReadStream;
-  std::ofstream * m_WriteStream;
+  METAIO_STREAM::ifstream * m_ReadStream;
+  METAIO_STREAM::ofstream * m_WriteStream;
 
   std::string m_FileName;
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.h
@@ -122,7 +122,8 @@ public:
                       MET_ValueEnumType _elementType,
                       int               _elementNumberOfChannels = 1,
                       void *            _elementData = nullptr,
-                      bool              _allocElementMemory = true);
+                      bool              _allocElementMemory = true,
+                      bool              _initializePosition = true);
 
   bool
   InitializeEssential(int               _nDims,
@@ -131,7 +132,8 @@ public:
                       MET_ValueEnumType _elementType,
                       int               _elementNumberOfChannels = 1,
                       void *            _elementData = nullptr,
-                      bool              _allocElementMemory = true);
+                      bool              _allocElementMemory = true,
+                      bool              _initializePosition = true);
 
   int
   HeaderSize() const;
@@ -251,6 +253,60 @@ public:
   void
   ElementToIntensityFunctionOffset(double _elementOffset);
 
+  // (Copied from ITK's definition of Direction and Origin)
+  //
+  //  The position and orientation of an image is defined by its "Origin"
+  // and its "Directions".  The "Origin" is the physical position of the
+  // pixel whose "Index" is all zeros. The "Direction" of an image is a
+  // matrix whose columns indicate the direction in physical space that
+  // each dimension of the image traverses. The first column defines the
+  // direction that the fastest moving index in the image traverses in
+  // physical space while the last column defines the direction that the
+  // slowest moving index in the image traverses in physical space.
+  // 
+  // Set the direction cosines of the image. The direction cosines
+  // are vectors that point from one pixel to the next.
+  //
+  // Each column of the matrix indicates the direction cosines of the unit vector
+  // that is parallel to the lines of the image grid corresponding to that
+  // dimension. For example, an image with Direction matrix
+  //
+  //    0.866   0.500
+  //   -0.500   0.866
+  //
+  // has an image grid were the fastest changing index (dimension[0]) walks
+  // over a line that in physical space is oriented parallel to the vector
+  // (0.866, -0.5). The second fastest changing index (dimension[1]) walks along
+  // a line that in Physical space is oriented parallel to the vector
+  // (0.5, 0.866)
+  //
+  // The columns of the Direction matrix are expected to form an
+  // orthogonal right handed coordinate system.  But this is not
+  // checked nor enforced in itk::ImageBase.
+  //
+  // For details, please see:
+  //
+  // https://www.itk.org/Wiki/Proposals:Orientation#Some_notes_on_the_DICOM_convention_and_current_ITK_usage
+  const double *
+  ElementOrigin() const;
+  double
+  ElementOrigin(int _i) const;
+  void
+  ElementOrigin(const double * _position);
+  void
+  ElementOrigin(const float * _position);
+  void
+  ElementOrigin(int _i, double _value);
+
+  const double *
+  ElementDirection() const;
+  double
+  ElementDirection(int _i, int _j) const;
+  void
+  ElementDirection(const double * _direction);
+  void
+  ElementDirection(int _i, int _j, double _value);
+
   bool
   AutoFreeElementData() const;
   void
@@ -303,16 +359,16 @@ public:
 
 
   static bool
-  CanReadStream(std::ifstream * _stream) ;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) ;
 
   bool
-  ReadStream(int _nDims, std::ifstream * _stream, bool _readElements = true, void * _buffer = nullptr);
+  ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream, bool _readElements = true, void * _buffer = nullptr);
 
   bool
   ReadROIStream(int *           _indexMin,
                 int *           _indexMax,
                 int             _nDims,
-                std::ifstream * _stream,
+                METAIO_STREAM::ifstream * _stream,
                 bool            _readElements = true,
                 void *          _buffer = nullptr,
                 unsigned int    subSamplingFactor = 1);
@@ -340,7 +396,7 @@ public:
            bool         _append = false);
 
   bool
-  WriteStream(std::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
+  WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
 
 
   bool
@@ -380,6 +436,9 @@ protected:
   double m_ElementToIntensityFunctionSlope{};
   double m_ElementToIntensityFunctionOffset{};
 
+  double m_ElementOrigin[10]{};     // "ElementOrigin = "          0,0,0
+  double m_ElementDirection[100]{}; // "ElementDirection = " 1,0,0,0,1,0,0,0,1
+                                   
   bool m_AutoFreeElementData{};
 
   void * m_ElementData{};
@@ -402,13 +461,13 @@ protected:
   // _dataQuantity is expressed in number of pixels. Internally it will be
   // scaled by the number of components and number of bytes per component.
   bool
-  M_ReadElements(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
+  M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
 
   // _totalDataQuantity and _dataQuantity are expressed in number of pixels.
   // Internally they will be scaled by the number of components and number of
   // bytes per component.
   bool
-  M_ReadElementsROI(std::ifstream * _fstream,
+  M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream,
                     void *          _data,
                     std::streamoff  _dataQuantity,
                     int *           _indexMin,
@@ -417,20 +476,20 @@ protected:
                     std::streamoff  _totalDataQuantity = 0);
 
   bool
-  M_ReadElementData(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
+  M_ReadElementData(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
 
   bool
-  M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 
   bool
-  M_WriteElementsROI(std::ofstream * _fstream,
+  M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
                      const void *    _data,
                      std::streampos  _dataPos,
                      const int *     _indexMin,
                      const int *     _indexMax);
 
   bool
-  M_WriteElementData(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElementData(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 
   static bool
   M_FileExists(const char * filename) ;
@@ -450,6 +509,7 @@ private:
              MET_ValueEnumType _elementType,
              int               _elementNumberOfChannels,
              void *            _elementData);
+
 };
 
 #  if (METAIO_USE_NAMESPACE)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaLandmark.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaLandmark.cxx
@@ -245,20 +245,20 @@ MetaLandmark::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("NPoints", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NPoints = static_cast<int>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("ElementType", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     MET_StringToType(reinterpret_cast<char *>(mF->value), &m_ElementType);
   }
 
 
   mF = MET_GetFieldRecord("PointDim", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     strcpy(m_PointDim, reinterpret_cast<char *>(mF->value));
   }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaLine.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaLine.cxx
@@ -255,19 +255,19 @@ MetaLine::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("NPoints", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NPoints = static_cast<int>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("ElementType", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     MET_StringToType(reinterpret_cast<char *>(mF->value), &m_ElementType);
   }
 
   mF = MET_GetFieldRecord("PointDim", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     strcpy(m_PointDim, reinterpret_cast<char *>(mF->value));
   }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaMesh.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaMesh.h
@@ -115,7 +115,7 @@ public:
   virtual ~MeshDataBase() = default;
 
   virtual void
-  Write(std::ofstream * stream) = 0;
+  Write(METAIO_STREAM::ofstream * stream) = 0;
   virtual unsigned int
   GetSize() = 0;
   virtual MET_ValueEnumType
@@ -123,8 +123,8 @@ public:
   int m_Id;
 
 protected:
-  std::ifstream * m_ReadStream{};
-  std::ofstream * m_WriteStream{};
+  METAIO_STREAM::ifstream * m_ReadStream{};
+  METAIO_STREAM::ofstream * m_WriteStream{};
 };
 
 /** Mesh point data class for basic types (i.e int, float ... ) */
@@ -142,7 +142,7 @@ public:
   }
 
   void
-  Write(std::ofstream * stream) override
+  Write(METAIO_STREAM::ofstream * stream) override
   {
     // char* id = new char[sizeof(int)];
     // The file is written as LSB by default

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.h
@@ -35,6 +35,7 @@ class METAIO_EXPORT MetaObject
   // PROTECTED
 protected:
   std::set<std::string> m_ReservedKeywords = {
+    "FileFormatVersion",
     "ObjectType",
     "ObjectSubType",
     "NDims",
@@ -56,13 +57,16 @@ protected:
 
   typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-  std::ifstream * m_ReadStream;
-  std::ofstream * m_WriteStream;
+  METAIO_STREAM::ifstream * m_ReadStream;
+  METAIO_STREAM::ofstream * m_WriteStream;
 
   FieldsContainerType m_Fields;
   FieldsContainerType m_UserDefinedWriteFields;
   FieldsContainerType m_UserDefinedReadFields;
   FieldsContainerType m_AdditionalReadFields;
+
+  unsigned int m_FileFormatVersion;
+  unsigned int m_APIVersion;
 
   std::string m_FileName;
 
@@ -143,6 +147,16 @@ public:
   GetReservedKeywords() const;
 
   void
+  FileFormatVersion(unsigned int _fileFormatVersion);
+  unsigned int
+  FileFormatVersion() const;
+
+  void
+  APIVersion(unsigned int _APIVersion);
+  unsigned int
+  APIVersion() const;
+
+  void
   FileName(const char * _fileName);
   const char *
   FileName() const;
@@ -154,7 +168,7 @@ public:
   Read(const char * _fileName = nullptr);
 
   bool
-  ReadStream(int _nDims, std::ifstream * _stream);
+  ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream);
 
   virtual bool
   Write(const char * _fileName = nullptr);
@@ -204,21 +218,21 @@ public:
   Offset(const double * _position);
   void
   Offset(int _i, double _value);
-  const double *
+  virtual const double *
   Position() const;
-  double
+  virtual double
   Position(int _i) const;
-  void
+  virtual void
   Position(const double * _position);
-  void
+  virtual void
   Position(int _i, double _value);
-  const double *
+  virtual const double *
   Origin() const;
-  double
+  virtual double
   Origin(int _i) const;
-  void
+  virtual void
   Origin(const double * _position);
-  void
+  virtual void
   Origin(int _i, double _value);
 
   //    TransformMatrix(...)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaScene.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaScene.cxx
@@ -115,7 +115,7 @@ MetaScene::Read(const char * _headerName)
     strcpy(suf, &_headerName[i]);
   }
 
-MetaObject::M_Destroy();
+  MetaObject::M_Destroy();
 
   Clear();
 
@@ -130,7 +130,7 @@ MetaObject::M_Destroy();
 
   M_PrepareNewReadStream();
 
-  m_ReadStream->open(m_FileName, std::ios::binary | std::ios::in);
+  m_ReadStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
   if (!m_ReadStream->rdbuf()->is_open())
   {
@@ -172,6 +172,7 @@ MetaObject::M_Destroy();
       if (!strncmp(subtype, "Vessel", 6))
       {
         auto * vesseltube = new MetaVesselTube();
+        vesseltube->APIVersion(m_APIVersion);
         vesseltube->SetEvent(m_Event);
         vesseltube->ReadStream(m_NDims, m_ReadStream);
         m_ObjectList.push_back(vesseltube);
@@ -179,6 +180,7 @@ MetaObject::M_Destroy();
       else if (!strncmp(subtype, "DTI", 3))
       {
         auto * dtitube = new MetaDTITube();
+        dtitube->APIVersion(m_APIVersion);
         dtitube->SetEvent(m_Event);
         dtitube->ReadStream(m_NDims, m_ReadStream);
         m_ObjectList.push_back(dtitube);
@@ -186,6 +188,7 @@ MetaObject::M_Destroy();
       else
       {
         auto * tube = new MetaTube();
+        tube->APIVersion(m_APIVersion);
         tube->SetEvent(m_Event);
         tube->ReadStream(m_NDims, m_ReadStream);
         m_ObjectList.push_back(tube);
@@ -196,6 +199,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Transform", 9))
     {
       auto * transform = new MetaTransform();
+      transform->APIVersion(m_APIVersion);
       transform->SetEvent(m_Event);
       transform->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(transform);
@@ -204,6 +208,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "TubeGraph", 9))
     {
       auto * tubeGraph = new MetaTubeGraph();
+      tubeGraph->APIVersion(m_APIVersion);
       tubeGraph->SetEvent(m_Event);
       tubeGraph->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(tubeGraph);
@@ -212,6 +217,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Ellipse", 7) || ((objectType.empty()) && !strcmp(suf, "elp")))
     {
       auto * ellipse = new MetaEllipse();
+      ellipse->APIVersion(m_APIVersion);
       ellipse->SetEvent(m_Event);
       ellipse->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(ellipse);
@@ -220,6 +226,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Contour", 7) || ((objectType.empty()) && !strcmp(suf, "ctr")))
     {
       auto * contour = new MetaContour();
+      contour->APIVersion(m_APIVersion);
       contour->SetEvent(m_Event);
       contour->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(contour);
@@ -228,6 +235,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Arrow", 5))
     {
       auto * arrow = new MetaArrow();
+      arrow->APIVersion(m_APIVersion);
       arrow->SetEvent(m_Event);
       arrow->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(arrow);
@@ -236,6 +244,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Gaussian", 8) || ((objectType.empty()) && !strcmp(suf, "gau")))
     {
       auto * gaussian = new MetaGaussian();
+      gaussian->APIVersion(m_APIVersion);
       gaussian->SetEvent(m_Event);
       gaussian->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(gaussian);
@@ -245,6 +254,7 @@ MetaObject::M_Destroy();
              ((objectType.empty()) && (!strcmp(suf, "mhd") || !strcmp(suf, "mha"))))
     {
       auto * image = new MetaImage();
+      image->APIVersion(m_APIVersion);
       image->SetEvent(m_Event);
       image->ReadStream(m_NDims, m_ReadStream);
       image->ElementByteOrderFix();
@@ -254,6 +264,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Blob", 4) || ((objectType.empty()) && !strcmp(suf, "blb")))
     {
       auto * blob = new MetaBlob();
+      blob->APIVersion(m_APIVersion);
       blob->SetEvent(m_Event);
       blob->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(blob);
@@ -262,6 +273,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Landmark", 8) || ((objectType.empty()) && !strcmp(suf, "ldm")))
     {
       auto * landmark = new MetaLandmark();
+      landmark->APIVersion(m_APIVersion);
       landmark->SetEvent(m_Event);
       landmark->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(landmark);
@@ -270,6 +282,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Surface", 5) || ((objectType.empty()) && !strcmp(suf, "suf")))
     {
       auto * surface = new MetaSurface();
+      surface->APIVersion(m_APIVersion);
       surface->SetEvent(m_Event);
       surface->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(surface);
@@ -278,6 +291,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Line", 4) || ((objectType.empty()) && !strcmp(suf, "lin")))
     {
       auto * line = new MetaLine();
+      line->APIVersion(m_APIVersion);
       line->SetEvent(m_Event);
       line->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(line);
@@ -286,6 +300,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Group", 5) || ((objectType.empty()) && !strcmp(suf, "grp")))
     {
       auto * group = new MetaGroup();
+      group->APIVersion(m_APIVersion);
       group->SetEvent(m_Event);
       group->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(group);
@@ -294,6 +309,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "AffineTransform", 15) || ((objectType.empty()) && !strcmp(suf, "trn")))
     {
       auto * group = new MetaGroup();
+      group->APIVersion(m_APIVersion);
       group->SetEvent(m_Event);
       group->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(group);
@@ -301,6 +317,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "Mesh", 4) || ((objectType.empty()) && !strcmp(suf, "msh")))
     {
       auto * mesh = new MetaMesh();
+      mesh->APIVersion(m_APIVersion);
       mesh->SetEvent(m_Event);
       mesh->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(mesh);
@@ -308,6 +325,7 @@ MetaObject::M_Destroy();
     else if (!strncmp(objectType.c_str(), "FEMObject", 9) || ((objectType.empty()) && !strcmp(suf, "fem")))
     {
       auto * femobject = new MetaFEMObject();
+      femobject->APIVersion(m_APIVersion);
       femobject->SetEvent(m_Event);
       femobject->ReadStream(m_NDims, m_ReadStream);
       m_ObjectList.push_back(femobject);
@@ -343,19 +361,10 @@ MetaScene::Write(const char * _headName)
 
   if (!m_WriteStream)
   {
-    m_WriteStream = new std::ofstream;
+    m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
-#ifdef __sgi
-  // Create the file. This is required on some older sgi's
-  {
-    std::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  m_WriteStream->open(m_FileName, std::ios::out);
-#else
-  m_WriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  m_WriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!m_WriteStream->rdbuf()->is_open())
   {
@@ -414,8 +423,7 @@ MetaScene::M_SetupReadFields()
   MET_FieldRecordType * mF;
 
   mF = new MET_FieldRecordType;
-  MET_InitReadField(mF, "NObjects", MET_INT, false);
-  mF->required = true;
+  MET_InitReadField(mF, "NObjects", MET_INT, true);
   mF->terminateRead = true;
   m_Fields.push_back(mF);
 
@@ -429,6 +437,13 @@ MetaScene::M_SetupWriteFields()
   this->ClearFields();
 
   MET_FieldRecordType * mF;
+
+  if (m_FileFormatVersion > 0)
+  {
+    mF = new MET_FieldRecordType;
+    MET_InitWriteField(mF, "FileFormatVersion", MET_UINT, m_FileFormatVersion);
+    m_Fields.push_back(mF);
+  }
 
   if (strlen(m_Comment) > 0)
   {
@@ -473,7 +488,7 @@ MetaScene::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("NObjects", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NObjects = static_cast<int>(mF->value[0]);
   }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaSurface.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaSurface.cxx
@@ -244,19 +244,19 @@ MetaSurface::M_Read()
   MET_FieldRecordType * mF;
 
   mF = MET_GetFieldRecord("NPoints", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     m_NPoints = static_cast<int>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("ElementType", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     MET_StringToType(reinterpret_cast<char *>(mF->value), &m_ElementType);
   }
 
   mF = MET_GetFieldRecord("PointDim", &m_Fields);
-  if (mF->defined)
+  if (mF && mF->defined)
   {
     strcpy(m_PointDim, reinterpret_cast<char *>(mF->value));
   }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
@@ -590,7 +590,7 @@ MET_ValueToValue(MET_ValueEnumType _fromType,
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
 std::streamoff
-MET_UncompressStream(std::ifstream *            stream,
+MET_UncompressStream(METAIO_STREAM::ifstream *            stream,
                      std::streamoff             uncompressedSeekPosition,
                      unsigned char *            uncompressedData,
                      std::streamoff             uncompressedDataSize,
@@ -1909,6 +1909,66 @@ MET_SwapByteIfSystemMSB(void * val, MET_ValueEnumType _type)
     }
   }
 }
+
+
+void MET_PrintFieldRecord(std::ostream & _fp, MET_FieldRecordType * _mf)
+{
+  if (_mf == nullptr)
+  {
+    _fp << "NULL Field Record" << '\n';
+    return;
+  }
+  _fp << "Name = " << _mf->name << '\n';
+  _fp << "Type = " << MET_ValueTypeName[_mf->type] << '\n';
+  _fp << "Defined = " << _mf->defined << '\n';
+  _fp << "Length = " << _mf->length << '\n';
+  _fp << "DependsOn = " << _mf->dependsOn << '\n';
+  _fp << "Required = " << _mf->required << '\n';
+  _fp << "TerminateRead = " << _mf->terminateRead << '\n';
+  _fp << "Value = ";
+  if (!_mf->defined)
+  {
+    _fp << "Undefined" << '\n';
+    return;
+  }
+  if (_mf->type == MET_STRING)
+  {
+    _fp << reinterpret_cast<char *>(_mf->value) << '\n';
+  }
+  else if (_mf->type == MET_ASCII_CHAR || _mf->type == MET_CHAR || _mf->type == MET_UCHAR ||
+           _mf->type == MET_SHORT || _mf->type == MET_USHORT || _mf->type == MET_LONG ||
+           _mf->type == MET_ULONG || _mf->type == MET_INT || _mf->type == MET_UINT ||
+           _mf->type == MET_FLOAT || _mf->type == MET_DOUBLE)
+  {
+    _fp << _mf->name << " : " << _mf->value[0] << '\n';
+  }
+  else if (_mf->type == MET_CHAR_ARRAY || _mf->type == MET_UCHAR_ARRAY || _mf->type == MET_SHORT_ARRAY ||
+           _mf->type == MET_USHORT_ARRAY || _mf->type == MET_INT_ARRAY || _mf->type == MET_UINT_ARRAY ||
+           _mf->type == MET_FLOAT_ARRAY || _mf->type == MET_DOUBLE_ARRAY)
+  {
+    _fp << _mf->value[0];
+    for (int i = 1; i < _mf->length; i++)
+    {
+      _fp << ", " << _mf->value[i];
+    }
+    _fp << '\n';
+  }
+  else if (_mf->type == MET_FLOAT_MATRIX)
+  {
+    _fp << '\n';
+    int count = 0;
+    for (int i = 0; i < _mf->length; i++)
+    {
+      _fp << _mf->value[count++];
+      for (int j = 1; j < _mf->length; j++)
+      {
+        _fp << ", " << _mf->value[count++];
+      }
+      _fp << '\n';
+    }
+  }
+}
+
 
 #if (METAIO_USE_NAMESPACE)
 };

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.h
@@ -349,7 +349,7 @@ MET_PerformUncompression(const unsigned char * sourceCompressed,
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
 std::streamoff
-MET_UncompressStream(std::ifstream *            stream,
+MET_UncompressStream(METAIO_STREAM::ifstream *            stream,
                      std::streamoff             uncompressedSeekPosition,
                      unsigned char *            uncompressedData,
                      std::streamoff             uncompressedDataSize,
@@ -441,6 +441,10 @@ MET_Read(std::istream &                       fp,
          bool                                 display_warnings = true,
          std::vector<MET_FieldRecordType *> * newFields = nullptr);
 
+
+METAIO_EXPORT
+void
+MET_PrintFieldRecord(std::ostream & _fp, MET_FieldRecordType * _mf);
 
 METAIO_EXPORT
 std::string

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta2Object.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta2Object.cxx
@@ -40,25 +40,31 @@ main(int, char *[])
   float myMatrix[4];
   for (i = 0; i < 4; i++)
   {
-    myMatrix[i] = i;
+    myMatrix[i] = static_cast<float>(i);
   }
   tObj.AddUserField("MyMatrix", MET_FLOAT_MATRIX, 2, myMatrix);
 
+  std::cout << "*** Writing this info..." << std::endl;
   tObj.PrintInfo();
   tObj.Write();
 
   tObj.Clear();
   tObj.ClearUserFields();
 
+  std::cout << "*** Adding user fields..." << std::endl;
   tObj.AddUserField("MyName", MET_STRING);
   tObj.AddUserField("MyArray", MET_INT_ARRAY, 3);
   tObj.AddUserField("MyMatrix", MET_FLOAT_MATRIX, 2);
 
+  std::cout << "*** Pre-reading..." << std::endl;
+  tObj.PrintInfo();
+  std::cout << "*** Reading..." << std::endl;
   tObj.Read();
+  std::cout << "*** Reading results..." << std::endl;
   tObj.PrintInfo();
 
   char * name = static_cast<char *>(tObj.GetUserField("MyName"));
-  if (strcmp(name, "Julien") != 0)
+  if (name == nullptr || strcmp(name, "Julien") != 0)
   {
     std::cout << "MyName: FAIL" << '\n';
     return EXIT_FAILURE;
@@ -69,7 +75,7 @@ main(int, char *[])
   int * array = static_cast<int *>(tObj.GetUserField("MyArray"));
   for (i = 0; i < 3; i++)
   {
-    if (array[i] != i + 1)
+    if (array == nullptr || array[i] != i + 1)
     {
       std::cout << "MyArray: FAIL" << '\n';
       delete[] array;
@@ -82,7 +88,7 @@ main(int, char *[])
   auto * matrix = static_cast<float *>(tObj.GetUserField("MyMatrix"));
   for (i = 0; i < 4; i++)
   {
-    if (matrix[i] != i)
+    if (matrix == nullptr || matrix[i] != i)
     {
       std::cout << "MyMatrix: FAIL" << '\n';
       delete[] matrix;

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta4Tube.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta4Tube.cxx
@@ -25,10 +25,11 @@ main(int, char *[])
   for (i = 0; i < 10; i++)
   {
     pnt = new TubePnt(3);
-    pnt->m_X[0] = i;
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
-    pnt->m_R = i;
+    float i_f = static_cast<float>(i);
+    pnt->m_X[0] = i_f;
+    pnt->m_X[1] = i_f;
+    pnt->m_X[2] = i_f;
+    pnt->m_R = i_f;
     tube1->GetPoints().push_back(pnt);
   }
 
@@ -38,10 +39,11 @@ main(int, char *[])
   for (i = 0; i < 5; i++)
   {
     pnt = new TubePnt(3);
-    pnt->m_X[0] = i;
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
-    pnt->m_R = i;
+    float i_f = static_cast<float>(i);
+    pnt->m_X[0] = i_f;
+    pnt->m_X[1] = i_f;
+    pnt->m_X[2] = i_f;
+    pnt->m_R = i_f;
     tube2->GetPoints().push_back(pnt);
   }
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta5Blob.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta5Blob.cxx
@@ -20,8 +20,8 @@ main(int, char *[])
   {
     pnt = new BlobPnt(3);
     pnt->m_X[0] = static_cast<float>(0.2);
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
+    pnt->m_X[1] = static_cast<float>(i);
+    pnt->m_X[2] = static_cast<float>(i);
     blob.GetPoints().push_back(pnt);
   }
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta6Surface.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta6Surface.cxx
@@ -15,11 +15,12 @@ main(int, char *[])
   {
     pnt = new SurfacePnt(3);
     pnt->m_X[0] = static_cast<float>(0.2);
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
+    float i_f = static_cast<float>(i);
+    pnt->m_X[1] = i_f;
+    pnt->m_X[2] = i_f;
     pnt->m_V[0] = static_cast<float>(0.8);
-    pnt->m_V[1] = i;
-    pnt->m_V[2] = i;
+    pnt->m_V[1] = i_f;
+    pnt->m_V[2] = i_f;
     surface->GetPoints().push_back(pnt);
   }
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta7Line.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta7Line.cxx
@@ -15,14 +15,15 @@ main(int, char *[])
   {
     pnt = new LinePnt(3);
     pnt->m_X[0] = static_cast<float>(0.2);
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
+    float i_f = static_cast<float>(i);
+    pnt->m_X[1] = i_f;
+    pnt->m_X[2] = i_f;
     pnt->m_V[0][0] = static_cast<float>(0.3);
-    pnt->m_V[0][1] = i;
-    pnt->m_V[0][2] = i;
+    pnt->m_V[0][1] = i_f;
+    pnt->m_V[0][2] = i_f;
     pnt->m_V[1][0] = static_cast<float>(0.4);
-    pnt->m_V[1][1] = i + 1;
-    pnt->m_V[1][2] = i + 1;
+    pnt->m_V[1][1] = i_f + 1;
+    pnt->m_V[1][2] = i_f + 1;
     Line->GetPoints().push_back(pnt);
   }
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta9Landmark.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/tests/testMeta9Landmark.cxx
@@ -16,8 +16,8 @@ main(int, char *[])
   {
     pnt = new LandmarkPnt(3);
     pnt->m_X[0] = static_cast<float>(0.2);
-    pnt->m_X[1] = i;
-    pnt->m_X[2] = i;
+    pnt->m_X[1] = static_cast<float>(i);
+    pnt->m_X[2] = static_cast<float>(i);
     Landmark.GetPoints().push_back(pnt);
   }
 


### PR DESCRIPTION
When reading/writing spatial objects via Meta, provide the option of using MetaIO version 1, which fixes bugs in the original MetaIO and SpatialObject implementations.

Specifically,
- ElementOrigin, ElementDirection, and ElementSpacing are used for the image index to physical space transform specification
- TransformMatrix, Position, and CenterOfRotation are used for the object-to-parent transform in the spatialobject scene graph.

Note that this PR is dependent on PR https://github.com/InsightSoftwareConsortium/ITK/pull/4739 being merged.