### PR TITLE
ENH: Specify rtd custom domain in the documentation config file

### DIFF
--- a/Documentation/docs/conf.py
+++ b/Documentation/docs/conf.py
@@ -6,11 +6,20 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
 from datetime import date
 
 project = 'ITK'
 copyright = f'{date.today().year}, NumFOCUS'
 author = 'Insight Software Consortium'
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "docs.itk.org")
+
+html_context = {}
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 extensions = [
     'sphinx.ext.napoleon',


### PR DESCRIPTION
Specify the Read The Docs custom domain in the documentation config file.

Read the Docs is deprecating Sphinx context injection at build time starting Monday, Oct 7, 2024, so any custom domain specified in the Read the Docs admin needs to be defined in the configuration file.

Documentation:
https://about.readthedocs.com/blog/2024/07/addons-by-default/

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]