### PR TITLE
COMP: Fix Python GPU Wrapping

### DIFF
--- a/Modules/Filtering/GPUImageFilterBase/wrapping/itkGPUCastImageFilter.wrap
+++ b/Modules/Filtering/GPUImageFilterBase/wrapping/itkGPUCastImageFilter.wrap
@@ -23,7 +23,7 @@ foreach(from ${from_types})
 endforeach()
 itk_end_wrap_class()
 
-itk_wrap_class("itk::CastImageFilter" POINTER)
+itk_wrap_class("itk::CastImageFilter" POINTER_WITH_SUPERCLASS)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   # Add from == to pixel type first for preference
   foreach(to ${to_types})
@@ -183,7 +183,7 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
 endforeach()
 itk_end_wrap_class()
 
-itk_wrap_class("itk::GPUCastImageFilter" POINTER)
+itk_wrap_class("itk::GPUCastImageFilter" POINTER_WITH_SUPERCLASS)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   # Add from == to pixel type first for preference
   foreach(to ${to_types})

--- a/Modules/Filtering/GPUSmoothing/wrapping/itkGPUDiscreteGaussianImageFilter.wrap
+++ b/Modules/Filtering/GPUSmoothing/wrapping/itkGPUDiscreteGaussianImageFilter.wrap
@@ -1,3 +1,6 @@
+set(types "${WRAP_ITK_SCALAR}")
+itk_wrap_include("itkGPUImage.h")
+
 itk_wrap_class("itk::DiscreteGaussianImageFilter" POINTER)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   foreach(t ${types})


### PR DESCRIPTION
Attempting to close #3777. As suggested in the issue, marking `itkCastImageFilter` and `itkGPUCastImageFilter` as `POINTER_WITH_SUPERCLASS` allows compiling.

---

I still encounter an issue where certain wrapped filters fail with `OpenCL Error : CL_INVALID_MEM_OBJECT`. Note the same C++ filters succeed.

This is reproducible with:

```
cmake -DITK_WRAP_PYTHON=ON -DITK_USE_GPU=ON ...
cmake --build ...
ctest -R itkGPU
```

```
Test project ...
      Start  959: itkGPUGradientAnisotropicDiffusionImageFilterTest2D
 1/24 Test  #959: itkGPUGradientAnisotropicDiffusionImageFilterTest2D .........   Passed    0.15 sec
      Start  960: itkGPUGradientAnisotropicDiffusionImageFilterTest3D
 2/24 Test  #960: itkGPUGradientAnisotropicDiffusionImageFilterTest3D .........   Passed    0.42 sec
...
      Start 3151: itkGPUGradientAnisotropicDiffusionImageFilterPythonTest2D
20/24 Test #3151: itkGPUGradientAnisotropicDiffusionImageFilterPythonTest2D ...   Passed    4.43 sec
      Start 3152: itkGPUGradientAnisotropicDiffusionImageFilterPythonTest3D
21/24 Test #3152: itkGPUGradientAnisotropicDiffusionImageFilterPythonTest3D ...***Failed    0.81 sec
...
The following tests FAILED:
	3152 - itkGPUGradientAnisotropicDiffusionImageFilterPythonTest3D (Failed)
	3157 - itkGPUMeanImageFilterPythonTest2D (Failed)
```

There are also some filters that don't have wrapped tests that show the same behavior; for example `itkGPUDiscreteGaussianImageFilter`.

Minimal example using `itkGPUDiscreteGaussianImageFilter`:

```python
>>> import numpy as np
>>> import itk
>>> im = itk.GetImageFromArray(np.random.normal(size=(50,50,50)).astype('f'))
>>> gpu_im = itk.cast_image_filter(im, ttype=(itk.Image[itk.F, 3], itk.GPUImage[itk.F, 3]))
...
>>> gpu_im.UpdateBuffers()
>>> blur = itk.gpu_discrete_gaussian_image_filter(gpu_im, variance=2)
Platform  : NVIDIA CUDA
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../Wrapping/Generators/Python/itk/support/helpers.py", line 182, in image_filter_wrapper
    return image_filter(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../Wrapping/Generators/Python/itk/itkGPUDiscreteGaussianImageFilterPython.py", line 2859, in gpu_discrete_gaussian_image_filter
    return instance.__internal_call__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../Wrapping/Generators/Python/itk/ITKCommonBasePython.py", line 3312, in __internal_call__
    self.UpdateLargestPossibleRegion()
  File ".../Wrapping/Generators/Python/itk/ITKCommonBasePython.py", line 3100, in UpdateLargestPossibleRegion
    return _ITKCommonBasePython.itkProcessObject_UpdateLargestPossibleRegion(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: .../ITK/Modules/Core/GPUCommon/include/itkGPUKernelManager.h:130:
OpenCL Error : CL_INVALID_MEM_OBJECT
```

---

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
  - Should create Python wrapping tests for these filters.
