### PR TITLE
STYLE: Rename _GetImageViewFromArray to _get_image_view_from_contiguous_array

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.h
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.h
@@ -73,10 +73,11 @@ public:
   _GetArrayViewFromImage(ImageType * image);
 
   /**
-   * Get an ITK image from a Python array
+   * Get an ITK image from a contiguous Python array. Internal helper function for the implementation of
+   * `itkPyBuffer.GetImageViewFromArray`.
    */
   static OutputImagePointer
-  _GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent);
+  _get_image_view_from_contiguous_array(PyObject * arr, PyObject * shape, PyObject * numOfComponent);
 };
 
 } // namespace itk

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -52,7 +52,7 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
 
 template <class TImage>
 auto
-PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent)
+PyBuffer<TImage>::_get_image_view_from_contiguous_array(PyObject * arr, PyObject * shape, PyObject * numOfComponent)
   -> OutputImagePointer
 {
   Py_buffer pyBuffer{};

--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -99,11 +99,11 @@
 
         if is_vector:
             if ndarr.flags['C_CONTIGUOUS']:
-                imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray(ndarr, ndarr.shape[-2::-1], ndarr.shape[-1])
+                imgview = itkPyBuffer@PyBufferTypes@._get_image_view_from_contiguous_array(ndarr, ndarr.shape[-2::-1], ndarr.shape[-1])
             else:
-                imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray(ndarr, ndarr.shape[-1:0:-1], ndarr.shape[0])
+                imgview = itkPyBuffer@PyBufferTypes@._get_image_view_from_contiguous_array(ndarr, ndarr.shape[-1:0:-1], ndarr.shape[0])
         else:
-            imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray(ndarr, ndarr.shape[::-1], 1)
+            imgview = itkPyBuffer@PyBufferTypes@._get_image_view_from_contiguous_array(ndarr, ndarr.shape[::-1], 1)
 
         # Keep a reference
         imgview._SetBase(ndarr)


### PR DESCRIPTION
Aims to make the difference clearer between the C++ `itk::PyBuffer` member
function (which only supports contiguous arrays as input) and the Python method
`itkPyBuffer.GetImageViewFromArray` (which supports *both* contiguous and
non-contiguous arrays).

The new name of the member function is more Pythonic (using snake case), but it
is also more in accordance with the C++ standard (which reserves identifiers
that begin with an underscore, followed by an uppercase letter).
- Follow-up to pull request #4888