### PR TITLE
STYLE: Remove unused "one-filled" `direction` matrices from tests

### DIFF
--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -68,9 +68,6 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
 
   typename TImage::PointType origin{};
 
-  typename TImage::DirectionType direction;
-  direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
-
   auto fixedImageSource = GaussianImageSourceType::New();
 
   fixedImageSource->SetSize(size);

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -96,9 +96,6 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
 
   typename TImage::PointType origin{};
 
-  typename TImage::DirectionType direction;
-  direction.Fill(itk::NumericTraits<CoordinateRepresentationType>::OneValue());
-
   auto fixedImageSource = GaussianImageSourceType::New();
 
   fixedImageSource->SetSize(size);


### PR DESCRIPTION
These matrices were just filled with `1`, but never used afterwards.

This commit prevents "unused variable" warnings, which would occur when the matrices would be filled during their initialization, instead of by calling the `Fill` member function.

----

- Addresses warnings from https://open.cdash.org/viewBuildError.php?type=1&buildid=9983771 (triggered by pull request #4891) saying _warning: unused variable 'direction' [-Wunused-variable]_
