### PR TITLE
STYLE: Improve ivar printing in `PrintSelf` methods

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -307,15 +307,8 @@ PolygonSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
-  os << indent << "OrientationInObjectSpace Time: " << m_OrientationInObjectSpaceMTime << std::endl;
-  if (m_IsClosed)
-  {
-    os << indent << "IsClosed: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "IsClosed: False" << std::endl;
-  }
+  os << indent << "OrientationInObjectSpaceMTime: " << m_OrientationInObjectSpaceMTime << std::endl;
+  os << indent << "IsClosed: " << (m_IsClosed ? "On" : "Off") << std::endl;
   os << indent << "ThicknessInObjectSpace: " << m_ThicknessInObjectSpace << std::endl;
 }
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -257,65 +257,17 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::os
 
   os << indent << "State: " << m_State << std::endl;
   os << indent << "PatchRadius: " << m_PatchRadius << std::endl;
-  if (m_KernelBandwidthEstimation)
-  {
-    os << indent << "KernelBandwidthEstimation: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "KernelBandwidthEstimation: Off" << std::endl;
-  }
-
+  os << indent << "KernelBandwidthEstimation: " << (m_KernelBandwidthEstimation ? "On" : "Off") << std::endl;
   os << indent << "KernelBandwidthUpdateFrequency: " << m_KernelBandwidthUpdateFrequency << std::endl;
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
   os << indent << "ElapsedIterations: " << m_ElapsedIterations << std::endl;
-
-  if (m_NoiseModel == NoiseModelEnum::GAUSSIAN)
-  {
-    os << indent << "NoiseModelEnum::GAUSSIAN" << std::endl;
-  }
-  else if (m_NoiseModel == NoiseModelEnum::RICIAN)
-  {
-    os << indent << "NoiseModelEnum::RICIAN" << std::endl;
-  }
-  else if (m_NoiseModel == NoiseModelEnum::POISSON)
-  {
-    os << indent << "NoiseModelEnum::POISSON" << std::endl;
-  }
-  else
-  {}
-
+  os << indent << "NoiseModel: " << m_NoiseModel << std::endl;
   os << indent << "SmoothingWeight: " << m_SmoothingWeight << std::endl;
   os << indent << "NoiseModelFidelityWeight: " << m_NoiseModelFidelityWeight << std::endl;
-
-  if (m_AlwaysTreatComponentsAsEuclidean)
-  {
-    os << indent << "AlwaysTreatComponentsAsEuclidean: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "AlwaysTreatComponentsAsEuclidean: Off" << std::endl;
-  }
-
-  if (m_ComponentSpace == Self::ComponentSpaceEnum::EUCLIDEAN)
-  {
-    os << indent << "ComponentSpace: EUCLIDEAN" << std::endl;
-  }
-  else if (m_ComponentSpace == Self::ComponentSpaceEnum::RIEMANNIAN)
-  {
-    os << indent << "ComponentSpace: RIEMANNIAN" << std::endl;
-  }
-  else
-  {}
-
-  if (m_ManualReinitialization)
-  {
-    os << indent << "ManualReinitialization: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "ManualReinitialization: Off" << std::endl;
-  }
+  os << indent << "AlwaysTreatComponentsAsEuclidean: " << (m_AlwaysTreatComponentsAsEuclidean ? "On" : "Off")
+     << std::endl;
+  os << indent << "ComponentSpace: " << m_ComponentSpace << std::endl;
+  os << indent << "ManualReinitialization: " << (m_ManualReinitialization ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2388,33 +2388,11 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
     os << "(Cannot be computed: input not set)" << std::endl;
   }
 
-  if (m_UseSmoothDiscPatchWeights)
-  {
-    os << indent << "UseSmoothDiscPatchWeights: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseSmoothDiscPatchWeights: Off" << std::endl;
-  }
+  os << indent << "UseSmoothDiscPatchWeights: " << (m_UseSmoothDiscPatchWeights ? "On" : "Off") << std::endl;
+  os << indent << "UseFastTensorComputations: " << (m_UseFastTensorComputations ? "On" : "Off") << std::endl;
 
-  if (m_UseFastTensorComputations)
-  {
-    os << indent << "UseFastTensorComputations: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseFastTensorComputations: Off" << std::endl;
-  }
-
-  os << indent << "Kernel bandwidth sigma: " << m_KernelBandwidthSigma << std::endl;
-  if (m_KernelBandwidthSigmaIsSet)
-  {
-    os << indent << "KernelBandwidthSigmaIsSet: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "KernelBandwidthSigmaIsSet: Off" << std::endl;
-  }
+  os << indent << "KernelBandwidthSigma: " << m_KernelBandwidthSigma << std::endl;
+  os << indent << "KernelBandwidthSigmaIsSet: " << (m_KernelBandwidthSigmaIsSet ? "On" : "Off") << std::endl;
 
   os << indent << "IntensityRescaleInvFactor: " << m_IntensityRescaleInvFactor << std::endl;
 
@@ -2425,17 +2403,10 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   os << indent << "KernelBandwidthFractionPixelsForEstimation: " << m_KernelBandwidthFractionPixelsForEstimation
      << std::endl;
 
-  if (m_ComputeConditionalDerivatives)
-  {
-    os << indent << "ComputeConditionalDerivatives: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "ComputeConditionalDerivatives: Off" << std::endl;
-  }
+  os << indent << "ComputeConditionalDerivatives: " << (m_ComputeConditionalDerivatives ? "On" : "Off") << std::endl;
 
-  os << indent << "Min sigma: " << m_MinSigma << std::endl;
-  os << indent << "Min probability: " << m_MinProbability << std::endl;
+  os << indent << "MinSigma: " << m_MinSigma << std::endl;
+  os << indent << "MinProbability: " << m_MinProbability << std::endl;
 
   os << indent << "SigmaUpdateDecimationFactor: " << m_SigmaUpdateDecimationFactor << std::endl;
   os << indent << "Sigma update convergence tolerance: " << m_SigmaUpdateConvergenceTolerance << std::endl;
@@ -2444,14 +2415,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
 
   os << indent << "NoiseSigma: " << m_NoiseSigma << std::endl;
   os << indent << "NoiseSigmaSquared: " << m_NoiseSigmaSquared << std::endl;
-  if (m_NoiseSigmaIsSet)
-  {
-    os << indent << "NoiseSigmaIsSet: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "NoiseSigmaIsSet: Off" << std::endl;
-  }
+  os << indent << "NoiseSigmaIsSet: " << (m_NoiseSigmaIsSet ? "On" : "Off") << std::endl;
 
   itkPrintSelfObjectMacro(Sampler);
   itkPrintSelfObjectMacro(UpdateBuffer);

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -85,16 +85,9 @@ GaborImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  if (this->GetCalculateImaginaryPart())
-  {
-    os << indent << "Calculate complex part: true " << std::endl;
-  }
-  else
-  {
-    os << indent << "Calculate complex part: false " << std::endl;
-  }
+  os << indent << "CalculateImaginaryPart: " << (m_CalculateImaginaryPart ? "On" : "Off") << std::endl;
   os << indent << "Frequency: " << this->GetFrequency() << std::endl;
-  os << indent << "Phase offset: " << m_PhaseOffset << std::endl;
+  os << indent << "PhaseOffset: " << m_PhaseOffset << std::endl;
   os << indent << "Sigma: " << this->GetSigma() << std::endl;
   os << indent << "Mean: " << this->GetMean() << std::endl;
 }

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -210,41 +210,10 @@ DCMTKSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "SeriesUIDs[" << i << "]: " << m_SeriesUIDs[i] << std::endl;
   }
 
-  if (m_UseSeriesDetails)
-  {
-    os << indent << "UseSeriesDetails: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseSeriesDetails: False" << std::endl;
-  }
-
-  if (m_Recursive)
-  {
-    os << indent << "Recursive: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "Recursive: False" << std::endl;
-  }
-
-  if (m_LoadSequences)
-  {
-    os << indent << "LoadSequences: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "LoadSequences: False" << std::endl;
-  }
-
-  if (m_LoadPrivateTags)
-  {
-    os << indent << "LoadPrivateTags: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "LoadPrivateTags: False" << std::endl;
-  }
+  os << indent << "UseSeriesDetails: " << (m_UseSeriesDetails ? "On" : "Off") << std::endl;
+  os << indent << "Recursive: " << (m_Recursive ? "On" : "Off") << std::endl;
+  os << indent << "LoadSequences: " << (m_LoadSequences ? "On" : "Off") << std::endl;
+  os << indent << "LoadPrivateTags: " << (m_LoadPrivateTags ? "On" : "Off") << std::endl;
 }
 
 void

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -385,40 +385,16 @@ ImageFileWriter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "File Name: " << (m_FileName.data() ? m_FileName.data() : "(none)") << std::endl;
+  os << indent << "FileName: " << m_FileName << std::endl;
 
   itkPrintSelfObjectMacro(ImageIO);
 
-  os << indent << "IO Region: " << m_PasteIORegion << '\n';
-  os << indent << "Number of Stream Divisions: " << m_NumberOfStreamDivisions << '\n';
-  os << indent << "CompressionLevel: " << m_CompressionLevel << '\n';
-
-  if (m_UseCompression)
-  {
-    os << indent << "Compression: On\n";
-  }
-  else
-  {
-    os << indent << "Compression: Off\n";
-  }
-
-  if (m_UseInputMetaDataDictionary)
-  {
-    os << indent << "UseInputMetaDataDictionary: On\n";
-  }
-  else
-  {
-    os << indent << "UseInputMetaDataDictionary: Off\n";
-  }
-
-  if (m_FactorySpecifiedImageIO)
-  {
-    os << indent << "FactorySpecifiedmageIO: On\n";
-  }
-  else
-  {
-    os << indent << "FactorySpecifiedmageIO: Off\n";
-  }
+  os << indent << "PasteIORegion: " << m_PasteIORegion << std::endl;
+  os << indent << "NumberOfStreamDivisions: " << m_NumberOfStreamDivisions << std::endl;
+  os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
+  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
+  os << indent << "UseInputMetaDataDictionary: " << (m_UseInputMetaDataDictionary ? "On" : "Off") << std::endl;
+  os << indent << "FactorySpecifiedImageIO: " << (m_FactorySpecifiedImageIO ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -357,19 +357,16 @@ ImageSeriesWriter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   itkPrintSelfObjectMacro(ImageIO);
 
+  os << indent << "UserSpecifiedImageIO: " << (m_UserSpecifiedImageIO ? "On" : "Off") << std::endl;
+  for (unsigned int i = 0; i < m_FileNames.size(); ++i)
+  {
+    os << indent << "FileNames[" << i << "]: " << m_FileNames[i] << std::endl;
+  }
+  os << indent << "SeriesFormat: " << m_SeriesFormat << std::endl;
   os << indent << "StartIndex: " << m_StartIndex << std::endl;
   os << indent << "IncrementIndex: " << m_IncrementIndex << std::endl;
-  os << indent << "SeriesFormat: " << m_SeriesFormat << std::endl;
+  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
   os << indent << "MetaDataDictionaryArray: " << m_MetaDataDictionaryArray << std::endl;
-
-  if (m_UseCompression)
-  {
-    os << indent << "Compression: On\n";
-  }
-  else
-  {
-    os << indent << "Compression: Off\n";
-  }
 }
 } // end namespace itk
 

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -1164,9 +1164,9 @@ ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "IOByteOrderEnum: " << this->GetByteOrderAsString(m_ByteOrder) << std::endl;
   os << indent << "IORegion: " << std::endl;
   m_IORegion.Print(os, indent.GetNextIndent());
-  os << indent << "Number of Components/Pixel: " << m_NumberOfComponents << '\n';
-  os << indent << "Pixel Type: " << this->GetPixelTypeAsString(m_PixelType) << std::endl;
-  os << indent << "Component Type: " << this->GetComponentTypeAsString(m_ComponentType) << std::endl;
+  os << indent << "NumberOfComponents/Pixel: " << m_NumberOfComponents << std::endl;
+  os << indent << "PixeType: " << this->GetPixelTypeAsString(m_PixelType) << std::endl;
+  os << indent << "ComponentType: " << this->GetComponentTypeAsString(m_ComponentType) << std::endl;
   os << indent << "Dimensions: " << m_Dimensions << std::endl;
   os << indent << "Origin: " << m_Origin << std::endl;
   os << indent << "Spacing: " << m_Spacing << std::endl;
@@ -1175,57 +1175,15 @@ ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
   {
     os << indent << direction << std::endl;
   }
-  if (m_UseCompression)
-  {
-    os << indent << "UseCompression: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseCompression: Off" << std::endl;
-  }
+  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
   os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
   os << indent << "MaximumCompressionLevel: " << m_MaximumCompressionLevel << std::endl;
   os << indent << "Compressor: " << m_Compressor << std::endl;
-  if (m_UseStreamedReading)
-  {
-    os << indent << "UseStreamedReading: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseStreamedReading: Off" << std::endl;
-  }
-  if (m_UseStreamedWriting)
-  {
-    os << indent << "UseStreamedWriting: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "UseStreamedWriting: Off" << std::endl;
-  }
-  if (m_ExpandRGBPalette)
-  {
-    os << indent << "ExpandRGBPalette: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "ExpandRGBPalette: Off" << std::endl;
-  }
-  if (m_IsReadAsScalarPlusPalette)
-  {
-    os << indent << "IsReadAsScalarPlusPalette: True" << std::endl;
-  }
-  else
-  {
-    os << indent << "IsReadAsScalarPlusPalette: False" << std::endl;
-  }
-  if (m_WritePalette)
-  {
-    os << indent << "WritePalette: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "WritePalette: Off" << std::endl;
-  }
+  os << indent << "UseStreamedReading: " << (m_UseStreamedReading ? "On" : "Off") << std::endl;
+  os << indent << "UseStreamedWriting: " << (m_UseStreamedWriting ? "On" : "Off") << std::endl;
+  os << indent << "ExpandRGBPalette: " << (m_ExpandRGBPalette ? "On" : "Off") << std::endl;
+  os << indent << "IsReadAsScalarPlusPalette: " << (m_IsReadAsScalarPlusPalette ? "On" : "Off") << std::endl;
+  os << indent << "WritePalette: " << (m_WritePalette ? "On" : "Off") << std::endl;
 }
 
 } // namespace itk

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -464,35 +464,14 @@ MeshFileWriter<TInputMesh>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "File Name: " << (m_FileName.data() ? m_FileName.data() : "(none)") << std::endl;
+  os << indent << "FileName: " << m_FileName << std::endl;
 
-  os << indent << "Mesh IO: ";
-  if (m_MeshIO.IsNull())
-  {
-    os << "(none)\n";
-  }
-  else
-  {
-    os << m_MeshIO << '\n';
-  }
+  itkPrintSelfObjectMacro(MeshIO);
 
-  if (m_UseCompression)
-  {
-    os << indent << "Compression: On\n";
-  }
-  else
-  {
-    os << indent << "Compression: Off\n";
-  }
-
-  if (m_FactorySpecifiedMeshIO)
-  {
-    os << indent << "FactorySpecifiedMeshIO: On\n";
-  }
-  else
-  {
-    os << indent << "FactorySpecifiedMeshIO: Off\n";
-  }
+  os << indent << "UserSpecifiedMeshIO: " << (m_UserSpecifiedMeshIO ? "On" : "Off") << std::endl;
+  os << indent << "FactorySpecifiedMeshIO: " << (m_FactorySpecifiedMeshIO ? "On" : "Off") << std::endl;
+  os << indent << "UseCompression: " << (m_UseCompression ? "On" : "Off") << std::endl;
+  os << indent << "FileTypeIsBINARY: " << (m_FileTypeIsBINARY ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -541,15 +541,7 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf
   os << indent << "NumberOfSamples: " << m_NumberOfSamples << std::endl;
   os << indent << "NumberOfBins: " << m_NumberOfBins << std::endl;
   os << indent << "Minnorm: " << m_Minnorm << std::endl;
-
-  if (m_DoInverse)
-  {
-    os << indent << "DoInverse: On" << std::endl;
-  }
-  else
-  {
-    os << indent << "DoInverse: Off" << std::endl;
-  }
+  os << indent << "DoInverse: " << (m_DoInverse ? "On" : "Off") << std::endl;
 }
 } // end namespace itk
 


### PR DESCRIPTION
Improve ivar printing in `PrintSelf` methods:
- Use the `itkPrintSelfObjectMacro` macro to avoid boilerplate code when printing smart pointers/objects that can be null pointers.
- Rely on the enum classes ostream insertion operator overload to directly print such variables. Avoid boilerplate code.
- Increase consistency when printing boolean ivars: use the `({ivar} ? "On" : "Off")`  recipe in agreement with the ITK SW Guide.
- Do not check whether `std::string` types ivars are empty to conditionally print their contents; rely on the ostream insertion operator overload to print the appropriate content.
- Print the member variable names verbatim to conform to the ITK SW Guide.
- Prefer using `std::endl` instead of `\n` to add a new line for the sake of consistency.

Take advantage of the commit to print ivars that had been missed in the modified classes.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)