### PR TITLE
BUG: Replace `SetPoints` with `SetPointsByCoordinates` in wrapping tests

### DIFF
--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -52,7 +52,7 @@ for i in range(NumberOfPoints):
 arr = itk.array_view_from_vector_container(v_point)
 points_vc = itk.vector_container_from_array(arr.flatten())
 
-point_set.SetPoints(points_vc)
+point_set.SetPointsByCoordinates(points_vc)
 
 
 # Check the serialization of mesh

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -50,7 +50,7 @@ for i in range(NumberOfPoints):
 arr = itk.array_view_from_vector_container(v_point)
 points_vc = itk.vector_container_from_array(arr.flatten())
 
-mesh.SetPoints(points_vc)
+mesh.SetPointsByCoordinates(points_vc)
 
 
 # Set Cells in the Mesh as Triangle Cell
@@ -171,7 +171,7 @@ try:
 
         # Create a new ITK Mesh using data from VTK Mesh
         itk_mesh = MeshType.New()
-        itk_mesh.SetPoints(itk.vector_container_from_array(points_numpy))
+        itk_mesh.SetPointsByCoordinates(itk.vector_container_from_array(points_numpy))
         itk_mesh.SetCellsArray(itk.vector_container_from_array(polys_numpy), itk.CommonEnums.CellGeometry_TRIANGLE_CELL)
         itk_mesh.SetPointData(itk.vector_container_from_array(point_data_numpy))
         itk_mesh.SetCellData(itk.vector_container_from_array(cell_data_numpy))


### PR DESCRIPTION
When the points are specified by a flat VectorContainer of coordinates, passing those points to `SetPoints` may lead to undefined behavior. `SetPointsByCoordinates` is in that case preferred.

- Partially addresses issue #4848
- Related to pull request #4860

Aims to address a comment by @PranjalSahu at https://github.com/InsightSoftwareConsortium/ITK/pull/4860#issuecomment-2375249386 saying:
> We should also replace all the older tests using SetPoints with the new method to ensure everything else is working.