### PR TITLE
ENH: Finalize ITKv5 API changes for ITKv6

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -172,8 +172,8 @@ public:
 
   /** Returns the N-dimensional index of the iterator's position in
    * the image. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex() const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex() const
   {
     return m_Loop;
   }
@@ -186,12 +186,12 @@ public:
 
   /** Function that "dereferences" a ConstNeighborhoodIterator,
    * returning a Neighborhood of pixel values. */
-  ITK_ITERATOR_VIRTUAL NeighborhoodType
-                       GetNeighborhood() const ITK_ITERATOR_FINAL;
+  NeighborhoodType
+  GetNeighborhood() const;
 
   /** Returns the pixel value located at a linear array location i. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPixel(const NeighborIndexType i) const ITK_ITERATOR_FINAL
+  PixelType
+  GetPixel(const NeighborIndexType i) const
   {
     if (!m_NeedToUseBoundaryCondition || this->InBounds())
     {
@@ -211,13 +211,13 @@ public:
    * image and the pixel value returned is an actual pixel in the
    * image. Sets "IsInBounds" to false if the location is outside the
    * image and the pixel value returned is a boundary condition. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPixel(NeighborIndexType i, bool & IsInBounds) const ITK_ITERATOR_FINAL;
+  PixelType
+  GetPixel(NeighborIndexType i, bool & IsInBounds) const;
 
   /** Returns the pixel value located at the itk::Offset o from the center of
       the neighborhood. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPixel(const OffsetType & o) const ITK_ITERATOR_FINAL
+  PixelType
+  GetPixel(const OffsetType & o) const
   {
     bool inbounds;
 
@@ -229,8 +229,8 @@ public:
    * image and the pixel value returned is an actual pixel in the
    * image. Sets "IsInBounds" to false if the offset is outside the
    * image and the pixel value returned is a boundary condition. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPixel(const OffsetType & o, bool & IsInBounds) const ITK_ITERATOR_FINAL
+  PixelType
+  GetPixel(const OffsetType & o, bool & IsInBounds) const
   {
     return (this->GetPixel(this->GetNeighborhoodIndex(o), IsInBounds));
   }
@@ -238,8 +238,8 @@ public:
   /** Returns the pixel value located i pixels distant from the neighborhood
    *  center in the positive specified "axis" direction. No bounds checking
    *  is done on the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetNext(const unsigned int axis, NeighborIndexType i) const ITK_ITERATOR_FINAL
+  PixelType
+  GetNext(const unsigned int axis, NeighborIndexType i) const
   {
     return (this->GetPixel(this->GetCenterNeighborhoodIndex() + (i * this->GetStride(axis))));
   }
@@ -247,8 +247,8 @@ public:
   /** Returns the pixel value located one pixel distant from the neighborhood
    *  center in the specified positive axis direction. No bounds checking is
    *  done on the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetNext(const unsigned int axis) const ITK_ITERATOR_FINAL
+  PixelType
+  GetNext(const unsigned int axis) const
   {
     return (this->GetPixel(this->GetCenterNeighborhoodIndex() + this->GetStride(axis)));
   }
@@ -256,8 +256,8 @@ public:
   /** Returns the pixel value located i pixels distant from the neighborhood
    *  center in the negative specified "axis" direction. No bounds checking
    *  is done on the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPrevious(const unsigned int axis, NeighborIndexType i) const ITK_ITERATOR_FINAL
+  PixelType
+  GetPrevious(const unsigned int axis, NeighborIndexType i) const
   {
     return (this->GetPixel(this->GetCenterNeighborhoodIndex() - (i * this->GetStride(axis))));
   }
@@ -265,24 +265,24 @@ public:
   /** Returns the pixel value located one pixel distant from the neighborhood
    *  center in the specified negative axis direction. No bounds checking is
    *  done on the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL PixelType
-                       GetPrevious(const unsigned int axis) const ITK_ITERATOR_FINAL
+  PixelType
+  GetPrevious(const unsigned int axis) const
   {
     return (this->GetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis)));
   }
 
   /** Returns the image index for neighbor pixel at offset o from the center of
       the neighborhood. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex(const OffsetType & o) const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex(const OffsetType & o) const
   {
     return (this->GetIndex() + o);
   }
 
   /** Returns the image index for neighbor pixel at index i in the
       neighborhood. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex(NeighborIndexType i) const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex(NeighborIndexType i) const
   {
     return (this->GetIndex() + this->GetOffset(i));
   }
@@ -326,31 +326,31 @@ public:
   }
 
   /** Method for rewinding the iterator to its beginning pixel. */
-  ITK_ITERATOR_VIRTUAL void
-  GoToBegin() ITK_ITERATOR_FINAL;
+  void
+  GoToBegin();
 
   /** Method for sending the iterator to one past the last pixel in its
    * region. */
-  ITK_ITERATOR_VIRTUAL void
-  GoToEnd() ITK_ITERATOR_FINAL;
+  void
+  GoToEnd();
 
   /** Initializes the iterator to walk a particular image and a particular
    * region of that image. */
-  ITK_ITERATOR_VIRTUAL void
-  Initialize(const SizeType & radius, const ImageType * ptr, const RegionType & region) ITK_ITERATOR_FINAL;
+  void
+  Initialize(const SizeType & radius, const ImageType * ptr, const RegionType & region);
 
   /** Method for determining whether the iterator is at the
    * beginning of its iteration region. */
-  ITK_ITERATOR_VIRTUAL bool
-  IsAtBegin() const ITK_ITERATOR_FINAL
+  bool
+  IsAtBegin() const
   {
     return (this->GetCenterPointer() == m_Begin);
   }
 
   /** Method for determining whether the iterator has reached the
    * end of its iteration region. */
-  ITK_ITERATOR_VIRTUAL bool
-  IsAtEnd() const ITK_ITERATOR_FINAL
+  bool
+  IsAtEnd() const
   {
     if (this->GetCenterPointer() > m_End)
     {
@@ -486,16 +486,16 @@ public:
    * object during the time it is referenced.  The overriding condition
    * can be of a different type than the default type as long as it is
    * a subclass of ImageBoundaryCondition. */
-  ITK_ITERATOR_VIRTUAL void
-  OverrideBoundaryCondition(const ImageBoundaryConditionPointerType i) ITK_ITERATOR_FINAL
+  void
+  OverrideBoundaryCondition(const ImageBoundaryConditionPointerType i)
   {
     m_BoundaryCondition = i;
   }
 
   /** Resets the boundary condition to the internal, default conditions
    * specified by the template parameter. */
-  ITK_ITERATOR_VIRTUAL void
-  ResetBoundaryCondition() ITK_ITERATOR_FINAL
+  void
+  ResetBoundaryCondition()
   {
     m_BoundaryCondition = &m_InternalBoundaryCondition;
   }
@@ -540,14 +540,14 @@ public:
   }
 
   /** Set the region to iterate over. */
-  ITK_ITERATOR_VIRTUAL void
-  SetRegion(const RegionType & region) ITK_ITERATOR_FINAL;
+  void
+  SetRegion(const RegionType & region);
 
 protected:
   /** Default method for setting the coordinate location of the iterator.
    * Loop indices correspond to the actual Image region index. */
-  ITK_ITERATOR_VIRTUAL void
-  SetLoop(const IndexType & p) ITK_ITERATOR_FINAL
+  void
+  SetLoop(const IndexType & p)
   {
     m_Loop = p;
     m_IsInBoundsValid = false;
@@ -556,28 +556,28 @@ protected:
   /** Method for setting internal loop boundaries.  This
    * method must be defined in each subclass because
    * each subclass may handle loop boundaries differently. */
-  ITK_ITERATOR_VIRTUAL void
-  SetBound(const SizeType &) ITK_ITERATOR_FINAL;
+  void
+  SetBound(const SizeType &);
 
   /** Default method for setting the values of the internal pointers
    * to itk::Image memory buffer locations.  This method should
    * generally only be called when the iterator is initialized.
    * \sa SetLocation */
-  ITK_ITERATOR_VIRTUAL void
-  SetPixelPointers(const IndexType &) ITK_ITERATOR_FINAL;
+  void
+  SetPixelPointers(const IndexType &);
 
   /** Default method for setting the index of the first pixel in the
    * iteration region. */
-  ITK_ITERATOR_VIRTUAL void
-  SetBeginIndex(const IndexType & start) ITK_ITERATOR_FINAL
+  void
+  SetBeginIndex(const IndexType & start)
   {
     m_BeginIndex = start;
   }
 
   /** Default method for setting the index of the first pixel in the
    * iteration region. */
-  ITK_ITERATOR_VIRTUAL void
-  SetEndIndex() ITK_ITERATOR_FINAL;
+  void
+  SetEndIndex();
 
   /** The starting index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIterator is defined. */

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -133,24 +133,24 @@ public:
 
   /** Returns the N-dimensional index of the iterator's position in
    * the image. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex() const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex() const
   {
     return m_Loop;
   }
 
   /** Returns the image index for neighbor pixel at offset o from the center of
       the neighborhood. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex(const OffsetType & o) const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex(const OffsetType & o) const
   {
     return (this->GetIndex() + o);
   }
 
   /** Returns the image index for neighbor pixel at index i in the
       neighborhood. */
-  ITK_ITERATOR_VIRTUAL IndexType
-                       GetIndex(NeighborIndexType i) const ITK_ITERATOR_FINAL
+  IndexType
+  GetIndex(NeighborIndexType i) const
   {
     return (this->GetIndex() + this->GetOffset(i));
   }
@@ -176,31 +176,31 @@ public:
   GetBoundingBoxAsImageRegion() const;
 
   /** Method for rewinding the iterator to its beginning image index. */
-  ITK_ITERATOR_VIRTUAL void
-  GoToBegin() ITK_ITERATOR_FINAL;
+  void
+  GoToBegin();
 
   /** Method for sending the iterator to one past the last index in its
    * region. */
-  ITK_ITERATOR_VIRTUAL void
-  GoToEnd() ITK_ITERATOR_FINAL;
+  void
+  GoToEnd();
 
   /** Initializes the iterator to walk a particular image and a particular
    * region of that image. */
-  ITK_ITERATOR_VIRTUAL void
-  Initialize(const SizeType & radius, const ImageType * ptr, const RegionType & region) ITK_ITERATOR_FINAL;
+  void
+  Initialize(const SizeType & radius, const ImageType * ptr, const RegionType & region);
 
   /** Virtual method for determining whether the iterator is at the
    * beginning of its iteration region. */
-  ITK_ITERATOR_VIRTUAL bool
-  IsAtBegin() const ITK_ITERATOR_FINAL
+  bool
+  IsAtBegin() const
   {
     return (this->GetIndex() == m_BeginIndex);
   }
 
   /** Virtual method for determining whether the iterator has reached the
    * end of its iteration region. */
-  ITK_ITERATOR_VIRTUAL bool
-  IsAtEnd() const ITK_ITERATOR_FINAL;
+  bool
+  IsAtEnd() const;
 
   /** Increments the pointers in the ConstNeighborhoodIteratorWithOnlyIndex,
    * wraps across boundaries automatically, accounting for
@@ -336,8 +336,8 @@ public:
 protected:
   /** Default method for setting the coordinate location of the iterator.
    * Loop indices correspond to the actual Image region index. */
-  ITK_ITERATOR_VIRTUAL void
-  SetLoop(const IndexType & p) ITK_ITERATOR_FINAL
+  void
+  SetLoop(const IndexType & p)
   {
     m_Loop = p;
     m_IsInBoundsValid = false;
@@ -346,21 +346,21 @@ protected:
   /** Virtual method for setting internal loop boundaries.  This
    * method must be defined in each subclass because
    * each subclass may handle loop boundaries differently. */
-  ITK_ITERATOR_VIRTUAL void
-  SetBound(const SizeType &) ITK_ITERATOR_FINAL;
+  void
+  SetBound(const SizeType &);
 
   /** Default method for setting the first index of the
    * iteration region. */
-  ITK_ITERATOR_VIRTUAL void
-  SetBeginIndex(const IndexType & start) ITK_ITERATOR_FINAL
+  void
+  SetBeginIndex(const IndexType & start)
   {
     m_BeginIndex = start;
   }
 
   /** Default method for setting the last index of the
    * iteration region. */
-  ITK_ITERATOR_VIRTUAL void
-  SetEndIndex() ITK_ITERATOR_FINAL;
+  void
+  SetEndIndex();
 
   /** The starting index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIteratorWithOnlyIndex is defined. */

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -122,7 +122,7 @@ public:
       this->GoToBegin();
     }
 
-    ITK_ITERATOR_VIRTUAL ~ConstIterator() = default;
+    ~ConstIterator() = default;
 
     ConstIterator &
     operator=(const ConstIterator & o)
@@ -326,13 +326,13 @@ public:
   /** Add/Remove a neighborhood offset (from the center of the neighborhood)
    *  to/from the active list.  Active list offsets are the only locations
    *  updated and accessible through the iterator.  */
-  ITK_ITERATOR_VIRTUAL void
-  ActivateOffset(const OffsetType & off) ITK_ITERATOR_FINAL
+  void
+  ActivateOffset(const OffsetType & off)
   {
     this->ActivateIndex(Superclass::GetNeighborhoodIndex(off));
   }
-  ITK_ITERATOR_VIRTUAL void
-  DeactivateOffset(const OffsetType & off) ITK_ITERATOR_FINAL
+  void
+  DeactivateOffset(const OffsetType & off)
   {
     this->DeactivateIndex(Superclass::GetNeighborhoodIndex(off));
   }
@@ -350,8 +350,8 @@ public:
   }
 
   /** Removes all active pixels from this neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  ClearActiveList() ITK_ITERATOR_FINAL
+  void
+  ClearActiveList()
   {
     m_ActiveIndexList.clear();
     m_CenterIsActive = false;
@@ -422,9 +422,9 @@ protected:
       argument is an index location calculated as an offset into a linear
       array which represents the image region defined by the radius of this
       iterator, with the smallest dimension as the fastest increasing index. */
-  ITK_ITERATOR_VIRTUAL void ActivateIndex(NeighborIndexType) ITK_ITERATOR_FINAL;
+  void ActivateIndex(NeighborIndexType);
 
-  ITK_ITERATOR_VIRTUAL void DeactivateIndex(NeighborIndexType) ITK_ITERATOR_FINAL;
+  void DeactivateIndex(NeighborIndexType);
 
 
   bool          m_CenterIsActive{ false };

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1330,31 +1330,6 @@ compilers.
   ITK_MACROEND_NOOP_STATEMENT
 
 
-/** Defines to provide compatibility with derived iterators.
- *
- * With ITKv5 several methods for Image Iterators have been
- * devirtualized for performance reasons. These definitions may help
- * provide legacy compatibility, or help  detecting derived iterators
- * relying on the virtual  interface.
- */
-#if !defined(ITK_LEGACY_REMOVE)
-#  define ITK_ITERATOR_VIRTUAL virtual
-#  define ITK_ITERATOR_OVERRIDE override
-#  define ITK_ITERATOR_FINAL final
-#else
-#  define ITK_ITERATOR_VIRTUAL
-#  define ITK_ITERATOR_OVERRIDE
-#  define ITK_ITERATOR_FINAL
-#endif
-
-#if defined(ITK_LEGACY_REMOVE)
-// A macro for methods which are const in ITKv5 and ITKv6 require const for functions
-#  define ITKv5_CONST static_assert(false, "ERROR: ITKv5_CONST must be replaced with 'const'")
-#else
-// A macro for methods which are const in after ITKv4
-#  define ITKv5_CONST const
-#endif
-
 #define itkExceptionObject_h
 #include "itkExceptionObject.h"
 #undef itkExceptionObject_h
@@ -1426,6 +1401,13 @@ itkDynamicCastInDebugMode(TSource x)
     static_assert(false, "ERROR: ITK_STATIC_ASSERT_MSG must be replaced with 'static_assert'")
 #  define ITK_THREAD_LOCAL static_assert(false, "ERROR: ITK_THREAD_LOCAL must be replaced with 'thread_local'")
 
+// A macro for methods which are const in ITKv5 and ITKv6 require const for functions
+#  define ITKv5_CONST static_assert(false, "ERROR: ITKv5_CONST must be replaced with 'const'")
+
+#  define ITK_ITERATOR_VIRTUAL static_assert(false, "ERROR: ITK_ITERATOR_VIRTUAL must be removed'")
+#  define ITK_ITERATOR_OVERRIDE static_assert(false, "ERROR: ITK_ITERATOR_OVERRIDE must be removed")
+#  define ITK_ITERATOR_FINAL static_assert(false, "ERROR: ITK_ITERATOR_FINAL must be removed")
+
 #else
 // DEPRECATED: These macros are left here for compatibility with remote modules.
 // Once they have been removed from all known remote modules, this code should
@@ -1461,6 +1443,13 @@ itkDynamicCastInDebugMode(TSource x)
 #  define ITK_STATIC_ASSERT(X) static_assert(X, #  X)
 #  define ITK_STATIC_ASSERT_MSG(X, MSG) static_assert(X, MSG)
 #  define ITK_THREAD_LOCAL thread_local
+
+// A macro for methods which are const in after ITKv4
+#  define ITKv5_CONST const
+
+#  define ITK_ITERATOR_VIRTUAL  /*purposefully empty for ITKv6, iterators are not virtual for performance reasons*/
+#  define ITK_ITERATOR_OVERRIDE /*purposefully empty for ITKv6, iterators are not virtual for performance reasons*/
+#  define ITK_ITERATOR_FINAL    /*purposefully empty for ITKv6, iterators are not virtual for performance reasons*/
 #endif
 
 #endif // end of itkMacro.h

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -262,8 +262,8 @@ public:
   }
 
   /** Returns the central pixel of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetCenterPixel(const PixelType & p) ITK_ITERATOR_FINAL
+  void
+  SetCenterPixel(const PixelType & p)
   {
     this->m_NeighborhoodAccessorFunctor.Set(this->operator[]((this->Size()) >> 1), p);
   }
@@ -271,23 +271,23 @@ public:
   /** Virtual function that replaces the pixel values in the image
    * neighborhood that are pointed to by this NeighborhoodIterator with
    * the pixel values contained in a Neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetNeighborhood(const NeighborhoodType &) ITK_ITERATOR_FINAL;
+  void
+  SetNeighborhood(const NeighborhoodType &);
 
   /** Special SetPixel method which quietly ignores out-of-bounds attempts.
    *  Sets status TRUE if pixel has been set, FALSE otherwise.  */
-  ITK_ITERATOR_VIRTUAL void
-  SetPixel(const unsigned int i, const PixelType & v, bool & status) ITK_ITERATOR_FINAL;
+  void
+  SetPixel(const unsigned int i, const PixelType & v, bool & status);
 
   /** Set the pixel at the ith location. */
-  ITK_ITERATOR_VIRTUAL void
-  SetPixel(const unsigned int i, const PixelType & v) ITK_ITERATOR_FINAL;
+  void
+  SetPixel(const unsigned int i, const PixelType & v);
 
   //  { *(this->operator[](i)) = v; }
 
   /** Set the pixel at offset o from the neighborhood center */
-  ITK_ITERATOR_VIRTUAL void
-  SetPixel(const OffsetType o, const PixelType & v) ITK_ITERATOR_FINAL
+  void
+  SetPixel(const OffsetType o, const PixelType & v)
   {
     this->SetPixel(this->GetNeighborhoodIndex(o), v);
   }
@@ -296,8 +296,8 @@ public:
   /** Sets the pixel value located i pixels distant from the neighborhood center in
       the positive specified "axis" direction. No bounds checking is done on
       the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetNext(const unsigned int axis, const unsigned int i, const PixelType & v) ITK_ITERATOR_FINAL
+  void
+  SetNext(const unsigned int axis, const unsigned int i, const PixelType & v)
   {
     this->SetPixel(this->GetCenterNeighborhoodIndex() + (i * this->GetStride(axis)), v);
   }
@@ -305,8 +305,8 @@ public:
   /** Sets the pixel value located one pixel distant from the neighborhood center in
       the specified positive axis direction. No bounds checking is done on the
       size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetNext(const unsigned int axis, const PixelType & v) ITK_ITERATOR_FINAL
+  void
+  SetNext(const unsigned int axis, const PixelType & v)
   {
     this->SetPixel(this->GetCenterNeighborhoodIndex() + this->GetStride(axis), v);
   }
@@ -314,8 +314,8 @@ public:
   /** Sets the pixel value located i pixels distant from the neighborhood center in
       the negative specified "axis" direction. No bounds checking is done on
       the size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetPrevious(const unsigned int axis, const unsigned int i, const PixelType & v) ITK_ITERATOR_FINAL
+  void
+  SetPrevious(const unsigned int axis, const unsigned int i, const PixelType & v)
   {
     this->SetPixel(this->GetCenterNeighborhoodIndex() - (i * this->GetStride(axis)), v);
   }
@@ -323,8 +323,8 @@ public:
   /** Sets the pixel value located one pixel distant from the neighborhood center in
       the specified negative axis direction. No bounds checking is done on the
       size of the neighborhood. */
-  ITK_ITERATOR_VIRTUAL void
-  SetPrevious(const unsigned int axis, const PixelType & v) ITK_ITERATOR_FINAL
+  void
+  SetPrevious(const unsigned int axis, const PixelType & v)
   {
     this->SetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis), v);
   }

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -186,7 +186,7 @@ public:
       : ConstIterator(s)
     {}
 
-    ~Iterator() ITK_ITERATOR_OVERRIDE = default;
+    ~Iterator() = default;
     Iterator &
     operator=(const Iterator & o)
     {


### PR DESCRIPTION
With ITKv5 several methods for Image Iterators have been devirtualized for performance reasons.

The temporary definitions provided legacy compatibility. Error messages are now triggered to help detect
virtualized iterators.

Methods that were non-const in ITKv4, compile-time conditionally const in ITKv5, are now unconditionally const for itkv6.
## PR Checklist
- [ ] Finalize API ITKv6 API No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)