### PR TITLE
Remove top-level const from return types in "Bridge/NumPy", and other style commits

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.h
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.h
@@ -75,7 +75,7 @@ public:
   /**
    * Get an ITK image from a Python array
    */
-  static const OutputImagePointer
+  static OutputImagePointer
   _GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent);
 };
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -66,7 +66,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
 template <class TImage>
 auto
 PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent)
-  -> const OutputImagePointer
+  -> OutputImagePointer
 {
   PyObject * item = nullptr;
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -58,9 +58,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
   len *= sizeof(ComponentType);
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, itkImageBuffer, len, 0, PyBUF_CONTIG);
-  PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
-
-  return memoryView;
+  return PyMemoryView_FromBuffer(&pyBuffer);
 }
 
 template <class TImage>

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -68,8 +68,6 @@ auto
 PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent)
   -> OutputImagePointer
 {
-  PyObject * item = nullptr;
-
   Py_buffer pyBuffer{};
 
   SizeType      size;
@@ -95,7 +93,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
 
   for (unsigned int i = 0; i < dimension; ++i)
   {
-    item = PySequence_Fast_GET_ITEM(shapeseq, i);
+    PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, i);
     size[i] = static_cast<SizeValueType>(PyInt_AsLong(item));
     sizeFortran[dimension - 1 - i] = static_cast<SizeValueType>(PyInt_AsLong(item));
     numberOfPixels *= size[i];

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.h
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.h
@@ -61,7 +61,7 @@ public:
   /**
    * Get a vnl vector from a Python array
    */
-  static const typename VectorContainerType::Pointer
+  static typename VectorContainerType::Pointer
   _vector_container_from_array(PyObject * arr, PyObject * shape);
 };
 

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -51,7 +51,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 
 template <typename TElementIdentifier, typename TElement>
 auto
-PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * shape) ->
+PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * const shape) ->
   typename VectorContainerType::Pointer
 {
   Py_buffer pyBuffer{};
@@ -68,9 +68,8 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
-  PyObject * const   obj = shape;
-  PyObject * const   shapeseq = PySequence_Fast(obj, "expected sequence");
-  const unsigned int dimension = PySequence_Size(obj);
+  PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
+  const unsigned int dimension = PySequence_Size(shape);
 
   PyObject *   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
   const size_t numberOfElements = static_cast<size_t>(PyInt_AsLong(item));

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -44,9 +44,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
   len *= sizeof(DataType);
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
-  PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
-
-  return memoryView;
+  return PyMemoryView_FromBuffer(&pyBuffer);
 }
 
 template <typename TElementIdentifier, typename TElement>

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -51,7 +51,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 
 template <typename TElementIdentifier, typename TElement>
 auto
-PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * shape) -> const
+PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * shape) ->
   typename VectorContainerType::Pointer
 {
   Py_buffer pyBuffer{};

--- a/Modules/Bridge/NumPy/include/itkPyVnl.h
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.h
@@ -63,7 +63,7 @@ public:
   /**
    * Get a vnl vector from a Python array
    */
-  static const VectorType
+  static VectorType
   _GetVnlVectorFromArray(PyObject * arr, PyObject * shape);
 
   /**
@@ -75,7 +75,7 @@ public:
   /**
    * Get a vnl matrix from a Python array
    */
-  static const MatrixType
+  static MatrixType
   _GetVnlMatrixFromArray(PyObject * arr, PyObject * shape);
 };
 

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -114,8 +114,6 @@ template <class TElement>
 auto
 PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * const shape) -> MatrixType
 {
-  PyObject * item = nullptr;
-
   Py_buffer pyBuffer{};
 
   size_t numberOfElements = 1;
@@ -139,7 +137,7 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * const shape) 
 
   for (unsigned int i = 0; i < 2; ++i)
   {
-    item = PySequence_Fast_GET_ITEM(shapeseq, i);
+    PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, i);
     size[i] = static_cast<unsigned int>(PyInt_AsLong(item));
     numberOfElements *= size[i];
   }

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -51,7 +51,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 
 template <class TElement>
 auto
-PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> VectorType
+PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * const shape) -> VectorType
 {
   Py_buffer pyBuffer{};
 
@@ -67,9 +67,8 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> Vec
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
-  PyObject * const   obj = shape;
-  PyObject * const   shapeseq = PySequence_Fast(obj, "expected sequence");
-  const unsigned int dimension = PySequence_Size(obj);
+  PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
+  const unsigned int dimension = PySequence_Size(shape);
 
   PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
   const size_t     numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
@@ -113,7 +112,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
 template <class TElement>
 auto
-PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> MatrixType
+PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * const shape) -> MatrixType
 {
   PyObject * item = nullptr;
 
@@ -135,9 +134,8 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> Mat
   const Py_ssize_t   bufferLength = pyBuffer.len;
   const void * const buffer = pyBuffer.buf;
 
-  PyObject * const   obj = shape;
-  PyObject * const   shapeseq = PySequence_Fast(obj, "expected sequence");
-  const unsigned int dimension = PySequence_Size(obj);
+  PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
+  const unsigned int dimension = PySequence_Size(shape);
 
   for (unsigned int i = 0; i < 2; ++i)
   {

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -80,9 +80,7 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * const shape) 
     return VectorType();
   }
   const auto * const data = static_cast<const DataType *>(buffer);
-  VectorType         output(data, numberOfElements);
-
-  return output;
+  return VectorType(data, numberOfElements);
 }
 
 template <class TElement>
@@ -150,9 +148,7 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * const shape) 
   }
 
   const auto * const data = static_cast<const DataType *>(buffer);
-  MatrixType         output(data, size[0], size[1]);
-
-  return output;
+  return MatrixType(data, size[0], size[1]);
 }
 
 

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -51,7 +51,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 
 template <class TElement>
 auto
-PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> const VectorType
+PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> VectorType
 {
   Py_buffer pyBuffer{};
 
@@ -113,7 +113,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
 template <class TElement>
 auto
-PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> const MatrixType
+PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> MatrixType
 {
   PyObject * item = nullptr;
 

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -44,9 +44,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
   len *= sizeof(DataType);
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
-  PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
-
-  return memoryView;
+  return PyMemoryView_FromBuffer(&pyBuffer);
 }
 
 template <class TElement>
@@ -103,9 +101,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
   len *= sizeof(DataType);
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
-  PyObject * const memoryView = PyMemoryView_FromBuffer(&pyBuffer);
-
-  return memoryView;
+  return PyMemoryView_FromBuffer(&pyBuffer);
 }
 
 template <class TElement>


### PR DESCRIPTION
- Following pull request #4872