### PR TITLE
STYLE: Use `unique_ptr` for m_CostFunctionAdaptor members in Optimizers

### DIFF
--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
@@ -23,6 +23,8 @@
 #include "itkCommand.h"
 #include "ITKOptimizersExport.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 /** \class MultipleValuedNonLinearVnlOptimizer
@@ -126,8 +128,8 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
-  bool                      m_UseGradient{};
+  std::unique_ptr<CostFunctionAdaptorType> m_CostFunctionAdaptor;
+  bool                                     m_UseGradient{};
 
   CommandType::Pointer m_Command{};
 

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
@@ -23,6 +23,8 @@
 #include "itkCommand.h"
 #include "ITKOptimizersExport.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 /** \class SingleValuedNonLinearVnlOptimizer
@@ -139,7 +141,7 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
+  std::unique_ptr<CostFunctionAdaptorType> m_CostFunctionAdaptor;
 
   bool m_Maximize{};
 

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -37,23 +37,17 @@ MultipleValuedNonLinearVnlOptimizer::MultipleValuedNonLinearVnlOptimizer()
 /**
  * Destructor
  */
-MultipleValuedNonLinearVnlOptimizer::~MultipleValuedNonLinearVnlOptimizer()
-{
-  delete m_CostFunctionAdaptor;
-  m_CostFunctionAdaptor = nullptr;
-}
+MultipleValuedNonLinearVnlOptimizer::~MultipleValuedNonLinearVnlOptimizer() = default;
 
 void
 MultipleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
-  if (m_CostFunctionAdaptor == adaptor)
+  if (m_CostFunctionAdaptor.get() == adaptor)
   {
     return;
   }
 
-  delete m_CostFunctionAdaptor;
-
-  m_CostFunctionAdaptor = adaptor;
+  m_CostFunctionAdaptor.reset(adaptor);
 
   this->SetUseCostFunctionGradient(m_UseGradient);
 
@@ -63,13 +57,13 @@ MultipleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorT
 const MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 MultipleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor() const
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 MultipleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 /** The purpose of this method is to get around the lack of const
@@ -77,7 +71,7 @@ MultipleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 MultipleValuedNonLinearVnlOptimizer::GetNonConstCostFunctionAdaptor() const
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 void
@@ -134,6 +128,6 @@ MultipleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent)
   os << indent << "Cached Derivative: " << m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << m_CachedCurrentPosition << std::endl;
   os << indent << "Command observer " << m_Command.GetPointer() << std::endl;
-  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
+  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor.get() << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -33,23 +33,17 @@ SingleValuedNonLinearVnlOptimizer::SingleValuedNonLinearVnlOptimizer()
 }
 
 /** Destructor */
-SingleValuedNonLinearVnlOptimizer::~SingleValuedNonLinearVnlOptimizer()
-{
-  delete m_CostFunctionAdaptor;
-  m_CostFunctionAdaptor = nullptr;
-}
+SingleValuedNonLinearVnlOptimizer::~SingleValuedNonLinearVnlOptimizer() = default;
 
 void
 SingleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
-  if (m_CostFunctionAdaptor == adaptor)
+  if (m_CostFunctionAdaptor.get() == adaptor)
   {
     return;
   }
 
-  delete m_CostFunctionAdaptor;
-
-  m_CostFunctionAdaptor = adaptor;
+  m_CostFunctionAdaptor.reset(adaptor);
 
   m_CostFunctionAdaptor->AddObserver(IterationEvent(), m_Command);
 }
@@ -57,13 +51,13 @@ SingleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorTyp
 const SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor() const
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 /** The purpose of this method is to get around the lack of
@@ -71,7 +65,7 @@ SingleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizer::GetNonConstCostFunctionAdaptor() const
 {
-  return m_CostFunctionAdaptor;
+  return m_CostFunctionAdaptor.get();
 }
 
 /** The purpose of this method is to get around the lack of iteration reporting
@@ -103,6 +97,6 @@ SingleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent) c
   os << indent << "Cached Derivative: " << m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << m_CachedCurrentPosition << std::endl;
   os << indent << "Command observer " << m_Command.GetPointer() << std::endl;
-  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
+  os << indent << "Cost Function adaptor" << m_CostFunctionAdaptor.get() << std::endl;
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
@@ -24,6 +24,8 @@
 #include "itkSingleValuedVnlCostFunctionAdaptorv4.h"
 #include "itkCommand.h"
 
+#include <memory> // For unique_ptr.
+
 namespace itk
 {
 /**
@@ -124,7 +126,7 @@ private:
   void
   IterationReport(const EventObject & event);
 
-  CostFunctionAdaptorType * m_CostFunctionAdaptor{};
+  std::unique_ptr<CostFunctionAdaptorType> m_CostFunctionAdaptor;
 
   CommandType::Pointer m_Command{};
 

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -29,14 +29,7 @@ SingleValuedNonLinearVnlOptimizerv4::SingleValuedNonLinearVnlOptimizerv4()
   this->m_CachedDerivative.Fill(DerivativeType::ValueType{});
 }
 
-SingleValuedNonLinearVnlOptimizerv4::~SingleValuedNonLinearVnlOptimizerv4()
-{
-  if (this->m_CostFunctionAdaptor)
-  {
-    delete this->m_CostFunctionAdaptor;
-    this->m_CostFunctionAdaptor = nullptr;
-  }
-}
+SingleValuedNonLinearVnlOptimizerv4::~SingleValuedNonLinearVnlOptimizerv4() = default;
 
 void
 SingleValuedNonLinearVnlOptimizerv4::StartOptimization(bool doOnlyInitialization)
@@ -67,17 +60,12 @@ SingleValuedNonLinearVnlOptimizerv4::StartOptimization(bool doOnlyInitialization
 void
 SingleValuedNonLinearVnlOptimizerv4::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
-  if (this->m_CostFunctionAdaptor == adaptor)
+  if (this->m_CostFunctionAdaptor.get() == adaptor)
   {
     return;
   }
 
-  if (this->m_CostFunctionAdaptor)
-  {
-    delete this->m_CostFunctionAdaptor;
-  }
-
-  this->m_CostFunctionAdaptor = adaptor;
+  this->m_CostFunctionAdaptor.reset(adaptor);
 
   this->m_CostFunctionAdaptor->AddObserver(IterationEvent(), this->m_Command);
 }
@@ -85,19 +73,19 @@ SingleValuedNonLinearVnlOptimizerv4::SetCostFunctionAdaptor(CostFunctionAdaptorT
 const SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizerv4::GetCostFunctionAdaptor() const
 {
-  return this->m_CostFunctionAdaptor;
+  return this->m_CostFunctionAdaptor.get();
 }
 
 SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizerv4::GetCostFunctionAdaptor()
 {
-  return this->m_CostFunctionAdaptor;
+  return this->m_CostFunctionAdaptor.get();
 }
 
 SingleValuedNonLinearVnlOptimizerv4::CostFunctionAdaptorType *
 SingleValuedNonLinearVnlOptimizerv4::GetNonConstCostFunctionAdaptor() const
 {
-  return this->m_CostFunctionAdaptor;
+  return this->m_CostFunctionAdaptor.get();
 }
 
 void
@@ -118,6 +106,6 @@ SingleValuedNonLinearVnlOptimizerv4::PrintSelf(std::ostream & os, Indent indent)
   os << indent << "Cached Derivative: " << this->m_CachedDerivative << std::endl;
   os << indent << "Cached current positiion: " << this->m_CachedCurrentPosition << std::endl;
   os << indent << "Command observer " << this->m_Command.GetPointer() << std::endl;
-  os << indent << "Cost Function adaptor" << this->m_CostFunctionAdaptor << std::endl;
+  os << indent << "Cost Function adaptor" << this->m_CostFunctionAdaptor.get() << std::endl;
 }
 } // end namespace itk


### PR DESCRIPTION
Defaulted the corresponding Optimizer destructors.

Following C++ Core Guidelines, Oct 3, 2024, ["Use `unique_ptr` or `shared_ptr` to avoid forgetting to `delete` objects created using `new`"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-smart)