### PR TITLE
STYLE: Add constexpr to variables initialized by MakeFilled

### DIFF
--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -80,7 +80,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   m_ImageRegion = this->m_Image->GetBufferedRegion();
 
   // Build and setup the neighborhood iterator
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType tmp_iter(radius, this->m_Image, m_ImageRegion);
   m_NeighborhoodIterator = tmp_iter;

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -193,7 +193,7 @@ void
 ScaleTransform<TParametersValueType, VDimension>::SetIdentity()
 {
   Superclass::SetIdentity();
-  auto i = MakeFilled<ScaleType>(1.0);
+  constexpr auto i = MakeFilled<ScaleType>(1.0);
   this->SetScale(i);
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -132,7 +132,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
   // Setup the kernel that spans the immediate neighbors of the current
   // input pixel - used to determine if that pixel abuts a non-object
   // pixel, i.e., is a boundary pixel
-  auto bKernelSize = MakeFilled<RadiusType>(1);
+  constexpr auto bKernelSize = MakeFilled<RadiusType>(1);
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
@@ -95,8 +95,8 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::ComputeConvolut
 
   // Flip the kernel
   using FlipperType = FlipImageFilter<TImage>;
-  auto flipper = FlipperType::New();
-  auto axesArray = MakeFilled<typename FlipperType::FlipAxesArrayType>(true);
+  auto           flipper = FlipperType::New();
+  constexpr auto axesArray = MakeFilled<typename FlipperType::FlipAxesArrayType>(true);
   flipper->SetFlipAxes(axesArray);
   flipper->SetInput(kernelImage);
 

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -299,8 +299,8 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
 
   // Flip the moving images along all dimensions so that the correlation can be more easily handled.
   using FlipperType = itk::FlipImageFilter<LocalInputImageType>;
-  auto flipAxes = MakeFilled<typename FlipperType::FlipAxesArrayType>(true);
-  auto rotater = FlipperType::New();
+  constexpr auto flipAxes = MakeFilled<typename FlipperType::FlipAxesArrayType>(true);
+  auto           rotater = FlipperType::New();
   rotater->SetFlipAxes(flipAxes);
   rotater->SetInput(inputImage);
   rotater->Update();

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -361,7 +361,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
   itkDebugMacro("Calculating the B-spline displacement field. ");
 
-  auto close = MakeFilled<ArrayType>(false);
+  constexpr auto close = MakeFilled<ArrayType>(false);
 
   auto bspliner = BSplineFilterType::New();
   bspliner->SetOrigin(this->m_BSplineDomainOrigin);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -127,7 +127,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * 
   m_BufferedRegion = output->GetBufferedRegion();
   m_StartIndex = m_BufferedRegion.GetIndex();
   m_LastIndex = m_StartIndex + m_BufferedRegion.GetSize();
-  auto offset = MakeFilled<typename LevelSetImageType::OffsetType>(1);
+  constexpr auto offset = MakeFilled<typename LevelSetImageType::OffsetType>(1);
   m_LastIndex -= offset;
 
   // allocate memory for the PointTypeImage

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -436,7 +436,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
   m_OutputOrigin = oImage->GetOrigin();
   m_OutputDirection = oImage->GetDirection();
 
-  auto offset = MakeFilled<typename OutputImageType::OffsetType>(1);
+  constexpr auto offset = MakeFilled<typename OutputImageType::OffsetType>(1);
   m_LastIndex -= offset;
 
   // Checking for handles only requires an image to keep track of
@@ -608,7 +608,7 @@ template <typename TInput, typename TOutput>
 bool
 FastMarchingImageFilterBase<TInput, TOutput>::DoesVoxelChangeViolateStrictTopology(const NodeType & idx) const
 {
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
   It.SetLocation(idx);
@@ -644,7 +644,7 @@ template <typename TInput, typename TOutput>
 bool
 FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed2D(const NodeType & idx) const
 {
-  auto radius = MakeFilled<NeighborhoodRadiusType>(1);
+  constexpr auto radius = MakeFilled<NeighborhoodRadiusType>(1);
 
   NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
   It.SetLocation(idx);
@@ -804,7 +804,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed3D(const NodeT
 {
   std::bitset<8> neighborhoodPixels;
 
-  auto radius = MakeFilled<NeighborhoodRadiusType>(1);
+  constexpr auto radius = MakeFilled<NeighborhoodRadiusType>(1);
 
   NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetRequestedRegion());
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -42,7 +42,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::CannyEdgeDetectionImag
   m_UpdateBuffer1 = OutputImageType::New();
 
   // Set up neighborhood slices for all the dimensions.
-  auto r = MakeFilled<typename Neighborhood<OutputImagePixelType, ImageDimension>::RadiusType>(1);
+  constexpr auto r = MakeFilled<typename Neighborhood<OutputImagePixelType, ImageDimension>::RadiusType>(1);
 
   // Dummy neighborhood used to set up the slices
   Neighborhood<OutputImagePixelType, ImageDimension> it;

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -102,7 +102,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Genera
   typename TInputImage::RegionType inputRequestedRegion;
   inputRequestedRegion = inputPtr->GetRequestedRegion();
 
-  auto r1 = MakeFilled<RadiusType>(1);
+  constexpr auto r1 = MakeFilled<RadiusType>(1);
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(r1);
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
@@ -89,7 +89,7 @@ public:
   BinaryCrossStructuringElement()
   {
     // Default structuring element is defined to be 3x3x3...
-    auto radius = MakeFilled<RadiusType>(1);
+    constexpr auto radius = MakeFilled<RadiusType>(1);
     Self::SetRadius(radius);
     Self::CreateStructuringElement();
   }

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -349,7 +349,7 @@ public:
 
     m_DifferenceFunctions.resize(m_FunctionCount, nullptr);
 
-    auto radius = MakeFilled<RadiusType>(1);
+    constexpr auto radius = MakeFilled<RadiusType>(1);
 
     for (unsigned int i = 0; i < this->m_FunctionCount; ++i)
     {

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -74,7 +74,7 @@ template <typename TImage>
 void
 ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 {
-  auto radius = MakeFilled<typename ShapedNeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename ShapedNeighborhoodIteratorType::RadiusType>(1);
 
   using FaceCalculatorType = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>;
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -871,7 +871,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
 
     for (SizeValueType level = 0; level < this->m_NumberOfLevels; ++level)
     {
-      auto shrinkFactors = MakeFilled<ShrinkFactorsPerDimensionContainerType>(1);
+      constexpr auto shrinkFactors = MakeFilled<ShrinkFactorsPerDimensionContainerType>(1);
       this->SetShrinkFactorsPerDimension(level, shrinkFactors);
     }
 

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -439,7 +439,7 @@ public:
   {
     m_SegmentationFunction = s;
 
-    auto r = MakeFilled<typename SegmentationFunctionType::RadiusType>(1);
+    constexpr auto r = MakeFilled<typename SegmentationFunctionType::RadiusType>(1);
 
     m_SegmentationFunction->Initialize(r);
     this->SetDifferenceFunction(m_SegmentationFunction);

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -134,7 +134,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
   LevelSetLayerType & layerPlus2 = this->m_LevelSet->GetLayer(outputLayer);
   const auto          plus2 = static_cast<LevelSetOutputType>(outputLayer);
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> im_nbc;
 
@@ -197,7 +197,7 @@ BinaryImageToLevelSetImageAdaptor<TInput,
 
   LevelSetLayerType & layer0 = this->m_LevelSet->GetLayer(LevelSetType::ZeroLayer());
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> im_nbc;
 
@@ -260,7 +260,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
   LevelSetLayerType &     layerMinus1 = this->m_LevelSet->GetLayer(LevelSetType::MinusOneLayer());
   LevelSetLayerType &     layerPlus1 = this->m_LevelSet->GetLayer(LevelSetType::PlusOneLayer());
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> im_nbc;
 
@@ -399,7 +399,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDi
   LevelSetLayerType & layerMinus1 = this->m_LevelSet->GetLayer(LevelSetType::MinusOneLayer());
   LevelSetLayerType & layerPlus1 = this->m_LevelSet->GetLayer(LevelSetType::PlusOneLayer());
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> im_nbc;
 
@@ -541,7 +541,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
 
   LevelSetLayerType & layer = this->m_LevelSet->GetLayer(LevelSetType::ZeroLayer());
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> im_nbc;
 
@@ -603,7 +603,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
 
   ZeroFluxNeumannBoundaryCondition<InternalImageType> sp_nbc;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -169,7 +169,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithUnPhasedP
   // neighborhood iterator
   ZeroFluxNeumannBoundaryCondition<LabelImageType> sp_nbc;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -258,7 +258,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithPhasedPro
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> sp_nbc;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -352,7 +352,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::CompactLayersToSing
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> sp_nbc;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
@@ -65,7 +65,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Update()
   // neighborhood iterator
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -184,7 +184,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerPlusOne()
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -283,7 +283,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerMinusOne()
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -379,7 +379,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Con(const LevelSetInput
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -104,7 +104,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   /** todo: put neighborhood creation in protected method */
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -194,7 +194,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -355,7 +355,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -460,7 +460,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -565,7 +565,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -669,7 +669,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -796,7 +796,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
@@ -853,7 +853,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 {
   ZeroFluxNeumannBoundaryCondition<LabelImageType> spNBC;
 
-  auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 


### PR DESCRIPTION
Suggests evaluating its value at compile-time, rather than at runtime.

Found by regular expressions:

    ^( [ ]+)(auto \w+[ ]+= MakeFilled<.+>\(-?\d+\);)
    ^( [ ]+)(auto \w+[ ]+= MakeFilled<.+>\(\d.0\);)
    ^( [ ]+)(auto \w+[ ]+= MakeFilled<.+>\(false\);)
    ^( [ ]+)(auto \w+[ ]+= MakeFilled<.+>\(true\);)

Inspired by a comment by Hans Johnson (@hjmjohnson) at
https://github.com/InsightSoftwareConsortium/ITK/pull/4924#discussion_r1826864385