### PR TITLE
STYLE: Replace Fill calls with `auto var = itk::MakeFilled<T>` in tests

### DIFF
--- a/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonTest.cxx
@@ -204,8 +204,7 @@ itkAdaptorComparisonTest(int, char *[])
   vector_image->SetRegions(region);
   vector_image->Allocate();
 
-  VectorImageType::PixelType initialVectorValue;
-  initialVectorValue.Fill(1.2345); // arbitrary value;
+  auto initialVectorValue = itk::MakeFilled<VectorImageType::PixelType>(1.2345); // arbitrary value;
   vector_image->FillBuffer(initialVectorValue);
 
   // Time trials

--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -287,11 +287,10 @@ public:
 
     //============ Test Copy with Round/Cast Type ====================================
     {
-      AggregateType         known3s{ { 3, 3, 3, 3 } };
-      AggregateType         threes{};
-      AggregateType         known4s{ { 4, 4, 4, 4 } };
-      itk::Point<double, 4> p1;
-      p1.Fill(3.5);
+      AggregateType known3s{ { 3, 3, 3, 3 } };
+      AggregateType threes{};
+      AggregateType known4s{ { 4, 4, 4, 4 } };
+      auto          p1 = itk::MakeFilled<itk::Point<double, 4>>(3.5);
       threes.CopyWithRound(p1);
       ITK_EXPECT_VECTOR_NEAR(threes, known4s, 0);
 

--- a/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionTest.cxx
@@ -50,14 +50,12 @@ itkConicShellInteriorExteriorSpatialFunctionTest(int, char *[])
                                     InteriorExteriorSpatialFunction);
 
   // Set the conic shell properties
-  ConicShellInteriorExteriorSpatialFunctionType::InputType origin;
-  origin.Fill(1.0);
+  auto origin = itk::MakeFilled<ConicShellInteriorExteriorSpatialFunctionType::InputType>(1.0);
 
   conicShellInteriorExteriorSpatialFunction->SetOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, conicShellInteriorExteriorSpatialFunction->GetOrigin());
 
-  ConicShellInteriorExteriorSpatialFunctionType::GradientType originGradient;
-  originGradient.Fill(1.6);
+  auto originGradient = itk::MakeFilled<ConicShellInteriorExteriorSpatialFunctionType::GradientType>(1.6);
   originGradient.GetVnlVector().normalize();
   conicShellInteriorExteriorSpatialFunction->SetOriginGradient(originGradient);
 

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -192,8 +192,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   printnb<itk::ConstNeighborhoodIterator<TestImageType>>(ra_it, false);
 
   println("Adding [1, 1, 1, 1]");
-  OffsetType a_off;
-  a_off.Fill(1);
+  auto a_off = itk::MakeFilled<OffsetType>(1);
   ra_it += a_off;
   printnb<itk::ConstNeighborhoodIterator<TestImageType>>(ra_it, false);
 

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -241,8 +241,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   ra_it.SetLocation(loc);
 
   std::cout << "Adding [1, 1, 1, 1]" << std::endl;
-  OffsetType a_off;
-  a_off.Fill(1);
+  auto a_off = itk::MakeFilled<OffsetType>(1);
   ra_it += a_off;
   for (unsigned int i = 0; i < 4; ++i)
   {

--- a/Modules/Core/Common/test/itkFrustumSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFrustumSpatialFunctionTest.cxx
@@ -43,8 +43,7 @@ itkFrustumSpatialFunctionTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(frustrumSpatialFunction, FrustumSpatialFunction, InteriorExteriorSpatialFunction);
 
   // Set the frustum properties
-  FrustumSpatialFunctionType::InputType apex;
-  apex.Fill(1.1);
+  auto apex = itk::MakeFilled<FrustumSpatialFunctionType::InputType>(1.1);
 
   frustrumSpatialFunction->SetApex(apex);
   ITK_TEST_SET_GET_VALUE(apex, frustrumSpatialFunction->GetApex());

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -62,8 +62,7 @@ ComputeOffset(TImage * image, unsigned int count, unsigned int repeat)
   typename TImage::OffsetValueType offset = 0;
   typename TImage::OffsetValueType accum = 0;
   typename TImage::IndexType       index;
-  typename TImage::OffsetType      indexIncr;
-  indexIncr.Fill(1);
+  auto                             indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
 
   for (unsigned int j = 0; j < repeat; ++j)
   {
@@ -86,8 +85,7 @@ ComputeFastOffset(TImage * image, unsigned int count, unsigned int repeat)
   typename TImage::OffsetValueType offset = 0;
   typename TImage::OffsetValueType accum = 0;
   typename TImage::IndexType       index;
-  typename TImage::OffsetType      indexIncr;
-  indexIncr.Fill(1);
+  auto                             indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
 
   const typename TImage::OffsetValueType * offsetTable = image->GetOffsetTable();
 

--- a/Modules/Core/Common/test/itkImageIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorTest.cxx
@@ -68,8 +68,7 @@ itkImageIteratorTest(int, char *[])
   o3->SetSpacing(spacing3D);
 
   o3->Allocate();
-  itk::Vector<unsigned short, 5> fillValue;
-  fillValue.Fill(itk::NumericTraits<unsigned short>::max());
+  auto fillValue = itk::MakeFilled<itk::Vector<unsigned short, 5>>(itk::NumericTraits<unsigned short>::max());
   o3->FillBuffer(fillValue);
 
   std::cout << "Setting/Getting a pixel" << std::endl;

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -264,8 +264,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<char,4>, 3 > " << std::endl;
   using VC = itk::Vector<char, 4>;
-  VC vc;
-  vc.Fill(127);
+  auto                                            vc = itk::MakeFilled<VC>(127);
   itkImageIteratorWithIndexTestIteratorTester<VC> TesterVC(vc);
   if (TesterVC.TestIterator() == false)
   {
@@ -282,8 +281,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<unsigned char,4>, 3 > " << std::endl;
   using VUC = itk::Vector<unsigned char, 4>;
-  VUC vuc;
-  vuc.Fill(10);
+  auto                                             vuc = itk::MakeFilled<VUC>(10);
   itkImageIteratorWithIndexTestIteratorTester<VUC> TesterVUC(vuc);
   if (TesterVUC.TestIterator() == false)
   {
@@ -300,8 +298,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<short,4>, 3 > " << std::endl;
   using VS = itk::Vector<short, 4>;
-  VS vs;
-  vs.Fill(10);
+  auto                                            vs = itk::MakeFilled<VS>(10);
   itkImageIteratorWithIndexTestIteratorTester<VS> TesterVS(vs);
   if (TesterVS.TestIterator() == false)
   {
@@ -318,8 +315,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<unsigned short,4>, 3 > " << std::endl;
   using VUS = itk::Vector<unsigned short, 4>;
-  VUS vus;
-  vus.Fill(10);
+  auto                                             vus = itk::MakeFilled<VUS>(10);
   itkImageIteratorWithIndexTestIteratorTester<VUS> TesterVUS(vus);
   if (TesterVUS.TestIterator() == false)
   {
@@ -336,8 +332,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<int,4>, 3 > " << std::endl;
   using VI = itk::Vector<int, 4>;
-  VI vi;
-  vi.Fill(10);
+  auto                                            vi = itk::MakeFilled<VI>(10);
   itkImageIteratorWithIndexTestIteratorTester<VI> TesterVI(vi);
   if (TesterVI.TestIterator() == false)
   {
@@ -354,8 +349,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<unsigned int,4>, 3 > " << std::endl;
   using VUI = itk::Vector<unsigned int, 4>;
-  VUI vui;
-  vui.Fill(10);
+  auto                                             vui = itk::MakeFilled<VUI>(10);
   itkImageIteratorWithIndexTestIteratorTester<VUI> TesterVUI(vui);
   if (TesterVUI.TestIterator() == false)
   {
@@ -372,8 +366,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<float,4>, 3 > " << std::endl;
   using VF = itk::Vector<float, 4>;
-  VF vf;
-  vf.Fill(10);
+  auto                                            vf = itk::MakeFilled<VF>(10);
   itkImageIteratorWithIndexTestIteratorTester<VF> TesterVF(vf);
   if (TesterVF.TestIterator() == false)
   {
@@ -390,8 +383,7 @@ itkImageIteratorWithIndexTest(int, char *[])
 
   std::cout << "Testing with Image< itk::Vector<double,4>, 3 > " << std::endl;
   using VD = itk::Vector<double, 4>;
-  VD vd;
-  vd.Fill(10);
+  auto                                            vd = itk::MakeFilled<VD>(10);
   itkImageIteratorWithIndexTestIteratorTester<VD> TesterVD(vd);
   if (TesterVD.TestIterator() == false)
   {

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -62,10 +62,8 @@ itkImageTest(int, char *[])
   image->GetSource();
   image->DisconnectPipeline();
 
-  Image::SpacingType spacing;
-  spacing.Fill(1.0);
-  Image::PointType origin;
-  origin.Fill(1.0);
+  auto                 spacing = itk::MakeFilled<Image::SpacingType>(1.0);
+  auto                 origin = itk::MakeFilled<Image::PointType>(1.0);
   Image::DirectionType direction;
   direction[0][0] = .5;
   direction[0][1] = .7;
@@ -127,9 +125,8 @@ itkImageTest(int, char *[])
   region.SetSize(size);
   image->SetRegions(region);
 
-  auto               imageRef = Image::New();
-  Image::SpacingType spacingRef;
-  spacingRef.Fill(2);
+  auto                 imageRef = Image::New();
+  auto                 spacingRef = itk::MakeFilled<Image::SpacingType>(2);
   Image::PointType     originRef{};
   Image::DirectionType directionRef;
   directionRef.SetIdentity();
@@ -161,9 +158,8 @@ itkImageTest(int, char *[])
   }
 
   using Image3D = itk::Image<float, 3>;
-  auto                 volume = Image3D::New();
-  Image3D::SpacingType spacingVol;
-  spacingVol.Fill(1);
+  auto                   volume = Image3D::New();
+  auto                   spacingVol = itk::MakeFilled<Image3D::SpacingType>(1);
   Image3D::PointType     originVol{};
   Image3D::DirectionType directionVol;
   directionVol.SetIdentity();

--- a/Modules/Core/Common/test/itkMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixTest.cxx
@@ -85,8 +85,7 @@ itkMatrixTest(int, char *[])
   MatrixType matrix4;
   matrix4 = matrix.GetTranspose();
 
-  MatrixType matrix5;
-  matrix5.Fill(1.7);
+  auto matrix5 = itk::MakeFilled<MatrixType>(1.7);
 
   constexpr NumericType value = 2;
   matrix5[1][1] = value;
@@ -332,8 +331,7 @@ itkMatrixTest(int, char *[])
   }
 
   using LargeMatrixType = itk::Matrix<NumericType, 7, 7>;
-  LargeMatrixType matrixBad;
-  matrixBad.Fill(2.0);
+  auto matrixBad = itk::MakeFilled<LargeMatrixType>(2.0);
   ITK_TRY_EXPECT_EXCEPTION(matrixBad.GetInverse());
 
   matrixBad.SetIdentity();

--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
@@ -68,8 +68,7 @@ itkPointSetToImageFilterTest1(int argc, char * argv[])
 
 
   BinaryImageType::SpacingType::ValueType spacingValue = 1.0;
-  BinaryImageType::SpacingType            spacing;
-  spacing.Fill(spacingValue);
+  auto                                    spacing = itk::MakeFilled<BinaryImageType::SpacingType>(spacingValue);
   filter->SetSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, filter->GetSpacing());
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -426,8 +426,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
     tensor3D(2, 1) = 0.0; // overrides (1,2)
     tensor3D(2, 2) = 29.0;
 
-    Double3DMatrixType matrix3D;
-    matrix3D.Fill(1.0);
+    auto                matrix3D = itk::MakeFilled<Double3DMatrixType>(1.0);
     std::vector<double> ans;
     ans.push_back(26);
     ans.push_back(23);

--- a/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
@@ -52,8 +52,7 @@ public:
     BeforeThreadedExecution() override
     {
       this->m_DomainInThreadedExecution.resize(this->GetNumberOfWorkUnitsUsed());
-      DomainType unsetDomain;
-      unsetDomain.Fill(-1);
+      auto unsetDomain = itk::MakeFilled<DomainType>(-1);
       for (auto & i : m_DomainInThreadedExecution)
       {
         i = unsetDomain;

--- a/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionTest.cxx
@@ -44,8 +44,7 @@ itkTorusInteriorExteriorSpatialFunctionTest(int, char *[])
     torusInteriorExteriorSpatialFunction, TorusInteriorExteriorSpatialFunction, InteriorExteriorSpatialFunction);
 
   // Set the torus properties
-  TorusInteriorExteriorSpatialFunctionType::InputType origin;
-  origin.Fill(1.0);
+  auto origin = itk::MakeFilled<TorusInteriorExteriorSpatialFunctionType::InputType>(1.0);
 
   torusInteriorExteriorSpatialFunction->SetOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, torusInteriorExteriorSpatialFunction->GetOrigin());

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
@@ -155,8 +155,7 @@ itkImageAdaptorTest(int, char *[])
   }
 
 
-  myImageType::PointType imageOrigin;
-  imageOrigin.Fill(10.0);
+  auto imageOrigin = itk::MakeFilled<myImageType::PointType>(10.0);
   myImage->SetOrigin(imageOrigin);
   if (myImage->GetOrigin() != myAdaptor->GetOrigin())
   {
@@ -184,8 +183,7 @@ itkImageAdaptorTest(int, char *[])
   }
 
 
-  myImageType::SpacingType imageSpacing;
-  imageSpacing.Fill(10.0);
+  auto imageSpacing = itk::MakeFilled<myImageType::SpacingType>(10.0);
 
   myImage->SetSpacing(imageSpacing);
   if (myImage->GetSpacing() != myAdaptor->GetSpacing())

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -707,8 +707,7 @@ itkVectorImageTest(int, char * argv[])
       std::cout << "Testing ConstNeighborhoodIterator...." << std::endl;
 
       using ConstNeighborhoodIteratorType = itk::ConstNeighborhoodIterator<VectorImageType>;
-      ConstNeighborhoodIteratorType::RadiusType radius;
-      radius.Fill(1);
+      auto radius = itk::MakeFilled<ConstNeighborhoodIteratorType::RadiusType>(1);
 
       ConstNeighborhoodIteratorType::RegionType region = vectorImage->GetBufferedRegion();
       auto                                      size = ConstNeighborhoodIteratorType::SizeType::Filled(4);
@@ -782,8 +781,7 @@ itkVectorImageTest(int, char * argv[])
 
       // Test operator-
       --cNit;
-      ConstNeighborhoodIteratorType::OffsetType offset;
-      offset.Fill(1);
+      auto offset = itk::MakeFilled<ConstNeighborhoodIteratorType::OffsetType>(1);
       cNit -= offset;
       itk::VariableLengthVector<PixelType> pixel = cNit.GetCenterPixel();
       itk::VariableLengthVector<PixelType> correctAnswer(VectorLength);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -132,8 +132,7 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   }
 
   // test continuous index
-  typename FunctionType::ContinuousIndexType cindex;
-  cindex.Fill(8.0);
+  auto       cindex = itk::MakeFilled<typename FunctionType::ContinuousIndexType>(8.0);
   OutputType continuousIndexOutput = function->EvaluateAtContinuousIndex(cindex);
   std::cout << "ContinuousIndex: " << cindex << " Derivative: ";
   std::cout << continuousIndexOutput << std::endl;
@@ -144,8 +143,7 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
     result = EXIT_FAILURE;
   }
 
-  typename FunctionType::PointType point;
-  point.Fill(8.0);
+  auto       point = itk::MakeFilled<typename FunctionType::PointType>(8.0);
   OutputType pointOutput = function->Evaluate(point);
   std::cout << "Point: " << point << " Derivative: ";
   std::cout << pointOutput << std::endl;

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -76,8 +76,7 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
     std::cout << "Index: " << index << " is inside the BufferedRegion." << std::endl;
   }
 
-  FunctionType::ContinuousIndexType cindex;
-  cindex.Fill(8.0);
+  auto       cindex = itk::MakeFilled<FunctionType::ContinuousIndexType>(8.0);
   OutputType continuousIndexOutput = function->EvaluateAtContinuousIndex(cindex);
   std::cout << "ContinuousIndex: " << cindex << " Derivative: ";
   std::cout << continuousIndexOutput << std::endl;
@@ -88,8 +87,7 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
     result = EXIT_FAILURE;
   }
 
-  FunctionType::PointType point;
-  point.Fill(8.0);
+  auto       point = itk::MakeFilled<FunctionType::PointType>(8.0);
   OutputType pointOutput = function->Evaluate(point);
   std::cout << "Point: " << point << " Derivative: ";
   std::cout << pointOutput << std::endl;

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -101,9 +101,7 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   // Testing Set/GetMaximumError()
   {
     std::cout << "Testing Set/GetMaximumError(): ";
-    GFunctionType::ErrorArrayType setError;
-
-    setError.Fill(0.05);
+    auto setError = itk::MakeFilled<GFunctionType::ErrorArrayType>(0.05);
     gaussianFunction->SetMaximumError(setError);
 
     const GFunctionType::ErrorArrayType & readError = gaussianFunction->GetMaximumError();
@@ -187,8 +185,7 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   blurredvalue_point = gaussianFunction->Evaluate(pt);
 
 
-  GFunctionType::ContinuousIndexType continuousIndex;
-  continuousIndex.Fill(25);
+  auto                      continuousIndex = itk::MakeFilled<GFunctionType::ContinuousIndexType>(25);
   GFunctionType::OutputType blurredvalue_continuousIndex;
   blurredvalue_continuousIndex = gaussianFunction->EvaluateAtContinuousIndex(continuousIndex);
 

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -104,8 +104,7 @@ TestGaussianDerivativeImageFunction()
   typename DoGFunctionType::OutputType gradientPoint;
   gradientPoint = DoG->Evaluate(pt);
 
-  typename DoGFunctionType::ContinuousIndexType continuousIndex;
-  continuousIndex.Fill(25);
+  auto continuousIndex = itk::MakeFilled<typename DoGFunctionType::ContinuousIndexType>(25);
   typename DoGFunctionType::OutputType gradientContinuousIndex;
   gradientContinuousIndex = DoG->EvaluateAtContinuousIndex(continuousIndex);
 

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -32,8 +32,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(interpolator, GaussianInterpolateImageFunction, InterpolateImageFunction);
 
-  InterpolatorType::ArrayType sigma;
-  sigma.Fill(1.0);
+  auto sigma = itk::MakeFilled<InterpolatorType::ArrayType>(1.0);
   interpolator->SetSigma(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, interpolator->GetSigma());
 

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -56,10 +56,8 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
     small_image->Allocate();
 
     {
-      ImageType::SpacingType spacing;
-      spacing.Fill(FOV / static_cast<double>(small_ySize));
-      ImageType::PointType origin;
-      origin.Fill(0.5 * FOV / static_cast<double>(small_ySize));
+      auto spacing = itk::MakeFilled<ImageType::SpacingType>(FOV / static_cast<double>(small_ySize));
+      auto origin = itk::MakeFilled<ImageType::PointType>(0.5 * FOV / static_cast<double>(small_ySize));
 
       small_image->SetOrigin(origin);
       small_image->SetSpacing(spacing);
@@ -128,10 +126,8 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
     large_image->Allocate();
 
     {
-      ImageType::SpacingType spacing;
-      spacing.Fill(FOV / static_cast<double>(large_ySize));
-      ImageType::PointType origin;
-      origin.Fill(0.5 * FOV / static_cast<double>(large_ySize));
+      auto spacing = itk::MakeFilled<ImageType::SpacingType>(FOV / static_cast<double>(large_ySize));
+      auto origin = itk::MakeFilled<ImageType::PointType>(0.5 * FOV / static_cast<double>(large_ySize));
 
       large_image->SetOrigin(origin);
       large_image->SetSpacing(spacing);

--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -84,8 +84,7 @@ itkNeighborhoodOperatorImageFunctionTest(int, char *[])
 
   std::cout << "EvaluateAtContinuousIndex: ";
 
-  FunctionType::ContinuousIndexType continuousIndex;
-  continuousIndex.Fill(25);
+  auto continuousIndex = itk::MakeFilled<FunctionType::ContinuousIndexType>(25);
 
   function->EvaluateAtContinuousIndex(continuousIndex);
 

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -56,8 +56,7 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   PointType origin{};
 
-  SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<SpacingType>(1.0);
 
   /* Set origin and spacing of physical coordinates */
   image->SetOrigin(origin);

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
@@ -37,14 +37,12 @@ itkRegularSphereMeshSourceTest(int, char *[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  PointType center;
-  center.Fill(7.4);
+  auto center = itk::MakeFilled<PointType>(7.4);
 
   constexpr double radius = 1.5;
   const double     tolerance = 1e-5;
 
-  VectorType scale;
-  scale.Fill(radius);
+  auto scale = itk::MakeFilled<VectorType>(radius);
 
   mySphereMeshSource->SetCenter(center);
   ITK_TEST_SET_GET_VALUE(center, mySphereMeshSource->GetCenter());

--- a/Modules/Core/Mesh/test/itkSimplexMeshAdaptTopologyFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshAdaptTopologyFilterTest.cxx
@@ -45,9 +45,8 @@ itkSimplexMeshAdaptTopologyFilterTest(int argc, char * argv[])
   // declare the triangle to simplex mesh filter
   using SimplexFilterType = itk::TriangleMeshToSimplexMeshFilter<TriangleMeshType, SimplexMeshType>;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(10);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(10);
   PointType::ValueType scaleInit[3] = { 3, 3, 3 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
@@ -36,9 +36,8 @@ itkTriangleMeshToBinaryImageFilterTest1(int argc, char * argv[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(50);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(50);
   PointType::ValueType scaleInit[3] = { 10, 10, 10 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
@@ -43,9 +43,8 @@ itkTriangleMeshToBinaryImageFilterTest2(int argc, char * argv[])
 
   using TriangleFilterType = itk::SimplexMeshToTriangleMeshFilter<SimplexMeshType, TriangleMeshType>;
   using TriangleMeshPointer = TriangleMeshType::Pointer;
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(-5);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(-5);
   PointType::ValueType scaleInit[3] = { 10, 10, 10 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
@@ -42,14 +42,12 @@ itkVTKPolyDataWriterTest02(int argc, char * argv[])
   using PointType = SphereMeshSourceType::PointType;
   using VectorType = SphereMeshSourceType::VectorType;
 
-  PointType center;
-  center.Fill(7.4);
+  auto center = itk::MakeFilled<PointType>(7.4);
 
   constexpr double radius = 1.5;
   const double     tolerance = 1e-5;
 
-  VectorType scale;
-  scale.Fill(radius);
+  auto scale = itk::MakeFilled<VectorType>(radius);
 
   mySphereMeshSource->SetCenter(center);
   mySphereMeshSource->SetResolution(1);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
@@ -45,8 +45,7 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
 
   PointType center{};
 
-  VectorType scale;
-  scale.Fill(1.0);
+  auto scale = itk::MakeFilled<VectorType>(1.0);
 
   mySphereMeshSource->SetCenter(center);
   mySphereMeshSource->SetResolution(1);

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
@@ -140,11 +140,9 @@ itkContourSpatialObjectPointTest(int, char *[])
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::ContourSpatialObjectPoint
-    ContourSpatialObjectPoint3DType::CovariantVectorType normal;
-    normal.Fill(276);
+    auto normal = itk::MakeFilled<ContourSpatialObjectPoint3DType::CovariantVectorType>(276);
     pOriginal.SetNormalInObjectSpace(normal);
-    ContourSpatialObjectPoint3DType::PointType picked;
-    picked.Fill(277);
+    auto picked = itk::MakeFilled<ContourSpatialObjectPoint3DType::PointType>(277);
     pOriginal.SetPickedPointInObjectSpace(picked);
 
     // Copy

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -63,8 +63,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   TubePointListType list;
 
-  TubeType::TransformType::OffsetType offset;
-  offset.Fill(10);
+  auto offset = itk::MakeFilled<TubeType::TransformType::OffsetType>(10);
   tube1->GetModifiableObjectToParentTransform()->SetOffset(offset);
 
   for (unsigned int i = 0; i < 10; ++i)
@@ -533,14 +532,11 @@ itkDTITubeSpatialObjectTest(int, char *[])
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::TubeSpatialObjectPoint
-    TubePointType::VectorType tangent;
-    tangent.Fill(1);
+    auto tangent = itk::MakeFilled<TubePointType::VectorType>(1);
     pOriginal.SetTangentInObjectSpace(tangent);
-    TubePointType::CovariantVectorType normal1;
-    normal1.Fill(2);
+    auto normal1 = itk::MakeFilled<TubePointType::CovariantVectorType>(2);
     pOriginal.SetNormal1InObjectSpace(normal1);
-    TubePointType::CovariantVectorType normal2;
-    normal2.Fill(3);
+    auto normal2 = itk::MakeFilled<TubePointType::CovariantVectorType>(3);
     pOriginal.SetNormal2InObjectSpace(normal2);
     pOriginal.SetRadiusInObjectSpace(1.0);
     pOriginal.SetMedialness(2.0);

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -85,13 +85,11 @@ itkEllipseSpatialObjectTest(int, char *[])
   myEllipse2->SetRadiusInObjectSpace(1);
   myEllipse->AddChild(myEllipse2);
 
-  EllipseType::TransformType::OffsetType offset;
-  offset.Fill(10);
+  auto offset = itk::MakeFilled<EllipseType::TransformType::OffsetType>(10);
   myEllipse->GetModifiableObjectToWorldTransform()->SetOffset(offset);
   myEllipse->ComputeObjectToParentTransform();
 
-  EllipseType::TransformType::OffsetType offset2;
-  offset2.Fill(15);
+  auto offset2 = itk::MakeFilled<EllipseType::TransformType::OffsetType>(15);
   myEllipse2->GetModifiableObjectToWorldTransform()->SetOffset(offset2);
   myEllipse2->ComputeObjectToParentTransform();
 

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -98,8 +98,7 @@ itkGaussianSpatialObjectTest(int, char *[])
 
   std::cout << "SetOffset" << std::endl;
   const GaussianType::TransformType::OffsetType::ValueType offset10 = 10.0;
-  GaussianType::TransformType::OffsetType                  offset;
-  offset.Fill(offset10);
+  auto offset = itk::MakeFilled<GaussianType::TransformType::OffsetType>(offset10);
   myGaussian->GetModifiableObjectToWorldTransform()->SetOffset(offset);
   myGaussian->ComputeObjectToParentTransform();
 
@@ -109,8 +108,7 @@ itkGaussianSpatialObjectTest(int, char *[])
 
   std::cout << "SetOffset2" << std::endl;
   const GaussianType::TransformType::OffsetType::ValueType offset15 = 15.0;
-  GaussianType::TransformType::OffsetType                  offset2;
-  offset2.Fill(offset15);
+  auto offset2 = itk::MakeFilled<GaussianType::TransformType::OffsetType>(offset15);
   myGaussian2->GetModifiableObjectToWorldTransform()->SetOffset(offset2);
   myGaussian2->ComputeObjectToParentTransform();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -47,8 +47,7 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   ImageType::PointType origin{};
   image->SetOrigin(origin);
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(1);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1);
   image->SetSpacing(spacing);
 
   ImageType::IndexType index{};

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -48,8 +48,7 @@ itkImageSpatialObjectTest(int, char *[])
   ImageType::SizeType   size = { { 10, 10, 10 } };
   ImageType::IndexType  index = { { 0, 0, 0 } };
   ImageType::RegionType region;
-  ImageType::PointType  origin;
-  origin.Fill(5);
+  auto                  origin = itk::MakeFilled<ImageType::PointType>(5);
 
   region.SetSize(size);
   region.SetIndex(index);
@@ -78,8 +77,7 @@ itkImageSpatialObjectTest(int, char *[])
   imageSO->SetImage(image);
   imageSO->Update();
 
-  ImageSpatialObject::TransformType::OffsetType offset;
-  offset.Fill(5);
+  auto offset = itk::MakeFilled<ImageSpatialObject::TransformType::OffsetType>(5);
 
   imageSO->GetModifiableObjectToParentTransform()->SetOffset(offset);
   imageSO->Update();

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -176,8 +176,7 @@ itkLineSpatialObjectTest(int, char *[])
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::LineSpatialObjectPoint
-    VectorType normal;
-    normal.Fill(276);
+    auto normal = itk::MakeFilled<VectorType>(276);
     pOriginal.SetNormalInObjectSpace(normal, 0);
 
     // Copy

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -43,8 +43,7 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   ellipse->Update();
 
   // Center the circle in the image
-  EllipseType::TransformType::OffsetType offset;
-  offset.Fill(25);
+  auto offset = itk::MakeFilled<EllipseType::TransformType::OffsetType>(25);
   ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->Update();
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -31,17 +31,15 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   using EllipseType = itk::EllipseSpatialObject<2>;
 
   // Image Definition
-  auto                   size = ImageType::SizeType::Filled(50);
-  ImageType::SpacingType spacing;
-  spacing.Fill(1);
+  auto size = ImageType::SizeType::Filled(50);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1);
 
   // Circle definition
   auto ellipse = EllipseType::New();
   ellipse->SetRadiusInObjectSpace(10);
   ellipse->Update();
 
-  EllipseType::VectorType offset;
-  offset.Fill(25);
+  auto offset = itk::MakeFilled<EllipseType::VectorType>(25);
   ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->Update();
 
@@ -182,8 +180,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   radii[2] = 0;
   ellipse3D->SetRadiusInObjectSpace(radii);
 
-  Ellipse3DType::VectorType offset3D;
-  offset3D.Fill(25);
+  auto offset3D = itk::MakeFilled<Ellipse3DType::VectorType>(25);
   offset3D[2] = 0; // first slice
   ellipse3D->GetModifiableObjectToParentTransform()->SetOffset(offset3D);
   ellipse3D->Update();

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -171,8 +171,7 @@ itkSurfaceSpatialObjectTest(int, char *[])
 
 
     // itk::SurfaceSpatialObjectPoint
-    VectorType normal;
-    normal.Fill(276);
+    auto normal = itk::MakeFilled<VectorType>(276);
     pOriginal.SetNormalInObjectSpace(normal);
 
     Surface->AddPoint(pOriginal);

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -66,8 +66,7 @@ itkTubeSpatialObjectTest(int, char *[])
 
   TubePointListType list;
 
-  TubeType::TransformType::OffsetType offset;
-  offset.Fill(10);
+  auto offset = itk::MakeFilled<TubeType::TransformType::OffsetType>(10);
   tube1->GetModifiableObjectToParentTransform()->SetOffset(offset);
 
   for (unsigned int i = 0; i < 10; ++i)
@@ -546,15 +545,11 @@ itkTubeSpatialObjectTest(int, char *[])
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::TubeSpatialObjectPoint
-    TubePointType::VectorType tangent;
-
-    tangent.Fill(1);
+    auto tangent = itk::MakeFilled<TubePointType::VectorType>(1);
     pOriginal.SetTangentInObjectSpace(tangent);
-    TubePointType::CovariantVectorType normal1;
-    normal1.Fill(2);
+    auto normal1 = itk::MakeFilled<TubePointType::CovariantVectorType>(2);
     pOriginal.SetNormal1InObjectSpace(normal1);
-    TubePointType::CovariantVectorType normal2;
-    normal2.Fill(3);
+    auto normal2 = itk::MakeFilled<TubePointType::CovariantVectorType>(3);
     pOriginal.SetNormal2InObjectSpace(normal2);
     pOriginal.SetRadiusInObjectSpace(1.0);
     pOriginal.SetMedialness(2.0);

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -70,8 +70,7 @@ itkBSplineDeformableTransformTest1()
   std::cout << region << std::endl;
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(2.0);
+  auto spacing = itk::MakeFilled<SpacingType>(2.0);
 
   /**
    * Instantiate a transform
@@ -297,8 +296,7 @@ itkBSplineDeformableTransformTest1()
    */
   {
     using VectorType = TransformType::InputVectorType;
-    VectorType vector;
-    vector.Fill(1.0);
+    auto vector = itk::MakeFilled<VectorType>(1.0);
 
     bool pass = false;
     try
@@ -321,8 +319,7 @@ itkBSplineDeformableTransformTest1()
 
   {
     using VectorType = TransformType::InputCovariantVectorType;
-    VectorType vector;
-    vector.Fill(1.0);
+    auto vector = itk::MakeFilled<VectorType>(1.0);
 
     bool pass = false;
     try
@@ -604,8 +601,7 @@ itkBSplineDeformableTransformTest3()
   std::cout << region << std::endl;
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(2.0);
+  auto spacing = itk::MakeFilled<SpacingType>(2.0);
   /**
    * Instantiate a transform
    */

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -62,8 +62,7 @@ itkBSplineTransformTest1()
   OriginType origin{};
 
   using PhysicalDimensionsType = TransformType::PhysicalDimensionsType;
-  PhysicalDimensionsType dimensions;
-  dimensions.Fill(100);
+  auto dimensions = itk::MakeFilled<PhysicalDimensionsType>(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
   auto meshSize = MeshSizeType::Filled(10);
@@ -319,8 +318,7 @@ itkBSplineTransformTest1()
    */
   {
     using VectorType = TransformType::InputVectorType;
-    VectorType vector;
-    vector.Fill(1.0);
+    auto vector = itk::MakeFilled<VectorType>(1.0);
 
     bool pass = false;
     try
@@ -343,8 +341,7 @@ itkBSplineTransformTest1()
 
   {
     using VectorType = TransformType::InputCovariantVectorType;
-    VectorType vector;
-    vector.Fill(1.0);
+    auto vector = itk::MakeFilled<VectorType>(1.0);
 
     bool pass = false;
     try
@@ -615,8 +612,7 @@ itkBSplineTransformTest3()
   OriginType origin{};
 
   using PhysicalDimensionsType = TransformType::PhysicalDimensionsType;
-  PhysicalDimensionsType dimensions;
-  dimensions.Fill(100);
+  auto dimensions = itk::MakeFilled<PhysicalDimensionsType>(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
   auto meshSize = MeshSizeType::Filled(10);

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -412,8 +412,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
     translation[2] = 23;
     transform->SetTranslation(translation);
 
-    TransformType::ScaleVectorType scale;
-    scale.Fill(2.5);
+    auto scale = itk::MakeFilled<TransformType::ScaleVectorType>(2.5);
     transform->SetScale(scale);
 
     TransformType::SkewVectorType skew{};

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -46,8 +46,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     vnlVector.fill(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformVector(vnlVector));
 
-    typename TransformType::InputCovariantVectorType covVector;
-    covVector.Fill(1.0);
+    auto covVector = itk::MakeFilled<typename TransformType::InputCovariantVectorType>(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformCovariantVector(covVector));
 
     auto                                         point = itk::MakeFilled<typename TransformType::InputPointType>(1.0);
@@ -130,8 +129,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
 
     {
       // Projecting  an itk::Point
-      TransformType::InputPointType p;
-      p.Fill(10);
+      auto                          p = itk::MakeFilled<TransformType::InputPointType>(10);
       TransformType::InputPointType q;
       q = p + ioffset;
       TransformType::OutputPointType s;
@@ -189,8 +187,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
 
     {
       // Project an itk::Point
-      TransformType::InputPointType p;
-      p.Fill(10.0);
+      auto                          p = itk::MakeFilled<TransformType::InputPointType>(10.0);
       TransformType::InputPointType q;
       q = p + ioffset;
       TransformType::OutputPointType s;

--- a/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
@@ -484,8 +484,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
 
     transform->SetTranslation(translation);
 
-    TransformType::ScaleVectorType scale;
-    scale.Fill(2.5);
+    auto scale = itk::MakeFilled<TransformType::ScaleVectorType>(2.5);
 
     transform->SetScale(scale);
 

--- a/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
@@ -490,8 +490,7 @@ itkScaleVersor3DTransformTest(int, char *[])
 
     transform->SetTranslation(translation);
 
-    TransformType::ScaleVectorType scale;
-    scale.Fill(2.5);
+    auto scale = itk::MakeFilled<TransformType::ScaleVectorType>(2.5);
 
     transform->SetScale(scale);
 

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -62,8 +62,7 @@ public:
   OutputPointType
   TransformPoint(const InputPointType & itkNotUsed(inputPoint)) const override
   {
-    OutputPointType outPoint;
-    outPoint.Fill(22.0);
+    auto outPoint = itk::MakeFilled<OutputPointType>(22.0);
     return outPoint;
   }
 
@@ -71,8 +70,7 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType & itkNotUsed(inputVector)) const override
   {
-    OutputVectorType outVector;
-    outVector.Fill(12.2);
+    auto outVector = itk::MakeFilled<OutputVectorType>(12.2);
     return outVector;
   }
 
@@ -93,8 +91,7 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType & itkNotUsed(inputVector)) const override
   {
-    OutputCovariantVectorType outVector;
-    outVector.Fill(8.9);
+    auto outVector = itk::MakeFilled<OutputCovariantVectorType>(8.9);
     return outVector;
   }
 
@@ -108,8 +105,7 @@ public:
   OutputDiffusionTensor3DType
   TransformDiffusionTensor3D(const InputDiffusionTensor3DType & itkNotUsed(tensor)) const override
   {
-    OutputDiffusionTensor3DType outTensor;
-    outTensor.Fill(2.1);
+    auto outTensor = itk::MakeFilled<OutputDiffusionTensor3DType>(2.1);
     return outTensor;
   }
 
@@ -123,8 +119,7 @@ public:
   OutputSymmetricSecondRankTensorType
   TransformSymmetricSecondRankTensor(const InputSymmetricSecondRankTensorType & itkNotUsed(tensor)) const override
   {
-    OutputSymmetricSecondRankTensorType outTensor;
-    outTensor.Fill(10.0);
+    auto outTensor = itk::MakeFilled<OutputSymmetricSecondRankTensorType>(10.0);
     return outTensor;
   }
 
@@ -190,8 +185,7 @@ public:
     std::cout << "Testing itkTransform<" << VInputDimension << ',' << VOutputDimension << '>' << std::endl;
     auto transform = TransformType::New();
 
-    InputPointType pnt;
-    pnt.Fill(2.9);
+    auto pnt = itk::MakeFilled<InputPointType>(2.9);
 
     transform->TransformPoint(pnt);
     std::cout << "TransformPoint()                              OK" << std::endl;

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -214,8 +214,7 @@ N4(int argc, char * argv[])
   correcter->SetMaximumNumberOfIterations(maximumNumberOfIterations);
   ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, correcter->GetMaximumNumberOfIterations());
 
-  typename CorrecterType::ArrayType numberOfFittingLevels;
-  numberOfFittingLevels.Fill(
+  auto numberOfFittingLevels = itk::MakeFilled<typename CorrecterType::ArrayType>(
     static_cast<typename CorrecterType::VariableSizeArrayType::SizeValueType>(numIters.size()));
   correcter->SetNumberOfFittingLevels(numberOfFittingLevels);
   ITK_TEST_SET_GET_VALUE(numberOfFittingLevels, correcter->GetNumberOfFittingLevels());

--- a/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
@@ -73,11 +73,9 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
   paramsFill(outlier) = 99.0;
   paramsFill(outlier + 1) = 99.0;
 
-  DisplacementTransformType::ArrayType meshSizeForUpdateField;
-  meshSizeForUpdateField.Fill(15);
+  auto meshSizeForUpdateField = itk::MakeFilled<DisplacementTransformType::ArrayType>(15);
   displacementTransform->SetMeshSizeForTheUpdateField(meshSizeForUpdateField);
-  DisplacementTransformType::ArrayType meshSizeForVelocityField;
-  meshSizeForVelocityField.Fill(30);
+  auto meshSizeForVelocityField = itk::MakeFilled<DisplacementTransformType::ArrayType>(30);
   displacementTransform->SetMeshSizeForTheConstantVelocityField(meshSizeForVelocityField);
   displacementTransform->SetSplineOrder(3);
   displacementTransform->SetParameters(paramsFill);

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -43,13 +43,13 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
 
 
   typename DisplacementTransformType::ArrayType::ValueType controlPointsUpdateFieldVal = 4;
-  typename DisplacementTransformType::ArrayType            controlPointsUpdateField;
-  controlPointsUpdateField.Fill(controlPointsUpdateFieldVal);
+  auto                                                     controlPointsUpdateField =
+    itk::MakeFilled<typename DisplacementTransformType::ArrayType>(controlPointsUpdateFieldVal);
   ITK_TEST_SET_GET_VALUE(controlPointsUpdateField, displacementTransform->GetNumberOfControlPointsForTheUpdateField());
 
   typename DisplacementTransformType::ArrayType::ValueType controlPointsTotalFieldVal = 0;
-  typename DisplacementTransformType::ArrayType            controlPointsTotalField;
-  controlPointsTotalField.Fill(controlPointsTotalFieldVal);
+  auto                                                     controlPointsTotalField =
+    itk::MakeFilled<typename DisplacementTransformType::ArrayType>(controlPointsTotalFieldVal);
   ITK_TEST_SET_GET_VALUE(controlPointsTotalField, displacementTransform->GetNumberOfControlPointsForTheTotalField());
 
   using FieldType = DisplacementTransformType::DisplacementFieldType;
@@ -82,12 +82,10 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   paramsFill(outlier) = 99.0;
   paramsFill(outlier + 1) = 99.0;
 
-  DisplacementTransformType::ArrayType meshSizeForUpdateField;
-  meshSizeForUpdateField.Fill(15);
+  auto meshSizeForUpdateField = itk::MakeFilled<DisplacementTransformType::ArrayType>(15);
   displacementTransform->SetMeshSizeForTheUpdateField(meshSizeForUpdateField);
 
-  DisplacementTransformType::ArrayType meshSizeForTotalField;
-  meshSizeForTotalField.Fill(30);
+  auto meshSizeForTotalField = itk::MakeFilled<DisplacementTransformType::ArrayType>(30);
   displacementTransform->SetMeshSizeForTheTotalField(meshSizeForTotalField);
 
   typename DisplacementTransformType::SplineOrderType splineOrder = 3;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -82,8 +82,7 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   pointSet->SetPoint(2, point3);
   pointSet->SetPointData(2, ones_points);
 
-  BSplineFilterType::ArrayType numberOfControlPoints;
-  numberOfControlPoints.Fill(4);
+  auto numberOfControlPoints = itk::MakeFilled<BSplineFilterType::ArrayType>(4);
 
   auto bspliner = BSplineFilterType::New();
 
@@ -109,8 +108,7 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(splineOrder, bspliner->GetSplineOrder());
 
   typename BSplineFilterType::ArrayType::ValueType numberOfFittingLevelsVal = 8;
-  typename BSplineFilterType::ArrayType            numberOfFittingLevels;
-  numberOfFittingLevels.Fill(numberOfFittingLevelsVal);
+  auto numberOfFittingLevels = itk::MakeFilled<typename BSplineFilterType::ArrayType>(numberOfFittingLevelsVal);
   bspliner->SetNumberOfFittingLevels(numberOfFittingLevelsVal);
   ITK_TEST_SET_GET_VALUE(numberOfFittingLevels, bspliner->GetNumberOfFittingLevels());
 
@@ -122,13 +120,11 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_BOOLEAN(bspliner, EstimateInverse, false);
 
   typename BSplineFilterType::OriginType::ValueType bSplineDomainOriginVal = 0.0;
-  typename BSplineFilterType::OriginType            bSplineDomainOrigin;
-  bSplineDomainOrigin.Fill(bSplineDomainOriginVal);
+  auto bSplineDomainOrigin = itk::MakeFilled<typename BSplineFilterType::OriginType>(bSplineDomainOriginVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainOrigin, bspliner->GetBSplineDomainOrigin());
 
   typename BSplineFilterType::SpacingType::ValueType bSplineDomainSpacingVal = 1.0;
-  typename BSplineFilterType::SpacingType            bSplineDomainSpacing;
-  bSplineDomainSpacing.Fill(bSplineDomainSpacingVal);
+  auto bSplineDomainSpacing = itk::MakeFilled<typename BSplineFilterType::SpacingType>(bSplineDomainSpacingVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainSpacing, bspliner->GetBSplineDomainSpacing());
 
   typename BSplineFilterType::SizeType::value_type bSplineDomainSizeVal = 0;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
@@ -66,8 +66,7 @@ itkDisplacementFieldTransformCloneTest(int, char *[])
   field->SetRegions(region);
   field->Allocate();
 
-  DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill(1);
+  auto zeroVector = itk::MakeFilled<DisplacementTransformType::OutputVectorType>(1);
   field->FillBuffer(zeroVector);
   displacementTransform->SetDisplacementField(field);
 

--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
@@ -71,8 +71,7 @@ itkExponentialDisplacementFieldImageFilterTest(int, char *[])
   IteratorType it(inputImage, inputImage->GetBufferedRegion());
 
   // Initialize the content of Image A
-  PixelType vectorValue;
-  vectorValue.Fill(5.0); // FIXME: replace with something more interesting...
+  auto vectorValue = itk::MakeFilled<PixelType>(5.0); // FIXME: replace with something more interesting...
 
   it.GoToBegin();
   while (!it.IsAtEnd())

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -58,8 +58,7 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Creating an input displacement field
   auto field = DisplacementFieldType::New();
 
-  DisplacementFieldType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
 
   DisplacementFieldType::PointType origin{};
 

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -62,8 +62,7 @@ itkIterativeInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Creating an input displacement field
   auto field = DisplacementFieldType::New();
 
-  DisplacementFieldType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
 
   DisplacementFieldType::PointType origin{};
 

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -53,8 +53,7 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
 
   itk::SimpleFilterWatcher watcher(filter);
 
-  DisplacementFieldType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
 
   DisplacementFieldType::PointType origin{};
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -29,16 +29,13 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
 
   constexpr unsigned int splineOrder = 3;
 
-  TimeVaryingVelocityFieldControlPointLatticeType::PointType origin;
-  origin.Fill(-2.0);
+  auto origin = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::PointType>(-2.0);
 
-  TimeVaryingVelocityFieldControlPointLatticeType::SpacingType spacing;
-  spacing.Fill(2.0);
+  auto spacing = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SpacingType>(2.0);
 
   auto size = TimeVaryingVelocityFieldControlPointLatticeType::SizeType::Filled(25);
 
-  VectorType displacement1;
-  displacement1.Fill(0.1);
+  auto displacement1 = itk::MakeFilled<VectorType>(0.1);
 
   TimeVaryingVelocityFieldControlPointLatticeType::Pointer timeVaryingVelocityFieldControlPointLattice =
     TimeVaryingVelocityFieldControlPointLatticeType::New();
@@ -144,16 +141,14 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
 
   transform->IntegrateVelocityField();
 
-  TransformType::InputPointType point;
-  point.Fill(1.3);
+  auto point = itk::MakeFilled<TransformType::InputPointType>(1.3);
 
   using OutputPointType = TransformType::OutputPointType;
   OutputPointType transformedPoint = transform->TransformPoint(point);
 
   std::cout << point << ", " << transformedPoint << transform->TransformPoint(point) << std::endl;
 
-  VectorType displacement;
-  displacement.Fill(0.1);
+  auto displacement = itk::MakeFilled<VectorType>(0.1);
 
   point += displacement;
   if (point.EuclideanDistanceTo(transformedPoint) > 0.1)

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -47,13 +47,11 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
 
   TimeVaryingVelocityFieldType::PointType origin{};
 
-  TimeVaryingVelocityFieldType::SpacingType spacing;
-  spacing.Fill(2.0);
+  auto spacing = itk::MakeFilled<TimeVaryingVelocityFieldType::SpacingType>(2.0);
 
   auto size = TimeVaryingVelocityFieldType::SizeType::Filled(25);
 
-  VectorType constantVelocity;
-  constantVelocity.Fill(0.1);
+  auto constantVelocity = itk::MakeFilled<VectorType>(0.1);
 
   auto constantVelocityField = TimeVaryingVelocityFieldType::New();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
@@ -34,13 +34,11 @@ itkTimeVaryingVelocityFieldTransformTest(int, char *[])
 
   TimeVaryingVelocityFieldType::PointType origin{};
 
-  TimeVaryingVelocityFieldType::SpacingType spacing;
-  spacing.Fill(2.0);
+  auto spacing = itk::MakeFilled<TimeVaryingVelocityFieldType::SpacingType>(2.0);
 
   auto size = TimeVaryingVelocityFieldType::SizeType::Filled(25);
 
-  VectorType displacement1;
-  displacement1.Fill(0.1);
+  auto displacement1 = itk::MakeFilled<VectorType>(0.1);
 
   auto timeVaryingVelocityField = TimeVaryingVelocityFieldType::New();
 
@@ -120,15 +118,13 @@ itkTimeVaryingVelocityFieldTransformTest(int, char *[])
   // Now Clone the Transform and test transform again
   TransformType::Pointer clone = transform->Clone();
 
-  TransformType::InputPointType point;
-  point.Fill(1.3);
+  auto point = itk::MakeFilled<TransformType::InputPointType>(1.3);
 
   using OutputPointType = TransformType::OutputPointType;
   OutputPointType transformedPoint = transform->TransformPoint(point);
   OutputPointType cloneTransformedPoint = clone->TransformPoint(point);
 
-  VectorType displacement;
-  displacement.Fill(0.1);
+  auto displacement = itk::MakeFilled<VectorType>(0.1);
 
   point += displacement;
 

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
@@ -71,12 +71,10 @@ itkTransformToDisplacementFieldFilterTest(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
 
   // Create output information.
-  auto        size = SizeType::Filled(20);
-  IndexType   index{};
-  SpacingType spacing;
-  spacing.Fill(0.7);
-  OriginType origin;
-  origin.Fill(-10.0);
+  auto      size = SizeType::Filled(20);
+  IndexType index{};
+  auto      spacing = itk::MakeFilled<SpacingType>(0.7);
+  auto      origin = itk::MakeFilled<OriginType>(-10.0);
 
   // Create transforms.
   auto affineTransform = AffineTransformType::New();

--- a/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
@@ -32,8 +32,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(32);
+  auto   center = itk::MakeFilled<TPoint>(32);
   double radius = 16;
 
   double accum = 0.0;

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -26,8 +26,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(16);
+  auto   center = itk::MakeFilled<TPoint>(16);
   double radius = 10;
 
   double accum = 0.0;

--- a/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterTest.cxx
@@ -47,8 +47,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(50);
+  auto   center = itk::MakeFilled<TPoint>(50);
   double radius = 19.5;
 
   double accum = 0.0;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -51,8 +51,7 @@ FastMarchingImageFilterBaseTestFunction()
   fastMarchingFilter->SetOutputRegion(outputRegion);
   ITK_TEST_SET_GET_VALUE(outputRegion, fastMarchingFilter->GetOutputRegion());
 
-  typename FastMarchingImageFilterType::OutputSpacingType outputSpacing;
-  outputSpacing.Fill(1.0);
+  auto outputSpacing = itk::MakeFilled<typename FastMarchingImageFilterType::OutputSpacingType>(1.0);
   fastMarchingFilter->SetOutputSpacing(outputSpacing);
   ITK_TEST_SET_GET_VALUE(outputSpacing, fastMarchingFilter->GetOutputSpacing());
 

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
@@ -50,8 +50,7 @@ NormalizeSineWave(double frequencyPerImage, unsigned int order, double pixelSpac
   image->SetRegions(ImageType::RegionType(size));
   image->Allocate();
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(pixelSpacing);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(pixelSpacing);
 
   image->SetSpacing(spacing);
 

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
@@ -96,14 +96,12 @@ itkDiscreteGaussianDerivativeImageFilterTest(int argc, char * argv[])
     maxKernelWidth = std::stoi(argv[7]);
   }
 
-  DerivativeFilterType::ArrayType variance;
-  variance.Fill(sigma * sigma);
+  auto variance = itk::MakeFilled<DerivativeFilterType::ArrayType>(sigma * sigma);
 
   derivativeFilter->SetVariance(variance);
   ITK_TEST_SET_GET_VALUE(variance, derivativeFilter->GetVariance());
 
-  DerivativeFilterType::ArrayType maxError;
-  maxError.Fill(maxErrorVal);
+  auto maxError = itk::MakeFilled<DerivativeFilterType::ArrayType>(maxErrorVal);
 
   derivativeFilter->SetMaximumError(maxErrorVal);
   ITK_TEST_SET_GET_VALUE(maxError, derivativeFilter->GetMaximumError());

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -47,12 +47,10 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
   region.SetIndex(start);
   region.SetSize(size);
 
-  PointType origin;
-  origin.Fill(-1.25);
+  auto origin = itk::MakeFilled<PointType>(-1.25);
   origin[0] = -20.0;
 
-  SpacingType spacing;
-  spacing.Fill(0.1);
+  auto spacing = itk::MakeFilled<SpacingType>(0.1);
 
   inputImage->SetOrigin(origin);
   inputImage->SetSpacing(spacing);

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
@@ -58,8 +58,7 @@ itkZeroCrossingBasedEdgeDetectionImageFilterTest(int argc, char * argv[])
     }
   }
 
-  FilterType::ArrayType variance;
-  variance.Fill(varianceValue);
+  auto variance = itk::MakeFilled<FilterType::ArrayType>(varianceValue);
   filter->SetVariance(variance);
   ITK_TEST_SET_GET_VALUE(variance, filter->GetVariance());
 
@@ -76,8 +75,7 @@ itkZeroCrossingBasedEdgeDetectionImageFilterTest(int argc, char * argv[])
     }
   }
 
-  FilterType::ArrayType maximumError;
-  maximumError.Fill(maximumErrorValue);
+  auto maximumError = itk::MakeFilled<FilterType::ArrayType>(maximumErrorValue);
   filter->SetMaximumError(maximumError);
   ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -76,14 +76,12 @@ itkVectorGradientMagnitudeImageFilterTest1(int argc, char * argv[])
   ITK_TEST_SET_GET_BOOLEAN(filter, UseImageSpacing, useImageSpacing);
 
   auto derivativeWeightsValue = static_cast<FilterType::DerivativeWeightsType::ValueType>(std::stod(argv[4]));
-  FilterType::DerivativeWeightsType derivativeWeights;
-  derivativeWeights.Fill(derivativeWeightsValue);
+  auto derivativeWeights = itk::MakeFilled<FilterType::DerivativeWeightsType>(derivativeWeightsValue);
   filter->SetDerivativeWeights(derivativeWeights);
   ITK_TEST_SET_GET_VALUE(derivativeWeights, filter->GetDerivativeWeights());
 
   auto componentWeightsValue = static_cast<FilterType::ComponentWeightsType::ValueType>(std::stod(argv[5]));
-  FilterType::ComponentWeightsType componentWeights;
-  componentWeights.Fill(componentWeightsValue);
+  auto componentWeights = itk::MakeFilled<FilterType::ComponentWeightsType>(componentWeightsValue);
   filter->SetComponentWeights(componentWeights);
   ITK_TEST_SET_GET_VALUE(componentWeights, filter->GetComponentWeights());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -47,10 +47,9 @@ BSpline(int argc, char * argv[])
 
   // Reconstruction of the scalar field from the control points
 
-  typename ScalarFieldType::PointType   origin{};
-  auto                                  size = ScalarFieldType::SizeType::Filled(100);
-  typename ScalarFieldType::SpacingType spacing;
-  spacing.Fill(1.0);
+  typename ScalarFieldType::PointType origin{};
+  auto                                size = ScalarFieldType::SizeType::Filled(100);
+  auto                                spacing = itk::MakeFilled<typename ScalarFieldType::SpacingType>(1.0);
 
   using BSplinerType = itk::BSplineControlPointImageFilter<ScalarFieldType, ScalarFieldType>;
   auto bspliner = BSplinerType::New();
@@ -58,8 +57,7 @@ BSpline(int argc, char * argv[])
   bspliner->SetInput(reader->GetOutput());
 
   typename BSplinerType::ArrayType::ValueType closeDimensionVal = 0;
-  typename BSplinerType::ArrayType            closeDimension;
-  closeDimension.Fill(closeDimensionVal);
+  auto closeDimension = itk::MakeFilled<typename BSplinerType::ArrayType>(closeDimensionVal);
   bspliner->SetCloseDimension(closeDimension);
   ITK_TEST_SET_GET_VALUE(closeDimension, bspliner->GetCloseDimension());
 
@@ -102,8 +100,7 @@ BSpline(int argc, char * argv[])
   // and seeing if the output is the same. In this example we double the
   // resolution twice as the refinement is doubled at every level.
   //
-  typename BSplinerType::ArrayType numberOfRefinementLevels;
-  numberOfRefinementLevels.Fill(3);
+  auto numberOfRefinementLevels = itk::MakeFilled<typename BSplinerType::ArrayType>(3);
 
   typename BSplinerType::ControlPointLatticeType::Pointer refinedControlPointLattice =
     bspliner->RefineControlPointLattice(numberOfRefinementLevels);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -92,14 +92,12 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
     }
   }
 
-  BSplinerType::ArrayType bSplineOrder;
-  bSplineOrder.Fill(bSplineOrderValue);
+  auto bSplineOrder = itk::MakeFilled<BSplinerType::ArrayType>(bSplineOrderValue);
   bspliner->SetSplineOrder(bSplineOrder);
   ITK_TEST_SET_GET_VALUE(bSplineOrder, bspliner->GetSplineOrder());
 
   BSplinerType::ArrayType::ValueType closeDimensionValue = 0;
-  BSplinerType::ArrayType            closeDimension;
-  closeDimension.Fill(closeDimensionValue);
+  auto                               closeDimension = itk::MakeFilled<BSplinerType::ArrayType>(closeDimensionValue);
   bspliner->SetCloseDimension(closeDimension);
   ITK_TEST_SET_GET_VALUE(closeDimension, bspliner->GetCloseDimension());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -92,8 +92,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
   unsigned int splineOrder = 0u;
   ITK_TRY_EXPECT_EXCEPTION(filter->SetSplineOrder(splineOrder));
 
-  FilterType::ArrayType splineOrderArray;
-  splineOrderArray.Fill(4u);
+  auto splineOrderArray = itk::MakeFilled<FilterType::ArrayType>(4u);
   filter->SetSplineOrder(splineOrderArray);
   ITK_TEST_SET_GET_VALUE(splineOrderArray, filter->GetSplineOrder());
 
@@ -106,8 +105,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
   unsigned int numberOfLevels = 0u;
   ITK_TRY_EXPECT_EXCEPTION(filter->SetNumberOfLevels(numberOfLevels));
 
-  FilterType::ArrayType numberOfLevelsArray;
-  numberOfLevelsArray.Fill(4u);
+  auto numberOfLevelsArray = itk::MakeFilled<FilterType::ArrayType>(4u);
   filter->SetNumberOfLevels(numberOfLevelsArray);
   ITK_TEST_SET_GET_VALUE(numberOfLevelsArray, filter->GetNumberOfLevels());
 
@@ -117,8 +115,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(numberOfLevelsArray, filter->GetNumberOfLevels());
 
 
-  FilterType::ArrayType ncps;
-  ncps.Fill(4u);
+  auto ncps = itk::MakeFilled<FilterType::ArrayType>(4u);
   filter->SetNumberOfControlPoints(ncps);
   ITK_TEST_SET_GET_VALUE(ncps, filter->GetNumberOfControlPoints());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
@@ -77,8 +77,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest2(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BSplineScatteredDataPointSetToImageFilter, PointSetToImageFilter);
 
   // Define the parametric domain
-  ImageType::SpacingType spacing;
-  spacing.Fill(0.01);
+  auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(0.01);
   auto                 size = ImageType::SizeType::Filled(101);
   ImageType::PointType origin{};
 
@@ -92,8 +91,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest2(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(bSplineEpsilon, filter->GetBSplineEpsilon());
 
   filter->SetSplineOrder(3);
-  FilterType::ArrayType ncps;
-  ncps.Fill(4);
+  auto ncps = itk::MakeFilled<FilterType::ArrayType>(4);
   filter->SetNumberOfControlPoints(ncps);
   filter->SetNumberOfLevels(5);
   filter->SetGenerateOutputImage(false);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
@@ -94,8 +94,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest3(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BSplineScatteredDataPointSetToImageFilter, PointSetToImageFilter);
 
   // Define the parametric domain
-  ImageType::SpacingType spacing;
-  spacing.Fill(0.001);
+  auto                spacing = itk::MakeFilled<ImageType::SpacingType>(0.001);
   ImageType::SizeType size;
   // Adding 0.5 to avoid rounding errors
   size.Fill(static_cast<unsigned int>(1.0 / spacing[0] + .5) + 1);
@@ -107,8 +106,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest3(int argc, char * argv[])
   filter->SetInput(pointSet);
 
   filter->SetSplineOrder(3);
-  FilterType::ArrayType ncps;
-  ncps.Fill(4);
+  auto ncps = itk::MakeFilled<FilterType::ArrayType>(4);
   filter->SetNumberOfControlPoints(ncps);
 
   // We set an extreme number of levels to show how this

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
@@ -47,10 +47,9 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
 
   using FilterType = itk::BSplineScatteredDataPointSetToImageFilter<PointSetType, VectorImageType>;
 
-  auto                         size = VectorImageType::SizeType::Filled(100);
-  VectorImageType::PointType   origin{};
-  VectorImageType::SpacingType spacing;
-  spacing.Fill(1);
+  auto                           size = VectorImageType::SizeType::Filled(100);
+  VectorImageType::PointType     origin{};
+  auto                           spacing = itk::MakeFilled<VectorImageType::SpacingType>(1);
   VectorImageType::DirectionType direction;
   direction.SetIdentity();
 
@@ -158,8 +157,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
   // transform.  Specifically, this includes the final
   // number of control points and the spline order.
   filter->SetSplineOrder(SplineOrder);
-  FilterType::ArrayType ncps;
-  ncps.Fill(4);
+  auto ncps = itk::MakeFilled<FilterType::ArrayType>(4);
   filter->SetNumberOfControlPoints(ncps);
   filter->SetNumberOfLevels(3);
   FilterType::ArrayType close{};
@@ -194,8 +192,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest4(int, char *[])
   using InputPointType = TransformType::InputPointType;
   using OutputPointType = TransformType::OutputPointType;
 
-  InputPointType inputPoint;
-  inputPoint.Fill(50.0);
+  auto inputPoint = itk::MakeFilled<InputPointType>(50.0);
 
   OutputPointType outputPoint = transform->TransformPoint(inputPoint);
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -160,8 +160,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest5(int argc, char * argv[])
   filter->SetNumberOfLevels(4);
   filter->SetGenerateOutputImage(false);
 
-  FilterType::ArrayType close;
-  close.Fill(1);
+  auto close = itk::MakeFilled<FilterType::ArrayType>(1);
   filter->SetCloseDimension(close);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -95,8 +95,7 @@ itkResampleImageTest(int, char *[])
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   resample->SetOutputSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -100,8 +100,7 @@ itkResampleImageTest7(int, char *[])
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   resample->SetOutputSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -98,8 +98,8 @@ public:
   OutputPointType
   TransformPoint(const InputPointType & inputPoint) const override
   {
-    OutputPointType outputPoint;
-    outputPoint.Fill(std::numeric_limits<typename OutputPointType::ValueType>::max());
+    auto outputPoint =
+      itk::MakeFilled<OutputPointType>(std::numeric_limits<typename OutputPointType::ValueType>::max());
     for (unsigned int d = 0; d < 2; ++d)
     {
       outputPoint[d] = inputPoint[d] * 0.5;
@@ -197,8 +197,7 @@ itkResampleImageTest8(int, char *[])
   resample->SetOutputOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
 
-  OutputImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<OutputImageType::SpacingType>(1.0);
   resample->SetOutputSpacing(spacing);
   ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
 

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -270,8 +270,7 @@ TEST(SliceImageFilterTests, Coverage)
   filter->SetStop(13);
   EXPECT_EQ(idx, filter->GetStop());
 
-  FilterType::ArrayType a;
-  a.Fill(14);
+  auto a = itk::MakeFilled<FilterType::ArrayType>(14);
   filter->SetStep(a);
   EXPECT_EQ(a, filter->GetStep());
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -183,8 +183,7 @@ itkWarpImageFilterTest(int, char *[])
   warper->SetEdgePaddingValue(padValue);
   ITK_TEST_SET_GET_VALUE(padValue, warper->GetEdgePaddingValue());
 
-  itk::FixedArray<double, ImageDimension> array;
-  array.Fill(2.0);
+  auto array = itk::MakeFilled<itk::FixedArray<double, ImageDimension>>(2.0);
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
@@ -192,8 +191,7 @@ itkWarpImageFilterTest(int, char *[])
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
-  WarperType::PointType ptarray;
-  ptarray.Fill(-10.0);
+  auto ptarray = itk::MakeFilled<WarperType::PointType>(-10.0);
   warper->SetOutputOrigin(ptarray.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -180,8 +180,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   command->SetCallbackFunction(&progressWatch, &ShowProgressObject::ShowProgress);
   warper->AddObserver(itk::ProgressEvent(), command);
 
-  itk::FixedArray<double, ImageDimension> array;
-  array.Fill(2.0);
+  auto array = itk::MakeFilled<itk::FixedArray<double, ImageDimension>>(2.0);
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
@@ -189,8 +188,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
-  WarperType::PointType ptarray;
-  ptarray.Fill(-10.0);
+  auto ptarray = itk::MakeFilled<WarperType::PointType>(-10.0);
   warper->SetOutputOrigin(ptarray.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -117,8 +117,7 @@ itkAddImageFilterFrameTest(int, char *[])
   myImageType3Pointer outputImage = filter->GetOutput();
 
   // Make Image B have a different origin
-  myImageType2::PointType borigin;
-  borigin.Fill(0.01);
+  auto borigin = itk::MakeFilled<myImageType2::PointType>(0.01);
   inputImageB->SetOrigin(borigin);
 
 
@@ -138,8 +137,7 @@ itkAddImageFilterFrameTest(int, char *[])
   // Make Image B have a different spacing
   inputImageB->CopyInformation(inputImageA);
 
-  myImageType2::SpacingType bspacing;
-  bspacing.Fill(1.001);
+  auto bspacing = itk::MakeFilled<myImageType2::SpacingType>(1.001);
   inputImageB->SetSpacing(bspacing);
 
   // Execute the filter

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -58,9 +58,8 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
 
   // Generate a synthetic ellipse image
   using EllipseType = itk::EllipseSpatialObject<2>;
-  auto                   ellipse = EllipseType::New();
-  EllipseType::PointType center;
-  center.Fill(20);
+  auto ellipse = EllipseType::New();
+  auto center = itk::MakeFilled<EllipseType::PointType>(20);
   ellipse->SetCenterInObjectSpace(center);
   ellipse->SetRadiusInObjectSpace(10);
   ellipse->Update();

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -60,8 +60,7 @@ itkGridImageSourceTest(int argc, char * argv[])
 
   ImageType::PointType origin{};
 
-  ImageType::SpacingType imageSpacing;
-  imageSpacing.Fill(1.0);
+  auto imageSpacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
   ImageType::DirectionType direction;
   direction.SetIdentity();
@@ -78,9 +77,8 @@ itkGridImageSourceTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(scale, gridImage->GetScale());
 
 
-  auto                      sigmaValue = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[3]));
-  GridSourceType::ArrayType sigma;
-  sigma.Fill(sigmaValue);
+  auto sigmaValue = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[3]));
+  auto sigma = itk::MakeFilled<GridSourceType::ArrayType>(sigmaValue);
   auto variableSigma = static_cast<bool>(std::stoi(argv[4]));
 
   if (variableSigma)
@@ -95,9 +93,8 @@ itkGridImageSourceTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(sigma, gridImage->GetSigma());
 
 
-  auto                      spacing = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[5]));
-  GridSourceType::ArrayType gridSpacing;
-  gridSpacing.Fill(spacing);
+  auto spacing = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[5]));
+  auto gridSpacing = itk::MakeFilled<GridSourceType::ArrayType>(spacing);
 
 
   auto variableGridSpacing = static_cast<bool>(std::stoi(argv[6]));
@@ -112,16 +109,14 @@ itkGridImageSourceTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(gridSpacing, gridImage->GetGridSpacing());
 
 
-  auto                      offset = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[7]));
-  GridSourceType::ArrayType gridOffset;
-  gridOffset.Fill(offset);
+  auto offset = static_cast<GridSourceType::ArrayType::ValueType>(std::stod(argv[7]));
+  auto gridOffset = itk::MakeFilled<GridSourceType::ArrayType>(offset);
   gridImage->SetGridOffset(gridOffset);
   ITK_TEST_SET_GET_VALUE(gridOffset, gridImage->GetGridOffset());
 
 
-  auto                          gridAllDimensions = static_cast<bool>(std::stoi(argv[8]));
-  GridSourceType::BoolArrayType whichDimension;
-  whichDimension.Fill(gridAllDimensions);
+  auto gridAllDimensions = static_cast<bool>(std::stoi(argv[8]));
+  auto whichDimension = itk::MakeFilled<GridSourceType::BoolArrayType>(gridAllDimensions);
 
   bool toggleLastGridDimension = std::stod(argv[9]);
   if (toggleLastGridDimension)

--- a/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
@@ -105,8 +105,7 @@ itkStatisticsUniqueLabelMapFilterTest1(int argc, char * argv[])
   labelMapConverter->SetBackgroundValue(PixelType{});
 
   using StructuringElementType = itk::FlatStructuringElement<Dimension>;
-  StructuringElementType::RadiusType radius;
-  radius.Fill(radiusValue);
+  auto radius = itk::MakeFilled<StructuringElementType::RadiusType>(radiusValue);
 
   StructuringElementType structuringElement = StructuringElementType::Box(radius);
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -32,8 +32,7 @@ itkFlatStructuringElementTest(int, char *[])
   bool radiusIsParametric = true;
 
   using SE2Type = itk::FlatStructuringElement<2>;
-  SE2Type::RadiusType r2;
-  r2.Fill(scalarRadius);
+  auto r2 = itk::MakeFilled<SE2Type::RadiusType>(scalarRadius);
 
   SE2Type::Self result2{};
   result2.RadiusIsParametricOn();

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
@@ -85,8 +85,7 @@ itkFlatStructuringElementTest3(int argc, char * argv[])
   {
     using SE2Type = itk::FlatStructuringElement<2>;
 
-    SE2Type::RadiusType r2;
-    r2.Fill(radius);
+    auto    r2 = itk::MakeFilled<SE2Type::RadiusType>(radius);
     SE2Type P = SE2Type::Polygon(r2, lines);
     SEToFile(P, outputImage);
   }
@@ -94,8 +93,7 @@ itkFlatStructuringElementTest3(int argc, char * argv[])
   {
     using SE3Type = itk::FlatStructuringElement<3>;
 
-    SE3Type::RadiusType r3;
-    r3.Fill(radius);
+    auto    r3 = itk::MakeFilled<SE3Type::RadiusType>(radius);
     SE3Type P = SE3Type::Polygon(r3, lines);
     SEToFile(P, outputImage);
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -64,8 +64,7 @@ itkGrayscaleDilateImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -64,8 +64,7 @@ itkGrayscaleErodeImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -57,8 +57,7 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // Test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 
   ITK_TEST_SET_GET_VALUE(FilterType::AlgorithmEnum::HISTO, filter->GetAlgorithm());

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
@@ -57,8 +57,7 @@ itkGrayscaleMorphologicalOpeningImageFilterTest2(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // Test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
 
   ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -55,8 +55,7 @@ itkMapGrayscaleDilateImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -55,8 +55,7 @@ itkMapGrayscaleErodeImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -56,8 +56,7 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -56,8 +56,7 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius: " << filter->GetRadius() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
@@ -55,8 +55,7 @@ itkMapMaskedRankImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -84,8 +83,7 @@ itkMapMaskedRankImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
@@ -52,8 +52,7 @@ itkMapRankImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -66,8 +65,7 @@ itkMapRankImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
@@ -54,8 +54,7 @@ itkMaskedRankImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -83,8 +82,7 @@ itkMaskedRankImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
@@ -76,8 +76,7 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
 
 
   using SRType = itk::FlatStructuringElement<dim>;
-  SRType::RadiusType elementRadius;
-  elementRadius.Fill(4);
+  auto   elementRadius = itk::MakeFilled<SRType::RadiusType>(4);
   SRType structuringElement2 = SRType::Box(elementRadius);
 
   using Gradient1Type = itk::MorphologicalGradientImageFilter<IType, IType, SRType>;

--- a/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkRankImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -64,8 +63,7 @@ itkRankImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -42,8 +42,7 @@ itkShapedIteratorFromStructuringElementTest(int, char *[])
   CreateImagex(image);
 
   using StructuringElementType = itk::BinaryBallStructuringElement<PixelType, 2>;
-  StructuringElementType::RadiusType elementRadius;
-  elementRadius.Fill(2);
+  auto elementRadius = itk::MakeFilled<StructuringElementType::RadiusType>(2);
 
   StructuringElementType structuringElement;
   structuringElement.SetRadius(elementRadius);

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -91,9 +91,8 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
 
   // Set up the path
   std::cout << "Making a square Path with v0 at (24,24) -> (24,104) -> (104,104) -> (104,24)" << std::endl;
-  auto       inputPath = PolyLineParametricPathType::New();
-  VertexType v;
-  v.Fill(24);
+  auto inputPath = PolyLineParametricPathType::New();
+  auto v = itk::MakeFilled<VertexType>(24);
   inputPath->AddVertex(v);
   v[0] = 24;
   v[1] = 104;

--- a/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
@@ -73,8 +73,7 @@ itkOrthogonalSwath2DPathFilterTest(int, char *[])
   std::cout << "Making a square Path with v0 at (24,24) -> (24,104) -> (104,104) -> (104,24)" << std::endl;
   auto inputPath = PolyLineParametricPathType::New();
 
-  VertexType v;
-  v.Fill(24);
+  auto v = itk::MakeFilled<VertexType>(24);
   inputPath->AddVertex(v);
   v[0] = 24;
   v[1] = 104;

--- a/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
@@ -40,8 +40,7 @@ itkPathToImageFilterTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(path, PolyLineParametricPath, ParametricPath);
 
   std::cout << "Making a square Path with v0 at (30,30) and v2 at (33,33)" << std::endl;
-  VertexType v;
-  v.Fill(30);
+  auto v = itk::MakeFilled<VertexType>(30);
   path->AddVertex(v);
   v[0] = 33;
   v[1] = 30;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
@@ -43,8 +43,7 @@ itkRegularSphereQuadEdgeMeshSourceTest(int argc, char * argv[])
 
   PointType center{};
 
-  VectorType scale;
-  scale.Fill(1.0);
+  auto scale = itk::MakeFilled<VectorType>(1.0);
 
   mySphereMeshSource->SetCenter(center);
   mySphereMeshSource->SetResolution(1);

--- a/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkBoxMeanImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -59,8 +58,7 @@ itkBoxMeanImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
@@ -50,8 +50,7 @@ itkBoxSigmaImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   if (filter->GetRadius() != r1)
   {
     std::cerr << "Wrong default Radius." << std::endl;
@@ -59,8 +58,7 @@ itkBoxSigmaImageFilterTest(int argc, char * argv[])
   }
 
   // set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   if (filter->GetRadius() != r5)
   {

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
@@ -64,8 +64,7 @@ itkDiscreteGaussianImageFilterTest(int argc, char * argv[])
 
   // Set the value of the standard deviation of the Gaussian used for smoothing
   FilterType::SigmaArrayType::ValueType sigmaValue = 1.0;
-  FilterType::SigmaArrayType            sigma;
-  sigma.Fill(sigmaValue);
+  auto                                  sigma = itk::MakeFilled<FilterType::SigmaArrayType>(sigmaValue);
 
   filter->SetSigma(sigmaValue);
   ITK_TEST_SET_GET_VALUE(sigmaValue, filter->GetSigma());
@@ -86,14 +85,12 @@ itkDiscreteGaussianImageFilterTest(int argc, char * argv[])
 
   // Set other filter properties
   FilterType::ArrayType::ValueType varianceValue = 1.0;
-  FilterType::ArrayType            variance;
-  variance.Fill(varianceValue);
+  auto                             variance = itk::MakeFilled<FilterType::ArrayType>(varianceValue);
   filter->SetVariance(variance);
   ITK_TEST_SET_GET_VALUE(variance, filter->GetVariance());
 
   FilterType::ArrayType::ValueType maximumErrorValue = 0.01;
-  FilterType::ArrayType            maximumError;
-  maximumError.Fill(maximumErrorValue);
+  auto                             maximumError = itk::MakeFilled<FilterType::ArrayType>(maximumErrorValue);
   filter->SetMaximumError(maximumError);
   ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
 

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
@@ -50,8 +50,7 @@ NormalizeSineWave(double frequencyPerImage, unsigned int order, double pixelSpac
   image->SetRegions(ImageType::RegionType(size));
   image->Allocate();
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(pixelSpacing);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(pixelSpacing);
 
   image->SetSpacing(spacing);
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -140,8 +140,7 @@ itkSmoothingRecursiveGaussianImageFilterTest(int argc, char * argv[])
 
   // Set the value of the standard deviation of the Gaussian used for smoothing
   SmoothingRecursiveGaussianImageFilterType::SigmaArrayType::ValueType sigmaValue = std::stod(argv[4]);
-  SmoothingRecursiveGaussianImageFilterType::SigmaArrayType            sigma;
-  sigma.Fill(sigmaValue);
+  auto sigma = itk::MakeFilled<SmoothingRecursiveGaussianImageFilterType::SigmaArrayType>(sigmaValue);
 
   filter->SetSigma(sigmaValue);
   ITK_TEST_SET_GET_VALUE(sigmaValue, filter->GetSigma());

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -46,8 +46,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   // Test the 2D case
   std::cout << "Testing VTKPolyDataMeshIO for a mesh with 2D tensor pixels..." << std::endl;
 
-  Mesh2dType::PointType point2d;
-  point2d.Fill(1);
+  auto point2d = itk::MakeFilled<Mesh2dType::PointType>(1);
 
   Mesh2dType::PixelType pixel2d{};
 
@@ -87,8 +86,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   // Test the 3D case
   std::cout << "Testing VTKPolyDataMeshIO for a mesh with 3D tensor pixels..." << std::endl;
 
-  Mesh3dType::PointType point3d;
-  point3d.Fill(1);
+  auto point3d = itk::MakeFilled<Mesh3dType::PointType>(1);
 
   Mesh3dType::PixelType pixel3d{};
 

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -55,16 +55,14 @@ ReadWriteTest(const std::string fileName, const bool isRealDisplacementField, co
     typename FieldType::RegionType region{ start, size };
     knownField->SetRegions(region);
 
-    typename FieldType::SpacingType spacing;
-    spacing.Fill(requiredSpacing);
+    auto spacing = itk::MakeFilled<typename FieldType::SpacingType>(requiredSpacing);
     knownField->SetSpacing(spacing);
-    typename FieldType::PointType origin;
-    origin.Fill(requiredOrigin);
+    auto origin = itk::MakeFilled<typename FieldType::PointType>(requiredOrigin);
     knownField->SetOrigin(origin);
     knownField->Allocate();
 
-    typename DisplacementTransformType::OutputVectorType zeroVector;
-    zeroVector.Fill(aNumberThatCanNotBeRepresentedInFloatingPoint);
+    auto zeroVector = itk::MakeFilled<typename DisplacementTransformType::OutputVectorType>(
+      aNumberThatCanNotBeRepresentedInFloatingPoint);
     knownField->FillBuffer(zeroVector);
 
     displacementTransform->SetDisplacementField(knownField);

--- a/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -88,8 +88,7 @@ itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
 
   auto sigmaVal =
     static_cast<typename GaussianDerivativeImageFunctionType::VarianceArrayType::ValueType>(sigma * sigma);
-  typename GaussianDerivativeImageFunctionType::VarianceArrayType variance;
-  variance.Fill(sigmaVal);
+  auto variance = itk::MakeFilled<typename GaussianDerivativeImageFunctionType::VarianceArrayType>(sigmaVal);
 
   function->SetVariance(sigmaVal);
   ITK_TEST_SET_GET_VALUE(variance, function->GetVariance());

--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -78,9 +78,9 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
     useImageSpacing = static_cast<bool>(std::stoi(argv[7]));
   }
 
-  double                                                                    varianceValue = sigma * sigma;
-  typename DiscreteGradientMagnitudeGaussianFunctionType::VarianceArrayType varianceArray;
-  varianceArray.Fill(varianceValue);
+  double varianceValue = sigma * sigma;
+  auto   varianceArray =
+    itk::MakeFilled<typename DiscreteGradientMagnitudeGaussianFunctionType::VarianceArrayType>(varianceValue);
 
   function->SetVariance(varianceArray);
   ITK_TEST_SET_GET_VALUE(varianceArray, function->GetVariance());

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -66,9 +66,8 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
     maxKernelWidth = std::stoi(argv[5]);
   }
 
-  double                                                       varianceValue = sigma * sigma;
-  typename HessianGaussianImageFunctionType::VarianceArrayType varianceArray;
-  varianceArray.Fill(varianceValue);
+  double varianceValue = sigma * sigma;
+  auto   varianceArray = itk::MakeFilled<typename HessianGaussianImageFunctionType::VarianceArrayType>(varianceValue);
 
   function->SetVariance(varianceArray);
   ITK_TEST_SET_GET_VALUE(varianceArray, function->GetVariance());

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -55,16 +55,14 @@ itkFastApproximateRankImageFilterTest(int argc, char * argv[])
   using RadiusType = FilterType::RadiusType;
 
   // Test default values
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = itk::MakeFilled<RadiusType>(1);
   ITK_TEST_SET_GET_VALUE(r1, filter->GetRadius());
 
   auto rank = 0.5;
   ITK_TEST_SET_GET_VALUE(rank, filter->GetRank());
 
   // Set radius with a radius type
-  RadiusType r5;
-  r5.Fill(5);
+  auto r5 = itk::MakeFilled<RadiusType>(5);
   filter->SetRadius(r5);
   ITK_TEST_SET_GET_VALUE(r5, filter->GetRadius());
 

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -83,8 +83,7 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   DeformationIteratorType it(inputDisplacementField, inputDisplacementField->GetBufferedRegion());
 
   // Initialize the content of the input image
-  DeformationPixelType vectorValue;
-  vectorValue.Fill(5.0); // FIXME: replace with something more interesting...
+  auto vectorValue = itk::MakeFilled<DeformationPixelType>(5.0); // FIXME: replace with something more interesting...
 
   it.GoToBegin();
   while (!it.IsAtEnd())

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -285,8 +285,7 @@ itkImageFunctionTest(int, char *[])
   }
 
   /* IsInsideBuffer with Point type */
-  PointType point;
-  point.Fill(1);
+  auto point = itk::MakeFilled<PointType>(1);
   if (!function->IsInsideBuffer(point))
   {
     std::cout << "Error with IsInsideBuffer 1P." << std::endl;

--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -50,9 +50,7 @@ public:
 
     itk::SimpleFilterWatcher watcher(fractalFilter, "FractalDimensionFilter");
 
-    typename FractalFilterType::RadiusType radius;
-
-    radius.Fill(5);
+    auto radius = itk::MakeFilled<typename FractalFilterType::RadiusType>(5);
     fractalFilter->SetNeighborhoodRadius(radius);
     ITK_TEST_SET_GET_VALUE(radius, fractalFilter->GetNeighborhoodRadius());
 

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -75,8 +75,7 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   inputDisplacementField->Allocate();
 
   // Initialize the content of the input image
-  DeformationPixelType vectorValue;
-  vectorValue.Fill(5.0); // FIXME: replace with something more interesting...
+  auto vectorValue = itk::MakeFilled<DeformationPixelType>(5.0); // FIXME: replace with something more interesting...
   inputDisplacementField->FillBuffer(vectorValue);
 
   // Declare the type for the itk::WarpHarmonicEnergyCalculator
@@ -92,8 +91,7 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   auto useImageSpacing = static_cast<bool>(std::stoi(argv[1]));
   ITK_TEST_SET_GET_BOOLEAN(calculator, UseImageSpacing, useImageSpacing);
 
-  CalculatorType::WeightsType derivativeWeights;
-  derivativeWeights.Fill(std::stod(argv[2]));
+  auto derivativeWeights = itk::MakeFilled<CalculatorType::WeightsType>(std::stod(argv[2]));
   calculator->SetDerivativeWeights(derivativeWeights);
   ITK_TEST_SET_GET_VALUE(derivativeWeights, calculator->GetDerivativeWeights());
 

--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -73,8 +73,7 @@ itkWarpJacobianDeterminantFilterTest(int, char *[])
   DeformationIteratorType it(inputDisplacementField, inputDisplacementField->GetBufferedRegion());
 
   // Initialize the content of Image A
-  DeformationPixelType vectorValue;
-  vectorValue.Fill(5.0); // FIXME: replace with something more interesting...
+  auto vectorValue = itk::MakeFilled<DeformationPixelType>(5.0); // FIXME: replace with something more interesting...
 
   it.GoToBegin();
   while (!it.IsAtEnd())

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -95,8 +95,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(32);
+  auto   center = itk::MakeFilled<TPoint>(32);
   double radius = 19.5;
 
   double accum = 0.0;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -100,9 +100,8 @@ itkRegistrationParameterScalesFromPhysicalShiftPointSetTest(int, char *[])
   upperRightPoint[1] = virtualDomainSize[1];
 
   // Make a simple point set
-  PointType             testPoint;
-  PointType::VectorType offset;
-  offset.Fill(0.1);
+  PointType testPoint;
+  auto      offset = itk::MakeFilled<PointType::VectorType>(0.1);
   testPoint[0] = 0.0;
   testPoint[1] = 0.0;
   fixedPoints->SetPoint(0, testPoint);

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
@@ -40,9 +40,8 @@ itkHistogramToTextureFeaturesFilterNaNTest(int, char *[])
 
   // Generate co-occurence matrix
   using MatrixGeneratorType = itk::Statistics::ScalarImageToCooccurrenceMatrixFilter<ImageType>;
-  auto                            generator = MatrixGeneratorType::New();
-  MatrixGeneratorType::OffsetType offset;
-  offset.Fill(1);
+  auto generator = MatrixGeneratorType::New();
+  auto offset = itk::MakeFilled<MatrixGeneratorType::OffsetType>(1);
   generator->SetOffset(offset);
   generator->SetInput(image);
   generator->Update();

--- a/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
@@ -49,8 +49,7 @@ itkVectorContainerToListSampleAdaptorTest(int, char *[])
   container->Reserve(containerSize);
   for (unsigned int i = 0; i < container->Size(); ++i)
   {
-    VectorType vector;
-    vector.Fill(std::pow(i, 2));
+    auto vector = itk::MakeFilled<VectorType>(std::pow(i, 2));
     container->InsertElement(i, vector);
   }
 

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -30,15 +30,13 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
    * Define the transformation domain
    */
   using PointType = TransformType::PointType;
-  PointType origin;
-  origin.Fill(-5.0);
+  auto origin = itk::MakeFilled<PointType>(-5.0);
 
   using SizeType = TransformType::SizeType;
   auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(1.2);
+  auto spacing = itk::MakeFilled<SpacingType>(1.2);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -56,8 +54,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   displacementField->FillBuffer(zeroVector);
 
 
-  TransformType::OutputVectorType nonzeroVector;
-  nonzeroVector.Fill(10.3);
+  auto nonzeroVector = itk::MakeFilled<TransformType::OutputVectorType>(10.3);
 
   auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
@@ -71,8 +68,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   transform->SetConstantVelocityField(displacementField);
   transform->IntegrateVelocityField();
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto                           point = itk::MakeFilled<TransformType::InputPointType>(50.0);
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 
   SpacingType spacingBefore = transform->GetConstantVelocityField()->GetSpacing();
@@ -86,8 +82,7 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
 
   std::cout << "Instantiate adaptor." << std::endl;
 
-  SpacingType requiredSpacing;
-  requiredSpacing.Fill(0.6);
+  auto     requiredSpacing = itk::MakeFilled<SpacingType>(0.6);
   SizeType requiredSize;
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -31,15 +31,13 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
    * Define the transformation domain
    */
   using PointType = TransformType::PointType;
-  PointType origin;
-  origin.Fill(-5.0);
+  auto origin = itk::MakeFilled<PointType>(-5.0);
 
   using SizeType = TransformType::SizeType;
   auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(1.2);
+  auto spacing = itk::MakeFilled<SpacingType>(1.2);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -57,8 +55,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   displacementField->FillBuffer(zeroVector);
 
 
-  TransformType::OutputVectorType nonzeroVector;
-  nonzeroVector.Fill(10.3);
+  auto nonzeroVector = itk::MakeFilled<TransformType::OutputVectorType>(10.3);
 
   auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
@@ -71,8 +68,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   auto transform = TransformType::New();
   transform->SetDisplacementField(displacementField);
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto                           point = itk::MakeFilled<TransformType::InputPointType>(50.0);
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 
   SpacingType spacingBefore = transform->GetDisplacementField()->GetSpacing();
@@ -86,8 +82,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
 
   std::cout << "Instantiate adaptor." << std::endl;
 
-  SpacingType requiredSpacing;
-  requiredSpacing.Fill(0.6);
+  auto     requiredSpacing = itk::MakeFilled<SpacingType>(0.6);
   SizeType requiredSize;
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {

--- a/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
@@ -32,12 +32,10 @@ itkBSplineTransformParametersAdaptorTest(int, char *[])
    */
 
   using OriginType = TransformType::OriginType;
-  OriginType origin;
-  origin.Fill(5.0);
+  auto origin = itk::MakeFilled<OriginType>(5.0);
 
   using PhysicalDimensionsType = TransformType::PhysicalDimensionsType;
-  PhysicalDimensionsType dimensions;
-  dimensions.Fill(100);
+  auto dimensions = itk::MakeFilled<PhysicalDimensionsType>(100);
 
   using MeshSizeType = TransformType::MeshSizeType;
   auto meshSize = MeshSizeType::Filled(10);
@@ -72,8 +70,7 @@ itkBSplineTransformParametersAdaptorTest(int, char *[])
   auto index = CoefficientImageType::IndexType::Filled(5);
   transform->GetCoefficientImages()[0]->SetPixel(index, 5.0);
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto point = itk::MakeFilled<TransformType::InputPointType>(50.0);
 
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 

--- a/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
@@ -57,11 +57,9 @@ itkBlockMatchingImageFilterTest(int argc, char * argv[])
 
   // Parameters used for FS and BM
   using RadiusType = InputImageType::SizeType;
-  RadiusType blockRadius;
-  blockRadius.Fill(2);
+  auto blockRadius = itk::MakeFilled<RadiusType>(2);
 
-  RadiusType searchRadius;
-  searchRadius.Fill(7);
+  auto searchRadius = itk::MakeFilled<RadiusType>(7);
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
 

--- a/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -30,15 +30,13 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
    * Define the transformation domain
    */
   using PointType = TransformType::PointType;
-  PointType origin;
-  origin.Fill(-5.0);
+  auto origin = itk::MakeFilled<PointType>(-5.0);
 
   using SizeType = TransformType::SizeType;
   auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(1.2);
+  auto spacing = itk::MakeFilled<SpacingType>(1.2);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -55,8 +53,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
   TransformType::OutputVectorType zeroVector{};
   displacementField->FillBuffer(zeroVector);
 
-  TransformType::OutputVectorType nonzeroVector;
-  nonzeroVector.Fill(10.3);
+  auto nonzeroVector = itk::MakeFilled<TransformType::OutputVectorType>(10.3);
 
   auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
@@ -69,8 +66,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
   auto transform = TransformType::New();
   transform->SetDisplacementField(displacementField);
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto                           point = itk::MakeFilled<TransformType::InputPointType>(50.0);
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 
   SpacingType spacingBefore = transform->GetDisplacementField()->GetSpacing();
@@ -84,8 +80,7 @@ itkDisplacementFieldTransformParametersAdaptorTest(int, char *[])
 
   std::cout << "Instantiate adaptor." << std::endl;
 
-  SpacingType requiredSpacing;
-  requiredSpacing.Fill(0.6);
+  auto     requiredSpacing = itk::MakeFilled<SpacingType>(0.6);
   SizeType requiredSize;
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {

--- a/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -31,15 +31,13 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
    * Define the transformation domain
    */
   using PointType = TransformType::PointType;
-  PointType origin;
-  origin.Fill(-5.0);
+  auto origin = itk::MakeFilled<PointType>(-5.0);
 
   using SizeType = TransformType::SizeType;
   auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(1.2);
+  auto spacing = itk::MakeFilled<SpacingType>(1.2);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -57,8 +55,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   displacementField->FillBuffer(zeroVector);
 
 
-  TransformType::OutputVectorType nonzeroVector;
-  nonzeroVector.Fill(10.3);
+  auto nonzeroVector = itk::MakeFilled<TransformType::OutputVectorType>(10.3);
 
   auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
@@ -72,8 +69,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   transform->SetConstantVelocityField(displacementField);
   transform->IntegrateVelocityField();
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto                           point = itk::MakeFilled<TransformType::InputPointType>(50.0);
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 
   SpacingType spacingBefore = transform->GetConstantVelocityField()->GetSpacing();
@@ -87,8 +83,7 @@ itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
 
   std::cout << "Instantiate adaptor." << std::endl;
 
-  SpacingType requiredSpacing;
-  requiredSpacing.Fill(0.6);
+  auto     requiredSpacing = itk::MakeFilled<SpacingType>(0.6);
   SizeType requiredSize;
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {

--- a/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -31,15 +31,13 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
    * Define the transformation domain
    */
   using PointType = TransformType::PointType;
-  PointType origin;
-  origin.Fill(-5.0);
+  auto origin = itk::MakeFilled<PointType>(-5.0);
 
   using SizeType = TransformType::SizeType;
   auto size = SizeType::Filled(65);
 
   using SpacingType = TransformType::SpacingType;
-  SpacingType spacing;
-  spacing.Fill(1.2);
+  auto spacing = itk::MakeFilled<SpacingType>(1.2);
 
   using DirectionType = TransformType::DirectionType;
   DirectionType direction;
@@ -57,8 +55,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
   displacementField->FillBuffer(zeroVector);
 
 
-  TransformType::OutputVectorType nonzeroVector;
-  nonzeroVector.Fill(10.3);
+  auto nonzeroVector = itk::MakeFilled<TransformType::OutputVectorType>(10.3);
 
   auto index = DisplacementFieldType::IndexType::Filled(40);
   displacementField->SetPixel(index, nonzeroVector);
@@ -71,8 +68,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
   auto transform = TransformType::New();
   transform->SetDisplacementField(displacementField);
 
-  TransformType::InputPointType point;
-  point.Fill(50.0);
+  auto                           point = itk::MakeFilled<TransformType::InputPointType>(50.0);
   TransformType::OutputPointType outputPointBeforeAdapt = transform->TransformPoint(point);
 
   SpacingType spacingBefore = transform->GetDisplacementField()->GetSpacing();
@@ -86,8 +82,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int,
 
   std::cout << "Instantiate adaptor." << std::endl;
 
-  SpacingType requiredSpacing;
-  requiredSpacing.Fill(0.6);
+  auto     requiredSpacing = itk::MakeFilled<SpacingType>(0.6);
   SizeType requiredSize;
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -252,8 +252,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 
     standardDeviation = 1.0;
-    RegistrationType::StandardDeviationsType standardDeviations;
-    standardDeviations.Fill(standardDeviation);
+    auto standardDeviations = itk::MakeFilled<RegistrationType::StandardDeviationsType>(standardDeviation);
     registrator->SetStandardDeviations(standardDeviations);
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -254,8 +254,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 
     standardDeviation = 1.0;
-    RegistrationType::StandardDeviationsType standardDeviations;
-    standardDeviations.Fill(standardDeviation);
+    auto standardDeviations = itk::MakeFilled<RegistrationType::StandardDeviationsType>(standardDeviation);
     registrator->SetStandardDeviations(standardDeviations);
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -279,8 +279,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 
     standardDeviation = 1.0;
-    RegistrationType::StandardDeviationsType standardDeviations;
-    standardDeviations.Fill(standardDeviation);
+    auto standardDeviations = itk::MakeFilled<RegistrationType::StandardDeviationsType>(standardDeviation);
     registrator->SetStandardDeviations(standardDeviations);
     // ITK_TEST_SET_GET_VALUE( standardDeviations, registrator->GetStandardDeviations() );
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -151,11 +151,10 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
   constexpr itk::SizeValueType imageSize = 6;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -128,11 +128,10 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -36,11 +36,10 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -255,8 +255,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
   using RegionType = FieldType::RegionType;
   using RealType = DisplacementFieldTransformType::ScalarType;
 
-  FieldType::SpacingType spacing;
-  spacing.Fill(static_cast<RealType>(1.0));
+  auto spacing = itk::MakeFilled<FieldType::SpacingType>(static_cast<RealType>(1.0));
 
   FieldType::DirectionType direction{};
   for (unsigned int d = 0; d < Dimension; ++d)

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -99,8 +99,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   using FieldType = typename DisplacementFieldTransformType::DisplacementFieldType;
   using RegionType = typename FieldType::RegionType;
 
-  typename FieldType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<typename FieldType::SpacingType>(1.0);
 
   typename FieldType::DirectionType direction{};
   for (unsigned int d = 0; d < Dimension; ++d)
@@ -231,8 +230,7 @@ itkEuclideanDistancePointSetMetricTest2Run()
   metric->SetVirtualDomain(spacing, origin, direction, badRegion);
   ITK_TRY_EXPECT_EXCEPTION(metric->Initialize());
 
-  typename FieldType::SpacingType badSpacing;
-  badSpacing.Fill(0.5);
+  auto badSpacing = itk::MakeFilled<typename FieldType::SpacingType>(0.5);
   metric->SetVirtualDomain(badSpacing, origin, direction, region);
   ITK_TRY_EXPECT_EXCEPTION(metric->Initialize());
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -63,8 +63,8 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
 
   auto size = TImage::SizeType::Filled(ImageSize);
 
-  typename TImage::SpacingType spacing;
-  spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
+  auto spacing =
+    itk::MakeFilled<typename TImage::SpacingType>(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
   typename TImage::PointType origin{};
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -386,11 +386,10 @@ itkImageToImageMetricv4Test(int, char ** const)
   using DimensionSizeType = unsigned int;
   constexpr DimensionSizeType imageSize = 4;
 
-  ImageToImageMetricv4TestImageType::SizeType    size = { { imageSize, imageSize } };
-  ImageToImageMetricv4TestImageType::IndexType   index = { { 0, 0 } };
-  ImageToImageMetricv4TestImageType::RegionType  region{ index, size };
-  ImageToImageMetricv4TestImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  ImageToImageMetricv4TestImageType::SizeType   size = { { imageSize, imageSize } };
+  ImageToImageMetricv4TestImageType::IndexType  index = { { 0, 0 } };
+  ImageToImageMetricv4TestImageType::RegionType region{ index, size };
+  auto spacing = itk::MakeFilled<ImageToImageMetricv4TestImageType::SpacingType>(1.0);
   ImageToImageMetricv4TestImageType::PointType     origin{};
   ImageToImageMetricv4TestImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -36,11 +36,10 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -38,11 +38,10 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   using VectorType = itk::Vector<double, vectorLength>;
   using ImageType = itk::Image<VectorType, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -34,11 +34,10 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType
 
   using ImageType = typename TMetric::FixedImageType;
 
-  auto                            size = ImageType::SizeType::Filled(imageSize);
-  typename ImageType::IndexType   index{};
-  typename ImageType::RegionType  region{ index, size };
-  typename ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                              size = ImageType::SizeType::Filled(imageSize);
+  typename ImageType::IndexType     index{};
+  typename ImageType::RegionType    region{ index, size };
+  auto                              spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
   typename ImageType::PointType     origin{};
   typename ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -39,11 +39,10 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -34,11 +34,10 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                   size = ImageType::SizeType::Filled(imageSize);
-  ImageType::IndexType   index{};
-  ImageType::RegionType  region{ index, size };
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                     size = ImageType::SizeType::Filled(imageSize);
+  ImageType::IndexType     index{};
+  ImageType::RegionType    region{ index, size };
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -209,11 +209,10 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
 
   using ImageType = itk::Image<double, ImageDimensionality>;
 
-  auto                            size = ImageType::SizeType::Filled(imageSize);
-  typename ImageType::IndexType   virtualIndex{};
-  typename ImageType::RegionType  region{ virtualIndex, size };
-  typename ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto                              size = ImageType::SizeType::Filled(imageSize);
+  typename ImageType::IndexType     virtualIndex{};
+  typename ImageType::RegionType    region{ virtualIndex, size };
+  auto                              spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
   typename ImageType::PointType     origin{};
   typename ImageType::DirectionType direction;
   direction.SetIdentity();
@@ -409,8 +408,7 @@ itkMetricImageGradientTest(int argc, char * argv[])
         transform->SetIdentity();
 
         transform->Rotate2D(itk::Math::pi * rotationDegrees / 180);
-        ImageType::PointType center;
-        center.Fill((imageSize - 1) / 2.0);
+        auto center = itk::MakeFilled<ImageType::PointType>((imageSize - 1) / 2.0);
         transform->SetCenter(center);
 
         using ImageType = itk::Image<double, 2>;

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -91,8 +91,8 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
 
   auto size = TImage::SizeType::Filled(ImageSize);
 
-  typename TImage::SpacingType spacing;
-  spacing.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
+  auto spacing =
+    itk::MakeFilled<typename TImage::SpacingType>(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
 
   typename TImage::PointType origin{};
 

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -176,8 +176,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   ImageType::PointType origin{};
   origin[0] = 0.8;
 
-  ImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   spacing[1] = 1.2;
 
   auto moving = ImageType::New();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -235,11 +235,9 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
 
   auto fieldTransform = DisplacementFieldTransformType::New();
 
-  typename DisplacementFieldTransformType::ArrayType updateControlPoints;
-  updateControlPoints.Fill(10);
+  auto updateControlPoints = itk::MakeFilled<typename DisplacementFieldTransformType::ArrayType>(10);
 
-  typename DisplacementFieldTransformType::ArrayType velocityControlPoints;
-  velocityControlPoints.Fill(10);
+  auto velocityControlPoints = itk::MakeFilled<typename DisplacementFieldTransformType::ArrayType>(10);
 
   fieldTransform->SetNumberOfControlPointsForTheUpdateField(updateControlPoints);
   fieldTransform->SetNumberOfControlPointsForTheConstantVelocityField(velocityControlPoints);
@@ -250,9 +248,8 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
   displacementFieldSimple->InPlaceOn();
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -197,9 +197,8 @@ PerformBSplineImageRegistration(int argc, char * argv[])
   //
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -278,9 +278,8 @@ PerformBSplineSyNImageRegistration(int argc, char * argv[])
   }
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -281,9 +281,8 @@ PerformExpImageRegistration(int argc, char * argv[])
   std::cout << "ConstantVelocityFieldSetTime: " << fieldTransform->GetConstantVelocityFieldSetTime() << std::endl;
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -277,9 +277,8 @@ PerformSimpleImageRegistration(int argc, char * argv[])
   displacementFieldSimple->SetObjectName("displacementFieldSimple");
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -276,9 +276,8 @@ PerformSimpleImageRegistrationWithMaskAndSampling(int argc, char * argv[])
   displacementFieldSimple->SetObjectName("displacementFieldSimple");
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -312,9 +312,8 @@ PerformDisplacementFieldImageRegistration(int argc, char * argv[])
   }
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -191,9 +191,8 @@ PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
   affineWriter->Update();
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -235,9 +235,8 @@ PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
   velocityField->FillBuffer(zeroVector);
 
   using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  auto                                       correlationMetric = CorrelationMetricType::New();
-  typename CorrelationMetricType::RadiusType radius;
-  radius.Fill(4);
+  auto correlationMetric = CorrelationMetricType::New();
+  auto radius = itk::MakeFilled<typename CorrelationMetricType::RadiusType>(4);
   correlationMetric->SetRadius(radius);
   correlationMetric->SetUseMovingImageGradientFilter(false);
   correlationMetric->SetUseFixedImageGradientFilter(false);

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -98,8 +98,7 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   // Slice 1
   // Vector no. 1
-  VecImagePixelType vec;
-  vec.Fill(21);
+  auto vec = itk::MakeFilled<VecImagePixelType>(21);
   outIt.Set(vec);
   ++outIt;
   // Vector no. 2

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
@@ -52,9 +52,8 @@ itkDeformableSimplexMesh3DBalloonForceFilterTest(int argc, char * argv[])
   // declare the triangle to simplex mesh filter
   using SimplexFilterType = itk::TriangleMeshToSimplexMeshFilter<TriangleMeshType, SimplexMeshType>;
 
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(10);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(10);
   PointType::ValueType scaleInit[3] = { 3, 3, 3 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
@@ -70,9 +70,8 @@ itkDeformableSimplexMesh3DFilterTest(int, char *[])
   using SimplexVolumeType = itk::SimplexMeshVolumeCalculator<SimplexMeshType>;
 
   // create the actual mesh, sphere
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(10);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(10);
   PointType::ValueType scaleInit[3] = { 3, 3, 3 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
@@ -49,9 +49,8 @@ itkDeformableSimplexMesh3DGradientConstraintForceFilterTest(int, char *[])
 
   // note : image is volume of 20x20x20 starting at 0,0,0 so make sure
   // the mesh sits on image in space
-  auto      mySphereMeshSource = SphereMeshSourceType::New();
-  PointType center;
-  center.Fill(10);
+  auto                 mySphereMeshSource = SphereMeshSourceType::New();
+  auto                 center = itk::MakeFilled<PointType>(10);
   PointType::ValueType scaleInit[PointDimension] = { 5, 5, 5 };
   VectorType           scale = scaleInit;
 

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -47,8 +47,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(50);
+  auto   center = itk::MakeFilled<TPoint>(50);
   double radius = 19.5;
 
   double accum = 0.0;
@@ -65,8 +64,7 @@ template <typename TPoint>
 double
 SimpleVelocity(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(50);
+  auto center = itk::MakeFilled<TPoint>(50);
 
   double value;
   double x = p[0] - center[0];

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -226,8 +226,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   costFunction->SetShapeParameterMeans(mean);
   costFunction->SetShapeParameterStandardDeviations(stddev);
 
-  CostFunctionType::WeightsType weights;
-  weights.Fill(1.0);
+  auto weights = itk::MakeFilled<CostFunctionType::WeightsType>(1.0);
   weights[1] = 10.0;
   costFunction->SetWeights(weights);
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
@@ -295,8 +295,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2(int, char *[])
   costFunction->SetShapeParameterMeans(mean);
   costFunction->SetShapeParameterStandardDeviations(stddev);
 
-  CostFunctionType::WeightsType weights;
-  weights.Fill(1.0);
+  auto weights = itk::MakeFilled<CostFunctionType::WeightsType>(1.0);
   weights[1] = 10.0;
   costFunction->SetWeights(weights);
 

--- a/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
@@ -48,8 +48,7 @@ template <typename TPoint>
 double
 SimpleSignedDistance(const TPoint & p)
 {
-  TPoint center;
-  center.Fill(50);
+  auto   center = itk::MakeFilled<TPoint>(50);
   double radius = 19.5;
 
   double accum = 0.0;

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -149,8 +149,7 @@ itkShapePriorMAPCostFunctionTest(int, char *[])
   costFunction->SetShapeParameterMeans(shapeMean);
   costFunction->SetShapeParameterStandardDeviations(shapeStdDev);
 
-  CostFunctionType::WeightsType weights;
-  weights.Fill(1.5);
+  auto weights = itk::MakeFilled<CostFunctionType::WeightsType>(1.5);
 
   costFunction->SetWeights(weights);
 

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -81,8 +81,7 @@ protected:
     function->SetCurvatureWeight(0.0);
     function->SetShapePriorWeight(1.0);
 
-    typename ShapePriorFunctionType::RadiusType radius;
-    radius.Fill(1);
+    auto radius = itk::MakeFilled<typename ShapePriorFunctionType::RadiusType>(1);
     function->Initialize(radius);
 
     this->SetDifferenceFunction(function);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -422,8 +422,7 @@ itkMRFImageFilterTest(int, char *[])
   using OutImageFacesCalculator = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ClassImageType>;
   using OutImageFaceListType = OutImageFacesCalculator::FaceListType;
 
-  OutImageNeighborhoodRadiusType outImageNeighborhoodRadius;
-  outImageNeighborhoodRadius.Fill(1);
+  auto outImageNeighborhoodRadius = itk::MakeFilled<OutImageNeighborhoodRadiusType>(1);
 
   // Define the face list for the input/labelled image
   OutImageFacesCalculator outImageFacesCalculator;


### PR DESCRIPTION
Replaced code of the form

    T var;
    var.Fill(x);

with `auto var = itk::MakeFilled<T>(x);`

Following C++ Core Guidelines, Oct 3, 2024, "Always initialize an object", https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always

Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+)([^ ].*)[ ]+(\w+);[\r\n]+\1\3\.Fill\(
    Replace with: $1auto $3 = itk::MakeFilled<$2>\(
    Filters: itk*Test*.cxx
    [v] Match case
    (*) Regular expression

Follow-up to
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4881
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4884
- pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4887