### PR TITLE
ENH: Update SpatialObjects for MetaIO v1

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -38,11 +38,6 @@ ArrowSpatialObject<TDimension>::Clear()
 {
   Superclass::Clear();
 
-  this->GetProperty().SetRed(1);
-  this->GetProperty().SetGreen(0);
-  this->GetProperty().SetBlue(0);
-  this->GetProperty().SetAlpha(1);
-
   m_DirectionInObjectSpace.Fill(0);
   m_DirectionInObjectSpace[0] = 1; // along the x direction by default
   m_PositionInObjectSpace.Fill(0);

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -65,7 +65,6 @@ MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType *
     arrowSO->SetPositionInObjectSpace(positionInObjectSpace);
   }
 
-  std::cout << directionInObjectSpace << std::endl;
   arrowSO->SetDirectionInObjectSpace(directionInObjectSpace);
 
   arrowSO->Update();

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -41,6 +41,8 @@ MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType *
   }
   ArrowSpatialObjectPointer arrowSO = ArrowSpatialObjectType::New();
 
+  this->MetaObjectToSpatialObjectBase(mo, arrowSO);
+
   float lengthInObjectSpace = metaArrow->Length();
   arrowSO->SetLengthInObjectSpace(lengthInObjectSpace);
 
@@ -53,17 +55,19 @@ MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType *
     positionInObjectSpace[i] = metaPosition[i];
     directionInObjectSpace[i] = metaDirection[i];
   }
-  arrowSO->SetPositionInObjectSpace(positionInObjectSpace);
+  if (mo->APIVersion() == 1)
+  {
+    // if not using new API, then the position is already stored as Offset.
+    // Really not certain how to handle the old case since it produced a bug...with
+    //    position being stored in the Offset and the Position!  But then the WorldPosition
+    //    would compose offset with position, which would be wrong...   It really never
+    //    worked correctly...
+    arrowSO->SetPositionInObjectSpace(positionInObjectSpace);
+  }
+
+  std::cout << directionInObjectSpace << std::endl;
   arrowSO->SetDirectionInObjectSpace(directionInObjectSpace);
 
-  // convert the other fields
-  arrowSO->GetProperty().SetName(metaArrow->Name());
-  arrowSO->SetId(metaArrow->ID());
-  arrowSO->SetParentId(metaArrow->ParentID());
-  arrowSO->GetProperty().SetRed(metaArrow->Color()[0]);
-  arrowSO->GetProperty().SetGreen(metaArrow->Color()[1]);
-  arrowSO->GetProperty().SetBlue(metaArrow->Color()[2]);
-  arrowSO->GetProperty().SetAlpha(metaArrow->Color()[3]);
   arrowSO->Update();
 
   return arrowSO.GetPointer();
@@ -81,13 +85,13 @@ MetaArrowConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectTyp
   }
 
   auto * mo = new MetaArrow(VDimension);
+  mo->APIVersion(1);
+  mo->FileFormatVersion(1);
+
+  this->SpatialObjectToMetaObjectBase(spatialObject, mo);
 
   float metaLength = arrowSO->GetLengthInObjectSpace();
-
-  if (arrowSO->GetParent())
-  {
-    mo->ParentID(arrowSO->GetParent()->GetId());
-  }
+  mo->Length(metaLength);
 
   // convert position and direction
   double                                 metaPosition[VDimension];
@@ -101,15 +105,6 @@ MetaArrowConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectTyp
   }
   mo->Position(metaPosition);
   mo->Direction(metaDirection);
-
-  // convert the rest of the parameters
-  mo->Length(metaLength);
-  mo->ID(arrowSO->GetId());
-
-  mo->Color(arrowSO->GetProperty().GetRed(),
-            arrowSO->GetProperty().GetGreen(),
-            arrowSO->GetProperty().GetBlue(),
-            arrowSO->GetProperty().GetAlpha());
 
   return mo;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -53,7 +53,11 @@ public:
 
   using SpatialObjectType = SpatialObject<VDimension>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
   using MetaObjectType = MetaObject;
+
+  itkSetMacro(MetaIOVersion, unsigned int);
+  itkGetConstMacro(MetaIOVersion, unsigned int);
 
   /** Read a MetaIO file, return a SpatialObject */
   virtual SpatialObjectPointer
@@ -62,6 +66,12 @@ public:
   /** Write a MetaIO file based on this SpatialObject */
   virtual bool
   WriteMeta(const SpatialObjectType * spatialObject, const char * name);
+
+  void
+  MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer spatialObject);
+
+  void
+  SpatialObjectToMetaObjectBase(SpatialObjectConstPointer spatialObject, MetaObjectType * mo);
 
   /** Convert the MetaObject to Spatial Object */
   virtual SpatialObjectPointer
@@ -88,7 +98,8 @@ protected:
 
 
 private:
-  bool m_WriteImagesInSeparateFile{ false };
+  bool         m_WriteImagesInSeparateFile{ false };
+  unsigned int m_MetaIOVersion{ 0 };
 };
 
 } // namespace itk

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -33,10 +33,10 @@ MetaConverterBase<VDimension>::MetaObjectToSpatialObjectBase(const MetaObjectTyp
   typename SpatialObject<VDimension>::TransformType::OffsetType off;
   typename SpatialObject<VDimension>::TransformType::MatrixType mat;
   typename SpatialObject<VDimension>::TransformType::CenterType cen;
-  for (int i = 0; i < VDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     off[i] = mo->Offset()[i];
-    for (int j = 0; j < VDimension; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       mat[i][j] = mo->TransformMatrix()[i * VDimension + j];
     }
@@ -68,10 +68,10 @@ MetaConverterBase<VDimension>::SpatialObjectToMetaObjectBase(SpatialObjectConstP
     double                                                          mo_off[10];
     double                                                          mo_mat[100];
     double                                                          mo_cen[10];
-    for (int i = 0; i < VDimension; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       mo_off[i] = tfm->GetOffset()[i];
-      for (int j = 0; j < VDimension; ++j)
+      for (unsigned int j = 0; j < VDimension; ++j)
       {
         mo_mat[i * VDimension + j] = tfm->GetMatrix()[i][j];
       }

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -29,10 +29,10 @@ MetaConverterBase<VDimension>::MetaObjectToSpatialObjectBase(const MetaObjectTyp
 {
   rval->SetId(mo->ID());
   rval->SetParentId(mo->ParentID());
-  SpatialObject<VDimension>::TransformType::Pointer    tfm = SpatialObject<VDimension>::TransformType::New();
-  SpatialObject<VDimension>::TransformType::OffsetType off;
-  SpatialObject<VDimension>::TransformType::MatrixType mat;
-  SpatialObject<VDimension>::TransformType::CenterType cen;
+  typename SpatialObject<VDimension>::TransformType::Pointer    tfm = SpatialObject<VDimension>::TransformType::New();
+  typename SpatialObject<VDimension>::TransformType::OffsetType off;
+  typename SpatialObject<VDimension>::TransformType::MatrixType mat;
+  typename SpatialObject<VDimension>::TransformType::CenterType cen;
   for (int i = 0; i < VDimension; ++i)
   {
     off[i] = mo->Offset()[i];
@@ -64,10 +64,10 @@ MetaConverterBase<VDimension>::SpatialObjectToMetaObjectBase(SpatialObjectConstP
   if (spatialObject->GetParent())
   {
     mo->ParentID(spatialObject->GetParent()->GetId());
-    SpatialObject<VDimension>::TransformType::ConstPointer tfm = spatialObject->GetObjectToParentTransform();
-    double                                                 mo_off[10];
-    double                                                 mo_mat[100];
-    double                                                 mo_cen[10];
+    typename SpatialObject<VDimension>::TransformType::ConstPointer tfm = spatialObject->GetObjectToParentTransform();
+    double                                                          mo_off[10];
+    double                                                          mo_mat[100];
+    double                                                          mo_cen[10];
     for (int i = 0; i < VDimension; ++i)
     {
       mo_off[i] = tfm->GetOffset()[i];

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -24,14 +24,82 @@ namespace itk
 {
 
 template <unsigned int VDimension>
+void
+MetaConverterBase<VDimension>::MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer rval)
+{
+  rval->SetId(mo->ID());
+  rval->SetParentId(mo->ParentID());
+  SpatialObject<VDimension>::TransformType::Pointer    tfm = SpatialObject<VDimension>::TransformType::New();
+  SpatialObject<VDimension>::TransformType::OffsetType off;
+  SpatialObject<VDimension>::TransformType::MatrixType mat;
+  SpatialObject<VDimension>::TransformType::CenterType cen;
+  for (int i = 0; i < VDimension; ++i)
+  {
+    off[i] = mo->Offset()[i];
+    for (int j = 0; j < VDimension; ++j)
+    {
+      mat[i][j] = mo->TransformMatrix()[i * VDimension + j];
+    }
+    cen[i] = mo->CenterOfRotation()[i];
+  }
+  tfm->SetCenter(cen);
+  tfm->SetMatrix(mat);
+  tfm->SetOffset(off);
+  rval->SetObjectToParentTransform(tfm);
+  rval->GetProperty().SetName(mo->Name());
+  rval->GetProperty().SetRed(mo->Color()[0]);
+  rval->GetProperty().SetGreen(mo->Color()[1]);
+  rval->GetProperty().SetBlue(mo->Color()[2]);
+  rval->GetProperty().SetAlpha(mo->Color()[3]);
+}
+
+template <unsigned int VDimension>
+void
+MetaConverterBase<VDimension>::SpatialObjectToMetaObjectBase(SpatialObjectConstPointer spatialObject,
+                                                             MetaObjectType *          mo)
+{
+  mo->APIVersion(m_MetaIOVersion);
+
+  mo->ID(spatialObject->GetId());
+  if (spatialObject->GetParent())
+  {
+    mo->ParentID(spatialObject->GetParent()->GetId());
+    SpatialObject<VDimension>::TransformType::ConstPointer tfm = spatialObject->GetObjectToParentTransform();
+    double                                                 mo_off[10];
+    double                                                 mo_mat[100];
+    double                                                 mo_cen[10];
+    for (int i = 0; i < VDimension; ++i)
+    {
+      mo_off[i] = tfm->GetOffset()[i];
+      for (int j = 0; j < VDimension; ++j)
+      {
+        mo_mat[i * VDimension + j] = tfm->GetMatrix()[i][j];
+      }
+      mo_cen[i] = tfm->GetCenter()[i];
+    }
+    mo->CenterOfRotation(mo_cen);
+    mo->TransformMatrix(mo_mat);
+    mo->Offset(mo_off);
+  }
+  mo->Name(spatialObject->GetProperty().GetName().c_str());
+  mo->Color(spatialObject->GetProperty().GetRed(),
+            spatialObject->GetProperty().GetGreen(),
+            spatialObject->GetProperty().GetBlue(),
+            spatialObject->GetProperty().GetAlpha());
+}
+
+template <unsigned int VDimension>
 auto
 MetaConverterBase<VDimension>::ReadMeta(const char * name) -> SpatialObjectPointer
 {
   SpatialObjectPointer rval;
   MetaObjectType *     mo = this->CreateMetaObject();
 
+  mo->APIVersion(m_MetaIOVersion);
   mo->Read(name);
+
   rval = this->MetaObjectToSpatialObject(mo);
+
   delete mo;
   return rval;
 }
@@ -41,7 +109,11 @@ bool
 MetaConverterBase<VDimension>::WriteMeta(const SpatialObjectType * spatialObject, const char * name)
 {
   MetaObject * mo = this->SpatialObjectToMetaObject(spatialObject);
+
+  mo->APIVersion(m_MetaIOVersion);
+  mo->FileFormatVersion(m_MetaIOVersion);
   mo->Write(name);
+
   delete mo;
   return true;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -103,7 +103,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::MetaObjectToSpati
 
   typename ImageType::Pointer myImage = this->AllocateImage(imageMO);
 
-  MetaObjectToSpatialObjectBase(imageMO, imageSO);
+  this->MetaObjectToSpatialObjectBase(imageMO, imageSO);
 
   itk::ImageRegionIteratorWithIndex<ImageType> it(myImage, myImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)
@@ -153,7 +153,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::SpatialObjectToMe
   imageMO->APIVersion(1);
   imageMO->FileFormatVersion(1);
 
-  SpatialObjectToMetaObjectBase(imageSO, imageMO);
+  this->SpatialObjectToMetaObjectBase(imageSO, imageMO);
 
   imageMO->ElementOrigin(origin);
   imageMO->ElementDirection(direction);

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -69,6 +69,15 @@ public:
   using MetaConverterPointer = typename MetaConverterBaseType::Pointer;
   using ConverterMapType = std::map<std::string, MetaConverterPointer>;
 
+  /** Choose the API and FileFormat version for MetaIO.
+   *    Version 0 (default) is not able to fully / accurately represent
+   *       a SpatialObject scene (image transform and parent-object
+   *       transforms are intermingled.
+   *    Version 1 fixes the bugs in Version 0, but introduces new
+   *       tag-value pairs that won't be processed by older readers/apps. */
+  itkSetMacro(MetaIOVersion, unsigned int);
+  itkGetConstMacro(MetaIOVersion, unsigned int);
+
   /** Read a MetaFile and create a Scene SpatialObject. */
   SpatialObjectPointer
   ReadMeta(const std::string & name);
@@ -151,15 +160,12 @@ private:
   void
   SetTransform(SpatialObjectType * so, const MetaObject * meta);
 
-  double m_Orientation[100]{};
-  double m_Position[10]{};
-  double m_CenterOfRotation[10]{};
-
   MetaEvent *      m_Event{};
   bool             m_BinaryPoints{};
   bool             m_WriteImagesInSeparateFile{};
   unsigned int     m_TransformPrecision{};
   ConverterMapType m_ConverterMap{};
+  unsigned int     m_MetaIOVersion{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -105,6 +105,7 @@ itkMetaArrowConverterTest(int argc, char * argv[])
 
   // set up itkArrow
   auto itkArrow = SpatialObjectType::New();
+  itkArrow->SetId(0);
   itkArrow->SetDirectionInObjectSpace(direction);
   itkArrow->SetPositionInObjectSpace(position);
   itkArrow->SetLengthInObjectSpace(length);
@@ -120,6 +121,7 @@ itkMetaArrowConverterTest(int argc, char * argv[])
 
   // set up metaArrow
   auto * metaArrow = new MetaArrow(Dimensions);
+  metaArrow->ID(2);
   metaArrow->Length(static_cast<float>(length));
   metaArrow->Position((const double *)mPosition);
   metaArrow->Direction((const double *)mDirection);
@@ -353,6 +355,8 @@ itkMetaArrowConverterTest(int argc, char * argv[])
       itk::Math::abs(reLoadDirectionNorm[2] - directionNorm[2]) > precisionLimit)
   {
     std::cout << "Didn't read direction properly [FAILED]" << std::endl;
+    std::cout << "  Direction: " << reLoadDirectionNorm << std::endl;
+    std::cout << "    vs: " << directionNorm << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << "[PASSED]  Reading: direction" << std::endl;

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
@@ -63,6 +63,12 @@ public:
   void
   Update();
 
+  /** Set the version of MetaIO to use */
+  void
+  SetMetaIOVersion(unsigned int ver);
+  unsigned int
+  GetMetaIOVersion(void) const;
+
   /** Set the filename  */
   itkSetStringMacro(FileName);
 

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
@@ -43,6 +43,20 @@ SpatialObjectReader<VDimension, PixelType, TMeshTraits>::Update()
   }
 }
 
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+void
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::SetMetaIOVersion(unsigned int ver)
+{
+  m_MetaToSpatialConverter->SetMetaIOVersion(ver);
+}
+
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+unsigned int
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::GetMetaIOVersion(void) const
+{
+  return m_MetaToSpatialConverter->GetMetaIOVersion();
+}
+
 /** Add a converter for a new MetaObject/SpatialObject type */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -81,6 +81,16 @@ public:
   itkGetConstMacro(BinaryPoints, bool);
   itkBooleanMacro(BinaryPoints);
 
+  /** Set the version of MetaIO to use.
+   *    Version 0 cannot accurately represented ImageSpatialObjects.
+   *    Version 1 fixes bugs in Version 0, but introduces new tag-value
+   *      pairs that might throw warnings on older readers. */
+
+  void
+  SetMetaIOVersion(unsigned int ver);
+  unsigned int
+  GetMetaIOVersion(void) const;
+
   void
   SetTransformPrecision(unsigned int precision);
 

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
@@ -31,6 +31,20 @@ SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SpatialObjectWriter()
   m_MetaToSpatialConverter = MetaSceneConverterType::New();
 }
 
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+void
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SetMetaIOVersion(unsigned int ver)
+{
+  m_MetaToSpatialConverter->SetMetaIOVersion(ver);
+}
+
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+unsigned int
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::GetMetaIOVersion(void) const
+{
+  return m_MetaToSpatialConverter->GetMetaIOVersion();
+}
+
 /** Set the precision at which the transform should be written */
 template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void


### PR DESCRIPTION
When reading/writing spatial objects via Meta, provide the option
    of using MetaIO version 1, which fixes bugs in the original MetaIO
    and SpatialObject implementations.

Specifically,
- ElementOrigin, ElementDirection, and ElementSpacing are used for the image index to physical space transform specification
- TransformMatrix, Position, and CenterOfRotation are used for the object-to-parent transform in the spatialobject scene graph.
