### PR TITLE
BUG: `QuadEdgeMeshPoint` should be properly initialized by `{}`

### DIFF
--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -59,7 +59,7 @@ public:
 #endif
 
 public:
-  QuadEdgeMeshPoint();
+  QuadEdgeMeshPoint() = default;
   QuadEdgeMeshPoint(const Self &) = default;
   QuadEdgeMeshPoint(QuadEdgeMeshPoint &&) = default;
   QuadEdgeMeshPoint &
@@ -118,7 +118,7 @@ protected:
   Initialize();
 
 protected:
-  TQuadEdge * m_Edge; /**< Entry edge for this point into an Onext ring */
+  TQuadEdge * m_Edge{}; /**< Entry edge for this point into an Onext ring */
 };
 } // end namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
@@ -30,12 +30,6 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::Initialize()
   m_Edge = static_cast<TQuadEdge *>(nullptr);
 }
 
-// ---------------------------------------------------------------------
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::QuadEdgeMeshPoint()
-{
-  this->Initialize();
-}
 
 // ---------------------------------------------------------------------
 template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>


### PR DESCRIPTION
Defaulted the default-constructor of `QuadEdgeMeshPoint`, and added an initializer to its data member m_Edge, to ensure that an instance of this type can be properly initialized by an empty initializer list, `{}`.

Aims to fix the dynamic analysis defects reported by Jon Haitz Legarreta Gorroño (@jhlegarreta) at https://github.com/InsightSoftwareConsortium/ITK/pull/4884#issuecomment-2426580344