### PR TITLE
COMP: Exclude AnatomicalOrientation::FromEnum warning when wrapping

### DIFF
--- a/Modules/Core/Common/include/itkAnatomicalOrientation.h
+++ b/Modules/Core/Common/include/itkAnatomicalOrientation.h
@@ -438,7 +438,7 @@ public:
    *
    * @param legacyOrientation
    */
-#  if defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT)
+#  if defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_WRAPPING)
   [[deprecated("Use the AnatomicalOrientation::FromEnum type instead.")]]
 #  endif
   AnatomicalOrientation(LegacyOrientationType legacyOrientation);


### PR DESCRIPTION
To keep the other legacy options enabled. Closes #4950.
