### PR TITLE
Replace `T var; var = x` with `T var = x` for `Region`, `Index`, and `Size` variables

### DIFF
--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
@@ -63,9 +63,7 @@ template <typename TImage>
 void
 ImageRegionExclusionConstIteratorWithIndex<TImage>::SetExclusionRegionToInsetRegion()
 {
-  RegionType excludeRegion;
-
-  excludeRegion = this->m_Region;
+  RegionType excludeRegion = this->m_Region;
   for (unsigned int i = 0; i < TImage::ImageDimension; ++i)
   {
     if (excludeRegion.GetSize()[i] >= 2)

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -134,8 +134,7 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRe
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -144,8 +144,7 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::G
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -250,8 +250,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType
   }
 
   // first direction
-  typename InternalImageType::IndexType ind;
-  ind = index;
+  typename InternalImageType::IndexType ind = index;
 
   // Define the region of the iterator
   typename InternalImageType::RegionType region;

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -503,10 +503,8 @@ RegressionTestHelper(const char *       testImageFilename,
   }
 
   // The sizes of the baseline and test image must match
-  typename ImageType::SizeType baselineSize;
-  baselineSize = baselineReader->GetOutput()->GetLargestPossibleRegion().GetSize();
-  typename ImageType::SizeType testSize;
-  testSize = testReader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  typename ImageType::SizeType baselineSize = baselineReader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  typename ImageType::SizeType testSize = testReader->GetOutput()->GetLargestPossibleRegion().GetSize();
 
   if (baselineSize != testSize)
   {
@@ -907,8 +905,7 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
   reader->SetFileName(testImageFilename);
   reader->UpdateLargestPossibleRegion();
 
-  ImageType::SizeType size;
-  size = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType size = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
 
   // Get the center slice of the image,  In 3D, the first slice
   // is often a black slice with little debugging information.

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -785,9 +785,7 @@ void
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::Log1PImage(InternalImageType * source,
                                                                                 InternalImageType * target)
 {
-  InternalImageRegionType region;
-
-  region = source->GetRequestedRegion();
+  InternalImageRegionType region = source->GetRequestedRegion();
 
   ImageRegionIterator<InternalImageType> s_iter(source, region);
   ImageRegionIterator<InternalImageType> t_iter(target, region);
@@ -816,9 +814,7 @@ void
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::ExpImage(InternalImageType * source,
                                                                               InternalImageType * target)
 {
-  InternalImageRegionType region;
-
-  region = source->GetLargestPossibleRegion();
+  InternalImageRegionType region = source->GetLargestPossibleRegion();
 
   ImageRegionIterator<InternalImageType> s_iter(source, region);
   ImageRegionIterator<InternalImageType> t_iter(target, region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -59,8 +59,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::GenerateInputRe
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Kernel.GetRadius());

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -377,8 +377,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   InputSizeType &       FFTImageSize)
 {
   typename LocalInputImageType::PixelType constantPixel = 0;
-  typename LocalInputImageType::SizeType  upperPad;
-  upperPad = FFTImageSize - inputImage->GetLargestPossibleRegion().GetSize();
+  typename LocalInputImageType::SizeType  upperPad = FFTImageSize - inputImage->GetLargestPossibleRegion().GetSize();
 
   using PadType = itk::ConstantPadImageFilter<LocalInputImageType, RealImageType>;
   auto padder = PadType::New();

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -62,8 +62,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
 
   // get a copy of the input requested region which was set up by the
   // superclass (NeighborhoodOperatorImageFilter)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // set the mask requested region to match the input requested region
   if (maskPtr->GetLargestPossibleRegion().IsInside(inputRequestedRegion))

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -486,8 +486,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
   for (ImageRegionIteratorWithIndex<WeightsImageType> pwIt(physicalWeightsImage, physicalRegion); !pwIt.IsAtEnd();
        ++pwIt)
   {
-    typename WeightsImageType::IndexType curIndex;
-    curIndex = pwIt.GetIndex();
+    typename WeightsImageType::IndexType curIndex = pwIt.GetIndex();
     // Compute distances of each pixel from center pixel
     Vector<DistanceType, ImageDimension> distanceVector;
     for (unsigned int d = 0; d < ImageDimension; ++d)

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -166,8 +166,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GenerateInputRequeste
 
   // Get a copy of the input requested region (should equal the output
   // requested region)
-  typename InputImageType::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename InputImageType::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
   // Pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(voxelNeighborhoodSize);
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -106,8 +106,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_NeighborhoodRadius);

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -124,9 +124,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
   using InputRegionType = typename InputImageType::RegionType;
   using InputSizeType = typename InputImageType::SizeType;
 
-  InputRegionType region;
-
-  region = inputImage->GetLargestPossibleRegion();
+  InputRegionType region = inputImage->GetLargestPossibleRegion();
 
   InputSizeType size = region.GetSize();
 

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
@@ -47,8 +47,7 @@ GPUNeighborhoodOperatorImageFilter< TInputImage, TOutputImage, TOperatorValueTyp
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius( m_Operator.GetRadius() );

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -92,8 +92,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -49,8 +49,7 @@ DerivativeImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(oper.GetRadius());

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -68,8 +68,7 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateInputR
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
@@ -55,8 +55,7 @@ LaplacianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(oper.GetRadius());

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
@@ -48,8 +48,7 @@ SobelEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequested
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(oper.GetRadius());

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -58,8 +58,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
@@ -64,8 +64,7 @@ BoxImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Radius);

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -62,8 +62,7 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
 
   // get a copy of the input requested region which was set up by the
   // superclass (NeighborhoodOperatorImageFilter)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // set the mask requested region to match the input requested region
   if (maskPtr->GetLargestPossibleRegion().IsInside(inputRequestedRegion))

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -45,8 +45,7 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Operator.GetRadius());

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -44,8 +44,7 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::GenerateInputR
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Operator.GetRadius());

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -64,8 +64,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedR
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by one, which is the value of the first
   // coordinate of the operator radius.

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -99,8 +99,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Genera
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   constexpr auto r1 = MakeFilled<RadiusType>(1);
   // pad the input requested region by the operator radius

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -351,8 +351,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
   typename TOutputImage::Pointer scratchImage;
   scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
-  RegionType scratchRegion;
-  scratchRegion = inputPtr->GetBufferedRegion();
+  RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;
   // scratchImage only needs the 1/2 the space of the original
   // image for the first dimension.
@@ -466,8 +465,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
   typename TOutputImage::Pointer scratchImage;
   scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
-  RegionType scratchRegion;
-  scratchRegion = inputPtr->GetBufferedRegion();
+  RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;
 
   // scratchImage 2 times the space of the original image .

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -554,8 +554,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   // to the IsLinear() call.
   if (!isSpecialCoordinatesImage && transform->GetTransformCategory() == TransformType::TransformCategoryEnum::Linear)
   {
-    typename TInputImage::RegionType inputRequestedRegion;
-    inputRequestedRegion = ImageAlgorithm::EnlargeRegionOverBox(output->GetRequestedRegion(), output, input, transform);
+    typename TInputImage::RegionType inputRequestedRegion =
+      ImageAlgorithm::EnlargeRegionOverBox(output->GetRequestedRegion(), output, input, transform);
 
     const typename TInputImage::RegionType inputLargestRegion(input->GetLargestPossibleRegion());
     if (inputLargestRegion.IsInside(inputRequestedRegion.GetIndex()) ||

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -104,9 +104,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     typename TInputImage::SizeType   inputLargSize;
     typename TInputImage::IndexType  inputLargIndex;
     typename TOutputImage::SizeType  outputSize;
-    typename TOutputImage::IndexType outputIndex;
-
-    outputIndex = this->GetOutput()->GetRequestedRegion().GetIndex();
+    typename TOutputImage::IndexType outputIndex = this->GetOutput()->GetRequestedRegion().GetIndex();
     outputSize = this->GetOutput()->GetRequestedRegion().GetSize();
     inputLargSize = this->GetInput()->GetLargestPossibleRegion().GetSize();
     inputLargIndex = this->GetInput()->GetLargestPossibleRegion().GetIndex();

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -144,9 +144,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateInputReq
     typename TInputImage::SizeType   inputLargSize;
     typename TInputImage::IndexType  inputLargIndex;
     typename TOutputImage::SizeType  outputSize;
-    typename TOutputImage::IndexType outputIndex;
-
-    outputIndex = this->GetOutput()->GetRequestedRegion().GetIndex();
+    typename TOutputImage::IndexType outputIndex = this->GetOutput()->GetRequestedRegion().GetIndex();
     outputSize = this->GetOutput()->GetRequestedRegion().GetSize();
     inputLargSize = this->GetInput()->GetLargestPossibleRegion().GetSize();
     inputLargIndex = this->GetInput()->GetLargestPossibleRegion().GetIndex();

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -168,8 +168,7 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
       {
         // We've hit the start of a run
         SizeValueType length = 0;
-        IndexType     thisIndex;
-        thisIndex = inLineIt.GetIndex();
+        IndexType     thisIndex = inLineIt.GetIndex();
         ++length;
         ++inLineIt;
         while (!inLineIt.IsAtEndOfLine() && inLineIt.Get() == this->m_InputForegroundValue)

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -107,8 +107,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateInputRequ
 
     // get a copy of the marker image requested region (should equal
     // the output requested region)
-    MarkerImageRegionType markerRequestedRegion;
-    markerRequestedRegion = markerPtr->GetRequestedRegion();
+    MarkerImageRegionType markerRequestedRegion = markerPtr->GetRequestedRegion();
 
     // pad the marker requested region by the elementary operator radius
     markerRequestedRegion.PadByRadius(1);

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -107,8 +107,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateInputReque
 
     // get a copy of the marker image requested region (should equal
     // the output requested region)
-    MarkerImageRegionType markerRequestedRegion;
-    markerRequestedRegion = markerPtr->GetRequestedRegion();
+    MarkerImageRegionType markerRequestedRegion = markerPtr->GetRequestedRegion();
 
     // pad the marker requested region by the elementary operator radius
     markerRequestedRegion.PadByRadius(1);

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -106,8 +106,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   using TTempImage = Image<double, NDimensions>;
   auto tempPtr = TTempImage::New();
 
-  typename TTempImage::RegionType tempRegion;
-  tempRegion = inputPtr->GetRequestedRegion();
+  typename TTempImage::RegionType tempRegion = inputPtr->GetRequestedRegion();
 
   tempPtr->SetRegions(tempRegion);
   tempPtr->Allocate();

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -138,8 +138,7 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRe
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -47,8 +47,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequeste
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   RadiusType radius{};

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -162,8 +162,7 @@ MultiphaseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputImage, 
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  FeatureRegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  FeatureRegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(radius);

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -27,9 +27,7 @@ template <typename TVector>
 MahalanobisDistanceMetric<TVector>::MahalanobisDistanceMetric()
 
 {
-  MeasurementVectorSizeType size;
-
-  size = this->GetMeasurementVectorSize();
+  MeasurementVectorSizeType size = this->GetMeasurementVectorSize();
 
   this->m_Covariance.set_size(size, size);
   this->m_InverseCovariance.set_size(size, size);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -190,9 +190,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
       MeasurementType lastBinMax = this->GetOutput()->GetDimensionMaxs(0)[this->GetOutput()->GetSize(0) - 1];
 
       PixelType pixelIntensity(PixelType{});
-      IndexType index;
-
-      index = centerIndex + offset;
+      IndexType index = centerIndex + offset;
       IndexType lastGoodIndex = centerIndex;
       bool      runLengthSegmentAlreadyVisited = false;
 

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -58,8 +58,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Radius);

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -58,8 +58,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
 
   // get a copy of the input requested region (should equal the output
   // requested region)
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion = inputPtr->GetRequestedRegion();
+  typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(m_Radius);

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -108,8 +108,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
         {
           for (t = 1; t >= -1; t = t - 2)
           {
-            IndexType NeighborIndex;
-            NeighborIndex = CurrentPositionIndex;
+            IndexType NeighborIndex = CurrentPositionIndex;
             NeighborIndex[Dimension] += t;
             if (outputImage->GetRequestedRegion().IsInside(NeighborIndex))
             {
@@ -187,8 +186,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
           {
             for (t = -1; t <= 1; t = t + 2)
             {
-              IndexType NeighborIndex;
-              NeighborIndex = SeedIndex;
+              IndexType NeighborIndex = SeedIndex;
               NeighborIndex[Dimension] += t;
               if (outputImage->GetRequestedRegion().IsInside(NeighborIndex))
               {


### PR DESCRIPTION
- Follow-up to pull request #4941