### PR TITLE
STYLE: Remove unnecessary iterator `GoToBegin()` calls from Core

### DIFF
--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
@@ -88,8 +88,6 @@ UnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGe
   ImageScanlineConstIterator inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator      outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -191,9 +191,6 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedApplyUpdate
   ImageRegionIterator<UpdateBufferType> u(m_UpdateBuffer, regionToProcess);
   ImageRegionIterator<OutputImageType>  o(this->GetOutput(), regionToProcess);
 
-  u.GoToBegin();
-  o.GoToBegin();
-
   while (!u.IsAtEnd())
   {
     o.Value() += static_cast<PixelType>(u.Value() * dt); // no adaptor
@@ -259,7 +256,6 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedCalculateCh
     UpdateIteratorType       bU(m_UpdateBuffer, *fIt);
 
     bD.GoToBegin();
-    bU.GoToBegin();
     while (!bD.IsAtEnd())
     {
       bU.Value() = df->ComputeUpdate(bD, globalData);

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -1037,11 +1037,6 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
   InputImageIterator it3(m_InputImage, m_RegionOfInterest);
   InputImageIterator it4(m_InputImage, m_RegionOfInterest);
 
-  it1.GoToBegin();
-  it2.GoToBegin();
-  it3.GoToBegin();
-  it4.GoToBegin();
-
   InputImageSizeType inputImageSize = m_RegionOfInterest.GetSize();
   m_ImageWidth = inputImageSize[0];
   m_ImageHeight = inputImageSize[1];

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
@@ -108,7 +108,6 @@ ImageToParametricSpaceFilter<TInputImage, TOutputMesh>::GenerateData()
 
     PointsContainerIterator point = points->Begin();
 
-    itr.GoToBegin();
     while (!itr.IsAtEnd())
     {
       (point.Value())[component] = itr.Get();
@@ -123,7 +122,6 @@ ImageToParametricSpaceFilter<TInputImage, TOutputMesh>::GenerateData()
     PointDataContainerIterator data = pointData->Begin();
     image = this->GetInput(0);
     ImageRegionConstIteratorWithIndex<InputImageType> itr(image, image->GetRequestedRegion());
-    itr.GoToBegin();
     while (!itr.IsAtEnd())
     {
       //  The data at each point is the index

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -119,11 +119,10 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
 
     using MaskIteratorType = ImageRegionConstIteratorWithIndex<MaskImageType>;
     MaskIteratorType it(maskImage, maskImage->GetLargestPossibleRegion());
-    it.GoToBegin();
-    IndexType  ind;
-    PointType  pnt;
-    PointType  tPnt;
-    VectorType mv;
+    IndexType        ind;
+    PointType        pnt;
+    PointType        tPnt;
+    VectorType       mv;
     while (!it.IsAtEnd())
     {
       if (it.Get() > 0) // if inside the mask
@@ -186,10 +185,9 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
 
     using IteratorType = ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType it(m_Image, region);
-    it.GoToBegin();
-    IndexType  ind;
-    PointType  pnt;
-    VectorType mv;
+    IndexType    ind;
+    PointType    pnt;
+    VectorType   mv;
     while (!it.IsAtEnd())
     {
       ind = it.GetIndex();

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -110,9 +110,6 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageRegionIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
 
-  inputIt.GoToBegin();
-  outputIt.GoToBegin();
-
   while (!inputIt.IsAtEnd())
   {
     const InputPixelType x = inputIt.Get();


### PR DESCRIPTION
When an ITK iterator is just constructed by `IteratorType(image, region)`, it is already initialized at the begin of the region, as was tested and documented by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4815 commit 66e6d8be08c45d29cb120fd925451a35480fc631 and 9eb13596cef6009c026b2ee837ea52ee05d00f11.

- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3953 commit 5a60ed00adbc108e5c81bd2ddfbc988f28eaf722
"STYLE: Remove unnecessary iterator `GoToBegin()` calls from Filtering", 7 March 2023