### PR TITLE
COMP: Bump ITKTotalVariation remote module

### DIFF
--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG b615ce13394fb5fb16bf8abc2390f5dab73ac27e
+  GIT_TAG 0b4f9450f7c98b8db6dee5990bbd9be5d6e6c4d2
   )


### PR DESCRIPTION
CMake fixes to address CMake IMPORTED target:

  The link interface of target "proxTV" contains:

    OpenMP::OpenMP_CXX

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target. * An ALIAS target is missing.