### PR TITLE
ENH: Add `itk::RelabelComponentImageFilter` signedness check

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -27,6 +27,12 @@
 #include "itkTestingMacros.h"
 
 
+using SignedPixelType = signed short;
+
+// Explicit template instantiation to test compile-time support of signed types
+template class itk::RelabelComponentImageFilter<itk::Image<SignedPixelType>, itk::Image<SignedPixelType>>;
+
+
 int
 itkRelabelComponentImageFilterTest(int argc, char * argv[])
 {


### PR DESCRIPTION
Add a template instantiation to check that the `itk::RelabelComponentImageFilter` class does not trigger compiler warnings with signed pixel types.

Ensures regressions are not introduced after the fix in commit 108a2cf.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)