### PR TITLE
ENH: Add `itk::MakeVectorContainer(std::vector<TElement>)`

### DIFF
--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -561,6 +561,18 @@ protected:
     , VectorType(first, last)
   {}
 };
+
+
+/** Makes a VectorContainer that has a copy of the specified `std::vector`. */
+template <typename TElement>
+auto
+MakeVectorContainer(std::vector<TElement> stdVector)
+{
+  auto vectorContainer = VectorContainer<SizeValueType, TElement>::New();
+  vectorContainer->CastToSTLContainer() = std::move(stdVector);
+  return vectorContainer;
+}
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -100,3 +100,38 @@ TEST(VectorContainer, HasValueOfCreatedElementAtIdentifier)
     ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, i);
   }
 }
+
+
+// Tests MakeVectorContainer.
+TEST(VectorContainer, Make)
+{
+  const auto checkCopy = [](const auto & stdVector) {
+    const auto vectorContainer = itk::MakeVectorContainer(stdVector);
+    ASSERT_NE(vectorContainer, nullptr);
+    EXPECT_EQ(vectorContainer->CastToSTLConstContainer(), stdVector);
+  };
+
+  const auto checkMove = [](auto stdVector) {
+    const auto * const originalData = stdVector.data();
+    const auto         vectorContainer = itk::MakeVectorContainer(std::move(stdVector));
+
+    // After the "move", the vectorContainer should hold the original data pointer.
+    ASSERT_NE(vectorContainer, nullptr);
+    EXPECT_EQ(vectorContainer->CastToSTLConstContainer().data(), originalData);
+  };
+
+  checkCopy(std::vector<int>());
+  checkCopy(std::vector<int>{ 0, 1 });
+  checkCopy(std::vector<double>());
+  checkCopy(std::vector<double>{ std::numeric_limits<double>::lowest(),
+                                 std::numeric_limits<double>::denorm_min(),
+                                 std::numeric_limits<double>::min(),
+                                 std::numeric_limits<double>::epsilon(),
+                                 std::numeric_limits<double>::max() });
+
+  for (const unsigned int numberOfElements : { 1, 2 })
+  {
+    checkMove(std::vector<int>(numberOfElements));
+    checkMove(std::vector<double>(numberOfElements));
+  }
+}


### PR DESCRIPTION
Eases making an `itk::VectorContainer` based on a specific `std::vector` instance.