### PR TITLE
BUG: Fix ImageToRectilinearFEM tests arg checks

### DIFF
--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
@@ -26,7 +26,14 @@
 int
 itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
 {
-  if (argc != 11)
+  constexpr int inputFileDataCheckArgs = 8;
+  // numberOfNodesToTest (a least 1) + nodeNumber (at least 1) + nodeCoords (2 per node)
+  constexpr unsigned int minArgNodes = 4;
+  // numberOfElementsToTest (a least 1) + elementNumber (at least 1) + elementNodes (4 per element)
+  constexpr unsigned int minArgElements = 6;
+  int                    minArgC = inputFileDataCheckArgs + minArgNodes + minArgElements;
+
+  if (argc < minArgC)
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName"
@@ -37,8 +44,42 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
               << " expectedNumberOfNodes"
               << " expectedNumberOfElements"
               << " numberOfNodesToTest"
-              << " nodeNumber"
-              << " elementNumber" << std::endl;
+              << " nodeNumber (numberOfNodesToTest)"
+              << " nodeCoords (2*numberOfNodesToTest)"
+              << " numberOfElementsToTest"
+              << " elementNumber (numberOfElementsToTest)"
+              << " elementNodes (4*numberOfElementsToTest)" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+
+  constexpr unsigned int Dimension = 2;
+  constexpr unsigned int nodeSize = 4;
+
+  // Check the provided node and element argument numbers
+  const auto numberOfNodesToTest = static_cast<unsigned int>(std::stoi(argv[8]));
+  int        nodeData = numberOfNodesToTest * (1 + Dimension);
+  int        nodeTestData = 1 + nodeData;
+  if (argc < inputFileDataCheckArgs + nodeTestData)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Specified: " << numberOfNodesToTest << " nodes to test: "
+              << "this requires" << nodeTestData << " arguments(1 node number and " << Dimension
+              << " coordinates per node number); " << inputFileDataCheckArgs + nodeTestData - argc << " missing."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto numberOfElementsToTest = static_cast<unsigned int>(std::stoi(argv[9 + numberOfNodesToTest * 3]));
+  int        elementData = numberOfElementsToTest * (1 + nodeSize);
+  int        elementTestData = 1 + elementData;
+  if (argc < inputFileDataCheckArgs + nodeTestData + elementTestData)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Specified " << numberOfElementsToTest << " elements to test: "
+              << "this requires " << elementData << " arguments (1 element number and " << nodeSize
+              << " nodes per element number); " << inputFileDataCheckArgs + nodeTestData + elementTestData - argc
+              << " missing." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -48,14 +89,14 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
   // the initialization of the itk::FEMFactoryBase::GetFactory()
   itk::FEMFactoryBase::GetFactory()->RegisterDefaultTypes();
 
-  using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, Dimension>;
   using ImageFileReaderType = itk::ImageFileReader<ImageType>;
   double tolerance = 0.0001;
 
   vnl_vector<unsigned int> pixelsPerElement;
   vnl_vector<unsigned int> numberOfElements;
-  pixelsPerElement.set_size(2);
-  numberOfElements.set_size(2);
+  pixelsPerElement.set_size(Dimension);
+  numberOfElements.set_size(Dimension);
   pixelsPerElement[0] = static_cast<unsigned int>(std::stoi(argv[2]));
   pixelsPerElement[1] = static_cast<unsigned int>(std::stoi(argv[3]));
   numberOfElements[0] = static_cast<unsigned int>(std::stoi(argv[4]));
@@ -89,7 +130,7 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
   meshFilter->SetMaterial(m);
   meshFilter->Update();
 
-  using FEMObjectType = itk::fem::FEMObject<2>;
+  using FEMObjectType = itk::fem::FEMObject<Dimension>;
   FEMObjectType::Pointer femObject = meshFilter->GetOutput();
   std::cout << "FEM Object Generation Test:";
   if (!femObject)
@@ -106,7 +147,7 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
 
   vnl_vector<unsigned int> testPixelsPerElement = meshFilter->GetPixelsPerElement();
   vnl_vector<unsigned int> testNumberOfElements = meshFilter->GetNumberOfElements();
-  for (unsigned int i = 0; i < 2; ++i)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     std::cout << "Pixels per Element Test " << i << ':';
     if (testPixelsPerElement[i] != pixelsPerElement[i])
@@ -202,12 +243,12 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
     std::cout << " [PASSED]" << std::endl;
   }
 
-  const auto numberOfNodesToTest = static_cast<unsigned int>(std::stoi(argv[8]));
+
   for (unsigned int i = 0; i < numberOfNodesToTest; ++i)
   {
     auto               nodeNumber = static_cast<unsigned int>(std::stoi(argv[9 + i * 3]));
     vnl_vector<double> loc;
-    loc.set_size(2);
+    loc.set_size(Dimension);
     loc[0] = std::stod(argv[9 + i * 3 + 1]);
     loc[1] = std::stod(argv[9 + i * 3 + 2]);
     std::cout << "Node (" << nodeNumber << ") Test " << i << ": ";
@@ -226,12 +267,11 @@ itkImageToRectilinearFEMObjectFilter2DTest(int argc, char * argv[])
     }
   }
 
-  const auto numberOfElementsToTest = static_cast<unsigned int>(std::stoi(argv[9 + numberOfNodesToTest * 3]));
   for (unsigned int i = 0; i < numberOfElementsToTest; ++i)
   {
     auto            elementNumber = static_cast<unsigned int>(std::stoi(argv[10 + numberOfNodesToTest * 3 + i * 5]));
     vnl_vector<int> nodes;
-    nodes.set_size(4);
+    nodes.set_size(nodeSize);
     nodes[0] = std::stoi(argv[10 + numberOfNodesToTest * 3 + i * 5 + 1]);
     nodes[1] = std::stoi(argv[10 + numberOfNodesToTest * 3 + i * 5 + 2]);
     nodes[2] = std::stoi(argv[10 + numberOfNodesToTest * 3 + i * 5 + 3]);

--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
@@ -26,7 +26,14 @@
 int
 itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
 {
-  if (argc != 13)
+  constexpr int inputFileDataCheckArgs = 10;
+  // numberOfNodesToTest (a least 1) + nodeNumber (at least 1) + nodeCoords (3 per node)
+  constexpr unsigned int minArgNodes = 5;
+  // numberOfElementsToTest (a least 1) + elementNumber (at least 1) + elementNodes (8 per element)
+  constexpr unsigned int minArgElements = 10;
+  int                    minArgC = inputFileDataCheckArgs + minArgNodes + minArgElements;
+
+  if (argc < minArgC)
   {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName"
@@ -38,9 +45,43 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
               << " numberOfElementsZ"
               << " expectedNumberOfNodes"
               << " expectedNumberOfElements"
+              << " nodeCoords (3*numberOfNodesToTest)"
+              << " numberOfElementsToTest"
               << " numberOfNodesToTest"
-              << " nodeNumber"
-              << " elementNumber" << std::endl;
+              << " nodeNumber (numberOfNodesToTest)"
+              << " numberOfElementsToTest"
+              << " elementNumber (numberOfElementsToTest)"
+              << " elementNodes (8*numberOfElementsToTest)" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  constexpr unsigned int Dimension = 3;
+  constexpr unsigned int nodeSize = 8;
+
+  // Check the provided node and element argument numbers
+  const auto numberOfNodesToTest = static_cast<unsigned int>(std::stoi(argv[10]));
+  int        nodeData = numberOfNodesToTest * (1 + Dimension);
+  int        nodeTestData = 1 + nodeData;
+  if (argc < inputFileDataCheckArgs + nodeTestData)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Specified: " << numberOfNodesToTest << " nodes to test: "
+              << "this requires" << nodeTestData << " arguments(1 node number and " << Dimension
+              << " coordinates per node number); " << inputFileDataCheckArgs + nodeTestData - argc << " missing."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto numberOfElementsToTest = static_cast<unsigned int>(std::stoi(argv[11 + numberOfNodesToTest * 4]));
+  int        elementData = numberOfElementsToTest * (1 + nodeSize);
+  int        elementTestData = 1 + elementData;
+  if (argc < inputFileDataCheckArgs + nodeTestData + elementTestData)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Specified " << numberOfElementsToTest << " elements to test: "
+              << "this requires " << elementData << " arguments (1 element number and " << nodeSize
+              << " nodes per element number); " << inputFileDataCheckArgs + nodeTestData + elementTestData - argc
+              << " missing." << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -50,14 +91,14 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
   // the initialization of the itk::FEMFactoryBase::GetFactory()
   itk::FEMFactoryBase::GetFactory()->RegisterDefaultTypes();
 
-  using ImageType = itk::Image<unsigned char, 3>;
+  using ImageType = itk::Image<unsigned char, Dimension>;
   using ImageFileReaderType = itk::ImageFileReader<ImageType>;
   double tolerance = 0.001;
 
   vnl_vector<unsigned int> pixelsPerElement;
   vnl_vector<unsigned int> numberOfElements;
-  pixelsPerElement.set_size(3);
-  numberOfElements.set_size(3);
+  pixelsPerElement.set_size(Dimension);
+  numberOfElements.set_size(Dimension);
   pixelsPerElement[0] = static_cast<unsigned int>(std::stoi(argv[2]));
   pixelsPerElement[1] = static_cast<unsigned int>(std::stoi(argv[3]));
   pixelsPerElement[2] = static_cast<unsigned int>(std::stoi(argv[4]));
@@ -94,7 +135,7 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
   meshFilter->SetMaterial(m);
   meshFilter->Update();
 
-  using FEMObjectType = itk::fem::FEMObject<3>;
+  using FEMObjectType = itk::fem::FEMObject<Dimension>;
   FEMObjectType::Pointer femObject = meshFilter->GetOutput();
   std::cout << "FEM Object Generation Test:";
   if (!femObject)
@@ -111,7 +152,7 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
 
   vnl_vector<unsigned int> testPixelsPerElement = meshFilter->GetPixelsPerElement();
   vnl_vector<unsigned int> testNumberOfElements = meshFilter->GetNumberOfElements();
-  for (unsigned int i = 0; i < 3; ++i)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     std::cout << "Pixels per Element Test " << i << ':';
     if (testPixelsPerElement[i] != pixelsPerElement[i])
@@ -209,12 +250,11 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
   }
 
 
-  const auto numberOfNodesToTest = static_cast<unsigned int>(std::stoi(argv[10]));
   for (unsigned int i = 0; i < numberOfNodesToTest; ++i)
   {
     auto               nodeNumber = static_cast<unsigned int>(std::stoi(argv[11 + i * 4]));
     vnl_vector<double> loc;
-    loc.set_size(3);
+    loc.set_size(Dimension);
     loc[0] = std::stod(argv[11 + i * 4 + 1]);
     loc[1] = std::stod(argv[11 + i * 4 + 2]);
     loc[2] = std::stod(argv[11 + i * 4 + 3]);
@@ -236,7 +276,6 @@ itkImageToRectilinearFEMObjectFilter3DTest(int argc, char * argv[])
     }
   }
 
-  const auto numberOfElementsToTest = static_cast<unsigned int>(std::stoi(argv[11 + numberOfNodesToTest * 4]));
   for (unsigned int i = 0; i < numberOfElementsToTest; ++i)
   {
     auto            elementNumber = static_cast<unsigned int>(std::stoi(argv[12 + numberOfNodesToTest * 4 + i * 9]));


### PR DESCRIPTION
Fix ImageToRectilinearFEM tests arg checks:
- Fix the value for the `argc` comparison.

Take advantage of the commit to:
- Define the test data dimension as a constant so that it can be reused.
- Add additional checks to test that the provided node and element argument numbers match the expected numbers.

Fixes #4782.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)