### PR TITLE
COMP: Add ITKMontage's PhaseCorrelationOptimizer to API ignore list

### DIFF
--- a/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
@@ -35,6 +35,8 @@ totalAPI = 0
 exclude = [
     # The following class API could be updated.
     "GDCMSeriesFileNames",
+    "TileMontage",
+    "PhaseCorrelationOptimizer",  # from Montage remote module
     "HistogramToRunLengthFeaturesFilter",
     "HistogramToTextureFeaturesFilter",
     "ScalarImageToRunLengthFeaturesFilter",


### PR DESCRIPTION
Meant to address:

```log
> python "M:/Dashboard/ITK/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py"
...
Traceback (most recent call last):
  File "M:\Dashboard\ITK\Wrapping\Generators\Python\Tests\verifyGetOutputAPIConsistency.py", line 104, in <module>
    tot, w = checkGetOutputConsistency(o, t)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "M:\Dashboard\ITK\Wrapping\Generators\Python\Tests\verifyGetOutputAPIConsistency.py", line 83, in checkGetOutputConsistency
    i.GetOutput()
TypeError: itkPhaseCorrelationOptimizerF2.GetOutput() missing 1 required positional argument: 'index' itkTestDriver: Process exited with return value: 1
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)

