### PR TITLE
BUG: Fix itkFrequencyImageRegionIterator

### DIFF
--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -174,8 +174,11 @@ private:
   void
   Init()
   {
-    this->m_FrequencyOrigin = this->m_Image->GetOrigin();
-    this->m_FrequencySpacing = this->m_Image->GetSpacing();
+    for (unsigned int dim = 0; dim < ImageType::ImageDimension; ++dim)
+    {
+      this->m_FrequencyOrigin[dim] = this->m_Image->GetOrigin()[dim];
+      this->m_FrequencySpacing[dim] = this->m_Image->GetSpacing()[dim];
+    }
   }
 
   FrequencyType m_FrequencyOrigin;

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
@@ -67,7 +67,7 @@ class ITK_TEMPLATE_EXPORT FrequencyImageRegionIteratorWithIndex
 public:
   /** Standard class type alias. */
   using Self = FrequencyImageRegionIteratorWithIndex;
-  using Superclass = ImageRegionIteratorWithIndex<TImage>;
+  using Superclass = FrequencyImageRegionConstIteratorWithIndex<TImage>;
 
   /** Types inherited from the Superclass */
   using typename Superclass::IndexType;

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -26,6 +26,8 @@
 #include "itkHalfHermitianToRealInverseFFTImageFilter.h"
 #include "itkFFTShiftImageFilter.h"
 #include "itkFrequencyBandImageFilter.h" // Simplest of frequency filters for testing
+#include "itkFrequencyImageRegionConstIteratorWithIndex.h"
+#include "itkFrequencyImageRegionIteratorWithIndex.h"
 #include "itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h"
 #include "itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h"
 #include "itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h"
@@ -264,7 +266,9 @@ compareAllTypesOfIterators(typename TImageType::Pointer image, double difference
 // Checks that an iterator that is just constructed by `IteratorType(image, region)` is at the begin.
 TEST_F(FrequencyIterators, AreConstructedAtBegin)
 {
-  CheckIteratorsConstructedAtBegin<itk::FrequencyFFTLayoutImageRegionConstIteratorWithIndex,
+  CheckIteratorsConstructedAtBegin<itk::FrequencyImageRegionConstIteratorWithIndex,
+                                   itk::FrequencyImageRegionIteratorWithIndex,
+                                   itk::FrequencyFFTLayoutImageRegionConstIteratorWithIndex,
                                    itk::FrequencyFFTLayoutImageRegionIteratorWithIndex,
                                    itk::FrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex,
                                    itk::FrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex,


### PR DESCRIPTION
Test it via recently added gtest (see #4827)

Closes #4828


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)

