### PR TITLE
Remove zero-filling memset calls and replace them with `()` or `{}`

### DIFF
--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -447,9 +447,7 @@ template <unsigned int VDimension>
 Offset<VDimension>
 Offset<VDimension>::GetBasisOffset(unsigned int dim)
 {
-  Self ind;
-
-  memset(ind.m_InternalArray, 0, sizeof(OffsetValueType) * VDimension);
+  Self ind{};
   ind.m_InternalArray[dim] = 1;
   return ind;
 }

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -157,8 +157,8 @@ FloatingPointExceptions::Enable()
   itk_feenableexcept(FE_DIVBYZERO);
   itk_feenableexcept(FE_INVALID);
 #  if defined(ITK_FPE_USE_SIGNAL_HANDLER)
-  struct sigaction act;
-  memset(&act, 0, sizeof(struct sigaction));
+  struct sigaction act
+  {};
   act.sa_sigaction = fhdl;
   sigemptyset(&act.sa_mask);
   act.sa_flags = SA_SIGINFO;

--- a/Modules/Core/Common/test/itkFixedArrayTest2.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest2.cxx
@@ -38,11 +38,7 @@ itkFixedArrayTest2(int, char *[])
   // Declare an array of nelements FixedArray
   // and add a small margin to play with pointers
   // but not map outside the allocated memory
-  auto * vec = new ArrayType[nelements + 8];
-
-  // Fill it up with zeros
-  memset(vec, 0, (nelements + 8) * sizeof(ArrayType));
-
+  auto * vec = new ArrayType[nelements + 8]();
 
   // Display the alignment of the array
   std::cout << "Initial alignment: " << (((size_t)vec) & 7) << '\n';

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -409,13 +409,12 @@ BioRadImageIO::Write(const void * buffer)
   }
 
   // Write the BioRad header information
-  bioradheader header, *p;
-  p = &header;
+  bioradheader   header{};
+  bioradheader * p = &header;
   if (sizeof(header) != BIORAD_HEADER_LENGTH)
   {
     itkExceptionMacro("Problem of alignement on your platform");
   }
-  memset(p, 0, BIORAD_HEADER_LENGTH); // Set everything to zero
   // In particular `notes' needs to be set to zero to indicate there is no notes
   header.nx = static_cast<unsigned short>(m_Dimensions[0]);
   header.ny = static_cast<unsigned short>(m_Dimensions[1]);

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -180,8 +180,7 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
                                                         << "Reason: " << reason);
   }
 
-  curImage = new GEImageHeader;
-  memset(curImage, 0, sizeof(GEImageHeader));
+  curImage = new GEImageHeader();
 
   std::ifstream f;
   this->OpenFileForReading(f, FileNameToRead);

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -177,10 +177,7 @@ MRCHeaderObject::IsOriginalHeaderBigEndian() const
 }
 
 MRCHeaderObject::MRCHeaderObject()
-
-
 {
-  memset(&this->m_Header, 0, sizeof(Header));
   this->m_BigEndianHeader = ByteSwapper<void *>::SystemIsBE();
 }
 

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -342,9 +342,7 @@ MRCImageIO::UpdateHeaderWithMinMaxMean(const TPixelType * bufferBegin)
 void
 MRCImageIO::UpdateHeaderFromImageIO()
 {
-  MRCHeaderObject::Header header;
-
-  memset(&header, 0, sizeof(MRCHeaderObject::Header));
+  MRCHeaderObject::Header header{};
 
   itkAssertOrThrowMacro(this->GetNumberOfDimensions() != 0, "Invalid Dimension for Writting");
   if (this->GetNumberOfDimensions() > 3)

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -526,7 +526,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
   }
 
   // Zero out struct.
-  memset((void *)pPar, 0, sizeof(struct par_parameter));
+  *pPar = {};
   // Need to set strings to UNDEFINED to avoid segmentation faults.
   strcpy(pPar->patient_name, UNDEFINED);
   strcpy(pPar->exam_name, UNDEFINED);

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -211,10 +211,10 @@ struct image_info_defV4
 struct image_info_defV3
 GetImageInformationDefinitionV3(std::string file, int lineNum, PhilipsPAR * philipsPARClass)
 {
-  struct image_info_defV3 tempInfo;
-  std::string             currentLine = "";
+  struct image_info_defV3 tempInfo
+  {};
+  std::string currentLine = "";
 
-  memset((void *)&tempInfo, 0, sizeof(struct image_info_defV3));
   if (lineNum < 89)
   {
     tempInfo.problemreading = 1;
@@ -252,10 +252,10 @@ GetImageInformationDefinitionV3(std::string file, int lineNum, PhilipsPAR * phil
 struct image_info_defV4
 GetImageInformationDefinitionV4(std::string file, int lineNum, PhilipsPAR * philipsPARClass)
 {
-  struct image_info_defV4 tempInfo;
-  std::string             currentLine = "";
+  struct image_info_defV4 tempInfo
+  {};
+  std::string currentLine = "";
 
-  memset((void *)&tempInfo, 0, sizeof(struct image_info_defV4));
   if (lineNum < 92)
   {
     tempInfo.problemreading = 1;
@@ -298,10 +298,10 @@ GetImageInformationDefinitionV4(std::string file, int lineNum, PhilipsPAR * phil
 struct image_info_defV4
 GetImageInformationDefinitionV41(std::string file, int lineNum, PhilipsPAR * philipsPARClass)
 {
-  struct image_info_defV4 tempInfo;
-  std::string             currentLine = "";
+  struct image_info_defV4 tempInfo
+  {};
+  std::string currentLine = "";
 
-  memset((void *)&tempInfo, 0, sizeof(struct image_info_defV4));
   if (lineNum < 99)
   {
     tempInfo.problemreading = 1;
@@ -347,10 +347,10 @@ GetImageInformationDefinitionV41(std::string file, int lineNum, PhilipsPAR * phi
 struct image_info_defV4
 GetImageInformationDefinitionV42(std::string file, int lineNum, PhilipsPAR * philipsPARClass)
 {
-  struct image_info_defV4 tempInfo;
-  std::string             currentLine = "";
+  struct image_info_defV4 tempInfo
+  {};
+  std::string currentLine = "";
 
-  memset((void *)&tempInfo, 0, sizeof(struct image_info_defV4));
   if (lineNum < 101)
   {
     tempInfo.problemreading = 1;

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -519,9 +519,8 @@ PhilipsRECImageIO::CanReadFile(const char * FileNameToRead)
   const std::string HeaderFileName = GetHeaderFileName(filename);
 
   // Try to read the par file.
-  struct par_parameter par;
-  // Zero out par_parameter.
-  memset(&par, 0, sizeof(struct par_parameter));
+  struct par_parameter par
+  {};
 
   auto philipsPAR = PhilipsPAR::New();
   try
@@ -546,10 +545,8 @@ void
 PhilipsRECImageIO::ReadImageInformation()
 {
   const std::string    HeaderFileName = GetHeaderFileName(this->m_FileName);
-  struct par_parameter par;
-
-  // Zero out par_parameter.
-  memset(&par, 0, sizeof(struct par_parameter));
+  struct par_parameter par
+  {};
 
   // Read PAR file.
   auto philipsPAR = PhilipsPAR::New();

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -219,8 +219,7 @@ MINCTransformIOTemplate<TParametersValueType>::WriteOneTransform(const int      
   {
     if (matrixOffsetTransform)
     {
-      VIO_Transform lin;
-      memset(&lin, 0, sizeof(VIO_Transform));
+      VIO_Transform lin{};
 
       MatrixType matrix = matrixOffsetTransform->GetMatrix();
       OffsetType offset = matrixOffsetTransform->GetOffset();

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -236,7 +236,6 @@ MINCTransformIOTemplate<TParametersValueType>::WriteOneTransform(const int      
       Transform_elem(lin, 3, 3) = 1.0;
 
       xfm.emplace_back();
-      memset(&xfm.back(), 0, sizeof(VIO_General_transform));
       create_linear_transform(&xfm.back(), &lin);
     }
     else if (transformType.find("DisplacementFieldTransform_") != std::string::npos &&

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -858,9 +858,7 @@ VTKImageIO::WriteSymmetricTensorBufferAsBinary(std::ostream &                 os
   std::streamsize bytesRemaining = num;
   const SizeType  componentSize = this->GetComponentSize();
   SizeType        pixelSize;
-  char            zero[1024];
-
-  memset(zero, 0, 1024);
+  constexpr char  zero[1024]{};
 
   switch (this->GetNumberOfComponents())
   {


### PR DESCRIPTION
- Replaced memset calls with `{}` assignment or initialization
- Replaced memset calls after `new T` with just `()` (doing `new T()` instead)
- Removed some `memset` calls that had no effect at all
---
- Follow-up to pull request #4863 commit aaff35cc345d3a587cfb3626c8cb93d72e2b7640