### PR TITLE
STYLE: Remove redundant non-const `Object::AddObserver` overload

### DIFF
--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -152,15 +152,11 @@ public:
    * which can be used later to remove the event or retrieve the
    * command.
    *
-   * \note This member function is overloaded for const and non-const,
-   * just for backward compatibility. Removing the non-const overload
-   * appears to break the use of SWIG %pythonprepend in
+   * \note The parameter name `cmd` is part of the interface to SWIG! It is used by the %pythonprepend section in
    * ITK/Wrapping/Generators/Python/PyBase/pyBase.i
    */
   unsigned long
-  AddObserver(const EventObject & event, Command *);
-  unsigned long
-  AddObserver(const EventObject & event, Command *) const;
+  AddObserver(const EventObject & event, Command * cmd) const;
 
   /** \brief A convenient method to add an C++ lambda function as an observer.
    *

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -457,13 +457,6 @@ Object::GetGlobalWarningDisplay()
 }
 
 unsigned long
-Object::AddObserver(const EventObject & event, Command * cmd)
-{
-  const auto & thisAsConst = *this;
-  return thisAsConst.AddObserver(event, cmd);
-}
-
-unsigned long
 Object::AddObserver(const EventObject & event, Command * cmd) const
 {
   if (!this->m_SubjectImplementation)

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -322,18 +322,10 @@ str = str
 
     %pythonprepend itkObject::AddObserver %{
         import itk
-        if len(args) == 3 and not issubclass(args[2].__class__, itk.Command) and callable(args[2]):
-            args = list(args)
+        if not issubclass(cmd.__class__, itk.Command) and callable(cmd):
             pycommand = itk.PyCommand.New()
-            pycommand.SetCommandCallable( args[2] )
-            args[2] = pycommand
-            args = tuple(args)
-        elif len(args) == 2 and not issubclass(args[1].__class__, itk.Command) and callable(args[1]):
-            args = list(args)
-            pycommand = itk.PyCommand.New()
-            pycommand.SetCommandCallable( args[1] )
-            args[1] = pycommand
-            args = tuple(args)
+            pycommand.SetCommandCallable( cmd )
+            cmd = pycommand
     %}
 
 %enddef


### PR DESCRIPTION
The `const` overload of `Object::AddObserver` can serve both "const" and "non-const" instances of and references to an `itk::Object`, so the non-const overload should not be necessary.

Note: this is an ABI change, and it might affect the SWIG output, but it should be acceptable for ITK 6.

----

Related pull requests:
- #3636
- #3669
- #4685 by Piyush Aggarwal (@tm9k1)
