### PR TITLE
BUG: permissive cosine computation from non-orthogonal sform had reve…

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -2097,7 +2097,7 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
 
         if (svd.singularities() == 0)
         {
-          mat = svd.V() * svd.U().conjugate_transpose();
+          mat = svd.U() * svd.V().conjugate_transpose();
           mat44 _mat;
 
           for (int i = 0; i < 3; ++i)

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -224,7 +224,10 @@ itk_add_test(
   DATA{${ITK_DATA_ROOT}/Input/LPSLabels_noqform.nii.gz}
   DATA{${ITK_DATA_ROOT}/Input/LPSLabels_nosform.nii.gz}
   DATA{${ITK_DATA_ROOT}/Input/NonOrthoSform.nii.gz}
-  ${ITK_TEST_OUTPUT_DIR})
+  ${ITK_TEST_OUTPUT_DIR}
+  8.0 # Tolerance in degrees for direction recovered from non-orthogonal sform
+  )
+
 
 itk_add_test(
   NAME
@@ -236,7 +239,9 @@ itk_add_test(
   DATA{Input/SmallVoxels_noqform.nii.gz}
   DATA{Input/SmallVoxels_nosform.nii.gz}
   DATA{Input/SmallVoxelsNonOrthoSform.nii.gz}
-  ${ITK_TEST_OUTPUT_DIR})
+  ${ITK_TEST_OUTPUT_DIR}
+  4.0 # Tolerance in degrees for direction recovered from non-orthogonal sform
+  )
 
 itk_add_test(
   NAME


### PR DESCRIPTION
…rsed SVD components

U and V were reversed in the reconstruction of M, according to definitions here

https://vxl.github.io/doc/release/core/vnl/html/classvnl__svd.html

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

As discussed in #4839 

cc: @vfonov @hjmjohnson 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
