### PR TITLE
COMP: Avoid re-init of ostringstream in ThresholdImageFilterTest

### DIFF
--- a/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
@@ -76,7 +76,7 @@ itkThresholdImageFilterTest(int, char *[])
     std::ostringstream os;
     os << "Filter: " << threshold.GetPointer();
     itk::OutputWindowDisplayText(os.str().c_str());
-    os = {};
+    os.str("");
     os << "Output #0: " << threshold->GetOutput(0);
     itk::OutputWindowDisplayText(os.str().c_str());
 
@@ -97,7 +97,7 @@ itkThresholdImageFilterTest(int, char *[])
     std::ostringstream os;
     os << "Filter: " << threshold.GetPointer();
     itk::OutputWindowDisplayText(os.str().c_str());
-    os = {};
+    os.str("");
     os << "Output #0: " << threshold->GetOutput(0);
     itk::OutputWindowDisplayText(os.str().c_str());
 
@@ -120,7 +120,7 @@ itkThresholdImageFilterTest(int, char *[])
     std::ostringstream os;
     os << "Filter: " << threshold.GetPointer();
     itk::OutputWindowDisplayText(os.str().c_str());
-    os = {};
+    os.str("");
     os << "Output #0: " << threshold->GetOutput(0);
     itk::OutputWindowDisplayText(os.str().c_str());
 


### PR DESCRIPTION
This is to work around build failures on Intel macOS:

> Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx:79:8: error: no viable overloaded '='
    os = {};
    ~~ ^ ~~

Also, it is more efficient to clear the std::ostringstream
object using os.str(""); rather than reinitializing it. This avoids
unnecessary reallocation and keeps the code cleaner.
