### PR TITLE
BUG: Python wrapping needs std::string pass by value in some cases

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -91,18 +91,12 @@ public:
   GetAlpha() const;
 
   void
-  SetName(const std::string & name)
+  SetName(std::string name)
   {
-    m_Name = name;
+    m_Name = std::move(name);
   }
 
-  std::string &
-  GetName()
-  {
-    return m_Name;
-  }
-
-  const std::string &
+  std::string
   GetName() const
   {
     return m_Name;
@@ -111,7 +105,7 @@ public:
   void
   SetTagScalarValue(const std::string & tag, double value);
   void
-  SetTagStringValue(const std::string & tag, const std::string & value);
+  SetTagStringValue(const std::string & tag, std::string value);
 
   bool
   GetTagScalarValue(const std::string & tag, double & value) const;

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -102,7 +102,7 @@ SpatialObjectProperty::SetTagScalarValue(const std::string & tag, double value)
 }
 
 void
-SpatialObjectProperty::SetTagStringValue(const std::string & tag, const std::string & value)
+SpatialObjectProperty::SetTagStringValue(const std::string & tag, std::string value)
 {
   m_StringDictionary[tag] = value;
 }


### PR DESCRIPTION
std::string * isn't wrapped in the SWIG wrapping used by ITK.  As a result, the returned object will be unknown if std::string is passed by reference or returned by reference in certain cases.

This commit fixes this issue for SpatialObjectProperty member functions.

Here is the behavior before these changes:
<img width="459" alt="WithoutFix" src="https://github.com/user-attachments/assets/2e5deb1e-2864-4372-9f84-e79642dfa5a9">

Here is the behavior with these changes:
<img width="401" alt="WithFix" src="https://github.com/user-attachments/assets/40cea84a-5cb8-4067-be5d-1ca16c502e44">
