### PR TITLE
COMP: change itkLegacyMacro to never require a trailing semi colon

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -161,6 +161,7 @@ StatementMacros:
   - INTEL_PRAGMA_WARN_POP
   - INTEL_SUPPRESS_warning_1292
   - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
 TabWidth:        2
 UseTab:          Never
 ...

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -122,7 +122,7 @@ public:
   ComputeCorners() const;
 
   /** Compute and return the corners of the bounding box */
-  itkLegacyMacro(const PointsContainer * GetCorners());
+  itkLegacyMacro(const PointsContainer * GetCorners();)
 
   /** Method that actually computes bounding box. */
   bool

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -321,16 +321,16 @@ ITK_GCC_PRAGMA_POP
   End() const;
 
   /** Get a begin ReverseIterator. */
-  itkLegacyMacro(ReverseIterator rBegin());
+  itkLegacyMacro(ReverseIterator rBegin();)
 
   /** Get a begin ConstReverseIterator. */
-  itkLegacyMacro(ConstReverseIterator rBegin() const);
+  itkLegacyMacro(ConstReverseIterator rBegin() const;)
 
   /** Get an end ReverseIterator. */
-  itkLegacyMacro(ReverseIterator rEnd());
+  itkLegacyMacro(ReverseIterator rEnd();)
 
   /** Get an end ConstReverseIterator. */
-  itkLegacyMacro(ConstReverseIterator rEnd() const);
+  itkLegacyMacro(ConstReverseIterator rEnd() const;)
 
   constexpr const_iterator
   cbegin() const noexcept

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -625,7 +625,7 @@ OutputWindowDisplayDebugText(const char *);
 // declared in their class.  Example usage:
 //
 //   // \deprecated Replaced by MyOtherMethod() as of ITK 2.0.
-//   itkLegacyMacro(void MyMethod());
+//   itkLegacyMacro(void MyMethod();)
 //
 // See below for what to do for the method definition.
 #if defined(ITK_LEGACY_REMOVE)
@@ -633,10 +633,10 @@ OutputWindowDisplayDebugText(const char *);
 #else
 #  if defined(ITK_LEGACY_SILENT) || defined(ITK_LEGACY_TEST)
 //   Provide legacy methods with no warnings.
-#    define itkLegacyMacro(method) method
+#    define itkLegacyMacro(method) method /* no ';' */
 #  else
 //   Request compile-time warnings for uses of deprecated methods.
-#    define itkLegacyMacro(method) [[deprecated]] method
+#    define itkLegacyMacro(method) [[deprecated]] method /* no ';' */
 #  endif
 #endif
 

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -154,8 +154,8 @@ public:
    * starting threads.
    *
    * Deprecated: use Get/Set GlobalDefaultThreader. */
-  itkLegacyMacro(static void SetGlobalDefaultUseThreadPool(const bool GlobalDefaultUseThreadPool));
-  itkLegacyMacro(static bool GetGlobalDefaultUseThreadPool());
+  itkLegacyMacro(static void SetGlobalDefaultUseThreadPool(const bool GlobalDefaultUseThreadPool);)
+  itkLegacyMacro(static bool GetGlobalDefaultUseThreadPool();)
 
   using ThreaderEnum = MultiThreaderBaseEnums::Threader;
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/include/itkPlatformMultiThreader.h
+++ b/Modules/Core/Common/include/itkPlatformMultiThreader.h
@@ -112,7 +112,7 @@ public:
    * each of the required m_NumberOfWorkUnits methods) using m_NumberOfWorkUnits
    * threads. As a side effect the m_NumberOfWorkUnits will be checked against the
    * current m_GlobalMaximumNumberOfThreads and clamped if necessary. */
-  itkLegacyMacro(void MultipleMethodExecute());
+  itkLegacyMacro(void MultipleMethodExecute();)
 
   /** Set the SingleMethod to f() and the UserData field of the
    * WorkUnitInfo that is passed to it will be data.
@@ -124,17 +124,17 @@ public:
 
   /** Set the MultipleMethod at the given index to f() and the UserData
    * field of the WorkUnitInfo that is passed to it will be data. */
-  itkLegacyMacro(void SetMultipleMethod(ThreadIdType index, ThreadFunctionType, void * data));
+  itkLegacyMacro(void SetMultipleMethod(ThreadIdType index, ThreadFunctionType, void * data);)
 
   /** Create a new thread for the given function. Return a thread id
    * which is a number between 0 and ITK_MAX_THREADS - 1. This
    * id should be used to kill the thread at a later time.
    * Deprecated. Use C++11 thread support instead. */
-  itkLegacyMacro(ThreadIdType SpawnThread(ThreadFunctionType, void * data));
+  itkLegacyMacro(ThreadIdType SpawnThread(ThreadFunctionType, void * data);)
 
   /** Terminate the thread that was created with a SpawnThreadExecute()
    * Deprecated. Use C++11 thread support instead. */
-  itkLegacyMacro(void TerminateThread(ThreadIdType thread_id));
+  itkLegacyMacro(void TerminateThread(ThreadIdType thread_id);)
 
   void
   SetMaximumNumberOfThreads(ThreadIdType numberOfThreads) override;

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -116,7 +116,7 @@ public:
   /** Compute axis aligned bounding box from the image mask.
    * \note With ITK 5.0, this function is superseded by `ComputeMyBoundingBoxInIndexSpace()`
    */
-  itkLegacyMacro(RegionType GetAxisAlignedBoundingBoxRegion() const);
+  itkLegacyMacro(RegionType GetAxisAlignedBoundingBoxRegion() const;)
 
 #endif
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -74,7 +74,7 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Approximate the normals of the surface. */
-  itkLegacyMacro(bool Approximate3DNormals());
+  itkLegacyMacro(bool Approximate3DNormals();)
 #endif
 
   /** Compute the normals to the surface from neighboring points. */

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -530,7 +530,7 @@ public:
                       << this->GetNameOfClass());
   }
   itkLegacyMacro(virtual void ComputeJacobianWithRespectToPosition(const InputPointType & x, JacobianType & jacobian)
-                   const);
+                   const;)
 
 
   /** This provides the ability to get a local jacobian value
@@ -541,7 +541,7 @@ public:
   virtual void
   ComputeInverseJacobianWithRespectToPosition(const InputPointType & pnt, InverseJacobianPositionType & jacobian) const;
   itkLegacyMacro(virtual void ComputeInverseJacobianWithRespectToPosition(const InputPointType & x,
-                                                                          JacobianType &         jacobian) const);
+                                                                          JacobianType &         jacobian) const;)
 
   /** Apply this transform to an image without resampling.
    *

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -347,7 +347,7 @@ protected:
   /** Cast pixel from interpolator output to PixelType. */
   itkLegacyMacro(virtual PixelType CastPixelWithBoundsChecking(const InterpolatorOutputType value,
                                                                const ComponentType          minComponent,
-                                                               const ComponentType          maxComponent) const);
+                                                               const ComponentType          maxComponent) const;)
 
 private:
   static PixelComponentType

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -316,8 +316,8 @@ public:
    * This parameter was introduced to reduce the memory used by images
    * internally, at the cost of performance.
    */
-  itkLegacyMacro(unsigned int GetInternalNumberOfStreamDivisions() const);
-  itkLegacyMacro(void SetInternalNumberOfStreamDivisions(unsigned int));
+  itkLegacyMacro(unsigned int GetInternalNumberOfStreamDivisions() const;)
+  itkLegacyMacro(void SetInternalNumberOfStreamDivisions(unsigned int);)
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking


### PR DESCRIPTION
Previously, some places *required* a trailing semi and some places required *no* trailing semi.

For example, I see no way to force this kind of usage to have a trailing semi, because that would stick a semi right before the function definition, which isn't allowed:

```
  itkLegacyMacro(static ThreadIdType GetGlobalDefaultNumberOfThreads())
  {
                          "can affect all MultiThreaderBase's derived classes in ITK");
    return Superclass::GetGlobalDefaultNumberOfThreads();
  }
```

Such existing uses only work if inside `#if !defined(ITK_LEGACY_REMOVE)` because only that variation of the definition of the `itkLegacyMacro` macro doesn't require a trailing semi.

It's rather strange for users to both require and forbid traling semis, so this change chooses the only way that can work in all cases.

Fixes various -Wextra-semi warnings.
