### PR TITLE
Remove `VectorContainer` Identifier template argument from `DefaultStaticMeshTraits`, tests, and comments 

### DIFF
--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -96,7 +96,7 @@ public:
 
   /** The container type for use in storing points.  It must conform to
    * the IndexedContainer interface. */
-  using PointsContainer = VectorContainer<PointIdentifier, PointType>;
+  using PointsContainer = VectorContainer<PointType>;
 
   /** The container type that will be used to store boundary links
    * back to cells.  This must conform to the STL "set" interface. */
@@ -114,7 +114,7 @@ public:
 
   /** The container type for use in storing cells.  It must conform to
    * the IndexedContainer interface. */
-  using CellsContainer = VectorContainer<CellIdentifier, CellType *>;
+  using CellsContainer = VectorContainer<CellType *>;
 
   /** The CellLinks container should be a container of PointCellLinksContainer,
    * which should be a container conforming to the STL "set" interface. */
@@ -122,15 +122,15 @@ public:
 
   /** The container type for use in storing point links back to cells.
    * It must conform to the IndexedContainer interface. */
-  using CellLinksContainer = VectorContainer<PointIdentifier, PointCellLinksContainer>;
+  using CellLinksContainer = VectorContainer<PointCellLinksContainer>;
 
   /** The container type for use in storing point data.  It must conform to
    * the IndexedContainer interface. */
-  using PointDataContainer = VectorContainer<PointIdentifier, PixelType>;
+  using PointDataContainer = VectorContainer<PixelType>;
 
   /** The container type for use in storing cell data.  It must conform to
    * the IndexedContainer interface. */
-  using CellDataContainer = VectorContainer<CellIdentifier, CellPixelType>;
+  using CellDataContainer = VectorContainer<CellPixelType>;
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSTLContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLContainerAdaptor.h
@@ -32,7 +32,7 @@ namespace itk
  * Here's a usage example of STLContainerAdaptor:
  *
    \code
-       itk::STLContainerAdaptor<itk::VectorContainer<size_t, ElementType>> vecAdaptor(aContainer);
+       itk::STLContainerAdaptor<itk::VectorContainer<ElementType>> vecAdaptor(aContainer);
        std::vector<ElementType> & vec = vecAdaptor.GetSTLContainerRef();
        // do things with vec ...
        // upon return from function, vecAdaptor is destroyed and aContainer is Modified()

--- a/Modules/Core/Common/test/itkModifiedTimeTest.cxx
+++ b/Modules/Core/Common/test/itkModifiedTimeTest.cxx
@@ -24,7 +24,7 @@ itkModifiedTimeTest(int, char *[])
 {
 
   using Point = itk::Point<double, 3>;
-  using PointsContainer = itk::VectorContainer<unsigned long, Point>;
+  using PointsContainer = itk::VectorContainer<Point>;
   using BoundingBox = itk::BoundingBox<unsigned long, 3, double, PointsContainer>;
 
   Point p, q, r;

--- a/Modules/Core/Common/test/itkPointGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkPointGeometryTest.cxx
@@ -265,7 +265,7 @@ itkPointGeometryTest(int, char *[])
     const double           tolerance = 1e-10;
     PointType              combination;
     constexpr unsigned int NP = 3;
-    using VectorOfPoints = itk::VectorContainer<unsigned long, PointType>;
+    using VectorOfPoints = itk::VectorContainer<PointType>;
     auto points = VectorOfPoints::New();
     points->Reserve(NP);
     constexpr double K = 12.0;

--- a/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
+++ b/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
@@ -37,7 +37,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
     std::cout << "Testing the VectorContainer " << std::endl;
 
-    using VectorContainerType = itk::VectorContainer<IndexType, ElementType>;
+    using VectorContainerType = itk::VectorContainer<ElementType>;
 
     auto vectorContainer = VectorContainerType::New();
 

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
@@ -27,7 +27,7 @@ class IteratorRangeDomainThreaderAssociate
 public:
   using Self = IteratorRangeDomainThreaderAssociate;
 
-  using DomainContainerType = itk::VectorContainer<unsigned int, int>;
+  using DomainContainerType = itk::VectorContainer<int>;
   using DomainContainerPointer = DomainContainerType::Pointer;
   using ThreadedPartitionerType = itk::ThreadedIteratorRangePartitioner<DomainContainerType::ConstIterator>;
 

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -23,13 +23,10 @@
 #include <cstdlib>
 #include <string>
 
-// The tested ElementIdentifier type.
-using TestedElementIdentifierType = size_t;
-
 // Test template instantiations for various TElement template arguments:
-template class itk::detail::VectorContainer<TestedElementIdentifierType, int>;
-template class itk::detail::VectorContainer<TestedElementIdentifierType, bool>;
-template class itk::detail::VectorContainer<TestedElementIdentifierType, std::string>;
+template class itk::detail::VectorContainer<itk::SizeValueType, int>;
+template class itk::detail::VectorContainer<itk::SizeValueType, bool>;
+template class itk::detail::VectorContainer<itk::SizeValueType, std::string>;
 
 
 namespace
@@ -42,11 +39,11 @@ AssertSameType()
 }
 
 
-template <typename TElementIdentifier, typename TElement>
+template <typename TElement>
 constexpr bool
 AssertVectorContainerHasSamePublicNestedTypesAsStdVector()
 {
-  using VectorContainerType = itk::VectorContainer<TElementIdentifier, TElement>;
+  using VectorContainerType = itk::VectorContainer<TElement>;
   using StdVectorType = std::vector<TElement>;
 
   // Check the list of nested types of `std::vector` from section [vector.overview] of the C++ Standard Working Draft of
@@ -68,15 +65,15 @@ AssertVectorContainerHasSamePublicNestedTypesAsStdVector()
 }
 
 
-static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<TestedElementIdentifierType, int>());
-static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<TestedElementIdentifierType, bool>());
+static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<int>());
+static_assert(AssertVectorContainerHasSamePublicNestedTypesAsStdVector<bool>());
 
 
-template <typename TElementIdentifier, typename TElement>
+template <typename TElement>
 void
-ExpectContainerHasValueOfCreatedElementAtIdentifier(const TElementIdentifier identifier, const TElement value)
+ExpectContainerHasValueOfCreatedElementAtIdentifier(const itk::SizeValueType identifier, const TElement value)
 {
-  const auto vectorContainer = itk::VectorContainer<TElementIdentifier, TElement>::New();
+  const auto vectorContainer = itk::VectorContainer<TElement>::New();
 
   vectorContainer->CreateElementAt(identifier) = value;
 
@@ -90,7 +87,7 @@ ExpectContainerHasValueOfCreatedElementAtIdentifier(const TElementIdentifier ide
 TEST(VectorContainer, HasValueOfCreatedElementAtIdentifier)
 {
   // Just pick a "pseudo-random" (magic) number as ElementIdentifier.
-  constexpr TestedElementIdentifierType magicIdentifier = 42;
+  constexpr itk::SizeValueType magicIdentifier = 42;
 
   ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, true);
   ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, false);

--- a/Modules/Core/Common/test/itkVectorContainerTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerTest.cxx
@@ -19,7 +19,7 @@
 #include "itkVectorContainer.h"
 #include "itkTestingMacros.h"
 
-using ContainerType = itk::VectorContainer<size_t, double>;
+using ContainerType = itk::VectorContainer<double>;
 
 int
 itkVectorContainerTest(int, char *[])

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
@@ -66,7 +66,7 @@ public:
   using NodePairContainerConstIterator = typename NodePairContainerType::ConstIterator;
 
   /*
-  using NodeContainerType = VectorContainer< IdentifierType, NodeType >;
+  using NodeContainerType = VectorContainer<NodeType>;
   using NodeContainerPointer = typename NodeContainerType::Pointer;
   using NodeContainerIterator = typename NodeContainerType::Iterator;
   using NodeContainerConstIterator = typename NodeContainerType::ConstIterator;

--- a/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
@@ -426,8 +426,7 @@ itkCommonPrintTest(int, char *[])
     itk::VarianceImageFunction<InputType, float>::New();
   std::cout << "------------VarianceImageFunction" << VarianceImageFunctionObj;
 
-  itk::VectorContainer<unsigned long, PointType>::Pointer VectorContainerObj =
-    itk::VectorContainer<unsigned long, PointType>::New();
+  itk::VectorContainer<PointType>::Pointer VectorContainerObj = itk::VectorContainer<PointType>::New();
   std::cout << "------------VectorContainer" << VectorContainerObj;
 
   itk::VectorImage<float, 3>::Pointer VectorImageObj = itk::VectorImage<float, 3>::New();

--- a/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
@@ -25,7 +25,7 @@ itkVectorContainerToListSampleAdaptorTest(int, char *[])
 
   using VectorType = itk::Vector<double, 5>;
 
-  using ContainerType = itk::VectorContainer<unsigned int, VectorType>;
+  using ContainerType = itk::VectorContainer<VectorType>;
 
   using AdaptorType = itk::Statistics::VectorContainerToListSampleAdaptor<ContainerType>;
 

--- a/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
+++ b/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
@@ -138,7 +138,7 @@ itkPointsLocatorTest(int, char *[])
   constexpr unsigned int PointDimension = 3;
   using PointType = itk::Point<float, PointDimension>;
 
-  using VectorContainerType = itk::VectorContainer<unsigned int, PointType>;
+  using VectorContainerType = itk::VectorContainer<PointType>;
   using MapContainerType = itk::MapContainer<unsigned int, PointType>;
 
   std::cout << "VectorContainerType" << std::endl;


### PR DESCRIPTION
- Following pull request #4856 commit edae0bcd6e0dcf679abd08d77792d0867c693878

Note that this pull request should not affect the API or the ABI of ITK in any way.  😇 