### PR TITLE
STYLE: Replace `Fill(T{})` on local variables with `{}` initialization

### DIFF
--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -219,9 +219,7 @@ auto
 BarycentricCombination<TPointContainer, TWeightContainer>::Evaluate(const PointContainerPointer & points,
                                                                     const WeightContainerType &   weights) -> PointType
 {
-  using ValueType = typename PointType::ValueType;
-  PointType barycentre;
-  barycentre.Fill(ValueType{}); // set to null
+  PointType barycentre{}; // set to null
 
   typename TPointContainer::Iterator point = points->Begin();
   typename TPointContainer::Iterator final = points->End();

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -344,8 +344,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   PixelType          zeroPixel{};
 
   ScalarDerivativeType componentDerivativeOut;
-  ScalarDerivativeType componentDerivative;
-  componentDerivative.Fill(OutputValueType{});
+  ScalarDerivativeType componentDerivative{};
 
   for (unsigned int dim = 0; dim < Self::ImageDimension; ++dim)
   {

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -154,8 +154,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ComputeMyBoundingB
 
   if (it == end)
   {
-    typename BoundingBoxType::PointType pnt;
-    pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
+    typename BoundingBoxType::PointType pnt{};
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
     return;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -38,8 +38,7 @@ template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::Clear()
 {
-  typename BoundingBoxType::PointType pnt;
-  pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
+  typename BoundingBoxType::PointType pnt{};
   m_FamilyBoundingBoxInObjectSpace->SetMinimum(pnt);
   m_FamilyBoundingBoxInObjectSpace->SetMaximum(pnt);
   m_FamilyBoundingBoxInWorldSpace->SetMinimum(pnt);
@@ -601,8 +600,7 @@ template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::ComputeMyBoundingBox()
 {
-  typename BoundingBoxType::PointType pnt;
-  pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
+  typename BoundingBoxType::PointType pnt{};
   if (m_MyBoundingBoxInObjectSpace->GetMinimum() != pnt || m_MyBoundingBoxInObjectSpace->GetMaximum() != pnt)
   {
     m_MyBoundingBoxInObjectSpace->SetMinimum(pnt);
@@ -638,8 +636,7 @@ SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const st
 {
   itkDebugMacro("Computing Bounding Box");
 
-  typename BoundingBoxType::PointType zeroPnt;
-  zeroPnt.Fill(typename BoundingBoxType::PointType::ValueType{});
+  typename BoundingBoxType::PointType zeroPnt{};
   m_FamilyBoundingBoxInObjectSpace->SetMinimum(zeroPnt);
   m_FamilyBoundingBoxInObjectSpace->SetMaximum(zeroPnt);
   bool bbDefined = false;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -127,8 +127,7 @@ TubeSpatialObject<TDimension, TTubePointType>::ComputeMyBoundingBox()
 
   if (it == end)
   {
-    typename BoundingBoxType::PointType pnt;
-    pnt.Fill(typename BoundingBoxType::PointType::ValueType{});
+    typename BoundingBoxType::PointType pnt{};
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
     this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
     return;

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -153,8 +153,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Befor
   using SliceErodeType = BinaryErodeImageFilter<SliceInternalImageType, SliceInternalImageType, SliceKernelType>;
   auto serode = SliceErodeType::New();
   using RadiusType = typename SliceKernelType::RadiusType;
-  RadiusType srad;
-  srad.Fill(typename RadiusType::SizeValueType{});
+  RadiusType srad{};
   for (unsigned int i = 0, j = 0; i < ImageDimension; ++i)
   {
     if (j != static_cast<unsigned int>(m_SliceDimension) && (j < (ImageDimension - 1)))

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -631,8 +631,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelTy
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelPointType emptyCentroid;
-    emptyCentroid.Fill(typename LabelPointType::ValueType{});
+    LabelPointType emptyCentroid{};
     return emptyCentroid;
   }
   else
@@ -652,8 +651,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetWeightedCentroid(Labe
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelPointType emptyCentroid;
-    emptyCentroid.Fill(typename LabelPointType::ValueType{});
+    LabelPointType emptyCentroid{};
     return emptyCentroid;
   }
   else
@@ -710,8 +708,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixel
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelPointType emptyAxesLength;
-    emptyAxesLength.Fill(typename AxesLengthType::ValueType{});
+    LabelPointType emptyAxesLength{};
     return emptyAxesLength;
   }
   else
@@ -801,8 +798,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixe
   mapIt = m_LabelGeometryMapper.find(label);
   if (mapIt == m_LabelGeometryMapper.end())
   {
-    BoundingBoxType emptyBox;
-    emptyBox.Fill(typename BoundingBoxType::ValueType{});
+    BoundingBoxType emptyBox{};
     // label does not exist, return a default value
     return emptyBox;
   }
@@ -840,8 +836,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(Label
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelSizeType emptySize;
-    emptySize.Fill(typename LabelSizeType::SizeValueType{});
+    LabelSizeType emptySize{};
     return emptySize;
   }
   else
@@ -904,8 +899,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxSi
     //     LabelSizeType emptySize;
     //     emptySize.Fill( LabelSizeType::SizeValueType{});
     //     return emptySize;
-    LabelPointType emptySize;
-    emptySize.Fill(typename LabelPointType::ValueType{});
+    LabelPointType emptySize{};
     return emptySize;
   }
   else
@@ -925,8 +919,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxOr
   if (mapIt == m_LabelGeometryMapper.end())
   {
     // label does not exist, return a default value
-    LabelPointType emptySize;
-    emptySize.Fill(typename LabelPointType::ValueType{});
+    LabelPointType emptySize{};
     return emptySize;
   }
   else

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -413,8 +413,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   }
   else
   {
-    VirtualOriginType origin;
-    origin.Fill(typename VirtualOriginType::ValueType{});
+    VirtualOriginType origin{};
     return origin;
   }
 }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -525,8 +525,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
   InputImagePixelType originPixelVec;
 
   // Variable to store the modified pixel vector value.
-  InputImagePixelType changedPixelVec;
-  changedPixelVec.Fill(typename InputImagePixelType::ValueType{});
+  InputImagePixelType changedPixelVec{};
 
   // Set a variable to store the offset index.
   LabelledImageIndexType offsetIndex3D{};


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+[^ ].* )(\w+);[\r\n]+ [ ]+\2\.Fill\(.*{}\);
    Replace with: $1$2{};
    Directory: D:\Src\ITK\Modules

- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4897 commit 47335501a5a16c6eb42538a829d4b49229284dd6
"STYLE: Replace `Fill(0)` on local variables with `{}` initialization"