### PR TITLE
STYLE: Remove `const` from `const std::string` return types

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -147,7 +147,7 @@ public:
   itkSetMacro(TypeName, std::string);
 
   /** Get the typename of the SpatialObject */
-  virtual const std::string
+  virtual std::string
   GetTypeName() const
   {
     return m_TypeName;

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -162,7 +162,7 @@ template <>
 class NumericTraits<std::string>
 {
 public:
-  static const std::string
+  static std::string
   ZeroValue()
   {
     return std::string("");

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -162,7 +162,7 @@ protected:
 
   /* The following struct returns the string name of computation type */
   /* default implementation */
-  static inline const std::string
+  static inline std::string
   GetTypeNameString()
   {
     itkGenericExceptionMacro("Unknown ScalarType" << typeid(ScalarType).name());
@@ -203,14 +203,14 @@ TransformIOBaseTemplate<double>::CorrectTransformPrecisionType(std::string & inp
 }
 
 template <>
-inline const std::string
+inline std::string
 TransformIOBaseTemplate<float>::GetTypeNameString()
 {
   return std::string("float");
 }
 
 template <>
-inline const std::string
+inline std::string
 TransformIOBaseTemplate<double>::GetTypeNameString()
 {
   return std::string("double");

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -160,8 +160,8 @@ private:
   GetH5TypeFromString() const;
 };
 
-const std::string ITKIOTransformHDF5_EXPORT
-                  GetTransformName(int);
+std::string ITKIOTransformHDF5_EXPORT
+            GetTransformName(int);
 
 /** This helps to meet backward compatibility */
 using HDF5TransformIO = HDF5TransformIOTemplate<double>;

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -495,7 +495,7 @@ const std::string HDF5CommonPathNames::OSVersion("/OSVersion");
 // Since (for now) transforms are ordered in a file, but
 // not named, I name them by their order in the file,
 // beginning with zero.
-const std::string
+std::string
 GetTransformName(int i)
 {
   std::stringstream s;

--- a/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
@@ -146,7 +146,7 @@ public:
   itkGetConstMacro(FunctionConvergenceTolerance, double);
 
   /** Report the reason for stopping. */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /** Return Current Value */

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
@@ -92,7 +92,7 @@ public:
   PrintArray(MeasureType * array);
 
   /** Report the reason for stopping. */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -131,7 +131,7 @@ public:
   itkGetConstReferenceMacro(MaximumNumberOfIterations, SizeValueType);
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -160,7 +160,7 @@ public:
 
   /** Get Stop condition. */
   itkGetConstReferenceMacro(StopCondition, StopConditionGradientDescentOptimizerEnum);
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /** Get Gradient condition. */

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -191,7 +191,7 @@ public:
   itkGetConstReferenceMacro(InfinityNormOfProjectedGradient, double);
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /** Returns false unconditionally because LBFGSBOptimizer does not support using scales. */

--- a/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
@@ -168,7 +168,7 @@ public:
   GetValue() const;
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
@@ -86,7 +86,7 @@ public:
   MeasureType
   GetValue() const;
 
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
@@ -187,7 +187,7 @@ public:
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);
 
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOptimizer.h
@@ -88,7 +88,7 @@ public:
   {}
 
   /** Get the reason for termination */
-  virtual const std::string
+  virtual std::string
   GetStopConditionDescription() const;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -193,7 +193,7 @@ public:
   GetValue() const;
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /** Print the swarm information to the given output stream. Each line

--- a/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
@@ -142,7 +142,7 @@ public:
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);
 
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -140,7 +140,7 @@ public:
   itkGetConstReferenceMacro(Gradient, DerivativeType);
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -251,7 +251,7 @@ public:
   itkGetConstMacro(Tolerance, double);
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -39,7 +39,7 @@ AmoebaOptimizer::AmoebaOptimizer()
 AmoebaOptimizer::~AmoebaOptimizer() = default;
 
 
-const std::string
+std::string
 AmoebaOptimizer::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -374,7 +374,7 @@ CumulativeGaussianOptimizer::VerticalBestShift(MeasureType * originalArray, Meas
   return (c / size);
 }
 
-const std::string
+std::string
 CumulativeGaussianOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -184,7 +184,7 @@ ExhaustiveOptimizer::IncrementIndex(ParametersType & newPosition)
   }
 }
 
-const std::string
+std::string
 ExhaustiveOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -29,7 +29,7 @@ GradientDescentOptimizer::GradientDescentOptimizer()
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 }
 
-const std::string
+std::string
 GradientDescentOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -374,7 +374,7 @@ LBFGSBOptimizerHelper::report_iter()
   }
 }
 
-const std::string
+std::string
 LBFGSBOptimizer::GetStopConditionDescription() const
 {
   std::ostringstream stopConditionDescription;

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -260,7 +260,7 @@ LBFGSOptimizer::GetOptimizer()
   return m_VnlOptimizer.get();
 }
 
-const std::string
+std::string
 LBFGSOptimizer::GetStopConditionDescription() const
 {
   m_StopConditionDescription.str("");

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -198,7 +198,7 @@ LevenbergMarquardtOptimizer::GetOptimizer() const
   return m_VnlOptimizer.get();
 }
 
-const std::string
+std::string
 LevenbergMarquardtOptimizer::GetStopConditionDescription() const
 {
   std::ostringstream reason, outcome;

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -287,7 +287,7 @@ OnePlusOneEvolutionaryOptimizer::StartOptimization()
  *
  */
 
-const std::string
+std::string
 OnePlusOneEvolutionaryOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -72,7 +72,7 @@ Optimizer::SetCurrentPosition(const ParametersType & param)
   this->Modified();
 }
 
-const std::string
+std::string
 Optimizer::GetStopConditionDescription() const
 {
   std::ostringstream description;

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -133,7 +133,7 @@ ParticleSwarmOptimizerBase::GetValue() const
 }
 
 
-const std::string
+std::string
 ParticleSwarmOptimizerBase::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -527,7 +527,7 @@ PowellOptimizer::StartOptimization()
 /**
  *
  */
-const std::string
+std::string
 PowellOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -237,7 +237,7 @@ RegularStepGradientDescentBaseOptimizer::AdvanceOneStep()
   this->InvokeEvent(IterationEvent());
 }
 
-const std::string
+std::string
 RegularStepGradientDescentBaseOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -393,7 +393,7 @@ SPSAOptimizer::GuessParameters(SizeValueType numberOfGradientEstimates, double i
   this->SetSa(initialStepSize * std::pow(m_A + 1.0, m_Alpha) / averageAbsoluteGradient.max_value());
 }
 
-const std::string
+std::string
 SPSAOptimizer::GetStopConditionDescription() const
 {
   std::ostringstream reason;

--- a/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
@@ -134,7 +134,7 @@ public:
   itkGetConstMacro(FunctionConvergenceTolerance, double);
 
   /** Report the reason for stopping. */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /** Method for getting access to the internal optimizer. */

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
@@ -138,7 +138,7 @@ public:
   itkGetConstReferenceMacro(CurrentIndex, ParametersType);
 
   /** Get the reason for termination */
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
   /**  Set the position to initialize the optimization. */

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -203,7 +203,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::IncrementIndex(ParametersT
 }
 
 template <typename TInternalComputationValueType>
-const std::string
+std::string
 ExhaustiveOptimizerv4<TInternalComputationValueType>::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -118,7 +118,7 @@ public:
   StopOptimization();
 
   /** Get the reason for termination */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
   /** Modify the gradient in place, to advance the optimization.

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -81,7 +81,7 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 template <typename TInternalComputationValueType>
 auto
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GetStopConditionDescription() const
-  -> const StopConditionReturnStringType
+  -> StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -214,7 +214,7 @@ public:
   void
   ResumeOptimization() override;
 
-  virtual const StopConditionReturnStringType
+  virtual StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
   /**

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
@@ -217,7 +217,7 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::UpdateProgress(
 }
 
 template <typename TInternalComputationValueType>
-const typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::StopConditionReturnStringType
+typename LBFGS2Optimizerv4Template<TInternalComputationValueType>::StopConditionReturnStringType
 LBFGS2Optimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
 {
   switch (m_StatusCode)

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
@@ -138,7 +138,7 @@ public:
   itkGetConstMacro(GradientConvergenceTolerance, double);
 
   /** Get the reason for termination */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -113,7 +113,7 @@ public:
   ResumeOptimization() override;
 
   /** Get the reason for termination */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
   /** Get the list of optimizers currently held. */

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -87,7 +87,7 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetMetricValues
 template <typename TInternalComputationValueType>
 auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
-  -> const StopConditionReturnStringType
+  -> StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -127,7 +127,7 @@ public:
   ResumeOptimization();
 
   /** Get the reason for termination */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override;
 
   /** Get the list of parameters over which to search.  */

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -111,7 +111,7 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::InstantiateLocalOp
 template <typename TInternalComputationValueType>
 auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
-  -> const StopConditionReturnStringType
+  -> StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -265,7 +265,7 @@ public:
   StartOptimization(bool doOnlyInitialization = false);
 
   /** Stop condition return string type */
-  virtual const StopConditionReturnStringType
+  virtual StopConditionReturnStringType
   GetStopConditionDescription() const = 0;
 
   /** Returns true if derived optimizer supports using scales.

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
@@ -165,7 +165,7 @@ public:
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);
 
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -275,7 +275,7 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
 }
 
 template <typename TInternalComputationValueType>
-const std::string
+std::string
 OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
@@ -131,7 +131,7 @@ public:
   itkGetConstReferenceMacro(MetricWorstPossibleValue, double);
   itkSetMacro(MetricWorstPossibleValue, double);
 
-  const std::string
+  std::string
   GetStopConditionDescription() const override;
 
 protected:

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -528,7 +528,7 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
 }
 
 template <typename TInternalComputationValueType>
-const std::string
+std::string
 PowellOptimizerv4<TInternalComputationValueType>::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
@@ -87,7 +87,7 @@ public:
   itkGetConstReferenceMacro(CachedCurrentPosition, ParametersType);
 
   /** Get the reason for termination */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override = 0;
 
 protected:

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -38,7 +38,7 @@ AmoebaOptimizerv4::AmoebaOptimizerv4()
 AmoebaOptimizerv4::~AmoebaOptimizerv4() = default;
 
 
-const std::string
+std::string
 AmoebaOptimizerv4::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -152,7 +152,7 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetOptimizer() -> InternalOptim
 }
 
 template <typename TInternalVnlOptimizerType>
-const std::string
+std::string
 LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetStopConditionDescription() const
 {
   m_StopConditionDescription.str("");

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
@@ -135,7 +135,7 @@ public:
   }
 
   /** Stop condition return string type */
-  const StopConditionReturnStringType
+  StopConditionReturnStringType
   GetStopConditionDescription() const override
   {
     return std::string("Placeholder test return string");


### PR DESCRIPTION
Removing this `const` enables move semantics, which may improve the performance.

Following C++ Core Guidelines, Oct 3, 2024, Don’t return `const T`: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-const