### PR TITLE
BUG: Missing writing of the nifti descrip field.

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1776,6 +1776,17 @@ NiftiImageIO::WriteImageInformation()
       strcpy(this->m_NiftiImage->aux_file, temp.c_str());
     }
   }
+  if (itk::ExposeMetaData<std::string>(thisDic, "ITK_FileNotes", temp))
+  {
+    if (temp.length() > 79)
+    {
+      itkExceptionMacro("ITK_FileNotes (Nifti descrip field) too long, Nifti limit is 79 characters");
+    }
+    else
+    {
+      strcpy(this->m_NiftiImage->descrip, temp.c_str());
+    }
+  }
 
   // Enable RAS conversion based on metadata and flags
   this->m_ConvertRAS = (m_ConvertRASVectors && this->m_NiftiImage->intent_code == NIFTI_INTENT_VECTOR) ||

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -148,6 +148,8 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
     itk::MetaDataDictionary & dictionary = vi->GetMetaDataDictionary();
     itk::EncapsulateMetaData<std::string>(dictionary, "intent_code", intentCode);
   }
+  std::string description("text description of file content");
+  itk::EncapsulateMetaData<std::string>(vi->GetMetaDataDictionary(), "ITK_FileNotes", description);
   try
   {
     itk::IOTestHelper::WriteImage<VectorImageType, itk::NiftiImageIO>(vi, fname);
@@ -190,6 +192,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   {
     const itk::MetaDataDictionary & dictionary = readback->GetMetaDataDictionary();
     std::string                     readIntentCode;
+    std::string                     readDescription;
     if (itk::ExposeMetaData<std::string>(dictionary, "intent_code", readIntentCode))
     {
       if (readIntentCode != intentCode)
@@ -201,6 +204,19 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
     else
     {
       std::cout << "The read image should have an intent_code in its dictionary" << std::endl;
+      same = false;
+    }
+    if (itk::ExposeMetaData<std::string>(dictionary, "ITK_FileNotes", readDescription))
+    {
+      if (readDescription != description)
+      {
+        std::cout << "ITK_FileNotes is different: " << readDescription << " != " << description << std::endl;
+        same = false;
+      }
+    }
+    else
+    {
+      std::cout << "The read image should have a ITK_FileNotes (nifti descrip field) in its dictionary" << std::endl;
       same = false;
     }
   }


### PR DESCRIPTION
The nifti descrip field is currently only read and exposed via the ITK_FileNotes metadata dictionary variable. Setting the ITK_FileNotes via the metadata dictionary has no effect while writing. This commit writes the contents of the ITK_FileNotes variable if it is found in the metadata dictionary.
