### PR TITLE
COMP: missing include in itkMetaDataObjectDetail.h

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataObjectDetail.h
+++ b/Modules/Core/Common/include/itkMetaDataObjectDetail.h
@@ -21,7 +21,7 @@
 
 #include <type_traits>
 #include <utility>
-#include <ostream>
+#include <iosfwd>
 
 namespace itk
 {

--- a/Modules/Core/Common/include/itkMetaDataObjectDetail.h
+++ b/Modules/Core/Common/include/itkMetaDataObjectDetail.h
@@ -21,6 +21,7 @@
 
 #include <type_traits>
 #include <utility>
+#include <ostream>
 
 namespace itk
 {


### PR DESCRIPTION
Missing include in tkMetaDataObjectDetail.h.
On my system (Arch Linux, GCC 14.2.1, cmake 3.30.5) it didn't compile without this edit.
