### PR TITLE
Use `assign` in PyVectorContainer, declare `len` variables const

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -80,11 +80,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   }
   const auto * const data = static_cast<const DataType *>(buffer);
   auto               output = VectorContainerType::New();
-  output->resize(numberOfElements);
-  for (size_t ii = 0; ii < numberOfElements; ++ii)
-  {
-    output->SetElement(ii, data[ii]);
-  }
+  output->assign(data, data + numberOfElements);
 
   return output;
 }

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -40,8 +40,7 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
   void * vectorBuffer = buffer;
 
   // Computing the length of data
-  Py_ssize_t len = vector->Size();
-  len *= sizeof(DataType);
+  const auto len = static_cast<Py_ssize_t>(vector->size() * sizeof(DataType));
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -37,12 +37,10 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 
   DataType * buffer = vector->CastToSTLContainer().data();
 
-  void * vectorBuffer = buffer;
-
   // Computing the length of data
   const auto len = static_cast<Py_ssize_t>(vector->size() * sizeof(DataType));
 
-  PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, buffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);
 }
 

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -40,8 +40,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
   void * vectorBuffer = buffer;
 
   // Computing the length of data
-  Py_ssize_t len = vector->size();
-  len *= sizeof(DataType);
+  const auto len = static_cast<Py_ssize_t>(vector->size() * sizeof(DataType));
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);
@@ -97,8 +96,7 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
   void * matrixBuffer = buffer;
 
   // Computing the length of data
-  Py_ssize_t len = matrix->size();
-  len *= sizeof(DataType);
+  const auto len = static_cast<Py_ssize_t>(matrix->size() * sizeof(DataType));
 
   PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -37,12 +37,10 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 
   DataType * buffer = vector->data_block();
 
-  void * vectorBuffer = buffer;
-
   // Computing the length of data
   const auto len = static_cast<Py_ssize_t>(vector->size() * sizeof(DataType));
 
-  PyBuffer_FillInfo(&pyBuffer, nullptr, vectorBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, buffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);
 }
 
@@ -93,12 +91,10 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 
   DataType * buffer = matrix->data_block();
 
-  void * matrixBuffer = buffer;
-
   // Computing the length of data
   const auto len = static_cast<Py_ssize_t>(matrix->size() * sizeof(DataType));
 
-  PyBuffer_FillInfo(&pyBuffer, nullptr, matrixBuffer, len, 0, PyBUF_CONTIG);
+  PyBuffer_FillInfo(&pyBuffer, nullptr, buffer, len, 0, PyBUF_CONTIG);
   return PyMemoryView_FromBuffer(&pyBuffer);
 }
 


### PR DESCRIPTION
A few more coding style improvements in PyVectorContainer and PyVnl.