### PR TITLE
BUG: Propogate MetaIOVersion to child objects in scene I/O

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -144,6 +144,7 @@ private:
   {
     auto converter = TConverter::New();
     // needed just for Image & ImageMask
+    converter->SetMetaIOVersion(m_MetaIOVersion);
     converter->SetWriteImagesInSeparateFile(this->m_WriteImagesInSeparateFile);
     return converter->SpatialObjectToMetaObject(so);
   }
@@ -152,6 +153,7 @@ private:
   MetaObjectToSpatialObject(const MetaObject * mo)
   {
     auto converter = TConverter::New();
+    converter->SetMetaIOVersion(m_MetaIOVersion);
     return converter->MetaObjectToSpatialObject(mo);
   }
   void

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -281,6 +281,8 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
       }
       currentMeta = converterIt->second->SpatialObjectToMetaObject(*it);
     }
+    currentMeta->APIVersion(m_MetaIOVersion);
+    currentMeta->FileFormatVersion(m_MetaIOVersion);
     metaScene->AddObject(currentMeta);
     ++it;
   }


### PR DESCRIPTION
The ITK I/O methods for SpatialObjectRead and SpatialObjectWrite have functions for setting the MetaIO version to use when reading/writing files.  See the MetaIO commit: https://github.com/Kitware/MetaIO/commit/eb952d5b2dbbccc27a99cc1b4cb27410f5267981

However, in multi-object MetaIO files (i.e., metaScene files) the user specification of the MetaIO version was not propagated to the readers used for the components objects of the file - resulting in warnings and errors.

This update and a corresponding MetaIO update (https://github.com/Kitware/MetaIO/pull/129) address this error.