### PR TITLE
COMP: Conditional compilations missing variables

### DIFF
--- a/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
@@ -28,7 +28,15 @@
 // dimensions are taken from the array.The data types used are float and
 // double.
 int
-itkFFTWF_FFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+itkFFTWF_FFTTest(
+#  ifndef ITK_USE_CUFFTW
+  int    argc,
+  char * argv[]
+#  else
+  int    itkNotUsed(argc),
+  char * itkNotUsed(argv)[]
+#  endif
+)
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageCF1 = itk::Image<std::complex<float>, 1>;

--- a/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
@@ -26,7 +26,15 @@
 // template argument and the size of these dimensions are taken from
 // the array.The data types used are float and double.
 int
-itkFFTWF_RealFFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+itkFFTWF_RealFFTTest(
+#  ifndef ITK_USE_CUFFTW
+  int    argc,
+  char * argv[]
+#  else
+  int    itkNotUsed(argc),
+  char * itkNotUsed(argv)[]
+#  endif
+)
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageCF1 = itk::Image<std::complex<float>, 1>;

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
@@ -27,7 +27,15 @@
 // of these dimensions are taken from the array.The data types used are float
 // and double.
 int
-itkVnlFFTWF_FFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+itkVnlFFTWF_FFTTest(
+#  ifndef ITK_USE_CUFFTW
+  int    argc,
+  char * argv[]
+#  else
+  int    itkNotUsed(argc),
+  char * itkNotUsed(argv)[]
+#  endif
+)
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageF2 = itk::Image<float, 2>;
@@ -37,9 +45,13 @@ itkVnlFFTWF_FFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   itk::FFTWGlobalConfiguration::SetPlanRigor(FFTW_EXHAUSTIVE);
   itk::FFTWGlobalConfiguration::SetWriteWisdomCache(true);
   itk::FFTWGlobalConfiguration::SetReadWisdomCache(true);
-  if (argc > 1)
+  if (argc == 2)
   {
     itk::FFTWGlobalConfiguration::SetWisdomCacheBase(argv[1]);
+  }
+  else
+  {
+    std::cout << "ERROR: Incorrect number of arguments supplied " << argv[0] << " <wisdom_cache_base>" << std::endl;
   }
   std::cout << "WriteWisdomCache  " << itk::FFTWGlobalConfiguration::GetWriteWisdomCache() << std::endl;
   std::cout << "ReadWisdomCache  " << itk::FFTWGlobalConfiguration::GetReadWisdomCache() << std::endl;

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
@@ -27,7 +27,15 @@
 // template argument and the size of these dimensions are taken from
 // the array. The data types used are float and double.
 int
-itkVnlFFTWF_RealFFTTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+itkVnlFFTWF_RealFFTTest(
+#  ifndef ITK_USE_CUFFTW
+  int    argc,
+  char * argv[]
+#  else
+  int    itkNotUsed(argc),
+  char * itkNotUsed(argv)[]
+#  endif
+)
 {
   using ImageF1 = itk::Image<float, 1>;
   using ImageF2 = itk::Image<float, 2>;


### PR DESCRIPTION
When building FFTW and not CUFFTW the tests use the argc and argv variables that are otherwise ignored.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)