### PR TITLE
Replace `T var; var.Fill` with `auto var = T::Filled`, for both `Index` and `Size`

### DIFF
--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -39,8 +39,7 @@ namespace itk
          using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
          DerivativeOperatorType derivativeOperator;
          derivativeOperator.SetDirection(0); // X dimension
-         itk::Size<2> radius;
-         radius.Fill(1); // A radius of 1 in both dimensions is a 3x3 operator
+         auto radius = itk::Size<2>::Filled(1); // A radius of 1 in both dimensions is a 3x3 operator
          derivativeOperator.CreateToRadius(radius);
    \endcode
  * and creates a kernel that looks like:

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -70,9 +70,7 @@ LaplacianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coe
 
   // Here we set the radius to 1's, here the
   // operator is 3x3 for 2D, 3x3x3 for 3D.
-  SizeType r;
-
-  r.Fill(1);
+  auto r = SizeType::Filled(1);
   this->SetRadius(r);
 
   // Create a vector of the correct size to hold the coefficients.

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -35,8 +35,7 @@ namespace itk
  * 1) Set the direction by calling  \code SetDirection \endcode
  * 2) call
    \code
-   itk::Size<2> radius;
-   radius.Fill(1);
+   auto radius = itk::Size<2>::Filled(1);
    sobelOperator.CreateToRadius(radius);
    \endcode
  * 3) You may optionally scale the coefficients of this operator using the

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -61,8 +61,7 @@ CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   mean.fill(PixelComponentRealType{});
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition
-  typename InputImageType::SizeType kernelSize;
-  kernelSize.Fill(m_NeighborhoodRadius);
+  auto kernelSize = InputImageType::SizeType::Filled(m_NeighborhoodRadius);
 
   ConstNeighborhoodIterator<InputImageType> it(
     kernelSize, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -66,8 +66,7 @@ ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexT
   }
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition
-  typename InputImageType::SizeType kernelSize;
-  kernelSize.Fill(m_NeighborhoodRadius);
+  auto kernelSize = InputImageType::SizeType::Filled(m_NeighborhoodRadius);
 
   ConstNeighborhoodIterator<InputImageType> it(
     kernelSize, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -60,8 +60,7 @@ VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType &
   }
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition
-  typename InputImageType::SizeType kernelSize;
-  kernelSize.Fill(m_NeighborhoodRadius);
+  auto kernelSize = InputImageType::SizeType::Filled(m_NeighborhoodRadius);
 
   ConstNeighborhoodIterator<InputImageType> it(
     kernelSize, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -54,8 +54,7 @@ VectorMeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   }
 
   // Create an N-d neighborhood kernel, using a zeroflux boundary condition
-  typename InputImageType::SizeType kernelSize;
-  kernelSize.Fill(m_NeighborhoodRadius);
+  auto kernelSize = InputImageType::SizeType::Filled(m_NeighborhoodRadius);
 
   ConstNeighborhoodIterator<InputImageType> it(
     kernelSize, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -321,8 +321,7 @@ public:
   SizeType
   GetRadius() const override
   {
-    SizeType radius;
-    radius.Fill(VRadius);
+    auto radius = SizeType::Filled(VRadius);
     return radius;
   }
 

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -64,8 +64,7 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   }
 
   // Set the radius for the neighborhood
-  Size<ImageDimension> radius;
-  radius.Fill(VRadius);
+  auto radius = Size<ImageDimension>::Filled(VRadius);
 
   // Initialize the neighborhood
   IteratorType it(radius, image, image->GetBufferedRegion());
@@ -145,8 +144,7 @@ WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBou
   }
 
   // Position the neighborhood at the index of interest
-  Size<ImageDimension> radius;
-  radius.Fill(VRadius);
+  auto         radius = Size<ImageDimension>::Filled(VRadius);
   IteratorType nit(radius, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());
   nit.SetLocation(baseIndex);
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -556,8 +556,7 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Comp
   // Zero all components of jacobian
   jacobian.SetSize(SpaceDimension, this->GetNumberOfParameters());
   jacobian.Fill(0.0);
-  SizeType supportSize;
-  supportSize.Fill(SplineOrder + 1);
+  auto supportSize = SizeType::Filled(SplineOrder + 1);
 
   ContinuousIndexType index =
     this->m_CoefficientImages[0]

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -53,8 +53,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::BSplineTransfo
 
   DirectionType meshDirection;
   meshDirection.SetIdentity();
-  MeshSizeType meshSize;
-  meshSize.Fill(1);
+  auto meshSize = MeshSizeType::Filled(1);
 
   this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -48,11 +48,10 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Get values from superclass
-  InputPixelType foregroundValue = this->GetForegroundValue();
-  InputPixelType backgroundValue = this->GetBackgroundValue();
-  KernelType     kernel = this->GetKernel();
-  InputSizeType  radius;
-  radius.Fill(1);
+  InputPixelType                    foregroundValue = this->GetForegroundValue();
+  InputPixelType                    backgroundValue = this->GetBackgroundValue();
+  KernelType                        kernel = this->GetKernel();
+  auto                              radius = InputSizeType::Filled(1);
   typename TOutputImage::RegionType outputRegion = output->GetBufferedRegion();
 
   // compute the size of the temp image. It is needed to create the progress

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -48,11 +48,10 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Get values from superclass
-  InputPixelType foregroundValue = this->GetForegroundValue();
-  InputPixelType backgroundValue = this->GetBackgroundValue();
-  KernelType     kernel = this->GetKernel();
-  InputSizeType  radius;
-  radius.Fill(1);
+  InputPixelType                    foregroundValue = this->GetForegroundValue();
+  InputPixelType                    backgroundValue = this->GetBackgroundValue();
+  KernelType                        kernel = this->GetKernel();
+  auto                              radius = InputSizeType::Filled(1);
   typename TOutputImage::RegionType outputRegion = output->GetBufferedRegion();
 
   // compute the size of the temp image. It is needed to create the progress

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -139,8 +139,7 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   ImageRegionIteratorWithIndex<BoolImageType> kernelImageItIndex(tmpSEImage, tmpSEImage->GetRequestedRegion());
 
   // Neighborhood iterator on SE element temp image
-  InputSizeType padBy;
-  padBy.Fill(1);
+  auto                                padBy = InputSizeType::Filled(1);
   NeighborhoodIterator<BoolImageType> SEoNeighbIt(padBy, tmpSEImage, tmpSEImage->GetRequestedRegion());
   SEoNeighbIt.OverrideBoundaryCondition(&cbc);
   SizeValueType neighborhoodSize = SEoNeighbIt.Size();

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -474,8 +474,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
 
   // Allocate the patch weights (mask) as an image.
   // Done in physical space.
-  typename WeightsImageType::SizeType physicalSize;
-  physicalSize.Fill(physicalDiameter);
+  auto                                  physicalSize = WeightsImageType::SizeType::Filled(physicalDiameter);
   typename WeightsImageType::RegionType physicalRegion(physicalSize);
   auto                                  physicalWeightsImage = WeightsImageType::New();
   physicalWeightsImage->SetRegions(physicalRegion);
@@ -681,8 +680,7 @@ typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataSt
   using FaceCalculatorType = typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>;
   using FaceListType = typename FaceCalculatorType::FaceListType;
 
-  typename InputImageType::SizeType radius;
-  radius.Fill(1);
+  auto radius = InputImageType::SizeType::Filled(1);
 
   if (m_NumIndependentComponents != 1)
   {

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -482,8 +482,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
   physicalWeightsImage->Allocate();
   physicalWeightsImage->FillBuffer(1.0);
 
-  typename WeightsImageType::IndexType centerIndex;
-  centerIndex.Fill(patchRadius);
+  auto centerIndex = WeightsImageType::IndexType::Filled(patchRadius);
 
   unsigned int pos = 0;
   for (ImageRegionIteratorWithIndex<WeightsImageType> pwIt(physicalWeightsImage, physicalRegion); !pwIt.IsAtEnd();

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -177,8 +177,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ThreadedGene
   InputImage1ConstPointer input = this->GetInput();
 
   // Find the data-set boundary "faces"
-  SizeType radius;
-  radius.Fill(1);
+  auto radius = SizeType::Filled(1);
 
   using FaceListType = typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImage1Type>::FaceListType;
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -53,8 +53,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::FastMarchingImageFilterBase()
   m_StartIndex.Fill(0);
   m_LastIndex.Fill(0);
 
-  OutputSizeType outputSize;
-  outputSize.Fill(16);
+  auto outputSize = OutputSizeType::Filled(16);
 
   NodeType outputIndex{};
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -107,8 +107,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   typename OutputImageType::Pointer input = m_GaussianFilter->GetOutput();
 
   // Set iterator radius
-  Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto radius = Size<ImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;
@@ -322,8 +321,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
   ListNodeType * node;
 
   // Assign iterator radius
-  Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto radius = Size<ImageDimension>::Filled(1);
 
   ConstNeighborhoodIterator<TOutputImage> oit(
     radius, multiplyImageFilterOutput, multiplyImageFilterOutput->GetRequestedRegion());
@@ -398,8 +396,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   typename InputImageType::Pointer output = m_UpdateBuffer1;
 
   // Set iterator radius
-  Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto radius = Size<ImageDimension>::Filled(1);
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>                        bC;

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -152,8 +152,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
   if (m_ComputeStructureTensors)
   {
     // tensor calculations access points in 2 X m_BlockRadius + 1 radius
-    SizeType onesSize;
-    onesSize.Fill(1);
+    auto onesSize = SizeType::Filled(1);
     // Define the area in which tensors are going to be computed.
     const SizeType blockSize = m_BlockRadius + m_BlockRadius + onesSize;
     safeIndex += blockSize;
@@ -231,8 +230,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
 
         Matrix<SpacePrecisionType, ImageDimension, 1> gradI; // vector declared as column matrix
 
-        SizeType radius;
-        radius.Fill(1); // iterate over neighbourhood of a voxel
+        auto radius = SizeType::Filled(1); // iterate over neighbourhood of a voxel
 
         RegionType center;
         center.SetSize(radius);

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -42,8 +42,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Label
   m_Opacity = 0.5;
   m_Type = CONTOUR;
   m_Priority = HIGH_LABEL_ON_TOP;
-  SizeType s;
-  s.Fill(1);
+  auto s = SizeType::Filled(1);
   m_ContourThickness = SizeType(s);
   s.Fill(0);
   m_DilationRadius = SizeType(s);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -187,8 +187,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
     collapsedPhiLattices[i] = PointDataImageType::New();
     collapsedPhiLattices[i]->CopyInformation(inputPtr);
 
-    typename PointDataImageType::SizeType size;
-    size.Fill(1);
+    auto size = PointDataImageType::SizeType::Filled(1);
     for (unsigned int j = 0; j < i; ++j)
     {
       size[j] = inputPtr->GetLargestPossibleRegion().GetSize()[j];

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -558,8 +558,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
     collapsedPhiLattices[i] = PointDataImageType::New();
     collapsedPhiLattices[i]->CopyInformation(this->m_PhiLattice);
 
-    typename PointDataImageType::SizeType size;
-    size.Fill(1);
+    auto size = PointDataImageType::SizeType::Filled(1);
     for (unsigned int j = 0; j < i; ++j)
     {
       size[j] = this->m_PhiLattice->GetLargestPossibleRegion().GetSize()[j];
@@ -886,8 +885,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
     collapsedPhiLattices[i]->SetSpacing(this->m_PhiLattice->GetSpacing());
     collapsedPhiLattices[i]->SetDirection(this->m_PhiLattice->GetDirection());
 
-    typename PointDataImageType::SizeType size;
-    size.Fill(1);
+    auto size = PointDataImageType::SizeType::Filled(1);
     for (unsigned int j = 0; j < i; ++j)
     {
       size[j] = this->m_PhiLattice->GetLargestPossibleRegion().GetSize()[j];

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -197,8 +197,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   // Determine the last dimension for the tile image. This dimension will
   // be large enough to accommodate left-over images.
-  OutputSizeType outputSize;
-  outputSize.Fill(1);
+  auto outputSize = OutputSizeType::Filled(1);
 
   if (m_Layout[OutputImageDimension - 1] == 0)
   {
@@ -216,8 +215,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     m_Layout[OutputImageDimension - 1] = outputSize[OutputImageDimension - 1];
   }
 
-  OutputSizeType tileSize;
-  tileSize.Fill(1);
+  auto tileSize = OutputSizeType::Filled(1);
 
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -415,8 +415,7 @@ protected:
 
     LineRegion.SetSize(PretendSize);
     fakeImage->SetRegions(LineRegion);
-    PretendSizeType kernelRadius;
-    kernelRadius.Fill(1);
+    auto                 kernelRadius = PretendSizeType::Filled(1);
     LineNeighborhoodType lnit(kernelRadius, fakeImage, LineRegion);
 
     if (wholeNeighborhood)

--- a/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.hxx
@@ -53,10 +53,8 @@ AutoCropLabelMapFilter<TInputImage>::GenerateOutputInformation()
   }
 
   // find the bounding box of the objects
-  IndexType minIdx;
-  minIdx.Fill(NumericTraits<typename TInputImage::IndexValueType>::max());
-  IndexType maxIdx;
-  maxIdx.Fill(NumericTraits<typename TInputImage::IndexValueType>::NonpositiveMin());
+  auto minIdx = IndexType::Filled(NumericTraits<typename TInputImage::IndexValueType>::max());
+  auto maxIdx = IndexType::Filled(NumericTraits<typename TInputImage::IndexValueType>::NonpositiveMin());
 
   const InputImageType * inputImage = this->GetInput();
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -104,10 +104,8 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       else
       {
         // Compute the bounding box of all the objects which don't have that label
-        IndexType mins;
-        mins.Fill(NumericTraits<IndexValueType>::max());
-        IndexType maxs;
-        maxs.Fill(NumericTraits<IndexValueType>::NonpositiveMin());
+        auto mins = IndexType::Filled(NumericTraits<IndexValueType>::max());
+        auto maxs = IndexType::Filled(NumericTraits<IndexValueType>::NonpositiveMin());
         for (typename InputImageType::ConstIterator loit(this->GetInput()); !loit.IsAtEnd(); ++loit)
         {
           if (loit.GetLabel() != m_Label)
@@ -168,10 +166,8 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
         // Just find the bounding box of the object with that label
 
         const LabelObjectType * labelObject = input->GetLabelObject(m_Label);
-        IndexType               mins;
-        mins.Fill(NumericTraits<IndexValueType>::max());
-        IndexType maxs;
-        maxs.Fill(NumericTraits<IndexValueType>::NonpositiveMin());
+        auto                    mins = IndexType::Filled(NumericTraits<IndexValueType>::max());
+        auto                    maxs = IndexType::Filled(NumericTraits<IndexValueType>::NonpositiveMin());
         // Iterate over all the lines
         typename LabelObjectType::ConstLineIterator lit(labelObject);
         while (!lit.IsAtEnd())

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -96,13 +96,11 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   // Init the vars
   SizeValueType                           nbOfPixels = 0;
   ContinuousIndex<double, ImageDimension> centroid{};
-  IndexType                               mins;
-  mins.Fill(NumericTraits<IndexValueType>::max());
-  IndexType maxs;
-  maxs.Fill(NumericTraits<IndexValueType>::NonpositiveMin());
-  SizeValueType nbOfPixelsOnBorder = 0;
-  double        perimeterOnBorder = 0;
-  MatrixType    centralMoments{};
+  auto                                    mins = IndexType::Filled(NumericTraits<IndexValueType>::max());
+  auto                                    maxs = IndexType::Filled(NumericTraits<IndexValueType>::NonpositiveMin());
+  SizeValueType                           nbOfPixelsOnBorder = 0;
+  double                                  perimeterOnBorder = 0;
+  MatrixType                              centralMoments{};
 
   using LengthType = typename LabelObjectType::LengthType;
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -432,8 +432,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputeFeretDiameter(LabelObjectType *
   IndexListType idxList;
 
   using NeighborIteratorType = typename itk::ConstNeighborhoodIterator<LabelImageType>;
-  SizeType neighborHoodRadius;
-  neighborHoodRadius.Fill(1);
+  auto                                      neighborHoodRadius = SizeType::Filled(1);
   NeighborIteratorType                      it(neighborHoodRadius, m_LabelImage, m_LabelImage->GetBufferedRegion());
   ConstantBoundaryCondition<LabelImageType> lcbc;
   // Use label + 1 to have a label different of the current label on the border

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -141,8 +141,7 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
   NOutputIterator   outNIt;
   InputIteratorType mskIt;
   CNInputIterator   mskNIt;
-  ISizeType         kernelRadius;
-  kernelRadius.Fill(1);
+  auto              kernelRadius = ISizeType::Filled(1);
   if (m_UseInternalCopy)
   {
     FaceCalculatorType faceCalculator;

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -106,8 +106,7 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
     // Note : all comments refer to finding regional minima, because
     // it is briefer and clearer than trying to describe both regional
     // maxima and minima processes at the same time
-    ISizeType kernelRadius;
-    kernelRadius.Fill(1);
+    auto            kernelRadius = ISizeType::Filled(1);
     NOutputIterator outNIt(kernelRadius, output, output->GetRequestedRegion());
     setConnectivity(&outNIt, m_FullyConnected);
 

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -110,9 +110,8 @@ BoxAccumulateFunction(const TInputImage *               inputImage,
   using InputIterator = ImageRegionConstIterator<TInputImage>;
 
   using NOutputIterator = ShapedNeighborhoodIterator<TOutputImage>;
-  InputIterator                  inIt(inputImage, inputRegion);
-  typename TInputImage::SizeType kernelRadius;
-  kernelRadius.Fill(1);
+  InputIterator inIt(inputImage, inputRegion);
+  auto          kernelRadius = TInputImage::SizeType::Filled(1);
 
   NOutputIterator noutIt(kernelRadius, outputImage, outputRegion);
   // this iterator is fully connected
@@ -165,8 +164,7 @@ std::vector<typename TImage::OffsetType>
 CornerOffsets(const TImage * im)
 {
   using NIterator = ShapedNeighborhoodIterator<TImage>;
-  typename TImage::SizeType unitradius;
-  unitradius.Fill(1);
+  auto                                     unitradius = TImage::SizeType::Filled(1);
   NIterator                                n1(unitradius, im, im->GetRequestedRegion());
   unsigned int                             centerIndex = n1.GetCenterNeighborhoodIndex();
   typename NIterator::OffsetType           offset;
@@ -564,9 +562,8 @@ BoxSquareAccumulateFunction(const TInputImage *               inputImage,
   using InputIterator = ImageRegionConstIterator<TInputImage>;
 
   using NOutputIterator = ShapedNeighborhoodIterator<TOutputImage>;
-  InputIterator                  inIt(inputImage, inputRegion);
-  typename TInputImage::SizeType kernelRadius;
-  kernelRadius.Fill(1);
+  InputIterator inIt(inputImage, inputRegion);
+  auto          kernelRadius = TInputImage::SizeType::Filled(1);
 
   NOutputIterator noutIt(kernelRadius, outputImage, outputRegion);
   // this iterator is fully connected

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -132,8 +132,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateKernelImage()
     kernelSource->SetOrigin(inputOrigin);
     kernelSource->SetDirection(this->GetInput()->GetDirection());
 
-    KernelSizeType kernelSize;
-    kernelSize.Fill(1);
+    auto kernelSize = KernelSizeType::Filled(1);
     for (size_t dim = 0; dim < this->GetFilterDimensionality(); ++dim)
     {
       kernelSize[dim] = static_cast<SizeValueType>(this->GetKernelRadius(dim)) * 2 + 1;

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -86,8 +86,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
 
   SizeValueType buffsize = output->GetRequestedRegion().GetNumberOfPixels();
 
-  SizeType kernelRadius;
-  kernelRadius.Fill(1);
+  auto kernelRadius = SizeType::Filled(1);
   using FaceCalculatorType = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>;
   FaceCalculatorType                        faceCalculator;
   typename FaceCalculatorType::FaceListType faceList =
@@ -211,8 +210,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
   OffsetVecType &       Offsets)
 {
   using NeighType = ConstShapedNeighborhoodIterator<TOutputImage>;
-  SizeType KernRad;
-  KernRad.Fill(1);
+  auto      KernRad = SizeType::Filled(1);
   NeighType It(KernRad, this->GetOutput(), this->GetOutput()->GetRequestedRegion());
   setConnectivity(&It, m_FullyConnected);
   typename NeighType::IndexListType                 OffsetList;

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -111,16 +111,14 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
   kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
-  typename KernelImageType::IndexType centerIndex;
-  centerIndex.Fill(2 * m_OperatorArray[0].GetRadius()[0]); // include also
-                                                           // boundaries
+  auto centerIndex = KernelImageType::IndexType::Filled(2 * m_OperatorArray[0].GetRadius()[0]); // include also
+                                                                                                // boundaries
   kernelImage->SetPixel(centerIndex, itk::NumericTraits<TOutput>::OneValue());
 
   // Create an image region to be used later that does not include boundaries
   RegionType kernelRegion;
   size.Fill(2 * m_OperatorArray[0].GetRadius()[0] + 1);
-  typename RegionType::IndexType origin;
-  origin.Fill(m_OperatorArray[0].GetRadius()[0]);
+  auto origin = RegionType::IndexType::Filled(m_OperatorArray[0].GetRadius()[0]);
   kernelRegion.SetSize(size);
   kernelRegion.SetIndex(origin);
 

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -104,8 +104,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
   using RegionType = typename KernelImageType::RegionType;
   RegionType region;
 
-  typename RegionType::SizeType size;
-  size.Fill(4 * m_OperatorArray[0].GetRadius()[0] + 1);
+  auto size = RegionType::SizeType::Filled(4 * m_OperatorArray[0].GetRadius()[0] + 1);
   region.SetSize(size);
 
   kernelImage->SetRegions(region);

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -124,14 +124,12 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
-  typename KernelImageType::IndexType centerIndex;
-  centerIndex.Fill(2 * maxRadius); // include also boundaries
+  auto centerIndex = KernelImageType::IndexType::Filled(2 * maxRadius); // include also boundaries
 
   // Create an image region to be used later that does not include boundaries
   RegionType kernelRegion;
   size.Fill(2 * maxRadius + 1);
-  typename RegionType::IndexType origin;
-  origin.Fill(maxRadius);
+  auto origin = RegionType::IndexType::Filled(maxRadius);
   kernelRegion.SetSize(size);
   kernelRegion.SetIndex(origin);
 

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -117,8 +117,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   using RegionType = typename KernelImageType::RegionType;
   RegionType region;
 
-  typename RegionType::SizeType size;
-  size.Fill(4 * maxRadius + 1);
+  auto size = RegionType::SizeType::Filled(4 * maxRadius + 1);
   region.SetSize(size);
 
   kernelImage->SetRegions(region);

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -110,8 +110,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
   using RegionType = typename KernelImageType::RegionType;
   RegionType region;
 
-  typename RegionType::SizeType size;
-  size.Fill(4 * maxRadius + 1);
+  auto size = RegionType::SizeType::Filled(4 * maxRadius + 1);
   region.SetSize(size);
 
   kernelImage->SetRegions(region);

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -117,14 +117,12 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
   kernelImage->AllocateInitialized();
 
   // Initially the kernel image will be an impulse at the center
-  typename KernelImageType::IndexType centerIndex;
-  centerIndex.Fill(2 * maxRadius); // include also boundaries
+  auto centerIndex = KernelImageType::IndexType::Filled(2 * maxRadius); // include also boundaries
 
   // Create an image region to be used later that does not include boundaries
   RegionType kernelRegion;
   size.Fill(2 * maxRadius + 1);
-  typename RegionType::IndexType origin;
-  origin.Fill(maxRadius);
+  auto origin = RegionType::IndexType::Filled(maxRadius);
   kernelRegion.SetSize(size);
   kernelRegion.SetIndex(origin);
 

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -724,8 +724,7 @@ Solver<VDimension>::InitializeInterpolationGrid(const InterpolationGridSizeType 
   // Set the interpolation grid (image) size, origin and spacing
   // from the given vectors, so that physical point of v1 is (0,0,0) and
   // physical point v2 is (size[0],size[1],size[2]).
-  InterpolationGridSizeType image_size;
-  image_size.Fill(1);
+  auto image_size = InterpolationGridSizeType::Filled(1);
   for (unsigned int i = 0; i < FEMDimension; ++i)
   {
     image_size[i] = size[i];

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -287,8 +287,7 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
   // start constructing window region and center region (single voxel)
   ImageRegionType window;
   ImageRegionType center;
-  ImageSizeType   windowSize;
-  windowSize.Fill(1);
+  auto            windowSize = ImageSizeType::Filled(1);
   center.SetSize(windowSize); // size of center region is 1
   windowSize += m_SearchRadius + m_SearchRadius;
   window.SetSize(windowSize); // size of window region is 1+2*m_BlockHalfWindow

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -599,8 +599,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
 
 
   // convert virtualPoint to a single point region
-  typename ImageRegionType::SizeType singlePointSize;
-  singlePointSize.Fill(1);
+  auto                  singlePointSize = ImageRegionType::SizeType::Filled(1);
   const ImageRegionType singlePointRegion(virtualIndex, singlePointSize);
 
   // use scanning variables just for a single point region

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -299,8 +299,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
         RealType spatialNorm{};
         RealType spatioTemporalNorm{};
 
-        typename TimeVaryingVelocityFieldType::SizeType radius;
-        radius.Fill(1);
+        auto radius = TimeVaryingVelocityFieldType::SizeType::Filled(1);
 
         using FaceCalculatorType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TimeVaryingVelocityFieldType>;
         FaceCalculatorType                        faceCalculator;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -362,8 +362,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
         RealType spatialNorm{};
         RealType spatioTemporalNorm{};
 
-        typename TimeVaryingVelocityFieldType::SizeType radius;
-        radius.Fill(1);
+        auto radius = TimeVaryingVelocityFieldType::SizeType::Filled(1);
 
         using FaceCalculatorType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TimeVaryingVelocityFieldType>;
         FaceCalculatorType                        faceCalculator;

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -55,8 +55,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
   using InputNeighborhoodIteratorType = ConstShapedNeighborhoodIterator<TInputImage>;
   using OutputNeighborhoodIteratorType = ConstShapedNeighborhoodIterator<TOutputImage>;
 
-  SizeType kernelRadius;
-  kernelRadius.Fill(1);
+  auto kernelRadius = SizeType::Filled(1);
 
   InputNeighborhoodIteratorType  init(kernelRadius, input, output->GetRequestedRegion());
   OutputNeighborhoodIteratorType onit(kernelRadius, output, output->GetRequestedRegion());

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -330,14 +330,12 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedPerturbClust
   const unsigned int numberOfClusterComponents = numberOfComponents + ImageDimension;
 
 
-  itk::Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto          radius = itk::Size<ImageDimension>::Filled(1);
   unsigned long center;
   unsigned long stride[ImageDimension];
 
 
-  typename InputImageType::SizeType searchRadius;
-  searchRadius.Fill(1);
+  auto searchRadius = InputImageType::SizeType::Filled(1);
 
 
   using NeighborhoodType = ConstNeighborhoodIterator<TInputImage>;
@@ -439,8 +437,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedConnectivity
   ConstantBoundaryCondition<TOutputImage> lbc;
   lbc.SetConstant(NumericTraits<typename OutputImageType::PixelType>::max());
 
-  itk::Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<ImageDimension>::Filled(1);
 
   using NeighborhoodType = ConstNeighborhoodIterator<TOutputImage, ConstantBoundaryCondition<TOutputImage>>;
 
@@ -769,8 +766,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::RelabelConnectedRegi
   ConstantBoundaryCondition<TOutputImage> lbc;
   lbc.SetConstant(NumericTraits<typename OutputImageType::PixelType>::max());
 
-  itk::Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto          radius = itk::Size<ImageDimension>::Filled(1);
   unsigned long center;
   unsigned long stride[ImageDimension];
 

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -118,8 +118,7 @@ MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::Generate
   MapType fah;
 
   // the radius which will be used for all the shaped iterators
-  Size<ImageDimension> radius;
-  radius.Fill(1);
+  auto radius = Size<ImageDimension>::Filled(1);
 
   // iterator for the marker image
   using MarkerIteratorType = ConstShapedNeighborhoodIterator<LabelImageType>;


### PR DESCRIPTION
- Follow-up to pull request #4887