### PR TITLE
Add `Vector.NormEqualsVnlVectorMagnitude` unit test, add "magnitude" to documentation

### DIFF
--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -41,7 +41,6 @@ ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const In
   VectorType vecOriginToTest = position - m_Origin;
 
   // Compute the length of this vector
-  // double vecDistance = vecOriginToTest.GetVnlVector().magnitude();
   double vecDistance = vecOriginToTest.GetNorm();
 
   // Check to see if this an allowed distance

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -102,7 +102,7 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::Evaluate(const InputType & po
   }
 
   if (itk::Math::abs(distanceFromCenter) <= (halfAxisLength) &&
-      m_Radius >= std::sqrt(std::pow(pointVector.GetVnlVector().magnitude(), 2.0) - std::pow(distanceFromCenter, 2.0)))
+      m_Radius >= std::sqrt(std::pow(pointVector.GetNorm(), 2.0) - std::pow(distanceFromCenter, 2.0)))
   {
     return 1;
   }

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -241,7 +241,7 @@ public:
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
-  /** Returns the Euclidean Norm of the vector  */
+  /** Returns the Euclidean Norm of the vector (also referred to as its "magnitude"). */
   RealValueType
   GetNorm() const;
 

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -22,8 +22,9 @@
 #include <gtest/gtest.h>
 
 #include <initializer_list>
-#include <iterator>    // For begin and end.
-#include <numeric>     // For iota.
+#include <iterator> // For begin and end.
+#include <numeric>  // For iota.
+#include <random>
 #include <type_traits> // For is_same.
 
 namespace
@@ -84,4 +85,23 @@ TEST(Vector, Make)
   const auto itkVector = itk::MakeVector(1, 2, 3, 4);
   const auto values = { 1, 2, 3, 4 };
   EXPECT_TRUE(std::equal(itkVector.begin(), itkVector.end(), values.begin(), values.end()));
+}
+
+
+// Tests that for an itk::Vector `v`, `v.GetNorm()` is equal to `v.GetVnlVector().magnitude()`.
+TEST(Vector, NormEqualsVnlVectorMagnitude)
+{
+  std::mt19937 randomEngine{};
+  const auto getRandomNumber = [&randomEngine] { return std::uniform_real_distribution<>{ -1.0, 1.0 }(randomEngine); };
+
+  using VectorType = itk::Vector<double>;
+
+  for (const auto & itkVector : { VectorType(),
+                                  itk::MakeVector(0.0, 0.0, 1.0),
+                                  itk::MakeFilled<VectorType>(1.0),
+                                  itk::MakeFilled<VectorType>(getRandomNumber()),
+                                  itk::MakeVector(getRandomNumber(), getRandomNumber(), getRandomNumber()) })
+  {
+    EXPECT_EQ(itkVector.GetNorm(), itkVector.GetVnlVector().magnitude());
+  }
 }

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -248,7 +248,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrixParameters
   scaleV[0] = M(0, 0);
   scaleV[1] = M(1, 0);
   scaleV[2] = M(2, 0);
-  m_Scale[0] = scaleV.GetVnlVector().magnitude();
+  m_Scale[0] = scaleV.GetNorm();
   M(0, 0) /= m_Scale[0];
   M(1, 0) /= m_Scale[0];
   M(2, 0) /= m_Scale[0];
@@ -260,7 +260,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrixParameters
   scaleV[0] = M(0, 1);
   scaleV[1] = M(1, 1);
   scaleV[2] = M(2, 1);
-  m_Scale[1] = scaleV.GetVnlVector().magnitude();
+  m_Scale[1] = scaleV.GetNorm();
   M(0, 1) /= m_Scale[1];
   M(1, 1) /= m_Scale[1];
   M(2, 1) /= m_Scale[1];
@@ -274,7 +274,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrixParameters
   scaleV[0] = M(0, 2);
   scaleV[1] = M(1, 2);
   scaleV[2] = M(2, 2);
-  m_Scale[2] = scaleV.GetVnlVector().magnitude();
+  m_Scale[2] = scaleV.GetNorm();
   M(0, 2) /= m_Scale[2];
   M(1, 2) /= m_Scale[2];
   M(2, 2) /= m_Scale[2];


### PR DESCRIPTION
Tests that `itkVector.GetNorm()` equals `itkVector.GetVnlVector().magnitude()`.