### PR TITLE
STYLE: Clean-up ByteSwapper, using private `SwapBytes` helper function

### DIFF
--- a/.github/workflows/itk_dict.txt
+++ b/.github/workflows/itk_dict.txt
@@ -277,6 +277,7 @@ btw
 buf
 bugfix
 bw
+byteswap
 byu
 bzip
 calc

--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -192,6 +192,11 @@ protected:
   SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamType * fp);
 
 private:
+  /** Swaps the bytes of the specified argument in-place. Assumes that its number of bytes is either 2, 4, or 8.
+   * Otherwise, it throws an exception. */
+  static void
+  SwapBytes(T &);
+
   static constexpr bool m_SystemIsBigEndian{
 #ifdef CMAKE_WORDS_BIGENDIAN
     true


### PR DESCRIPTION
Aims to reduce code duplication. Inspired by a suggestion from Bradley (@blowekamp) at https://github.com/InsightSoftwareConsortium/ITK/pull/4841/files#r1751777344