### PR TITLE
ENH: Backport libtiff fix of not displaying warning for unknown tags

### DIFF
--- a/Modules/ThirdParty/TIFF/src/itktiff/tif_dirread.c
+++ b/Modules/ThirdParty/TIFF/src/itktiff/tif_dirread.c
@@ -3538,9 +3538,12 @@ TIFFReadDirectory(TIFF* tif)
       TIFFReadDirectoryFindFieldInfo(tif,dp->tdir_tag,&fii);
       if (fii == FAILED_FII)
       {
-        TIFFWarningExt(tif->tif_clientdata, module,
-            "Unknown field with tag %d (0x%x) encountered",
-            dp->tdir_tag,dp->tdir_tag);
+        if (tif->tif_flags&TIFF_WARNABOUTUNKNOWNTAGS)
+        {
+          TIFFWarningExt(tif->tif_clientdata, module,
+              "Unknown field with tag %d (0x%x) encountered",
+              dp->tdir_tag,dp->tdir_tag);
+        }
                                 /* the following knowingly leaks the
                                    anonymous field structure */
         if (!_TIFFMergeFields(tif,
@@ -4181,16 +4184,22 @@ TIFFReadCustomDirectory(TIFF* tif, toff_t diroff,
     TIFFReadDirectoryFindFieldInfo(tif,dp->tdir_tag,&fii);
     if (fii == FAILED_FII)
     {
-      TIFFWarningExt(tif->tif_clientdata, module,
-          "Unknown field with tag %d (0x%x) encountered",
-          dp->tdir_tag, dp->tdir_tag);
+      if (tif->tif_flags&TIFF_WARNABOUTUNKNOWNTAGS)
+      {
+        TIFFWarningExt(tif->tif_clientdata, module,
+            "Unknown field with tag %d (0x%x) encountered",
+            dp->tdir_tag, dp->tdir_tag);
+      }
       if (!_TIFFMergeFields(tif, _TIFFCreateAnonField(tif,
             dp->tdir_tag,
             (TIFFDataType) dp->tdir_type),
                1)) {
-        TIFFWarningExt(tif->tif_clientdata, module,
-            "Registering anonymous field with tag %d (0x%x) failed",
-            dp->tdir_tag, dp->tdir_tag);
+        if (tif->tif_flags&TIFF_WARNABOUTUNKNOWNTAGS)
+        {
+          TIFFWarningExt(tif->tif_clientdata, module,
+              "Registering anonymous field with tag %d (0x%x) failed",
+              dp->tdir_tag, dp->tdir_tag);
+        }
         dp->tdir_tag=IGNORE;
       } else {
         TIFFReadDirectoryFindFieldInfo(tif,dp->tdir_tag,&fii);

--- a/Modules/ThirdParty/TIFF/src/itktiff/tif_open.c
+++ b/Modules/ThirdParty/TIFF/src/itktiff/tif_open.c
@@ -264,6 +264,9 @@ TIFFClientOpen(
         if (m&O_CREAT)
           tif->tif_flags |= TIFF_BIGTIFF;
         break;
+      case 'W':
+        tif->tif_flags |= TIFF_WARNABOUTUNKNOWNTAGS;
+        break;
     }
   /*
    * Read in TIFF header.

--- a/Modules/ThirdParty/TIFF/src/itktiff/tiffiop.h
+++ b/Modules/ThirdParty/TIFF/src/itktiff/tiffiop.h
@@ -122,6 +122,7 @@ struct tiff {
         #define TIFF_DIRTYSTRIP 0x200000 /* stripoffsets/stripbytecount dirty*/
         #define TIFF_PERSAMPLE  0x400000 /* get/set per sample tags as arrays */
         #define TIFF_BUFFERMMAP 0x800000 /* read buffer (tif_rawdata) points into mmap() memory */
+        #define TIFF_WARNABOUTUNKNOWNTAGS 0x1000000 /* emit a warning when encountering a unknown tag */
   uint64               tif_diroff;       /* file offset of current directory */
   uint64               tif_nextdiroff;   /* file offset of following directory */
   uint64*              tif_dirlist;      /* list of offsets to already seen directories to prevent IFD looping */


### PR DESCRIPTION
Backport of https://gitlab.com/libtiff/libtiff/-/commit/382a2eb68d65edc967dacb72871b6af85723a7f6 to ITK's libtiff version.

It was easier to backport this change than update ITK's libtiff to the latest version (mainly due to complexity of symbol mangling).
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.
