### PR TITLE
Deprecate `ByteSwapper::OStreamType`, fix "SwapWriteRange" member functions

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -201,6 +201,10 @@ private:
   static void
   SwapBytes(T &);
 
+  /** Swaps and writes the specified elements to the specified output stream. */
+  static void
+  SwapWriteRange(const T * ptr, SizeValueType numberOfElements, std::ostream & outputStream);
+
   static constexpr bool m_SystemIsBigEndian{
 #ifdef CMAKE_WORDS_BIGENDIAN
     true

--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -58,8 +58,12 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
-  /** Work around MSVC bug (including ByteSwapper.h in a templated class). */
-  using OStreamType = std::ostream;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** Work around old MSVC bug (including ByteSwapper.h in a templated class). */
+  using OStreamType
+    [[deprecated("ByteSwapper::OStreamType is deprecated from ITK 6. Just use `std::ostream` instead!")]] =
+      std::ostream;
+#endif
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ByteSwapper);
@@ -117,7 +121,7 @@ public:
    * others raise an exception. The method is used to
    * swap to and from Big Endian. */
   static void
-  SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp);
+  SwapWriteRangeFromSystemToBigEndian(const T * p, int num, std::ostream * fp);
 
   /** Generic swap method handles type T. The swapping is
    * done in-place. 2, 4 and 8 byte swapping
@@ -143,7 +147,7 @@ public:
    * others raise an exception. The method is used to
    * swap to and from Little Endian. */
   static void
-  SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp);
+  SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, std::ostream * fp);
 
 protected:
   ByteSwapper() = default;
@@ -161,7 +165,7 @@ protected:
   /** Swap and write a range of two-byte words. Num is the number of two-byte
    * words to swap and write. */
   static void
-  SwapWrite2Range(const void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite2Range(const void * ptr, BufferSizeType num, std::ostream * fp);
 
   /** Swap four bytes. */
   static void
@@ -175,7 +179,7 @@ protected:
   /** Swap and write a range of four-byte words. Num is the number of four-byte
    * words to swap and write. */
   static void
-  SwapWrite4Range(const void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite4Range(const void * ptr, BufferSizeType num, std::ostream * fp);
 
   /** Swap 8 bytes. */
   static void
@@ -189,7 +193,7 @@ protected:
   /** Swap and write a range of 8-byte words. Num is the number of four-byte
    * words to swap and write. */
   static void
-  SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamType * fp);
+  SwapWrite8Range(const void * ptr, BufferSizeType num, std::ostream * fp);
 
 private:
   /** Swaps the bytes of the specified argument in-place. Assumes that its number of bytes is either 2, 4, or 8.

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -65,7 +65,7 @@ template <typename T>
 void
 ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, std::ostream * fp)
 {
-  if constexpr (m_SystemIsBigEndian)
+  if constexpr (m_SystemIsBigEndian || sizeof(T) == 1)
   {
     num *= sizeof(T);
     fp->write(reinterpret_cast<const char *>(p), num);
@@ -74,8 +74,6 @@ ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, std::o
   {
     switch (sizeof(T))
     {
-      case 1:
-        return;
       case 2:
         Self::SwapWrite2Range(p, num, fp);
         return;
@@ -118,12 +116,10 @@ template <typename T>
 void
 ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, std::ostream * fp)
 {
-  if constexpr (m_SystemIsBigEndian)
+  if constexpr (m_SystemIsBigEndian && sizeof(T) > 1)
   {
     switch (sizeof(T))
     {
-      case 1:
-        return;
       case 2:
         Self::SwapWrite2Range(p, num, fp);
         return;

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -63,7 +63,7 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian([[maybe_unused]] T * p, [[maybe_u
 
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(const T * p, int num, std::ostream * fp)
 {
   if constexpr (m_SystemIsBigEndian)
   {
@@ -116,7 +116,7 @@ ByteSwapper<T>::SwapRangeFromSystemToLittleEndian([[maybe_unused]] T * p, [[mayb
 
 template <typename T>
 void
-ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, OStreamType * fp)
+ByteSwapper<T>::SwapWriteRangeFromSystemToLittleEndian(const T * p, int num, std::ostream * fp)
 {
   if constexpr (m_SystemIsBigEndian)
   {
@@ -175,7 +175,7 @@ ByteSwapper<T>::Swap2Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite2Range(const void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite2Range(const void * ptr, BufferSizeType num, std::ostream * fp)
 {
   BufferSizeType chunkSize = 1000000;
   if (num < chunkSize)
@@ -228,7 +228,7 @@ ByteSwapper<T>::Swap4Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite4Range(const void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite4Range(const void * ptr, BufferSizeType num, std::ostream * fp)
 {
   BufferSizeType chunkSize = 1000000;
 
@@ -286,7 +286,7 @@ ByteSwapper<T>::Swap8Range(void * ptr, BufferSizeType num)
 // Swap bunch of bytes. Num is the number of four byte words to swap.
 template <typename T>
 void
-ByteSwapper<T>::SwapWrite8Range(const void * ptr, BufferSizeType num, OStreamType * fp)
+ByteSwapper<T>::SwapWrite8Range(const void * ptr, BufferSizeType num, std::ostream * fp)
 {
   BufferSizeType chunkSize = 1000000;
   if (num < chunkSize)


### PR DESCRIPTION
The type alias `OStreamType` just served as a workaround to an old MSVC bug. This pull request deprecates (`ITK_FUTURE_LEGACY_REMOVE`) the type alias.

This pull request also has a fix for the behavior of `SwapWriteRangeFromSystemToBigEndian` and `SwapWriteRangeFromSystemToLittleEndian`, for when `sizeof(T) == 1`. The original code did nothing, in that case. With this pull request, those member functions will in that case just write the specified range to the output stream.