### PR TITLE
Expose a binary parameter to `meshwrite` function

### DIFF
--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -142,7 +142,7 @@ public:
   itkBooleanMacro(UseCompression);
 
 protected:
-  MeshFileWriter();
+  MeshFileWriter() = default;
   ~MeshFileWriter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -177,13 +177,11 @@ protected:
 
 private:
   std::string         m_FileName{};
-  MeshIOBase::Pointer m_MeshIO{};
-  bool                m_UserSpecifiedMeshIO{}; // track whether the MeshIO is
-                                               // user specified
-  bool m_FactorySpecifiedMeshIO{};             // track whether the factory
-                                               // mechanism set the MeshIO
-  bool m_UseCompression{};
-  bool m_FileTypeIsBINARY{};
+  MeshIOBase::Pointer m_MeshIO{ nullptr };
+  bool                m_UserSpecifiedMeshIO{ false };    // track whether the MeshIO is user specified
+  bool                m_FactorySpecifiedMeshIO{ false }; // track whether the factory mechanism set the MeshIO
+  bool                m_UseCompression{ false };
+  bool                m_FileTypeIsBINARY{ false };
 };
 
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -31,16 +31,6 @@
 namespace itk
 {
 template <typename TInputMesh>
-MeshFileWriter<TInputMesh>::MeshFileWriter()
-{
-  m_MeshIO = nullptr;
-  m_UseCompression = false;
-  m_FactorySpecifiedMeshIO = false;
-  m_UserSpecifiedMeshIO = false;
-  m_FileTypeIsBINARY = false;
-}
-
-template <typename TInputMesh>
 void
 MeshFileWriter<TInputMesh>::SetInput(const InputMeshType * input)
 {

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -216,6 +216,7 @@ assert type(mesh) == itk.Mesh[itk.F, 3]
 
 itk.meshwrite(mesh, sys.argv[5])
 itk.meshwrite(mesh, sys.argv[5], compression=True)
+itk.meshwrite(mesh, sys.argv[5], binary=True)
 
 # smoke test wasm / Python / NumPy conversion
 

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1389,7 +1389,7 @@ def imread(
 
 
 def meshwrite(
-    mesh: "itkt.Mesh", filename: fileiotype, compression: bool = False
+    mesh: "itkt.Mesh", filename: fileiotype, compression: bool = False, binary: bool = False
 ) -> None:
     """Write a mesh to a file.
 
@@ -1404,6 +1404,8 @@ def meshwrite(
     writer = itk.MeshFileWriter[type(mesh)].New(
         Input=mesh, FileName=f"{filename}", UseCompression=compression
     )
+    if binary:
+        writer.SetFileTypeAsBINARY()
     auto_pipeline.current = tmp_auto_pipeline
     writer.Update()
 


### PR DESCRIPTION
## PR Checklist
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

