### PR TITLE
dicom structured report prefix

### DIFF
--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -78,8 +78,10 @@ else(DCMTK_USE_ICU)
      )
 endif()
 
-set(_ITKDCMTK_LIB_NAMES dcmdata dcmimage dcmimgle dcmjpeg dcmjpls
-    dcmnet dcmpstat dcmqrdb dcmsr dcmtls ijg12 ijg16 ijg8 oflog ofstd oficonv)
+set(_ITKDCMTK_LIB_NAMES dcmdata dcmpstat dcmsr dcmqrdb dcmimgle
+  dcmimage dcmjpeg dcmjpls dcmnet
+  dcmwlm dcmrt dcmiod dcmfg
+  dcmseg dcmpmap ijg12 ijg16 ijg8 oflog ofstd oficonv)
 if(WIN32)
   set(ITKDCMTK_LIBDEP_WIN iphlpapi ws2_32 netapi32 wsock32)
 endif()

--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -16,4 +16,7 @@ set(DCMTK_GIT_REPOSITORY "https://github.com/InsightSoftwareConsortium/DCMTK.git
  #Matt McCormick (1):
        #Support CMAKE_CROSSCOMPILING_EMULATOR # pushed upstream in https://github.com/DCMTK/dcmtk/pull/94
 
-set(DCMTK_GIT_TAG "bed2645624b30823189b1afa0d0feb8c8964847e") # 20240311_DCMTK_PATCHES_FOR_ITK
+ #Shreeraj Jadhav (1):
+       #ENH: Replace HTML_HYPERLINK_PREFIX_FOR_CGI with std::string argument
+
+set(DCMTK_GIT_TAG "8197ee21a2e17be65b72508dca9a91d4d60725aa") # 20240311_DCMTK_PATCHES_FOR_ITK-1


### PR DESCRIPTION
The dsr2html tool uses a hardcoded literal string as a hyperlink prefix for refrenced composite objects (images, waveforms, etc.) in rendering the Key Object Selection documents.

Replace this literal with a string argument that will be passed by a calling application / function.

Pushed upstream: DCMTK/dcmtk#108