### PR TITLE
ENH: Add STL-style iterators and size() member function to `itk::Matrix`

### DIFF
--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -59,6 +59,24 @@ public:
   using ValueType = T;
   using ComponentType = T;
 
+  /** A pointer to the ValueType. */
+  using pointer = ValueType *;
+
+  /** A const pointer to the ValueType. */
+  using const_pointer = const ValueType *;
+
+  /** A reference to the ValueType. */
+  using reference = ValueType &;
+
+  /** A const reference to the ValueType. */
+  using const_reference = const ValueType &;
+
+  /** The return type of the non-const overloads of begin() and end(). */
+  using iterator = ValueType *;
+
+  /** The return type of cbegin() and cend(), and the const overloads of begin() and end(). */
+  using const_iterator = const ValueType *;
+
   /** Number Of Columns and Rows. */
   static constexpr unsigned int RowDimensions = VRows;
   static constexpr unsigned int ColumnDimensions = VColumns;
@@ -297,6 +315,55 @@ public:
    * and destructor) are implicitly defaulted, following the C++ "Rule of Zero".
    */
   Matrix() = default;
+
+  /** Returns the number of elements. */
+  constexpr unsigned int
+  size() const
+  {
+    return m_Matrix.size();
+  }
+
+  /** Returns an iterator to the first element. */
+  iterator
+  begin()
+  {
+    return m_Matrix.begin();
+  }
+
+  /** Returns an iterator just beyond the last element. */
+  iterator
+  end()
+  {
+    return m_Matrix.end();
+  }
+
+  /** Returns a const iterator to the first element. */
+  const_iterator
+  begin() const
+  {
+    return m_Matrix.begin();
+  }
+
+  /** Returns a const iterator just beyond the last element. */
+  const_iterator
+  end() const
+  {
+    return m_Matrix.end();
+  }
+
+  /** Returns a const iterator to the first element. */
+  const_iterator
+  cbegin() const
+  {
+    return m_Matrix.begin();
+  }
+
+  /** Returns a const iterator just beyond the last element. */
+  const_iterator
+  cend() const
+  {
+    return m_Matrix.end();
+  }
 
   void
   swap(Self & other)

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -91,6 +91,23 @@ Expect_Matrix_is_constructible_from_raw_array_of_arrays()
     }
   }
 }
+
+
+template <typename TMatrix>
+void
+Expect_MakeFilled_corresponds_with_Fill_member_function()
+{
+  using ValueType = typename TMatrix::ValueType;
+
+  for (const auto fillValue :
+       { ValueType(), std::numeric_limits<ValueType>::min(), std::numeric_limits<ValueType>::max() })
+  {
+    TMatrix matrixToBeFilled{};
+    matrixToBeFilled.Fill(fillValue);
+
+    EXPECT_EQ(itk::MakeFilled<TMatrix>(fillValue), matrixToBeFilled);
+  }
+}
 } // namespace
 
 
@@ -128,4 +145,35 @@ TEST(Matrix, IsConstructibleFromRawArrayOfArrays)
 {
   Expect_Matrix_is_constructible_from_raw_array_of_arrays<itk::Matrix<float>>();
   Expect_Matrix_is_constructible_from_raw_array_of_arrays<itk::Matrix<double, 2, 3>>();
+}
+
+
+// Tests that the result of MakeFilled corresponds with the resulting matrix after calling its Fill member function.
+TEST(Matrix, MakeFilled)
+{
+  Expect_MakeFilled_corresponds_with_Fill_member_function<itk::Matrix<float>>();
+  Expect_MakeFilled_corresponds_with_Fill_member_function<itk::Matrix<double, 2, 3>>();
+}
+
+
+// Tests that cbegin() and cend() return the same iterators as the corresponding begin() and end() member functions.
+TEST(Matrix, CBeginAndCEnd)
+{
+  const auto check = [](const auto & matrix) {
+    EXPECT_EQ(matrix.cbegin(), matrix.begin());
+    EXPECT_EQ(matrix.cend(), matrix.end());
+  };
+
+  check(itk::Matrix<float>());
+  check(itk::Matrix<double, 2, 3>());
+}
+
+
+// Tests that `size()` is equal to `end() - begin()`.
+TEST(Matrix, SizeIsDifferenceBetweenBeginEnd)
+{
+  const auto check = [](const auto & matrix) { EXPECT_EQ(matrix.size(), matrix.end() - matrix.begin()); };
+
+  check(itk::Matrix<float>());
+  check(itk::Matrix<double, 2, 3>());
 }


### PR DESCRIPTION
Forwarded iterators and `size()` from its internal `m_Matrix`. This commit enables calling `itk::MakeFilled<MatrixType>(fillValue)` to create a filled matrix.