### PR TITLE
Replace `Fill(T{})` with `{}` initialization, replace `T var; var.Fill` with `auto var = T::Filled` in tests

### DIFF
--- a/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
@@ -50,9 +50,8 @@ itkVtkMedianFilterTest(int argc, char * argv[])
   reader->SetFileName(inputFilename);
 
   // Create and setup a median filter
-  auto                      medianFilter = FilterType::New();
-  FilterType::InputSizeType radius;
-  radius.Fill(2);
+  auto medianFilter = FilterType::New();
+  auto radius = FilterType::InputSizeType::Filled(2);
   if (argc > 2)
   {
     radius.Fill(std::stoi(argv[2]));

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -249,14 +249,12 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
 
   // Create a "dummy" image.
   const auto image = ImageType::New();
-  SizeType   imageSize;
-  imageSize.Fill(1);
+  auto       imageSize = SizeType::Filled(1);
   image->SetRegions(imageSize);
   image->AllocateInitialized();
 
   // Create a radius, (just) large enough for all offsets activated below here.
-  SizeType radius;
-  radius.Fill(1);
+  auto radius = SizeType::Filled(1);
 
   itk::ConstShapedNeighborhoodIterator<ImageType> shapedNeighborhoodIterator{ radius,
                                                                               image,

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -345,8 +345,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     }
 
     // Setup and iterate over the first region
-    ChangeRegionTestImageType::IndexType region1Start;
-    region1Start.Fill(1);
+    auto region1Start = ChangeRegionTestImageType::IndexType::Filled(1);
 
     auto regionSize = ChangeRegionTestImageType::SizeType::Filled(1);
 
@@ -382,8 +381,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     }
 
     // Change iteration region
-    ChangeRegionTestImageType::IndexType region2start;
-    region2start.Fill(2);
+    auto region2start = ChangeRegionTestImageType::IndexType::Filled(2);
 
     ChangeRegionTestImageType::RegionType region2(region2start, regionSize);
 

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -319,8 +319,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     using ChangeRegionTestImageType = itk::Image<int, 2>;
     ChangeRegionTestImageType::IndexType imageCorner{};
 
-    ChangeRegionTestImageType::SizeType imageSize;
-    imageSize.Fill(4);
+    auto imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
 
     ChangeRegionTestImageType::RegionType imageRegion(imageCorner, imageSize);
 
@@ -349,14 +348,12 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     ChangeRegionTestImageType::IndexType region1Start;
     region1Start.Fill(1);
 
-    ChangeRegionTestImageType::SizeType regionSize;
-    regionSize.Fill(1);
+    auto regionSize = ChangeRegionTestImageType::SizeType::Filled(1);
 
     ChangeRegionTestImageType::RegionType region1(region1Start, regionSize);
 
     // Create the radius (a 3x3 region)
-    ChangeRegionTestImageType::SizeType neighborhoodRadius;
-    neighborhoodRadius.Fill(1);
+    auto neighborhoodRadius = ChangeRegionTestImageType::SizeType::Filled(1);
 
     using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ChangeRegionTestImageType>;
     NeighborhoodIteratorType neighborhoodIterator(neighborhoodRadius, image, region1);

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -445,8 +445,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
     }
 
     // Setup and iterate over the first region
-    ChangeRegionTestImageType::IndexType region1Start;
-    region1Start.Fill(1);
+    auto region1Start = ChangeRegionTestImageType::IndexType::Filled(1);
 
     auto regionSize = ChangeRegionTestImageType::SizeType::Filled(1);
 
@@ -495,8 +494,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
     //}
 
     // Change iteration region
-    ChangeRegionTestImageType::IndexType region2start;
-    region2start.Fill(2);
+    auto region2start = ChangeRegionTestImageType::IndexType::Filled(2);
 
     ChangeRegionTestImageType::RegionType region2(region2start, regionSize);
 

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -419,8 +419,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
     using ChangeRegionTestImageType = itk::Image<int, 2>;
     ChangeRegionTestImageType::IndexType imageCorner{};
 
-    ChangeRegionTestImageType::SizeType imageSize;
-    imageSize.Fill(4);
+    auto imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
 
     ChangeRegionTestImageType::RegionType imageRegion(imageCorner, imageSize);
 
@@ -449,14 +448,12 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
     ChangeRegionTestImageType::IndexType region1Start;
     region1Start.Fill(1);
 
-    ChangeRegionTestImageType::SizeType regionSize;
-    regionSize.Fill(1);
+    auto regionSize = ChangeRegionTestImageType::SizeType::Filled(1);
 
     ChangeRegionTestImageType::RegionType region1(region1Start, regionSize);
 
     // Create the radius (a 3x3 region)
-    ChangeRegionTestImageType::SizeType neighborhoodRadius;
-    neighborhoodRadius.Fill(1);
+    auto neighborhoodRadius = ChangeRegionTestImageType::SizeType::Filled(1);
 
     // Use the first two offsets
     std::vector<itk::Offset<2>>           offsets;

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
@@ -119,9 +119,7 @@ int
 itkImageAlgorithmCopyTest(int, char *[])
 {
   using ImageType3D = itk::Image<char, 3>;
-  ImageType3D::SizeType size3d;
-
-  size3d.Fill(16);
+  auto size3d = ImageType3D::SizeType::Filled(16);
   AverageTestCopy<ImageType3D>(size3d);
 
   size3d.Fill(32);
@@ -134,9 +132,7 @@ itkImageAlgorithmCopyTest(int, char *[])
   AverageTestCopy<ImageType3D>(size3d);
 
   using ImageType2D = itk::Image<char, 2>;
-  ImageType2D::SizeType size2d;
-
-  size2d.Fill(16);
+  auto size2d = ImageType2D::SizeType::Filled(16);
   AverageTestCopy<ImageType2D>(size2d);
 
   size2d.Fill(32);

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -65,8 +65,7 @@ itkImageAlgorithmCopyTest2(int, char *[])
 
 
   RegionType::IndexType index{};
-  RegionType::SizeType  size;
-  size.Fill(64);
+  auto                  size = RegionType::SizeType::Filled(64);
 
   RegionType region{ index, size };
 

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -153,9 +153,8 @@ void
 ExpectRangeIsNotEmptyForNonEmptyImage()
 {
   // First create a non-empty image:
-  const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(1);
+  const auto image = TImage::New();
+  auto       imageSize = TImage::SizeType::Filled(1);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->Allocate();
@@ -178,9 +177,8 @@ void
 ExpectMakeImageBufferRangeReturnsCorrectRangeForNonEmptyImage()
 {
   // First create a non-empty image:
-  const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(1);
+  const auto image = TImage::New();
+  auto       imageSize = TImage::SizeType::Filled(1);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->Allocate();

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -40,8 +40,7 @@ public:
   {
     m_Image = ImageType::New();
 
-    typename ImageType::SizeType size;
-    size.Fill(100);
+    auto size = ImageType::SizeType::Filled(100);
 
     typename ImageType::IndexType start{};
 

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
@@ -36,11 +36,10 @@ itkImageRandomNonRepeatingIteratorWithIndexTest2(int, char *[])
   using RandomConstIteratorType = itk::ImageRandomNonRepeatingConstIteratorWithIndex<ImageType>;
   constexpr unsigned long N = 10;
   constexpr int           Seed = 42;
-  ImageType::SizeType     size;
-  size.Fill(N);
-  ImageType::IndexType  start{};
-  ImageType::RegionType region{ start, size };
-  auto                  myImage = ImageType::New();
+  auto                    size = ImageType::SizeType::Filled(N);
+  ImageType::IndexType    start{};
+  ImageType::RegionType   region{ start, size };
+  auto                    myImage = ImageType::New();
   myImage->SetRegions(region);
   myImage->Allocate();
   using WalkType = std::vector<ImageType::IndexType>;

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -34,8 +34,7 @@ public:
   {
     m_Image = ImageType::New();
 
-    typename ImageType::SizeType size;
-    size.Fill(100);
+    auto size = ImageType::SizeType::Filled(100);
 
     typename ImageType::IndexType start{};
 

--- a/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -282,8 +282,7 @@ itkImageRegionExclusionIteratorWithIndexTest(int, char *[])
           exclusionStart[1] = j;
           exclusionStart[2] = k;
 
-          SizeType exclusionSize;
-          exclusionSize.Fill(s);
+          auto exclusionSize = SizeType::Filled(s);
 
           RegionType exclusionRegion(exclusionStart, exclusionSize);
 
@@ -300,8 +299,7 @@ itkImageRegionExclusionIteratorWithIndexTest(int, char *[])
   // Test exclusion region completely outside the region.
   IndexType exclusionStart;
   exclusionStart.Fill(-3);
-  SizeType exclusionSize;
-  exclusionSize.Fill(2);
+  auto       exclusionSize = SizeType::Filled(2);
   RegionType exclusionRegion(exclusionStart, exclusionSize);
 
   if (!RunTest(region, exclusionRegion))

--- a/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -297,8 +297,7 @@ itkImageRegionExclusionIteratorWithIndexTest(int, char *[])
   }
 
   // Test exclusion region completely outside the region.
-  IndexType exclusionStart;
-  exclusionStart.Fill(-3);
+  auto       exclusionStart = IndexType::Filled(-3);
   auto       exclusionSize = SizeType::Filled(2);
   RegionType exclusionRegion(exclusionStart, exclusionSize);
 

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -137,8 +137,7 @@ itkImageRegionIteratorTest(int, char *[])
     using TestImageType = itk::Image<int, 2>;
     TestImageType::IndexType imageCorner{};
 
-    TestImageType::SizeType imageSize;
-    imageSize.Fill(3);
+    auto imageSize = TestImageType::SizeType::Filled(3);
 
     TestImageType::RegionType imageRegion(imageCorner, imageSize);
 
@@ -166,8 +165,7 @@ itkImageRegionIteratorTest(int, char *[])
     // Setup and iterate over the first region
     TestImageType::IndexType region1Start{};
 
-    TestImageType::SizeType regionSize;
-    regionSize.Fill(2);
+    auto regionSize = TestImageType::SizeType::Filled(2);
 
     TestImageType::RegionType region1(region1Start, regionSize);
 

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -188,8 +188,7 @@ itkImageRegionIteratorTest(int, char *[])
     }
 
     // Change iteration region
-    TestImageType::IndexType region2start;
-    region2start.Fill(1);
+    auto region2start = TestImageType::IndexType::Filled(1);
 
     TestImageType::RegionType region2(region2start, regionSize);
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -155,9 +155,8 @@ void
 ExpectRangeIsNotEmptyForNonEmptyImage()
 {
   // First create a non-empty image:
-  const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(1);
+  const auto image = TImage::New();
+  auto       imageSize = TImage::SizeType::Filled(1);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->Allocate();

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -208,8 +208,7 @@ itkImageScanlineIteratorTest1(int, char *[])
     }
 
     // Change iteration region
-    TestImageType::IndexType region2start;
-    region2start.Fill(1);
+    auto region2start = TestImageType::IndexType::Filled(1);
 
     TestImageType::RegionType region2(region2start, regionSize);
 

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -150,8 +150,7 @@ itkImageScanlineIteratorTest1(int, char *[])
     using TestImageType = itk::Image<int, 2>;
     TestImageType::IndexType imageCorner{};
 
-    TestImageType::SizeType imageSize;
-    imageSize.Fill(3);
+    auto imageSize = TestImageType::SizeType::Filled(3);
 
     TestImageType::RegionType imageRegion(imageCorner, imageSize);
 
@@ -182,8 +181,7 @@ itkImageScanlineIteratorTest1(int, char *[])
     // Setup and iterate over the first region
     TestImageType::IndexType region1Start{};
 
-    TestImageType::SizeType regionSize;
-    regionSize.Fill(2);
+    auto regionSize = TestImageType::SizeType::Filled(2);
 
     TestImageType::RegionType region1(region1Start, regionSize);
 

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -122,8 +122,7 @@ itkImageTest(int, char *[])
   image->SetDirection(direction);
   Image::RegionType region;
   Image::IndexType  index{};
-  Image::SizeType   size;
-  size.Fill(4);
+  auto              size = Image::SizeType::Filled(4);
   region.SetIndex(index);
   region.SetSize(size);
   image->SetRegions(region);
@@ -153,8 +152,7 @@ itkImageTest(int, char *[])
                                                                           imageRef.GetPointer(),
                                                                           static_cast<TransformType *>(nullptr));
   Image::IndexType  correctIndex{};
-  Image::SizeType   correctSize;
-  correctSize.Fill(3);
+  auto              correctSize = Image::SizeType::Filled(3);
   if (!(boxRegion.GetIndex() == correctIndex) || !(boxRegion.GetSize() == correctSize))
   {
     std::cerr << "EnlargeRegionOverBox test failed: "

--- a/Modules/Core/Common/test/itkImageTransformTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformTest.cxx
@@ -49,8 +49,7 @@ TestTransform()
   auto size = SizeType::Filled(10);
   region.SetSize(size);
 
-  IndexType index;
-  index.Fill(5);
+  auto index = IndexType::Filled(5);
 
   std::cout << "TransformIndexToPhysicalPoint..." << std::endl;
   orientedImage->TransformIndexToPhysicalPoint(index, point);

--- a/Modules/Core/Common/test/itkImageTransformTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformTest.cxx
@@ -46,8 +46,7 @@ TestTransform()
   typename ImageType::PointType point;
   RegionType                    region;
 
-  SizeType size;
-  size.Fill(10);
+  auto size = SizeType::Filled(10);
   region.SetSize(size);
 
   IndexType index;

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -44,8 +44,7 @@ itkLineIteratorTest(int argc, char * argv[])
   // Set up a test image
   ImageType::RegionType::IndexType index{};
 
-  ImageType::RegionType::SizeType size;
-  size.Fill(200);
+  auto size = ImageType::RegionType::SizeType::Filled(200);
 
   ImageType::RegionType region{ index, size };
 

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -99,11 +99,9 @@ NeighborhoodAlgorithmTest()
 
   IndexType ind{};
 
-  SizeType size;
-  size.Fill(5);
+  auto size = SizeType::Filled(5);
 
-  SizeType radius;
-  radius.Fill(1);
+  auto radius = SizeType::Filled(1);
 
   RegionType region(ind, size);
 

--- a/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -35,8 +35,7 @@ itkPhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   auto image = Image::New();
   // image->DebugOn();
   // image->GetSource();
-  SizeType size;
-  size.Fill(5); // 5x5x5 sampling of data
+  auto       size = SizeType::Filled(5); // 5x5x5 sampling of data
   RegionType region;
   region.SetSize(size);
   image->SetRegions(region);

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -133,9 +133,8 @@ template <typename TImage>
 void
 ExpectRangeIsEmptyForAnEmptyContainerOfShapeOffsets()
 {
-  const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(1);
+  const auto image = TImage::New();
+  auto       imageSize = TImage::SizeType::Filled(1);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->Allocate();
@@ -157,9 +156,8 @@ void
 ExpectRangeIsNotEmptyForNonEmptyImageAndShapeOffsetContainer()
 {
   // First create a non-empty image:
-  const auto                image = TImage::New();
-  typename TImage::SizeType imageSize;
-  imageSize.Fill(1);
+  const auto image = TImage::New();
+  auto       imageSize = TImage::SizeType::Filled(1);
   image->SetRegions(imageSize);
   SetVectorLengthIfImageIsVectorImage(*image, 1);
   image->Allocate();

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -58,8 +58,7 @@ DoConvolution(typename ImageType::Pointer inputImage, unsigned long int directio
 
   sobelOperator.SetDirection(direction);
 
-  itk::Size<Dimension> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<Dimension>::Filled(1);
   sobelOperator.CreateToRadius(radius);
 
   NeighborhoodIteratorType it(radius, inputImage, inputImage->GetRequestedRegion());

--- a/Modules/Core/Common/test/itkSobelOperatorImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageFilterTest.cxx
@@ -54,8 +54,7 @@ itkSobelOperatorImageFilterTest(int argc, char * argv[])
       auto direction = std::stoul(argv[2]);
       sobelOperator.SetDirection(direction);
 
-      itk::Size<Dimension> radius;
-      radius.Fill(1);
+      auto radius = itk::Size<Dimension>::Filled(1);
       sobelOperator.CreateToRadius(radius);
     }
     filter->SetOperator(sobelOperator);

--- a/Modules/Core/Common/test/itkSobelOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorTest.cxx
@@ -44,8 +44,7 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.SetDirection(direction);
     ITK_TEST_SET_GET_VALUE(direction, sobelOperator.GetDirection());
 
-    itk::Size<Dimension2D> radius;
-    radius.Fill(1);
+    auto radius = itk::Size<Dimension2D>::Filled(1);
     sobelOperator.CreateToRadius(radius);
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesHoriz{
@@ -86,8 +85,7 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.SetDirection(direction);
     ITK_TEST_SET_GET_VALUE(direction, sobelOperator.GetDirection());
 
-    itk::Size<Dimension3D> radius;
-    radius.Fill(1);
+    auto radius = itk::Size<Dimension3D>::Filled(1);
     sobelOperator.CreateToRadius(radius);
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesX{
@@ -140,8 +138,7 @@ itkSobelOperatorTest(int, char *[])
 
     unsigned long direction = 0;
     sobelOperator.SetDirection(direction);
-    itk::Size<Dimension4D> radius;
-    radius.Fill(1);
+    auto radius = itk::Size<Dimension4D>::Filled(1);
     ITK_TRY_EXPECT_EXCEPTION(sobelOperator.CreateToRadius(radius));
   }
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -39,8 +39,7 @@ itkSymmetricSecondRankTensorImageReadTest(int argc, char * argv[])
 
   auto matrixImage = MatrixImageType::New();
 
-  MatrixImageType::SizeType size;
-  size.Fill(10);
+  auto size = MatrixImageType::SizeType::Filled(10);
 
   MatrixImageType::IndexType start{};
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -37,8 +37,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
 
   auto tensorImageInput = TensorImageType::New();
 
-  TensorImageType::SizeType size;
-  size.Fill(10);
+  auto size = TensorImageType::SizeType::Filled(10);
 
   TensorImageType::IndexType start{};
 

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -474,8 +474,7 @@ itkVectorImageTest(int, char * argv[])
         f[i] = i;
       }
       start.Fill(0);
-      VectorImageType::SizeType size;
-      size.Fill(11);
+      auto size = VectorImageType::SizeType::Filled(11);
       size[Dimension - 1] = 5;
       unsigned long midCtr = 1;
       for (unsigned int i = 0; i < Dimension; ++i)
@@ -586,10 +585,9 @@ itkVectorImageTest(int, char * argv[])
     // Create an image using itk::Vector
     using VectorPixelType = itk::Vector<PixelType, VectorLength>;
     using VectorImageType = itk::Image<itk::Vector<PixelType, VectorLength>, Dimension>;
-    auto                       image = VectorImageType::New();
-    VectorImageType::IndexType start{};
-    VectorImageType::SizeType  size;
-    size.Fill(5);
+    auto                        image = VectorImageType::New();
+    VectorImageType::IndexType  start{};
+    auto                        size = VectorImageType::SizeType::Filled(5);
     VectorImageType::RegionType region(start, size);
     image->SetRegions(region);
     image->Allocate();
@@ -715,9 +713,8 @@ itkVectorImageTest(int, char * argv[])
       radius.Fill(1);
 
       ConstNeighborhoodIteratorType::RegionType region = vectorImage->GetBufferedRegion();
-      ConstNeighborhoodIteratorType::SizeType   size;
-      size.Fill(4);
-      ConstNeighborhoodIteratorType::IndexType index;
+      auto                                      size = ConstNeighborhoodIteratorType::SizeType::Filled(4);
+      ConstNeighborhoodIteratorType::IndexType  index;
       index.Fill(1);
       region.SetIndex(index);
       region.SetSize(size);

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -57,8 +57,7 @@ testVectorImageAdaptor(typename TAdaptor::Pointer &                             
   bool failed = false;
 
   using AdaptedImageType = itk::Image<PixelType, Dimension>;
-  typename AdaptedImageType::IndexType index;
-  index.Fill(10);
+  auto index = AdaptedImageType::IndexType::Filled(10);
   std::cout << "Before adaptor initialization, vectorImage->GetPixel(" << index << ")[" << componentToExtract
             << "] = " << vectorImage->GetPixel(index)[componentToExtract] << std::endl;
 
@@ -559,8 +558,7 @@ itkVectorImageTest(int, char * argv[])
           lcit.NextLine();
         }
 
-        VectorImageType::IndexType idx;
-        idx.Fill(1);
+        auto               idx = VectorImageType::IndexType::Filled(1);
         LinearIteratorType lit(vectorImage, vectorImage->GetBufferedRegion());
         lit.SetIndex(idx);
         lit.Set(f);
@@ -714,8 +712,7 @@ itkVectorImageTest(int, char * argv[])
 
       ConstNeighborhoodIteratorType::RegionType region = vectorImage->GetBufferedRegion();
       auto                                      size = ConstNeighborhoodIteratorType::SizeType::Filled(4);
-      ConstNeighborhoodIteratorType::IndexType  index;
-      index.Fill(1);
+      auto                                      index = ConstNeighborhoodIteratorType::IndexType::Filled(1);
       region.SetIndex(index);
       region.SetSize(size);
 
@@ -754,8 +751,7 @@ itkVectorImageTest(int, char * argv[])
       // Test GoToEnd()
       cNit.GoToEnd();
       --cNit;
-      ConstNeighborhoodIteratorType::IndexType endIndex;
-      endIndex.Fill(4);
+      auto endIndex = ConstNeighborhoodIteratorType::IndexType::Filled(4);
       if (cNit.GetPixel(centerIndex) != vectorImage->GetPixel(endIndex))
       {
         std::cerr << "  GoToEnd [FAILED]" << std::endl;

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
@@ -85,8 +85,7 @@ itkVectorImageToImageAdaptorTest(int, char *[])
   }
 
   // test Get/SetPixel() methods
-  VectorImageToImageAdaptorType::IndexType index;
-  index.Fill(10);
+  auto index = VectorImageToImageAdaptorType::IndexType::Filled(10);
   ITK_TEST_EXPECT_EQUAL(PixelType(componentToExtract), vectorImageToImageAdaptor->GetPixel(index));
 
   PixelType v = 4.4f;

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -732,8 +732,7 @@ set2DInterpData(ImageType2D::Pointer imgPtr)
                         -225.6000, -84.6000,  0,         28.2000,   0,        -84.6000, -543.0000, -289.6000, -108.6000,
                         0,         36.2000,   0,         -108.6000 };
 
-  ImageType2D::IndexType index;
-  index.Fill(10);
+  auto index = ImageType2D::IndexType::Filled(10);
 
   ImageType2D::RegionType region{ index, size };
 

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -31,9 +31,8 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
 
   auto                   image = FloatImage::New();
   FloatImage::RegionType region;
-  FloatImage::SizeType   size;
-  size.Fill(64);
-  FloatImage::IndexType index{};
+  auto                   size = FloatImage::SizeType::Filled(64);
+  FloatImage::IndexType  index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -38,9 +38,8 @@ itkCentralDifferenceImageFunctionOnVectorSpeedTestRun(char * argv[])
   using PixelType = itk::Vector<float, vecLength>;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto                         image = ImageType::New();
-  typename ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                           image = ImageType::New();
+  auto                           size = ImageType::SizeType::Filled(imageSize);
   typename ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -52,9 +52,8 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   using PixelType = itk::Vector<float, VectorLength>;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto                         image = ImageType::New();
-  typename ImageType::SizeType size;
-  size.Fill(16);
+  auto                           image = ImageType::New();
+  auto                           size = ImageType::SizeType::Filled(16);
   typename ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
@@ -42,9 +42,8 @@ itkCentralDifferenceImageFunctionSpeedTest(int argc, char * argv[])
   using PixelType = unsigned int;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                  image = ImageType::New();
+  auto                  size = ImageType::SizeType::Filled(imageSize);
   ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -30,9 +30,8 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
   using PixelType = unsigned int;
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(16);
+  auto                  image = ImageType::New();
+  auto                  size = ImageType::SizeType::Filled(16);
   ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -58,8 +58,7 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   // Test the derivative of Gaussian image function
   auto gaussianFunction = GFunctionType::New();
   gaussianFunction->SetInputImage(image);
-  itk::Index<2> index;
-  index.Fill(25);
+  auto index = itk::Index<2>::Filled(25);
 
   // Testing Set/GetVariance()
   std::cout << "Testing Set/GetVariance(): ";

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -94,8 +94,7 @@ TestGaussianDerivativeImageFunction()
   std::cout << "[PASSED] " << std::endl;
 
   std::cout << "Testing consistency within Index/Point/ContinuousIndex: ";
-  itk::Index<Dimension> index;
-  index.Fill(25);
+  auto                                 index = itk::Index<Dimension>::Filled(25);
   typename DoGFunctionType::OutputType gradientIndex;
   gradientIndex = DoG->EvaluateAtIndex(index);
 

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -45,8 +45,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(3);
+  auto size = ImageType::SizeType::Filled(3);
 
   ImageType::RegionType region{ start, size };
 
@@ -69,8 +68,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
 
   interpolator->SetInputImage(image);
 
-  typename ImageType::SizeType radius;
-  radius.Fill(1);
+  auto radius = ImageType::SizeType::Filled(1);
   for (unsigned int d = 0; d < ImageType::ImageDimension; ++d)
   {
     ITK_TEST_SET_GET_VALUE(radius[d], interpolator->GetRadius()[d]);

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -150,8 +150,7 @@ RunLinearInterpolateTest()
   auto variablevectorinterpolator = VariableVectorInterpolatorType::New();
   variablevectorinterpolator->SetInputImage(variablevectorimage);
 
-  typename ImageType::SizeType radius;
-  radius.Fill(1);
+  auto radius = ImageType::SizeType::Filled(1);
   for (unsigned int d = 0; d < Dimensions; ++d)
   {
     ITK_TEST_SET_GET_VALUE(radius[d], interpolator->GetRadius()[d]);

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -60,8 +60,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
 
   IndexType start{};
 
-  SizeType size;
-  size.Fill(3);
+  auto size = SizeType::Filled(3);
 
   RegionType region{ start, size };
 

--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -66,8 +66,7 @@ itkNeighborhoodOperatorImageFunctionTest(int, char *[])
 
   function->SetOperator(oper);
 
-  itk::Index<3> index;
-  index.Fill(25);
+  auto index = itk::Index<3>::Filled(25);
 
   FunctionType::OutputType Blur;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
@@ -48,9 +48,8 @@ itkTriangleMeshToBinaryImageFilterTest1(int argc, char * argv[])
   mySphereMeshSource->Update();
 
   using ImageType = itk::Image<unsigned char, 3>;
-  auto                im = ImageType::New();
-  ImageType::SizeType imSize;
-  imSize.Fill(100);
+  auto im = ImageType::New();
+  auto imSize = ImageType::SizeType::Filled(100);
   im->SetRegions(imSize);
   im->Allocate();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -95,8 +95,7 @@ Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the
 
   // Expected size: the "region size" of a single pixel (1x1, in 2D, 1x1x1 in 3D).
   const itk::Size<VImageDimension> expectedSize = [] {
-    itk::Size<VImageDimension> size;
-    size.Fill(1);
+    auto size = itk::Size<VImageDimension>::Filled(1);
     return size;
   }();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
@@ -215,8 +215,7 @@ Test2dImageMask()
 
   auto imageFilter = SpatialObjectToImageFilterType::New();
 
-  itk::Size<2> size;
-  size.Fill(10);
+  auto size = itk::Size<2>::Filled(10);
   //  The SpatialObjectToImageFilter requires that the user defines the grid
   //  parameters of the output image. This includes the number of pixels along
   //  each dimension, the pixel spacing, and image direction

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -31,8 +31,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   using EllipseType = itk::EllipseSpatialObject<2>;
 
   // Image Definition
-  ImageType::SizeType size;
-  size.Fill(50);
+  auto                   size = ImageType::SizeType::Filled(50);
   ImageType::SpacingType spacing;
   spacing.Fill(1);
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -126,8 +126,7 @@ itkBSplineDeformableTransformTest1()
   /**
    * Populate the spline coefficients with some values.
    */
-  CoefficientImageType::IndexType index;
-  index.Fill(5);
+  auto index = CoefficientImageType::IndexType::Filled(5);
 
   coeffImage[1]->SetPixel(index, 1.0);
 
@@ -646,8 +645,7 @@ itkBSplineDeformableTransformTest3()
   /**
    * Populate the spline coefficients with some values.
    */
-  CoefficientImageType::IndexType index;
-  index.Fill(5);
+  auto index = CoefficientImageType::IndexType::Filled(5);
 
   coeffImage[1]->SetPixel(index, 1.0);
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -64,9 +64,8 @@ itkBSplineDeformableTransformTest1()
   OriginType origin{};
 
   using RegionType = TransformType::RegionType;
-  RegionType           region;
-  RegionType::SizeType size;
-  size.Fill(10);
+  RegionType region;
+  auto       size = RegionType::SizeType::Filled(10);
   region.SetSize(size);
   std::cout << region << std::endl;
 
@@ -600,9 +599,8 @@ itkBSplineDeformableTransformTest3()
   OriginType origin{};
 
   using RegionType = TransformType::RegionType;
-  RegionType           region;
-  RegionType::SizeType size;
-  size.Fill(10);
+  RegionType region;
+  auto       size = RegionType::SizeType::Filled(10);
   region.SetSize(size);
   std::cout << region << std::endl;
 

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
@@ -117,8 +117,7 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
   transformInitializer->SetImage(fixedImage);
   ITK_TEST_SET_GET_VALUE(fixedImage, transformInitializer->GetImage());
 
-  TransformType::MeshSizeType meshSize;
-  meshSize.Fill(4);
+  auto meshSize = TransformType::MeshSizeType::Filled(4);
 
   transformInitializer->SetTransformDomainMeshSize(meshSize);
   ITK_TEST_SET_GET_VALUE(meshSize, transformInitializer->GetTransformDomainMeshSize());

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -162,8 +162,7 @@ itkBSplineTransformTest1()
   /**
    * Populate the spline coefficients with some values.
    */
-  CoefficientImageType::IndexType index;
-  index.Fill(5);
+  auto index = CoefficientImageType::IndexType::Filled(5);
 
   coeffImage[1]->SetPixel(index, 1.0);
 
@@ -674,8 +673,7 @@ itkBSplineTransformTest3()
   /**
    * Populate the spline coefficients with some values.
    */
-  CoefficientImageType::IndexType index;
-  index.Fill(5);
+  auto index = CoefficientImageType::IndexType::Filled(5);
 
   coeffImage[1]->SetPixel(index, 1.0);
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -66,8 +66,7 @@ itkBSplineTransformTest1()
   dimensions.Fill(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
-  MeshSizeType meshSize;
-  meshSize.Fill(10);
+  auto meshSize = MeshSizeType::Filled(10);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -621,8 +620,7 @@ itkBSplineTransformTest3()
   dimensions.Fill(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
-  MeshSizeType meshSize;
-  meshSize.Fill(10);
+  auto meshSize = MeshSizeType::Filled(10);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
@@ -124,8 +124,7 @@ public:
     auto bsplineTransform = TransformType::New();
 
     using MeshSizeType = typename TransformType::MeshSizeType;
-    MeshSizeType meshSize;
-    meshSize.Fill(4);
+    auto meshSize = MeshSizeType::Filled(4);
 
     using PhysicalDimensionsType = typename TransformType::PhysicalDimensionsType;
     PhysicalDimensionsType fixedDimensions;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
@@ -142,8 +142,7 @@ public:
 
 
     using MeshSizeType = typename TransformType::MeshSizeType;
-    MeshSizeType meshSize;
-    meshSize.Fill(numberOfGridCells);
+    auto meshSize = MeshSizeType::Filled(numberOfGridCells);
 
     using PhysicalDimensionsType = typename TransformType::PhysicalDimensionsType;
     PhysicalDimensionsType fixedDimensions;

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
@@ -50,9 +50,8 @@ itkBinaryClosingByReconstructionImageFilterTest(int argc, char * argv[])
 
 
   using KernelType = itk::BinaryBallStructuringElement<bool, Dimension>;
-  KernelType           ball;
-  KernelType::SizeType ballSize;
-  ballSize.Fill(std::stoi(argv[5]));
+  KernelType ball;
+  auto       ballSize = KernelType::SizeType::Filled(std::stoi(argv[5]));
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
@@ -48,9 +48,8 @@ itkBinaryMorphologicalClosingImageFilterTest(int argc, char * argv[])
   reader->SetFileName(argv[1]);
 
   using KernelType = itk::BinaryBallStructuringElement<InputPixelType, dim>;
-  KernelType           ball;
-  KernelType::SizeType ballSize;
-  ballSize.Fill(std::stoi(argv[3]));
+  KernelType ball;
+  auto       ballSize = KernelType::SizeType::Filled(std::stoi(argv[3]));
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
@@ -48,9 +48,8 @@ itkBinaryMorphologicalOpeningImageFilterTest(int argc, char * argv[])
   reader->SetFileName(argv[1]);
 
   using KernelType = itk::BinaryBallStructuringElement<InputPixelType, dim>;
-  KernelType           ball;
-  KernelType::SizeType ballSize;
-  ballSize.Fill(std::stoi(argv[3]));
+  KernelType ball;
+  auto       ballSize = KernelType::SizeType::Filled(std::stoi(argv[3]));
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
@@ -47,9 +47,8 @@ itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
   reader->Update();
 
   using KernelType = itk::BinaryBallStructuringElement<bool, dim>;
-  KernelType           ball;
-  KernelType::SizeType ballSize;
-  ballSize.Fill(std::stoi(argv[3]));
+  KernelType ball;
+  auto       ballSize = KernelType::SizeType::Filled(std::stoi(argv[3]));
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
@@ -190,8 +190,7 @@ itkConvolutionImageFilterTest(int argc, char * argv[])
   // Test for invalid request region.
   ImageType::IndexType invalidIndex;
   invalidIndex.Fill(1000);
-  ImageType::SizeType invalidSize;
-  invalidSize.Fill(1000);
+  auto                  invalidSize = ImageType::SizeType::Filled(1000);
   ImageType::RegionType invalidRequestRegion(invalidIndex, invalidSize);
   convoluter->GetOutput()->SetRequestedRegion(invalidRequestRegion);
   try

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
@@ -188,8 +188,7 @@ itkConvolutionImageFilterTest(int argc, char * argv[])
   }
 
   // Test for invalid request region.
-  ImageType::IndexType invalidIndex;
-  invalidIndex.Fill(1000);
+  auto                  invalidIndex = ImageType::IndexType::Filled(1000);
   auto                  invalidSize = ImageType::SizeType::Filled(1000);
   ImageType::RegionType invalidRequestRegion(invalidIndex, invalidSize);
   convoluter->GetOutput()->SetRequestedRegion(invalidRequestRegion);

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -226,8 +226,7 @@ itkFFTConvolutionImageFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_EXCEPTION(convoluter->Update());
 
   // Test for invalid request region.
-  ImageType::IndexType invalidIndex;
-  invalidIndex.Fill(1000);
+  auto                  invalidIndex = ImageType::IndexType::Filled(1000);
   auto                  invalidSize = ImageType::SizeType::Filled(1000);
   ImageType::RegionType invalidRequestRegion(invalidIndex, invalidSize);
   convoluter->GetOutput()->SetRequestedRegion(invalidRequestRegion);

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -228,8 +228,7 @@ itkFFTConvolutionImageFilterTest(int argc, char * argv[])
   // Test for invalid request region.
   ImageType::IndexType invalidIndex;
   invalidIndex.Fill(1000);
-  ImageType::SizeType invalidSize;
-  invalidSize.Fill(1000);
+  auto                  invalidSize = ImageType::SizeType::Filled(1000);
   ImageType::RegionType invalidRequestRegion(invalidIndex, invalidSize);
   convoluter->GetOutput()->SetRequestedRegion(invalidRequestRegion);
 

--- a/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
@@ -148,10 +148,9 @@ itkCurvatureFlowTest(int argc, char * argv[])
     std::cout << "Test when wrong function type." << std::endl;
     using FunctionType = itk::DummyFunction<ImageType>;
     filter = FilterType::New();
-    auto                function = FunctionType::New();
-    auto                dummy = ImageType::New();
-    ImageType::SizeType size;
-    size.Fill(3);
+    auto                  function = FunctionType::New();
+    auto                  dummy = ImageType::New();
+    auto                  size = ImageType::SizeType::Filled(3);
     ImageType::RegionType region(size);
     dummy->SetRegions(region);
     dummy->Allocate();

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -207,8 +207,7 @@ doDenoising(const std::string & inputFileName,
       filter->GetNoiseModel() == FilterType::NoiseModelEnum::POISSON)
   {
     typename ImageT::IndexType::IndexValueType indexValue = 0;
-    typename ImageT::IndexType                 pixelIndex;
-    pixelIndex.Fill(indexValue);
+    auto                                       pixelIndex = ImageT::IndexType::Filled(indexValue);
 
     typename ImageT::PixelType originalPixelValue = inputImage->GetPixel(pixelIndex);
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -132,8 +132,7 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   ITK_TEST_EXPECT_EQUAL(bSplineDomainSpacing, bspliner->GetBSplineDomainSpacing());
 
   typename BSplineFilterType::SizeType::value_type bSplineDomainSizeVal = 0;
-  typename BSplineFilterType::SizeType             bSplineDomainSize;
-  bSplineDomainSize.Fill(bSplineDomainSizeVal);
+  auto bSplineDomainSize = BSplineFilterType::SizeType::Filled(bSplineDomainSizeVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainSize, bspliner->GetBSplineDomainSize());
 
   typename BSplineFilterType::DirectionType bSplineDomainDirection;

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -35,8 +35,7 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
   TimeVaryingVelocityFieldControlPointLatticeType::SpacingType spacing;
   spacing.Fill(2.0);
 
-  TimeVaryingVelocityFieldControlPointLatticeType::SizeType size;
-  size.Fill(25);
+  auto size = TimeVaryingVelocityFieldControlPointLatticeType::SizeType::Filled(25);
 
   VectorType displacement1;
   displacement1.Fill(0.1);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   TimeVaryingVelocityFieldType::SpacingType spacing;
   spacing.Fill(2.0);
 
-  TimeVaryingVelocityFieldType::SizeType size;
-  size.Fill(25);
+  auto size = TimeVaryingVelocityFieldType::SizeType::Filled(25);
 
   VectorType constantVelocity;
   constantVelocity.Fill(0.1);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
@@ -37,8 +37,7 @@ itkTimeVaryingVelocityFieldTransformTest(int, char *[])
   TimeVaryingVelocityFieldType::SpacingType spacing;
   spacing.Fill(2.0);
 
-  TimeVaryingVelocityFieldType::SizeType size;
-  size.Fill(25);
+  auto size = TimeVaryingVelocityFieldType::SizeType::Filled(25);
 
   VectorType displacement1;
   displacement1.Fill(0.1);

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
@@ -71,8 +71,7 @@ itkTransformToDisplacementFieldFilterTest(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
 
   // Create output information.
-  SizeType size;
-  size.Fill(20);
+  auto        size = SizeType::Filled(20);
   IndexType   index{};
   SpacingType spacing;
   spacing.Fill(0.7);

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -72,8 +72,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
 
 
   // Create input image.
-  SizeType size;
-  size.Fill(24);
+  auto        size = SizeType::Filled(24);
   IndexType   index{};
   SpacingType spacing;
   spacing[0] = 1.1;
@@ -135,9 +134,8 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   // Set Output information.
   IndexType   outputIndex{};
   SpacingType outputSpacing;
-  SizeType    outputSize;
-  outputSize.Fill(24);
-  RegionType outputRegion{ outputIndex, outputSize };
+  auto        outputSize = SizeType::Filled(24);
+  RegionType  outputRegion{ outputIndex, outputSize };
   outputSpacing[0] = 1.0;
   outputSpacing[1] = 2.0;
   outputSpacing[2] = 3.0;

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -149,8 +149,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   auto eulerTransform = TransformType::New();
   {
     // Set the options.
-    IndexType imageCenter;
-    imageCenter.Fill(11);
+    auto      imageCenter = IndexType::Filled(11);
     PointType centerPoint;
     image->TransformIndexToPhysicalPoint(imageCenter, centerPoint);
     eulerTransform->SetCenter(centerPoint);

--- a/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
@@ -74,9 +74,8 @@ itkApproximateSignedDistanceMapImageFilterTest(int argc, char * argv[])
   const InputPixelType     insideValue = std::stoi(argv[1]);
   constexpr InputPixelType outsideValue = 0;
 
-  auto                     image = InputImageType::New();
-  InputImageType::SizeType size;
-  size.Fill(64);
+  auto                       image = InputImageType::New();
+  auto                       size = InputImageType::SizeType::Filled(64);
   InputImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
@@ -35,8 +35,7 @@ itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
   auto image1 = Image1Type::New();
   auto image2 = Image2Type::New();
 
-  Image1Type::SizeType size;
-  size.Fill(50);
+  auto size = Image1Type::SizeType::Filled(50);
 
   image1->SetRegions(size);
   image2->SetRegions(size);

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -43,8 +43,7 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
   auto image1 = Image1Type::New();
   auto image2 = Image2Type::New();
 
-  Image1Type::SizeType size;
-  size.Fill(50);
+  auto size = Image1Type::SizeType::Filled(50);
 
   image1->SetRegions(size);
   image2->SetRegions(size);

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -35,8 +35,7 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
   auto image1 = Image1Type::New();
   auto image2 = Image2Type::New();
 
-  Image1Type::SizeType size;
-  size.Fill(50);
+  auto size = Image1Type::SizeType::Filled(50);
 
   image1->SetRegions(size);
   image2->SetRegions(size);

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -67,8 +67,7 @@ FastChamferDistanceImageFilterTest(unsigned int iPositive, unsigned int iNegativ
   using ImageType = itk::Image<PixelType, VDimension>;
   using PointType = itk::Point<double, VDimension>;
 
-  typename ImageType::SizeType size;
-  size.Fill(32);
+  auto                           size = ImageType::SizeType::Filled(32);
   typename ImageType::IndexType  index{};
   typename ImageType::RegionType region{ index, size };
 

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
@@ -41,8 +41,7 @@ itkHausdorffDistanceImageFilterTest(int argc, char * argv[])
   auto image1 = Image1Type::New();
   auto image2 = Image2Type::New();
 
-  Image1Type::SizeType size;
-  size.Fill(50);
+  auto size = Image1Type::SizeType::Filled(50);
 
   image1->SetRegions(size);
   image2->SetRegions(size);

--- a/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
@@ -73,9 +73,8 @@ itkIsoContourDistanceImageFilterTest(int, char *[])
   using PointType = itk::Point<double, ImageDimension>;
 
   // Fill an input image with simple signed distance function
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto                  image = ImageType::New();
+  auto                  size = ImageType::SizeType::Filled(128);
   ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -52,8 +52,7 @@ test(int testIdx)
    * give the same output as DaniessonDistanceMapImageFilter  */
 
   /* Allocate the 2D image */
-  myImageType2D1::SizeType size2D;
-  size2D.Fill(9);
+  auto size2D = myImageType2D1::SizeType::Filled(9);
 
   myImageType2D1::IndexType index2D{};
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -42,8 +42,7 @@ FastMarchingImageFilterBaseTestFunction()
   bool overrideOutputInformation = true;
   ITK_TEST_SET_GET_BOOLEAN(fastMarchingFilter, OverrideOutputInformation, overrideOutputInformation);
 
-  typename FastMarchingImageFilterType::OutputSizeType outputSize;
-  outputSize.Fill(32);
+  auto outputSize = FastMarchingImageFilterType::OutputSizeType::Filled(32);
   fastMarchingFilter->SetOutputSize(outputSize);
   ITK_TEST_SET_GET_VALUE(outputSize, fastMarchingFilter->GetOutputSize());
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -151,8 +151,7 @@ itkFastMarchingTest(int argc, char * argv[])
 
   auto outputRegionIndexValue =
     static_cast<typename FloatFMType::LevelSetImageType::IndexType::IndexValueType>(std::stoi(argv[5]));
-  typename FloatFMType::LevelSetImageType::IndexType outputRegionIndex;
-  outputRegionIndex.Fill(outputRegionIndexValue);
+  auto outputRegionIndex = FloatFMType::LevelSetImageType::IndexType::Filled(outputRegionIndexValue);
   typename FloatFMType::OutputRegionType outputRegion{ outputRegionIndex, size };
   marcher->SetOutputRegion(outputRegion);
   ITK_TEST_SET_GET_VALUE(outputRegion, marcher->GetOutputRegion());

--- a/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
@@ -37,8 +37,7 @@ itkSimilarityIndexImageFilterTest(int, char *[])
   auto image1 = Image1Type::New();
   auto image2 = Image2Type::New();
 
-  Image1Type::SizeType size;
-  size.Fill(8);
+  auto size = Image1Type::SizeType::Filled(8);
 
   image1->SetRegions(size);
   image2->SetRegions(size);

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
@@ -45,8 +45,7 @@ NormalizeSineWave(double frequencyPerImage, unsigned int order, double pixelSpac
   using ImageType = itk::Image<double, ImageDimension>;
   auto image = ImageType::New();
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto size = ImageType::SizeType::Filled(imageSize);
 
   image->SetRegions(ImageType::RegionType(size));
   image->Allocate();

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -38,8 +38,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
 
   auto inputImage = ImageType::New();
 
-  SizeType size;
-  size.Fill(21);
+  auto size = SizeType::Filled(21);
   size[0] = 401;
 
   IndexType start{};

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -316,8 +316,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
 
   ImageType::RegionType region;
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::IndexType index{};
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -140,8 +140,7 @@ itkHoughTransform2DLinesImageTest(int, char *[])
 
   ImageType::RegionType region;
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::IndexType index{};
 

--- a/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
@@ -79,8 +79,7 @@ itkMaskFeaturePointSelectionFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(nonConnectivity, filter->GetNonConnectivity());
 
   auto blockRadiusValue = static_cast<typename FilterType::SizeType::SizeValueType>(std::stod(argv[4]));
-  typename FilterType::SizeType blockRadius;
-  blockRadius.Fill(blockRadiusValue);
+  auto blockRadius = FilterType::SizeType::Filled(blockRadiusValue);
   filter->SetBlockRadius(blockRadius);
   ITK_TEST_SET_GET_VALUE(blockRadius, filter->GetBlockRadius());
 

--- a/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
@@ -91,9 +91,7 @@ itkSimpleContourExtractorImageFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(outputBackgroundValue, filter->GetOutputBackgroundValue());
 
 
-  FilterType::InputSizeType radius;
-
-  radius.Fill(1);
+  auto radius = FilterType::InputSizeType::Filled(1);
 
   filter->SetRadius(radius);
 

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -42,8 +42,7 @@ struct Utilities
   {
     auto image = ImageType::New();
 
-    typename ImageType::SizeType imageSize;
-    imageSize.Fill(5);
+    auto imageSize = ImageType::SizeType::Filled(5);
     image->SetRegions(typename ImageType::RegionType(imageSize));
     image->Allocate();
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -37,8 +37,7 @@ public:
   {
     m_Image = ImageType::New();
 
-    typename ImageType::SizeType size;
-    size.Fill(inputImageSize);
+    auto size = ImageType::SizeType::Filled(inputImageSize);
 
     typename ImageType::IndexType start{};
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -106,8 +106,7 @@ static typename TOutputImageType::Pointer
 CreateImage(unsigned int size)
 {
   using ImageType = itk::Image<char, TOutputImageType::ImageDimension>;
-  typename ImageType::SizeType imageSize;
-  imageSize.Fill(size);
+  auto imageSize = ImageType::SizeType::Filled(size);
   using RandomImageSourceType = itk::RandomImageSource<ImageType>;
   auto randomImageSource = RandomImageSourceType::New();
   randomImageSource->SetNumberOfWorkUnits(1); // to produce reproducible results

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
@@ -68,8 +68,7 @@ itkLabelMapContourOverlayImageFilterTest1(int argc, char * argv[])
   colorizer->SetType(type);
   ITK_TEST_SET_GET_VALUE(type, colorizer->GetType());
 
-  ColorizerType::SizeType r;
-  r.Fill(std::stoi(argv[6]));
+  auto r = ColorizerType::SizeType::Filled(std::stoi(argv[6]));
   colorizer->SetContourThickness(r);
   ITK_TEST_SET_GET_VALUE(r, colorizer->GetContourThickness());
 

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
@@ -59,8 +59,7 @@ itkLabelMapContourOverlayImageFilterTest2(int argc, char * argv[])
   colorizer->SetFeatureImage(reader2->GetOutput());
   colorizer->SetOpacity(std::stod(argv[4]));
   colorizer->SetType(std::stoi(argv[5]));
-  ColorizerType::SizeType r;
-  r.Fill(std::stoi(argv[6]));
+  auto r = ColorizerType::SizeType::Filled(std::stoi(argv[6]));
   colorizer->SetContourThickness(r);
   r.Fill(std::stoi(argv[7]));
   colorizer->SetDilationRadius(r);

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
@@ -55,8 +55,7 @@ itkLabelMapContourOverlayImageFilterTest3(int argc, char * argv[])
   colorizer->SetFeatureImage(reader2->GetOutput());
   colorizer->SetOpacity(std::stod(argv[4]));
   colorizer->SetType(std::stoi(argv[5]));
-  ColorizerType::SizeType r;
-  r.Fill(std::stoi(argv[6]));
+  auto r = ColorizerType::SizeType::Filled(std::stoi(argv[6]));
   colorizer->SetContourThickness(r);
   r.Fill(std::stoi(argv[7]));
   colorizer->SetDilationRadius(r);

--- a/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
@@ -60,8 +60,7 @@ itkLabelToRGBImageFilterTest(int argc, char * argv[])
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 
-  typename FilterType::OutputPixelType backgroundColor;
-  backgroundColor.Fill(typename FilterType::OutputPixelValueType{});
+  typename FilterType::OutputPixelType backgroundColor{};
   filter->SetBackgroundColor(backgroundColor);
   ITK_TEST_SET_GET_VALUE(backgroundColor, filter->GetBackgroundColor());
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -61,8 +61,7 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
 
   auto inputImage = myImageType::New();
 
-  mySizeType size;
-  size.Fill(8);
+  auto size = mySizeType::Filled(8);
 
   myIndexType start{};
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -47,9 +47,8 @@ BSpline(int argc, char * argv[])
 
   // Reconstruction of the scalar field from the control points
 
-  typename ScalarFieldType::PointType origin{};
-  typename ScalarFieldType::SizeType  size;
-  size.Fill(100);
+  typename ScalarFieldType::PointType   origin{};
+  auto                                  size = ScalarFieldType::SizeType::Filled(100);
   typename ScalarFieldType::SpacingType spacing;
   spacing.Fill(1.0);
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
@@ -79,8 +79,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest2(int argc, char * argv[])
   // Define the parametric domain
   ImageType::SpacingType spacing;
   spacing.Fill(0.01);
-  ImageType::SizeType size;
-  size.Fill(101);
+  auto                 size = ImageType::SizeType::Filled(101);
   ImageType::PointType origin{};
 
   filter->SetSize(size);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
@@ -47,8 +47,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
 
   using FilterType = itk::BSplineScatteredDataPointSetToImageFilter<PointSetType, VectorImageType>;
 
-  VectorImageType::SizeType size;
-  size.Fill(100);
+  auto                         size = VectorImageType::SizeType::Filled(100);
   VectorImageType::PointType   origin{};
   VectorImageType::SpacingType spacing;
   spacing.Fill(1);

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -132,8 +132,7 @@ itkChangeInformationImageFilterTest(int, char *[])
 
   using SizeType = itk::Size<ImageDimension>;
 
-  SizeType size;
-  size.Fill(20);
+  auto size = SizeType::Filled(20);
 
   inputImage->SetRegions(size);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
@@ -34,8 +34,7 @@ itkInterpolateImageFilterTest(int, char *[])
 
   // fill images
   using SizeType = InputImageType::SizeType;
-  SizeType size;
-  size.Fill(5);
+  auto size = SizeType::Filled(5);
 
   auto image1 = InputImageType::New();
   image1->SetRegions(size);

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -80,8 +80,7 @@ protected:
     {
       auto image = TImage::New();
 
-      typename TImage::SizeType imageSize;
-      imageSize.Fill(size);
+      auto imageSize = TImage::SizeType::Filled(size);
       image->SetRegions(typename TImage::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -82,8 +82,7 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   resample = itk::ResampleImageFilter<InputImageType, ImageType>::New();
   resample->SetInput(image);
 
-  ImageSizeType cubeSize;
-  cubeSize.Fill(7);
+  auto cubeSize = ImageSizeType::Filled(7);
   resample->SetSize(cubeSize);
 
   //  ImageType::SpacingType spacing;

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -44,8 +44,7 @@ sliceCallBack(itk::Object * object, const itk::EventObject &, void *)
   // std::cout << "callback! slice: " << filter->GetSliceIndex() << std::endl;
 
   // set half of the slice number as radius
-  MedianType::InputSizeType radius;
-  radius.Fill(filter->GetSliceIndex() / 2);
+  auto radius = MedianType::InputSizeType::Filled(filter->GetSliceIndex() / 2);
   median->SetRadius(radius);
 }
 

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -217,11 +217,9 @@ TEST(SliceImageFilterTests, Empty)
   SourceType::SizeValueType size[] = { 32, 32 };
   source->SetSize(size);
 
-  int                  step[ImageDimension] = { 1, 1 };
-  ImageType::IndexType start;
-  start.Fill(10);
-  ImageType::IndexType stop;
-  stop.Fill(10);
+  int  step[ImageDimension] = { 1, 1 };
+  auto start = ImageType::IndexType::Filled(10);
+  auto stop = ImageType::IndexType::Filled(10);
 
 
   ImageType::Pointer img;
@@ -255,8 +253,7 @@ TEST(SliceImageFilterTests, Coverage)
   auto filter = FilterType::New();
   std::cout << filter;
 
-  FilterType::IndexType idx;
-  idx.Fill(10);
+  auto idx = FilterType::IndexType::Filled(10);
 
   filter->SetStart(idx);
   EXPECT_EQ(idx, filter->GetStart());

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -73,8 +73,7 @@ protected:
     {
       auto image = InputImageType::New();
 
-      typename InputImageType::SizeType imageSize;
-      imageSize.Fill(size);
+      auto imageSize = InputImageType::SizeType::Filled(size);
       image->SetRegions(RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -207,8 +207,7 @@ itkWarpImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(outputDirection, warper->GetOutputDirection());
 
   typename WarperType::IndexType::value_type outputStartIndexVal = 0;
-  typename WarperType::IndexType             outputStartIndex;
-  outputStartIndex.Fill(outputStartIndexVal);
+  auto                                       outputStartIndex = WarperType::IndexType::Filled(outputStartIndexVal);
   warper->SetOutputStartIndex(outputStartIndex);
   ITK_TEST_SET_GET_VALUE(outputStartIndex, warper->GetOutputStartIndex());
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -213,8 +213,7 @@ itkWarpImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(outputStartIndex, warper->GetOutputStartIndex());
 
   typename WarperType::SizeType::value_type outputSizeVal = 0;
-  typename WarperType::SizeType             outputSize;
-  outputSize.Fill(outputSizeVal);
+  auto                                      outputSize = WarperType::SizeType::Filled(outputSizeVal);
   warper->SetOutputSize(outputSize);
   ITK_TEST_SET_GET_VALUE(outputSize, warper->GetOutputSize());
 

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
@@ -35,8 +35,7 @@ itkIntensityWindowingImageFilterTest(int, char *[])
 
   TestInputImage::RegionType region;
 
-  TestInputImage::SizeType size;
-  size.Fill(64);
+  auto size = TestInputImage::SizeType::Filled(64);
 
   TestInputImage::IndexType index{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -47,8 +47,7 @@ itkMatrixIndexSelectionImageFilterTest(int argc, char * argv[])
   auto                       image = InputImageType::New();
   InputImageType::RegionType region;
 
-  InputImageType::SizeType size;
-  size.Fill(100);
+  auto size = InputImageType::SizeType::Filled(100);
 
   InputImageType::IndexType index{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -32,8 +32,7 @@ InitializeImage(ImageType * image, const typename ImageType::PixelType & value)
   typename ImageType::Pointer inputImage(image);
 
   // Define their size, and start index
-  typename ImageType::SizeType size;
-  size.Fill(2);
+  auto size = ImageType::SizeType::Filled(2);
 
   typename ImageType::IndexType start{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
@@ -40,8 +40,7 @@ itkRescaleIntensityImageFilterTest(int, char *[])
 
   TestInputImage::RegionType region;
 
-  TestInputImage::SizeType size;
-  size.Fill(64);
+  auto size = TestInputImage::SizeType::Filled(64);
 
   TestInputImage::IndexType index{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -35,9 +35,8 @@ itkShiftScaleImageFilterTest(int, char *[])
 
   auto                       inputImage = TestInputImage::New();
   TestInputImage::RegionType region;
-  TestInputImage::SizeType   size;
-  size.Fill(64);
-  TestInputImage::IndexType index{};
+  auto                       size = TestInputImage::SizeType::Filled(64);
+  TestInputImage::IndexType  index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
@@ -67,9 +67,8 @@ itkTernaryOperatorImageFilterTest(int, char *[])
   using MaskImageType = itk::Image<MaskPixelType, ImageDimension>;
   using GrayImageType = itk::Image<GrayPixelType, ImageDimension>;
 
-  MaskImageType::IndexType origin{};
-  MaskImageType::SizeType  size;
-  size.Fill(20);
+  MaskImageType::IndexType  origin{};
+  auto                      size = MaskImageType::SizeType::Filled(20);
   MaskImageType::RegionType region(origin, size);
 
   auto mask = MaskImageType::New();

--- a/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
@@ -31,8 +31,7 @@ itkVectorMagnitudeImageFilterTest(int, char *[])
   using FloatImageType = itk::Image<float, 2>;
 
   // Define the size start index of the image
-  VectorImageType::SizeType size;
-  size.Fill(3);
+  auto size = VectorImageType::SizeType::Filled(3);
 
   VectorImageType::IndexType start{};
 

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -34,8 +34,7 @@ itkGaborImageSourceTestHelper(char * outputFilename, bool calculcateImaginaryPar
 
   if constexpr (ImageDimension == 2)
   {
-    typename ImageType::SizeType size;
-    size.Fill(64 * 4);
+    auto size = ImageType::SizeType::Filled(64 * 4);
     gaborImage->SetSize(size);
   }
 

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -55,9 +55,8 @@ itkGridImageSourceTest(int argc, char * argv[])
 
 
   // Specify image parameters
-  auto                size = static_cast<ImageType::SizeValueType>(std::stod(argv[2]));
-  ImageType::SizeType imageSize;
-  imageSize.Fill(size);
+  auto size = static_cast<ImageType::SizeValueType>(std::stod(argv[2]));
+  auto imageSize = ImageType::SizeType::Filled(size);
 
   ImageType::PointType origin{};
 

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -84,8 +84,7 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  itk::Size<ImageDimension> size;
-  size.Fill(64);
+  auto size = itk::Size<ImageDimension>::Filled(64);
 
   auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};

--- a/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
@@ -46,8 +46,7 @@ itkAdaptiveHistogramEqualizationImageFilterTest(int argc, char * argv[])
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  FilterType::ImageSizeType radius;
-  radius.Fill(std::stoi(argv[3]));
+  auto radius = FilterType::ImageSizeType::Filled(std::stoi(argv[3]));
 
   auto filter = FilterType::New();
 

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
@@ -49,8 +49,7 @@ protected:
     {
       auto image = ImageType::New();
 
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(m_ImageSize);
+      auto                           imageSize = ImageType::SizeType::Filled(m_ImageSize);
       typename ImageType::RegionType region(imageSize);
       image->SetRegions(region);
       image->Allocate();

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterGTest.cxx
@@ -54,8 +54,7 @@ protected:
 
       auto image = ImageType::New();
 
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(m_ImageSize);
+      auto                           imageSize = ImageType::SizeType::Filled(m_ImageSize);
       typename ImageType::RegionType region(imageSize);
       image->SetRegions(region);
       image->Allocate();

--- a/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
@@ -48,9 +48,8 @@ itkStatisticsImageFilterTest(int argc, char * argv[])
 
   auto                   image = FloatImage::New();
   FloatImage::RegionType region;
-  FloatImage::SizeType   size;
-  size.Fill(64);
-  FloatImage::IndexType index{};
+  auto                   size = FloatImage::SizeType::Filled(64);
+  FloatImage::IndexType  index{};
 
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
@@ -58,9 +58,8 @@ itkAttributeUniqueLabelMapFilterTest1(int argc, char * argv[])
 
   using KernelType = itk::FlatStructuringElement<dim>;
   using DilateType = itk::BinaryDilateImageFilter<ImageType, ImageType, KernelType>;
-  auto                 dilate = DilateType::New();
-  KernelType::SizeType rad;
-  rad.Fill(15);
+  auto dilate = DilateType::New();
+  auto rad = KernelType::SizeType::Filled(15);
   dilate->SetKernel(KernelType::Ball(rad));
 
   using OIType = itk::ObjectByObjectLabelMapFilter<LabelMapType, LabelMapType, DilateType>;

--- a/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
@@ -119,8 +119,7 @@ itkLabelMapMaskImageFilterTest(int argc, char * argv[])
     ITK_TEST_SET_GET_VALUE(false, maskFilter->GetCrop());
   }
 
-  MaskFilterType::SizeType border;
-  border.Fill(std::stoi(argv[8]));
+  auto border = MaskFilterType::SizeType::Filled(std::stoi(argv[8]));
   maskFilter->SetCropBorder(border);
   ITK_TEST_SET_GET_VALUE(border, maskFilter->GetCropBorder());
 

--- a/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
@@ -57,9 +57,8 @@ itkLabelUniqueLabelMapFilterTest1(int argc, char * argv[])
 
   using KernelType = itk::FlatStructuringElement<dim>;
   using DilateType = itk::BinaryDilateImageFilter<ImageType, ImageType, KernelType>;
-  auto                 dilate = DilateType::New();
-  KernelType::SizeType rad;
-  rad.Fill(15);
+  auto dilate = DilateType::New();
+  auto rad = KernelType::SizeType::Filled(15);
   dilate->SetKernel(KernelType::Ball(rad));
 
   using OIType = itk::ObjectByObjectLabelMapFilter<LabelMapType, LabelMapType, DilateType>;

--- a/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
@@ -54,9 +54,8 @@ itkObjectByObjectLabelMapFilterTest(int argc, char * argv[])
 
   using KernelType = itk::FlatStructuringElement<dim>;
   using DilateType = itk::BinaryDilateImageFilter<ImageType, ImageType, KernelType>;
-  auto                 dilate = DilateType::New();
-  KernelType::SizeType rad;
-  rad.Fill(3);
+  auto dilate = DilateType::New();
+  auto rad = KernelType::SizeType::Filled(3);
   dilate->SetKernel(KernelType::Ball(rad));
 
   using ObOType = itk::ObjectByObjectLabelMapFilter<LabelMapType>;

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -59,8 +59,7 @@ protected:
     {
       auto image = ImageType::New();
 
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(25);
+      auto imageSize = ImageType::SizeType::Filled(25);
       image->SetRegions(typename ImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -61,8 +61,7 @@ protected:
     {
       auto image = ImageType::New();
 
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(25);
+      auto imageSize = ImageType::SizeType::Filled(25);
       image->SetRegions(typename ImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);
@@ -75,8 +74,7 @@ protected:
     {
       auto image = ImageType::New();
 
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(25);
+      auto imageSize = ImageType::SizeType::Filled(25);
       image->SetRegions(typename ImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);
@@ -98,8 +96,7 @@ protected:
     {
       auto image = LabelImageType::New();
 
-      typename LabelImageType::SizeType imageSize;
-      imageSize.Fill(25);
+      auto imageSize = LabelImageType::SizeType::Filled(25);
       image->SetRegions(typename ImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);

--- a/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
@@ -80,8 +80,7 @@ protected:
       const size_t size = 25;
       auto         image = LabelImageType::New();
 
-      typename LabelImageType::SizeType imageSize;
-      imageSize.Fill(size);
+      auto imageSize = LabelImageType::SizeType::Filled(size);
       image->SetRegions(typename LabelImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);
@@ -108,9 +107,8 @@ protected:
 
       using KernelType = itk::FlatStructuringElement<Dimension>;
       using DilateType = itk::BinaryDilateImageFilter<LabelImageType, LabelImageType, KernelType>;
-      auto                          dilate = DilateType::New();
-      typename KernelType::SizeType rad;
-      rad.Fill(dilateRadius);
+      auto dilate = DilateType::New();
+      auto rad = KernelType::SizeType::Filled(dilateRadius);
       dilate->SetKernel(KernelType::Ball(rad));
 
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
@@ -57,9 +57,8 @@ itkOpeningByReconstructionImageFilterTest2(int argc, char * argv[])
 
   // Define regions of input image
   RegionType region;
-  SizeType   size;
-  size.Fill(std::stoi(argv[2]));
-  IndexType index{};
+  auto       size = SizeType::Filled(std::stoi(argv[2]));
+  IndexType  index{};
   region.SetSize(size);
   region.SetIndex(index);
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -24,8 +24,7 @@ CreateImagex(LocalImageType::Pointer & image)
 {
   LocalImageType::IndexType start{};
 
-  LocalImageType::SizeType size;
-  size.Fill(10);
+  auto size = LocalImageType::SizeType::Filled(10);
 
   LocalImageType::RegionType region(start, size);
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
@@ -49,8 +49,7 @@ itkRecursiveGaussianImageFilterOnTensorsTest(int, char *[])
   using ConstIteratorType = itk::ImageLinearConstIteratorWithIndex<ImageType>;
 
   // Create the 9x9 input image
-  ImageType::SizeType size;
-  size.Fill(9);
+  auto                  size = ImageType::SizeType::Filled(9);
   ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   auto                  inputImage = ImageType::New();

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -47,8 +47,7 @@ itkRecursiveGaussianImageFilterOnVectorImageTest(int, char *[])
   vector1.Fill(1.0);
 
   // Create the 9x9 input image
-  ImageType::SizeType size;
-  size.Fill(9);
+  auto                  size = ImageType::SizeType::Filled(9);
   ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   auto                  inputImage = ImageType::New();

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
@@ -45,8 +45,7 @@ NormalizeSineWave(double frequencyPerImage, unsigned int order, double pixelSpac
   using ImageType = itk::Image<double, ImageDimension>;
   auto image = ImageType::New();
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto size = ImageType::SizeType::Filled(imageSize);
 
   image->SetRegions(ImageType::RegionType(size));
   image->Allocate();

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
@@ -109,9 +109,8 @@ itkBinaryThresholdSpatialFunctionTest(int, char *[])
 
   // Set up a dummy image
   using ImageType = itk::Image<unsigned char, Dimension>;
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto image = ImageType::New();
+  auto size = ImageType::SizeType::Filled(10);
   image->SetRegions(size);
   image->Allocate();
   image->FillBuffer(255);

--- a/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
@@ -52,8 +52,7 @@ itkGDCMImageOrientationPatientTest(int argc, char * argv[])
   spacing2D[0] = 10.0;
   spacing2D[1] = 100.0;
 
-  Image2DType::SizeType size2D;
-  size2D.Fill(16);
+  auto size2D = Image2DType::SizeType::Filled(16);
 
   auto src2D = RandomImageSource2DType::New();
   src2D->SetMin(0);

--- a/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
@@ -57,8 +57,7 @@ itkGDCMImagePositionPatientTest(int argc, char * argv[])
   direction2D[0][1] = .7;
   direction2D[1][0] = .7;
   direction2D[1][1] = .5;
-  Image2DType::SizeType size2D;
-  size2D.Fill(16);
+  auto size2D = Image2DType::SizeType::Filled(16);
 
   auto src2D = RandomImageSource2DType::New();
   src2D->SetMin(0);

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -271,8 +271,7 @@ HDF5ReadWriteTest(const char * fileName)
     success = EXIT_FAILURE;
   }
 
-  itk::Array<char> metaDataCharArray2;
-  metaDataCharArray2.Fill(char{});
+  itk::Array<char> metaDataCharArray2{};
   if (!itk::ExposeMetaData<itk::Array<char>>(metaDict2, "TestCharArray", metaDataCharArray2) ||
       metaDataCharArray2 != metaDataCharArray)
   {

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -36,10 +36,7 @@ itkImageFileWriterTest(int argc, char * argv[])
   auto                    image = ImageNDType::New();
   ImageNDType::RegionType region;
   ImageNDType::IndexType  index;
-  ImageNDType::SizeType   size;
-
-
-  size.Fill(5);
+  auto                    size = ImageNDType::SizeType::Filled(5);
   index.Fill(0);
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -177,9 +177,7 @@ itkLargeImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
 
     return ActualTest<ImageType>(filename, size);
   }
@@ -190,9 +188,7 @@ itkLargeImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
     size[2] = atol(argv[3]);
 
     return ActualTest<ImageType>(filename, size);

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -36,8 +36,7 @@ itkMatrixImageWriteReadTest(int argc, char * argv[])
 
   auto matrixImage1 = MatrixImageType::New();
 
-  MatrixImageType::SizeType size;
-  size.Fill(10);
+  auto size = MatrixImageType::SizeType::Filled(10);
 
   MatrixImageType::IndexType start{};
 

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -38,8 +38,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
   // Create the 16x16 input image
   auto inputImage = ImageType::New();
 
-  ImageType::SizeType size;
-  size.Fill(16);
+  auto                  size = ImageType::SizeType::Filled(16);
   ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -60,8 +60,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   using ConstIteratorType = itk::ImageLinearConstIteratorWithIndex<ImageType>;
 
   // Create the 9x9 input image
-  ImageType::SizeType size;
-  size.Fill(9);
+  auto                  size = ImageType::SizeType::Filled(9);
   ImageType::IndexType  index{};
   ImageType::RegionType region{ index, size };
   inputImage->SetRegions(region);

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -51,9 +51,8 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
     using PixelType = typename ImageType::PixelType;
 
     // allocate an 10x10x10 image
-    auto                         image = ImageType::New();
-    typename ImageType::SizeType m_ImageSize;
-    m_ImageSize.Fill(10);
+    auto image = ImageType::New();
+    auto m_ImageSize = ImageType::SizeType::Filled(10);
     image->SetRegions(m_ImageSize);
     image->Allocate();
 

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -172,9 +172,7 @@ itkLargeMetaImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
 
     return ActualTest<ImageType>(filename, size);
   }
@@ -185,9 +183,7 @@ itkLargeMetaImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
     size[2] = atol(argv[3]);
 
     return ActualTest<ImageType>(filename, size);

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -170,8 +170,7 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   auto volume = ImageType3D::New();
 
-  ImageType3D::SizeType size3D;
-  size3D.Fill(10);
+  auto                    size3D = ImageType3D::SizeType::Filled(10);
   ImageType3D::IndexType  start3D{};
   ImageType3D::RegionType region3D{ start3D, size3D };
 
@@ -213,8 +212,7 @@ itkPNGImageIOTest(int argc, char * argv[])
   //
   auto image = ImageType2D::New();
 
-  ImageType2D::SizeType size2D;
-  size2D.Fill(10);
+  auto                    size2D = ImageType2D::SizeType::Filled(10);
   ImageType2D::IndexType  start2D{};
   ImageType2D::RegionType region2D{ start2D, size2D };
 
@@ -255,8 +253,7 @@ itkPNGImageIOTest(int argc, char * argv[])
   //
   auto line = ImageType1D::New();
 
-  ImageType1D::SizeType size1D;
-  size1D.Fill(10);
+  auto                    size1D = ImageType1D::SizeType::Filled(10);
   ImageType1D::IndexType  start1D{};
   ImageType1D::RegionType region1D{ start1D, size1D };
   line->SetRegions(region1D);

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -174,9 +174,7 @@ itkLargeTIFFImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
 
     return itkLargeTIFFImageWriteReadTestHelper<ImageType>(filename, size);
   }
@@ -187,9 +185,7 @@ itkLargeTIFFImageWriteReadTest(int argc, char * argv[])
     using PixelType = unsigned short;
     using ImageType = itk::Image<PixelType, Dimension>;
 
-    ImageType::SizeType size;
-
-    size.Fill(atol(argv[2]));
+    auto size = ImageType::SizeType::Filled(atol(argv[2]));
     size[2] = atol(argv[3]);
 
     return itkLargeTIFFImageWriteReadTestHelper<ImageType>(filename, size);

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -49,9 +49,8 @@ ReadWriteTest(const std::string fileName, const bool isRealDisplacementField, co
   using FieldType = typename DisplacementTransformType::DisplacementFieldType;
   auto knownField = FieldType::New(); // This is based on itk::Image
   {
-    constexpr int                dimLength = 20;
-    typename FieldType::SizeType size;
-    size.Fill(dimLength);
+    constexpr int                  dimLength = 20;
+    auto                           size = FieldType::SizeType::Filled(dimLength);
     typename FieldType::IndexType  start{};
     typename FieldType::RegionType region{ start, size };
     knownField->SetRegions(region);

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -99,9 +99,8 @@ public:
       writer->SetImageIO(vtkIO);
 
       // allocate an 10x10x10 image
-      auto                         image = ImageType::New();
-      typename ImageType::SizeType imageSize;
-      imageSize.Fill(10);
+      auto image = ImageType::New();
+      auto imageSize = ImageType::SizeType::Filled(10);
       image->SetRegions(imageSize);
       image->Allocate();
 

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
@@ -51,9 +51,8 @@ itkVTKImageIO2Test2(int argc, char * argv[])
 
   {
     // allocate an 10x10x10 image
-    auto                image = ImageType::New();
-    ImageType::SizeType imageSize;
-    imageSize.Fill(10);
+    auto image = ImageType::New();
+    auto imageSize = ImageType::SizeType::Filled(10);
     image->SetRegions(imageSize);
     image->Allocate();
 

--- a/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
@@ -71,8 +71,7 @@ itkReleaseDataFilterTest(int, char *[])
   mean1->SetInput(monitor1->GetOutput());
 
   // define the neighborhood size used for the mean filter
-  ImageType::SizeType neighRadius;
-  neighRadius.Fill(2);
+  auto neighRadius = ImageType::SizeType::Filled(2);
   mean1->SetRadius(neighRadius);
 
   auto monitor2a = MonitorFilter::New();

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -124,8 +124,7 @@ itkImageFunctionTest(int, char *[])
 
   auto image = ImageType::New();
 
-  IndexType start;
-  start.Fill(1);
+  auto     start = IndexType::Filled(1);
   SizeType size;
   size[0] = 3;
   size[1] = 4;

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -57,8 +57,7 @@ class EigenAnalysis2DImageFilterTester
     typename myImageType::Pointer inputImage(image);
 
     // Define their size, and start index
-    mySizeType size;
-    size.Fill(2);
+    auto size = mySizeType::Filled(2);
 
     myIndexType start{};
 

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -235,8 +235,7 @@ itkRegistrationParameterScalesEstimatorTest(int, char *[])
   auto                      movingImage = MovingImageType::New();
   VirtualImageType::Pointer virtualImage = fixedImage;
 
-  MovingImageType::SizeType size;
-  size.Fill(100);
+  auto size = MovingImageType::SizeType::Filled(100);
 
   movingImage->SetRegions(size);
   fixedImage->SetRegions(size);

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
@@ -128,8 +128,7 @@ itkRegistrationParameterScalesFromIndexShiftTest(int, char *[])
   auto                      movingImage = MovingImageType::New();
   VirtualImageType::Pointer virtualImage = fixedImage;
 
-  MovingImageType::SizeType size;
-  size.Fill(100);
+  auto size = MovingImageType::SizeType::Filled(100);
 
   movingImage->SetRegions(size);
   fixedImage->SetRegions(size);

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
@@ -128,8 +128,7 @@ itkRegistrationParameterScalesFromJacobianTest(int, char *[])
   auto                      movingImage = MovingImageType::New();
   VirtualImageType::Pointer virtualImage = fixedImage;
 
-  MovingImageType::SizeType size;
-  size.Fill(100);
+  auto size = MovingImageType::SizeType::Filled(100);
 
   movingImage->SetRegions(size);
   fixedImage->SetRegions(size);

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
@@ -128,8 +128,7 @@ itkRegistrationParameterScalesFromPhysicalShiftTest(int, char *[])
   auto                      movingImage = MovingImageType::New();
   VirtualImageType::Pointer virtualImage = fixedImage;
 
-  MovingImageType::SizeType size;
-  size.Fill(100);
+  auto size = MovingImageType::SizeType::Filled(100);
 
   movingImage->SetRegions(size);
   fixedImage->SetRegions(size);

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -48,9 +48,8 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   using SamplerType = itk::Statistics::GaussianRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
   using WriterType = itk::ImageFileWriter<FloatImage>;
 
-  auto     inImage = FloatImage::New();
-  SizeType sz;
-  sz.Fill(35);
+  auto       inImage = FloatImage::New();
+  auto       sz = SizeType::Filled(35);
   IndexType  idx{};
   RegionType region{ idx, sz };
 

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
@@ -32,8 +32,7 @@ itkHistogramToTextureFeaturesFilterNaNTest(int, char *[])
   // Build a constant image
   auto                  image = ImageType::New();
   ImageType::RegionType region;
-  ImageType::SizeType   size;
-  size.Fill(256);
+  auto                  size = ImageType::SizeType::Filled(256);
   region.SetSize(size);
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -74,9 +74,8 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   using SamplerType = itk::Statistics::SpatialNeighborSubsampler<AdaptorType, RegionType>;
   using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
 
-  auto     inImage = ImageType::New();
-  SizeType sz;
-  sz.Fill(25);
+  auto       inImage = ImageType::New();
+  auto       sz = SizeType::Filled(25);
   IndexType  idx{};
   RegionType region{ idx, sz };
 

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -108,8 +108,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
   // creates an image and allocate memory
   auto image = ImageType::New();
 
-  ImageType::SizeType size;
-  size.Fill(5);
+  auto size = ImageType::SizeType::Filled(5);
 
   ImageType::IndexType index{};
 

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
@@ -222,8 +222,7 @@ itkSubsampleTest(int, char *[])
 
   std::cout << subsample->GetTotalFrequency() << std::endl;
 
-  ArrayPixelImageType::IndexType index;
-  index.Fill(2); // index {2, 2, 2} = instance identifier (offset from image)
+  auto index = ArrayPixelImageType::IndexType::Filled(2); // index {2, 2, 2} = instance identifier (offset from image)
   ArrayPixelImageType::PixelType     pixel = filter->GetInput()->GetPixel(index);
   ListSampleType::InstanceIdentifier ind =
     static_cast<FloatImage::OffsetValueType>(filter->GetInput()->ComputeOffset(index));

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -51,10 +51,9 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
 
   auto                          inImage = FloatImage::New();
   typename SizeType::value_type regionSizeVal = 35;
-  SizeType                      sz;
-  sz.Fill(regionSizeVal);
-  IndexType  idx{};
-  RegionType region{ idx, sz };
+  auto                          sz = SizeType::Filled(regionSizeVal);
+  IndexType                     idx{};
+  RegionType                    region{ idx, sz };
 
   inImage->SetRegions(region);
   inImage->AllocateInitialized();

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -34,8 +34,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   origin.Fill(-5.0);
 
   using SizeType = TransformType::SizeType;
-  SizeType size;
-  size.Fill(65);
+  auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing;

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -59,8 +59,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   TransformType::OutputVectorType nonzeroVector;
   nonzeroVector.Fill(10.3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(40);
+  auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
 
   /**

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -35,8 +35,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   origin.Fill(-5.0);
 
   using SizeType = TransformType::SizeType;
-  SizeType size;
-  size.Fill(65);
+  auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing;

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -60,8 +60,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   TransformType::OutputVectorType nonzeroVector;
   nonzeroVector.Fill(10.3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(40);
+  auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
 
   /**

--- a/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
@@ -40,8 +40,7 @@ itkBSplineTransformParametersAdaptorTest(int, char *[])
   dimensions.Fill(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
-  MeshSizeType meshSize;
-  meshSize.Fill(10);
+  auto meshSize = MeshSizeType::Filled(10);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;

--- a/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
@@ -69,8 +69,7 @@ itkBSplineTransformParametersAdaptorTest(int, char *[])
   transform->SetParameters(parameters);
 
   using CoefficientImageType = TransformType::ImageType;
-  CoefficientImageType::IndexType index;
-  index.Fill(5);
+  auto index = CoefficientImageType::IndexType::Filled(5);
   transform->GetCoefficientImages()[0]->SetPixel(index, 5.0);
 
   TransformType::InputPointType point;

--- a/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -58,8 +58,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
   TransformType::OutputVectorType nonzeroVector;
   nonzeroVector.Fill(10.3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(40);
+  auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
 
   /**

--- a/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -34,8 +34,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
   origin.Fill(-5.0);
 
   using SizeType = TransformType::SizeType;
-  SizeType size;
-  size.Fill(65);
+  auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing;

--- a/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -60,8 +60,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   TransformType::OutputVectorType nonzeroVector;
   nonzeroVector.Fill(10.3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(40);
+  auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
 
   /**

--- a/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -35,8 +35,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   origin.Fill(-5.0);
 
   using SizeType = TransformType::SizeType;
-  SizeType size;
-  size.Fill(65);
+  auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing;

--- a/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -35,8 +35,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
   origin.Fill(-5.0);
 
   using SizeType = TransformType::SizeType;
-  SizeType size;
-  size.Fill(65);
+  auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing;

--- a/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -60,8 +60,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
   TransformType::OutputVectorType nonzeroVector;
   nonzeroVector.Fill(10.3);
 
-  DisplacementFieldType::IndexType index;
-  index.Fill(40);
+  auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
 
   /**

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -70,9 +70,8 @@ itkImageRegistrationMethodTest(int, char *[])
   auto interpolator = InterpolatorType::New();
   auto registration = RegistrationType::New();
 
-  FixedImageType::SizeType size;
-  size.Fill(4); // the size of image have to be at least 4 in each dimension to
-                // compute gradient image inside the metric.
+  auto size = FixedImageType::SizeType::Filled(4); // the size of image have to be at least 4 in each dimension to
+                                                   // compute gradient image inside the metric.
   FixedImageType::RegionType region(size);
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -61,8 +61,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   auto transform = TransformType::New();
   auto interpolator = InterpolatorType::New();
 
-  FixedImageType::SizeType fixedImageSize;
-  fixedImageSize.Fill(128);
+  auto fixedImageSize = FixedImageType::SizeType::Filled(128);
 
   // Create fixed image
   auto fixedImage = FixedImageType::New();
@@ -80,8 +79,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
     }
   }
 
-  MovingImageType::SizeType movingImageSize;
-  movingImageSize.Fill(128);
+  auto movingImageSize = MovingImageType::SizeType::Filled(128);
 
   // Create moving image
   auto movingImage = MovingImageType::New();

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -537,8 +537,7 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   {
     dimensions[dim] = imgFixed->GetSpacing()[dim] * (imgFixed->GetLargestPossibleRegion().GetSize()[dim] - 1);
   }
-  typename TransformType::MeshSizeType meshSize;
-  meshSize.Fill(4);
+  auto meshSize = TransformType::MeshSizeType::Filled(4);
 
   auto transformer = TransformType::New();
 

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -86,8 +86,7 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(registration, MultiResolutionImageRegistrationMethod, ProcessObject);
 
 
-  FixedImageType::SizeType size;
-  size.Fill(8);
+  auto size = FixedImageType::SizeType::Filled(8);
 
   FixedImageType::RegionType region(size);
   fixedImage->SetRegions(region);

--- a/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
+++ b/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
@@ -127,14 +127,12 @@ itkPhysicsBasedNonRigidRegistrationMethodTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(nonConnectivity, filter->GetNonConnectivity());
 
   auto blockRadiusValue = static_cast<PBNRRFilterType::ImageSizeType::SizeValueType>(std::stod(argv[8]));
-  PBNRRFilterType::ImageSizeType blockRadius;
-  blockRadius.Fill(blockRadiusValue);
+  auto blockRadius = PBNRRFilterType::ImageSizeType::Filled(blockRadiusValue);
   filter->SetBlockRadius(blockRadius);
   ITK_TEST_SET_GET_VALUE(blockRadius, filter->GetBlockRadius());
 
   auto searchRadiusValue = static_cast<PBNRRFilterType::ImageSizeType::SizeValueType>(std::stod(argv[9]));
-  PBNRRFilterType::ImageSizeType searchRadius;
-  searchRadius.Fill(searchRadiusValue);
+  auto searchRadius = PBNRRFilterType::ImageSizeType::Filled(searchRadiusValue);
   filter->SetSearchRadius(searchRadius);
   ITK_TEST_SET_GET_VALUE(searchRadius, filter->GetSearchRadius());
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -151,8 +151,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
   constexpr itk::SizeValueType imageSize = 6;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;
@@ -245,8 +244,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   const MetricType::RadiusType constRadius = metric->GetRadius();
   ITK_TEST_EXPECT_EQUAL(neighborhoodRadius0, constRadius);
 
-  itk::Size<ImageDimension> neighborhoodRadius;
-  neighborhoodRadius.Fill(1);
+  auto neighborhoodRadius = itk::Size<ImageDimension>::Filled(1);
 
   metric->SetRadius(neighborhoodRadius);
   ITK_TEST_SET_GET_VALUE(neighborhoodRadius, metric->GetRadius());

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
@@ -159,9 +159,8 @@ itkANTSNeighborhoodCorrelationImageToImageRegistrationTest(int argc, char * argv
 
   // The metric
   using MetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                 metric = MetricType::New();
-  itk::Size<Dimension> radSize;
-  radSize.Fill(2);
+  auto metric = MetricType::New();
+  auto radSize = itk::Size<Dimension>::Filled(2);
   metric->SetRadius(radSize);
 
   // Assign images and transforms.

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -128,8 +128,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -36,8 +36,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -268,8 +268,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
   FieldType::PointType origin;
   origin.Fill(static_cast<RealType>(0.0));
 
-  RegionType::SizeType regionSize;
-  regionSize.Fill(static_cast<itk::SizeValueType>(pointMax) + 1);
+  auto regionSize = RegionType::SizeType::Filled(static_cast<itk::SizeValueType>(pointMax) + 1);
 
   RegionType::IndexType regionIndex{};
 

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -110,8 +110,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
 
   typename FieldType::PointType origin{};
 
-  typename RegionType::SizeType regionSize;
-  regionSize.Fill(static_cast<itk::SizeValueType>(pointMax + 1.0));
+  auto regionSize = RegionType::SizeType::Filled(static_cast<itk::SizeValueType>(pointMax + 1.0));
 
   typename RegionType::IndexType regionIndex{};
 
@@ -227,8 +226,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
 
   // Test with invalid virtual domain, i.e.
   // one that doesn't match the displacement field.
-  typename RegionType::SizeType badSize;
-  badSize.Fill(static_cast<itk::SizeValueType>(pointMax / 2.0));
+  auto       badSize = RegionType::SizeType::Filled(static_cast<itk::SizeValueType>(pointMax / 2.0));
   RegionType badRegion{ regionIndex, badSize };
   metric->SetVirtualDomain(spacing, origin, direction, badRegion);
   ITK_TRY_EXPECT_EXCEPTION(metric->Initialize());

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -67,8 +67,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
   typename TImage::SpacingType spacing;
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
-  typename TImage::PointType origin;
-  origin.Fill(CoordinateRepresentationType{});
+  typename TImage::PointType origin{};
 
   typename TImage::DirectionType direction;
   direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -61,8 +61,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
   // Declare Gaussian Sources
   using GaussianImageSourceType = itk::GaussianImageSource<TImage>;
 
-  typename TImage::SizeType size;
-  size.Fill(ImageSize);
+  auto size = TImage::SizeType::Filled(ImageSize);
 
   typename TImage::SpacingType spacing;
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -36,8 +36,7 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -38,8 +38,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   using VectorType = itk::Vector<double, vectorLength>;
   using ImageType = itk::Image<VectorType, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -34,8 +34,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType
 
   using ImageType = typename TMetric::FixedImageType;
 
-  typename ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                            size = ImageType::SizeType::Filled(imageSize);
   typename ImageType::IndexType   index{};
   typename ImageType::RegionType  region{ index, size };
   typename ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -39,8 +39,7 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -34,8 +34,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                   size = ImageType::SizeType::Filled(imageSize);
   ImageType::IndexType   index{};
   ImageType::RegionType  region{ index, size };
   ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -209,8 +209,7 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
 
   using ImageType = itk::Image<double, ImageDimensionality>;
 
-  typename ImageType::SizeType size;
-  size.Fill(imageSize);
+  auto                            size = ImageType::SizeType::Filled(imageSize);
   typename ImageType::IndexType   virtualIndex{};
   typename ImageType::RegionType  region{ virtualIndex, size };
   typename ImageType::SpacingType spacing;

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -95,8 +95,7 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
   typename TImage::SpacingType spacing;
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
-  typename TImage::PointType origin;
-  origin.Fill(CoordinateRepresentationType{});
+  typename TImage::PointType origin{};
 
   typename TImage::DirectionType direction;
   direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -89,8 +89,7 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
   // Declare Gaussian Sources
   using GaussianImageSourceType = itk::GaussianImageSource<TImage>;
 
-  typename TImage::SizeType size;
-  size.Fill(ImageSize);
+  auto size = TImage::SizeType::Filled(ImageSize);
 
   typename TImage::SpacingType spacing;
   spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -165,8 +165,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   std::cout << "Generate input images and initial field";
   std::cout << std::endl;
 
-  SizeType size;
-  size.Fill(256);
+  auto size = SizeType::Filled(256);
   size[1] = 251;
 
   IndexType index{};

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -177,8 +177,7 @@ itkQuasiNewtonOptimizerv4RegistrationTestMain(int argc, char * argv[])
     auto nbcMetric = ANCMetricType::New();
     metric = nbcMetric.GetPointer();
 
-    itk::Size<Dimension> radSize;
-    radSize.Fill(2);
+    auto radSize = itk::Size<Dimension>::Filled(2);
     nbcMetric->SetRadius(radSize);
   }
   else

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
@@ -39,9 +39,8 @@ itkConnectedComponentImageFilterBackgroundTest(int argc, char * argv[])
 
   // Create an image with an arbitrary background value and a number
   // of islands with pixel values above and below the background value
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(512);
+  auto image = ImageType::New();
+  auto size = ImageType::SizeType::Filled(512);
   image->SetRegions(size);
   image->Allocate();
   image->FillBuffer(0);

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTooManyObjectsTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTooManyObjectsTest.cxx
@@ -29,9 +29,8 @@ itkConnectedComponentImageFilterTooManyObjectsTest(int itkNotUsed(argc), char *[
 
   // create a test input image with more objects in it than what the output type
   // can handle - 255
-  auto                img = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(512);
+  auto img = ImageType::New();
+  auto size = ImageType::SizeType::Filled(512);
   img->SetRegions(size);
   img->Allocate();
   img->FillBuffer(0);

--- a/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
@@ -50,9 +50,8 @@ itkVectorConnectedComponentImageFilterTest(int argc, char * argv[])
   // create an image of vectors
   auto                  image = ImageType::New();
   ImageType::RegionType region;
-  ImageType::SizeType   size;
-  size.Fill(100);
-  ImageType::IndexType index{};
+  auto                  size = ImageType::SizeType::Filled(100);
+  ImageType::IndexType  index{};
 
   region.SetSize(size);
   region.SetIndex(index);

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
@@ -77,8 +77,7 @@ itkDeformableSimplexMesh3DBalloonForceFilterTest(int argc, char * argv[])
 
   auto originalImage = OriginalImageType::New();
 
-  ImageSizeType imageSize;
-  imageSize.Fill(20);
+  auto imageSize = ImageSizeType::Filled(20);
   originalImage->SetRegions(imageSize);
   originalImage->Allocate();
 

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
@@ -96,8 +96,7 @@ itkDeformableSimplexMesh3DFilterTest(int, char *[])
   std::cout << "Creating dummy image...";
   auto originalImage = OriginalImageType::New();
 
-  ImageSizeType imageSize;
-  imageSize.Fill(20);
+  auto imageSize = ImageSizeType::Filled(20);
   originalImage->SetRegions(imageSize);
   originalImage->Allocate();
 

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
@@ -74,8 +74,7 @@ itkDeformableSimplexMesh3DGradientConstraintForceFilterTest(int, char *[])
 
   auto originalImage = OriginalImageType::New();
 
-  ImageSizeType imageSize;
-  imageSize.Fill(20);
+  auto imageSize = ImageSizeType::Filled(20);
   originalImage->SetRegions(imageSize);
   originalImage->Allocate();
 

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -119,8 +119,7 @@ test_RegionGrowKLMExceptionHandling()
   using ImageType5D = itk::Image<itk::Vector<double, NUMBANDS2>, NUMDIM5D>;
   auto image5D = ImageType5D::New();
 
-  ImageType5D::SizeType imageSize5D;
-  imageSize5D.Fill(sizeLen);
+  auto imageSize5D = ImageType5D::SizeType::Filled(sizeLen);
 
   ImageType5D::IndexType index5D{};
 
@@ -144,8 +143,7 @@ test_RegionGrowKLMExceptionHandling()
   ITK_EXERCISE_BASIC_OBJECT_METHODS(exceptionTestingFilter5D, KLMRegionGrowImageFilter, RegionGrowImageFilter);
 
 
-  KLMRegionGrowImageFilterType5D::GridSizeType gridSize5D;
-  gridSize5D.Fill(1);
+  auto gridSize5D = KLMRegionGrowImageFilterType5D::GridSizeType::Filled(1);
 
   exceptionTestingFilter5D->SetInput(image5D);
   exceptionTestingFilter5D->SetGridSize(gridSize5D);
@@ -235,10 +233,9 @@ test_regiongrowKLM1D()
 
   auto image = ImageType::New();
 
-  unsigned int        numPixels = 100;
-  unsigned int        numPixelsHalf = 50;
-  ImageType::SizeType imageSize;
-  imageSize.Fill(numPixels);
+  unsigned int numPixels = 100;
+  unsigned int numPixelsHalf = 50;
+  auto         imageSize = ImageType::SizeType::Filled(numPixels);
 
   ImageType::IndexType index{};
 
@@ -284,8 +281,7 @@ test_regiongrowKLM1D()
   ITK_EXERCISE_BASIC_OBJECT_METHODS(KLMFilter, KLMRegionGrowImageFilter, RegionGrowImageFilter);
 
 
-  KLMRegionGrowImageFilterType::GridSizeType gridSize;
-  gridSize.Fill(1);
+  auto gridSize = KLMRegionGrowImageFilterType::GridSizeType::Filled(1);
 
   KLMFilter->SetInput(image);
   KLMFilter->SetGridSize(gridSize);
@@ -869,8 +865,7 @@ test_regiongrowKLM2D()
 
   auto KLMFilter = KLMRegionGrowImageFilterType::New();
 
-  KLMRegionGrowImageFilterType::GridSizeType gridSize;
-  gridSize.Fill(1);
+  auto gridSize = KLMRegionGrowImageFilterType::GridSizeType::Filled(1);
 
   KLMFilter->SetInput(image);
   KLMFilter->SetMaximumNumberOfRegions(2);
@@ -1334,8 +1329,7 @@ test_regiongrowKLM3D()
 
   auto KLMFilter = KLMRegionGrowImageFilterType::New();
 
-  KLMRegionGrowImageFilterType::GridSizeType gridSize;
-  gridSize.Fill(1);
+  auto gridSize = KLMRegionGrowImageFilterType::GridSizeType::Filled(1);
 
   KLMFilter->SetInput(image);
   KLMFilter->SetMaximumNumberOfRegions(2);

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -52,8 +52,7 @@ itkVotingBinaryImageFilterTestImp(const std::string & infname,
 
   filter->SetInput(reader->GetOutput());
 
-  typename FilterType::InputSizeType R;
-  R.Fill(itk::Math::CastWithRangeCheck<itk::SizeValueType>(radius));
+  auto R = FilterType::InputSizeType::Filled(itk::Math::CastWithRangeCheck<itk::SizeValueType>(radius));
   filter->SetRadius(R);
 
   filter->SetForegroundValue(itk::Math::CastWithRangeCheck<InputPixelType>(foregroundValue));

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
@@ -64,8 +64,7 @@ itkCurvesLevelSetImageFilterTest(int, char *[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(20);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(60);
+  auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
@@ -62,8 +62,7 @@ itkCurvesLevelSetImageFilterTest(int, char *[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(20);
+  auto                  squareStart = ImageType::IndexType::Filled(20);
   auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
@@ -61,8 +61,7 @@ itkCurvesLevelSetImageFilterZeroSigmaTest(int, char *[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(20);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(60);
+  auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
@@ -59,8 +59,7 @@ itkCurvesLevelSetImageFilterZeroSigmaTest(int, char *[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(20);
+  auto                  squareStart = ImageType::IndexType::Filled(20);
   auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -125,9 +125,8 @@ itkExtensionVelocitiesImageFilterTest(int, char *[])
   using PointType = itk::Point<double, ImageDimension>;
 
   // Fill an input image with simple signed distance function
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto                  image = ImageType::New();
+  auto                  size = ImageType::SizeType::Filled(128);
   ImageType::RegionType region(size);
 
   image->SetRegions(region);
@@ -218,8 +217,7 @@ itkExtensionVelocitiesImageFilterTest(int, char *[])
   // mask out the peak at near the center point
   ImageType::IndexType centerIndex;
   centerIndex.Fill(50 - 8);
-  ImageType::SizeType centerSize;
-  centerSize.Fill(17);
+  auto                  centerSize = ImageType::SizeType::Filled(17);
   ImageType::RegionType centerRegion{ centerIndex, centerSize };
 
   iter = Iterator(difference->GetOutput(), centerRegion);

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -215,8 +215,7 @@ itkExtensionVelocitiesImageFilterTest(int, char *[])
   difference->Update();
 
   // mask out the peak at near the center point
-  ImageType::IndexType centerIndex;
-  centerIndex.Fill(50 - 8);
+  auto                  centerIndex = ImageType::IndexType::Filled(50 - 8);
   auto                  centerSize = ImageType::SizeType::Filled(17);
   ImageType::RegionType centerRegion{ centerIndex, centerSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
@@ -56,8 +56,7 @@ itkGeodesicActiveContourLevelSetImageFilterTest(int, char *[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(20);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(60);
+  auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
@@ -54,8 +54,7 @@ itkGeodesicActiveContourLevelSetImageFilterTest(int, char *[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(20);
+  auto                  squareStart = ImageType::IndexType::Filled(20);
   auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
@@ -56,8 +56,7 @@ itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest(int, char *[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(20);
+  auto                  squareStart = ImageType::IndexType::Filled(20);
   auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
@@ -58,8 +58,7 @@ itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest(int, char *[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(20);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(60);
+  auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
@@ -30,8 +30,7 @@ itkLevelSetNeighborhoodExtractorTest(int, char *[])
   using SourceType = itk::FastMarchingImageFilter<ImageType>;
   auto source = SourceType::New();
 
-  ImageType::SizeType size;
-  size.Fill(17);
+  auto size = ImageType::SizeType::Filled(17);
 
   source->SetOutputSize(size);
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
@@ -35,8 +35,7 @@ itkLevelSetNeighborhoodExtractorTest(int, char *[])
   source->SetOutputSize(size);
 
   SourceType::NodeType node;
-  ImageType::IndexType index;
-  index.Fill(8);
+  auto                 index = ImageType::IndexType::Filled(8);
 
   node.SetIndex(index);
   node.SetValue(-4.0);

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
@@ -31,8 +31,7 @@ itkLevelSetVelocityNeighborhoodExtractorTest(int, char *[])
   using SourceType = itk::FastMarchingImageFilter<ImageType>;
   auto source = SourceType::New();
 
-  ImageType::SizeType size;
-  size.Fill(17);
+  auto size = ImageType::SizeType::Filled(17);
 
   source->SetOutputSize(size);
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
@@ -36,8 +36,7 @@ itkLevelSetVelocityNeighborhoodExtractorTest(int, char *[])
   source->SetOutputSize(size);
 
   SourceType::NodeType node;
-  ImageType::IndexType index;
-  index.Fill(8);
+  auto                 index = ImageType::IndexType::Filled(8);
 
   node.SetIndex(index);
   node.SetValue(-4.0);

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
@@ -64,8 +64,7 @@ itkNarrowBandCurvesLevelSetImageFilterTest(int argc, char * argv[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(10);
+  auto                  squareStart = ImageType::IndexType::Filled(10);
   auto                  squareSize = ImageType::SizeType::Filled(30);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
@@ -66,8 +66,7 @@ itkNarrowBandCurvesLevelSetImageFilterTest(int argc, char * argv[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(10);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(30);
+  auto                  squareSize = ImageType::SizeType::Filled(30);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
@@ -76,9 +76,8 @@ itkReinitializeLevelSetImageFilterTest(int, char *[])
   using PointType = itk::Point<double, ImageDimension>;
 
   // Fill an input image with simple signed distance function
-  auto                image = ImageType::New();
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto                  image = ImageType::New();
+  auto                  size = ImageType::SizeType::Filled(128);
   ImageType::RegionType region(size);
 
   image->SetRegions(region);

--- a/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
@@ -62,8 +62,7 @@ itkShapeDetectionLevelSetImageFilterTest(int, char *[])
 
   ImageType::IndexType squareStart;
   squareStart.Fill(20);
-  ImageType::SizeType squareSize;
-  squareSize.Fill(60);
+  auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
@@ -60,8 +60,7 @@ itkShapeDetectionLevelSetImageFilterTest(int, char *[])
   inputImage->Allocate();
   inputImage->FillBuffer(background);
 
-  ImageType::IndexType squareStart;
-  squareStart.Fill(20);
+  auto                  squareStart = ImageType::IndexType::Filled(20);
   auto                  squareSize = ImageType::SizeType::Filled(60);
   ImageType::RegionType squareRegion{ squareStart, squareSize };
 

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -82,8 +82,7 @@ itkShapePriorMAPCostFunctionTest(int, char *[])
   /**
    * Create an input level set and active region container
    */
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto                  size = ImageType::SizeType::Filled(128);
   ImageType::RegionType region;
   region.SetSize(size);
 

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -121,8 +121,7 @@ itkShapePriorSegmentationLevelSetFunctionTest(int, char *[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // create an input level set using the sphere signed distance function
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto                  size = ImageType::SizeType::Filled(128);
   ImageType::RegionType region;
   region.SetSize(size);
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -37,8 +37,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   using ListImageIteratorType = itk::ImageRegionConstIteratorWithIndex<ListImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -54,8 +54,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -63,8 +63,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -66,8 +66,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -61,8 +61,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -60,8 +60,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -54,8 +54,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -60,8 +60,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
   using InputImageIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -68,8 +68,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size.Fill(50);
+  auto size = InputImageType::SizeType::Filled(50);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMalcolmSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMalcolmSparseLevelSetImageTest.cxx
@@ -28,8 +28,7 @@ itkMalcolmSparseLevelSetImageTest(int, char *[])
   using LabelMapType = SparseLevelSetType::LabelMapType;
   using IndexType = LabelMapType::IndexType;
 
-  IndexType index;
-  index.Fill(3);
+  auto index = IndexType::Filled(3);
 
   auto labelMap = LabelMapType::New();
   labelMap->SetBackgroundValue(1);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -67,8 +67,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   using DomainMapImageFilterType = itk::LevelSetDomainMapImageFilter<IdListImageType, CacheImageType>;
 
   // load binary input
-  InputImageType::SizeType size;
-  size.Fill(1000);
+  auto size = InputImageType::SizeType::Filled(1000);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -68,8 +68,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   using DomainMapImageFilterType = itk::LevelSetDomainMapImageFilter<IdListImageType, CacheImageType>;
 
   // load binary input
-  InputImageType::SizeType size;
-  size.Fill(1000);
+  auto size = InputImageType::SizeType::Filled(1000);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -68,8 +68,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   using DomainMapImageFilterType = itk::LevelSetDomainMapImageFilter<IdListImageType, CacheImageType>;
 
   // load binary input
-  InputImageType::SizeType size;
-  size.Fill(1000);
+  auto size = InputImageType::SizeType::Filled(1000);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -68,8 +68,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   using DomainMapImageFilterType = itk::LevelSetDomainMapImageFilter<IdListImageType, CacheImageType>;
 
   // load binary input
-  InputImageType::SizeType size;
-  size.Fill(1000);
+  auto size = InputImageType::SizeType::Filled(1000);
 
   InputImageType::PointType origin;
   origin[0] = 0.0;

--- a/Modules/Segmentation/LevelSetsv4/test/itkShiSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkShiSparseLevelSetImageTest.cxx
@@ -28,8 +28,7 @@ itkShiSparseLevelSetImageTest(int, char *[])
   using LabelMapType = SparseLevelSetType::LabelMapType;
   using IndexType = LabelMapType::IndexType;
 
-  IndexType index;
-  index.Fill(3);
+  auto index = IndexType::Filled(3);
 
   auto labelMap = LabelMapType::New();
   labelMap->SetBackgroundValue(3);

--- a/Modules/Segmentation/LevelSetsv4/test/itkWhitakerSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkWhitakerSparseLevelSetImageTest.cxx
@@ -30,8 +30,7 @@ itkWhitakerSparseLevelSetImageTest(int, char *[])
   using LabelMapType = SparseLevelSetType::LabelMapType;
   using IndexType = LabelMapType::IndexType;
 
-  IndexType index;
-  index.Fill(3);
+  auto index = IndexType::Filled(3);
 
   auto labelMap = LabelMapType::New();
   labelMap->SetBackgroundValue(3);

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -54,8 +54,7 @@ itkNeighborhoodConnectedImageFilterTest(int argc, char * argv[])
   filter->SetLower(0);
   filter->SetUpper(210);
   using SizeType = FilterType::InputImageSizeType;
-  SizeType radius;
-  radius.Fill(5);
+  auto radius = SizeType::Filled(5);
 
   filter->SetRadius(radius);
   filter->SetReplaceValue(255);

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -245,8 +245,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   TEST_INITIALIZATION_ERROR(PrincipalComponentImages, badPCImages, pcImages);
 
   // A PC image of the wrong size
-  ImageType::SizeType badSize;
-  badSize.Fill(1);
+  auto                  badSize = ImageType::SizeType::Filled(1);
   ImageType::RegionType badRegion(badSize);
   badPCImages[1] = ImageType::New();
   badPCImages[1]->SetRegions(badRegion);

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
@@ -73,8 +73,7 @@ protected:
     {
       auto image = InputImageType::New();
 
-      typename InputImageType::SizeType imageSize;
-      imageSize.Fill(size);
+      auto imageSize = InputImageType::SizeType::Filled(size);
       image->SetRegions(typename InputImageType::RegionType(imageSize));
       image->Allocate();
       image->FillBuffer(0);

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -73,8 +73,7 @@ itkIsolatedWatershedImageFilterTest(int argc, char * argv[])
   ImageType::Pointer inputImage = reader->GetOutput();
 
   ImageType::RegionType region = inputImage->GetLargestPossibleRegion();
-  ImageType::IndexType  offset;
-  offset.Fill(10);
+  auto                  offset = ImageType::IndexType::Filled(10);
 
   seed1[0] = region.GetUpperIndex()[0] + offset[0];
   filter->SetSeed1(seed1);

--- a/Modules/Video/Core/test/itkVideoSourceTest.cxx
+++ b/Modules/Video/Core/test/itkVideoSourceTest.cxx
@@ -123,8 +123,7 @@ CreateEmptyFrame()
 
   FrameType::RegionType requestedRegion;
   FrameType::SizeType   sizeReq;
-  FrameType::IndexType  startReq;
-  startReq.Fill(2);
+  auto                  startReq = FrameType::IndexType::Filled(2);
   sizeReq[0] = 20;
   sizeReq[1] = 10;
   requestedRegion.SetSize(sizeReq);


### PR DESCRIPTION
Replaced code of the form

    Type var;
    var.Fill(ElementType{});

with `Type var{};`

And specifically when having a local index or size variable, replaced code of the form

    T var;
    var.Fill(x);

with `auto var = T::Filled(x);`

Following C++ Core Guidelines, Oct 3, 2024, "Always initialize an object",
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always

- Follow-up to pull request #4881
