### PR TITLE
Make the index type of VectorContainer `itk::SizeValueType` by default

### DIFF
--- a/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
@@ -36,7 +36,7 @@ namespace itk
  * Here's a usage example of STLContainerAdaptor
  *
    \code
-       itk::STLConstContainerAdaptor<itk::VectorContainer<SizeValueType, ElementType>> vecAdaptor(aContainer);
+       itk::STLConstContainerAdaptor<itk::VectorContainer<ElementType>> vecAdaptor(aContainer);
        const std::vector<ElementType> & vec = vecAdaptor.GetSTLContainerRef();
        // do things with vec ...
    \endcode

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -587,7 +587,7 @@ template <typename TElement>
 auto
 MakeVectorContainer(std::vector<TElement> stdVector)
 {
-  auto vectorContainer = VectorContainer<SizeValueType, TElement>::New();
+  auto vectorContainer = VectorContainer<TElement>::New();
   vectorContainer->CastToSTLContainer() = std::move(stdVector);
   return vectorContainer;
 }

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -21,10 +21,13 @@
 #include "itkObject.h"
 #include "itkObjectFactory.h"
 
+#include <type_traits> // For is_void_v.
 #include <utility>
 #include <vector>
 
 namespace itk
+{
+namespace detail
 {
 /** \class VectorContainer
  *  \brief Define a front-end to the STL "vector" container that conforms to the
@@ -561,6 +564,22 @@ protected:
     , VectorType(first, last)
   {}
 };
+} // namespace detail
+
+
+/** Alias template, allowing to use `itk::VectorContainer<TElement>` without having to explicitly specify its
+ * `ElementIdentifier` type.
+ *
+ * The template parameters `T1` and `T2` allow specifying the index type and the element type, as follows:
+ *
+ * \tparam T1 The index type OR (when `T2` is `void`) the element type.
+ *
+ * \tparam T2 The element type OR `void`. When `T2` is `void`, the element type is specified by the first template
+ * argument (T1), and the index type will be `SizeValueType`.
+ */
+template <typename T1, typename T2 = void>
+using VectorContainer = detail::VectorContainer<std::conditional_t<std::is_void_v<T2>, SizeValueType, T1>,
+                                                std::conditional_t<std::is_void_v<T2>, T1, T2>>;
 
 
 /** Makes a VectorContainer that has a copy of the specified `std::vector`. */

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -20,7 +20,7 @@
 
 #include "itkNumericTraits.h"
 
-namespace itk
+namespace itk::detail
 {
 
 template <typename TElementIdentifier, typename TElement>
@@ -183,6 +183,6 @@ template <typename TElementIdentifier, typename TElement>
 void
 VectorContainer<TElementIdentifier, TElement>::Squeeze()
 {}
-} // end namespace itk
+} // namespace itk::detail
 
 #endif

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -27,9 +27,9 @@
 using TestedElementIdentifierType = size_t;
 
 // Test template instantiations for various TElement template arguments:
-template class itk::VectorContainer<TestedElementIdentifierType, int>;
-template class itk::VectorContainer<TestedElementIdentifierType, bool>;
-template class itk::VectorContainer<TestedElementIdentifierType, std::string>;
+template class itk::detail::VectorContainer<TestedElementIdentifierType, int>;
+template class itk::detail::VectorContainer<TestedElementIdentifierType, bool>;
+template class itk::detail::VectorContainer<TestedElementIdentifierType, std::string>;
 
 
 namespace

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -184,7 +184,7 @@ public:
   using CellDataContainer = typename MeshTraits::CellDataContainer;
 
   /** For improving Python support for Triangle Meshes **/
-  using CellsVectorContainer = typename itk::VectorContainer<IdentifierType, IdentifierType>;
+  using CellsVectorContainer = typename itk::VectorContainer<IdentifierType>;
   using CellsVectorContainerPointer = typename CellsVectorContainer::Pointer;
 
   /** Used to support geometric operations on the toolkit. */

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -64,7 +64,7 @@ public:
   using typename Superclass::SpatialObjectPointType;
   using typename Superclass::TransformType;
   using typename Superclass::BoundingBoxType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   /** Method for creation through the object factory. */

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -87,7 +87,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::BoundingBoxType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   using InterpolationMethodEnum = ContourSpatialObjectEnums::InterpolationMethod;

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
@@ -56,7 +56,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::SpatialObjectPointType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
   using typename Superclass::VectorType;
   using typename Superclass::CovariantVectorType;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -49,7 +49,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::BoundingBoxType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   using ArrayType = FixedArray<double, TDimension>;

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
@@ -54,7 +54,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::BoundingBoxType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   /** Method for creation through the object factory. */

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -60,7 +60,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::BoundingBoxType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   /** Method for creation through the object factory. */

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -53,7 +53,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::BoundingBoxType;
 
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = typename PointContainerType::Pointer;
 
   /** Method for creation through the object factory. */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -101,7 +101,7 @@ public:
   using TransformPointer = typename TransformType::Pointer;
   using TransformConstPointer = const TransformType *;
 
-  using VectorContainerType = VectorContainer<IdentifierType, PointType>;
+  using VectorContainerType = VectorContainer<PointType>;
 
   using BoundingBoxType = BoundingBox<IdentifierType, VDimension, ScalarType, VectorContainerType>;
   using BoundingBoxPointer = typename BoundingBoxType::Pointer;

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -58,7 +58,7 @@ public:
   using typename Superclass::BoundingBoxType;
   using typename Superclass::CovariantVectorType;
 
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
 
   /** Method for creation through the object factory. */

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -57,7 +57,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::TransformType;
   using typename Superclass::SpatialObjectPointType;
-  using PointContainerType = VectorContainer<IdentifierType, PointType>;
+  using PointContainerType = VectorContainer<PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
   using typename Superclass::VectorType;
   using typename Superclass::CovariantVectorType;

--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -125,7 +125,7 @@ public:
   using PointIdentifier = typename PointSetType::PointIdentifier;
 
   /** VectorSet type alias. */
-  using VectorSetType = itk::VectorContainer<SizeValueType, InputVectorType>;
+  using VectorSetType = itk::VectorContainer<InputVectorType>;
   using VectorSetPointer = typename VectorSetType::Pointer;
 
   /** Get/Set the source landmarks list, which we will denote \f$ p \f$. */

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
@@ -82,7 +82,7 @@ public:
   /** AuxVarType type alias support */
   using AuxValueType = TAuxValue;
   using AuxValueVectorType = Vector<AuxValueType, AuxDimension>;
-  using AuxValueContainerType = VectorContainer<IdentifierType, AuxValueVectorType>;
+  using AuxValueContainerType = VectorContainer<AuxValueVectorType>;
 
   using AuxValueContainerPointer = typename AuxValueContainerType::Pointer;
   using AuxValueContainerConstIterator = typename AuxValueContainerType::ConstIterator;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
@@ -60,7 +60,7 @@ public:
   using OutputPixelType = typename OutputDomainType::PixelType;
 
   using NodePairType = NodePair<NodeType, OutputPixelType>;
-  using NodePairContainerType = VectorContainer<IdentifierType, NodePairType>;
+  using NodePairContainerType = VectorContainer<NodePairType>;
   using NodePairContainerPointer = typename NodePairContainerType::Pointer;
   using NodePairContainerIterator = typename NodePairContainerType::Iterator;
   using NodePairContainerConstIterator = typename NodePairContainerType::ConstIterator;

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.h
@@ -91,7 +91,7 @@ public:
   using ArrayType = FixedArray<RealType, Self::ImageDimension>;
   using BoolArrayType = FixedArray<bool, Self::ImageDimension>;
   using PixelArrayType = vnl_vector<RealType>;
-  using PixelArrayContainerType = VectorContainer<SizeValueType, PixelArrayType>;
+  using PixelArrayContainerType = VectorContainer<PixelArrayType>;
 
   /** Set/Get kernel function used to create the grid. */
   itkSetObjectMacro(KernelFunction, KernelFunctionType);

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -56,7 +56,7 @@ public:
   using StringVectorType = std::vector<StringType>;
   using StringStreamType = std::stringstream;
   using PointIdVector = std::vector<SizeValueType>;
-  using PolylinesContainerType = VectorContainer<SizeValueType, PointIdVector>;
+  using PolylinesContainerType = VectorContainer<PointIdVector>;
   using PolylinesContainerPointer = PolylinesContainerType::Pointer;
 
   /** Method for creation through the object factory. */

--- a/Modules/Registration/Common/include/itkPointsLocator.h
+++ b/Modules/Registration/Common/include/itkPointsLocator.h
@@ -38,7 +38,7 @@ namespace itk
  *
  * \ingroup ITKRegistrationCommon
  */
-template <typename TPointsContainer = VectorContainer<IdentifierType, Point<float, 3>>>
+template <typename TPointsContainer = VectorContainer<Point<float, 3>>>
 class ITK_TEMPLATE_EXPORT PointsLocator : public Object
 {
 public:

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -33,8 +33,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
 {
   using PointSetType = itk::PointSet<float, Dimension>;
   using PointType = typename PointSetType::PointType;
-  using IdentifierType = itk::IdentifierType;
-  using PointsContainerType = itk::VectorContainer<IdentifierType, PointType>;
+  using PointsContainerType = itk::VectorContainer<PointType>;
   using PointsLocatorType = itk::PointsLocator<PointsContainerType>;
   auto pointsLocator = PointsLocatorType::New();
 


### PR DESCRIPTION
For most use cases, it appears that the index type of `itk::VectorContainer` should just be `itk::SizeValueType` (or `itk::IdentifierType`, but that's just an alias of `itk::SizeValueType`).

This pull request allows users to write `itk::VectorContainer<ElementType>` as a shorthand for `itk::VectorContainer<itk::SizeValueType, ElementType>`.
