### PR TITLE
COMP: Specify GeometricalQuadEdge in PointSetBase wrapping QuadEdgeMesh

### DIFF
--- a/Modules/Core/QuadEdgeMesh/wrapping/itkQuadEdgeMeshBase.wrap
+++ b/Modules/Core/QuadEdgeMesh/wrapping/itkQuadEdgeMeshBase.wrap
@@ -21,7 +21,7 @@ itk_end_wrap_class()
 
 itk_wrap_class("itk::PointSetBase" POINTER)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
-  itk_wrap_template("MC${ITKM_IT}QEMPF${d}" "itk::MapContainer< ${ITKT_IT}, itk::QuadEdgeMeshPoint< float, ${d} > >")
+  itk_wrap_template("MC${ITKM_IT}QEMP${ITKM_F}${d}" "itk::MapContainer< ${ITKT_IT}, itk::QuadEdgeMeshPoint< float, ${d}, itk::GeometricalQuadEdge< ${ITKT_IT},${ITKT_IT},bool,bool,true > > >")
 endforeach()
 itk_end_wrap_class()
 


### PR DESCRIPTION
Aims to address Windows specific wrapping failures at the CI (https://open.cdash.org/viewBuildError.php?type=1&buildid=9948358), including:

    itkQuadEdgeMeshBase: warning(4): ITK type not wrapped, or currently not known: itk::QuadEdgeMeshPoint< float, 2 >

And locally, from Visual Studio 2022:

    Bin\ITK\Wrapping\Typedefs\itkQuadEdgeMeshBase.i(1220): warning 401: Nothing known about base class 'itk::PointSetBase< itk::MapContainer< unsigned long long,itk::QuadEdgeMeshPoint< float,2,itk::GeometricalQuadEdge< unsigned long long,unsigned long long,bool,bool > > > >'. Ignored.
    Bin\ITK\Wrapping\Typedefs\itkQuadEdgeMeshBase.i(1220): warning 401: Maybe you forgot to instantiate 'itk::PointSetBase< itk::MapContainer< unsigned long long,itk::QuadEdgeMeshPoint< float,2,itk::GeometricalQuadEdge< unsigned long long,unsigned long long,bool,bool > > > >' using %template.

As mentioned at https://github.com/InsightSoftwareConsortium/ITK/pull/4867#discussion_r1790748146