### PR TITLE
Add `SetPointsByCoordinates` to PointSet, add warning to `SetPoints(PointsVectorContainer *)`

### DIFF
--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -169,6 +169,10 @@ public:
   void
   SetPoints(PointsVectorContainer *);
 
+  /** Sets the points by specifying its coordinates. */
+  void
+  SetPointsByCoordinates(const std::vector<CoordRepType> & coordinates);
+
   /** Get the points container. */
   PointsContainer *
   GetPoints();

--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -164,7 +164,8 @@ public:
   void
   SetPoints(PointsContainer *);
 
-  /** Set the points container using a 1D vector. */
+  /** Set the points container using a 1D vector.
+  \warning This member function is unsafe. It may just work, but it may also lead to undefined behavior. */
   void
   SetPoints(PointsVectorContainer *);
 

--- a/Modules/Core/Common/include/itkPointSet.hxx
+++ b/Modules/Core/Common/include/itkPointSet.hxx
@@ -73,6 +73,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::SetPoints(PointsVectorContainer *
   {
     itkExceptionMacro("Number of entries in given 1d array incompatible with the point dimension");
   }
+
+  // Note: this cast is unsafe. It may lead to undefined behavior.
   auto * pointsPtr = reinterpret_cast<PointsContainer *>(points);
 
   m_PointsContainer = pointsPtr;

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1748,6 +1748,7 @@ set(ITKCommonGTests
     itkOffsetGTest.cxx
     itkOptimizerParametersGTest.cxx
     itkPointGTest.cxx
+    itkPointSetGTest.cxx
     itkRGBAPixelGTest.cxx
     itkRGBPixelGTest.cxx
     itkShapedImageNeighborhoodRangeGTest.cxx

--- a/Modules/Core/Common/test/itkPointSetGTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetGTest.cxx
@@ -1,0 +1,82 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkPointSet.h"
+#include "../../QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h"
+#include <gtest/gtest.h>
+#include <algorithm> // For equal.
+#include <numeric>   // For iota.
+
+namespace
+{
+template <typename TPointSet>
+void
+TestSetPointsByCoordinates(TPointSet & pointSet)
+{
+  using CoordRepType = typename TPointSet::CoordRepType;
+
+  static constexpr auto PointDimension = TPointSet::PointDimension;
+
+  for (unsigned int numberOfCoordinates{ 1 }; numberOfCoordinates < PointDimension; ++numberOfCoordinates)
+  {
+    // SetPointsByCoordinates is expected to throw an exception when the specified number of coordinates is not a
+    // multiple of PointDimension.
+    EXPECT_THROW(pointSet.SetPointsByCoordinates(std::vector<CoordRepType>(numberOfCoordinates)), itk::ExceptionObject);
+  }
+
+  for (const unsigned int numberOfPoints : { 2, 1, 0 })
+  {
+    std::vector<CoordRepType> coordinates(numberOfPoints * PointDimension);
+
+    // Just make sure that all coordinates have different values, for the purpose of the test.
+    std::iota(coordinates.begin(), coordinates.end(), CoordRepType());
+    {
+      const auto modifiedTime = pointSet.GetMTime();
+      pointSet.SetPointsByCoordinates(coordinates);
+      EXPECT_GT(pointSet.GetMTime(), modifiedTime);
+    }
+
+    using PointsContainerType = typename TPointSet::PointsContainer;
+    using PointIdentifier = typename TPointSet::PointIdentifier;
+    using PointType = typename TPointSet::PointType;
+
+    const typename PointsContainerType::ConstPointer points = pointSet.GetPoints();
+
+    ASSERT_NE(points, nullptr);
+    ASSERT_EQ(points->size(), numberOfPoints);
+
+    const typename PointsContainerType::STLContainerType & stlContainer = points->CastToSTLConstContainer();
+    auto                                                   coordinateIterator = coordinates.cbegin();
+
+    for (PointIdentifier pointIdentifier{}; pointIdentifier < numberOfPoints; ++pointIdentifier)
+    {
+      const PointType & point = stlContainer.at(pointIdentifier);
+      EXPECT_TRUE(std::equal(point.cbegin(), point.cend(), coordinateIterator));
+      coordinateIterator += PointDimension;
+    }
+  }
+}
+} // namespace
+
+
+TEST(PointSet, SetPointsByCoordinates)
+{
+  TestSetPointsByCoordinates(*itk::PointSet<int>::New());
+  TestSetPointsByCoordinates(*itk::PointSet<double, 2, itk::QuadEdgeMeshTraits<double, 2, bool, bool>>::New());
+}


### PR DESCRIPTION
- Added a warning to `PointSet::SetPoints(PointsVectorContainer *)`, mitigating issue #4848 
- Added `PointSet::SetPointsByCoordinates` as a safe alternative.