### PR TITLE
STYLE: Improve ivar printing in `itk::ProcessObject` `PrintSelf` method

### DIFF
--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1268,8 +1268,7 @@ ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
   }
 
   os << indent << "NumberOfRequiredOutputs: " << m_NumberOfRequiredOutputs << std::endl;
-  os << indent << "Number Of Work Units: " << m_NumberOfWorkUnits << std::endl;
-  os << indent << "ReleaseDataFlag: " << (this->GetReleaseDataFlag() ? "On" : "Off") << std::endl;
+  os << indent << "NumberOfWorkUnits: " << m_NumberOfWorkUnits << std::endl;
   os << indent << "ReleaseDataBeforeUpdateFlag: " << (m_ReleaseDataBeforeUpdateFlag ? "On" : "Off") << std::endl;
   os << indent << "AbortGenerateData: " << (m_AbortGenerateData ? "On" : "Off") << std::endl;
   os << indent << "Progress: " << progressFixedToFloat(m_Progress) << std::endl;


### PR DESCRIPTION
Improve ivar printing in `itk::ProcessObject` `PrintSelf` method:
- Print the member variable names verbatim to conform to the ITK SW Guide.
- Avoid printing data other than ivars (e.g. values obtained through `Get` methods).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)