### PR TITLE
STYLE: Run clang-format.exe manually at the client side

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -106,10 +106,16 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Get support region size. */
-  itkLegacyMacro(SizeType GetSupportSize() const) { return Self::SupportSize; }
+  itkLegacyMacro(SizeType GetSupportSize() const)
+  {
+    return Self::SupportSize;
+  }
 
   /** Get number of weights. */
-  itkLegacyMacro(unsigned int GetNumberOfWeights() const) { return Self::NumberOfWeights; }
+  itkLegacyMacro(unsigned int GetNumberOfWeights() const)
+  {
+    return Self::NumberOfWeights;
+  }
 #endif
 
 protected:

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -260,12 +260,12 @@ public:
 
   /** Allow the FixedArray to be indexed normally.  No bounds checking is done.
    */
-// false positive warnings with GCC
-ITK_GCC_PRAGMA_PUSH
-ITK_GCC_SUPPRESS_Warray_bounds
+  // false positive warnings with GCC
+  ITK_GCC_PRAGMA_PUSH
+  ITK_GCC_SUPPRESS_Warray_bounds
   constexpr reference       operator[](unsigned int index) { return m_InternalArray[index]; }
   constexpr const_reference operator[](unsigned int index) const { return m_InternalArray[index]; }
-ITK_GCC_PRAGMA_POP
+  ITK_GCC_PRAGMA_POP
 
   /** Set/Get element methods are more convenient in wrapping languages */
   void

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -121,7 +121,8 @@ namespace itk
 #if defined(__clang__) && defined(__has_warning)
 #  define ITK_CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
 #  define ITK_CLANG_PRAGMA_POP ITK_PRAGMA(clang diagnostic pop)
-#  define ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant ITK_PRAGMA(clang diagnostic ignored "-Wzero-as-null-pointer-constant")
+#  define ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant \
+    ITK_PRAGMA(clang diagnostic ignored "-Wzero-as-null-pointer-constant")
 #else
 #  define ITK_CLANG_PRAGMA_PUSH
 #  define ITK_CLANG_PRAGMA_POP

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -306,20 +306,20 @@ public:
     swap(this->m_Matrix, other.m_Matrix);
   }
 
-   inline void PrintSelf(std::ostream & os, Indent indent) const
-   {
-      os << indent << "Matrix (" << VRows << "x" << VColumns << ")\n";
-      for (unsigned int r = 0; r < VRows; ++r)
+  inline void
+  PrintSelf(std::ostream & os, Indent indent) const
+  {
+    os << indent << "Matrix (" << VRows << "x" << VColumns << ")\n";
+    for (unsigned int r = 0; r < VRows; ++r)
+    {
+      os << indent << "  ";
+      for (unsigned int c = 0; c < VColumns; ++c)
       {
-        os << indent << "  ";
-        for (unsigned int c = 0; c < VColumns; ++c)
-        {
-          os << m_Matrix(r, c) << " ";
-        }
-        os << "\n";
+        os << m_Matrix(r, c) << " ";
       }
-
-   }
+      os << "\n";
+    }
+  }
 
 private:
   InternalMatrixType m_Matrix{};

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -223,7 +223,10 @@ public:
     this->SetMaximumNumberOfThreads(numberOfThreads);
     this->SetNumberOfWorkUnits(this->GetMaximumNumberOfThreads()); // Might be clamped
   }
-  itkLegacyMacro(virtual ThreadIdType GetNumberOfThreads()) { return this->GetNumberOfWorkUnits(); }
+  itkLegacyMacro(virtual ThreadIdType GetNumberOfThreads())
+  {
+    return this->GetNumberOfWorkUnits();
+  }
 
   /** This is the structure that is passed to the thread that is
    * created from the SingleMethodExecute. It is passed in as a void *,

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -33,7 +33,8 @@
  */
 template <typename T>
 [[deprecated("Preferably use the C++ `[[maybe_unused]]` attribute instead!")]] inline void
-Unused(const T &){}
+Unused(const T &)
+{}
 #endif
 
 namespace itk

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -129,8 +129,8 @@ TEST(SmartPointer, EmptyAndNull)
   cptr = nullptr;
   EXPECT_TRUE(cptr.IsNull());
 
-ITK_CLANG_PRAGMA_PUSH
-ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  ITK_CLANG_PRAGMA_PUSH
+  ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
 
   // NOLINTNEXTLINE(modernize-use-nullptr)
   ptr = NULL; // Do not change NULL, null, Null in this file. This file intentionally contains usage of legacy NULL
@@ -138,7 +138,7 @@ ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
 
   // NOLINTNEXTLINE(modernize-use-nullptr)
   cptr = NULL; // Do not change NULL, null, Null in this file. This file intentionally contains usage of legacy NULL
-ITK_CLANG_PRAGMA_POP
+  ITK_CLANG_PRAGMA_POP
 
   EXPECT_TRUE(cptr.IsNull());
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -100,13 +100,25 @@ public:
   using Superclass::IsInsideInObjectSpace;
 
 #if !defined(ITK_LEGACY_REMOVE)
-  itkLegacyMacro(void SetRadius(double radius)) { this->SetRadiusInObjectSpace(radius); }
+  itkLegacyMacro(void SetRadius(double radius))
+  {
+    this->SetRadiusInObjectSpace(radius);
+  }
 
-  itkLegacyMacro(void SetRadius(ArrayType radii)) { this->SetRadiusInObjectSpace(radii); }
+  itkLegacyMacro(void SetRadius(ArrayType radii))
+  {
+    this->SetRadiusInObjectSpace(radii);
+  }
 
-  itkLegacyMacro(ArrayType GetRadius() const) { return this->GetRadiusInObjectSpace(); }
+  itkLegacyMacro(ArrayType GetRadius() const)
+  {
+    return this->GetRadiusInObjectSpace();
+  }
 
-  itkLegacyMacro(void SetRadiiInObjectSpace(ArrayType radii)) { this->SetRadiusInObjectSpace(radii); }
+  itkLegacyMacro(void SetRadiiInObjectSpace(ArrayType radii))
+  {
+    this->SetRadiusInObjectSpace(radii);
+  }
 #endif
 protected:
   /** Get the boundaries of a specific object.  This function needs to

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -123,9 +123,15 @@ public:
   GetEllipsoid() const;
 
 #if !defined(ITK_LEGACY_REMOVE)
-  itkLegacyMacro(void SetSigma(double sigma)) { return this->SetSigmaInObjectSpace(sigma); }
+  itkLegacyMacro(void SetSigma(double sigma))
+  {
+    return this->SetSigmaInObjectSpace(sigma);
+  }
 
-  itkLegacyMacro(double GetSigma() const) { return this->GetSigmaInObjectSpace(); }
+  itkLegacyMacro(double GetSigma() const)
+  {
+    return this->GetSigmaInObjectSpace();
+  }
 #endif
 protected:
   /** This function needs to be called every time one of the object's

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -116,7 +116,10 @@ public:
   }
 
 #if !defined(ITK_LEGACY_REMOVE)
-  itkLegacyMacro(const char * GetPixelTypeName()) { return m_PixelType.c_str(); }
+  itkLegacyMacro(const char * GetPixelTypeName())
+  {
+    return m_PixelType.c_str();
+  }
 #endif
 
   /** Set/Get the interpolator. */

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -96,7 +96,10 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** \deprecated Return the type of pixel used */
-  itkLegacyMacro(const char * GetPixelTypeName()) { return m_PixelType.c_str(); }
+  itkLegacyMacro(const char * GetPixelTypeName())
+  {
+    return m_PixelType.c_str();
+  }
 #endif
 
   /** Set/Get the precision for the IsInsideInObjectSpace function.

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -85,7 +85,10 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Compute the tangents and normals of the centerline of the tube. */
-  itkLegacyMacro(bool ComputeTangentAndNormals()) { return ComputeTangentsAndNormals(); }
+  itkLegacyMacro(bool ComputeTangentAndNormals())
+  {
+    return ComputeTangentsAndNormals();
+  }
 #endif
 
   /** Remove duplicate points. */

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -257,7 +257,10 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Get number of weights. */
-  itkLegacyMacro(unsigned long GetNumberOfWeights() const) { return m_WeightsFunction->GetNumberOfWeights(); }
+  itkLegacyMacro(unsigned long GetNumberOfWeights() const)
+  {
+    return m_WeightsFunction->GetNumberOfWeights();
+  }
 #endif
 
   /** Method to transform a vector -

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -302,14 +302,17 @@ private:
 
   /** Methods have empty implementations */
   void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const override{}
+  SetFixedParametersGridSizeFromTransformDomainInformation() const override
+  {}
   void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const override{}
+  SetFixedParametersGridOriginFromTransformDomainInformation() const override
+  {}
   void
   SetFixedParametersGridSpacingFromTransformDomainInformation() const override
   {}
   void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const override{}
+  SetFixedParametersGridDirectionFromTransformDomainInformation() const override
+  {}
 
   /** Check if a continuous index is inside the valid region. */
   bool

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -153,7 +153,8 @@ protected:
   /** Default superclass implementation ensures that input images
    * occupy same physical space. This is not needed for this filter. */
   void
-  VerifyInputInformation() const override{}
+  VerifyInputInformation() const override
+  {}
 
 private:
   bool m_Normalize{ false };

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -166,7 +166,8 @@ public:
 
   /** Trigger the computation of the displacement field by integrating the velocity field. */
   virtual void
-  IntegrateVelocityField(){}
+  IntegrateVelocityField()
+  {}
 
   /**
    * Set the lower time bound defining the integration domain of the transform.

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -48,7 +48,8 @@ class NullImageToImageFilterDriver
 {
 public:
   NullImageToImageFilterDriver()
-    : m_Filter(nullptr){}
+    : m_Filter(nullptr)
+  {}
 
   using ImageSizeType = typename TInputImage::SizeType;
   using InputPixelType = typename TInputImage::PixelType;

--- a/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
@@ -135,7 +135,7 @@ protected:
   /**
    * Constructor
    */
-  CommandIterationUpdatev4(){}
+  CommandIterationUpdatev4() {}
 
 private:
   /**

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -226,8 +226,14 @@ public:
   /** Set the number of work units to use when threading.
    *
    * NOTE: deprecated. Use SetNumberOfWorkUnits() */
-  itkLegacyMacro(virtual void SetNumberOfThreads(ThreadIdType number)) { return this->SetNumberOfWorkUnits(number); }
-  itkLegacyMacro(virtual const ThreadIdType & GetNumberOfThreads() const) { return this->m_NumberOfWorkUnits; }
+  itkLegacyMacro(virtual void SetNumberOfThreads(ThreadIdType number))
+  {
+    return this->SetNumberOfWorkUnits(number);
+  }
+  itkLegacyMacro(virtual const ThreadIdType & GetNumberOfThreads() const)
+  {
+    return this->m_NumberOfWorkUnits;
+  }
 #endif // !ITK_LEGACY_REMOVE
 
   /** Get the number of work units set to be used. */

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
@@ -107,7 +107,8 @@ public:
 
   /** Initialize the transform using the specified fixed parameters */
   void
-  AdaptTransformParameters() override{}
+  AdaptTransformParameters() override
+  {}
 
 protected:
   TransformParametersAdaptor() = default;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -465,10 +465,22 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   /** UseFixedSampledPointSet is deprecated and has been replaced
    * with UseSampledPointsSet. */
-  itkLegacyMacro(virtual void SetUseFixedSampledPointSet(bool v)) { this->SetUseSampledPointSet(v); }
-  itkLegacyMacro(virtual bool GetUseFixedSampledPointSet() const) { return this->GetUseSampledPointSet(); }
-  itkLegacyMacro(virtual void UseFixedSampledPointSetOn()) { return this->UseSampledPointSetOn(); }
-  itkLegacyMacro(virtual void UseFixedSampledPointSetOff()) { return this->UseSampledPointSetOff(); }
+  itkLegacyMacro(virtual void SetUseFixedSampledPointSet(bool v))
+  {
+    this->SetUseSampledPointSet(v);
+  }
+  itkLegacyMacro(virtual bool GetUseFixedSampledPointSet() const)
+  {
+    return this->GetUseSampledPointSet();
+  }
+  itkLegacyMacro(virtual void UseFixedSampledPointSetOn())
+  {
+    return this->UseSampledPointSetOn();
+  }
+  itkLegacyMacro(virtual void UseFixedSampledPointSetOff())
+  {
+    return this->UseSampledPointSetOff();
+  }
 #endif
 
 
@@ -515,7 +527,10 @@ public:
    * GetValue() has been called.
    *
    * NOTE: deprecated. Use GetNumberOfWorkUnitsUsed() */
-  itkLegacyMacro(virtual ThreadIdType GetNumberOfThreadsUsed() const) { return this->GetNumberOfWorkUnitsUsed(); }
+  itkLegacyMacro(virtual ThreadIdType GetNumberOfThreadsUsed() const)
+  {
+    return this->GetNumberOfWorkUnitsUsed();
+  }
 
   /** Set number of threads to use. This the maximum number of threads to use
    * when multithreaded.  The actual number of threads used (may be less than
@@ -527,7 +542,10 @@ public:
   {
     this->SetMaximumNumberOfWorkUnits(count);
   }
-  itkLegacyMacro(virtual ThreadIdType GetMaximumNumberOfThreads() const) { return this->GetMaximumNumberOfWorkUnits(); }
+  itkLegacyMacro(virtual ThreadIdType GetMaximumNumberOfThreads() const)
+  {
+    return this->GetMaximumNumberOfWorkUnits();
+  }
 #endif // !ITK_LEGACY_REMOVE
 
 


### PR DESCRIPTION
Ran at bash:

    find . -regex '.*itk.*\.\(hxx\|h\|cxx\)' -exec /f/bin/ITK/ClangFormat-prefix/src/ClangFormat/clang-format.exe -style=file -i {} \;

Manually reverted changes in ThirdParty.

At the moment, the "client side" is responsible for running clang-format.exe

Related commits:

- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4712 commit c7e8b2506b5fecb28b5b9ab451aebbabe4bfe05f
"BUG: Remove Apply clang-format to PR", June 5, 2024

- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4707 commit 4b0d263e955b8da9ac1284d25f3ba007e376aff9
"ENH: Remove Clang Format Linter Action", June 3 2024