### PR TITLE
ENH: Suppress irrelevant TIFF warnings

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -24,8 +24,33 @@
 
 #include "itk_tiff.h"
 
+#include "itksys/SystemTools.hxx"
+
 namespace itk
 {
+
+TIFFErrorHandler _ITKTIFFsavedWarningHandler = nullptr;
+
+// This warning handler suppresses log messages starting with "Unknown field with tag" because these kind of messages
+// are harmless (they just mean that the TIFF file contains custom tags) and they would flood the console when reading images
+// that contains hundreds of frames, hiding actual errors or relevant warnings.
+static void
+ITKTIFFTagNotFoundSuppressWarningHandler(const char * module, const char * fmt, va_list ap)
+{
+  if (fmt != nullptr)
+  {
+    if (itksys::SystemTools::StringStartsWith(fmt, "Unknown field with tag"))
+    {
+      // ignore unknown field warnings
+      return;
+    }
+  }
+  // call the saved warning handler
+  if (_ITKTIFFsavedWarningHandler != nullptr)
+  {
+    _ITKTIFFsavedWarningHandler(module, fmt, ap);
+  }
+}
 
 bool
 TIFFImageIO::CanReadFile(const char * file)
@@ -40,16 +65,18 @@ TIFFImageIO::CanReadFile(const char * file)
   }
 
   // Now check if this is a valid TIFF image
-  TIFFErrorHandler save = TIFFSetErrorHandler(nullptr);
-  int              res = m_InternalImage->Open(file);
-  if (res)
+  TIFFErrorHandler savedErrorHandler = TIFFSetErrorHandler(nullptr);
+  TIFFErrorHandler savedWarningHandler = TIFFSetWarningHandler(ITKTIFFTagNotFoundSuppressWarningHandler);
+  _ITKTIFFsavedWarningHandler = savedWarningHandler;
+  bool success = (m_InternalImage->Open(file) != 0);
+  if (!success)
   {
-    TIFFSetErrorHandler(save);
-    return true;
+    m_InternalImage->Clean();
   }
-  m_InternalImage->Clean();
-  TIFFSetErrorHandler(save);
-  return false;
+  TIFFSetErrorHandler(savedErrorHandler);
+  TIFFSetWarningHandler(savedWarningHandler);
+  _ITKTIFFsavedWarningHandler = nullptr;
+  return success;
 }
 
 void
@@ -152,6 +179,9 @@ TIFFImageIO::ReadVolume(void * buffer)
   const size_t width{ m_InternalImage->m_Width };
   const size_t height{ m_InternalImage->m_Height };
 
+  TIFFErrorHandler savedWarningHandler = TIFFSetWarningHandler(ITKTIFFTagNotFoundSuppressWarningHandler);
+  _ITKTIFFsavedWarningHandler = savedWarningHandler;
+
   for (uint16_t page = 0; page < m_InternalImage->m_NumberOfPages; ++page)
   {
     if (m_InternalImage->m_IgnoredSubFiles > 0)
@@ -175,6 +205,9 @@ TIFFImageIO::ReadVolume(void * buffer)
 
     TIFFReadDirectory(m_InternalImage->m_Image);
   }
+
+  TIFFSetWarningHandler(savedWarningHandler);
+  _ITKTIFFsavedWarningHandler = nullptr;
 }
 
 void


### PR DESCRIPTION
_Submitted on behalf of @lassoan by cherry-picking commit from [lassoan/ITK@tiff_unknown_tag_warning_suppress/](https://github.com/lassoan/ITK/commits/tiff_unknown_tag_warning_suppress/)_

LibTIFF logs hundreds of messages like "TIFFReadDirectory: Warning, Unknown field with tag 65280 (0xff00) encountered." when reading a volume from a TIFF file list that contains custom tags. Presence of custom tags is harmless and it should not flood the console or application log with warnings, because message display can significantly slow down image loading and excessive amount of irrelevant messages makes it difficult to notice important messages.

For background, see https://github.com/SlicerMorph/SlicerMorph/issues/320

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
