### PR TITLE
Pixi python-exe task

### DIFF
--- a/Documentation/docs/contributing/build_test_itk.md
+++ b/Documentation/docs/contributing/build_test_itk.md
@@ -59,6 +59,24 @@ cd src/ITK
 pixi run test-python
 ```
 
+To run a python interpreter with the locally built `itk` Python package:
+
+```shell
+pixi run python-exe
+```
+
+A Python script can also be passed in, e.g.
+
+```shell
+pixi run python-exe ./test.py
+```
+
+To run a python interpreter with a locally built `itk` Python package with debug symbols,
+
+```shell
+pixi run python-exe-debug
+```
+
 ### Further testing and development
 
 Additional pixi tasks to run specific steps of the `configure`, `build`, `test` development process or create builds with other [CMake build types] are listed with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,12 @@ cmd = "ctest -j3 --test-dir build-python"
 description = "Test ITK Python"
 depends-on = ["build-python"]
 
+[tool.pixi.feature.python.tasks.python-exe]
+cmd = '''cp ./build-python/Wrapping/Generators/Python/WrapITK.pth $(python -c "import site; print(next(p for p in site.getsitepackages() if \'site-packages\' in p))") &&
+  python'''
+description = "Run a Python executable with the development ITK Python package"
+depends-on = ["build-python"]
+
 [tool.pixi.feature.python.tasks.configure-debug-python]
 cmd = '''cmake
   -Bbuild-debug-python
@@ -126,6 +132,12 @@ depends-on = ["configure-debug-python"]
 [tool.pixi.feature.python.tasks.test-debug-python]
 cmd = "ctest -j3 --test-dir build-debug-python"
 description = "Test ITK Python - Debug"
+depends-on = ["build-debug-python"]
+
+[tool.pixi.feature.python.tasks.python-exe-debug]
+cmd = '''cp ./build-python/Wrapping/Generators/Python/WrapITK.pth $(python -c "import site; print(next(p for p in site.getsitepackages() if \'site-packages\' in p))") &&
+  python'''
+description = "Run a Python executable with the development ITK Python Debug build package"
 depends-on = ["build-debug-python"]
 
 [tool.pixi.environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,12 +115,12 @@ cmd = '''cmake
   -DCMAKE_BUILD_TYPE:STRING=Debug
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK Python - Debug"
-outputs = ["build-debug/CMakeFiles/"]
+outputs = ["build-debug-python/CMakeFiles/"]
 
 [tool.pixi.feature.python.tasks.build-debug-python]
 cmd = "cmake --build build-debug-python"
 description = "Build ITK Python - Debug"
-outputs = ["build-debug/lib/**"]
+outputs = ["build-debug-python/lib/**"]
 depends-on = ["configure-debug-python"]
 
 [tool.pixi.feature.python.tasks.test-debug-python]


### PR DESCRIPTION
Call `pixi run python-exe` to run a python interpreter with the locally built `itk` Python package.

Facilitates development and debugging.

I used this in testing / debugging #4895. 