### PR TITLE
ENH: Fix dicom reading slices

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -57,6 +57,7 @@
 #include "gdcmDirectionCosines.h"
 
 #include <fstream>
+#include <itkImageBase.h>
 #include <sstream>
 
 namespace itk
@@ -681,7 +682,12 @@ GDCMImageIO::InternalReadImageInformation()
       const double * sp = image.GetSpacing();
       spacing[0] = sp[0];
       spacing[1] = sp[1];
-      spacing[2] = sp[2];
+      // A 2D dicom slice may not have an explicit interslice provided per
+      // file.  interslice distances can be computed after all slices are read.
+      // set to non-zero value here to avoid prematurely throwing an exception
+      // before the interslice thickness can be computed.
+      const auto abs_spacing_2 = std::abs(sp[2]); // Spacing may be negative at this point, will be fixed below
+      spacing[2] = (abs_spacing_2 < itk::DefaultImageCoordinateTolerance) ? 1.0 : sp[2];
     }
     break;
   }

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -27,6 +27,7 @@
 #include "itkMetaDataObject.h"
 #include <cstddef> // For ptrdiff_t.
 #include <iomanip>
+#include "itkImageBase.h"
 
 namespace itk
 {
@@ -432,9 +433,8 @@ ImageSeriesReader<TOutputImage>::GenerateData()
         SpacingScalarType dirNnorm = dirN.GetNorm();
 
         if (this->m_SpacingDefined &&
-            !Math::AlmostEquals(
-              dirNnorm,
-              outputSpacing[this->m_NumberOfDimensionsInImage])) // either non-uniform sampling or missing slice
+            std::abs(dirNnorm - outputSpacing[this->m_NumberOfDimensionsInImage]) >
+              itk::DefaultImageCoordinateTolerance) // either non-uniform sampling or missing slice
         {
           nonUniformSampling = true;
           spacingDeviation = itk::Math::abs(outputSpacing[this->m_NumberOfDimensionsInImage] - dirNnorm);


### PR DESCRIPTION
Dicom files that do not have explicit "SliceThickness" listed can still be used.  The actual "spacing between slices" is computed from the stack of slices when multiple dicoms are provided such that the initial setting of the "SliceThickness" placeholder is not used.  (NOTE: SliceThickness is used when a single slice is read into a 3D image).

This fixes an issue when a stack of 124 dicom slices does not have "SliceThickness" fields, but does have "ImagePositionPatient" for each slice. 

The previous implementation would throw an exception prior to getting to the code that explicitly computes the slice space from the "ImagePositionPatient" values.

The new code now allows ITK to make 3D nifti volumes that are compatible with those created by the dcm2niix package.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
