### PR TITLE
COMP: fixed compiler error with ITK_USE_GPU = YES

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1239,7 +1239,7 @@ compilers.
  * Construct a non-templatized helper class that
  * provides the GPU kernel source code as a const char*
  */
-#define itkGPUKernelClassMacro(kernel) class itkGPUKernelMacro(kernel) ITK_MACROEND_NOOP_STATEMENT
+#define itkGPUKernelClassMacro(kernel) class itkGPUKernelMacro(kernel)
 
 /**\def itkGPUKernelMacro
  * Equivalent to the original `itkGPUKernelClassMacro(kernel)` macro, but
@@ -1254,8 +1254,7 @@ compilers.
     kernel() = delete;                     \
     ~kernel() = delete;                    \
     static const char * GetOpenCLSource(); \
-  }                                        \
-  ITK_MACROEND_NOOP_STATEMENT
+  }
 
 #define itkGetOpenCLSourceFromKernelMacro(kernel)                             \
   static const char * GetOpenCLSource() { return kernel::GetOpenCLSource(); } \


### PR DESCRIPTION
The error was:

```
Modules/Core/GPUCommon/include/itkGPUImageOps.h:26:1: error: expected ';' after class
itkGPUKernelClassMacro(GPUImageOpsKernel);
^
```
