### PR TITLE
COMP: Set CastXML flag based on CMAKE_CXX_STANDARD

### DIFF
--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -802,11 +802,11 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::RelabelConnectedRegi
     labelIt.SetLocation(idx);
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      for (const auto &nIdx : { center + stride[j], center - stride[j] })
+      for (const auto & nIdx : { center + stride[j], center - stride[j] })
       {
         // When run in threaded mode, requiredLabel is the same as outputLabel and only the marker images is modified.
         // The label image must be checked first to avoid race conditions with the marker image.
-        if (labelIt.GetPixel(nIdx) == requiredLabel && markerIter.GetPixel(nIdx) == 0 )
+        if (labelIt.GetPixel(nIdx) == requiredLabel && markerIter.GetPixel(nIdx) == 0)
         {
           indexStack.push_back(labelIt.GetIndex(nIdx));
           markerIter.SetPixel(nIdx, 1);

--- a/Wrapping/macro_files/itk_auto_load_submodules.cmake
+++ b/Wrapping/macro_files/itk_auto_load_submodules.cmake
@@ -20,9 +20,9 @@ function(generate_castxml_commandline_flags)
   # Avoid missing omp.h include
   set(_castxml_cc_flags ${CMAKE_CXX_FLAGS})
   if(CMAKE_CXX_EXTENSIONS)
-    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX17_EXTENSION_COMPILE_OPTION}")
+    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_EXTENSION_COMPILE_OPTION}")
   else()
-    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX17_STANDARD_COMPILE_OPTION}")
+    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
   endif()
 
   # Aggressive optimization flags cause cast_xml to give invalid error conditions


### PR DESCRIPTION
We may bump the standard version in the future or remote modules may use a different standard version.
