### PR TITLE
Declare `GetImageDimension()` member functions constexpr, add compile-time tests

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -174,8 +174,8 @@ public:
   void
   Initialize() override;
 
-  /** Image dimension. The dimension of an image is fixed at construction. */
-  static unsigned int
+  /** Image dimension. The dimension of an image is fixed at compile-time. */
+  static constexpr unsigned int
   GetImageDimension()
   {
     return VImageDimension;

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
@@ -157,7 +157,7 @@ public:
   operator=(const Self & it);
 
   /** Get the dimension (size) of the index. */
-  static unsigned int
+  static constexpr unsigned int
   GetImageDimension()
   {
     return ImageDimension;

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -136,7 +136,7 @@ public:
   virtual ~ImageConstIteratorWithOnlyIndex() = default;
 
   /** Get the dimension (size) of the index. */
-  static unsigned int
+  static constexpr unsigned int
   GetImageDimension()
   {
     return ImageDimension;

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -105,8 +105,8 @@ public:
       in which case the SliceDimension is also one dimensional. */
   static constexpr unsigned int SliceDimension = ImageDimension - (ImageDimension > 1);
 
-  /** Dimension of the image available at run time. */
-  static unsigned int
+  /** Dimension of the image available at compile-time and at run time. */
+  static constexpr unsigned int
   GetImageDimension()
   {
     return ImageDimension;

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -29,6 +29,14 @@
 
 namespace
 {
+// Tells whether GetImageDimension() returns ImageDimension, for all of the specified values of VImageDimension.
+template <unsigned int... VImageDimension>
+constexpr bool GetImageDimension_returns_ImageDimension{ (
+  (itk::ImageBase<VImageDimension>::GetImageDimension() == VImageDimension) && ...) };
+
+static_assert(GetImageDimension_returns_ImageDimension<2, 3, 4>, "GetImageDimension() should return ImageDimension.");
+
+
 template <typename T1, typename T2>
 void
 Expect_same_type_and_equal_value(T1 && value1, T2 && value2)

--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -26,6 +26,14 @@
 
 namespace
 {
+// Tells whether GetImageDimension() returns ImageDimension, for all of the specified values of VImageDimension.
+template <unsigned int... VImageDimension>
+constexpr bool GetImageDimension_returns_ImageDimension{ (
+  (itk::ImageRegion<VImageDimension>::GetImageDimension() == VImageDimension) && ...) };
+
+static_assert(GetImageDimension_returns_ImageDimension<2, 3, 4>, "GetImageDimension() should return ImageDimension.");
+
+
 template <unsigned int VDimension>
 constexpr bool
 CheckTrivialCopyabilityOfImageRegion()


### PR DESCRIPTION
Allowed calling `GetImageDimension()` at compile-time.