### PR TITLE
Fix VS2022 code analysis warnings from "Bridge/NumPy", including `buffer` initializations

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -75,15 +75,12 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   PyObject * shapeseq = NULL;
   PyObject * item = NULL;
 
-  Py_ssize_t bufferLength;
-  Py_buffer  pyBuffer;
+  Py_buffer pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   SizeType      size;
   SizeType      sizeFortran;
   SizeValueType numberOfPixels = 1;
-
-  const void * buffer;
 
   long         numberOfComponents = 1;
   unsigned int dimension = 0;
@@ -96,11 +93,10 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
     PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
-  else
-  {
-    bufferLength = pyBuffer.len;
-    buffer = pyBuffer.buf;
-  }
+
+  const Py_ssize_t bufferLength = pyBuffer.len;
+  void * const     buffer = pyBuffer.buf;
+
   PyBuffer_Release(&pyBuffer);
 
   shapeseq = PySequence_Fast(shape, "expected sequence");

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -150,9 +150,9 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
 
   using InternalPixelType = typename TImage::InternalPixelType;
   using ImporterType = ImportImageContainer<SizeValueType, InternalPixelType>;
-  auto                importer = ImporterType::New();
-  constexpr bool      importImageFilterWillOwnTheBuffer = false;
-  InternalPixelType * data = (InternalPixelType *)buffer;
+  auto           importer = ImporterType::New();
+  constexpr bool importImageFilterWillOwnTheBuffer = false;
+  auto * const   data = static_cast<InternalPixelType *>(buffer);
   importer->SetImportPointer(data, numberOfPixels, importImageFilterWillOwnTheBuffer);
 
   OutputImagePointer output = TImage::New();

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -111,8 +111,8 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   for (unsigned int i = 0; i < dimension; ++i)
   {
     item = PySequence_Fast_GET_ITEM(shapeseq, i);
-    size[i] = (SizeValueType)PyInt_AsLong(item);
-    sizeFortran[dimension - 1 - i] = (SizeValueType)PyInt_AsLong(item);
+    size[i] = static_cast<SizeValueType>(PyInt_AsLong(item));
+    sizeFortran[dimension - 1 - i] = static_cast<SizeValueType>(PyInt_AsLong(item));
     numberOfPixels *= size[i];
   }
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -45,7 +45,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   ComponentType * buffer =
     const_cast<ComponentType *>(reinterpret_cast<const ComponentType *>(image->GetBufferPointer()));
 
-  void * itkImageBuffer = (void *)(buffer);
+  void * itkImageBuffer = buffer;
 
   // Computing the length of data
   const int numberOfComponents = image->GetNumberOfComponentsPerPixel();
@@ -59,7 +59,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   len *= numberOfComponents;
   len *= sizeof(ComponentType);
 
-  res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)itkImageBuffer, len, 0, PyBUF_CONTIG);
+  res = PyBuffer_FillInfo(&pyBuffer, NULL, itkImageBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -33,7 +33,6 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   Py_ssize_t len = 1;
-  size_t     pixelSize = sizeof(ComponentType);
   int        res = 0;
 
   if (!image)
@@ -58,7 +57,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   }
 
   len *= numberOfComponents;
-  len *= pixelSize;
+  len *= sizeof(ComponentType);
 
   res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)itkImageBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
@@ -89,8 +88,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   long         numberOfComponents = 1;
   unsigned int dimension = 0;
 
-
-  size_t pixelSize = sizeof(ComponentType);
   size_t len = 1;
 
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_ND | PyBUF_ANY_CONTIGUOUS) == -1)
@@ -125,7 +122,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
     isFortranContiguous = true;
   }
 
-  len = numberOfPixels * numberOfComponents * pixelSize;
+  len = numberOfPixels * numberOfComponents * sizeof(ComponentType);
   if (bufferLength != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of image and Buffer.");

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -96,8 +96,8 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
     PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
-  DataType * data = (DataType *)buffer;
-  auto       output = VectorContainerType::New();
+  const auto * const data = static_cast<const DataType *>(buffer);
+  auto               output = VectorContainerType::New();
   output->resize(numberOfElements);
   for (size_t ii = 0; ii < numberOfElements; ++ii)
   {

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -31,8 +31,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
   Py_buffer  pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
-  size_t elementSize = sizeof(DataType);
-  int    res = 0;
+  int res = 0;
 
   if (!vector)
   {
@@ -45,7 +44,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 
   // Computing the length of data
   Py_ssize_t len = vector->Size();
-  len *= elementSize;
+  len *= sizeof(DataType);
 
   res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)vectorBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
@@ -74,8 +73,6 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
 
   unsigned int dimension = 0;
 
-
-  size_t elementSize = sizeof(DataType);
   size_t len = 1;
 
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
@@ -97,7 +94,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
   numberOfElements = (size_t)PyInt_AsLong(item);
 
-  len = numberOfElements * elementSize;
+  len = numberOfElements * sizeof(DataType);
   if (bufferLength != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -63,13 +63,10 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   PyObject * shapeseq = NULL;
   PyObject * item = NULL;
 
-  Py_ssize_t bufferLength;
-  Py_buffer  pyBuffer;
+  Py_buffer pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   size_t numberOfElements = 1;
-
-  const void * buffer;
 
   unsigned int dimension = 0;
 
@@ -81,11 +78,9 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
     PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
-  else
-  {
-    bufferLength = pyBuffer.len;
-    buffer = pyBuffer.buf;
-  }
+
+  const Py_ssize_t   bufferLength = pyBuffer.len;
+  const void * const buffer = pyBuffer.buf;
 
   obj = shape;
   shapeseq = PySequence_Fast(obj, "expected sequence");

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -40,13 +40,13 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 
   DataType * buffer = vector->CastToSTLContainer().data();
 
-  void * vectorBuffer = (void *)(buffer);
+  void * vectorBuffer = buffer;
 
   // Computing the length of data
   Py_ssize_t len = vector->Size();
   len *= sizeof(DataType);
 
-  res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)vectorBuffer, len, 0, PyBUF_CONTIG);
+  res = PyBuffer_FillInfo(&pyBuffer, NULL, vectorBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -92,7 +92,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   dimension = PySequence_Size(obj);
 
   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
-  numberOfElements = (size_t)PyInt_AsLong(item);
+  numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
 
   len = numberOfElements * sizeof(DataType);
   if (bufferLength != len)

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -31,8 +31,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
   Py_buffer  pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
-  size_t elementSize = sizeof(DataType);
-  int    res = 0;
+  int res = 0;
 
   if (!vector)
   {
@@ -45,7 +44,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 
   // Computing the length of data
   Py_ssize_t len = vector->size();
-  len *= elementSize;
+  len *= sizeof(DataType);
 
   res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)vectorBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
@@ -73,8 +72,6 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
 
   unsigned int dimension = 0;
 
-
-  size_t elementSize = sizeof(DataType);
   size_t len = 1;
 
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
@@ -96,7 +93,7 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
   numberOfElements = (size_t)PyInt_AsLong(item);
 
-  len = numberOfElements * elementSize;
+  len = numberOfElements * sizeof(DataType);
   if (bufferLength != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");
@@ -118,8 +115,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
   Py_buffer  pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
-  size_t elementSize = sizeof(DataType);
-  int    res = 0;
+  int res = 0;
 
   if (!matrix)
   {
@@ -132,7 +128,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
   // Computing the length of data
   Py_ssize_t len = matrix->size();
-  len *= elementSize;
+  len *= sizeof(DataType);
 
   res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)matrixBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
@@ -160,7 +156,6 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
 
   unsigned int dimension = 0;
 
-  size_t       elementSize = sizeof(DataType);
   size_t       len = 1;
   unsigned int size[2];
 
@@ -187,7 +182,7 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
     numberOfElements *= size[i];
   }
 
-  len = numberOfElements * elementSize;
+  len = numberOfElements * sizeof(DataType);
   if (bufferLength != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of matrix and Buffer.");

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -91,7 +91,7 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   dimension = PySequence_Size(obj);
 
   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
-  numberOfElements = (size_t)PyInt_AsLong(item);
+  numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
 
   len = numberOfElements * sizeof(DataType);
   if (bufferLength != len)

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -62,13 +62,10 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   PyObject * shapeseq = NULL;
   PyObject * item = NULL;
 
-  Py_ssize_t bufferLength;
-  Py_buffer  pyBuffer;
+  Py_buffer pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   size_t numberOfElements = 1;
-
-  const void * buffer;
 
   unsigned int dimension = 0;
 
@@ -80,11 +77,9 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
     PyBuffer_Release(&pyBuffer);
     return VectorType();
   }
-  else
-  {
-    bufferLength = pyBuffer.len;
-    buffer = pyBuffer.buf;
-  }
+
+  const Py_ssize_t   bufferLength = pyBuffer.len;
+  const void * const buffer = pyBuffer.buf;
 
   obj = shape;
   shapeseq = PySequence_Fast(obj, "expected sequence");
@@ -146,13 +141,10 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
   PyObject * shapeseq = NULL;
   PyObject * item = NULL;
 
-  Py_ssize_t bufferLength;
-  Py_buffer  pyBuffer;
+  Py_buffer pyBuffer;
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   size_t numberOfElements = 1;
-
-  const void * buffer;
 
   unsigned int dimension = 0;
 
@@ -165,11 +157,9 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
     PyBuffer_Release(&pyBuffer);
     return MatrixType();
   }
-  else
-  {
-    bufferLength = pyBuffer.len;
-    buffer = pyBuffer.buf;
-  }
+
+  const Py_ssize_t   bufferLength = pyBuffer.len;
+  const void * const buffer = pyBuffer.buf;
 
   obj = shape;
   shapeseq = PySequence_Fast(obj, "expected sequence");

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -95,8 +95,8 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
     PyBuffer_Release(&pyBuffer);
     return VectorType();
   }
-  DataType * data = (DataType *)buffer;
-  VectorType output(data, numberOfElements);
+  const auto * const data = static_cast<const DataType *>(buffer);
+  VectorType         output(data, numberOfElements);
   PyBuffer_Release(&pyBuffer);
 
   return output;
@@ -180,8 +180,8 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
     return MatrixType();
   }
 
-  DataType * data = (DataType *)buffer;
-  MatrixType output(data, size[0], size[1]);
+  const auto * const data = static_cast<const DataType *>(buffer);
+  MatrixType         output(data, size[0], size[1]);
   PyBuffer_Release(&pyBuffer);
 
   return output;

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -40,13 +40,13 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 
   DataType * buffer = vector->data_block();
 
-  void * vectorBuffer = (void *)(buffer);
+  void * vectorBuffer = buffer;
 
   // Computing the length of data
   Py_ssize_t len = vector->size();
   len *= sizeof(DataType);
 
-  res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)vectorBuffer, len, 0, PyBUF_CONTIG);
+  res = PyBuffer_FillInfo(&pyBuffer, NULL, vectorBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);
@@ -124,13 +124,13 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
   DataType * buffer = matrix->data_block();
 
-  void * matrixBuffer = (void *)(buffer);
+  void * matrixBuffer = buffer;
 
   // Computing the length of data
   Py_ssize_t len = matrix->size();
   len *= sizeof(DataType);
 
-  res = PyBuffer_FillInfo(&pyBuffer, NULL, (void *)matrixBuffer, len, 0, PyBUF_CONTIG);
+  res = PyBuffer_FillInfo(&pyBuffer, NULL, matrixBuffer, len, 0, PyBUF_CONTIG);
   memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);


### PR DESCRIPTION
Fixed various Visual Studio 2022 Code Analysis warnings from "Bridge/NumPy": 
> warning C26493: Don't use C-style casts (type.4).
> warning C26494: Variable '...' is uninitialized. Always initialize an object (type.5).
> warning C26496: The variable '...' does not change after construction, mark it as const (con.4).
