### PR TITLE
STYLE: Replace `T var; var = x` with `T var = x` for types from `std`

### DIFF
--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -114,8 +114,7 @@ itkLineIteratorTest(int argc, char * argv[])
   endIndex.Fill(189);
   LineIteratorType it(output, startIndex, endIndex);
 
-  std::vector<IndexType>::iterator itBaseline;
-  itBaseline = baselineIndex.begin();
+  std::vector<IndexType>::iterator itBaseline = baselineIndex.begin();
   while (!it.IsAtEnd())
   {
     it.Set(255);

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -443,8 +443,7 @@ GetValidTypename(const std::type_info & intype, const std::vector<std::string> &
 {
   std::string                              typestr = GetTypename(intype);
   bool                                     isValid = false;
-  std::vector<std::string>::const_iterator validPos;
-  validPos = std::find(validtypes.begin(), validtypes.end(), typestr);
+  std::vector<std::string>::const_iterator validPos = std::find(validtypes.begin(), validtypes.end(), typestr);
   if (validPos != validtypes.end())
   {
     isValid = true;

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -207,8 +207,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   }
 
   // Test Row Names
-  std::vector<std::string> test_row_names;
-  test_row_names = dfo->GetRowHeaders();
+  std::vector<std::string> test_row_names = dfo->GetRowHeaders();
 
   std::vector<std::string> row_names;
   row_names.emplace_back("Jan");
@@ -225,8 +224,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   PrintVector(test_row_names);
 
   // Test Column Names
-  std::vector<std::string> test_col_names;
-  test_col_names = dfo->GetColumnHeaders();
+  std::vector<std::string> test_col_names = dfo->GetColumnHeaders();
 
   std::vector<std::string> col_names;
   col_names.emplace_back("Africa");
@@ -244,8 +242,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
 
 
   // Test a row (using index access)
-  std::vector<double> test_row_1;
-  test_row_1 = dfo->GetRow(1);
+  std::vector<double> test_row_1 = dfo->GetRow(1);
 
   std::vector<double> row_1;
   row_1.push_back(99);
@@ -262,8 +259,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   PrintVector(test_row_1);
 
   // Test a row (using string access)
-  std::vector<double> test_row_Jan;
-  test_row_Jan = dfo->GetRow("Jan");
+  std::vector<double> test_row_Jan = dfo->GetRow("Jan");
 
   std::vector<double> row_Jan;
   row_Jan.push_back(nan);
@@ -281,8 +277,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   PrintVector(test_row_Jan);
 
   // Test a column (using index)
-  std::vector<double> test_col_2;
-  test_col_2 = dfo->GetColumn(2);
+  std::vector<double> test_col_2 = dfo->GetColumn(2);
 
   std::vector<double> col_2;
   col_2.push_back(5);
@@ -299,8 +294,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   PrintVector(col_2);
 
   // Test a column (using string access)
-  std::vector<double> test_col_Africa;
-  test_col_Africa = dfo->GetColumn("Africa");
+  std::vector<double> test_col_Africa = dfo->GetColumn("Africa");
 
   std::vector<double> col_Africa;
   col_Africa.push_back(nan);
@@ -319,8 +313,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   // Test a row that does not exist
   try
   {
-    std::vector<double> test_row_Oct;
-    test_row_Oct = dfo->GetRow("Oct");
+    std::vector<double> test_row_Oct = dfo->GetRow("Oct");
     if (!test_row_Oct.empty())
     {
       std::cerr << "Row should be empty! Test Failed!";
@@ -336,8 +329,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   try
   {
     // Test column that does not exist
-    std::vector<double> test_col_Eur;
-    test_col_Eur = dfo->GetColumn("Eur");
+    std::vector<double> test_col_Eur = dfo->GetColumn("Eur");
     if (!test_col_Eur.empty())
     {
       std::cerr << "Column should be empty! Test Failed!";

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -183,8 +183,7 @@ ArchetypeSeriesFileNames::Scan()
     fit->NumericSortOn();
     names = fit->GetFileNames();
 
-    std::vector<std::string>::iterator ait;
-    ait = std::find(names.begin(), names.end(), pathPrefix + unixArchetype);
+    std::vector<std::string>::iterator ait = std::find(names.begin(), names.end(), pathPrefix + unixArchetype);
 
     // Accept the list if it contains the archetype and is not the
     // "trivial" list (containing only the archetype)

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -760,9 +760,7 @@ MINCImageIO::ReadImageInformation()
         {
           mitype_t    att_data_type;
           size_t      att_length;
-          std::string entry_key;
-
-          entry_key = group_name;
+          std::string entry_key = group_name;
           entry_key += ":";
           entry_key += attribute;
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -169,8 +169,7 @@ MakeNiftiImage(const char * filename)
     }
     catch (const itk::ExceptionObject & ex)
     {
-      std::string message;
-      message = "Problem found while writing image ";
+      std::string message = "Problem found while writing image ";
       message += filename;
       message += "\n";
       message += ex.GetLocation();
@@ -359,8 +358,7 @@ TestImageOfSymMats(const std::string & fname)
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while writing image ";
+    std::string message = "Problem found while writing image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();
@@ -379,8 +377,7 @@ TestImageOfSymMats(const std::string & fname)
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while reading image ";
+    std::string message = "Problem found while reading image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -156,8 +156,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while writing image ";
+    std::string message = "Problem found while writing image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();
@@ -176,8 +175,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while reading image ";
+    std::string message = "Problem found while reading image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
@@ -110,8 +110,7 @@ itkNiftiImageIOTest4(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while writing image ";
+    std::string message = "Problem found while writing image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();
@@ -130,8 +129,7 @@ itkNiftiImageIOTest4(int argc, char * argv[])
   }
   catch (const itk::ExceptionObject & ex)
   {
-    std::string message;
-    message = "Problem found while reading image ";
+    std::string message = "Problem found while reading image ";
     message += fname;
     message += "\n";
     message += ex.GetLocation();

--- a/Modules/IO/XML/test/itkDOMTest6.cxx
+++ b/Modules/IO/XML/test/itkDOMTest6.cxx
@@ -328,9 +328,7 @@ testStringToolsWithItkArray()
 void
 testStringToolsForStringOperations()
 {
-  std::string s;
-
-  s = " Hello World! ";
+  std::string s = " Hello World! ";
   if (itk::StringTools::TrimLeft(s) != "Hello World! ")
   {
     throw "testStringToolsForStringOperations: failed trimming left";

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
@@ -65,8 +65,7 @@ itkNarrowBandTest(int, char *[])
   }
 
   // Split the band
-  std::vector<RegionType> regions;
-  regions = band->SplitBand(10);
+  std::vector<RegionType> regions = band->SplitBand(10);
   //  RegionType region;
   using regionitType = std::vector<RegionType>::const_iterator;
   regionitType regionsit = regions.begin();

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -206,9 +206,7 @@ itkScalarImageToCooccurrenceListSampleFilterTest(int, char *[])
   val[1] = 8;
   baselineVectorList.emplace_back(val);
 
-  std::vector<MeasurementVectorType>::const_iterator it;
-
-  it = baselineVectorList.begin();
+  std::vector<MeasurementVectorType>::const_iterator it = baselineVectorList.begin();
 
   while (s_iter != sample->End())
   {


### PR DESCRIPTION
For Standard Library types that have a non-trivial default-constructor and a non-trivial assignment operator, `T var = x` is typically slightly faster than `T var; var = x`. Otherwise it's just a matter of style.

Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+)(std::[^ ]*)([ ]+)(\w+);[\r\n]+\1\4\ =
    Replace with: $1$2$3$4 =
    Filters: itk*.*
    Directory: D:\src\ITK\Modules
    [v] Match case
    (*) Regular expression

- Follow-up to pull request #4932 commit 5b121f493f17d61c52c197b0c5df530fe01c4f8c