### PR TITLE
hdf5 empty transform list

### DIFF
--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -434,6 +434,10 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
 
     ConstTransformListType & transformList = this->GetWriteTransformList();
 
+    if (transformList.empty())
+    {
+      itkExceptionMacro(<< "No transforms to write");
+    }
     std::string compositeTransformType = transformList.front()->GetTransformTypeAsString();
 
     CompositeTransformIOHelperTemplate<TParametersValueType> helper;


### PR DESCRIPTION
- BUG: ElementType with PolyLineParametricPath ContinuousIndex
- ENH: Add dict_from_polyline, polyline_from_dict
- COMP: Remove \brief with nothing after
- COMP: Fixed Cpp Warnings
- BUG: VTKPolyDataMeshIO support for reading VTK 5.1 format
- BUG: Mark GDCM macOS CMake variables as advanced
- BUG: Mark Module_FastBilateral as advanced
- BUG: Wrap SymmetricEigenAnalysisImageFilter with CovariantVector Image output
- BUG: Check output of StatisticsUniqueLabelMapFilterTest1
- BUG: Address bugs in unique label map filters
- BUG: Remove dilation output in test
- ENH: A GTest for LabelUniqueLabelMapFilter
- DOC: Update .zenodo
- COMP: macOS-11 Azure CI environment EOL
- BUG: HDF5TransformIO throw exception instead of segfault
