### PR TITLE
STYLE: Replace `Fill(0)` with `{}` initializer for local variables in tests

### DIFF
--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -287,10 +287,8 @@ public:
 
     //============ Test Copy with Round/Cast Type ====================================
     {
-      AggregateType known3s{ { 3, 3, 3, 3 } };
-      AggregateType threes;
-
-      threes.Fill(0);
+      AggregateType         known3s{ { 3, 3, 3, 3 } };
+      AggregateType         threes{};
       AggregateType         known4s{ { 4, 4, 4, 4 } };
       itk::Point<double, 4> p1;
       p1.Fill(3.5);

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -34,8 +34,7 @@ GetTestImage(int d1, int d2, int d3, int d4)
   sizeND[2] = d3;
   sizeND[3] = d4;
 
-  itk::Index<4> origND;
-  origND.Fill(0);
+  itk::Index<4> origND{};
 
   itk::ImageRegion<4> RegionND{ origND, sizeND };
 
@@ -318,8 +317,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   {
     // Create an image
     using ChangeRegionTestImageType = itk::Image<int, 2>;
-    ChangeRegionTestImageType::IndexType imageCorner;
-    imageCorner.Fill(0);
+    ChangeRegionTestImageType::IndexType imageCorner{};
 
     ChangeRegionTestImageType::SizeType imageSize;
     imageSize.Fill(4);

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -29,8 +29,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestGetTestImage(int d1, int d2, int d3
   sizeND[2] = d3;
   sizeND[3] = d4;
 
-  itk::Index<4> origND;
-  origND.Fill(0);
+  itk::Index<4> origND{};
 
   itk::ImageRegion<4> RegionND{ origND, sizeND };
 

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -417,8 +417,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
   {
     // Create an image
     using ChangeRegionTestImageType = itk::Image<int, 2>;
-    ChangeRegionTestImageType::IndexType imageCorner;
-    imageCorner.Fill(0);
+    ChangeRegionTestImageType::IndexType imageCorner{};
 
     ChangeRegionTestImageType::SizeType imageSize;
     imageSize.Fill(4);

--- a/Modules/Core/Common/test/itkFixedArrayTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest.cxx
@@ -70,8 +70,7 @@ itkFixedArrayTest(int, char *[])
   Set_c_Array(array3.GetDataPointer());
   Print_Array(array3, std::cout);
 
-  itk::FixedArray<int, 3> array4;
-  array4.Fill(0);
+  itk::FixedArray<int, 3> array4{};
   Print_Array(array4, std::cout);
 
   // Test operator!= and operator==

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
@@ -32,8 +32,7 @@ AverageTestCopy(typename TImage::SizeType & size)
   typename ImageType::RegionType region;
 
 
-  typename ImageType::IndexType index;
-  index.Fill(0);
+  typename ImageType::IndexType index{};
   region.SetSize(size);
   region.SetIndex(index);
 

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -64,9 +64,8 @@ itkImageAlgorithmCopyTest2(int, char *[])
   using RegionType = itk::ImageRegion<3>;
 
 
-  RegionType::IndexType index;
-  index.Fill(0);
-  RegionType::SizeType size;
+  RegionType::IndexType index{};
+  RegionType::SizeType  size;
   size.Fill(64);
 
   RegionType region{ index, size };

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -140,8 +140,7 @@ typename TImage::Pointer
 CreateSmallImage()
 {
   const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(0);
+  typename TImage::SizeType imageSize{};
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->AllocateInitialized();

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -40,8 +40,7 @@ template <typename TImage>
 void
 ComputeFastIndex(TImage * image, unsigned int count, unsigned int repeat)
 {
-  typename TImage::IndexType index;
-  index.Fill(0);
+  typename TImage::IndexType               index{};
   const typename TImage::IndexType &       bufferedRegionIndex = image->GetBufferedRegion().GetIndex();
   const typename TImage::OffsetValueType * offsetTable = image->GetOffsetTable();
 

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -33,8 +33,7 @@ itkImageDuplicatorTest(int, char *[])
   size[0] = 10;
   size[1] = 20;
   size[2] = 30;
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
   region.SetSize(size);
   region.SetIndex(index);
 

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -43,8 +43,7 @@ public:
     typename ImageType::SizeType size;
     size.Fill(100);
 
-    typename ImageType::IndexType start;
-    start.Fill(0);
+    typename ImageType::IndexType start{};
 
     typename ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -35,8 +35,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   size[1] = 4;
   size[2] = 4;
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -41,8 +41,7 @@ itkImageLinearIteratorTest(int, char *[])
   size0[1] = 100;
   size0[2] = 100;
 
-  ImageType::IndexType start0;
-  start0.Fill(0);
+  ImageType::IndexType start0{};
 
   ImageType::RegionType region0{ start0, size0 };
 

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -43,8 +43,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
 
   unsigned long numberOfSamples = 10;
 
-  ImageType::IndexType start0;
-  start0.Fill(0);
+  ImageType::IndexType start0{};
 
   ImageType::RegionType region0{ start0, size0 };
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -43,8 +43,7 @@ itkImageRandomIteratorTest(int, char *[])
 
   unsigned long numberOfSamples = 10;
 
-  ImageType::IndexType start0;
-  start0.Fill(0);
+  ImageType::IndexType start0{};
 
   ImageType::RegionType region0{ start0, size0 };
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -52,8 +52,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   unsigned long numberOfSamples = size[0] * size[1];
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -46,9 +46,8 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   size0[0] = 50;
   size0[1] = 50;
   size0[2] = 50;
-  unsigned long        numberOfSamples = 10;
-  ImageType::IndexType start0;
-  start0.Fill(0);
+  unsigned long         numberOfSamples = 10;
+  ImageType::IndexType  start0{};
   ImageType::RegionType region0{ start0, size0 };
   myImage->SetRegions(region0);
   myImage->Allocate();
@@ -58,8 +57,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   prioritySize[0] = 50;
   prioritySize[1] = 50;
   prioritySize[2] = 50;
-  PriorityImageType::IndexType priorityStart;
-  priorityStart.Fill(0);
+  PriorityImageType::IndexType  priorityStart{};
   PriorityImageType::RegionType priorityRegion{ priorityStart, prioritySize };
   priorityImage->SetRegions(priorityRegion);
   priorityImage->Allocate();

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
@@ -38,8 +38,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest2(int, char *[])
   constexpr int           Seed = 42;
   ImageType::SizeType     size;
   size.Fill(N);
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType  start{};
   ImageType::RegionType region{ start, size };
   auto                  myImage = ImageType::New();
   myImage->SetRegions(region);

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -37,8 +37,7 @@ public:
     typename ImageType::SizeType size;
     size.Fill(100);
 
-    typename ImageType::IndexType start;
-    start.Fill(0);
+    typename ImageType::IndexType start{};
 
     typename ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -135,8 +135,7 @@ itkImageRegionIteratorTest(int, char *[])
   {
     // Create an image
     using TestImageType = itk::Image<int, 2>;
-    TestImageType::IndexType imageCorner;
-    imageCorner.Fill(0);
+    TestImageType::IndexType imageCorner{};
 
     TestImageType::SizeType imageSize;
     imageSize.Fill(3);
@@ -165,8 +164,7 @@ itkImageRegionIteratorTest(int, char *[])
     }
 
     // Setup and iterate over the first region
-    TestImageType::IndexType region1Start;
-    region1Start.Fill(0);
+    TestImageType::IndexType region1Start{};
 
     TestImageType::SizeType regionSize;
     regionSize.Fill(2);

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -148,8 +148,7 @@ itkImageScanlineIteratorTest1(int, char *[])
   {
     // Create an image
     using TestImageType = itk::Image<int, 2>;
-    TestImageType::IndexType imageCorner;
-    imageCorner.Fill(0);
+    TestImageType::IndexType imageCorner{};
 
     TestImageType::SizeType imageSize;
     imageSize.Fill(3);
@@ -181,8 +180,7 @@ itkImageScanlineIteratorTest1(int, char *[])
     }
 
     // Setup and iterate over the first region
-    TestImageType::IndexType region1Start;
-    region1Start.Fill(0);
+    TestImageType::IndexType region1Start{};
 
     TestImageType::SizeType regionSize;
     regionSize.Fill(2);

--- a/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
@@ -40,8 +40,7 @@ itkImageSliceIteratorTest(int, char *[])
   size[1] = 100;
   size[2] = 100;
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -122,9 +122,8 @@ itkImageTest(int, char *[])
   direction.SetIdentity();
   image->SetDirection(direction);
   Image::RegionType region;
-  Image::IndexType  index;
-  index.Fill(0);
-  Image::SizeType size;
+  Image::IndexType  index{};
+  Image::SizeType   size;
   size.Fill(4);
   region.SetIndex(index);
   region.SetSize(size);
@@ -133,8 +132,7 @@ itkImageTest(int, char *[])
   auto               imageRef = Image::New();
   Image::SpacingType spacingRef;
   spacingRef.Fill(2);
-  Image::PointType originRef;
-  originRef.Fill(0);
+  Image::PointType     originRef{};
   Image::DirectionType directionRef;
   directionRef.SetIdentity();
   imageRef->SetSpacing(spacingRef);
@@ -155,9 +153,8 @@ itkImageTest(int, char *[])
                                                                           image.GetPointer(),
                                                                           imageRef.GetPointer(),
                                                                           static_cast<TransformType *>(nullptr));
-  Image::IndexType  correctIndex;
-  correctIndex.Fill(0);
-  Image::SizeType correctSize;
+  Image::IndexType  correctIndex{};
+  Image::SizeType   correctSize;
   correctSize.Fill(3);
   if (!(boxRegion.GetIndex() == correctIndex) || !(boxRegion.GetSize() == correctSize))
   {
@@ -170,8 +167,7 @@ itkImageTest(int, char *[])
   auto                 volume = Image3D::New();
   Image3D::SpacingType spacingVol;
   spacingVol.Fill(1);
-  Image3D::PointType originVol;
-  originVol.Fill(0);
+  Image3D::PointType     originVol{};
   Image3D::DirectionType directionVol;
   directionVol.SetIdentity();
   volume->SetSpacing(spacingVol);
@@ -179,9 +175,8 @@ itkImageTest(int, char *[])
   volume->SetDirection(directionVol);
 
   Image3D::RegionType cuboid;
-  Image3D::IndexType  indexCuboid;
-  indexCuboid.Fill(0);
-  Image3D::SizeType sizeCuboid;
+  Image3D::IndexType  indexCuboid{};
+  Image3D::SizeType   sizeCuboid;
   sizeCuboid[0] = 1;
   sizeCuboid[1] = 2;
   sizeCuboid[2] = 3;
@@ -196,9 +191,8 @@ itkImageTest(int, char *[])
     volume->GetLargestPossibleRegion(), volume.GetPointer(), imageRef.GetPointer(), projectionTransform);
 
   delete projectionTransform;
-  Image::IndexType correctRectangleIndex;
-  correctRectangleIndex.Fill(0);
-  Image::SizeType correctRectangleSize;
+  Image::IndexType correctRectangleIndex{};
+  Image::SizeType  correctRectangleSize;
   correctRectangleSize[0] = 1;
   correctRectangleSize[1] = 2;
   if (!(rectangleRegion.GetIndex() == correctRectangleIndex) || !(rectangleRegion.GetSize() == correctRectangleSize))

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -82,8 +82,7 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
 
   ImageVectorPointer imageOfVectors = ImageVectorType::New();
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   SizeType      size;
   constexpr int dimLength = 3;

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -42,8 +42,7 @@ itkLineIteratorTest(int argc, char * argv[])
 
 
   // Set up a test image
-  ImageType::RegionType::IndexType index;
-  index.Fill(0);
+  ImageType::RegionType::IndexType index{};
 
   ImageType::RegionType::SizeType size;
   size.Fill(200);

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -97,8 +97,7 @@ NeighborhoodAlgorithmTest()
   using IndexType = typename ImageType::IndexType;
   using SizeType = typename ImageType::SizeType;
 
-  IndexType ind;
-  ind.Fill(0);
+  IndexType ind{};
 
   SizeType size;
   size.Fill(5);

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -29,8 +29,7 @@ itkNeighborhoodIteratorTest(int, char *[])
   loc[2] = 2;
   loc[3] = 1;
 
-  itk::NeighborhoodIterator<TestImageType>::IndexType zeroIDX;
-  zeroIDX.Fill(0);
+  itk::NeighborhoodIterator<TestImageType>::IndexType zeroIDX{};
 
   itk::NeighborhoodIterator<TestImageType>::RadiusType radius;
   radius[0] = radius[1] = radius[2] = radius[3] = 1;

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -178,10 +178,8 @@ itkObjectFactoryTest2(int argc, char * argv[])
     MakeImage(10, static_cast<float>(0));
     MakeImage(10, static_cast<double>(0));
   }
-  itk::RGBPixel<unsigned char> rgbUC;
-  rgbUC.Fill(0);
-  itk::RGBPixel<unsigned short> rgbUS;
-  rgbUS.Fill(0);
+  itk::RGBPixel<unsigned char>  rgbUC{};
+  itk::RGBPixel<unsigned short> rgbUS{};
   MakeImage(10, rgbUC);
   MakeImage(10, rgbUS);
 

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -121,8 +121,7 @@ typename TImage::Pointer
 CreateSmallImage()
 {
   const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(0);
+  typename TImage::SizeType imageSize{};
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->AllocateInitialized();

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -42,8 +42,7 @@ itkSymmetricSecondRankTensorImageReadTest(int argc, char * argv[])
   MatrixImageType::SizeType size;
   size.Fill(10);
 
-  MatrixImageType::IndexType start;
-  start.Fill(0);
+  MatrixImageType::IndexType start{};
 
   MatrixImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -40,8 +40,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
   TensorImageType::SizeType size;
   size.Fill(10);
 
-  TensorImageType::IndexType start;
-  start.Fill(0);
+  TensorImageType::IndexType start{};
 
   TensorImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -397,8 +397,7 @@ ASSERT(v[0] == 13.0 && v[1] == 18.0 && v[2] == 23.0, "On-the-fly conversion fail
 
 {
   // Testing empty vectors
-  FloatVariableLengthVectorType v1;
-  v1.Fill(0);
+  FloatVariableLengthVectorType v1{};
   FloatVariableLengthVectorType v2 = v1;
   v1 = v2;
 

--- a/Modules/Core/Common/test/itkVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGeometryTest.cxx
@@ -152,8 +152,7 @@ itkVectorGeometryTest(int, char *[])
     vv[1] = 3;
     vv[2] = 5;
 
-    VectorType vw;
-    vw.Fill(0);
+    VectorType vw{};
 
     if (vv == vw)
     {

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -587,9 +587,8 @@ itkVectorImageTest(int, char * argv[])
     using VectorPixelType = itk::Vector<PixelType, VectorLength>;
     using VectorImageType = itk::Image<itk::Vector<PixelType, VectorLength>, Dimension>;
     auto                       image = VectorImageType::New();
-    VectorImageType::IndexType start;
-    start.Fill(0);
-    VectorImageType::SizeType size;
+    VectorImageType::IndexType start{};
+    VectorImageType::SizeType  size;
     size.Fill(5);
     VectorImageType::RegionType region(start, size);
     image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -142,8 +142,7 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
 
   // Compare 10 values at random points.
 
-  ImageType::IndexType last;
-  last.Fill(0);
+  ImageType::IndexType last{};
   last[0] = randImage->GetLargestPossibleRegion().GetSize()[0] - 1;
   ImageType::PointType lastPhysicalLocation;
   randImage->TransformIndexToPhysicalPoint(last, lastPhysicalLocation);

--- a/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
@@ -66,8 +66,7 @@ itkBSplineResampleImageFunctionTest(int, char *[])
 
   /** Compare 10 values at random points. */
 
-  ImageType::IndexType Last;
-  Last.Fill(0);
+  ImageType::IndexType Last{};
   Last[0] = randImage->GetLargestPossibleRegion().GetSize()[0] - 1;
   ImageType::PointType LastPhysicalLocation;
   randImage->TransformIndexToPhysicalPoint(Last, LastPhysicalLocation);

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -33,8 +33,7 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
   FloatImage::RegionType region;
   FloatImage::SizeType   size;
   size.Fill(64);
-  FloatImage::IndexType index;
-  index.Fill(0);
+  FloatImage::IndexType index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -78,8 +78,7 @@ itkCentralDifferenceImageFunctionOnVectorSpeedTestRun(char * argv[])
   typename ImageType::IndexType index;
 
   OutputType indexOutput;
-  OutputType total;
-  total.Fill(0);
+  OutputType total{};
 
   std::cout << "UseImageDirection: " << function->GetUseImageDirection() << std::endl;
 

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
@@ -74,8 +74,7 @@ itkCentralDifferenceImageFunctionSpeedTest(int argc, char * argv[])
 
   ImageType::IndexType index;
 
-  OutputType total;
-  total.Fill(0);
+  OutputType total{};
 
   std::cout << "UseImageDirection: " << function->GetUseImageDirection() << std::endl;
 

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -43,8 +43,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
 
   auto image = ImageType::New();
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::SizeType size;
   size.Fill(3);

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -43,8 +43,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   {
     RegionType region;
     {
-      IndexType start;
-      start.Fill(0);
+      IndexType start{};
 
       SizeType size;
       size[0] = small_xSize;
@@ -116,8 +115,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   {
     RegionType region;
     {
-      IndexType start;
-      start.Fill(0);
+      IndexType start{};
 
       SizeType size;
       size[0] = large_xSize;

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -60,8 +60,7 @@ RunLinearInterpolateTest()
   auto variablevectorimage = VariableVectorImageType::New();
   variablevectorimage->SetVectorLength(VectorDimension);
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   SizeType      size;
   constexpr int dimMaxLength = 3;

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -58,8 +58,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
   auto variablevectorimage = VariableVectorImageType::New();
   variablevectorimage->SetVectorLength(VectorDimension);
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   SizeType size;
   size.Fill(3);
@@ -130,8 +129,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
 
   interpolator->SetInputImage(image);
 
-  typename ImageType::SizeType radius;
-  radius.Fill(0);
+  typename ImageType::SizeType radius{};
   for (unsigned int d = 0; d < Dimension; ++d)
   {
     ITK_TEST_SET_GET_VALUE(radius[d], interpolator->GetRadius()[d]);

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -42,9 +42,8 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   /* Allocate a simple test image */
   auto      image = ImageType::New();
-  IndexType start;
-  start.Fill(0);
-  SizeType size;
+  IndexType start{};
+  SizeType  size;
   size[0] = 30;
   size[1] = 30;
   size[2] = 30;

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -80,8 +80,7 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   size[1] = 128;
   size[2] = 128;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region{ start, size };
 

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
@@ -96,8 +96,7 @@ itkConnectedRegionsMeshFilterTest1(int, char *[])
 
   auto meshSource = SphereMeshSourceType::New();
 
-  PointType center;
-  center.Fill(0);
+  PointType            center{};
   PointType::ValueType scaleInit[3] = { 1, 1, 1 };
   PointType            scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -64,9 +64,7 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   ImagePointer imageZ = ImageType::New();
 
   ImageType::SizeType  size;
-  ImageType::IndexType start;
-
-  start.Fill(0);
+  ImageType::IndexType start{};
   size[0] = 10;
   size[1] = 10;
 

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
@@ -63,8 +63,7 @@ itkRegularSphereMeshSourceTest(int, char *[])
 
   MeshType::Pointer myMesh = mySphereMeshSource->GetOutput();
 
-  PointType pt;
-  pt.Fill(0);
+  PointType pt{};
 
   bool testPassed = true;
 

--- a/Modules/Core/Mesh/test/itkSimplexMeshToTriangleMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshToTriangleMeshFilterTest.cxx
@@ -41,9 +41,8 @@ itkSimplexMeshToTriangleMeshFilterTest(int, char *[])
 
   using TriangleFilterType = itk::SimplexMeshToTriangleMeshFilter<SimplexMeshType, TriangleMeshType>;
   using TriangleMeshPointer = TriangleMeshType::Pointer;
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(0);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  PointType            center{};
   PointType::ValueType scaleInit[3] = { 5, 5, 5 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
@@ -42,9 +42,8 @@ itkSimplexMeshVolumeCalculatorTest(int, char *[])
   // Declare the type of the gradient image
   using SimplexFilterType = itk::TriangleMeshToSimplexMeshFilter<TriangleMeshType, SimplexMeshType>;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(0);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  PointType            center{};
   PointType::ValueType scaleInit[3] = { 10, 10, 10 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
@@ -31,8 +31,7 @@ itkSphereMeshSourceTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(mySphereMeshSource, SphereMeshSource, MeshSource);
 
 
-  fPointType center;
-  center.Fill(0);
+  fPointType            center{};
   fPointType::ValueType scaleInit[3] = { 1, 1, 1 };
   fPointType            scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
@@ -76,9 +76,8 @@ itkTriangleMeshCurvatureCalculatorTest(int argc, char * argv[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(0);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  PointType            center{};
   PointType::ValueType scaleInit_1[Dimension] = { 5, 5, 5 };
   VectorType           scale = scaleInit_1;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilter2Test.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilter2Test.cxx
@@ -42,9 +42,8 @@ itkTriangleMeshToSimplexMeshFilter2Test(int, char *[])
   // Declare the type of the gradient image
   using SimplexFilterType = itk::TriangleMeshToSimplexMeshFilter<TriangleMeshType, SimplexMeshType>;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(0);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  PointType            center{};
   PointType::ValueType scaleInit[3] = { 10, 10, 10 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilterTest.cxx
@@ -40,9 +40,8 @@ itkTriangleMeshToSimplexMeshFilterTest(int, char *[])
   // declare the triangle to simplex mesh filter
   using SimplexFilterType = itk::TriangleMeshToSimplexMeshFilter<TriangleMeshType, SimplexMeshType>;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(0);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  PointType            center{};
   PointType::ValueType scaleInit[3] = { 5, 5, 5 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
@@ -50,8 +50,7 @@ itkArrowSpatialObjectTest(int, char *[])
   // Testing the direction of the arrow
   std::cout << "Testing direction : ";
 
-  ArrowType::VectorType direction;
-  direction.Fill(0);
+  ArrowType::VectorType direction{};
   direction[1] = 1.0;
 
   myArrow->SetDirectionInObjectSpace(direction);

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -111,8 +111,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
     return EXIT_FAILURE;
   }
 
-  TubeType::CovariantVectorType expectedDerivative;
-  expectedDerivative.Fill(0);
+  TubeType::CovariantVectorType expectedDerivative{};
 
   if (expectedDerivative != derivative)
   {
@@ -556,8 +555,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
     pOriginal.SetAlpha3(11.0);
 
     // itk::DTITubeSpatialObjectTest.cxx
-    itk::DiffusionTensor3D<float> tensor;
-    tensor.Fill(0);
+    itk::DiffusionTensor3D<float> tensor{};
     pOriginal.SetTensorMatrix(tensor);
 
     // Copy

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -44,16 +44,14 @@ itkImageMaskSpatialObjectTest3(int, char *[])
 
   auto                 image = ImageType::New();
   ImageType::SizeType  size = { { 5, 5, 5 } };
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType origin{};
   image->SetOrigin(origin);
 
   ImageType::SpacingType spacing;
   spacing.Fill(1);
   image->SetSpacing(spacing);
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::DirectionType direction;
   direction.Fill(0.0);

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -71,8 +71,7 @@ itkImageSpatialObjectTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(imageSO, ImageSpatialObject, SpatialObject);
 
 
-  typename ImageSpatialObject::IndexType sliceNumber;
-  sliceNumber.Fill(0);
+  typename ImageSpatialObject::IndexType sliceNumber{};
   imageSO->SetSliceNumber(sliceNumber);
   ITK_TEST_SET_GET_VALUE(sliceNumber, imageSO->GetSliceNumber());
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -142,8 +142,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   size3D[0] = 50;
   size3D[1] = 50;
   size3D[2] = 3;
-  IndexType start;
-  start.Fill(0);
+  IndexType  start{};
   RegionType region3D;
   region3D.SetIndex(start);
   region3D.SetSize(size3D);

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -122,8 +122,7 @@ itkTubeSpatialObjectTest(int, char *[])
     return EXIT_FAILURE;
   }
 
-  TubeType::CovariantVectorType expectedDerivative;
-  expectedDerivative.Fill(0);
+  TubeType::CovariantVectorType expectedDerivative{};
 
   if (expectedDerivative != derivative)
   {

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -566,8 +566,7 @@ RegressionTestHelper(const char *       testImageFilename,
     using ExtractType = itk::Testing::ExtractSliceImageFilter<OutputType, DiffOutputType>;
     using WriterType = itk::ImageFileWriter<DiffOutputType>;
     using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
-    OutputType::SizeType size;
-    size.Fill(0);
+    OutputType::SizeType size{};
 
     auto rescale = RescaleType::New();
     rescale->SetOutputMinimum(itk::NumericTraits<unsigned char>::NonpositiveMin());
@@ -578,8 +577,7 @@ RegressionTestHelper(const char *       testImageFilename,
 
     // Get the center slice of the image,  In 3D, the first slice
     // is often a black slice with little debugging information.
-    OutputType::IndexType index;
-    index.Fill(0);
+    OutputType::IndexType index{};
     for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; ++i)
     {
       index[i] = size[i] / 2; // NOTE: Integer Divide used to get approximately
@@ -914,8 +912,7 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
 
   // Get the center slice of the image,  In 3D, the first slice
   // is often a black slice with little debugging information.
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
   for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; ++i)
   {
     index[i] = size[i] / 2; // NOTE: Integer Divide used to get approximately

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -416,8 +416,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
     scale.Fill(2.5);
     transform->SetScale(scale);
 
-    TransformType::SkewVectorType skew;
-    skew.Fill(0);
+    TransformType::SkewVectorType skew{};
     skew[0] = 0.1;
     skew[1] = 0.1;
     transform->SetSkew(skew);

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -62,14 +62,12 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     ITK_EXERCISE_BASIC_OBJECT_METHODS(transform, Rigid3DPerspectiveTransform, Transform);
 
 
-    typename TransformType::OffsetType fixedOffset;
-    fixedOffset.Fill(0);
+    typename TransformType::OffsetType fixedOffset{};
 
     transform->SetFixedOffset(fixedOffset);
     ITK_TEST_SET_GET_VALUE(fixedOffset, transform->GetFixedOffset());
 
-    typename TransformType::InputPointType centerOfRotation;
-    centerOfRotation.Fill(0);
+    typename TransformType::InputPointType centerOfRotation{};
     transform->SetCenterOfRotation(centerOfRotation);
     ITK_TEST_SET_GET_VALUE(centerOfRotation, transform->GetCenterOfRotation());
 

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
@@ -51,8 +51,7 @@ itkTensorFractionalAnisotropyImageFilterTest(int, char *[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
@@ -51,8 +51,7 @@ itkTensorRelativeAnisotropyImageFilterTest(int, char *[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
@@ -56,8 +56,7 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
   field->SetRegions(region);
   field->Allocate();
 
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
 
   displacementTransform->SetConstantVelocityField(field);

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -66,8 +66,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   field->SetRegions(region);
   field->Allocate();
 
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
 
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -248,8 +248,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   field->SetRegions(region);
   field->Allocate();
 
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
 
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -57,8 +57,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   field->SetRegions(region);
   field->Allocate();
 
-  FieldType::PixelType zeroVector;
-  zeroVector.Fill(0);
+  FieldType::PixelType zeroVector{};
   field->FillBuffer(zeroVector);
 
   displacementTransform->SetConstantVelocityField(field);

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -52,8 +52,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   field->SetRegions(region);
   field->Allocate();
 
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
 
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -60,9 +60,8 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
   integrator->SetUpperTimeBound(0.75);
   integrator->Update();
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(0);
-  VectorType displacementPixel;
+  DisplacementFieldType::IndexType index{};
+  VectorType                       displacementPixel;
 
   // This integration should result in a constant image of value
   // 0.75 * 0.1 - 0.3 * 0.1 = 0.045 with ~epsilon deviation

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -107,9 +107,8 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
 
   integrator->Update();
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(0);
-  VectorType displacement;
+  DisplacementFieldType::IndexType index{};
+  VectorType                       displacement;
 
   auto inverseIntegrator = IntegratorType::New();
 
@@ -178,8 +177,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   size[1] = 3;
   size[2] = 401;
   size[3] = 61;
-  ImportFilterType::IndexType start;
-  start.Fill(0);
+  ImportFilterType::IndexType start{};
 
   ImportFilterType::RegionType region{ start, size };
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
@@ -64,9 +64,8 @@ itkTimeVaryingVelocityFieldTransformTest(int, char *[])
 
   integrator->Print(std::cout, 3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(0);
-  VectorType displacementPixel;
+  DisplacementFieldType::IndexType index{};
+  VectorType                       displacementPixel;
 
   // This integration should result in a constant image of value
   // 0.75 * 0.1 - 0.3 * 0.1 = 0.045 with ~epsilon deviation

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
@@ -73,8 +73,7 @@ itkTransformToDisplacementFieldFilterTest(int argc, char * argv[])
   // Create output information.
   SizeType size;
   size.Fill(20);
-  IndexType index;
-  index.Fill(0);
+  IndexType   index{};
   SpacingType spacing;
   spacing.Fill(0.7);
   OriginType origin;

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -74,8 +74,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   // Create input image.
   SizeType size;
   size.Fill(24);
-  IndexType index;
-  index.Fill(0);
+  IndexType   index{};
   SpacingType spacing;
   spacing[0] = 1.1;
   spacing[1] = 2.2;
@@ -134,8 +133,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   }
 
   // Set Output information.
-  IndexType outputIndex;
-  outputIndex.Fill(0);
+  IndexType   outputIndex{};
   SpacingType outputSpacing;
   SizeType    outputSize;
   outputSize.Fill(24);

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -69,8 +69,7 @@ FastChamferDistanceImageFilterTest(unsigned int iPositive, unsigned int iNegativ
 
   typename ImageType::SizeType size;
   size.Fill(32);
-  typename ImageType::IndexType index;
-  index.Fill(0);
+  typename ImageType::IndexType  index{};
   typename ImageType::RegionType region{ index, size };
 
   auto inputImage = ImageType::New();

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
@@ -37,8 +37,7 @@ itkReflectiveImageRegionIteratorTest(int, char *[])
 
   ImageType::SizeType size = { { 4, 4, 4, 4 } };
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::RegionType region{ start, size };
 

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -55,8 +55,7 @@ test(int testIdx)
   myImageType2D1::SizeType size2D;
   size2D.Fill(9);
 
-  myImageType2D1::IndexType index2D;
-  index2D.Fill(0);
+  myImageType2D1::IndexType index2D{};
 
   myImageType2D1::RegionType region2D{ index2D, size2D };
 

--- a/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
@@ -87,8 +87,7 @@ itkHalfToFullHermitianImageFilterTest(int argc, char * argv[])
   }
 
   // Test that the full image has the Hermitian property.
-  ComplexImageType::IndexType conjugateRegionIndex;
-  conjugateRegionIndex.Fill(0);
+  ComplexImageType::IndexType conjugateRegionIndex{};
   conjugateRegionIndex[0] = static_cast<ComplexImageType::IndexValueType>(fftSize[0]) + indexShift[0];
   conjugateRegionIndex[1] = indexShift[1];
   ComplexImageType::SizeType conjugateRegionSize(size);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -159,8 +159,7 @@ itkFastMarchingBaseTest(int argc, char * argv[])
     typename ImageFastMarching::NodePairType node_pair;
     ImageType::OffsetType                    offset = { { 28, 35 } };
 
-    itk::Index<Dimension> index;
-    index.Fill(0);
+    itk::Index<Dimension> index{};
 
     node_pair.SetValue(0.0);
     node_pair.SetNode(index + offset);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -76,8 +76,7 @@ itkFastMarchingExtensionImageFilterTest(int, char *[])
 
   FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   AlivePoints->push_back(NodePairType(index + offset0, 0.));
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -86,8 +86,7 @@ itkFastMarchingImageFilterRealTest1(int itkNotUsed(argc), char * itkNotUsed(argv
 
   FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<Dimension> index;
-  index.Fill(0);
+  itk::Index<Dimension> index{};
 
   node_pair.SetValue(0.0);
   node_pair.SetNode(index + offset0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -94,8 +94,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
 
   FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<Dimension> index;
-  index.Fill(0);
+  itk::Index<Dimension> index{};
   index += offset0;
 
   aliveImage->SetPixel(index, 1.0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -55,8 +55,7 @@ itkFastMarchingImageFilterRealWithNumberOfElementsTest(int, char *[])
 
   FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   node_pair.SetValue(0.0);
   node_pair.SetNode(index + offset0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -80,8 +80,7 @@ itkFastMarchingTest(int argc, char * argv[])
 
   FloatImage::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   node.SetValue(0.0);
   node.SetIndex(index + offset0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -68,8 +68,7 @@ itkFastMarchingTest2(int, char *[])
 
   FloatImage::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   node.SetValue(0.0);
   node.SetIndex(index + offset0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -81,8 +81,7 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
 
   FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   AlivePoints->push_back(NodePairType(index + offset0, 0.));
   AlivePoints->push_back(NodePairType(index + offset0, 42.));

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -72,8 +72,7 @@ itkFastMarchingUpwindGradientTest(int, char *[])
 
   FloatImage::OffsetType offset0 = { { 28, 35 } };
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index<2> index{};
 
   node.SetValue(0.0);
   node.SetIndex(index + offset0);

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
@@ -45,8 +45,7 @@ itkCompose2DCovariantVectorImageFilterTest(int, char *[])
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
@@ -45,8 +45,7 @@ itkCompose2DVectorImageFilterTest(int, char *[])
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
@@ -47,8 +47,7 @@ itkCompose3DCovariantVectorImageFilterTest(int, char *[])
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
@@ -46,8 +46,7 @@ itkCompose3DVectorImageFilterTest(int, char *[])
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
@@ -47,8 +47,7 @@ itkComposeRGBImageFilterTest(int, char *[])
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
@@ -61,8 +61,7 @@ itkGradientVectorFlowImageFilterTest(int, char *[])
   size[0] = 128;
   size[1] = 128;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -57,8 +57,7 @@ itkHessian3DToVesselnessMeasureImageFilterTest(int argc, char * argv[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -42,8 +42,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
   size.Fill(21);
   size[0] = 401;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
@@ -54,8 +54,7 @@ itkHessianRecursiveGaussianFilterTest(int argc, char * argv[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -319,8 +319,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   ImageType::SizeType size;
   size.Fill(100);
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -143,8 +143,7 @@ itkHoughTransform2DLinesImageTest(int, char *[])
   ImageType::SizeType size;
   size.Fill(100);
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
@@ -49,8 +49,7 @@ itkUnsharpMaskImageFilterTestSimple(int, char *[])
   size[0] = 20;
   size[1] = 4;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -191,8 +191,7 @@ TEST(UnaryGeneratorImageFilter, SetFunctor)
 
   Utils::ImageType::Pointer outputImage;
 
-  Utils::IndexType idx;
-  idx.Fill(0);
+  Utils::IndexType idx{};
 
   // Test with C style function pointer
   filter->SetFunctor(static_cast<ValueFunctionType *>(std::cos));
@@ -261,8 +260,7 @@ TEST(BinaryGeneratorImageFilter, SetFunctor)
 
   Utils::ImageType::Pointer outputImage;
 
-  Utils::IndexType idx;
-  idx.Fill(0);
+  Utils::IndexType idx{};
 
   // Test with C style function pointer
   filter->SetFunctor(Utils::MyBinaryFunction1);
@@ -336,8 +334,7 @@ TEST(TernaryGeneratorImageFilter, SetFunctor)
 
   Utils::ImageType::Pointer outputImage;
 
-  Utils::IndexType idx;
-  idx.Fill(0);
+  Utils::IndexType idx{};
 
   // Test with C style function pointer
   filter->SetFunctor(Utils::MyTernaryFunction1);
@@ -404,8 +401,7 @@ TEST(TernaryGeneratorImageFilter, Constants)
 
   Utils::ImageType::Pointer outputImage;
 
-  Utils::IndexType idx;
-  idx.Fill(0);
+  Utils::IndexType idx{};
 
   // Test with C style function pointer
   filter->SetFunctor(Utils::MyTernaryFunction1);

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -40,8 +40,7 @@ public:
     typename ImageType::SizeType size;
     size.Fill(inputImageSize);
 
-    typename ImageType::IndexType start;
-    start.Fill(0);
+    typename ImageType::IndexType start{};
 
     typename ImageType::RegionType region{ start, size };
 
@@ -200,8 +199,7 @@ public:
       }
     }
 
-    IndexType zero_freq_index;
-    zero_freq_index.Fill(0);
+    IndexType zero_freq_index{};
     it.GoToBegin();
 
     if (it.GetIndex() == m_Image->GetLargestPossibleRegion().GetIndex() && it.GetFrequencyBin() != zero_freq_index)

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -64,8 +64,7 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   mySizeType size;
   size.Fill(8);
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -59,8 +59,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
   size[1] = imageSize;
   size[2] = imageSize;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -56,8 +56,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
@@ -49,8 +49,7 @@ itkGradientRecursiveGaussianFilterTest2(int, char *[])
   mySizeType size;
   size[0] = 64;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -64,8 +64,7 @@ itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   my
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -47,9 +47,8 @@ BSpline(int argc, char * argv[])
 
   // Reconstruction of the scalar field from the control points
 
-  typename ScalarFieldType::PointType origin;
-  origin.Fill(0);
-  typename ScalarFieldType::SizeType size;
+  typename ScalarFieldType::PointType origin{};
+  typename ScalarFieldType::SizeType  size;
   size.Fill(100);
   typename ScalarFieldType::SpacingType spacing;
   spacing.Fill(1.0);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
@@ -49,8 +49,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
 
   VectorImageType::SizeType size;
   size.Fill(100);
-  VectorImageType::PointType origin;
-  origin.Fill(0);
+  VectorImageType::PointType   origin{};
   VectorImageType::SpacingType spacing;
   spacing.Fill(1);
   VectorImageType::DirectionType direction;
@@ -164,8 +163,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
   ncps.Fill(4);
   filter->SetNumberOfControlPoints(ncps);
   filter->SetNumberOfLevels(3);
-  FilterType::ArrayType close;
-  close.Fill(0);
+  FilterType::ArrayType close{};
   filter->SetCloseDimension(close);
 
 

--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -66,8 +66,7 @@ itkConstantPadImageTest(int, char *[])
   float constant = 13.3f;
   constantPad->SetConstant(constant);
   // check the method using the SizeType rather than the simple table type.
-  ShortImage::SizeType stfactors;
-  stfactors.Fill(0);
+  ShortImage::SizeType stfactors{};
   constantPad->SetPadLowerBound(stfactors);
   constantPad->SetPadUpperBound(stfactors);
   constantPad->SetPadBound(stfactors);

--- a/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
@@ -46,8 +46,7 @@ itkRegionOfInterestImageFilterTest(int, char *[])
 
   auto image = ImageType::New();
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   SizeType size;
   size[0] = 40;

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -77,8 +77,7 @@ itkImageAdaptorNthElementTest(int, char *[])
   size[1] = 2;
   size[2] = 2; // Small size, because we are printing it
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
 
   myRegionType region{ start, size };

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
@@ -38,8 +38,7 @@ itkIntensityWindowingImageFilterTest(int, char *[])
   TestInputImage::SizeType size;
   size.Fill(64);
 
-  TestInputImage::IndexType index;
-  index.Fill(0);
+  TestInputImage::IndexType index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkMatrixIndexSelectionImageFilterTest(int argc, char * argv[])
   InputImageType::SizeType size;
   size.Fill(100);
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -35,8 +35,7 @@ InitializeImage(ImageType * image, const typename ImageType::PixelType & value)
   typename ImageType::SizeType size;
   size.Fill(2);
 
-  typename ImageType::IndexType start;
-  start.Fill(0);
+  typename ImageType::IndexType start{};
 
   typename ImageType::RegionType region{ start, size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
@@ -64,8 +64,7 @@ InitializeImage(InputImageType * image, double value)
   size[1] = 2;
   size[2] = 2;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region;
   region.SetIndex(start);

--- a/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
@@ -43,8 +43,7 @@ itkRescaleIntensityImageFilterTest(int, char *[])
   TestInputImage::SizeType size;
   size.Fill(64);
 
-  TestInputImage::IndexType index;
-  index.Fill(0);
+  TestInputImage::IndexType index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -37,8 +37,7 @@ itkShiftScaleImageFilterTest(int, char *[])
   TestInputImage::RegionType region;
   TestInputImage::SizeType   size;
   size.Fill(64);
-  TestInputImage::IndexType index;
-  index.Fill(0);
+  TestInputImage::IndexType index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -119,8 +119,7 @@ public:
     size[1] = 8;
     size[2] = 8;
 
-    IndexType start;
-    start.Fill(0);
+    IndexType start{};
 
     RegionType region;
     region.SetIndex(start);
@@ -227,8 +226,7 @@ public:
     size[1] = 8;
     size[2] = 8;
 
-    IndexType start;
-    start.Fill(0);
+    IndexType start{};
 
     RegionType region;
     region.SetIndex(start);

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
@@ -67,9 +67,8 @@ itkTernaryOperatorImageFilterTest(int, char *[])
   using MaskImageType = itk::Image<MaskPixelType, ImageDimension>;
   using GrayImageType = itk::Image<GrayPixelType, ImageDimension>;
 
-  MaskImageType::IndexType origin;
-  origin.Fill(0);
-  MaskImageType::SizeType size;
+  MaskImageType::IndexType origin{};
+  MaskImageType::SizeType  size;
   size.Fill(20);
   MaskImageType::RegionType region(origin, size);
 

--- a/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
@@ -34,8 +34,7 @@ itkVectorMagnitudeImageFilterTest(int, char *[])
   VectorImageType::SizeType size;
   size.Fill(3);
 
-  VectorImageType::IndexType start;
-  start.Fill(0);
+  VectorImageType::IndexType start{};
 
   VectorImageType::RegionType region(start, size);
 

--- a/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
@@ -79,9 +79,8 @@ itkGaussianImageSourceTest(int argc, char * argv[])
 
   // Test SetReferenceImage from GenerateImageSource base class.
   auto                 referenceImage = ImageType::New();
-  ImageType::IndexType startIndex;
-  startIndex.Fill(0);
-  ImageType::SizeType referenceSize;
+  ImageType::IndexType startIndex{};
+  ImageType::SizeType  referenceSize;
   referenceSize.SetSize(size);
   ImageType::RegionType region(startIndex, referenceSize);
   referenceImage->SetRegions(region);

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -77,8 +77,7 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
@@ -69,8 +69,7 @@ itkImagePCAShapeModelEstimatorTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkStatisticsImageFilterTest(int argc, char * argv[])
   FloatImage::RegionType region;
   FloatImage::SizeType   size;
   size.Fill(64);
-  FloatImage::IndexType index;
-  index.Fill(0);
+  FloatImage::IndexType index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
@@ -31,8 +31,7 @@ SEToFile(const TSEType & e, const std::string & fname)
 
   auto img = ImageType::New();
 
-  typename ImageType::IndexType start;
-  start.Fill(0);
+  typename ImageType::IndexType start{};
 
   typename ImageType::SizeType size;
   for (unsigned int i = 0; i < Dimension; ++i)

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
@@ -59,8 +59,7 @@ itkOpeningByReconstructionImageFilterTest2(int argc, char * argv[])
   RegionType region;
   SizeType   size;
   size.Fill(std::stoi(argv[2]));
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
   region.SetSize(size);
   region.SetIndex(index);
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -22,8 +22,7 @@ using LocalImageType = itk::Image<int, 2>;
 void
 CreateImagex(LocalImageType::Pointer & image)
 {
-  LocalImageType::IndexType start;
-  start.Fill(0);
+  LocalImageType::IndexType start{};
 
   LocalImageType::SizeType size;
   size.Fill(10);

--- a/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
@@ -98,8 +98,7 @@ itkPolyLineParametricPathTest(int, char *[])
   path2->AddVertex(v);
   PathType::InputType path2Input = path2->StartOfInput();
 
-  PathType::OffsetType zeroOffset;
-  zeroOffset.Fill(0);
+  PathType::OffsetType zeroOffset{};
 
   std::cout << "Starting degenerate path test" << std::endl;
   while (true)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
@@ -55,8 +55,7 @@ itkBinaryMask3DQuadEdgeMeshSourceTest(int, char *[])
   size[1] = 128;
   size[2] = 128;
 
-  IndexType start;
-  start.Fill(0);
+  IndexType start{};
 
   RegionType region{ start, size };
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
@@ -51,8 +51,7 @@ itkRecursiveGaussianImageFilterOnTensorsTest(int, char *[])
   // Create the 9x9 input image
   ImageType::SizeType size;
   size.Fill(9);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   auto                  inputImage = ImageType::New();
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -49,8 +49,7 @@ itkRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   // Create the 9x9 input image
   ImageType::SizeType size;
   size.Fill(9);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   auto                  inputImage = ImageType::New();
   inputImage->SetRegions(region);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -58,8 +58,7 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
     size[1] = 100;
     size[2] = 100;
 
-    myIndexType start;
-    start.Fill(0);
+    myIndexType start{};
 
     myRegionType region{ start, size };
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
@@ -56,8 +56,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest(int, char *[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
@@ -53,8 +53,7 @@ itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest(int, char *[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -51,8 +51,7 @@ itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   size[1] = 8;
   size[2] = 8;
 
-  myIndexType start;
-  start.Fill(0);
+  myIndexType start{};
 
   myRegionType region{ start, size };
 

--- a/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
@@ -167,8 +167,7 @@ itkThresholdImageFilterTest(int, char *[])
     PixelType outsideValue = 99;
     threshold->SetOutsideValue(outsideValue);
     ITK_TEST_SET_GET_VALUE(outsideValue, threshold->GetOutsideValue());
-    IntImage1DType::IndexType index;
-    index.Fill(0);
+    IntImage1DType::IndexType index{};
 
     PixelType lower = itk::NumericTraits<PixelType>::NonpositiveMin();
     threshold->SetLower(lower);

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -39,8 +39,7 @@ itkMatrixImageWriteReadTest(int argc, char * argv[])
   MatrixImageType::SizeType size;
   size.Fill(10);
 
-  MatrixImageType::IndexType start;
-  start.Fill(0);
+  MatrixImageType::IndexType start{};
 
   MatrixImageType::RegionType region{ start, size };
 

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -40,8 +40,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
 
   ImageType::SizeType size;
   size.Fill(16);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);
   inputImage->Allocate();

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -62,8 +62,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   // Create the 9x9 input image
   ImageType::SizeType size;
   size.Fill(9);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);
   inputImage->Allocate();

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -49,8 +49,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   Mesh2dType::PointType point2d;
   point2d.Fill(1);
 
-  Mesh2dType::PixelType pixel2d;
-  pixel2d.Fill(0);
+  Mesh2dType::PixelType pixel2d{};
 
   auto mesh2d = Mesh2dType::New();
   mesh2d->SetPoint(0, point2d);
@@ -91,8 +90,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   Mesh3dType::PointType point3d;
   point3d.Fill(1);
 
-  Mesh3dType::PixelType pixel3d;
-  pixel3d.Fill(0);
+  Mesh3dType::PixelType pixel3d{};
 
   auto mesh3d = Mesh3dType::New();
   mesh3d->SetPoint(0, point3d);

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -172,8 +172,7 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   ImageType3D::SizeType size3D;
   size3D.Fill(10);
-  ImageType3D::IndexType start3D;
-  start3D.Fill(0);
+  ImageType3D::IndexType  start3D{};
   ImageType3D::RegionType region3D{ start3D, size3D };
 
   volume->SetRegions(region3D);
@@ -216,8 +215,7 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   ImageType2D::SizeType size2D;
   size2D.Fill(10);
-  ImageType2D::IndexType start2D;
-  start2D.Fill(0);
+  ImageType2D::IndexType  start2D{};
   ImageType2D::RegionType region2D{ start2D, size2D };
 
   image->SetRegions(region2D);
@@ -259,8 +257,7 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   ImageType1D::SizeType size1D;
   size1D.Fill(10);
-  ImageType1D::IndexType start1D;
-  start1D.Fill(0);
+  ImageType1D::IndexType  start1D{};
   ImageType1D::RegionType region1D{ start1D, size1D };
   line->SetRegions(region1D);
 

--- a/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
@@ -53,8 +53,7 @@ itkRawImageIOTest3(int argc, char * argv[])
   size[1] = 293;
 
   ImageType::RegionType region;
-  ImageType::IndexType  index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
@@ -42,9 +42,7 @@ public:
 
     typename ImageType::RegionType region;
     typename ImageType::SizeType   size;
-    typename ImageType::IndexType  start;
-
-    start.Fill(0);
+    typename ImageType::IndexType  start{};
     size[0] = 16; // To fill the range of 8 bits image
     size[1] = 16;
 

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -272,8 +272,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
   RegionType region;
   region.SetSize(size);
-  itk::Index<3> zeroIndex;
-  zeroIndex.Fill(0);
+  itk::Index<3> zeroIndex{};
   region.SetIndex(zeroIndex);
   itkImage->SetRegions(region);
   itkImage->SetSpacing(spacing);

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -52,8 +52,7 @@ ReadWriteTest(const std::string fileName, const bool isRealDisplacementField, co
     constexpr int                dimLength = 20;
     typename FieldType::SizeType size;
     size.Fill(dimLength);
-    typename FieldType::IndexType start;
-    start.Fill(0);
+    typename FieldType::IndexType  start{};
     typename FieldType::RegionType region{ start, size };
     knownField->SetRegions(region);
 

--- a/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
@@ -100,8 +100,7 @@ itkReleaseDataFilterTest(int, char *[])
   streamer->SetNumberOfStreamDivisions(4);
 
 
-  ImageType::SizeType zeroSize;
-  zeroSize.Fill(0);
+  ImageType::SizeType zeroSize{};
 
 
   std::cout << "---- Updating \"a\" Pipeline ---" << std::endl;

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -60,8 +60,7 @@ class EigenAnalysis2DImageFilterTester
     mySizeType size;
     size.Fill(2);
 
-    myIndexType start;
-    start.Fill(0);
+    myIndexType start{};
 
     myRegionType region{ start, size };
 

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -293,8 +293,7 @@ itkRegistrationParameterScalesFromPhysicalShiftPointSetTest(int, char *[])
   using RegionType = itk::ImageRegion<Dimension>;
   RegionType region;
   region.SetSize(virtualDomainSize);
-  RegionType::IndexType index;
-  index.Fill(0);
+  RegionType::IndexType index{};
   region.SetIndex(index);
 
   auto field = FieldType::New();

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
@@ -39,8 +39,7 @@ itkCovarianceSampleFilterTest(int, char *[])
   auto                  image = ImageType::New();
   ImageType::RegionType region;
   ImageType::SizeType   size;
-  ImageType::IndexType  index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   size.Fill(5);
   region.SetIndex(index);
   region.SetSize(size);
@@ -53,8 +52,7 @@ itkCovarianceSampleFilterTest(int, char *[])
   ImageIterator iter(image, region);
 
   unsigned int          count = 0;
-  MeasurementVectorType temp;
-  temp.Fill(0);
+  MeasurementVectorType temp{};
 
   // fill the image
   while (!iter.IsAtEnd())

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -51,8 +51,7 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   auto     inImage = FloatImage::New();
   SizeType sz;
   sz.Fill(35);
-  IndexType idx;
-  idx.Fill(0);
+  IndexType  idx{};
   RegionType region{ idx, sz };
 
   inImage->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -40,8 +40,7 @@ itkScalarImageToCooccurrenceListSampleFilterTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -44,8 +44,7 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -46,8 +46,7 @@ itkScalarImageToCooccurrenceMatrixFilterTest2(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -43,8 +43,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
@@ -51,8 +51,7 @@ itkScalarImageToRunLengthMatrixFilterTest(int, char *[])
 
   region.SetSize(inputImageSize);
   {
-    InputImageType::IndexType index;
-    index.Fill(0);
+    InputImageType::IndexType index{};
     region.SetIndex(index);
   }
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -46,8 +46,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
 
   InputImageType::SizeType inputImageSize = { { IMGWIDTH, IMGHEIGHT } };
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType  index{};
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -77,8 +77,7 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   auto     inImage = ImageType::New();
   SizeType sz;
   sz.Fill(25);
-  IndexType idx;
-  idx.Fill(0);
+  IndexType  idx{};
   RegionType region{ idx, sz };
 
   inImage->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
@@ -40,8 +40,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
   auto                  image = ImageType::New();
   ImageType::RegionType region;
   ImageType::SizeType   size;
-  ImageType::IndexType  index;
-  index.Fill(0);
+  ImageType::IndexType  index{};
   size.Fill(5);
   region.SetIndex(index);
   region.SetSize(size);
@@ -54,8 +53,7 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
   ImageIterator iter(image, region);
 
   unsigned int          count = 0;
-  MeasurementVectorType temp;
-  temp.Fill(0);
+  MeasurementVectorType temp{};
 
   // fill the image
   while (!iter.IsAtEnd())

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -111,8 +111,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   ImageType::SizeType size;
   size.Fill(5);
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::RegionType region{ index, size };
 

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -53,8 +53,7 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   typename SizeType::value_type regionSizeVal = 35;
   SizeType                      sz;
   sz.Fill(regionSizeVal);
-  IndexType idx;
-  idx.Fill(0);
+  IndexType  idx{};
   RegionType region{ idx, sz };
 
   inImage->SetRegions(region);

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -53,8 +53,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   displacementField->SetDirection(direction);
   displacementField->Allocate();
 
-  TransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
 

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -54,8 +54,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   displacementField->SetDirection(direction);
   displacementField->Allocate();
 
-  TransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
 

--- a/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -53,8 +53,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
   displacementField->SetDirection(direction);
   displacementField->Allocate();
 
-  TransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
   TransformType::OutputVectorType nonzeroVector;

--- a/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -54,8 +54,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   displacementField->SetDirection(direction);
   displacementField->Allocate();
 
-  TransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
 

--- a/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -54,8 +54,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
   displacementField->SetDirection(direction);
   displacementField->Allocate();
 
-  TransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
 

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -382,8 +382,7 @@ itkFEMFiniteDifferenceFunctionLoadTest(int argc, char * argv[])
   SizeType size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -102,8 +102,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
   SizeType size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -103,8 +103,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
   SizeType size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -115,8 +115,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
   SizeType size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -134,8 +134,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -153,13 +153,11 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
@@ -145,8 +145,7 @@ itkANTSNeighborhoodCorrelationImageToImageRegistrationTest(int argc, char * argv
             << "fixedImage->GetBufferedRegion(): " << fixedImage->GetBufferedRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -130,13 +130,11 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -177,8 +177,7 @@ itkDemonsImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -38,13 +38,11 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 
@@ -100,8 +98,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   field->SetRegions(fixedImage->GetLargestPossibleRegion());
   field->CopyInformation(fixedImage);
   field->Allocate();
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   displacementTransform->SetDisplacementField(field);
   displacementTransform->SetGaussianSmoothingVarianceForTheUpdateField(5);

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -271,8 +271,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
   RegionType::SizeType regionSize;
   regionSize.Fill(static_cast<itk::SizeValueType>(pointMax) + 1);
 
-  RegionType::IndexType regionIndex;
-  regionIndex.Fill(0);
+  RegionType::IndexType regionIndex{};
 
   RegionType region{ regionIndex, regionSize };
 

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -116,8 +116,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   typename RegionType::SizeType regionSize;
   regionSize.Fill(static_cast<itk::SizeValueType>(pointMax + 1.0));
 
-  typename RegionType::IndexType regionIndex;
-  regionIndex.Fill(0);
+  typename RegionType::IndexType regionIndex{};
 
   RegionType region{ regionIndex, regionSize };
 
@@ -127,8 +126,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   displacementField->SetSpacing(spacing);
   displacementField->SetRegions(region);
   displacementField->Allocate();
-  typename DisplacementFieldTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  typename DisplacementFieldTransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
   displacementTransform->SetDisplacementField(displacementField);
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -391,8 +391,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   ImageToImageMetricv4TestImageType::RegionType  region{ index, size };
   ImageToImageMetricv4TestImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageToImageMetricv4TestImageType::PointType origin;
-  origin.Fill(0);
+  ImageToImageMetricv4TestImageType::PointType     origin{};
   ImageToImageMetricv4TestImageType::DirectionType direction;
   direction.SetIdentity();
 
@@ -566,8 +565,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   field->SetRegions(defregion);
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);
@@ -687,8 +685,7 @@ itkImageToImageMetricv4Test(int, char ** const)
             << std::endl;
   std::cout << "MetricCategory: " << metric->GetMetricCategory() << std::endl;
 
-  typename ImageToImageMetricv4TestMetricType::DerivativeType derivative;
-  derivative.Fill(0);
+  typename ImageToImageMetricv4TestMetricType::DerivativeType derivative{};
   metric->GetDerivative(derivative);
   std::cout << "Derivative: " << derivative << std::endl;
 

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -38,13 +38,11 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -223,8 +223,7 @@ itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, char * 
   std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
@@ -127,8 +127,7 @@ itkMattesMutualInformationImageToImageMetricv4RegistrationTest(int argc, char * 
   std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -40,13 +40,11 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -36,13 +36,11 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType
 
   typename ImageType::SizeType size;
   size.Fill(imageSize);
-  typename ImageType::IndexType index;
-  index.Fill(0);
+  typename ImageType::IndexType   index{};
   typename ImageType::RegionType  region{ index, size };
   typename ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  typename ImageType::PointType origin;
-  origin.Fill(0);
+  typename ImageType::PointType     origin{};
   typename ImageType::DirectionType direction;
   direction.SetIdentity();
 
@@ -153,8 +151,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2(int, char ** const)
     itk::MeanSquaresImageToImageMetricv4<VectorImageType, VectorImageType, VectorImageType, double, MetricTraitsType>;
 
   VectorMetricType::MeasureType    vectorMeasure = 0.0;
-  VectorMetricType::DerivativeType vectorDerivative;
-  vectorDerivative.Fill(0);
+  VectorMetricType::DerivativeType vectorDerivative{};
 
   itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<VectorMetricType>(vectorMeasure, vectorDerivative);
   std::cout << "vectorMeasure: " << vectorMeasure << " vectorDerivative: " << vectorDerivative << std::endl;
@@ -164,8 +161,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2(int, char ** const)
   using ScalarMetricType = itk::MeanSquaresImageToImageMetricv4<ScalarImageType, ScalarImageType, ScalarImageType>;
 
   ScalarMetricType::MeasureType    scalarMeasure = 0.0;
-  ScalarMetricType::DerivativeType scalarDerivative;
-  scalarDerivative.Fill(0);
+  ScalarMetricType::DerivativeType scalarDerivative{};
 
   itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<ScalarMetricType>(scalarMeasure, scalarDerivative);
   std::cout << "scalarMeasure: " << scalarMeasure << " scalarDerivative: " << scalarDerivative << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -124,8 +124,7 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -41,13 +41,11 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -36,13 +36,11 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
 
   ImageType::SizeType size;
   size.Fill(imageSize);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  ImageType::PointType origin;
-  origin.Fill(0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -128,8 +128,7 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -211,8 +211,7 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
 
   typename ImageType::SizeType size;
   size.Fill(imageSize);
-  typename ImageType::IndexType virtualIndex;
-  virtualIndex.Fill(0);
+  typename ImageType::IndexType   virtualIndex{};
   typename ImageType::RegionType  region{ virtualIndex, size };
   typename ImageType::SpacingType spacing;
   spacing.Fill(1.0);

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -216,8 +216,7 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
 
   // create images
   ImageType::Pointer    fixedImage = nullptr, movingImage = nullptr;
-  ImageType::OffsetType imageShift;
-  imageShift.Fill(0);
+  ImageType::OffsetType imageShift{};
   ObjectToObjectMultiMetricv4RegistrationTestCreateImages<ImageType>(fixedImage, movingImage, imageShift);
 
   using CorrelationMetricType = itk::CorrelationImageToImageMetricv4<ImageType, ImageType>;
@@ -231,8 +230,7 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
 
   std::cout << std::endl << "*** Single image metric: " << std::endl;
   CorrelationMetricType::MeasureType    singleValueResult = 0.0;
-  CorrelationMetricType::DerivativeType singleDerivativeResult;
-  singleDerivativeResult.Fill(0);
+  CorrelationMetricType::DerivativeType singleDerivativeResult{};
   ObjectToObjectMultiMetricv4RegistrationTestRun<CorrelationMetricType>(
     correlationMetric, numberOfIterations, singleValueResult, singleDerivativeResult, 1.0, true);
 
@@ -252,8 +250,7 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
   translationTransform->SetIdentity();
 
   CorrelationMetricType::MeasureType    multiValueResult = 0.0;
-  CorrelationMetricType::DerivativeType multiDerivativeResult;
-  multiDerivativeResult.Fill(0);
+  CorrelationMetricType::DerivativeType multiDerivativeResult{};
   ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
     multiMetric, numberOfIterations, multiValueResult, multiDerivativeResult, 1.0, true);
 

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -125,8 +125,7 @@ itkCurvatureRegistrationFilterTest(int, char *[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -124,8 +124,7 @@ itkDemonsRegistrationFilterTest(int, char *[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -136,8 +136,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -123,8 +123,7 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -139,8 +139,7 @@ itkLevelSetMotionRegistrationFilterTest(int argc, char * argv[])
   SizeType                 size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -169,8 +169,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   size.Fill(256);
   size[1] = 251;
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
   index[0] = 3;
 
   RegionType region{ index, size };

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -116,8 +116,7 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   SizeType                      size;
   size.SetSize(sizeArray);
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   RegionType region{ index, size };
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -118,8 +118,7 @@ itkQuasiNewtonOptimizerv4RegistrationTestMain(int argc, char * argv[])
             << "fixedImage->GetBufferedRegion(): " << fixedImage->GetBufferedRegion() << std::endl;
   field->Allocate();
   // Fill it with 0's
-  typename DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(0);
+  typename DisplacementTransformType::OutputVectorType zeroVector{};
   field->FillBuffer(zeroVector);
   // Assign to transform
   displacementTransform->SetDisplacementField(field);

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -66,8 +66,7 @@ itkKmeansModelEstimatorTest(int, char *[])
 
   VecImageType::SizeType vecImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  VecImageType::IndexType index;
-  index.Fill(0);
+  VecImageType::IndexType  index{};
   VecImageType::RegionType region;
 
   region.SetSize(vecImgSize);

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -71,8 +71,7 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   VecImageType::SizeType vecImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  VecImageType::IndexType index;
-  index.Fill(0);
+  VecImageType::IndexType  index{};
   VecImageType::RegionType region;
 
   region.SetSize(vecImgSize);
@@ -177,8 +176,7 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   ClassImageType::SizeType classImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  ClassImageType::IndexType classindex;
-  classindex.Fill(0);
+  ClassImageType::IndexType classindex{};
 
   ClassImageType::RegionType classregion;
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -42,9 +42,8 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   using OutputImageType = itk::Image<PixelType, Dimension>;
   using IndexType = typename InputImageType::IndexType;
 
-  auto      inputimg = InputImageType::New();
-  IndexType index;
-  index.Fill(0);
+  auto                                inputimg = InputImageType::New();
+  IndexType                           index{};
   typename InputImageType::RegionType region;
 
   typename InputImageType::SizeType size;

--- a/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
@@ -52,8 +52,7 @@ itkVectorConnectedComponentImageFilterTest(int argc, char * argv[])
   ImageType::RegionType region;
   ImageType::SizeType   size;
   size.Fill(100);
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -122,8 +122,7 @@ test_RegionGrowKLMExceptionHandling()
   ImageType5D::SizeType imageSize5D;
   imageSize5D.Fill(sizeLen);
 
-  ImageType5D::IndexType index5D;
-  index5D.Fill(0);
+  ImageType5D::IndexType index5D{};
 
   ImageType5D::RegionType region5D;
 
@@ -241,8 +240,7 @@ test_regiongrowKLM1D()
   ImageType::SizeType imageSize;
   imageSize.Fill(numPixels);
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::RegionType region{ index, imageSize };
 
@@ -825,8 +823,7 @@ test_regiongrowKLM2D()
   imageSize[1] = 20;
   unsigned int numPixels = 200;
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::RegionType region{ index, imageSize };
 
@@ -1276,8 +1273,7 @@ test_regiongrowKLM3D()
   imageSize[2] = 3;
   unsigned int numPixels = 10 * 20 * 3;
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::RegionType region{ index, imageSize };
 
@@ -1779,8 +1775,7 @@ test_regiongrowKLM4D()
   imageSize[3] = 7 * multVal;
   unsigned int numPixels = imageSize[0] * imageSize[1] * imageSize[2] * imageSize[3];
 
-  ImageType::IndexType index;
-  index.Fill(0);
+  ImageType::IndexType index{};
 
   ImageType::RegionType region{ index, imageSize };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -48,8 +48,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -53,8 +53,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -65,8 +65,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -74,8 +74,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -77,8 +77,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -72,8 +72,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -71,8 +71,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -65,8 +65,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -71,8 +71,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -79,8 +79,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -78,8 +78,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -79,8 +79,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -79,8 +79,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -79,8 +79,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  InputImageType::IndexType index;
-  index.Fill(0);
+  InputImageType::IndexType index{};
 
   InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -52,8 +52,7 @@ itkMRFImageFilterTest(int, char *[])
 
   VecImageType::SizeType vecImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  VecImageType::IndexType index;
-  index.Fill(0);
+  VecImageType::IndexType index{};
 
   VecImageType::RegionType region;
 
@@ -219,8 +218,7 @@ itkMRFImageFilterTest(int, char *[])
 
   ClassImageType::SizeType classImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  ClassImageType::IndexType classindex;
-  classindex.Fill(0);
+  ClassImageType::IndexType classindex{};
 
   ClassImageType::RegionType classregion;
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -89,8 +89,7 @@ itkRGBGibbsPriorFilterTest(int, char *[])
 
   VecImageType::SizeType vecImgSize = { { ImageWidth, ImageHeight, NumFrames } };
 
-  VecImageType::IndexType index;
-  index.Fill(0);
+  VecImageType::IndexType index{};
 
   VecImageType::RegionType region;
 
@@ -138,8 +137,7 @@ itkRGBGibbsPriorFilterTest(int, char *[])
 
   ClassImageType::SizeType classImgSize = { { ImageWidth, ImageHeight, NumFrames } };
 
-  ClassImageType::IndexType classindex;
-  classindex.Fill(0);
+  ClassImageType::IndexType classindex{};
 
   ClassImageType::RegionType classregion;
 

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -62,8 +62,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
 
   ImageType::SizeType imageSize = { { ImageWidth, ImageHeight } };
 
-  ImageType::IndexType startIndex;
-  startIndex.Fill(0);
+  ImageType::IndexType startIndex{};
 
   ImageType::RegionType region{ startIndex, imageSize };
 

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
@@ -46,8 +46,7 @@ itkVoronoiSegmentationImageFilterTest(int argc, char * argv[])
 
   auto                   inputImage = UShortImage::New();
   UShortImage::SizeType  size = { { width, height } };
-  UShortImage::IndexType index;
-  index.Fill(0);
+  UShortImage::IndexType index{};
 
   UShortImage::RegionType region;
 

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
@@ -81,8 +81,7 @@ itkMorphologicalWatershedFromMarkersImageFilterTest(int argc, char * argv[])
     size[i] = size[i] * 2;
   }
 
-  ImageType::RegionType::IndexType index;
-  index.Fill(0);
+  ImageType::RegionType::IndexType index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Video/Core/test/itkVideoSourceTest.cxx
+++ b/Modules/Video/Core/test/itkVideoSourceTest.cxx
@@ -114,9 +114,7 @@ CreateEmptyFrame()
 
   FrameType::RegionType largestRegion;
   FrameType::SizeType   sizeLR;
-  FrameType::IndexType  startLR;
-
-  startLR.Fill(0);
+  FrameType::IndexType  startLR{};
   sizeLR[0] = 50;
   sizeLR[1] = 40;
   largestRegion.SetSize(sizeLR);
@@ -239,8 +237,7 @@ itkVideoSourceTest(int, char *[])
     // get set
     if (region.GetNumberOfPixels() > 0)
     {
-      FrameType::IndexType idx;
-      idx.Fill(0);
+      FrameType::IndexType idx{};
       if (frame->GetPixel(idx) == 1)
       {
         std::cerr << "Pixel outside requested spatial region set to 1" << std::endl;

--- a/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
@@ -45,9 +45,7 @@ CreateInputFrame(InputPixelType val)
 
   InputFrameType::RegionType largestRegion;
   InputFrameType::SizeType   sizeLR;
-  InputFrameType::IndexType  startLR;
-
-  startLR.Fill(0);
+  InputFrameType::IndexType  startLR{};
   sizeLR[0] = 50;
   sizeLR[1] = 40;
   largestRegion.SetSize(sizeLR);
@@ -250,8 +248,7 @@ itkVideoToVideoFilterTest(int, char *[])
     }
 
     // Make sure nothing set outside of requested spatial region
-    OutputFrameType::IndexType idx;
-    idx.Fill(0);
+    OutputFrameType::IndexType idx{};
     if (frame->GetRequestedRegion().IsInside(idx))
     {
       std::cerr << "Filter set pixel outside of requested region" << std::endl;

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -53,8 +53,7 @@ CreateInputFrame(InputPixelType val)
 
   InputFrameType::RegionType largestRegion;
   InputFrameType::SizeType   sizeLR;
-  InputFrameType::IndexType  startLR;
-  startLR.Fill(0);
+  InputFrameType::IndexType  startLR{};
   sizeLR[0] = 50;
   sizeLR[1] = 40;
   largestRegion.SetSize(sizeLR);

--- a/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
@@ -53,8 +53,7 @@ CreateInputFrame(InputPixelType val)
 
   InputFrameType::RegionType largestRegion;
   InputFrameType::SizeType   sizeLR;
-  InputFrameType::IndexType  startLR;
-  startLR.Fill(0);
+  InputFrameType::IndexType  startLR{};
   sizeLR[0] = 50;
   sizeLR[1] = 40;
   largestRegion.SetSize(sizeLR);


### PR DESCRIPTION
Replaced code of the form

    T var;
    var.Fill(0);

with `T var{};`

Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+[^ ].* )(\w+);[\r\n]+ [ ]+\2\.Fill\(0\);
    Replace with: $1$2{};
    Filters: itk*Test*.cxx
    [v] Match case
    (*) Regular expression

The empty initializer list `{}` effectively zero-fills those variables.

----

When reviewing this pull request, it may be convenient to ignore whitespace changes: https://github.com/InsightSoftwareConsortium/ITK/pull/4881/files?w=1