### PR TITLE
Do not `Fill` default-constructed empty local variables in tests

### DIFF
--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -72,9 +72,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     ITK_TEST_SET_GET_VALUE(centerOfRotation, transform->GetCenterOfRotation());
 
     // This transform has no fixed parameters; empty method body; called for coverage purposes
-    typename TransformType::FixedParametersType::ValueType fixedParametersValues = 0;
-    typename TransformType::FixedParametersType            fixedParameters;
-    fixedParameters.Fill(fixedParametersValues);
+    const typename TransformType::FixedParametersType fixedParameters{};
     transform->SetFixedParameters(fixedParameters);
   }
 

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -86,9 +86,7 @@ public:
   OutputVectorPixelType
   TransformVector(const InputVectorPixelType & itkNotUsed(inputVector)) const override
   {
-    OutputVectorPixelType outVector;
-    outVector.Fill(88.8);
-    return outVector;
+    return {};
   }
 
   using Superclass::TransformCovariantVector;
@@ -103,9 +101,7 @@ public:
   OutputVectorPixelType
   TransformCovariantVector(const InputVectorPixelType & itkNotUsed(inputVector)) const override
   {
-    OutputVectorPixelType outVector;
-    outVector.Fill(6.9);
-    return outVector;
+    return {};
   }
 
   using Superclass::TransformDiffusionTensor3D;
@@ -120,9 +116,7 @@ public:
   OutputVectorPixelType
   TransformDiffusionTensor3D(const InputVectorPixelType & itkNotUsed(tensor)) const override
   {
-    OutputVectorPixelType outTensor;
-    outTensor.Fill(29.1);
-    return outTensor;
+    return {};
   }
 
   using Superclass::TransformSymmetricSecondRankTensor;
@@ -137,9 +131,7 @@ public:
   OutputVectorPixelType
   TransformSymmetricSecondRankTensor(const InputVectorPixelType & itkNotUsed(tensor)) const override
   {
-    OutputVectorPixelType outTensor;
-    outTensor.Fill(55.9);
-    return outTensor;
+    return {};
   }
 
   void


### PR DESCRIPTION
When a variable of type `OptimizerParameters` or `VariableLengthVector` is just default-constructed, it is entirely empty, and `Fill` has no effect at all. (It's different from an empty glass, in real life, that becomes non-empty when it is being filled 🍷.  ) 