### PR TITLE
COMP: Update DCMTK targets based on new DCMTK namespace

### DIFF
--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -93,7 +93,14 @@ if(ITK_USE_SYSTEM_DCMTK)
   set(ITKDCMTK_SYSTEM_INCLUDE_DIRS ${DCMTK_INCLUDE_DIRS})
 
   # Module standard library var
-  set(ITKDCMTK_LIBRARIES ${DCMTK_LIBRARIES})
+  set(ITKDCMTK_LIBRARIES)
+  foreach(lib IN LISTS DCMTK_LIBRARIES)
+    if(TARGET DCMTK::${lib})
+      list(APPEND ITKDCMTK_LIBRARIES DCMTK::${lib})
+    else()
+      list(APPEND ITKDCMTK_LIBRARIES ${lib})
+    endif()
+  endforeach()
 
   # When this module is loaded by an app, load DCMTK too.
   set(ITKDCMTK_EXPORT_CODE_INSTALL "


### PR DESCRIPTION

Exported targets now have the DCMTK namespace as of DCMTK/dcmtk@c684bb3.

> [!NOTE]
> Pull request submitted on behalf of @jamesobutler based on work associated with [jamesobutler/ITK@DCMTK-targets](https://github.com/jamesobutler/ITK/tree/DCMTK-targets) and done in the context of https://github.com/Slicer/Slicer/pull/6709

---------------

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)