### PR TITLE
Replace `#ifdef`s in ByteSwapper with `if constexpr`, mention C++20 `std::endian` in documentation

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -64,7 +64,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ByteSwapper);
 
-  /** Query the machine Endian-ness. */
+  /** Query the machine Endian-ness.
+  \note C++20 also allows querying the endianness, by using its enum class `std::endian`. */
   static constexpr bool
   SystemIsBigEndian()
   {

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -39,202 +39,170 @@ namespace itk
 //------Big Endian methods----------------------------------------------
 
 // Use different swap methods based on type
-#ifdef CMAKE_WORDS_BIGENDIAN
+
 template <typename T>
 void
-ByteSwapper<T>::SwapFromSystemToBigEndian(T *)
-{}
-#else
-template <typename T>
-void
-ByteSwapper<T>::SwapFromSystemToBigEndian(T * p)
+ByteSwapper<T>::SwapFromSystemToBigEndian([[maybe_unused]] T * p)
 {
-  switch (sizeof(T))
+  if constexpr (!m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::Swap2(p);
-      return;
-    case 4:
-      Self::Swap4(p);
-      return;
-    case 8:
-      Self::Swap8(p);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::Swap2(p);
+        return;
+      case 4:
+        Self::Swap4(p);
+        return;
+      case 8:
+        Self::Swap8(p);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
   }
 }
 
-#endif
-
-#ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
-ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T *, BufferSizeType)
+ByteSwapper<T>::SwapRangeFromSystemToBigEndian([[maybe_unused]] T * p, [[maybe_unused]] BufferSizeType num)
 {
-  // nothing needs to be done here...
-}
-
-#else
-
-#  ifdef __INTEL_COMPILER
-#    pragma warning disable 280 // remark #280: selector expression is constant
-#  endif
-template <typename T>
-void
-ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
-{
-  switch (sizeof(T))
+  if constexpr (!m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::Swap2Range(p, num);
-      return;
-    case 4:
-      Self::Swap4Range(p, num);
-      return;
-    case 8:
-      Self::Swap8Range(p, num);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::Swap2Range(p, num);
+        return;
+      case 4:
+        Self::Swap4Range(p, num);
+        return;
+      case 8:
+        Self::Swap8Range(p, num);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
   }
 }
 
-#endif
-
-#ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
 ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp)
 {
-  num *= sizeof(T);
-  fp->write(reinterpret_cast<const char *>(p), num);
-}
-
-#else
-template <typename T>
-void
-ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp)
-{
-  switch (sizeof(T))
+  if constexpr (m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::SwapWrite2Range(p, num, fp);
-      return;
-    case 4:
-      Self::SwapWrite4Range(p, num, fp);
-      return;
-    case 8:
-      Self::SwapWrite8Range(p, num, fp);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    num *= sizeof(T);
+    fp->write(reinterpret_cast<const char *>(p), num);
+  }
+  else
+  {
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::SwapWrite2Range(p, num, fp);
+        return;
+      case 4:
+        Self::SwapWrite4Range(p, num, fp);
+        return;
+      case 8:
+        Self::SwapWrite8Range(p, num, fp);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
   }
 }
 
-#endif
 
 //------Little Endian methods----------------------------------------------
 
-#ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
-ByteSwapper<T>::SwapFromSystemToLittleEndian(T * p)
+ByteSwapper<T>::SwapFromSystemToLittleEndian([[maybe_unused]] T * p)
 {
-  switch (sizeof(T))
+  if constexpr (m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::Swap2(p);
-      return;
-    case 4:
-      Self::Swap4(p);
-      return;
-    case 8:
-      Self::Swap8(p);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::Swap2(p);
+        return;
+      case 4:
+        Self::Swap4(p);
+        return;
+      case 8:
+        Self::Swap8(p);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
   }
 }
 
-#else
 template <typename T>
 void
-ByteSwapper<T>::SwapFromSystemToLittleEndian(T *)
-{}
-#endif
-
-#ifdef CMAKE_WORDS_BIGENDIAN
-template <typename T>
-void
-ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T * p, BufferSizeType num)
+ByteSwapper<T>::SwapRangeFromSystemToLittleEndian([[maybe_unused]] T * p, [[maybe_unused]] BufferSizeType num)
 {
-  switch (sizeof(T))
+  if constexpr (m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::Swap2Range(p, num);
-      return;
-    case 4:
-      Self::Swap4Range(p, num);
-      return;
-    case 8:
-      Self::Swap8Range(p, num);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::Swap2Range(p, num);
+        return;
+      case 4:
+        Self::Swap4Range(p, num);
+        return;
+      case 8:
+        Self::Swap8Range(p, num);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
   }
 }
 
-#else
-template <typename T>
-void
-ByteSwapper<T>::SwapRangeFromSystemToLittleEndian(T *, BufferSizeType)
-{}
-#endif
-
-#ifdef CMAKE_WORDS_BIGENDIAN
 template <typename T>
 void
 ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp)
 {
-  switch (sizeof(T))
+  if constexpr (m_SystemIsBigEndian)
   {
-    case 1:
-      return;
-    case 2:
-      Self::SwapWrite2Range(p, num, fp);
-      return;
-    case 4:
-      Self::SwapWrite4Range(p, num, fp);
-      return;
-    case 8:
-      Self::SwapWrite8Range(p, num, fp);
-      return;
-    default:
-      itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    switch (sizeof(T))
+    {
+      case 1:
+        return;
+      case 2:
+        Self::SwapWrite2Range(p, num, fp);
+        return;
+      case 4:
+        Self::SwapWrite4Range(p, num, fp);
+        return;
+      case 8:
+        Self::SwapWrite8Range(p, num, fp);
+        return;
+      default:
+        itkGenericExceptionMacro("Cannot swap number of bytes requested");
+    }
+  }
+  else
+  {
+    num *= sizeof(T);
+    fp->write(reinterpret_cast<const char *>(p), num);
   }
 }
 
-#else
-template <typename T>
-void
-ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp)
-{
-  num *= sizeof(T);
-  fp->write(reinterpret_cast<const char *>(p), num);
-}
-
-#endif
 
 // The following are the protected methods -------------------------
 //


### PR DESCRIPTION
- Follow-up to pull request #4835

Note: when reviewing, it may be helpful to ignore white-space changes: https://github.com/InsightSoftwareConsortium/ITK/pull/4841/files?w=1