### PR TITLE
Place various objects in tests on the stack, instead of on the heap

### DIFF
--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -411,29 +411,30 @@ itkQuadEdgeMeshCellInterfaceTest(int, char *[])
   mesh->Accept(multiVisitor);
 
   // test 4 very specific QELineCell destructor cases
-  auto *   test = new QELineCellType();
-  QEType * m_QuadEdgeGeom = test->GetQEGeom();
-  delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
-  m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
-  delete test;
-
-  test = new QELineCellType();
-  m_QuadEdgeGeom = test->GetQEGeom();
-  delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
-  m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
-  delete m_QuadEdgeGeom->GetRot()->GetRot();
-  m_QuadEdgeGeom->GetRot()->SetRot(nullptr);
-  delete test;
-
-  test = new QELineCellType();
-  m_QuadEdgeGeom = test->GetQEGeom();
-  delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
-  m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
-  delete m_QuadEdgeGeom->GetRot()->GetRot();
-  m_QuadEdgeGeom->GetRot()->SetRot(nullptr);
-  delete m_QuadEdgeGeom->GetRot();
-  m_QuadEdgeGeom->SetRot(nullptr);
-  delete test;
+  {
+    QELineCellType test;
+    QEType *       m_QuadEdgeGeom = test.GetQEGeom();
+    delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
+    m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
+  }
+  {
+    QELineCellType test;
+    QEType *       m_QuadEdgeGeom = test.GetQEGeom();
+    delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
+    m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
+    delete m_QuadEdgeGeom->GetRot()->GetRot();
+    m_QuadEdgeGeom->GetRot()->SetRot(nullptr);
+  }
+  {
+    QELineCellType test;
+    QEType *       m_QuadEdgeGeom = test.GetQEGeom();
+    delete m_QuadEdgeGeom->GetRot()->GetRot()->GetRot();
+    m_QuadEdgeGeom->GetRot()->GetRot()->SetRot(nullptr);
+    delete m_QuadEdgeGeom->GetRot()->GetRot();
+    m_QuadEdgeGeom->GetRot()->SetRot(nullptr);
+    delete m_QuadEdgeGeom->GetRot();
+    m_QuadEdgeGeom->SetRot(nullptr);
+  }
 
   return status;
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
@@ -18,6 +18,7 @@
 #ifndef itkLabelObjectLine_h
 #define itkLabelObjectLine_h
 
+#include "itkMacro.h"
 #include "itkIndex.h"
 #include "itkIndent.h"
 
@@ -42,6 +43,8 @@ template <unsigned int VImageDimension>
 class ITK_TEMPLATE_EXPORT LabelObjectLine
 {
 public:
+  ITK_DEFAULT_COPY_AND_MOVE(LabelObjectLine);
+
   static constexpr unsigned int ImageDimension = VImageDimension;
 
   using IndexType = Index<VImageDimension>;

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectLineComparatorTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectLineComparatorTest.cxx
@@ -37,49 +37,33 @@ itkLabelObjectLineComparatorTest(int, char *[])
   highIndex[0] = 14;
   highIndex[1] = 7;
 
-  auto * low = new LabelObjectLineType(lowIndex, 11);
-  auto * high = new LabelObjectLineType(highIndex, 11);
-  auto * lowlong = new LabelObjectLineType(lowIndex, 15);
+  LabelObjectLineType low(lowIndex, 11);
+  LabelObjectLineType high(highIndex, 11);
+  LabelObjectLineType lowlong(lowIndex, 15);
 
-  if (lessThan(*high, *low))
+  if (lessThan(high, low))
   {
     std::cerr << "Failed, high<low returned true." << std::endl;
-    delete low;
-    delete high;
-    delete lowlong;
     return (EXIT_FAILURE);
   }
 
-  if (!lessThan(*low, *high))
+  if (!lessThan(low, high))
   {
     std::cerr << "Failed, low<high returned false." << std::endl;
-    delete low;
-    delete high;
-    delete lowlong;
     return (EXIT_FAILURE);
   }
 
-  if (lessThan(*low, *low))
+  if (lessThan(low, low))
   {
     std::cerr << "Failed, low<low returned true." << std::endl;
-    delete low;
-    delete high;
-    delete lowlong;
     return (EXIT_FAILURE);
   }
 
-  if (!lessThan(*low, *lowlong))
+  if (!lessThan(low, lowlong))
   {
     std::cerr << "Failed, low<lowlong returned false." << std::endl;
-    delete low;
-    delete high;
-    delete lowlong;
     return (EXIT_FAILURE);
   }
-
-  delete low;
-  delete high;
-  delete lowlong;
 
   return (EXIT_SUCCESS);
 }

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectLineTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectLineTest.cxx
@@ -33,77 +33,67 @@ itkLabelObjectLineTest(int, char *[])
   nextIndex[0] = 14;
   nextIndex[1] = 7;
 
-  auto * labelLine = new LabelObjectLineType;
-  labelLine->SetIndex(currentIndex);
-  labelLine->SetLength(11);
+  LabelObjectLineType labelLine;
+  labelLine.SetIndex(currentIndex);
+  labelLine.SetLength(11);
 
   IndexType indexBack;
-  indexBack = labelLine->GetIndex();
+  indexBack = labelLine.GetIndex();
 
   if ((indexBack[0] != 3) || (indexBack[1] != 7))
   {
     std::cerr << "Set/Get Index failed on null constructor. " << indexBack << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
   LabelObjectLineType::LengthType length;
-  length = labelLine->GetLength();
+  length = labelLine.GetLength();
   if (length != 11)
   {
     std::cerr << "Set/Get length failed on null constructor." << length << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
-  delete labelLine;
 
-  labelLine = new LabelObjectLineType(currentIndex, 11);
-  indexBack = labelLine->GetIndex();
+  labelLine = LabelObjectLineType(currentIndex, 11);
+  indexBack = labelLine.GetIndex();
 
   if ((indexBack[0] != 3) || (indexBack[1] != 7))
   {
     std::cerr << "Set/Get Index failed on arg constructor. " << indexBack << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  if (labelLine->GetLength() != 11)
+  if (labelLine.GetLength() != 11)
   {
     std::cerr << "Set/Get length failed on arg constructor." << length << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  if (!labelLine->HasIndex(currentIndex))
+  if (!labelLine.HasIndex(currentIndex))
   {
     std::cerr << "Has Index failed." << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  if (labelLine->HasIndex(nextIndex))
+  if (labelLine.HasIndex(nextIndex))
   {
     std::cerr << "Has Index failed." << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  if (labelLine->IsNextIndex(currentIndex))
+  if (labelLine.IsNextIndex(currentIndex))
   {
     std::cerr << "Is Next Index failed." << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  if (!labelLine->IsNextIndex(nextIndex))
+  if (!labelLine.IsNextIndex(nextIndex))
   {
     std::cerr << "Is Next Index failed." << std::endl;
-    delete labelLine;
     return (EXIT_FAILURE);
   }
 
-  labelLine->Print(std::cout);
-  delete labelLine;
+  labelLine.Print(std::cout);
 
   return (EXIT_SUCCESS);
 }

--- a/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
@@ -47,8 +47,6 @@ itkThresholdImageFilterTest(int, char *[])
   FloatImage2DType::PointValueType origin[2] = { 15, 400 };
   random->SetOrigin(origin);
 
-  std::ostringstream * os;
-
   // Test #1, filter goes out of scope
   itk::OutputWindowDisplayText("Test #1: Filter goes out of scope -----------------");
   {
@@ -75,15 +73,12 @@ itkThresholdImageFilterTest(int, char *[])
     std::cout << "Output spacing: " << threshold->GetOutput()->GetSpacing()[0] << ", "
               << threshold->GetOutput()->GetSpacing()[1] << std::endl;
 
-    os = new std::ostringstream();
-    *os << "Filter: " << threshold.GetPointer();
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
-    os = new std::ostringstream();
-    *os << "Output #0: " << threshold->GetOutput(0);
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
-
+    std::ostringstream os;
+    os << "Filter: " << threshold.GetPointer();
+    itk::OutputWindowDisplayText(os.str().c_str());
+    os = {};
+    os << "Output #0: " << threshold->GetOutput(0);
+    itk::OutputWindowDisplayText(os.str().c_str());
 
     itk::OutputWindowDisplayText("Ending Test #1: filter goes out of scope");
     itk::OutputWindowDisplayText("End of Test #1 -----------------------------------");
@@ -99,14 +94,12 @@ itkThresholdImageFilterTest(int, char *[])
     threshold->SetInput(random->GetOutput());
     threshold->Update();
 
-    os = new std::ostringstream();
-    *os << "Filter: " << threshold.GetPointer();
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
-    os = new std::ostringstream();
-    *os << "Output #0: " << threshold->GetOutput(0);
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
+    std::ostringstream os;
+    os << "Filter: " << threshold.GetPointer();
+    itk::OutputWindowDisplayText(os.str().c_str());
+    os = {};
+    os << "Output #0: " << threshold->GetOutput(0);
+    itk::OutputWindowDisplayText(os.str().c_str());
 
     keep = threshold->GetOutput(0);
 
@@ -124,14 +117,12 @@ itkThresholdImageFilterTest(int, char *[])
     threshold->SetInput(random->GetOutput());
     threshold->Update();
 
-    os = new std::ostringstream;
-    *os << "Filter: " << threshold.GetPointer();
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
-    os = new std::ostringstream();
-    *os << "Output #0: " << threshold->GetOutput(0);
-    itk::OutputWindowDisplayText(os->str().c_str());
-    delete os;
+    std::ostringstream os;
+    os << "Filter: " << threshold.GetPointer();
+    itk::OutputWindowDisplayText(os.str().c_str());
+    os = {};
+    os << "Output #0: " << threshold->GetOutput(0);
+    itk::OutputWindowDisplayText(os.str().c_str());
 
     keep = threshold->GetOutput(0);
     keep->DisconnectPipeline();
@@ -184,10 +175,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != outsideValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter above failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter above failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -197,10 +188,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter above failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter above failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -212,10 +203,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter above failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter above failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -225,10 +216,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter below failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter below failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -238,10 +229,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != outsideValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter below failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter below failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -253,10 +244,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter below failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter below failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -266,10 +257,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter outside failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter outside failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -281,10 +272,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != inputValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter outside failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter outside failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
 
@@ -294,10 +285,10 @@ itkThresholdImageFilterTest(int, char *[])
     outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != outsideValue)
     {
-      os = new std::ostringstream;
-      *os << "Filter above failed:"
-          << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
-      itk::OutputWindowDisplayText(os->str().c_str());
+      std::ostringstream os;
+      os << "Filter above failed:"
+         << " lower: " << threshold->GetLower() << " upper: " << threshold->GetUpper() << " output: " << outputValue;
+      itk::OutputWindowDisplayText(os.str().c_str());
       return EXIT_FAILURE;
     }
   }


### PR DESCRIPTION
Following C++ Core Guidelines, Oct 3, 2024, ["Prefer scoped objects, don’t heap-allocate unnecessarily"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily)