### PR TITLE
ENH: Add Clone() and MakeDeepCopy() to PointSetBase

### DIFF
--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -162,6 +162,18 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+private:
+  void
+  DetachPointData() override
+  {
+    if (m_PointDataContainer)
+    {
+      // Make a new copy of the point data, detached from the original one.
+      const auto pointData = PointDataContainer::New();
+      pointData->CastToSTLContainer() = m_PointDataContainer->CastToSTLConstContainer();
+      m_PointDataContainer = pointData;
+    }
+  }
 }; // End Class: PointSet
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -67,6 +67,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(PointSetBase);
 
+  itkCloneMacro(Self);
+
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
   using CoordRepType = typename PointType::CoordRepType;
@@ -190,6 +192,25 @@ public:
 
   itkGetConstMacro(BufferedRegion, RegionType);
 
+
+  /** Returns a "deep copy" of this point set, having copied its points and point data. */
+  Pointer
+  MakeDeepCopy() const
+  {
+    const auto clone = this->Clone();
+    clone->Graft(this);
+
+    if (m_PointsContainer)
+    {
+      // Make a new copy of the points, detached from the original one.
+      const auto points = TPointsContainer::New();
+      points->CastToSTLContainer() = m_PointsContainer->CastToSTLConstContainer();
+      clone->m_PointsContainer = points;
+    }
+    clone->DetachPointData();
+    return clone;
+  }
+
 protected:
   /** Default-constructor, to be used by derived classes. */
   PointSetBase() = default;
@@ -215,6 +236,10 @@ protected:
   RegionType m_RequestedNumberOfRegions{};
   RegionType m_BufferedRegion{ -1 };
   RegionType m_RequestedRegion{ -1 };
+
+private:
+  virtual void
+  DetachPointData() = 0;
 };
 } // end namespace itk
 


### PR DESCRIPTION
`PointSetBase::MakeDeepCopy()` allows making a "deep copy" of a point set (rather than `PointSet::Graft`, which does a "shallow copy", or `Clone()`, which does not copy at all).

----

Background: for elastix (ITK/Python interface), we would like to be able to make a "deep copy" of a point set, including its points and point data. Unfortunately `PointSet::Clone()` doesn't do it. It does not copy anything at all!!! An alternative solution would be to adjust `PointSet::Clone()`, so that it would do the deep copy. Would that be better? What do you think?