### PR TITLE
Remove unnecessary PyBuffer_Release calls, and other "Bridge/NumPy"  style improvements

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkImportImageContainer.h"
+#include <memory> // For unique_ptr.
 
 namespace itk
 {
@@ -81,10 +82,11 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
     return nullptr;
   }
 
+  [[maybe_unused]] const std::unique_ptr<Py_buffer, decltype(&PyBuffer_Release)> bufferScopeGuard(&pyBuffer,
+                                                                                                  &PyBuffer_Release);
+
   const Py_ssize_t bufferLength = pyBuffer.len;
   void * const     buffer = pyBuffer.buf;
-
-  PyBuffer_Release(&pyBuffer);
 
   PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
   const unsigned int dimension = PySequence_Size(shape);
@@ -109,7 +111,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of image and Buffer.");
-    PyBuffer_Release(&pyBuffer);
     SWIG_Py_DECREF(shapeseq);
     return nullptr;
   }
@@ -150,7 +151,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   output->SetNumberOfComponentsPerPixel(numberOfComponents);
 
   SWIG_Py_DECREF(shapeseq);
-  PyBuffer_Release(&pyBuffer);
 
   return output;
 }

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -59,8 +59,6 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   PyBuffer_FillInfo(&pyBuffer, nullptr, itkImageBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
-  PyBuffer_Release(&pyBuffer);
-
   return memoryView;
 }
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -56,7 +56,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   len *= numberOfComponents;
   len *= sizeof(ComponentType);
 
-  const int        res = PyBuffer_FillInfo(&pyBuffer, nullptr, itkImageBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, itkImageBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -78,7 +78,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_ND | PyBUF_ANY_CONTIGUOUS) == -1)
   {
     PyErr_SetString(PyExc_RuntimeError, "Cannot get an instance of NumPy array.");
-    PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -109,7 +109,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
   }
 
   const size_t len = numberOfPixels * numberOfComponents * sizeof(ComponentType);
-  if (bufferLength != len)
+  if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of image and Buffer.");
     PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -45,8 +45,6 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
-  PyBuffer_Release(&pyBuffer);
-
   return memoryView;
 }
 

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -42,7 +42,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
   Py_ssize_t len = vector->Size();
   len *= sizeof(DataType);
 
-  const int        res = PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -58,7 +58,6 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
   {
     PyErr_SetString(PyExc_RuntimeError, "Cannot get an instance of NumPy array.");
-    PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
 

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -18,6 +18,7 @@
 #ifndef itkPyVectorContainer_hxx
 #define itkPyVectorContainer_hxx
 
+#include <memory> // For unique_ptr.
 #include <stdexcept>
 
 namespace itk
@@ -61,6 +62,9 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
     return nullptr;
   }
 
+  [[maybe_unused]] const std::unique_ptr<Py_buffer, decltype(&PyBuffer_Release)> bufferScopeGuard(&pyBuffer,
+                                                                                                  &PyBuffer_Release);
+
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
@@ -75,7 +79,6 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");
-    PyBuffer_Release(&pyBuffer);
     return nullptr;
   }
   const auto * const data = static_cast<const DataType *>(buffer);
@@ -85,7 +88,6 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   {
     output->SetElement(ii, data[ii]);
   }
-  PyBuffer_Release(&pyBuffer);
 
   return output;
 }

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -75,7 +75,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   const size_t numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
 
   const size_t len = numberOfElements * sizeof(DataType);
-  if (bufferLength != len)
+  if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");
     PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -42,7 +42,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
   Py_ssize_t len = vector->size();
   len *= sizeof(DataType);
 
-  const int        res = PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);
@@ -106,7 +106,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
   Py_ssize_t len = matrix->size();
   len *= sizeof(DataType);
 
-  const int        res = PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
   PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -57,7 +57,6 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
   {
     PyErr_SetString(PyExc_RuntimeError, "Cannot get an instance of NumPy array.");
-    PyBuffer_Release(&pyBuffer);
     return VectorType();
   }
 
@@ -125,7 +124,6 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
   if (PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
   {
     PyErr_SetString(PyExc_RuntimeError, "Cannot get an instance of NumPy array.");
-    PyBuffer_Release(&pyBuffer);
     return MatrixType();
   }
 

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -18,6 +18,7 @@
 #ifndef itkPyVnl_hxx
 #define itkPyVnl_hxx
 
+#include <memory> // For unique_ptr.
 #include <stdexcept>
 
 namespace itk
@@ -60,6 +61,9 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
     return VectorType();
   }
 
+  [[maybe_unused]] const std::unique_ptr<Py_buffer, decltype(&PyBuffer_Release)> bufferScopeGuard(&pyBuffer,
+                                                                                                  &PyBuffer_Release);
+
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
@@ -74,12 +78,10 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");
-    PyBuffer_Release(&pyBuffer);
     return VectorType();
   }
   const auto * const data = static_cast<const DataType *>(buffer);
   VectorType         output(data, numberOfElements);
-  PyBuffer_Release(&pyBuffer);
 
   return output;
 }
@@ -127,6 +129,9 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
     return MatrixType();
   }
 
+  [[maybe_unused]] const std::unique_ptr<Py_buffer, decltype(&PyBuffer_Release)> bufferScopeGuard(&pyBuffer,
+                                                                                                  &PyBuffer_Release);
+
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
@@ -145,13 +150,11 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of matrix and Buffer.");
-    PyBuffer_Release(&pyBuffer);
     return MatrixType();
   }
 
   const auto * const data = static_cast<const DataType *>(buffer);
   MatrixType         output(data, size[0], size[1]);
-  PyBuffer_Release(&pyBuffer);
 
   return output;
 }

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -74,7 +74,7 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> con
   const size_t     numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
 
   const size_t len = numberOfElements * sizeof(DataType);
-  if (bufferLength != len)
+  if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of vector and Buffer.");
     PyBuffer_Release(&pyBuffer);
@@ -148,7 +148,7 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> con
   }
 
   const size_t len = numberOfElements * sizeof(DataType);
-  if (bufferLength != len)
+  if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
   {
     PyErr_SetString(PyExc_RuntimeError, "Size mismatch of matrix and Buffer.");
     PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -45,8 +45,6 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
 
-  PyBuffer_Release(&pyBuffer);
-
   return memoryView;
 }
 
@@ -108,8 +106,6 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
   PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
-
-  PyBuffer_Release(&pyBuffer);
 
   return memoryView;
 }


### PR DESCRIPTION
According to https://docs.python.org/3.12/c-api/buffer.html#c.PyObject_GetBuffer, `PyBuffer_Release` should only be called after a _successful_ `PyObject_GetBuffer` call.

Also fixed a few MSVC 2022 warnings:
> warning C4189: 'res': local variable is initialized but not referenced
> warning C4389: '!=': signed/unsigned mismatch


