### PR TITLE
PERF: Add fast "move semantics" to SpatialObjectPoint classes

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
@@ -38,6 +38,8 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT ContourSpatialObjectPoint : public SpatialObjectPoint<TPointDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(ContourSpatialObjectPoint);
+
   using Self = ContourSpatialObjectPoint;
   using Superclass = SpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
@@ -46,9 +48,6 @@ public:
   /** Constructor. This one defines the number of dimensions
    *  in the ContourSpatialObjectPoint */
   ContourSpatialObjectPoint();
-
-  /** Copy Constructor */
-  ContourSpatialObjectPoint(const ContourSpatialObjectPoint & other);
 
   /** Default destructor. */
   ~ContourSpatialObjectPoint() override = default;
@@ -68,10 +67,6 @@ public:
   /** Set the normal : N-D case. */
   void
   SetNormalInObjectSpace(const CovariantVectorType & normal);
-
-  /** Copy a surface point to another. */
-  Self &
-  operator=(const ContourSpatialObjectPoint & rhs);
 
 protected:
   void

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -30,14 +30,6 @@ ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint(const ContourSpatialObjectPoint & other)
-  : Superclass(other)
-{
-  this->m_NormalInObjectSpace = other.GetNormalInObjectSpace();
-  this->m_PickedPointInObjectSpace = other.GetPickedPointInObjectSpace();
-}
-
-template <unsigned int TPointDimension>
 void
 ContourSpatialObjectPoint<TPointDimension>::SetPickedPointInObjectSpace(const PointType & point)
 {
@@ -63,19 +55,6 @@ auto
 ContourSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const -> const CovariantVectorType &
 {
   return m_NormalInObjectSpace;
-}
-
-template <unsigned int TPointDimension>
-auto
-ContourSpatialObjectPoint<TPointDimension>::operator=(const ContourSpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    Superclass::operator=(rhs);
-    this->m_NormalInObjectSpace = rhs.GetNormalInObjectSpace();
-    this->m_PickedPointInObjectSpace = rhs.GetPickedPointInObjectSpace();
-  }
-  return *this;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -60,6 +60,8 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT DTITubeSpatialObjectPoint : public TubeSpatialObjectPoint<TPointDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(DTITubeSpatialObjectPoint);
+
   using Self = DTITubeSpatialObjectPoint;
   using Superclass = TubeSpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
@@ -82,9 +84,6 @@ public:
   /** Constructor. This one defines the number of dimensions in the
    * DTITubeSpatialObjectPoint */
   DTITubeSpatialObjectPoint();
-
-  /** Copy Constructor */
-  DTITubeSpatialObjectPoint(const DTITubeSpatialObjectPoint & other);
 
   /** Default destructor. */
   ~DTITubeSpatialObjectPoint() override = default;
@@ -116,10 +115,6 @@ public:
   {
     return m_TensorMatrix;
   }
-
-  /** Copy one DTITubeSpatialObjectPoint to another. */
-  Self &
-  operator=(const DTITubeSpatialObjectPoint & rhs);
 
   /** Add a field to the point list. */
   void

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -37,24 +37,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint(const DTITubeSpatialObjectPoint & other)
-  : Superclass(other)
-{
-  m_Fields.clear();
-  const FieldListType & fields = other.GetFields();
-  auto                  it = fields.begin();
-  while (it != fields.end())
-  {
-    this->AddField(it->first.c_str(), it->second);
-    ++it;
-  }
-  for (unsigned int i = 0; i < 6; ++i)
-  {
-    m_TensorMatrix[i] = other.m_TensorMatrix[i];
-  }
-}
-
-template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
@@ -173,28 +155,6 @@ DTITubeSpatialObjectPoint<TPointDimension>::GetField(DTITubeSpatialObjectPointFi
   return -1;
 }
 
-template <unsigned int TPointDimension>
-auto
-DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    Superclass::operator=(rhs);
-    m_Fields.clear();
-    const FieldListType & fields = rhs.GetFields();
-    auto                  it = fields.begin();
-    while (it != fields.end())
-    {
-      this->AddField(it->first.c_str(), it->second);
-      ++it;
-    }
-    for (unsigned int i = 0; i < 6; ++i)
-    {
-      m_TensorMatrix[i] = rhs.m_TensorMatrix[i];
-    }
-  }
-  return *this;
-}
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -43,6 +43,8 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT LineSpatialObjectPoint : public SpatialObjectPoint<TPointDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(LineSpatialObjectPoint);
+
   using Self = LineSpatialObjectPoint;
   using Superclass = SpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
@@ -51,9 +53,6 @@ public:
 
   /** Constructor */
   LineSpatialObjectPoint();
-
-  /** Copy Constructor */
-  LineSpatialObjectPoint(const LineSpatialObjectPoint & other);
 
   /** Destructor */
   ~LineSpatialObjectPoint() override = default;
@@ -65,10 +64,6 @@ public:
   /** Set the normal. */
   void
   SetNormalInObjectSpace(CovariantVectorType & normal, unsigned int index);
-
-  /** Copy one LineSpatialObjectPoint to another */
-  Self &
-  operator=(const LineSpatialObjectPoint & rhs);
 
 protected:
   NormalArrayType m_NormalArrayInObjectSpace{};

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -36,13 +36,6 @@ LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint(const LineSpatialObjectPoint & other)
-  : Superclass(other)
-{
-  this->m_NormalArrayInObjectSpace = other.m_NormalArrayInObjectSpace;
-}
-
-template <unsigned int TPointDimension>
 auto
 LineSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace(unsigned int index) const -> const CovariantVectorType &
 {
@@ -64,19 +57,6 @@ void
 LineSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(CovariantVectorType & normal, unsigned int index)
 {
   m_NormalArrayInObjectSpace[index] = normal;
-}
-
-/** Copy a point to another */
-template <unsigned int TPointDimension>
-auto
-LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    Superclass::operator=(rhs);
-    this->m_NormalArrayInObjectSpace = rhs.m_NormalArrayInObjectSpace;
-  }
-  return *this;
 }
 
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -44,15 +44,14 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT SpatialObjectPoint
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(SpatialObjectPoint);
+
   using PointDimensionType = unsigned int;
 
   static constexpr PointDimensionType PointDimension = TPointDimension;
 
   /** Constructor. */
   SpatialObjectPoint();
-
-  /** Copy Constructor. */
-  SpatialObjectPoint(const SpatialObjectPoint & other);
 
   /** Default destructor. */
   virtual ~SpatialObjectPoint() = default;
@@ -127,10 +126,6 @@ public:
    *    spatialObject's objectToWorld transform */
   PointType
   GetPositionInWorldSpace() const;
-
-  /** Copy one SpatialObjectPoint to another */
-  Self &
-  operator=(const SpatialObjectPoint & rhs);
 
   /** Set/Get color of the point */
   void

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -40,16 +40,6 @@ SpatialObjectPoint<TPointDimension>::SpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-SpatialObjectPoint<TPointDimension>::SpatialObjectPoint(const SpatialObjectPoint & other)
-{
-  this->SetId(other.GetId());
-  this->SetPositionInObjectSpace(other.GetPositionInObjectSpace());
-  this->SetColor(other.GetColor());
-  this->SetSpatialObject(other.GetSpatialObject());
-  this->SetTagScalarDictionary(other.GetTagScalarDictionary());
-}
-
-template <unsigned int TPointDimension>
 void
 SpatialObjectPoint<TPointDimension>::SetPositionInWorldSpace(const PointType & point)
 {
@@ -81,21 +71,6 @@ SpatialObjectPoint<TPointDimension>::SetColor(double r, double g, double b, doub
   m_Color.SetGreen(g);
   m_Color.SetBlue(b);
   m_Color.SetAlpha(a);
-}
-
-template <unsigned int TPointDimension>
-auto
-SpatialObjectPoint<TPointDimension>::operator=(const SpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    this->SetId(rhs.GetId());
-    this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
-    this->SetColor(rhs.GetColor());
-    this->SetTagScalarDictionary(rhs.GetTagScalarDictionary());
-    this->SetSpatialObject(rhs.GetSpatialObject());
-  }
-  return *this;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -39,6 +39,8 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT SurfaceSpatialObjectPoint : public SpatialObjectPoint<TPointDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(SurfaceSpatialObjectPoint);
+
   using Self = SurfaceSpatialObjectPoint;
   using Superclass = SpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
@@ -47,9 +49,6 @@ public:
 
   /** Constructor */
   SurfaceSpatialObjectPoint();
-
-  /** Copy Constructor */
-  SurfaceSpatialObjectPoint(const SurfaceSpatialObjectPoint & other);
 
   /** Destructor */
   ~SurfaceSpatialObjectPoint() override = default;
@@ -69,10 +68,6 @@ public:
   /** Set the normal in world space. */
   void
   SetNormalInWorldSpace(const CovariantVectorType & normal);
-
-  /** Copy one SurfaceSpatialObjectPoint to another. */
-  Self &
-  operator=(const SurfaceSpatialObjectPoint & rhs);
 
 protected:
   CovariantVectorType m_NormalInObjectSpace{};

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -29,13 +29,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint(const SurfaceSpatialObjectPoint & other)
-  : Superclass(other)
-{
-  this->m_NormalInObjectSpace = other.m_NormalInObjectSpace;
-}
-
-template <unsigned int TPointDimension>
 void
 SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const CovariantVectorType & normal)
 {
@@ -83,17 +76,6 @@ SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
   os << indent << "NormalInObjectSpace: " << m_NormalInObjectSpace << std::endl;
 }
 
-template <unsigned int TPointDimension>
-auto
-SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    Superclass::operator=(rhs);
-    this->SetNormalInObjectSpace(rhs.GetNormalInObjectSpace());
-  }
-  return *this;
-}
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -39,6 +39,8 @@ template <unsigned int TPointDimension = 3>
 class ITK_TEMPLATE_EXPORT TubeSpatialObjectPoint : public SpatialObjectPoint<TPointDimension>
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(TubeSpatialObjectPoint);
+
   using Self = TubeSpatialObjectPoint;
   using Superclass = SpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
@@ -48,9 +50,6 @@ public:
   /** Constructor. This one defines the number of dimensions in the
    * TubeSpatialObjectPoint */
   TubeSpatialObjectPoint();
-
-  /** Copy Constructor */
-  TubeSpatialObjectPoint(const TubeSpatialObjectPoint & other);
 
   /** Default destructor. */
   ~TubeSpatialObjectPoint() override = default;
@@ -262,10 +261,6 @@ public:
   {
     return m_Alpha3;
   }
-
-  /** Copy one TubeSpatialObjectPoint to another */
-  Self &
-  operator=(const TubeSpatialObjectPoint & rhs);
 
 protected:
   VectorType          m_TangentInObjectSpace{};

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -43,27 +43,6 @@ TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint()
 }
 
 template <unsigned int TPointDimension>
-TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint(const TubeSpatialObjectPoint & other)
-  : Superclass(other)
-{
-  this->SetRadiusInObjectSpace(other.GetRadiusInObjectSpace());
-  this->SetTangentInObjectSpace(other.GetTangentInObjectSpace());
-  this->SetNormal1InObjectSpace(other.GetNormal1InObjectSpace());
-  this->SetNormal2InObjectSpace(other.GetNormal2InObjectSpace());
-
-  this->SetRidgeness(other.GetRidgeness());
-  this->SetMedialness(other.GetMedialness());
-  this->SetBranchness(other.GetBranchness());
-  this->SetCurvature(other.GetCurvature());
-  this->SetLevelness(other.GetLevelness());
-  this->SetRoundness(other.GetRoundness());
-  this->SetIntensity(other.GetIntensity());
-  this->SetAlpha1(other.GetAlpha1());
-  this->SetAlpha2(other.GetAlpha2());
-  this->SetAlpha3(other.GetAlpha3());
-}
-
-template <unsigned int TPointDimension>
 double
 TubeSpatialObjectPoint<TPointDimension>::GetRadiusInWorldSpace() const
 {
@@ -203,32 +182,6 @@ TubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent ind
   os << indent << "RadiusInObjectSpace: " << m_RadiusInObjectSpace << std::endl;
 }
 
-template <unsigned int TPointDimension>
-auto
-TubeSpatialObjectPoint<TPointDimension>::operator=(const TubeSpatialObjectPoint & rhs) -> Self &
-{
-  if (this != &rhs)
-  {
-    Superclass::operator=(rhs);
-
-    this->SetRadiusInObjectSpace(rhs.GetRadiusInObjectSpace());
-    this->SetTangentInObjectSpace(rhs.GetTangentInObjectSpace());
-    this->SetNormal1InObjectSpace(rhs.GetNormal1InObjectSpace());
-    this->SetNormal2InObjectSpace(rhs.GetNormal2InObjectSpace());
-
-    this->SetRidgeness(rhs.GetRidgeness());
-    this->SetMedialness(rhs.GetMedialness());
-    this->SetBranchness(rhs.GetBranchness());
-    this->SetCurvature(rhs.GetCurvature());
-    this->SetLevelness(rhs.GetLevelness());
-    this->SetRoundness(rhs.GetRoundness());
-    this->SetIntensity(rhs.GetIntensity());
-    this->SetAlpha1(rhs.GetAlpha1());
-    this->SetAlpha2(rhs.GetAlpha2());
-    this->SetAlpha3(rhs.GetAlpha3());
-  }
-  return *this;
-}
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -222,5 +222,8 @@ itk_add_test(
   itkNewMetaObjectTypeTest
   ${ITK_TEST_OUTPUT_DIR}/NewMetaObjectType.meta)
 
-set(ITKSpatialObjectsGTests itkImageMaskSpatialObjectGTest.cxx)
+set(ITKSpatialObjectsGTests
+  itkImageMaskSpatialObjectGTest.cxx
+  itkSpatialObjectPointGTest.cxx
+)
 creategoogletestdriver(ITKSpatialObjects "${ITKSpatialObjects-Test_LIBRARIES}" "${ITKSpatialObjectsGTests}")

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectPointGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectPointGTest.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header files to be tested:
+#include "itkContourSpatialObjectPoint.h"
+#include "itkDTITubeSpatialObjectPoint.h"
+#include "itkLineSpatialObjectPoint.h"
+#include "itkSpatialObjectPoint.h"
+#include "itkSurfaceSpatialObjectPoint.h"
+#include "itkTubeSpatialObjectPoint.h"
+
+#include <type_traits> // For is_nothrow_move_constructible_v and is_nothrow_move_assignable_v.
+
+
+// Note: we cannot assert nothrow_move_constructible, because SpatialObjectPoint internally has an `std::map`, which may
+// not be nothrow_move_constructible, at least in C++17.
+static_assert(std::is_move_constructible_v<itk::ContourSpatialObjectPoint<>>);
+static_assert(std::is_move_constructible_v<itk::DTITubeSpatialObjectPoint<>>);
+static_assert(std::is_move_constructible_v<itk::LineSpatialObjectPoint<>>);
+static_assert(std::is_move_constructible_v<itk::SpatialObjectPoint<>>);
+static_assert(std::is_move_constructible_v<itk::SurfaceSpatialObjectPoint<>>);
+static_assert(std::is_move_constructible_v<itk::TubeSpatialObjectPoint<>>);
+
+static_assert(std::is_nothrow_move_assignable_v<itk::ContourSpatialObjectPoint<>>);
+static_assert(std::is_nothrow_move_assignable_v<itk::DTITubeSpatialObjectPoint<>>);
+static_assert(std::is_nothrow_move_assignable_v<itk::LineSpatialObjectPoint<>>);
+static_assert(std::is_nothrow_move_assignable_v<itk::SpatialObjectPoint<>>);
+static_assert(std::is_nothrow_move_assignable_v<itk::SurfaceSpatialObjectPoint<>>);
+static_assert(std::is_nothrow_move_assignable_v<itk::TubeSpatialObjectPoint<>>);


### PR DESCRIPTION
Replaced hand-written copy-constructors and assignment operators by `ITK_DEFAULT_COPY_AND_MOVE` macro calls, in `SpatialObjectPoint` and its derived classes.

Will make the (compiler-generated) move-assignment operator of these classes `noexcept`, as tested.

----

- For the record, the `ITK_DEFAULT_COPY_AND_MOVE` macro was introduced with ITK 5.4, by pull request #4652 