### PR TITLE
ENH: Let `PointSet::Clone()` do a "deep copy", instead of no copy at all

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -97,3 +97,13 @@ Accessing outdated ITKv5 migration scripts
 git worktree add .../ITKv5.4 v5.4.0
 ls ../ITKv5/Utilities/ITKv5Preparation
 ```
+
+Class changes
+-------------
+
+The `Clone()` member function of `itk::PointSet` now does a "deep copy" of its
+data, creating a new instance that has a copy of the points, the point data and
+the region information properties of the original PointSet object. With previous
+ITK versions, `PointSet::Clone()` did not copy any data. (It previously just
+created a default-constructed PointSet object, like `PointSet::CreateAnother()`
+does.)

--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -162,6 +162,9 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  LightObject::Pointer
+  InternalClone() const override;
+
 }; // End Class: PointSet
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPointSet.hxx
+++ b/Modules/Core/Common/include/itkPointSet.hxx
@@ -143,6 +143,23 @@ PointSet<TPixelType, VDimension, TMeshTraits>::Graft(const DataObject * data)
   this->SetPointData(pointSet->m_PointDataContainer);
 }
 
+template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
+LightObject::Pointer
+PointSet<TPixelType, VDimension, TMeshTraits>::InternalClone() const
+{
+  LightObject::Pointer lightObject = Superclass::InternalClone();
+
+  if (auto * const clone = dynamic_cast<Self *>(lightObject.GetPointer()))
+  {
+    if (m_PointDataContainer)
+    {
+      clone->m_PointDataContainer = PointDataContainer::New();
+      clone->m_PointDataContainer->CastToSTLContainer() = m_PointDataContainer->CastToSTLConstContainer();
+    }
+    return lightObject;
+  }
+  itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");
+}
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -67,6 +67,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(PointSetBase);
 
+  itkCloneMacro(Self);
+
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
   using CoordRepType = typename PointType::CoordRepType;
@@ -199,6 +201,9 @@ protected:
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
+
+  LightObject::Pointer
+  InternalClone() const override;
 
   // If the RegionType is ITK_UNSTRUCTURED_REGION, then the following
   // variables represent the maximum number of region that the data

--- a/Modules/Core/Common/include/itkPointSetBase.hxx
+++ b/Modules/Core/Common/include/itkPointSetBase.hxx
@@ -350,6 +350,31 @@ PointSetBase<TPointsContainer>::VerifyRequestedRegion()
   return retval;
 }
 
+template <typename TPointsContainer>
+LightObject::Pointer
+PointSetBase<TPointsContainer>::InternalClone() const
+{
+  LightObject::Pointer lightObject = Superclass::InternalClone();
+
+  if (auto * const clone = dynamic_cast<Self *>(lightObject.GetPointer()))
+  {
+    if (m_PointsContainer)
+    {
+      clone->m_PointsContainer = TPointsContainer::New();
+      clone->m_PointsContainer->CastToSTLContainer() = m_PointsContainer->CastToSTLConstContainer();
+    }
+
+    clone->m_MaximumNumberOfRegions = m_MaximumNumberOfRegions;
+    clone->m_NumberOfRegions = m_NumberOfRegions;
+    clone->m_RequestedNumberOfRegions = m_RequestedNumberOfRegions;
+    clone->m_BufferedRegion = m_BufferedRegion;
+    clone->m_RequestedRegion = m_RequestedRegion;
+
+    return lightObject;
+  }
+  itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");
+}
+
 // Destructor. Must be defined here (rather than inside the class definition) because it is pure virtual.
 template <typename TPointsContainer>
 PointSetBase<TPointsContainer>::~PointSetBase() = default;


### PR DESCRIPTION
Implemented InternalClone() for PointSet and PointSetBase, in order to let `PointSet::Clone()` and `PointSetBase::Clone()` do a deep copy of its points and point data.

----

- Following the suggestion from Bradley (@blowekamp) to override InternalClone(), at https://github.com/InsightSoftwareConsortium/ITK/pull/4923#discussion_r1824841850

- Intended to supersede  pull request #4923
