### PR TITLE
STYLE: Replace `Fill(0.)` and `Fill(0u)` with `{}` initializer for local variables in tests

### DIFF
--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -48,8 +48,7 @@ itkImageToVTKImageFilterTest(int, char *[])
   origin[0] = -1.5;
   origin[1] = 0.222;
   origin[2] = 0;
-  DirectionType direction;
-  direction.Fill(0.0);
+  DirectionType direction{};
   direction[0][1] = 1;
   direction[1][0] = -1;
   direction[2][2] = 0.7;

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -31,8 +31,7 @@ public:
   OutputPointType
   TransformPoint(const InputPointType & inputPoint) const
   {
-    OutputPointType outputPoint;
-    outputPoint.Fill(0.0);
+    OutputPointType outputPoint{};
     // if InputPoint Dimension < 2 then embed point in 2D space
     // else project the point to 2D space.
     for (unsigned int d = 0; d < std::min(inputPoint.GetPointDimension(), outputPoint.GetPointDimension()); ++d)

--- a/Modules/Core/Common/test/itkMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixTest.cxx
@@ -33,8 +33,7 @@ itkMatrixTest(int, char *[])
 
   using vnlVectorType = vnl_vector_fixed<NumericType, 3>;
 
-  MatrixType matrix;
-  matrix.Fill(0.0);
+  MatrixType matrix{};
   matrix.SetIdentity();
 
   VectorType v1;

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -54,8 +54,7 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   image->SetRegions(region);
   image->Allocate();
 
-  PointType origin;
-  origin.Fill(0.0);
+  PointType origin{};
 
   SpacingType spacing;
   spacing.Fill(1.0);

--- a/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
@@ -101,8 +101,7 @@ InternalTest(int argc, char * argv[])
   imageIterator.GoToBegin();
 
   using PointType = typename InputMeshType::PointType;
-  PointType point;
-  point.Fill(0.);
+  PointType point{};
 
   using PointDataContainer = typename InputMeshType::PointDataContainer;
   using PointDataContainerPointer = typename InputMeshType::PointDataContainerPointer;

--- a/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
@@ -54,8 +54,7 @@ itkSphereMeshSourceTest(int, char *[])
   //  itk::Mesh<float>::PointsContainer::Iterator   m_output = myoutput->Begin();
 
   IPT * pt_ptr;
-  IPT   pt;
-  pt.Fill(0.0);
+  IPT   pt{};
   pt_ptr = &pt;
 
   for (int i = 0; i < 12; ++i)

--- a/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
@@ -64,8 +64,7 @@ itkVTKPolyDataWriterTest02(int argc, char * argv[])
 
   MeshType::Pointer myMesh = mySphereMeshSource->GetOutput();
 
-  PointType pt;
-  pt.Fill(0.);
+  PointType pt{};
 
   bool testPassed = true;
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
@@ -43,8 +43,7 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  PointType center;
-  center.Fill(0.0);
+  PointType center{};
 
   VectorType scale;
   scale.Fill(1.0);
@@ -62,8 +61,7 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
 
   MeshType::Pointer myMesh = mySphereMeshSource->GetOutput();
 
-  PointType pt;
-  pt.Fill(0.);
+  PointType pt{};
 
   myMesh->Print(std::cout);
 

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -41,8 +41,7 @@ itkGaussianSpatialObjectTest(int, char *[])
   myGaussian->SetSigmaInObjectSpace(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, myGaussian->GetSigmaInObjectSpace());
 
-  GaussianType::PointType center;
-  center.Fill(0.0);
+  GaussianType::PointType center{};
   myGaussian->SetCenterInObjectSpace(center);
   ITK_TEST_SET_GET_VALUE(center, myGaussian->GetCenterInObjectSpace());
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -53,8 +53,7 @@ itkImageMaskSpatialObjectTest3(int, char *[])
 
   ImageType::IndexType index{};
 
-  ImageType::DirectionType direction;
-  direction.Fill(0.0);
+  ImageType::DirectionType direction{};
   direction[0][1] = 1;
   direction[1][0] = 1;
   direction[2][2] = 1;

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -61,8 +61,7 @@ itkBSplineDeformableTransformTest1()
    */
 
   using OriginType = TransformType::OriginType;
-  OriginType origin;
-  origin.Fill(0.0);
+  OriginType origin{};
 
   using RegionType = TransformType::RegionType;
   RegionType           region;
@@ -598,8 +597,7 @@ itkBSplineDeformableTransformTest3()
    */
 
   using OriginType = TransformType::OriginType;
-  OriginType origin;
-  origin.Fill(0.0);
+  OriginType origin{};
 
   using RegionType = TransformType::RegionType;
   RegionType           region;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -59,8 +59,7 @@ itkBSplineTransformTest1()
    */
 
   using OriginType = TransformType::OriginType;
-  OriginType origin;
-  origin.Fill(0.0);
+  OriginType origin{};
 
   using PhysicalDimensionsType = TransformType::PhysicalDimensionsType;
   PhysicalDimensionsType dimensions;
@@ -615,8 +614,7 @@ itkBSplineTransformTest3()
    */
 
   using OriginType = TransformType::OriginType;
-  OriginType origin;
-  origin.Fill(0.0);
+  OriginType origin{};
 
   using PhysicalDimensionsType = TransformType::PhysicalDimensionsType;
   PhysicalDimensionsType dimensions;

--- a/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
@@ -214,8 +214,7 @@ itkQuaternionRigidTransformTest(int, char *[])
     rotation->SetIdentity();
     rotation->SetRotation(qrotation);
 
-    TransformType::OffsetType ioffset;
-    ioffset.Fill(0.0f);
+    TransformType::OffsetType ioffset{};
 
     // rotation->ComputeOffset();
 

--- a/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
@@ -269,8 +269,7 @@ itkRigid2DTransformTest(int, char *[])
       return EXIT_FAILURE;
     }
 
-    TransformType::OffsetType ioffset;
-    ioffset.Fill(0.0f);
+    TransformType::OffsetType ioffset{};
 
     rotation->SetOffset(ioffset);
 

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -107,8 +107,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     auto translation = TransformType::New();
     translation->SetFocalDistance(focal);
 
-    TransformType::OffsetType ioffset;
-    ioffset.Fill(0.0);
+    TransformType::OffsetType ioffset{};
 
     translation->SetOffset(ioffset);
     ITK_TEST_SET_GET_VALUE(ioffset, translation->GetOffset());
@@ -170,8 +169,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     auto rigid = TransformType::New();
     rigid->SetFocalDistance(focal);
 
-    TransformType::OffsetType ioffset;
-    ioffset.Fill(0.0);
+    TransformType::OffsetType ioffset{};
 
     rigid->SetOffset(ioffset);
 

--- a/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
@@ -310,8 +310,7 @@ itkRigid3DTransformTest(int, char *[])
 
     rotation->SetMatrix(mrotation);
 
-    TransformType::OffsetType ioffset;
-    ioffset.Fill(0.0f);
+    TransformType::OffsetType ioffset{};
 
     rotation->SetOffset(ioffset);
 

--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -102,14 +102,12 @@ itkTransformGeometryImageFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(inputImage = itk::ReadImage<ImageType>(argv[1]));
 
   // Set up transforms
-  ImageType::PointType center;
-  center.Fill(0.0);
+  ImageType::PointType center{};
   center[0] = 2.0; // In mm along X (RL-axis)
   center[1] = 5.0; // In mm along Y (AP-axis)
   center[2] = 7.0; // In mm along Z (IS-axis)
 
-  itk::Vector<double, Dimension> translation;
-  translation.Fill(0.);
+  itk::Vector<double, Dimension> translation{};
   translation[0] = 10.0; // In mm along X (RL-axis)
   translation[1] = 15.0; // In mm along Y (AP-axis)
   translation[2] = 20.0; // In mm along Z (IS-axis)

--- a/Modules/Core/Transform/test/itkVersorTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorTransformTest.cxx
@@ -440,8 +440,7 @@ itkVersorTransformTest(int, char *[])
 
     // Check the computed parameters
 
-    VectorType axis;
-    axis.Fill(0.0);
+    VectorType axis{};
     axis[2] = 1.0;
     VersorType v;
     v.Set(axis, a);

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -61,8 +61,7 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   DisplacementFieldType::SpacingType spacing;
   spacing.Fill(1.0);
 
-  DisplacementFieldType::PointType origin;
-  origin.Fill(0.0);
+  DisplacementFieldType::PointType origin{};
 
   DisplacementFieldType::RegionType region;
   DisplacementFieldType::SizeType   size;

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -65,8 +65,7 @@ itkIterativeInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   DisplacementFieldType::SpacingType spacing;
   spacing.Fill(1.0);
 
-  DisplacementFieldType::PointType origin;
-  origin.Fill(0.0);
+  DisplacementFieldType::PointType origin{};
 
   DisplacementFieldType::RegionType region;
   DisplacementFieldType::SizeType   size;

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -56,8 +56,7 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
   DisplacementFieldType::SpacingType spacing;
   spacing.Fill(1.0);
 
-  DisplacementFieldType::PointType origin;
-  origin.Fill(0.0);
+  DisplacementFieldType::PointType origin{};
 
   DisplacementFieldType::RegionType region;
   DisplacementFieldType::SizeType   size;

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -45,8 +45,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   using DisplacementFieldType = itk::Image<VectorType, 3>;
   using TimeVaryingVelocityFieldType = itk::Image<VectorType, 4>;
 
-  TimeVaryingVelocityFieldType::PointType origin;
-  origin.Fill(0.0);
+  TimeVaryingVelocityFieldType::PointType origin{};
 
   TimeVaryingVelocityFieldType::SpacingType spacing;
   spacing.Fill(2.0);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
@@ -32,8 +32,7 @@ itkTimeVaryingVelocityFieldTransformTest(int, char *[])
   using DisplacementFieldType = itk::Image<VectorType, ComponentDimension>;
   using TimeVaryingVelocityFieldType = itk::Image<VectorType, VelocityFieldDimension>;
 
-  TimeVaryingVelocityFieldType::PointType origin;
-  origin.Fill(0.0);
+  TimeVaryingVelocityFieldType::PointType origin{};
 
   TimeVaryingVelocityFieldType::SpacingType spacing;
   spacing.Fill(2.0);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -62,8 +62,7 @@ FastMarchingImageFilterBaseTestFunction()
   fastMarchingFilter->SetOutputDirection(outputDirection);
   ITK_TEST_SET_GET_VALUE(outputDirection, fastMarchingFilter->GetOutputDirection());
 
-  typename FastMarchingImageFilterType::OutputPointType outputOrigin;
-  outputOrigin.Fill(0.0);
+  typename FastMarchingImageFilterType::OutputPointType outputOrigin{};
   fastMarchingFilter->SetOutputOrigin(outputOrigin);
   ITK_TEST_SET_GET_VALUE(outputOrigin, fastMarchingFilter->GetOutputOrigin());
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest.cxx
@@ -45,8 +45,7 @@ itkFastMarchingQuadEdgeMeshFilterBaseTest(int, char *[])
 
   using FastMarchingType = itk::FastMarchingQuadEdgeMeshFilterBase<MeshType, MeshType>;
 
-  MeshType::PointType center;
-  center.Fill(0.);
+  MeshType::PointType center{};
 
   using SphereSourceType = itk::RegularSphereMeshSource<MeshType>;
   auto sphere_filter = SphereSourceType::New();

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest3.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest3.cxx
@@ -57,8 +57,7 @@ itkFastMarchingQuadEdgeMeshFilterBaseTest3(int, char *[])
   points->Reserve(100);
   pointdata->Reserve(100);
 
-  MeshType::PointType p;
-  p.Fill(0.);
+  MeshType::PointType p{};
 
   int k = 0;
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterWithNumberOfElementsTest.cxx
@@ -44,8 +44,7 @@ itkFastMarchingQuadEdgeMeshFilterWithNumberOfElementsTest(int, char *[])
 
   using FastMarchingType = itk::FastMarchingQuadEdgeMeshFilterBase<MeshType, MeshType>;
 
-  MeshType::PointType center;
-  center.Fill(0.);
+  MeshType::PointType center{};
 
   using SphereSourceType = itk::RegularSphereMeshSource<MeshType>;
   auto sphere_filter = SphereSourceType::New();

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -102,8 +102,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
     HessianImageType::Pointer outputImage = filter->GetOutput();
 
     // Get the value at the center of the image, the location of the peak of the Gaussian
-    PointType center;
-    center.Fill(0.0);
+    PointType center{};
 
     IndexType centerIndex = outputImage->TransformPhysicalPointToIndex(center);
 
@@ -157,8 +156,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
     HessianImageType::Pointer outputImage = filter->GetOutput();
 
     // Get the value at the center of the image, the location of the peak of the Gaussian
-    PointType center;
-    center.Fill(0.0);
+    PointType center{};
 
     IndexType centerIndex = outputImage->TransformPhysicalPointToIndex(center);
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -153,8 +153,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   //
   // Test with a change in image direction
   //
-  myImageType::DirectionType direction;
-  direction.Fill(0.0);
+  myImageType::DirectionType direction{};
   direction[0][0] = -1.0;
   direction[1][1] = -1.0;
   direction[2][2] = -1.0;

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -123,8 +123,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(ncps, filter->GetNumberOfControlPoints());
 
 
-  FilterType::ArrayType close;
-  close.Fill(0u);
+  FilterType::ArrayType close{};
   filter->SetCloseDimension(close);
   ITK_TEST_SET_GET_VALUE(close, filter->GetCloseDimension());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
@@ -81,8 +81,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest2(int argc, char * argv[])
   spacing.Fill(0.01);
   ImageType::SizeType size;
   size.Fill(101);
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
 
   filter->SetSize(size);
   filter->SetOrigin(origin);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
@@ -99,8 +99,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest3(int argc, char * argv[])
   ImageType::SizeType size;
   // Adding 0.5 to avoid rounding errors
   size.Fill(static_cast<unsigned int>(1.0 / spacing[0] + .5) + 1);
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
 
   filter->SetSize(size);
   filter->SetOrigin(origin);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -144,8 +144,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest5(int argc, char * argv[])
   size[0] = 1000;
   size[1] = 100;
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
 
   filter->SetSize(size);
   filter->SetOrigin(origin);

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -91,8 +91,7 @@ itkResampleImageTest(int, char *[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -107,8 +107,7 @@ itkResampleImageTest4(int argc, char * argv[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -110,8 +110,7 @@ itkResampleImageTest5(int argc, char * argv[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -121,8 +121,7 @@ itkResampleImageTest6(int argc, char * argv[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -96,8 +96,7 @@ itkResampleImageTest7(int, char *[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -193,8 +193,7 @@ itkResampleImageTest8(int, char *[])
   resample->SetOutputStartIndex(outputIndex);
   ITK_TEST_SET_GET_VALUE(outputIndex, resample->GetOutputStartIndex());
 
-  OutputImageType::PointType origin;
-  origin.Fill(0.0);
+  OutputImageType::PointType origin{};
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -59,8 +59,7 @@ itkGridImageSourceTest(int argc, char * argv[])
   ImageType::SizeType imageSize;
   imageSize.Fill(size);
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
 
   ImageType::SpacingType imageSpacing;
   imageSpacing.Fill(1.0);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
@@ -41,8 +41,7 @@ itkRegularSphereQuadEdgeMeshSourceTest(int argc, char * argv[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  PointType center;
-  center.Fill(0.0);
+  PointType center{};
 
   VectorType scale;
   scale.Fill(1.0);
@@ -60,8 +59,7 @@ itkRegularSphereQuadEdgeMeshSourceTest(int argc, char * argv[])
 
   MeshType::Pointer myMesh = mySphereMeshSource->GetOutput();
 
-  PointType pt;
-  pt.Fill(0.);
+  PointType pt{};
 
   for (unsigned int i = 0; i < myMesh->GetNumberOfPoints(); ++i)
   {

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -281,8 +281,7 @@ HDF5ReadWriteTest(const char * fileName)
     success = EXIT_FAILURE;
   }
 
-  itk::Array<double> metaDataDoubleArray2;
-  metaDataDoubleArray2.Fill(0.0);
+  itk::Array<double> metaDataDoubleArray2{};
   if (!itk::ExposeMetaData<itk::Array<double>>(metaDict2, "TestDoubleArray", metaDataDoubleArray2) ||
       metaDataDoubleArray2 != metaDataDoubleArray)
   {

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -25,8 +25,7 @@ template <>
 itk::ImageBase<1>::DirectionType
 PreFillDirection<1>()
 {
-  itk::ImageBase<1>::DirectionType myDirection;
-  myDirection.Fill(0.0);
+  itk::ImageBase<1>::DirectionType myDirection{};
   myDirection[0][0] = -1.0;
   return myDirection;
 }
@@ -35,8 +34,7 @@ template <>
 itk::ImageBase<2>::DirectionType
 PreFillDirection<2>()
 {
-  itk::ImageBase<2>::DirectionType myDirection;
-  myDirection.Fill(0.0);
+  itk::ImageBase<2>::DirectionType myDirection{};
   myDirection[0][1] = 1.0;
   myDirection[1][0] = -1.0;
   return myDirection;
@@ -46,8 +44,7 @@ template <>
 itk::ImageBase<3>::DirectionType
 PreFillDirection<3>()
 {
-  itk::ImageBase<3>::DirectionType myDirection;
-  myDirection.Fill(0.0);
+  itk::ImageBase<3>::DirectionType myDirection{};
   myDirection[0][2] = 1.0;
   myDirection[1][0] = -1.0;
   myDirection[2][1] = 1.0;
@@ -58,8 +55,7 @@ template <>
 itk::ImageBase<4>::DirectionType
 PreFillDirection<4>()
 {
-  itk::ImageBase<4>::DirectionType myDirection;
-  myDirection.Fill(0.0);
+  itk::ImageBase<4>::DirectionType myDirection{};
   myDirection[0][2] = 1.0;
   myDirection[1][0] = -1.0;
   myDirection[2][1] = 1.0;

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -176,8 +176,7 @@ check_nonlinear_double(const char * nonlinear_transform)
   field->SetOrigin(origin);
   field->Allocate();
 
-  DisplacementFieldType::PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
+  DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
   vnl_random                                      randgen(12345678);
@@ -303,8 +302,7 @@ check_nonlinear_float(const char * nonlinear_transform)
   field->SetOrigin(origin);
   field->Allocate();
 
-  DisplacementFieldType::PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
+  DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
   vnl_random                                      randgen(12345678);
@@ -574,8 +572,7 @@ check_composite2(const char * transform_file, const char * transform_grid_file)
   field->SetOrigin(origin);
   field->Allocate();
 
-  DisplacementFieldType::PixelType displacement;
-  displacement.Fill(0.0);
+  DisplacementFieldType::PixelType displacement{};
   displacement[0] = 1.0;
   field->FillBuffer(displacement);
 

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -156,8 +156,7 @@ compare_nonlinear_double(const char * nonlinear_transform)
   field->SetOrigin(origin);
   field->Allocate();
 
-  DisplacementFieldType::PixelType zeroDisplacement;
-  zeroDisplacement.Fill(0.0);
+  DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
   vnl_random                                               randgen(12345678);

--- a/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
@@ -28,8 +28,7 @@ itkTriangleHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   using VectorType = PointType::VectorType;
   using TriangleHelperType = itk::TriangleHelper<PointType>;
 
-  PointType Org;
-  Org.Fill(0.);
+  PointType Org{};
 
   PointType a;
   a[0] = 1.;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
@@ -261,8 +261,7 @@ itkRegistrationParameterScalesFromIndexShiftTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   using VectorType = itk::Vector<double, ImageDimension>;
 
-  VectorType zero;
-  zero.Fill(0.0);
+  VectorType zero{};
 
   auto field = FieldType::New();
   field->SetRegions(virtualImage->GetLargestPossibleRegion());

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
@@ -266,8 +266,7 @@ itkRegistrationParameterScalesFromJacobianTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   using VectorType = itk::Vector<double, ImageDimension>;
 
-  VectorType zero;
-  zero.Fill(0.0);
+  VectorType zero{};
 
   auto field = FieldType::New();
   field->SetRegions(virtualImage->GetLargestPossibleRegion());

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -287,8 +287,7 @@ itkRegistrationParameterScalesFromPhysicalShiftPointSetTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   using VectorType = itk::Vector<double, Dimension>;
 
-  VectorType zero;
-  zero.Fill(0.0);
+  VectorType zero{};
 
   using RegionType = itk::ImageRegion<Dimension>;
   RegionType region;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
@@ -308,8 +308,7 @@ itkRegistrationParameterScalesFromPhysicalShiftTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   using VectorType = itk::Vector<double, ImageDimension>;
 
-  VectorType zero;
-  zero.Fill(0.0);
+  VectorType zero{};
 
   auto field = FieldType::New();
   field->SetRegions(virtualImage->GetLargestPossibleRegion());

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -82,8 +82,7 @@ itkWeightedCentroidKdTreeGeneratorTest8(int argc, char * argv[])
 
   MeasurementVectorType result;
   MeasurementVectorType test_point;
-  MeasurementVectorType min_point;
-  min_point.Fill(0.0);
+  MeasurementVectorType min_point{};
 
   unsigned int numberOfFailedPoints = 0;
 

--- a/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
@@ -191,10 +191,8 @@ itkHistogramImageToImageMetricTest(int, char *[])
 
   std::cout << "Exercise the SetLowerBound() and SetUpperBound() methods " << std::endl;
 
-  MetricType::MeasurementVectorType lowerBound;
-  lowerBound.Fill(0.0);
-  MetricType::MeasurementVectorType upperBound;
-  upperBound.Fill(0.0);
+  MetricType::MeasurementVectorType lowerBound{};
+  MetricType::MeasurementVectorType upperBound{};
 
   metric->SetLowerBound(lowerBound);
   metric->SetUpperBound(upperBound);

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -142,8 +142,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   spacing[1] = 2.7;
   spacing[2] = 7.5;
 
-  InputImageType::DirectionType direction;
-  direction.Fill(0.0);
+  InputImageType::DirectionType direction{};
   direction[0][1] = -1;
   direction[1][2] = 1;
   direction[2][0] = 1;

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -435,8 +435,7 @@ itkFEMFiniteDifferenceFunctionLoadTest(int argc, char * argv[])
   FillWithCircle<InputImageType>(movingImage, center, radius, fgnd, bgnd);
 
   // Fill initial deformation with zero vectors
-  DeformationFieldVectorType zeroVec;
-  zeroVec.Fill(0.0);
+  DeformationFieldVectorType zeroVec{};
   FillImage<DeformationFieldImageType>(initField, zeroVec);
 
   using ImageWriterType = itk::ImageFileWriter<InputImageType>;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -143,8 +143,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
   FillWithCircle<InputImageType>(movingImage, center, radius, fgnd, bgnd);
 
   // Fill initial deformation with zero vectors
-  DeformationFieldVectorType zeroVec;
-  zeroVec.Fill(0.0);
+  DeformationFieldVectorType zeroVec{};
   FillImage<DeformationFieldImageType>(initField, zeroVec);
 
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -145,8 +145,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
   FillWithCircle<InputImageType>(movingImage, center, radius, fgnd, bgnd);
 
   // Fill initial deformation with zero vectors
-  DeformationFieldVectorType zeroVec;
-  zeroVec.Fill(0.0);
+  DeformationFieldVectorType zeroVec{};
   FillImage<DeformationFieldImageType>(initField, zeroVec);
 
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -162,8 +162,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
   FillWithCircle<InputImageType>(movingImage, center, radius, fgnd, bgnd);
 
   // Fill initial deformation with zero vectors
-  DeformationFieldVectorType zeroVec;
-  zeroVec.Fill(0.0);
+  DeformationFieldVectorType zeroVec{};
   FillImage<DeformationFieldImageType>(initField, zeroVec);
 
 

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -172,8 +172,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   using CasterType = itk::CastImageFilter<FieldType, FieldType>;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -44,8 +44,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
 
   // Create a few points and apply a small offset to make the moving points
   auto      pointMax = static_cast<float>(100.0);
-  PointType fixedPoint;
-  fixedPoint.Fill(0.0);
+  PointType fixedPoint{};
   fixedPoint[0] = 0.0;
   fixedPoint[1] = 0.0;
   fixedPoints->SetPoint(0, fixedPoint);
@@ -103,15 +102,13 @@ itkEuclideanDistancePointSetMetricTest2Run()
   typename FieldType::SpacingType spacing;
   spacing.Fill(1.0);
 
-  typename FieldType::DirectionType direction;
-  direction.Fill(0.0);
+  typename FieldType::DirectionType direction{};
   for (unsigned int d = 0; d < Dimension; ++d)
   {
     direction[d][d] = 1.0;
   }
 
-  typename FieldType::PointType origin;
-  origin.Fill(0.0);
+  typename FieldType::PointType origin{};
 
   typename RegionType::SizeType regionSize;
   regionSize.Fill(static_cast<itk::SizeValueType>(pointMax + 1.0));

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -45,8 +45,7 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
 
   // Create a few points and apply a small offset to make the moving points
   auto      pointMax = static_cast<float>(1.0);
-  PointType fixedPoint;
-  fixedPoint.Fill(0.0);
+  PointType fixedPoint{};
   fixedPoint[0] = 0.0;
   fixedPoint[1] = 0.0;
   fixedPoints->SetPoint(0, fixedPoint);

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -215,8 +215,7 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
   typename ImageType::RegionType  region{ virtualIndex, size };
   typename ImageType::SpacingType spacing;
   spacing.Fill(1.0);
-  typename ImageType::PointType origin;
-  origin.Fill(0.0);
+  typename ImageType::PointType     origin{};
   typename ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -269,8 +269,7 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
     using FieldType = DisplacementTransformType::DisplacementFieldType;
     using VectorType = itk::Vector<double, Dimension>;
 
-    VectorType zero;
-    zero.Fill(0.0);
+    VectorType zero{};
 
     auto field = FieldType::New();
     field->SetRegions(fixedImage->GetBufferedRegion());

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -163,8 +163,7 @@ itkCurvatureRegistrationFilterTest(int, char *[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   //-------------------------------------------------------------

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -162,8 +162,7 @@ itkDemonsRegistrationFilterTest(int, char *[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   using CasterType = itk::CastImageFilter<FieldType, FieldType>;

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -181,8 +181,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   using CasterType = itk::CastImageFilter<FieldType, FieldType>;

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -161,8 +161,7 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   using CasterType = itk::CastImageFilter<FieldType, FieldType>;

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -177,8 +177,7 @@ itkLevelSetMotionRegistrationFilterTest(int argc, char * argv[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   using CasterType = itk::CastImageFilter<FieldType, FieldType>;

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -174,8 +174,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
 
   RegionType region{ index, size };
 
-  ImageType::PointType origin;
-  origin.Fill(0.0);
+  ImageType::PointType origin{};
   origin[0] = 0.8;
 
   ImageType::SpacingType spacing;
@@ -222,8 +221,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   FillImage<FieldType>(initField, zeroVec);
 
   //----------------------------------------------------------------

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -154,8 +154,7 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   FillWithCircle<ImageType>(fixed, center, radius, fgnd, bgnd);
 
   // fill initial deformation with zero vectors
-  VectorType zeroVec;
-  zeroVec.Fill(0.0);
+  VectorType zeroVec{};
   initField->FillBuffer(zeroVec);
 
   std::cout << "Run registration and warp moving" << std::endl;


### PR DESCRIPTION
Replaced `Fill(0.)`, `Fill(0.0)`, `Fill(0.0f)`, and `Fill(0u)` calls with `{}` initializers.

- Follow-up to pull request #4881