### PR TITLE
STYLE: Use `std::abs`, instead of doing `if (x < 0) x = -x` manually

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -329,11 +329,7 @@ FloatAlmostEqual(T                                        x1,
     return false;
   }
 
-  typename Detail::FloatIEEE<T>::IntType ulps = FloatDifferenceULP(x1, x2);
-  if (ulps < 0)
-  {
-    ulps = -ulps;
-  }
+  typename Detail::FloatIEEE<T>::IntType ulps = std::abs(FloatDifferenceULP(x1, x2));
   return ulps <= maxUlps;
 }
 

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -20,6 +20,7 @@
 #include "vnl/algo/vnl_determinant.h"
 
 #include <algorithm> // For copy_n.
+#include <cmath>     // For abs.
 
 namespace itk
 {
@@ -237,12 +238,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType   x,
     denom += static_cast<double>(v21[i] * v21[i]);
   }
 
-  // trying to avoid an expensive fabs
-  double tolerance = 1.e-05 * num;
-  if (tolerance < 0.0)
-  {
-    tolerance = -tolerance;
-  }
+  double tolerance = std::abs(1.e-05 * num);
   if ((-tolerance < denom) && (denom < tolerance)) // numerically bad!
   {
     closestPoint = p1; // arbitrary, point is (numerically) far away

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -24,6 +24,8 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkProgressReporter.h"
 
+#include <cmath> // For abs.
+
 namespace itk
 {
 namespace Testing
@@ -165,12 +167,8 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const Out
         InputPixelType t = valid.Get();
 
         //  Assume a good match - so test center pixel first, for speed
-        RealType difference = static_cast<RealType>(t) - test.GetCenterPixel();
-        if (NumericTraits<RealType>::IsNegative(difference))
-        {
-          difference = -difference;
-        }
-        auto minimumDifference = static_cast<OutputPixelType>(difference);
+        RealType difference = std::abs(static_cast<RealType>(t) - test.GetCenterPixel());
+        auto     minimumDifference = static_cast<OutputPixelType>(difference);
 
         // If center pixel isn't good enough, then test the neighborhood
         if (minimumDifference > m_DifferenceThreshold)
@@ -182,12 +180,8 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const Out
           {
             // Use the RealType for the difference to make sure we get the
             // sign.
-            RealType differenceReal = static_cast<RealType>(t) - test.GetPixel(i);
-            if (NumericTraits<RealType>::IsNegative(differenceReal))
-            {
-              differenceReal = -differenceReal;
-            }
-            auto d = static_cast<OutputPixelType>(differenceReal);
+            RealType differenceReal = std::abs(static_cast<RealType>(t) - test.GetPixel(i));
+            auto     d = static_cast<OutputPixelType>(differenceReal);
             if (d < minimumDifference)
             {
               minimumDifference = d;

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -25,6 +25,8 @@
 #include "itkTotalProgressReporter.h"
 #include "itkStatisticsImageFilter.h"
 
+#include <cmath> // For abs.
+
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
@@ -280,12 +282,8 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       {
         // range distance between neighborhood pixel and neighborhood center
         pixel = static_cast<OutputPixelRealType>(b_iter.GetPixel(i));
-        rangeDistance = pixel - centerPixel;
         // flip sign if needed
-        if (rangeDistance < 0.0)
-        {
-          rangeDistance *= -1.0;
-        }
+        rangeDistance = std::abs(pixel - centerPixel);
 
         // if the range distance is close enough, then use the pixel
         if (rangeDistance < rangeDistanceThreshold)

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkFEMElement2DC0LinearLine.h"
+#include <cmath> // For abs.
 
 namespace itk
 {
@@ -144,13 +145,7 @@ Element2DC0LinearLine::DistanceToLine(const VectorType & x,
   //
   num = p21[0] * (x[0] - p1[0]) + p21[1] * (x[1] - p1[1]) + p21[2] * (x[2] - p1[2]);
   denom = p21[0] * p21[0] + p21[1] * p21[1] + p21[2] * p21[2];
-
-  // trying to avoid an expensive fabs
-  tolerance = 1e-5 * num;
-  if (tolerance < 0.0)
-  {
-    tolerance = -tolerance;
-  }
+  tolerance = std::abs(1e-5 * num);
   if (-tolerance < denom && denom < tolerance) // numerically bad!
   {
     closest = p1; // arbitrary, point is (numerically) far away

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -19,6 +19,7 @@
 #define itkEuclideanDistancePointMetric_hxx
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include <cmath> // For abs.
 
 namespace itk
 {
@@ -89,10 +90,7 @@ EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::Get
         minimumDistance = m_DistanceMap->GetPixel(index);
         // In case the provided distance map was signed,
         // we correct here the distance to take its absolute value.
-        if (minimumDistance < 0.0)
-        {
-          minimumDistance = -minimumDistance;
-        }
+        minimumDistance = std::abs(minimumDistance);
         closestPoint = true;
       }
     }


### PR DESCRIPTION
Aims to make the code clearer. Cases found by regular expressions like ` (\w+) = -\1;` and ` \w+ \*= -1;`

Removed old comments from inside two `DistanceToLine` member functions, saying that they are "trying to avoid an expensive fabs". `std::abs` isn't that expensive anymore nowadays.