### PR TITLE
BUG: Fix input argument count check in FEM test

### DIFF
--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -40,7 +40,7 @@ PrintK1(SolverType * S, int s);
 int
 itkFEMElement3DTest(int argc, char * argv[])
 {
-  if (argc != 3)
+  if (argc != 2)
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;


### PR DESCRIPTION
Fix input argument count check in FEM test: set the appropriate value to the number of expected arguments.

This test has never required three input arguments since its introduction in commit 23f10a989aca2146ba1f2782fa92fdca4fd7d280.

The number of required input arguments was set mistakenly to three in commit 60067a656d0d67c3bcdb4d1c3f3a6d300edca781.

Fixes:
```
Missing parameters.
Usage: itkFEMElement3DTest inputFileName
```

reported for example in:
https://open.cdash.org/viewTest.php?onlyfailed&buildid=9768301


Addresses some of the issues reported in #4782.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]