### PR TITLE
STYLE: Replace `Fill(0)` on local variables with `{}` initialization

### DIFF
--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -62,11 +62,9 @@ ExtractImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputImageReg
                 "InputImageDimension must be greater than OutputImageDimension");
   m_ExtractionRegion = extractRegion;
 
-  InputImageSizeType  inputSize = extractRegion.GetSize();
-  OutputImageSizeType outputSize;
-  outputSize.Fill(0);
-  OutputImageIndexType outputIndex;
-  outputIndex.Fill(0);
+  InputImageSizeType   inputSize = extractRegion.GetSize();
+  OutputImageSizeType  outputSize{};
+  OutputImageIndexType outputIndex{};
 
   /**
    * check to see if the number of non-zero entries in the extraction region
@@ -131,8 +129,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
     typename OutputImageType::SpacingType   outputSpacing;
     typename OutputImageType::DirectionType outputDirection;
-    typename OutputImageType::PointType     outputOrigin;
-    outputOrigin.Fill(0.0);
+    typename OutputImageType::PointType     outputOrigin{};
 
     if (static_cast<unsigned int>(OutputImageDimension) > static_cast<unsigned int>(InputImageDimension))
     {

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -216,9 +216,8 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
 
   for (unsigned int count = 0; count < numberOfInputCorners; ++count)
   {
-    ContinuousInputIndexType currentInputCornerIndex;
-    currentInputCornerIndex.Fill(0);
-    unsigned int localCount = count;
+    ContinuousInputIndexType currentInputCornerIndex{};
+    unsigned int             localCount = count;
 
     // For each dimension, set the current index to either
     // the highest or lowest index along this dimension.

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -68,9 +68,8 @@ FillImage(itk::Image<itk::Index<VDimension>, VDimension> * img)
   using ImageType = itk::Image<IndexType, VDimension>;
   const itk::Size<VDimension> size = img->GetRequestedRegion().GetSize();
 
-  unsigned int i;
-  IndexType    loop;
-  loop.Fill(0);
+  unsigned int                        i;
+  IndexType                           loop{};
   itk::ImageRegionIterator<ImageType> it(img, img->GetRequestedRegion());
 
   while (!it.IsAtEnd())

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -350,8 +350,7 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> 
 
   if (sum_weights != 0.)
   {
-    PointType oP;
-    oP.Fill(0.);
+    PointType oP{};
 
     for (i = 0; i < 3; ++i)
     {

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -170,9 +170,7 @@ auto
 TriangleHelper<TPoint>::ComputeCircumCenter(const PointType & iP1, const PointType & iP2, const PointType & iP3)
   -> PointType
 {
-  PointType oPt;
-
-  oPt.Fill(0.0);
+  PointType oPt{};
 
   CoordRepType a = iP2.SquaredEuclideanDistanceTo(iP3);
   CoordRepType b = iP1.SquaredEuclideanDistanceTo(iP3);

--- a/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
+++ b/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
@@ -253,8 +253,7 @@ AnatomicalOrientation::ConvertPositiveEnumToDirection(PositiveEnum orientationEn
   const AnatomicalOrientation o(orientationEnum);
 
   CoordinateEnum terms[Dimension] = { o.GetPrimaryTerm(), o.GetSecondaryTerm(), o.GetTertiaryTerm() };
-  DirectionType  direction;
-  direction.Fill(0.0);
+  DirectionType  direction{};
 
   for (unsigned int i = 0; i < Dimension; ++i)
   {

--- a/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
+++ b/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
@@ -132,8 +132,7 @@ SpatialOrientationAdapter::ToDirectionCosines(const OrientationType & Or)
     (static_cast<uint32_t>(Or) >>
      static_cast<uint32_t>(SpatialOrientationEnums::CoordinateMajornessTerms::ITK_COORDINATE_TertiaryMinor)) &
     0xff);
-  DirectionType direction;
-  direction.Fill(0.0);
+  DirectionType direction{};
   for (unsigned int i = 0; i < DirectionType::ColumnDimensions; ++i)
   {
     switch (terms[i])

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
@@ -79,9 +79,7 @@ template <typename TImageType>
 auto
 FiniteDifferenceFunction<TImageType>::ComputeNeighborhoodScales() const -> const NeighborhoodScalesType
 {
-  NeighborhoodScalesType neighborhoodScales;
-
-  neighborhoodScales.Fill(0.0);
+  NeighborhoodScalesType neighborhoodScales{};
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     if (this->m_Radius[i] > 0)

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -351,8 +351,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
 {
   for (unsigned int direction = 0; direction < Self::ImageDimension; ++direction)
   {
-    typename NeighborhoodType::SizeType size;
-    size.Fill(0);
+    typename NeighborhoodType::SizeType size{};
     size[direction] = static_cast<SizeValueType>(m_Sigma[direction] * m_Extent[direction]);
 
     NeighborhoodType gaussianNeighborhood;

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -159,8 +159,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
       // Set the derivative of the Gaussian first
       OperatorNeighborhoodType                                  dogNeighborhood;
       typename GaussianDerivativeSpatialFunctionType::InputType pt;
-      typename NeighborhoodType::SizeType                       size;
-      size.Fill(0);
+      typename NeighborhoodType::SizeType                       size{};
       size[direction] = static_cast<SizeValueType>(m_Sigma[direction] * m_Extent[direction]);
       dogNeighborhood.SetRadius(size);
       m_ImageNeighborhoodOffsets[direction] = GenerateRectangularImageNeighborhoodOffsets(size);

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -53,8 +53,7 @@ VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuo
    * neighbors. The weight for each neighbor is the fraction overlap
    * of the neighbor pixel with respect to a pixel centered on point.
    */
-  OutputType output;
-  output.Fill(0.0);
+  OutputType output{};
 
   using ScalarRealType = typename NumericTraits<PixelType>::ScalarRealType;
   ScalarRealType totalOverlap{};

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -33,8 +33,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::BinaryMask3DMeshSource()
   // Modify superclass default values, can be overridden by subclasses
   this->SetNumberOfRequiredInputs(1);
 
-  SizeType size;
-  size.Fill(0);
+  SizeType size{};
   m_RegionOfInterest.SetSize(size);
 
   this->GetOutput()->GetPoints()->Reserve(m_NodeLimit);

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -406,8 +406,7 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier 
   this->GetPoint(neighbors[2], &n3);
 
   // compute normals
-  CovariantVectorType normal;
-  normal.Fill(0.0);
+  CovariantVectorType normal{};
   CovariantVectorType z;
   z.SetVnlVector(vnl_cross_3d((n2 - n1).GetVnlVector(), (n3 - n1).GetVnlVector()));
   z.Normalize();

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
@@ -112,11 +112,9 @@ public:
     {
       using PointIdIterator = typename SimplexPolygonType::PointIdIterator;
       PointIdIterator it = poly->PointIdsBegin();
-      InputPointType  center;
-      center.Fill(0);
+      InputPointType  center{};
 
-      InputPointType p;
-      p.Fill(0);
+      InputPointType p{};
 
       while (it != poly->PointIdsEnd())
       {

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -26,9 +26,7 @@ namespace itk
 SimplexMeshGeometry::SimplexMeshGeometry()
 {
   double    c = 1.0 / 3.0;
-  PointType p;
-
-  p.Fill(0.0);
+  PointType p{};
 
   pos.Fill(0);
   oldPos.Fill(0);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
@@ -51,9 +51,8 @@ QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
   this->m_Mesh->DeleteFace(e->GetLeft());
 
   // create new point geometry
-  unsigned int sum = 0;
-  VectorType   vec;
-  vec.Fill(0);
+  unsigned int    sum = 0;
+  VectorType      vec{};
   PointIdentifier pid = this->m_Mesh->FindFirstUnusedPointIndex();
   using AssociatedBarycenters = std::map<QEType *, PointIdentifier>;
   AssociatedBarycenters m_AssocBary;

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -26,8 +26,7 @@ template <unsigned int TPointDimension>
 LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint()
 {
   unsigned int        ii = 0;
-  CovariantVectorType normal;
-  normal.Fill(0);
+  CovariantVectorType normal{};
   while (ii < TPointDimension - 1)
   {
     this->m_NormalArrayInObjectSpace[ii] = normal;

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -56,10 +56,8 @@ MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType
 
   auto it2 = tube->GetPoints().begin();
 
-  itk::CovariantVector<double, VDimension> v;
-  v.Fill(0.0);
-  itk::Vector<double, VDimension> t;
-  t.Fill(0.0);
+  itk::CovariantVector<double, VDimension> v{};
+  itk::Vector<double, VDimension>          t{};
 
   for (unsigned int identifier = 0; identifier < tube->GetPoints().size(); ++identifier)
   {

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -405,11 +405,9 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeTangentsAndNormals()
     ((TubePointType *)(this->GetPoint(it1)))->SetTangentInObjectSpace(tb);
   }
 
-  CovariantVectorType prevN1;
-  prevN1.Fill(0);
+  CovariantVectorType prevN1{};
   prevN1[TDimension - 1] = 1;
-  CovariantVectorType prevN2;
-  prevN2.Fill(0);
+  CovariantVectorType prevN2{};
   prevN2[TDimension - 2] = 1;
 
   it1 = 0;

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -67,12 +67,10 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputIma
                 "InputImageDimension must be greater than OutputImageDimension");
   m_ExtractionRegion = extractRegion;
 
-  unsigned int        nonzeroSizeCount = 0;
-  InputImageSizeType  inputSize = extractRegion.GetSize();
-  OutputImageSizeType outputSize;
-  outputSize.Fill(0);
-  OutputImageIndexType outputIndex;
-  outputIndex.Fill(0);
+  unsigned int         nonzeroSizeCount = 0;
+  InputImageSizeType   inputSize = extractRegion.GetSize();
+  OutputImageSizeType  outputSize{};
+  OutputImageIndexType outputIndex{};
 
   /**
    * check to see if the number of non-zero entries in the extraction region
@@ -144,8 +142,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   typename OutputImageType::SpacingType   outputSpacing;
   typename OutputImageType::DirectionType outputDirection;
-  typename OutputImageType::PointType     outputOrigin;
-  outputOrigin.Fill(0.0);
+  typename OutputImageType::PointType     outputOrigin{};
 
   if (static_cast<unsigned int>(OutputImageDimension) > static_cast<unsigned int>(InputImageDimension))
   {

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -47,8 +47,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::BSplineTransfo
   // dir[0][2],dir[1][2],dir[2][2]]
 
 
-  OriginType meshOrigin;
-  meshOrigin.Fill(0.0);
+  OriginType             meshOrigin{};
   PhysicalDimensionsType meshPhysical;
   meshPhysical.Fill(1.0);
 
@@ -305,8 +304,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParame
 
   // Set the origin parameters
   using PointType = typename ImageType::PointType;
-  PointType origin;
-  origin.Fill(0.0);
+  PointType origin{};
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     ScalarType gridSpacing = meshPhysical[i] / static_cast<ScalarType>(meshSize[i]);

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -142,8 +142,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
 
   for (unsigned int d = 0; d < cornerPoints->GetNumberOfPoints(); ++d)
   {
-    PointType corner;
-    corner.Fill(0.0);
+    PointType corner{};
     cornerPoints->GetPoint(d, &corner);
 
     RealType distance = corner.SquaredEuclideanDistanceTo(bbox->GetMinimum());
@@ -179,8 +178,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
       PointIdentifier oppositeCornerId =
         (static_cast<PointIdentifier>(1) << static_cast<PointIdentifier>(i)) ^ transformDomainOriginId;
 
-      PointType corner;
-      corner.Fill(0.0);
+      PointType corner{};
       cornerPoints->GetPoint(oppositeCornerId, &corner);
 
       VectorType vector = corner - transformDomainOrigin;
@@ -216,8 +214,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
 
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
-    PointType corner;
-    corner.Fill(0.0);
+    PointType corner{};
     cornerPoints->GetPoint(minCornerId[d], &corner);
 
     VectorType vector = corner - transformDomainOrigin;

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -299,9 +299,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::
   PreservationOfPrincipalDirectionDiffusionTensor3DReorientation(const InputDiffusionTensor3DType &  inputTensor,
                                                                  const InverseJacobianPositionType & jacobian) const
 {
-  Matrix<TParametersValueType, 3, 3> matrix;
-
-  matrix.Fill(0.0);
+  Matrix<TParametersValueType, 3, 3> matrix{};
   for (unsigned int i = 0; i < 3; ++i)
   {
     matrix(i, i) = 1.0;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -217,8 +217,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
 {
-  typename InputImageType::IndexType requiredIndex;
-  requiredIndex.Fill(0);
+  typename InputImageType::IndexType        requiredIndex{};
   const typename InputImageType::RegionType largestRegion = this->GetInput()->GetLargestPossibleRegion();
   const PatchRadiusType                     radius = this->GetPatchRadiusInVoxels();
   PatchRadiusType                           two;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -52,8 +52,7 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::Inte
 
   using BSplineFilterType = BSplineControlPointImageFilter<VelocityFieldType, VelocityFieldType>;
 
-  typename BSplineFilterType::ArrayType closeDimensions;
-  closeDimensions.Fill(0);
+  typename BSplineFilterType::ArrayType closeDimensions{};
   if (this->m_TemporalPeriodicity)
   {
     closeDimensions[VDimension] = 1;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -163,8 +163,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
   // Solve the initial value problem using fourth-order Runge-Kutta
   //    y' = f(t, y), y(t_0) = y_0
 
-  VectorType zeroVector;
-  zeroVector.Fill(0.0);
+  VectorType zeroVector{};
 
   // Initial conditions
 

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -343,8 +343,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Gene
 
   // Process image.
 
-  OffsetType offset;
-  offset.Fill(0);
+  OffsetType offset{};
 
   SizeValueType i = 0;
 

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -223,11 +223,9 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   // The result of this division is the offsetIndex, which is the index offset relative to the region of this thread.
   // The true pixel location (idx) is provided by the sum of the offsetIndex and the startIndex.
   InputSizeValueType index;
-  OutputIndexType    offsetIndex;
-  offsetIndex.Fill(0);
+  OutputIndexType    offsetIndex{};
   InputSizeValueType tempRow = NumberOfRows[m_CurrentDimension];
-  OutputIndexType    idx;
-  idx.Fill(0);
+  OutputIndexType    idx{};
 
   for (InputSizeValueType n = 0; n < tempRow; ++n)
   {

--- a/Modules/Filtering/FFT/test/itkFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkFFTTest.h
@@ -71,8 +71,7 @@ test_fft(unsigned int * SizeOfDimensions)
   // Set up spacing and origin to test passing of metadata
   typename RealImageType::PointType     origin;
   typename RealImageType::SpacingType   spacing;
-  typename RealImageType::DirectionType direction;
-  direction.Fill(0.0);
+  typename RealImageType::DirectionType direction{};
   for (unsigned int i = 0; i < VImageDimensions; ++i)
   {
     origin[i] = static_cast<typename RealImageType::PointValueType>(i) + 1.0;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -56,8 +56,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::FastMarchingImageFilterBase()
   OutputSizeType outputSize;
   outputSize.Fill(16);
 
-  NodeType outputIndex;
-  outputIndex.Fill(0);
+  NodeType outputIndex{};
 
   m_OutputRegion.SetSize(outputSize);
   m_OutputRegion.SetIndex(outputIndex);

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -227,8 +227,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
       // compute and add structure tensor into pointData
       if (m_ComputeStructureTensors)
       {
-        StructureTensorType tensor;
-        tensor.Fill(0);
+        StructureTensorType tensor{};
 
         Matrix<SpacePrecisionType, ImageDimension, 1> gradI; // vector declared as column matrix
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -69,8 +69,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   FixedArray<short, ImageDimension> direction;
   direction.Fill(1);
   int        axis = ImageDimension - 1;
-  OffsetType offset;
-  offset.Fill(0);
+  OffsetType offset{};
   RegionType stRegion;
   stRegion.SetSize(this->m_Kernel.GetSize());
   stRegion.PadByRadius(1); // must pad the region by one because of the translation

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -108,13 +108,11 @@ MovingHistogramImageFilterBase<TInputImage, TOutputImage, TKernel>::SetKernel(co
   // store the kernel offset list
   m_KernelOffsets = kernelOffsets;
 
-  FixedArray<SizeValueType, ImageDimension> axisCount;
-  axisCount.Fill(0);
+  FixedArray<SizeValueType, ImageDimension> axisCount{};
 
   for (unsigned int axis = 0; axis < ImageDimension; ++axis)
   {
-    OffsetType refOffset;
-    refOffset.Fill(0);
+    OffsetType refOffset{};
     for (int direction = -1; direction <= 1; direction += 2)
     {
       refOffset[axis] = direction;

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -169,9 +169,7 @@ public:
   IndexType
   GetFrequencyBin() const
   {
-    IndexType freqInd;
-
-    freqInd.Fill(0);
+    IndexType freqInd{};
     for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
     {
       if (this->m_PositionIndex[dim] <= m_LargestPositiveFrequencyIndex[dim])

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -177,8 +177,7 @@ public:
   IndexType
   GetFrequencyBin() const
   {
-    IndexType freqInd;
-    freqInd.Fill(0);
+    IndexType freqInd{};
     for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
     {
       if (this->m_PositionIndex[dim] <= m_LargestPositiveFrequencyIndex[dim])

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -169,9 +169,7 @@ public:
   IndexType
   GetFrequencyBin() const
   {
-    IndexType freqInd;
-
-    freqInd.Fill(0);
+    IndexType freqInd{};
     for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
     {
       freqInd[dim] = this->m_PositionIndex[dim] - this->m_ZeroFrequencyIndex[dim];

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -281,8 +281,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::CollapsePhiLattice(Po
        !It.IsAtEnd();
        ++It)
   {
-    PointDataType data;
-    data.Fill(0.0);
+    PointDataType                          data{};
     typename PointDataImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < this->m_SplineOrder[dimension] + 1; ++i)
     {
@@ -423,8 +422,7 @@ BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::RefineControlPoi
     auto refinedLattice = ControlPointLatticeType::New();
     refinedLattice->SetRegions(size);
     refinedLattice->Allocate();
-    PixelType data;
-    data.Fill(0.0);
+    PixelType data{};
     refinedLattice->FillBuffer(data);
 
     typename ControlPointLatticeType::IndexType            idx;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -235,8 +235,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTy
     }
   }
 
-  OutputType data;
-  data.Fill(0.0);
+  OutputType data{};
 
   for (ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
                                                        this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -453,8 +453,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
 
   for (unsigned int n = start; n < end; ++n)
   {
-    PointType point;
-    point.Fill(0.0);
+    PointType point{};
 
     input->GetPoint(n, &point);
 
@@ -707,8 +706,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
 
     for (ItP.GoToBegin(), ItO.GoToBegin(), ItD.GoToBegin(); !ItP.IsAtEnd(); ++ItP, ++ItO, ++ItD)
     {
-      PointDataType P;
-      P.Fill(0);
+      PointDataType P{};
       if (Math::NotAlmostEquals(ItO.Get(), typename PointDataType::ValueType{}))
       {
         P = ItD.Get() / ItO.Get();
@@ -755,8 +753,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::RefineC
   refinedLattice->SetRegions(size);
   refinedLattice->Allocate();
 
-  PointDataType data;
-  data.Fill(0.0);
+  PointDataType data{};
   refinedLattice->FillBuffer(data);
 
   typename PointDataImageType::IndexType            idx;
@@ -945,8 +942,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
 
   for (unsigned int n = start; n < end; ++n)
   {
-    PointType point;
-    point.Fill(0.0);
+    PointType point{};
 
     input->GetPoint(n, &point);
 
@@ -1001,8 +997,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Collaps
        !It.IsAtEnd();
        ++It)
   {
-    PointDataType data;
-    data.Fill(0.0);
+    PointDataType                          data{};
     typename PointDataImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < this->m_SplineOrder[dimension] + 1; ++i)
     {

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -290,8 +290,7 @@ SliceBySliceImageFilter<TInputImage,
       // not supported to avoid dealing with singularities, but we still account
       // for the direction matrix when collapsing the origin to an N-1
       // point.
-      typename InputImageType::IndexType originIndex;
-      originIndex.Fill(0);
+      typename InputImageType::IndexType originIndex{};
       originIndex[m_Dimension] = slice;
 
       typename InputImageType::PointType inputOrigin;

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -182,8 +182,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   }
 
 
-  typename TInputImage::SizeType inputRequestedRegionSize;
-  inputRequestedRegionSize.Fill(0);
+  typename TInputImage::SizeType inputRequestedRegionSize{};
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     if (outputRequestedRegionSize[i] > 0)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -121,8 +121,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   tmpVertex = pstartVertex;
   ++piter;
 
-  ImageIndexType tmpImageIndex;
-  tmpImageIndex.Fill(0);
+  ImageIndexType tmpImageIndex{};
 
   ImageLineIteratorType imit(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
   imit.SetDirection(0);

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -167,8 +167,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   typename TPolyline::ConstPointer   polylinePtr(dynamic_cast<const TPolyline *>(this->ProcessObject::GetInput(1)));
   typename TOutputImage::Pointer     outputImagePtr(dynamic_cast<TOutputImage *>(this->ProcessObject::GetOutput(0)));
 
-  OriginType originInput;
-  originInput.Fill(0.0);
+  OriginType originInput{};
   // outputImagePtr->SetOrigin(inputImagePtr->GetOrigin());
   outputImagePtr->SetOrigin(originInput);
   outputImagePtr->SetSpacing(inputImagePtr->GetSpacing());

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -194,14 +194,12 @@ ObjectByObjectLabelMapFilter<TInputImage,
   if (m_ConstrainPaddingToImage)
   {
     m_Crop->SetCropBorder(m_PadSize);
-    SizeType zero;
-    zero.Fill(0);
+    SizeType zero{};
     m_Pad->SetPadSize(zero);
   }
   else
   {
-    SizeType zero;
-    zero.Fill(0);
+    SizeType zero{};
     m_Crop->SetCropBorder(zero);
     m_Pad->SetPadSize(m_PadSize);
   }

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -95,16 +95,14 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   // Init the vars
   SizeValueType                           nbOfPixels = 0;
-  ContinuousIndex<double, ImageDimension> centroid;
-  centroid.Fill(0);
-  IndexType mins;
+  ContinuousIndex<double, ImageDimension> centroid{};
+  IndexType                               mins;
   mins.Fill(NumericTraits<IndexValueType>::max());
   IndexType maxs;
   maxs.Fill(NumericTraits<IndexValueType>::NonpositiveMin());
   SizeValueType nbOfPixelsOnBorder = 0;
   double        perimeterOnBorder = 0;
-  MatrixType    centralMoments;
-  centralMoments.Fill(0);
+  MatrixType    centralMoments{};
 
   using LengthType = typename LabelObjectType::LengthType;
 
@@ -551,8 +549,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
     const VectorLineType & ls = lIt.GetCenterPixel();
 
     // there are two intercepts on the 0 axis for each line
-    OffsetType no;
-    no.Fill(0);
+    OffsetType no{};
     no[0] = 1;
     // std::cout << no << "-> " << 2 * ls.size() << std::endl;
     intercepts[no] += 2 * static_cast<SizeValueType>(ls.size());
@@ -677,8 +674,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::PerimeterFromInterceptCount(TMapInterc
 
   for (int i = 0; i < dim; ++i)
   {
-    OffsetType no;
-    no.Fill(0);
+    OffsetType no{};
     no[i] = 1;
     // std::cout << no << ": " << intercepts[no] << std::endl;
     perimeter += pixelSize / spacing[i] * intercepts[no] / 2.0;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -96,18 +96,12 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
   double                sum2 = 0;
   double                sum3 = 0;
   double                sum4 = 0;
-  IndexType             minIdx;
-  minIdx.Fill(0);
-  IndexType maxIdx;
-  maxIdx.Fill(0);
-  PointType centerOfGravity;
-  centerOfGravity.Fill(0);
-  MatrixType centralMoments;
-  centralMoments.Fill(0);
-  MatrixType principalAxes;
-  principalAxes.Fill(0);
-  VectorType principalMoments;
-  principalMoments.Fill(0);
+  IndexType             minIdx{};
+  IndexType             maxIdx{};
+  PointType             centerOfGravity{};
+  MatrixType            centralMoments{};
+  MatrixType            principalAxes{};
+  VectorType            principalMoments{};
 
 
   // iterate over all the indexes

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -862,8 +862,7 @@ FlatStructuringElement<VDimension>::Box(RadiusType radius)
   {
     if (radius[i] != 0)
     {
-      LType L;
-      L.Fill(0);
+      LType L{};
       L[i] = radius[i] * 2 + 1;
       res.AddLine(L);
     }
@@ -896,8 +895,7 @@ FlatStructuringElement<VDimension>::Cross(RadiusType radius)
   }
   for (int d = 0; d < static_cast<int>(VDimension); ++d)
   {
-    OffsetType o;
-    o.Fill(0);
+    OffsetType o{};
     for (int i = -static_cast<int>(radius[d]); i <= static_cast<int>(radius[d]); ++i)
     {
       o[d] = i;

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -161,8 +161,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   FixedArray<short, ImageDimension> direction;
   direction.Fill(1);
   int        axis = ImageDimension - 1;
-  OffsetType offset;
-  offset.Fill(0);
+  OffsetType offset{};
   RegionType stRegion;
   stRegion.SetSize(this->m_Kernel.GetSize());
   stRegion.PadByRadius(1); // must pad the region by one because of the

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -53,8 +53,7 @@ HilbertPath<TIndexValue, VDimension>::TransformPathIndexToMultiDimensionalIndex(
   PathIndexType d = 0;
   PathIndexType e = 0;
 
-  IndexType index;
-  index.Fill(0);
+  IndexType index{};
 
   for (PathIndexType i = 0; i < this->m_HilbertOrder; ++i)
   {

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
@@ -35,9 +35,7 @@ PathToChainCodePathFilter<TInputPath, TOutputChainCodePath>::GenerateData()
 {
   OffsetType offset;
   OffsetType tempOffset;
-  OffsetType zeroOffset;
-
-  zeroOffset.Fill(0);
+  OffsetType zeroOffset{};
 
   InputPathInputType inputPathInput;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -285,9 +285,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetMeshBarycentre() -> InputP
 {
   InputMeshConstPointer input = this->GetInput();
 
-  InputPointType oCenter;
-
-  oCenter.Fill(0.0);
+  InputPointType oCenter{};
 
   const InputPointsContainer * points = input->GetPoints();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -89,13 +89,10 @@ protected:
 
     OutputCurvatureType oH(0.);
 
-    OutputVectorType Laplace;
-
-    Laplace.Fill(0.);
+    OutputVectorType Laplace{};
 
     OutputCurvatureType area(0.);
-    OutputVectorType    normal;
-    normal.Fill(0.);
+    OutputVectorType    normal{};
 
     if (qe != nullptr)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -92,8 +92,7 @@ protected:
 
     if (qe != nullptr)
     {
-      OutputVectorType Laplace;
-      Laplace.Fill(0.);
+      OutputVectorType Laplace{};
 
       OutputQEType * qe_it = qe;
 
@@ -107,8 +106,7 @@ protected:
         OutputPointType  q0, q1;
         OutputVectorType face_normal;
 
-        OutputVectorType normal;
-        normal.Fill(0.);
+        OutputVectorType normal{};
 
         OutputCurvatureType temp_area;
         OutputCoordType     temp_coeff;

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -51,8 +51,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequeste
   inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
-  RadiusType radius;
-  radius.Fill(0);
+  RadiusType radius{};
   for (size_t dim = 0; dim < ImageDimension; ++dim)
   {
     radius[dim] = this->GetKernelRadius(dim);
@@ -91,8 +90,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateKernelImage()
     }
 
     // Set up kernel image
-    typename RealImageType::IndexType index;
-    index.Fill(0);
+    typename RealImageType::IndexType  index{};
     typename RealImageType::RegionType region;
     region.SetSize(kernelSize);
     region.SetIndex(index);

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -455,8 +455,7 @@ MINCImageIO::ReadImageInformation()
   int numberOfComponents = 1;
   int usable_dimensions = 0;
 
-  Matrix<double, 3, 3> dir_cos;
-  dir_cos.Fill(0.0);
+  Matrix<double, 3, 3> dir_cos{};
   dir_cos.SetIdentity();
 
   Vector<double, 3> origin, sep;

--- a/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
@@ -110,9 +110,8 @@ TImageType::PointType
 ComputeCG(TImageType::Pointer img)
 {
   itk::ImageRegionConstIteratorWithIndex<TImageType> it(img, img->GetLargestPossibleRegion());
-  TImageType::PointType                              Cg;
-  Cg.Fill(0.0);
-  double sumMass = 0.0;
+  TImageType::PointType                              Cg{};
+  double                                             sumMass = 0.0;
   while (!it.IsAtEnd())
   {
     const double value = it.Value();

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -137,12 +137,9 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   ++pointIditer;
   unsigned int boundaryId2 = *pointIditer;
 
-  InputPointType ptA;
-  ptA.Fill(0.0);
-  InputPointType ptB;
-  ptB.Fill(0.0);
-  InputPointType ptC;
-  ptC.Fill(0.0);
+  InputPointType ptA{};
+  InputPointType ptB{};
+  InputPointType ptC{};
 
   inputMesh->GetPoint(boundaryId0, &ptA);
   inputMesh->GetPoint(boundaryId1, &ptB);

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -193,9 +193,8 @@ public:
       m_Eccentricity = 1;
       m_Elongation = 1;
       m_Orientation = 0;
-      LabelPointType emptyPoint;
-      emptyPoint.Fill(0);
-      unsigned int numberOfVertices = 1 << ImageDimension;
+      LabelPointType emptyPoint{};
+      unsigned int   numberOfVertices = 1 << ImageDimension;
       m_OrientedBoundingBoxVertices.resize(numberOfVertices, emptyPoint);
       m_OrientedBoundingBoxVolume = 0;
       m_OrientedBoundingBoxSize.Fill(0);

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -111,8 +111,7 @@ CalculateOrientedImage(const vnl_symmetric_eigensystem<double> &                
     center[i] = labelGeometry.m_Centroid[i] * inputImage->GetSpacing()[i];
     origin[i] = labelGeometry.m_OrientedBoundingBoxOrigin[i] * inputImage->GetSpacing()[i];
   }
-  typename TransformType::OutputVectorType translation;
-  translation.Fill(0);
+  typename TransformType::OutputVectorType translation{};
   transform->SetCenter(center);
   transform->SetTranslation(translation);
   transform->SetMatrix(rotationMatrix);
@@ -861,8 +860,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVe
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelPointType emptyPoint;
-    emptyPoint.Fill(0);
+    LabelPointType          emptyPoint{};
     BoundingBoxVerticesType emptyVertices;
     emptyVertices.resize(numberOfVertices, emptyPoint);
     return emptyVertices;

--- a/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
@@ -75,8 +75,7 @@ MiniPipelineSeparableImageFilter<TInputImage, TOutputImage, TFilter>::SetRadius(
   // set up the kernels
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    RadiusType rad;
-    rad.Fill(0);
+    RadiusType rad{};
     rad[i] = radius[i];
     m_Filters[i]->SetRadius(rad);
   }

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -146,8 +146,7 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   ImageRegionIteratorWithIndex<EigenValueImageType>  outputIt2(outputPtr2, region);
   ImageRegionIteratorWithIndex<EigenVectorImageType> outputIt3(outputPtr3, region);
 
-  EigenVectorType nullVector;
-  nullVector.Fill(0.0);
+  EigenVectorType nullVector{};
 
   // support progress methods/callbacks
   ProgressReporter progress(this, 0, region.GetNumberOfPixels());

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -228,9 +228,7 @@ public:
   void
   InitializeInterpolationGrid(const InterpolationGridSizeType & size)
   {
-    InterpolationGridPointType bb1;
-
-    bb1.Fill(0.0);
+    InterpolationGridPointType bb1{};
 
     InterpolationGridPointType bb2;
     for (unsigned int i = 0; i < FEMDimension; ++i)

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -731,8 +731,7 @@ Solver<VDimension>::InitializeInterpolationGrid(const InterpolationGridSizeType 
     image_size[i] = size[i];
   }
 
-  InterpolationGridPointType image_origin;
-  image_origin.Fill(0.0);
+  InterpolationGridPointType image_origin{};
   for (unsigned int i = 0; i < FEMDimension; ++i)
   {
     image_origin[i] = bb1[i];

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -98,8 +98,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
   typename FaceCalculatorType::FaceListType faceList = faceCalculator(input, input->GetRequestedRegion(), radius);
 
-  OffsetType center_offset;
-  center_offset.Fill(0);
+  OffsetType center_offset{};
 
   bool isInside;
 

--- a/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -40,8 +40,7 @@ void
 BSplineExponentialDiffeomorphicTransformParametersAdaptor<TTransform>::SetMeshSizeForTheConstantVelocityField(
   const ArrayType & meshSize)
 {
-  ArrayType numberOfControlPoints;
-  numberOfControlPoints.Fill(0);
+  ArrayType numberOfControlPoints{};
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
     if (meshSize[d] > 0)
@@ -60,8 +59,7 @@ void
 BSplineExponentialDiffeomorphicTransformParametersAdaptor<TTransform>::SetMeshSizeForTheUpdateField(
   const ArrayType & meshSize)
 {
-  ArrayType numberOfControlPoints;
-  numberOfControlPoints.Fill(0);
+  ArrayType numberOfControlPoints{};
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
     if (meshSize[d] > 0)

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -40,8 +40,7 @@ void
 BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>::SetMeshSizeForTheUpdateField(
   const ArrayType & meshSize)
 {
-  ArrayType numberOfControlPoints;
-  numberOfControlPoints.Fill(0);
+  ArrayType numberOfControlPoints{};
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
     if (meshSize[d] > 0)
@@ -60,8 +59,7 @@ void
 BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>::SetMeshSizeForTheTotalField(
   const ArrayType & meshSize)
 {
-  ArrayType numberOfControlPoints;
-  numberOfControlPoints.Fill(0);
+  ArrayType numberOfControlPoints{};
   for (unsigned int d = 0; d < SpaceDimension; ++d)
   {
     if (meshSize[d] > 0)

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -158,8 +158,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
   filter->SetNumberOfLevels(3);
 
-  typename FilterType::ArrayType close;
-  close.Fill(0);
+  typename FilterType::ArrayType close{};
   filter->SetCloseDimension(close);
 
   filter->Update();
@@ -645,8 +644,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   transform->SetIdentity();
 
   // Compute the centroids.
-  PointType fixedCentroid;
-  fixedCentroid.Fill(0.0);
+  PointType                    fixedCentroid{};
   PointsContainerConstIterator fixedItr = this->m_FixedLandmarks.begin();
   while (fixedItr != this->m_FixedLandmarks.end())
   {
@@ -659,8 +657,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   fixedCentroid[1] /= this->m_FixedLandmarks.size();
 
   PointsContainerConstIterator movingItr = this->m_MovingLandmarks.begin();
-  PointType                    movingCentroid;
-  movingCentroid.Fill(0.0);
+  PointType                    movingCentroid{};
   while (movingItr != this->m_MovingLandmarks.end())
   {
     movingCentroid[0] += (*movingItr)[0];
@@ -771,8 +768,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Comput
   const LandmarkPointContainer inputLandmarks) -> PointType3D
 {
   // Compute the centroids.
-  PointType3D centroid;
-  centroid.Fill(0.0);
+  PointType3D                  centroid{};
   PointsContainerConstIterator fixedItr = inputLandmarks.begin();
   while (fixedItr != inputLandmarks.end())
   {

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -857,8 +857,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
     m_TotalField->SetLargestPossibleRegion(m_FieldRegion);
     m_TotalField->Allocate();
 
-    VectorType disp;
-    disp.Fill(0.0);
+    VectorType disp{};
 
     FieldIterator fieldIter(m_TotalField, m_FieldRegion);
 
@@ -930,8 +929,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
     fieldIter.GoToBegin();
     while (!fieldIter.IsAtEnd())
     {
-      VectorType disp;
-      disp.Fill(0.0);
+      VectorType disp{};
       fieldIter.Set(disp);
       ++fieldIter;
     }

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
@@ -155,9 +155,8 @@ NCCRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeU
     }
   }
 
-  PixelType update;
-  update.Fill(0.0);
-  double updatenorm = 0.0;
+  PixelType update{};
+  double    updatenorm = 0.0;
   if ((sff * smm) != 0.0)
   {
     const double factor = 1.0 / std::sqrt(sff * smm);

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
@@ -28,8 +28,7 @@ typename EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPoin
   EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::
     GetLocalNeighborhoodValue(const PointType & point, const PixelType & itkNotUsed(pixel)) const
 {
-  PointType closestPoint;
-  closestPoint.Fill(0.0);
+  PointType closestPoint{};
 
   PointIdentifier pointId = this->m_MovingTransformedPointsLocator->FindClosestPoint(point);
   closestPoint = this->m_MovingTransformedPointSet->GetPoint(pointId);
@@ -53,8 +52,7 @@ EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TIn
                                          LocalDerivativeType & localDerivative,
                                          const PixelType &     itkNotUsed(pixel)) const
 {
-  PointType closestPoint;
-  closestPoint.Fill(0.0);
+  PointType closestPoint{};
 
   PointIdentifier pointId = this->m_MovingTransformedPointsLocator->FindClosestPoint(point);
   closestPoint = this->m_MovingTransformedPointSet->GetPoint(pointId);

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -84,8 +84,7 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
 
   localDerivative.Fill(0.0);
 
-  PointType weightedPoint;
-  weightedPoint.Fill(0.0);
+  PointType weightedPoint{};
 
   NeighborsIdentifierType neighborhood;
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -28,9 +28,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::
   SymmetricForcesDemonsRegistrationFunction()
 {
-  RadiusType r;
-
-  r.Fill(0);
+  RadiusType r{};
   this->SetRadius(r);
 
   m_TimeStep = 1.0;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -352,8 +352,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
 
   SizeValueType numberOfIntegrationSteps = this->m_NumberOfTimePointSamples + 2;
 
-  typename DisplacementFieldType::PixelType zeroVector;
-  zeroVector.Fill(0);
+  typename DisplacementFieldType::PixelType zeroVector{};
 
   velocityFieldPointSet->Initialize();
   velocityFieldWeights->Initialize();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -66,8 +66,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
 {
   using DisplacementFieldDuplicatorType = ImageDuplicator<DisplacementFieldType>;
   using DisplacementFieldTransformType = DisplacementFieldTransform<RealType, ImageDimension>;
-  typename DisplacementFieldType::PixelType zeroVector;
-  zeroVector.Fill(0);
+  typename DisplacementFieldType::PixelType zeroVector{};
 
   // This transform is used for the fixed image
   using IdentityTransformType = itk::IdentityTransform<RealType, ImageDimension>;

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -217,9 +217,8 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeGeometry()
 {
   PointType           Foot;
   CovariantVectorType normal;
-  CovariantVectorType z;
-  z.Fill(0.0);
-  VectorType tmp;
+  CovariantVectorType z{};
+  VectorType          tmp;
   //   IdentifierType idx = 0;
 
   const InputMeshType *        inputMesh = this->GetInput(0);
@@ -294,8 +293,7 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeDisplacement()
 
   typename GeometryMapType::Iterator dataIt = this->m_Data->Begin();
   SimplexMeshGeometry *              data;
-  VectorType                         displacement;
-  displacement.Fill(0.0);
+  VectorType                         displacement{};
 
   while (dataIt != this->m_Data->End())
   {

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -393,8 +393,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
   // now fun begins try to use all the above
   std::vector<ImageVoxel *>::iterator it;
   double                              mag, max = 0;
-  GradientIndexType                   coord3, coord2;
-  coord2.Fill(0);
+  GradientIndexType                   coord3, coord2{};
   for (it = m_Positive.begin(); it != m_Positive.end(); ++it)
   {
     coord3[0] = static_cast<GradientIndexValueType>((*it)->GetX());

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -112,8 +112,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateOutputImage()
   OutputRegionType region;
   region.SetSize(gridSize); // Constant grid size
 
-  OutputImageIndexType tmpIndex;
-  tmpIndex.Fill(0);
+  OutputImageIndexType tmpIndex{};
 
   for (unsigned int iregion = 0; iregion < m_InitialNumberOfRegions; ++iregion)
   {
@@ -201,8 +200,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateLabelledImage(Label
   InputRegionType region;
   region.SetSize(gridSize); // Constant grid size
 
-  InputImageIndexType tmpIndex;
-  tmpIndex.Fill(0);
+  InputImageIndexType tmpIndex{};
 
   for (unsigned int iregion = 0; iregion < m_InitialNumberOfRegions; ++iregion)
   {
@@ -329,8 +327,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
   InputRegionType region;
   region.SetSize(gridSize); // Constant grid size
 
-  InputImageIndexType tmpIndex;
-  tmpIndex.Fill(0);
+  InputImageIndexType tmpIndex{};
 
   for (RegionLabelType iregion = 0; iregion < m_InitialNumberOfRegions; ++iregion)
   {

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -189,9 +189,7 @@ template <typename TInputImage, typename TClassifiedImage>
 void
 RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
 {
-  LabelledImageIndexType offsetIndex3D;
-
-  offsetIndex3D.Fill(0);
+  LabelledImageIndexType offsetIndex3D{};
 
   int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
   int frame = m_ImageWidth * m_ImageHeight;
@@ -315,9 +313,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
   bool         changeflag;
   double       res = 0.0;
 
-  LabelledImageIndexType offsetIndex3D;
-
-  offsetIndex3D.Fill(0);
+  LabelledImageIndexType offsetIndex3D{};
 
   LabelledImagePixelType labelledPixel = 0;
 
@@ -533,8 +529,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
   changedPixelVec.Fill(typename InputImagePixelType::ValueType{});
 
   // Set a variable to store the offset index.
-  LabelledImageIndexType offsetIndex3D;
-  offsetIndex3D.Fill(0);
+  LabelledImageIndexType offsetIndex3D{};
 
   const unsigned int size = m_ImageWidth * m_ImageHeight * m_ImageDepth;
   const unsigned int frame = m_ImageWidth * m_ImageHeight;
@@ -656,9 +651,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, in
   const unsigned int frame = m_ImageWidth * m_ImageHeight;
   const unsigned int rowsize = m_ImageWidth;
 
-  LabelledImageIndexType offsetIndex3D;
-
-  offsetIndex3D.Fill(0);
+  LabelledImageIndexType offsetIndex3D{};
 
   m_Region[i] = l;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -1077,8 +1077,7 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
   m_BottomSite = &(m_SeedSites[0]);
   FortuneSite * currentSite = &(m_SeedSites[1]);
 
-  PointType currentCircle;
-  currentCircle.Fill(0.0);
+  PointType         currentCircle{};
   FortuneHalfEdge * leftHalfEdge;
   FortuneHalfEdge * rightHalfEdge;
   FortuneHalfEdge * left2HalfEdge;


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+[^ ].* )(\w+);[\r\n]+ [ ]+\2\.Fill\(0\.?0?\);
    Replace with: $1$2{};
    Filters: itk*.cxx;itk*.hxx;itk*.h
    Directory: D:\Src\ITK\Modules
    [v] Match case
    (*) Regular expression

- Follow-up to pull request #4881 commit 569a8b6fe9e3945c46e13f7b21e5512ebd61afaf