### PR TITLE
COMP: Fix AnatomicalOrientation Enum

### DIFF
--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -710,7 +710,7 @@ PhilipsRECImageIO::ReadImageInformation()
   AffineMatrix spacing;
   spacing.SetIdentity();
 
-  AnatomicalOrientation coord_orient(AnatomicalOrientation::FromEnum::RSA);
+  AnatomicalOrientation coord_orient(AnatomicalOrientation::NegativeEnum::RSA);
 
   switch (par.sliceorient)
   {


### PR DESCRIPTION
Addresses compilation errors on optional module.