### PR TITLE
COMP: Remove unused setuptools upgrade in Linux builds

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -53,7 +53,6 @@ jobs:
         sudo pip3 install ninja
         sudo apt-get update
         sudo apt-get install -y python3-venv
-        sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install lxml scikit-ci-addons
       displayName: 'Install dependencies'
 
@@ -126,7 +125,6 @@ jobs:
         sudo pip3 install ninja
         sudo apt-get update
         sudo apt-get install -y python3-venv
-        sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install lxml scikit-ci-addons
       displayName: 'Install dependencies'
 

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -52,7 +52,6 @@ jobs:
         set -x
         python3 -m pip install ninja typing-extensions
         python3 -m pip install --upgrade --pre numpy
-        python3 -m pip install --upgrade setuptools
         python3 -m pip install lxml scikit-ci-addons dask distributed
       displayName: 'Install dependencies'
 


### PR DESCRIPTION
Avoid unrelated `importlib_metadata` errors reported in #4781
