### PR TITLE
Replace `T * p; p = x` with `T * p = x`, use `auto *` for variables initialized by a pointer cast

### DIFF
--- a/Modules/Core/Common/test/itkLoggerManagerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerManagerTest.cxx
@@ -83,8 +83,7 @@ itkLoggerManagerTest(int argc, char * argv[])
     manager->Write(itk::Logger::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
     manager->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     std::cout << "  Message #3" << std::endl;
-    itk::Logger * pLogger;
-    pLogger = manager->GetLogger("org.itk.logTester.logger");
+    itk::Logger * pLogger = manager->GetLogger("org.itk.logTester.logger");
     if (pLogger == nullptr)
     {
       throw "LoggerManager::GetLogger() failed";

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -278,9 +278,7 @@ TEST(SmartPointer, ConvertingRegisterCount)
     Derived1Pointer d1ptr = Derived1::New();
     EXPECT_EQ(1, d1ptr->GetRegisterCount());
 
-    Derived1 * rptr;
-
-    rptr = d1ptr;
+    Derived1 * rptr = d1ptr;
     EXPECT_EQ(1, d1ptr->GetRegisterCount());
     EXPECT_TRUE(rptr != nullptr);
   }
@@ -290,9 +288,7 @@ TEST(SmartPointer, ConvertingRegisterCount)
     Derived1Pointer d1ptr = Derived1::New();
     EXPECT_EQ(1, d1ptr->GetRegisterCount());
 
-    const Derived1 * rptr;
-
-    rptr = d1ptr;
+    const Derived1 * rptr = d1ptr;
     EXPECT_EQ(1, d1ptr->GetRegisterCount());
     EXPECT_TRUE(rptr != nullptr);
   }

--- a/Modules/Core/GPUCommon/include/itkGPUImage.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.hxx
@@ -197,7 +197,7 @@ template <typename TPixel, unsigned int VImageDimension>
 void
 GPUImage<TPixel, VImageDimension>::Graft(const DataObject * data)
 {
-  const Self * ptr = dynamic_cast<const Self *>(data);
+  const auto * ptr = dynamic_cast<const Self *>(data);
   if (ptr)
   {
     this->Graft(ptr);

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -130,8 +130,7 @@ GPUKernelManager::LoadProgramFromFile(const char * filename, const char * cPream
     // get error message size
     clGetProgramBuildInfo(m_Program, m_Manager->GetDeviceId(0), CL_PROGRAM_BUILD_LOG, 0, nullptr, &paramValueSize);
 
-    char * paramValue;
-    paramValue = (char *)malloc(paramValueSize);
+    char * paramValue = (char *)malloc(paramValueSize);
 
     // get error message
     clGetProgramBuildInfo(
@@ -208,8 +207,7 @@ GPUKernelManager::LoadProgramFromString(const char * cSource, const char * cPrea
     // get error message size
     clGetProgramBuildInfo(m_Program, m_Manager->GetDeviceId(0), CL_PROGRAM_BUILD_LOG, 0, nullptr, &paramValueSize);
 
-    char * paramValue;
-    paramValue = (char *)malloc(paramValueSize);
+    char * paramValue = (char *)malloc(paramValueSize);
 
     // get error message
     clGetProgramBuildInfo(

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -328,7 +328,7 @@ void
 BSplineDecompositionImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
   // This filter requires all of the input image to be in the buffer
-  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
+  auto * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -328,9 +328,7 @@ void
 BSplineDecompositionImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
   // This filter requires all of the input image to be in the buffer
-  TOutputImage * imgData;
-
-  imgData = dynamic_cast<TOutputImage *>(output);
+  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -1378,11 +1378,9 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
 
   typename TriCell::CellAutoPointer        insertCell;
   typename OutputMeshType::PointIdentifier tripoints[3];
-  unsigned char *                          tp;
-  tp = (unsigned char *)malloc(3 * sizeof(unsigned char));
+  unsigned char *                          tp = (unsigned char *)malloc(3 * sizeof(unsigned char));
 
-  IdentifierType * tpl;
-  tpl = (IdentifierType *)malloc(3 * sizeof(IdentifierType));
+  IdentifierType * tpl = (IdentifierType *)malloc(3 * sizeof(IdentifierType));
 
   switch (static_cast<int>(celltype))
   {

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -59,7 +59,7 @@ template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 void
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::CopyInformation(const DataObject * data)
 {
-  const Superclass * mesh = dynamic_cast<const Superclass *>(data);
+  const auto * mesh = dynamic_cast<const Superclass *>(data);
 
   if (mesh == nullptr)
   {

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -59,9 +59,7 @@ template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 void
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::CopyInformation(const DataObject * data)
 {
-  const Superclass * mesh;
-
-  mesh = dynamic_cast<const Superclass *>(data);
+  const Superclass * mesh = dynamic_cast<const Superclass *>(data);
 
   if (mesh == nullptr)
   {

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -28,7 +28,7 @@ template <unsigned int VDimension, typename PixelType, typename TSpatialObjectTy
 auto
 MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::CreateMetaObject() -> MetaObjectType *
 {
-  MetaObjectType * mo = dynamic_cast<MetaObjectType *>(new ImageMetaObjectType);
+  auto * mo = dynamic_cast<MetaObjectType *>(new ImageMetaObjectType);
   mo->APIVersion(1);
   mo->FileFormatVersion(1);
   return mo;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -1211,7 +1211,7 @@ SpatialObject<TDimension>::CopyInformation(const DataObject * data)
   Superclass::CopyInformation(data);
 
   // Attempt to cast data to an ImageBase
-  const SpatialObject<TDimension> * soData = dynamic_cast<const SpatialObject<TDimension> *>(data);
+  const auto * soData = dynamic_cast<const SpatialObject<TDimension> *>(data);
 
   if (soData == nullptr)
   {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -1211,8 +1211,7 @@ SpatialObject<TDimension>::CopyInformation(const DataObject * data)
   Superclass::CopyInformation(data);
 
   // Attempt to cast data to an ImageBase
-  const SpatialObject<TDimension> * soData;
-  soData = dynamic_cast<const SpatialObject<TDimension> *>(data);
+  const SpatialObject<TDimension> * soData = dynamic_cast<const SpatialObject<TDimension> *>(data);
 
   if (soData == nullptr)
   {

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -60,8 +60,7 @@ TubeSpatialObject<TDimension, TTubePointType>::CopyInformation(const DataObject 
   Superclass::CopyInformation(data);
 
   // Attempt to cast data to an ImageBase
-  const TubeSpatialObject<TDimension> * soData;
-  soData = dynamic_cast<const TubeSpatialObject<TDimension> *>(data);
+  const TubeSpatialObject<TDimension> * soData = dynamic_cast<const TubeSpatialObject<TDimension> *>(data);
 
   if (soData == nullptr)
   {

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -60,7 +60,7 @@ TubeSpatialObject<TDimension, TTubePointType>::CopyInformation(const DataObject 
   Superclass::CopyInformation(data);
 
   // Attempt to cast data to an ImageBase
-  const TubeSpatialObject<TDimension> * soData = dynamic_cast<const TubeSpatialObject<TDimension> *>(data);
+  const auto * soData = dynamic_cast<const TubeSpatialObject<TDimension> *>(data);
 
   if (soData == nullptr)
   {

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -197,8 +197,7 @@ template <typename TOutputImage>
 void
 RandomImageSource<TOutputImage>::GenerateOutputInformation()
 {
-  TOutputImage * output;
-  output = this->GetOutput(0);
+  TOutputImage * output = this->GetOutput(0);
 
   const typename TOutputImage::RegionType largestPossibleRegion(this->m_Size);
   output->SetLargestPossibleRegion(largestPossibleRegion);

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -122,9 +122,8 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(m_OutputImageRegion);
 
   // Set the output spacing and origin
-  const ImageBase<InputImageDimension> * phyData;
-
-  phyData = dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
+  const ImageBase<InputImageDimension> * phyData =
+    dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
 
   if (phyData == nullptr)
   {

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -122,8 +122,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(m_OutputImageRegion);
 
   // Set the output spacing and origin
-  const ImageBase<InputImageDimension> * phyData =
-    dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
+  const auto * phyData = dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
 
   if (phyData == nullptr)
   {

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -95,9 +95,7 @@ void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // convert DataObject pointer to OutputImageType pointer
-  OutputImageType * outputPtr;
-
-  outputPtr = dynamic_cast<OutputImageType *>(ptr);
+  OutputImageType * outputPtr = dynamic_cast<OutputImageType *>(ptr);
 
   // get input image pointer
   typename Superclass::InputImagePointer inputPtr = const_cast<InputImageType *>(this->GetInput());

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -95,7 +95,7 @@ void
 CurvatureFlowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // convert DataObject pointer to OutputImageType pointer
-  OutputImageType * outputPtr = dynamic_cast<OutputImageType *>(ptr);
+  auto * outputPtr = dynamic_cast<OutputImageType *>(ptr);
 
   // get input image pointer
   typename Superclass::InputImagePointer inputPtr = const_cast<InputImageType *>(this->GetInput());

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -80,7 +80,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequested
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
+  auto * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();
@@ -126,7 +126,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreaderFullCallback(v
   ThreadIdType workUnitCount = workUnitInfo->NumberOfWorkUnits;
   using FilterStruct = typename ImageSource<TOutputImage>::ThreadStruct;
   auto * str = (FilterStruct *)(workUnitInfo->UserData);
-  Self * filter = static_cast<Self *>(str->Filter.GetPointer());
+  auto * filter = static_cast<Self *>(str->Filter.GetPointer());
 
   // execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -80,9 +80,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequested
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData;
-
-  imgData = dynamic_cast<TOutputImage *>(output);
+  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
@@ -72,7 +72,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
-  OutputImageType * outputPtr = dynamic_cast<OutputImageType *>(output);
+  auto * outputPtr = dynamic_cast<OutputImageType *>(output);
 
   // we need to enlarge the region in the fft direction to the
   // largest possible in that direction

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
@@ -37,7 +37,7 @@ Forward1DFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   Superclass::GenerateInputRequestedRegion();
 
   // get pointers to the inputs
-  InputImageType *  input = const_cast<InputImageType *>(this->GetInput());
+  auto *            input = const_cast<InputImageType *>(this->GetInput());
   OutputImageType * output = this->GetOutput();
 
   // we need to compute the input requested region (size and start index)
@@ -68,7 +68,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 Forward1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * out)
 {
-  OutputImageType * output = dynamic_cast<OutputImageType *>(out);
+  auto * output = dynamic_cast<OutputImageType *>(out);
 
   // we need to enlarge the region in the fft direction to the
   // largest possible in that direction

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
@@ -73,7 +73,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 Inverse1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * out)
 {
-  OutputImageType * output = dynamic_cast<OutputImageType *>(out);
+  auto * output = dynamic_cast<OutputImageType *>(out);
 
   // we need to enlarge the region in the fft direction to the
   // largest possible in that direction

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -99,7 +99,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::EnlargeOutputRequestedRegion(Da
 {
   // enlarge the requested region of the output
   // to the whole data set
-  TLevelSet * imgData = dynamic_cast<TLevelSet *>(output);
+  auto * imgData = dynamic_cast<TLevelSet *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -99,9 +99,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::EnlargeOutputRequestedRegion(Da
 {
   // enlarge the requested region of the output
   // to the whole data set
-  TLevelSet * imgData;
-
-  imgData = dynamic_cast<TLevelSet *>(output);
+  TLevelSet * imgData = dynamic_cast<TLevelSet *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -101,8 +101,7 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 
   // Set the output spacing and origin
-  const ImageBase<InputImageDimension> * phyData =
-    dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
+  const auto * phyData = dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
 
   if (phyData)
   {

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -101,9 +101,8 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 
   // Set the output spacing and origin
-  const ImageBase<InputImageDimension> * phyData;
-
-  phyData = dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
+  const ImageBase<InputImageDimension> * phyData =
+    dynamic_cast<const ImageBase<InputImageDimension> *>(this->GetInput());
 
   if (phyData)
   {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -153,7 +153,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeO
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
+  auto * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -153,9 +153,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeO
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData;
-
-  imgData = dynamic_cast<TOutputImage *>(output);
+  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -160,7 +160,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeOut
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
+  auto * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -160,9 +160,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::EnlargeOut
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TOutputImage * imgData;
-
-  imgData = dynamic_cast<TOutputImage *>(output);
+  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
@@ -152,8 +152,7 @@ setInt2DData(IntImageType2D::Pointer imgPtr)
 bool
 VerifyResultsHigherOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResults)
 {
-  double * ERptr;
-  ERptr = ExpectedResults;
+  double * ERptr = ExpectedResults;
 
   InputIterator ActualResultsIter(ActualResults, ActualResults->GetLargestPossibleRegion());
   double        percentErr = 0;
@@ -180,8 +179,7 @@ VerifyResultsHigherOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedRe
 bool
 VerifyResults3rdOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResults)
 {
-  double * ERptr;
-  ERptr = ExpectedResults;
+  double * ERptr = ExpectedResults;
 
   InputIterator ActualResultsIter(ActualResults, ActualResults->GetLargestPossibleRegion());
 
@@ -202,8 +200,7 @@ VerifyResults3rdOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResul
 bool
 VerifyResults2ndOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResults)
 {
-  double * ERptr;
-  ERptr = ExpectedResults;
+  double * ERptr = ExpectedResults;
 
   InputIterator ActualResultsIter(ActualResults, ActualResults->GetLargestPossibleRegion());
   double        percentErr = 0;
@@ -231,8 +228,7 @@ VerifyResults2ndOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResul
 bool
 VerifyResultsLowerOrderSpline(ImageTypePtr2D ActualResults, double * ExpectedResults)
 {
-  double * ERptr;
-  ERptr = ExpectedResults;
+  double * ERptr = ExpectedResults;
 
   InputIterator ActualResultsIter(ActualResults, ActualResults->GetLargestPossibleRegion());
   double        percentErr = 0;

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -640,7 +640,7 @@ template <typename TInputImage>
 void
 ContourExtractor2DImageFilter<TInputImage>::GenerateInputRequestedRegion()
 {
-  InputImageType * input = const_cast<InputImageType *>(this->GetInput());
+  auto * input = const_cast<InputImageType *>(this->GetInput());
 
   if (!input)
   {

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -678,8 +678,7 @@ GDCMImageIO::InternalReadImageInformation()
     break;
     default:
     {
-      const double * sp;
-      sp = image.GetSpacing();
+      const double * sp = image.GetSpacing();
       spacing[0] = sp[0];
       spacing[1] = sp[1];
       spacing[2] = sp[2];

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -367,9 +367,9 @@ GDCMImageIO::Read(void * pointer)
 
   if (m_SingleBit)
   {
-    const auto      copy = make_unique_for_overwrite<unsigned char[]>(len);
-    unsigned char * t = reinterpret_cast<unsigned char *>(pointer);
-    size_t          j = 0;
+    const auto copy = make_unique_for_overwrite<unsigned char[]>(len);
+    auto *     t = reinterpret_cast<unsigned char *>(pointer);
+    size_t     j = 0;
     for (size_t i = 0; i < len / 8; ++i)
     {
       const unsigned char c = t[i];

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -364,8 +364,7 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
       // This is a bit tricky to get the value as there is sometime no white
       // space
       // only a ':' separate field from value, we assume there is no other ':'
-      char * pch;
-      pch = strchr(line, ':');
+      char * pch = strchr(line, ':');
       sscanf(++pch, "%s", m_FidName); // delete any white space left
       itkDebugMacro("fidName was specified");
     }
@@ -376,8 +375,7 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
       // This is a bit tricky to get the value as there is sometime no white
       // space
       // only a ':' separate field from value, we assume there is no other ':'
-      char * pch;
-      pch = strchr(line, ':');
+      char * pch = strchr(line, ':');
       sscanf(++pch, "%s", m_SdtOrient); // delete any white space left
       itkDebugMacro("Orientation was specified");
     }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1264,7 +1264,7 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
       itkExceptionMacro("Cannot read TIFF image as a TIFF RGBA image");
     }
 
-    unsigned char * out = static_cast<unsigned char *>(buffer) + pixelOffset;
+    auto * out = static_cast<unsigned char *>(buffer) + pixelOffset;
     RGBAImageToBuffer<unsigned char>(out, tempImage);
   }
   else

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -219,8 +219,7 @@ LabelGeometryImageFilterTest(std::string labelImageName,
   writer->SetFileName(outputFileName);
   writer->SetInput(&matrix);
   writer->SetColumnHeaders(columnName);
-  MatrixType * matrixPointer;
-  matrixPointer = new MatrixType(matrix.data_block(), numberOfLabels, numberOfColumns);
+  MatrixType * matrixPointer = new MatrixType(matrix.data_block(), numberOfLabels, numberOfColumns);
   writer->SetInput(matrixPointer);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Write());

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
@@ -191,8 +191,7 @@ LinearSystemWrapperDenseVNL::Solve()
 void
 LinearSystemWrapperDenseVNL::SwapMatrices(unsigned int MatrixIndex1, unsigned int MatrixIndex2)
 {
-  vnl_matrix<Float> * tmp;
-  tmp = (*m_Matrices)[MatrixIndex1];
+  vnl_matrix<Float> * tmp = (*m_Matrices)[MatrixIndex1];
   (*m_Matrices)[MatrixIndex1] = (*m_Matrices)[MatrixIndex2];
   (*m_Matrices)[MatrixIndex2] = tmp;
 }
@@ -209,8 +208,7 @@ LinearSystemWrapperDenseVNL::SwapVectors(unsigned int VectorIndex1, unsigned int
 void
 LinearSystemWrapperDenseVNL::SwapSolutions(unsigned int SolutionIndex1, unsigned int SolutionIndex2)
 {
-  vnl_vector<Float> * tmp;
-  tmp = (*m_Solutions)[SolutionIndex1];
+  vnl_vector<Float> * tmp = (*m_Solutions)[SolutionIndex1];
   (*m_Solutions)[SolutionIndex1] = (*m_Solutions)[SolutionIndex2];
   (*m_Solutions)[SolutionIndex2] = tmp;
 }

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
@@ -224,8 +224,7 @@ LinearSystemWrapperVNL::Solve()
 void
 LinearSystemWrapperVNL::SwapMatrices(unsigned int MatrixIndex1, unsigned int MatrixIndex2)
 {
-  vnl_sparse_matrix<Float> * tmp;
-  tmp = (*m_Matrices)[MatrixIndex1];
+  vnl_sparse_matrix<Float> * tmp = (*m_Matrices)[MatrixIndex1];
   (*m_Matrices)[MatrixIndex1] = (*m_Matrices)[MatrixIndex2];
   (*m_Matrices)[MatrixIndex2] = tmp;
 }
@@ -233,8 +232,7 @@ LinearSystemWrapperVNL::SwapMatrices(unsigned int MatrixIndex1, unsigned int Mat
 void
 LinearSystemWrapperVNL::SwapVectors(unsigned int VectorIndex1, unsigned int VectorIndex2)
 {
-  vnl_vector<Float> * tmp;
-  tmp = (*m_Vectors)[VectorIndex1];
+  vnl_vector<Float> * tmp = (*m_Vectors)[VectorIndex1];
   (*m_Vectors)[VectorIndex1] = (*m_Vectors)[VectorIndex2];
   (*m_Vectors)[VectorIndex2] = tmp;
 }
@@ -242,8 +240,7 @@ LinearSystemWrapperVNL::SwapVectors(unsigned int VectorIndex1, unsigned int Vect
 void
 LinearSystemWrapperVNL::SwapSolutions(unsigned int SolutionIndex1, unsigned int SolutionIndex2)
 {
-  vnl_vector<Float> * tmp;
-  tmp = (*m_Solutions)[SolutionIndex1];
+  vnl_vector<Float> * tmp = (*m_Solutions)[SolutionIndex1];
   (*m_Solutions)[SolutionIndex1] = (*m_Solutions)[SolutionIndex2];
   (*m_Solutions)[SolutionIndex2] = tmp;
 }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -112,9 +112,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
 {
   size_t    numOffsets = this->m_Offsets->size();
   size_t    numFeatures = this->m_RequestedFeatures->size();
-  double ** features;
-
-  features = new double *[numOffsets];
+  double ** features = new double *[numOffsets];
   for (size_t i = 0; i < numOffsets; ++i)
   {
     features[i] = new double[numFeatures];

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -112,9 +112,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
 {
   size_t    numOffsets = m_Offsets->size();
   size_t    numFeatures = m_RequestedFeatures->size();
-  double ** features;
-
-  features = new double *[numOffsets];
+  double ** features = new double *[numOffsets];
   for (size_t i = 0; i < numOffsets; ++i)
   {
     features[i] = new double[numFeatures];

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -202,7 +202,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   registrator->UseMovingImageGradientOff();
 
   using FunctionType = RegistrationType::GPUDemonsRegistrationFunctionType;
-  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  auto * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   if (!fptr)
   {
     std::cout << "Invalid demons registration function ptr" << std::endl;

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -202,8 +202,7 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   registrator->UseMovingImageGradientOff();
 
   using FunctionType = RegistrationType::GPUDemonsRegistrationFunctionType;
-  FunctionType * fptr;
-  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   if (!fptr)
   {
     std::cout << "Invalid demons registration function ptr" << std::endl;

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -638,8 +638,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   Superclass::EnlargeOutputRequestedRegion(ptr);
 
   // set the output requested region to largest possible.
-  DisplacementFieldType * outputPtr;
-  outputPtr = dynamic_cast<DisplacementFieldType *>(ptr);
+  DisplacementFieldType * outputPtr = dynamic_cast<DisplacementFieldType *>(ptr);
 
   if (outputPtr)
   {

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -638,7 +638,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   Superclass::EnlargeOutputRequestedRegion(ptr);
 
   // set the output requested region to largest possible.
-  DisplacementFieldType * outputPtr = dynamic_cast<DisplacementFieldType *>(ptr);
+  auto * outputPtr = dynamic_cast<DisplacementFieldType *>(ptr);
 
   if (outputPtr)
   {

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -182,8 +182,7 @@ itkCurvatureRegistrationFilterTest(int, char *[])
 
   std::cout << "\n\n\nPrinting function" << std::endl;
   using FunctionType = RegistrationType::RegistrationFunctionType;
-  FunctionType * fptr;
-  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -182,7 +182,7 @@ itkCurvatureRegistrationFilterTest(int, char *[])
 
   std::cout << "\n\n\nPrinting function" << std::endl;
   using FunctionType = RegistrationType::RegistrationFunctionType;
-  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  auto * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -249,8 +249,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   registrator->InPlaceOn();
 
 
-  FunctionType * fptr;
-  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -249,7 +249,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   registrator->InPlaceOn();
 
 
-  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  auto * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
@@ -154,7 +154,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
   registrator->InPlaceOn();
 
 
-  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  auto * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
@@ -154,8 +154,7 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
   registrator->InPlaceOn();
 
 
-  FunctionType * fptr;
-  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   // exercise other member variables

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -230,7 +230,7 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   ITK_TEST_SET_GET_BOOLEAN(registrator, InPlace, inPlace);
 
   using FunctionType = RegistrationType::DemonsRegistrationFunctionType;
-  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  auto * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   using ProgressType = ShowProgressObject<RegistrationType>;

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -230,8 +230,7 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   ITK_TEST_SET_GET_BOOLEAN(registrator, InPlace, inPlace);
 
   using FunctionType = RegistrationType::DemonsRegistrationFunctionType;
-  FunctionType * fptr;
-  fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
+  FunctionType * fptr = dynamic_cast<FunctionType *>(registrator->GetDifferenceFunction().GetPointer());
   fptr->Print(std::cout);
 
   using ProgressType = ShowProgressObject<RegistrationType>;

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -61,9 +61,7 @@ void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
   // This filter requires all of the output image to be in the buffer
-  TOutputImage * imgData;
-
-  imgData = dynamic_cast<TOutputImage *>(output);
+  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
   imgData->SetRequestedRegionToLargestPossibleRegion();
 }
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -61,7 +61,7 @@ void
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
   // This filter requires all of the output image to be in the buffer
-  TOutputImage * imgData = dynamic_cast<TOutputImage *>(output);
+  auto * imgData = dynamic_cast<TOutputImage *>(output);
   imgData->SetRequestedRegionToLargestPossibleRegion();
 }
 

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -83,7 +83,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::EnlargeOutputRequestedRegion(DataObj
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TLevelSet * imgData = dynamic_cast<TLevelSet *>(output);
+  auto * imgData = dynamic_cast<TLevelSet *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -83,9 +83,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::EnlargeOutputRequestedRegion(DataObj
 {
   // this filter requires the all of the output image to be in
   // the buffer
-  TLevelSet * imgData;
-
-  imgData = dynamic_cast<TLevelSet *>(output);
+  TLevelSet * imgData = dynamic_cast<TLevelSet *>(output);
   if (imgData)
   {
     imgData->SetRequestedRegionToLargestPossibleRegion();

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -107,7 +107,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::EnlargeOutputRequestedRegion(Data
 {
   // this filter requires that all of the output images
   // are in the buffer
-  TClassifiedImage * imgData = dynamic_cast<TClassifiedImage *>(output);
+  auto * imgData = dynamic_cast<TClassifiedImage *>(output);
   imgData->SetRequestedRegionToLargestPossibleRegion();
 }
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -107,9 +107,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::EnlargeOutputRequestedRegion(Data
 {
   // this filter requires that all of the output images
   // are in the buffer
-  TClassifiedImage * imgData;
-
-  imgData = dynamic_cast<TClassifiedImage *>(output);
+  TClassifiedImage * imgData = dynamic_cast<TClassifiedImage *>(output);
   imgData->SetRequestedRegionToLargestPossibleRegion();
 }
 

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
@@ -112,7 +112,7 @@ private:
     checkMatchingTypes<TPixel, OutputPixelType>(outChannels);
 
     // We only change current if it no longer points at in, so this is safe
-    IplImage * current = const_cast<IplImage *>(in);
+    auto * current = const_cast<IplImage *>(in);
 
     bool freeCurrent = false;
     if (inChannels == 3 && outChannels == 1)
@@ -248,7 +248,7 @@ private:
     out->SetSpacing(spacing);
     out->Allocate();
     size_t       lineLength = imgWidth * inChannels * sizeof(TPixel);
-    void *       unpaddedBuffer = reinterpret_cast<void *>(new TPixel[imgHeight * lineLength]);
+    auto *       unpaddedBuffer = reinterpret_cast<void *>(new TPixel[imgHeight * lineLength]);
     unsigned int paddedBufPos = 0;
     unsigned int unpaddedBufPos = 0;
 
@@ -301,7 +301,7 @@ private:
 
       for (int r = 0; r < out->height; ++r)
       {
-        ValueType * ptr = reinterpret_cast<ValueType *>(out->imageData + r * out->widthStep);
+        auto * ptr = reinterpret_cast<ValueType *>(out->imageData + r * out->widthStep);
         for (int c = 0; c < out->width; ++c)
         {
           pixelIndex[0] = c;

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -350,7 +350,7 @@ OpenCVVideoIO::Read(void * buffer)
   this->UpdateReaderProperties();
 
   // Put the frame's buffer into the supplied output buffer
-  void * tempBuffer = reinterpret_cast<void *>(this->m_CVImage->imageData);
+  auto * tempBuffer = reinterpret_cast<void *>(this->m_CVImage->imageData);
   size_t bufferSize = this->m_CVImage->imageSize;
   memcpy(buffer, tempBuffer, bufferSize);
 }

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -104,8 +104,7 @@ itkOpenCVImageBridgeTestTemplatedScalar(char * argv)
             << std::endl;
 
   std::cout << "Test IplImage -> itk::Image..." << std::endl;
-  IplImage * inIpl;
-  inIpl = cvLoadImage(argv, CV_LOAD_IMAGE_ANYDEPTH);
+  IplImage * inIpl = cvLoadImage(argv, CV_LOAD_IMAGE_ANYDEPTH);
   if (!inIpl)
   {
     std::cerr << "Could not load input as IplImage" << std::endl;

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -610,7 +610,7 @@ VideoStream<TFrameType>::Allocate()
                         << ". Call "
                            "InitializeEmptyFrames to prepare the frame buffer correctly.");
     }
-    FrameType * frame = dynamic_cast<FrameType *>(m_DataObjectBuffer->GetBufferContents(i).GetPointer());
+    auto * frame = dynamic_cast<FrameType *>(m_DataObjectBuffer->GetBufferContents(i).GetPointer());
     if (!frame)
     {
       itkExceptionMacro("itk::VideoStream::SetAllLargestPossibleSpatialRegions "

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -264,8 +264,7 @@ TemporalDataObject::CopyInformation(const DataObject * data)
   // Standard call to the superclass' method
   Superclass::CopyInformation(data);
 
-  const TemporalDataObject * temporalData;
-  temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {
@@ -292,9 +291,7 @@ TemporalDataObject::CopyInformation(const DataObject * data)
 void
 TemporalDataObject::Graft(const DataObject * data)
 {
-  const TemporalDataObject * temporalData;
-
-  temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {
@@ -324,9 +321,7 @@ TemporalDataObject::Graft(const DataObject * data)
 void
 TemporalDataObject::SetRequestedRegion(const DataObject * data)
 {
-  const TemporalDataObject * temporalData;
-
-  temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -264,7 +264,7 @@ TemporalDataObject::CopyInformation(const DataObject * data)
   // Standard call to the superclass' method
   Superclass::CopyInformation(data);
 
-  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const auto * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {
@@ -291,7 +291,7 @@ TemporalDataObject::CopyInformation(const DataObject * data)
 void
 TemporalDataObject::Graft(const DataObject * data)
 {
-  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const auto * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {
@@ -321,7 +321,7 @@ TemporalDataObject::Graft(const DataObject * data)
 void
 TemporalDataObject::SetRequestedRegion(const DataObject * data)
 {
-  const TemporalDataObject * temporalData = dynamic_cast<const TemporalDataObject *>(data);
+  const auto * temporalData = dynamic_cast<const TemporalDataObject *>(data);
 
   if (temporalData)
   {


### PR DESCRIPTION
- Follow-up to pull request #4932

----

FYI, those cases of the form `T * p; p = x` were found by using the regular expression `^( [ ]+)([^ ].*\*)([ ]+)(\w+);[\r\n]+\1\4\ = `. It only found one "false positive", as the regular expression accidentally matches with these two lines of code at https://github.com/InsightSoftwareConsortium/ITK/blob/1fbb7e67ad9b4e7335a057d442739cd97b9622dc/Modules/IO/MINC/src/itkMINCImageIO.cxx#L1138-L1139

```cpp
            _start = _start + (_sz - 1) * _sep; 
            _sep = -_sep;  
```

I excluded this accidental case manually.