### PR TITLE
Remove some local variables from PyBuffer, declare others const, remove buffer pointer casts

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -39,17 +39,14 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
 
   image->Update();
 
-  ComponentType * buffer =
-    const_cast<ComponentType *>(reinterpret_cast<const ComponentType *>(image->GetBufferPointer()));
-
-  void * itkImageBuffer = buffer;
+  void * const buffer = image->GetBufferPointer();
 
   // Computing the length of data
   const unsigned int  numberOfComponents = image->GetNumberOfComponentsPerPixel();
   const SizeValueType numberOfPixels = image->GetBufferedRegion().GetNumberOfPixels();
   const auto          len = static_cast<Py_ssize_t>(numberOfPixels * numberOfComponents * sizeof(ComponentType));
 
-  PyBuffer_FillInfo(&pyBuffer, nullptr, itkImageBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, buffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);
 }
 

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -97,11 +97,7 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
     numberOfPixels *= size[i];
   }
 
-  bool isFortranContiguous = false;
-  if (pyBuffer.strides != nullptr && pyBuffer.itemsize == pyBuffer.strides[0])
-  {
-    isFortranContiguous = true;
-  }
+  const bool isFortranContiguous = pyBuffer.strides != nullptr && pyBuffer.itemsize == pyBuffer.strides[0];
 
   const size_t len = numberOfPixels * numberOfComponents * sizeof(ComponentType);
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -111,12 +111,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
     std::reverse(size.begin(), size.end());
   }
 
-  PointType origin;
-  origin.Fill(0.0);
-
-  SpacingType spacing;
-  spacing.Fill(1.0);
-
   using InternalPixelType = typename TImage::InternalPixelType;
   using ImporterType = ImportImageContainer<SizeValueType, InternalPixelType>;
   auto           importer = ImporterType::New();
@@ -126,8 +120,6 @@ PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObj
 
   OutputImagePointer output = TImage::New();
   output->SetRegions(size);
-  output->SetOrigin(origin);
-  output->SetSpacing(spacing);
   output->SetPixelContainer(importer);
   output->SetNumberOfComponentsPerPixel(numberOfComponents);
 


### PR DESCRIPTION
A few more coding style improvements of `itk::PyBuffer`.