### PR TITLE
Modernize initialization of local SmartPointer variables

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -214,7 +214,7 @@ template <typename T>
 inline void
 EncapsulateMetaData(MetaDataDictionary & Dictionary, const std::string & key, const T & invalue)
 {
-  typename MetaDataObject<T>::Pointer temp = MetaDataObject<T>::New();
+  auto temp = MetaDataObject<T>::New();
   temp->SetMetaDataObjectValue(invalue);
   Dictionary[key] = temp;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -29,7 +29,7 @@ MetaConverterBase<VDimension>::MetaObjectToSpatialObjectBase(const MetaObjectTyp
 {
   rval->SetId(mo->ID());
   rval->SetParentId(mo->ParentID());
-  typename SpatialObject<VDimension>::TransformType::Pointer    tfm = SpatialObject<VDimension>::TransformType::New();
+  auto                                                          tfm = SpatialObject<VDimension>::TransformType::New();
   typename SpatialObject<VDimension>::TransformType::OffsetType off;
   typename SpatialObject<VDimension>::TransformType::MatrixType mat;
   typename SpatialObject<VDimension>::TransformType::CenterType cen;

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -441,7 +441,7 @@ void
 GetImageType(const char * fileName, itk::IOPixelEnum & pixelType, itk::IOComponentEnum & componentType)
 {
   using ImageType = itk::Image<unsigned char, 3>;
-  itk::ImageFileReader<ImageType>::Pointer imageReader = itk::ImageFileReader<ImageType>::New();
+  auto imageReader = itk::ImageFileReader<ImageType>::New();
   imageReader->SetFileName(fileName);
   imageReader->UpdateOutputInformation();
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
@@ -88,8 +88,7 @@ public:
 protected:
   CurvatureAnisotropicDiffusionImageFilter()
   {
-    typename CurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::Pointer q =
-      CurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
+    auto q = CurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
     this->SetDifferenceFunction(q);
   }
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
@@ -81,8 +81,7 @@ public:
 protected:
   GradientAnisotropicDiffusionImageFilter()
   {
-    typename GradientNDAnisotropicDiffusionFunction<UpdateBufferType>::Pointer p =
-      GradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
+    auto p = GradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
     this->SetDifferenceFunction(p);
   }
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
@@ -100,8 +100,7 @@ public:
 protected:
   VectorCurvatureAnisotropicDiffusionImageFilter()
   {
-    typename VectorCurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::Pointer q =
-      VectorCurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
+    auto q = VectorCurvatureNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
     this->SetDifferenceFunction(q);
   }
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -93,8 +93,7 @@ public:
 protected:
   VectorGradientAnisotropicDiffusionImageFilter()
   {
-    typename VectorGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::Pointer p =
-      VectorGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
+    auto p = VectorGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
     this->SetDifferenceFunction(p);
   }
 

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -93,8 +93,7 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Find the minimum and maximum of the input image and use these values to
   // set m_UpperBinaryValue, m_LowerBinaryValue, and m_IsoSurfaceValue in the
   // parent class.
-  typename itk::MinimumMaximumImageCalculator<InputImageType>::Pointer minmax =
-    itk::MinimumMaximumImageCalculator<InputImageType>::New();
+  auto minmax = itk::MinimumMaximumImageCalculator<InputImageType>::New();
   minmax->SetImage(m_InputImage);
   minmax->ComputeMinimum();
   minmax->ComputeMaximum();

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -625,7 +625,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GenerateDat
   {
     itkDebugMacro("Searching slabs...");
 
-    typename MRASlabIdentifier<InputImageType>::Pointer identifier = MRASlabIdentifier<InputImageType>::New();
+    auto identifier = MRASlabIdentifier<InputImageType>::New();
     // Find slabs
     identifier->SetImage(this->GetInput());
     identifier->SetNumberOfSamples(m_SlabNumberOfSamples);

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -505,7 +505,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateB
   auto & pointDataSTLContainer = fieldPoints->GetPointData()->CastToSTLContainer();
   pointDataSTLContainer.reserve(numberOfIncludedPixels);
 
-  typename BSplineFilterType::WeightsContainerType::Pointer weights = BSplineFilterType::WeightsContainerType::New();
+  auto weights = BSplineFilterType::WeightsContainerType::New();
   weights->Initialize();
   auto & weightSTLContainer = weights->CastToSTLContainer();
   weightSTLContainer.reserve(numberOfIncludedPixels);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -70,11 +70,9 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   }
 
   /** set up erosion and dilation methods */
-  typename BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::Pointer dilate =
-    BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto dilate = BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
 
-  typename BinaryReconstructionByErosionImageFilter<OutputImageType>::Pointer erode =
-    BinaryReconstructionByErosionImageFilter<OutputImageType>::New();
+  auto erode = BinaryReconstructionByErosionImageFilter<OutputImageType>::New();
 
   // create the pipeline without input and output image
   dilate->ReleaseDataFlagOn();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -62,11 +62,9 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   }
 
   /** set up erosion and dilation methods */
-  typename BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::Pointer dilate =
-    BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto dilate = BinaryDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
 
-  typename BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::Pointer erode =
-    BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::New();
+  auto erode = BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::New();
 
   // create the pipeline without input and output image
   dilate->ReleaseDataFlagOn();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -48,11 +48,9 @@ BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   this->AllocateOutputs();
 
   /** set up erosion and dilation methods */
-  typename BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::Pointer dilate =
-    BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::New();
+  auto dilate = BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::New();
 
-  typename BinaryErodeImageFilter<TInputImage, TInputImage, TKernel>::Pointer erode =
-    BinaryErodeImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto erode = BinaryErodeImageFilter<TInputImage, TInputImage, TKernel>::New();
 
   dilate->SetKernel(this->GetKernel());
   dilate->ReleaseDataFlagOn();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -56,8 +56,7 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   this->AllocateOutputs();
 
   /** set up erosion and dilation methods */
-  typename BinaryErodeImageFilter<InputImageType, OutputImageType, TKernel>::Pointer erode =
-    BinaryErodeImageFilter<InputImageType, OutputImageType, TKernel>::New();
+  auto erode = BinaryErodeImageFilter<InputImageType, OutputImageType, TKernel>::New();
   erode->SetForegroundValue(m_ForegroundValue); // Intensity value to erode
   erode->SetBackgroundValue(m_BackgroundValue); // Replacement value of eroded voxels
   erode->SetKernel(this->GetKernel());
@@ -65,8 +64,7 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   erode->ReleaseDataFlagOn();
   erode->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
 
-  typename BinaryReconstructionByDilationImageFilter<OutputImageType>::Pointer dilate =
-    BinaryReconstructionByDilationImageFilter<OutputImageType>::New();
+  auto dilate = BinaryReconstructionByDilationImageFilter<OutputImageType>::New();
   dilate->SetForegroundValue(m_ForegroundValue);
   dilate->SetBackgroundValue(m_BackgroundValue);
   dilate->SetMarkerImage(erode->GetOutput());

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
@@ -28,7 +28,7 @@ BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::BinaryMinMaxCur
 {
   m_Threshold = 0.0;
 
-  typename BinaryMinMaxCurvatureFlowFunctionType::Pointer cffp = BinaryMinMaxCurvatureFlowFunctionType::New();
+  auto cffp = BinaryMinMaxCurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
@@ -28,8 +28,7 @@ BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::BinaryMinMaxCur
 {
   m_Threshold = 0.0;
 
-  typename BinaryMinMaxCurvatureFlowFunctionType::Pointer cffp;
-  cffp = BinaryMinMaxCurvatureFlowFunctionType::New();
+  typename BinaryMinMaxCurvatureFlowFunctionType::Pointer cffp = BinaryMinMaxCurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -29,7 +29,7 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::CurvatureFlowImageFilter()
   this->SetNumberOfIterations(0);
   m_TimeStep = 0.05f;
 
-  typename CurvatureFlowFunctionType::Pointer cffp = CurvatureFlowFunctionType::New();
+  auto cffp = CurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -29,8 +29,7 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::CurvatureFlowImageFilter()
   this->SetNumberOfIterations(0);
   m_TimeStep = 0.05f;
 
-  typename CurvatureFlowFunctionType::Pointer cffp;
-  cffp = CurvatureFlowFunctionType::New();
+  typename CurvatureFlowFunctionType::Pointer cffp = CurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -29,8 +29,7 @@ MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::MinMaxCurvatureFlowIm
 {
   m_StencilRadius = 2;
 
-  typename MinMaxCurvatureFlowFunctionType::Pointer cffp;
-  cffp = MinMaxCurvatureFlowFunctionType::New();
+  typename MinMaxCurvatureFlowFunctionType::Pointer cffp = MinMaxCurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -29,7 +29,7 @@ MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::MinMaxCurvatureFlowIm
 {
   m_StencilRadius = 2;
 
-  typename MinMaxCurvatureFlowFunctionType::Pointer cffp = MinMaxCurvatureFlowFunctionType::New();
+  auto cffp = MinMaxCurvatureFlowFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(cffp.GetPointer()));
 }

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -591,7 +591,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
                                            TTensorPixelType,
                                            TMaskImageType>::SetMaskImage(MaskImageType * maskImage)
 {
-  typename ImageMaskSpatialObject<3>::Pointer maskSpatialObject = ImageMaskSpatialObject<3>::New();
+  auto maskSpatialObject = ImageMaskSpatialObject<3>::New();
   maskSpatialObject->SetImage(maskImage);
   this->SetMaskSpatialObject(maskSpatialObject);
 }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -160,8 +160,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   //
   // cast might not be necessary, but CastImageFilter is optimized for
   // the case where the InputImageType == OutputImageType
-  typename CastImageFilter<TInputImage, RealVectorImageType>::Pointer caster =
-    CastImageFilter<TInputImage, RealVectorImageType>::New();
+  auto caster = CastImageFilter<TInputImage, RealVectorImageType>::New();
   caster->SetInput(this->GetInput());
   caster->Update();
   m_RealValuedInputImage = caster->GetOutput();

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -44,16 +44,14 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField,
   using DefaultVelocityFieldInterpolatorType =
     VectorLinearInterpolateImageFunction<TimeVaryingVelocityFieldType, ScalarType>;
 
-  typename DefaultVelocityFieldInterpolatorType::Pointer velocityFieldInterpolator =
-    DefaultVelocityFieldInterpolatorType::New();
+  auto velocityFieldInterpolator = DefaultVelocityFieldInterpolatorType::New();
 
   this->m_VelocityFieldInterpolator = velocityFieldInterpolator;
 
   using DefaultDisplacementFieldInterpolatorType =
     VectorLinearInterpolateImageFunction<DisplacementFieldType, ScalarType>;
 
-  typename DefaultDisplacementFieldInterpolatorType::Pointer deformationFieldInterpolator =
-    DefaultDisplacementFieldInterpolatorType::New();
+  auto deformationFieldInterpolator = DefaultDisplacementFieldInterpolatorType::New();
 
   this->m_DisplacementFieldInterpolator = deformationFieldInterpolator;
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -118,7 +118,7 @@ public:
   static void
   RegisterOneFactory()
   {
-    FFTImageFilterFactory::Pointer factory = FFTImageFilterFactory::New();
+    auto factory = FFTImageFilterFactory::New();
 
     ObjectFactoryBase::RegisterFactoryInternal(factory);
   }

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
@@ -81,8 +81,7 @@ protected:
   GPUGradientAnisotropicDiffusionImageFilter()
   {
     // Set DiffusionFunction
-    typename GPUGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::Pointer p =
-      GPUGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
+    auto p = GPUGradientNDAnisotropicDiffusionFunction<UpdateBufferType>::New();
     this->SetDifferenceFunction(p);
   }
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
@@ -61,8 +61,7 @@ public:
   static void
   RegisterOneFactory()
   {
-    GPUGradientAnisotropicDiffusionImageFilterFactory::Pointer factory =
-      GPUGradientAnisotropicDiffusionImageFilterFactory::New();
+    auto factory = GPUGradientAnisotropicDiffusionImageFilterFactory::New();
 
     itk::ObjectFactoryBase::RegisterFactory(factory);
   }

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -199,7 +199,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   localInput->Graft(this->GetInput());
 
   // First, determine the min and max intensity range
-  typename StatisticsImageFilter<TInputImage>::Pointer statistics = StatisticsImageFilter<TInputImage>::New();
+  auto statistics = StatisticsImageFilter<TInputImage>::New();
 
   statistics->SetInput(localInput);
   statistics->Update();

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -202,8 +202,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->Graft(this->GetOutput());
   this->m_OutputImage = output;
 
-  typename ZeroCrossingImageFilter<TOutputImage, TOutputImage>::Pointer zeroCrossFilter =
-    ZeroCrossingImageFilter<TOutputImage, TOutputImage>::New();
+  auto zeroCrossFilter = ZeroCrossingImageFilter<TOutputImage, TOutputImage>::New();
 
   this->AllocateUpdateBuffer();
 

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -106,8 +106,7 @@ DerivativeImageFilter<TInputImage, TOutputImage>::GenerateData()
     }
   }
 
-  typename NeighborhoodOperatorImageFilter<InputImageType, OutputImageType, OperatorValueType>::Pointer filter =
-    NeighborhoodOperatorImageFilter<InputImageType, OutputImageType, OperatorValueType>::New();
+  auto filter = NeighborhoodOperatorImageFilter<InputImageType, OutputImageType, OperatorValueType>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -51,8 +51,7 @@ LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Calculate the needed input image statistics
 
-  typename StatisticsImageFilter<InputImageType>::Pointer inputCalculator =
-    StatisticsImageFilter<InputImageType>::New();
+  auto inputCalculator = StatisticsImageFilter<InputImageType>::New();
 
   inputCalculator->SetInput(localInput);
   inputCalculator->Update();
@@ -129,8 +128,7 @@ LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
   binaryFilter->Update();
 
   // Calculate needed combined image statistics
-  typename StatisticsImageFilter<RealImageType>::Pointer enhancedCalculator =
-    StatisticsImageFilter<RealImageType>::New();
+  auto enhancedCalculator = StatisticsImageFilter<RealImageType>::New();
 
   enhancedCalculator->SetInput(binaryFilter->GetOutput());
   enhancedCalculator->Update();

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
@@ -43,12 +43,9 @@ ZeroCrossingBasedEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateDa
   typename InputImageType::ConstPointer input = this->GetInput();
 
   // Create the filters that are needed
-  typename DiscreteGaussianImageFilter<TInputImage, TOutputImage>::Pointer gaussianFilter =
-    DiscreteGaussianImageFilter<TInputImage, TOutputImage>::New();
-  typename LaplacianImageFilter<TInputImage, TOutputImage>::Pointer laplacianFilter =
-    LaplacianImageFilter<TInputImage, TOutputImage>::New();
-  typename ZeroCrossingImageFilter<TInputImage, TOutputImage>::Pointer zerocrossingFilter =
-    ZeroCrossingImageFilter<TInputImage, TOutputImage>::New();
+  auto gaussianFilter = DiscreteGaussianImageFilter<TInputImage, TOutputImage>::New();
+  auto laplacianFilter = LaplacianImageFilter<TInputImage, TOutputImage>::New();
+  auto zerocrossingFilter = ZeroCrossingImageFilter<TInputImage, TOutputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -176,8 +176,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Before
   //
   // cast might not be necessary, but CastImageFilter is optimized for
   // the case where the InputImageType == OutputImageType
-  typename CastImageFilter<TInputImage, RealVectorImageType>::Pointer caster =
-    CastImageFilter<TInputImage, RealVectorImageType>::New();
+  auto caster = CastImageFilter<TInputImage, RealVectorImageType>::New();
   caster->SetInput(this->GetInput());
   caster->GetOutput()->SetRequestedRegion(this->GetInput()->GetRequestedRegion());
   caster->Update();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -348,7 +348,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
-  typename TOutputImage::Pointer scratchImage = TOutputImage::New();
+  auto scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;
@@ -461,7 +461,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
-  typename TOutputImage::Pointer scratchImage = TOutputImage::New();
+  auto scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -348,8 +348,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
-  typename TOutputImage::Pointer scratchImage;
-  scratchImage = TOutputImage::New();
+  typename TOutputImage::Pointer scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;
@@ -462,8 +461,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
-  typename TOutputImage::Pointer scratchImage;
-  scratchImage = TOutputImage::New();
+  typename TOutputImage::Pointer scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
   currentSize = startSize;

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -83,8 +83,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     if (it.Get().m_ImageNumber >= 0)
     {
-      typename PasteImageFilter<TOutputImage, TempImageType>::Pointer paste =
-        PasteImageFilter<TOutputImage, TempImageType>::New();
+      auto paste = PasteImageFilter<TOutputImage, TempImageType>::New();
       paste->SetDestinationImage(output);
       paste->InPlaceOn();
 

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -399,7 +399,7 @@ protected:
     using PretendIndexType = typename PretendImageType::RegionType::IndexType;
     using LineNeighborhoodType = ConstShapedNeighborhoodIterator<PretendImageType>;
 
-    typename PretendImageType::Pointer fakeImage = PretendImageType::New();
+    auto fakeImage = PretendImageType::New();
 
     typename PretendImageType::RegionType LineRegion;
 

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -399,8 +399,7 @@ protected:
     using PretendIndexType = typename PretendImageType::RegionType::IndexType;
     using LineNeighborhoodType = ConstShapedNeighborhoodIterator<PretendImageType>;
 
-    typename PretendImageType::Pointer fakeImage;
-    fakeImage = PretendImageType::New();
+    typename PretendImageType::Pointer fakeImage = PretendImageType::New();
 
     typename PretendImageType::RegionType LineRegion;
 

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -51,8 +51,8 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDat
   {
     indSeed += outputRegionForThread.GetIndex(d);
   }
-  typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
-  const uint32_t                                       seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
+  auto           randn = Statistics::NormalVariateGenerator::New();
+  const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   // Convert the seed bit for bit to int32_t
   randn->Initialize(bit_cast<int32_t>(seed));
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -49,8 +49,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   {
     indSeed += outputRegionForThread.GetIndex(d);
   }
-  typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer rand =
-    Statistics::MersenneTwisterRandomVariateGenerator::New();
+  auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   rand->Initialize(seed);
 

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -50,11 +50,10 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   {
     indSeed += outputRegionForThread.GetIndex(d);
   }
-  typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer rand =
-    Statistics::MersenneTwisterRandomVariateGenerator::New();
+  auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   rand->Initialize(seed);
-  typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
+  auto randn = Statistics::NormalVariateGenerator::New();
   randn->Initialize(bit_cast<int32_t>(seed));
 
   // Define the portion of the input to walk for this thread, using

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -49,8 +49,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   {
     indSeed += outputRegionForThread.GetIndex(d);
   }
-  typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer rand =
-    Statistics::MersenneTwisterRandomVariateGenerator::New();
+  auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
   rand->Initialize(seed);
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
@@ -62,8 +62,7 @@ BlackTopHatImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   }
 
   // Need to subtract the input from the closed image
-  typename SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::Pointer subtract =
-    SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
+  auto subtract = SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
 
   subtract->SetInput1(close->GetOutput());
   subtract->SetInput2(this->GetInput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -68,8 +68,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
   this->AllocateOutputs();
 
   // Delegate to a dilate filter.
-  typename GrayscaleDilateImageFilter<TInputImage, TInputImage, TKernel>::Pointer dilate =
-    GrayscaleDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto dilate = GrayscaleDilateImageFilter<TInputImage, TInputImage, TKernel>::New();
 
   dilate->SetInput(this->GetInput());
   dilate->SetKernel(this->m_Kernel);
@@ -77,8 +76,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
   progress->RegisterInternalFilter(dilate, .5);
 
   // Delegate to a dilate filter.
-  typename ReconstructionByErosionImageFilter<TInputImage, TInputImage>::Pointer erode =
-    ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
+  auto erode = ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
 
   erode->SetMarkerImage(dilate->GetOutput());
   erode->SetMaskImage(this->GetInput());
@@ -114,8 +112,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
       ++inputIt;
     }
 
-    typename ReconstructionByErosionImageFilter<TInputImage, TInputImage>::Pointer erodeAgain =
-      ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
+    auto erodeAgain = ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
     erodeAgain->SetMaskImage(this->GetInput());
     erodeAgain->SetMarkerImage(tempImage);
     erodeAgain->SetFullyConnected(m_FullyConnected);

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -73,8 +73,7 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GenerateData()
   //
 
   // compute the minimum pixel value in the input
-  typename MinimumMaximumImageCalculator<TInputImage>::Pointer calculator =
-    MinimumMaximumImageCalculator<TInputImage>::New();
+  auto calculator = MinimumMaximumImageCalculator<TInputImage>::New();
   calculator->SetImage(inputImage);
   calculator->ComputeMaximum();
 
@@ -109,8 +108,7 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic dilation filter.
   //
   //
-  typename ReconstructionByErosionImageFilter<TInputImage, TInputImage>::Pointer erode =
-    ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
+  auto erode = ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -73,8 +73,7 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
   //
 
   // compute the minimum pixel value in the input
-  typename MinimumMaximumImageCalculator<TInputImage>::Pointer calculator =
-    MinimumMaximumImageCalculator<TInputImage>::New();
+  auto calculator = MinimumMaximumImageCalculator<TInputImage>::New();
   calculator->SetImage(inputImage);
   calculator->ComputeMinimum();
 
@@ -108,8 +107,7 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic dilation filter.
   //
   //
-  typename ReconstructionByDilationImageFilter<TInputImage, TInputImage>::Pointer dilate =
-    ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
+  auto dilate = ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -70,8 +70,7 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::GenerateData()
   //
 
   // compute the maximum pixel value in the input
-  typename MinimumMaximumImageCalculator<TInputImage>::Pointer calculator =
-    MinimumMaximumImageCalculator<TInputImage>::New();
+  auto calculator = MinimumMaximumImageCalculator<TInputImage>::New();
   calculator->SetImage(this->GetInput());
   calculator->ComputeMaximum();
 
@@ -110,8 +109,7 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic erosion filter.
   //
   //
-  typename ReconstructionByErosionImageFilter<TInputImage, TInputImage>::Pointer erode =
-    ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
+  auto erode = ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -179,8 +179,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateData()
   // separately. For efficiency, we will delegate to an instance that
   // is templated over <TInputImage, TInputImage> to avoid any
   // pixelwise casting until the final output image is configured.
-  typename GrayscaleGeodesicDilateImageFilter<TInputImage, TInputImage>::Pointer singleIteration =
-    GrayscaleGeodesicDilateImageFilter<TInputImage, TInputImage>::New();
+  auto singleIteration = GrayscaleGeodesicDilateImageFilter<TInputImage, TInputImage>::New();
   bool done = false;
 
   // set up the singleIteration filter. we are not using the grafting

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -179,8 +179,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateData()
   // separately. For efficiency, we will delegate to an instance that
   // is templated over <TInputImage, TInputImage> to avoid any
   // pixelwise casting until the final output image is configured.
-  typename GrayscaleGeodesicErodeImageFilter<TInputImage, TInputImage>::Pointer singleIteration =
-    GrayscaleGeodesicErodeImageFilter<TInputImage, TInputImage>::New();
+  auto singleIteration = GrayscaleGeodesicErodeImageFilter<TInputImage, TInputImage>::New();
   bool done = false;
 
   // set up the singleIteration filter. we are not using the grafting

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -80,8 +80,7 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::GenerateData()
   //
 
   // compute the minimum pixel value in the input
-  typename MinimumMaximumImageCalculator<TInputImage>::Pointer calculator =
-    MinimumMaximumImageCalculator<TInputImage>::New();
+  auto calculator = MinimumMaximumImageCalculator<TInputImage>::New();
   calculator->SetImage(this->GetInput());
   calculator->ComputeMinimum();
 
@@ -120,8 +119,7 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic dilation filter.
   //
   //
-  typename ReconstructionByDilationImageFilter<TInputImage, TInputImage>::Pointer dilate =
-    ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
+  auto dilate = ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -66,16 +66,14 @@ HConcaveImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a H-Minima filter.
   //
   //
-  typename HMinimaImageFilter<TInputImage, TInputImage>::Pointer hmin =
-    HMinimaImageFilter<TInputImage, TInputImage>::New();
+  auto hmin = HMinimaImageFilter<TInputImage, TInputImage>::New();
 
   hmin->SetInput(this->GetInput());
   hmin->SetHeight(m_Height);
   hmin->SetFullyConnected(m_FullyConnected);
 
   // Need to subtract the input from the H-Minima image
-  typename SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::Pointer subtract =
-    SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
+  auto subtract = SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
 
   subtract->SetInput1(hmin->GetOutput());
   subtract->SetInput2(this->GetInput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -67,16 +67,14 @@ HConvexImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a H-Maxima filter.
   //
   //
-  typename HMaximaImageFilter<TInputImage, TInputImage>::Pointer hmax =
-    HMaximaImageFilter<TInputImage, TInputImage>::New();
+  auto hmax = HMaximaImageFilter<TInputImage, TInputImage>::New();
 
   hmax->SetInput(this->GetInput());
   hmax->SetHeight(m_Height);
   hmax->SetFullyConnected(m_FullyConnected);
 
   // Need to subtract the H-Maxima image from the input
-  typename SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::Pointer subtract =
-    SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
+  auto subtract = SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
 
   subtract->SetInput1(this->GetInput());
   subtract->SetInput2(hmax->GetOutput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -72,8 +72,7 @@ HMaximaImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic dilation filter.
   //
   //
-  typename ReconstructionByDilationImageFilter<TInputImage, TInputImage>::Pointer dilate =
-    ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
+  auto dilate = ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();
@@ -87,7 +86,7 @@ HMaximaImageFilter<TInputImage, TOutputImage>::GenerateData()
   dilate->SetFullyConnected(m_FullyConnected);
 
   // Must cast to the output type
-  typename CastImageFilter<TInputImage, TOutputImage>::Pointer cast = CastImageFilter<TInputImage, TOutputImage>::New();
+  auto cast = CastImageFilter<TInputImage, TOutputImage>::New();
   cast->SetInput(dilate->GetOutput());
   cast->InPlaceOn();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -72,8 +72,7 @@ HMinimaImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Delegate to a geodesic erosion filter.
   //
   //
-  typename ReconstructionByErosionImageFilter<TInputImage, TInputImage>::Pointer erode =
-    ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
+  auto erode = ReconstructionByErosionImageFilter<TInputImage, TInputImage>::New();
 
   // Create a process accumulator for tracking the progress of this minipipeline
   auto progress = ProgressAccumulator::New();
@@ -87,7 +86,7 @@ HMinimaImageFilter<TInputImage, TOutputImage>::GenerateData()
   erode->SetFullyConnected(m_FullyConnected);
 
   // Must cast to the output type
-  typename CastImageFilter<TInputImage, TOutputImage>::Pointer cast = CastImageFilter<TInputImage, TOutputImage>::New();
+  auto cast = CastImageFilter<TInputImage, TOutputImage>::New();
   cast->SetInput(erode->GetOutput());
   cast->InPlaceOn();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -69,15 +69,13 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
   this->AllocateOutputs();
 
   // Delegate to an erode filter.
-  typename GrayscaleErodeImageFilter<TInputImage, TInputImage, TKernel>::Pointer erode =
-    GrayscaleErodeImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto erode = GrayscaleErodeImageFilter<TInputImage, TInputImage, TKernel>::New();
 
   erode->SetInput(this->GetInput());
   erode->SetKernel(this->m_Kernel);
 
   // Delegate to a dilate filter.
-  typename ReconstructionByDilationImageFilter<TInputImage, TInputImage>::Pointer dilate =
-    ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
+  auto dilate = ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
 
   dilate->SetMarkerImage(erode->GetOutput());
   dilate->SetMaskImage(this->GetInput());
@@ -115,8 +113,7 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
       ++inputIt;
     }
 
-    typename ReconstructionByDilationImageFilter<TInputImage, TInputImage>::Pointer dilateAgain =
-      ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
+    auto dilateAgain = ReconstructionByDilationImageFilter<TInputImage, TInputImage>::New();
     dilateAgain->SetMaskImage(this->GetInput());
     dilateAgain->SetMarkerImage(tempImage);
     dilateAgain->SetFullyConnected(m_FullyConnected);

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -76,8 +76,7 @@ RegionalMaximaImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageType *      output = this->GetOutput();
 
   // Delegate to the valued filter to find the minima
-  typename ValuedRegionalMaximaImageFilter<TInputImage, TInputImage>::Pointer regionalMax =
-    ValuedRegionalMaximaImageFilter<TInputImage, TInputImage>::New();
+  auto regionalMax = ValuedRegionalMaximaImageFilter<TInputImage, TInputImage>::New();
   regionalMax->SetInput(input);
   regionalMax->SetFullyConnected(m_FullyConnected);
   progress->RegisterInternalFilter(regionalMax, 0.67f);

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -77,8 +77,7 @@ RegionalMinimaImageFilter<TInputImage, TOutputImage>::GenerateData()
   OutputImageType *      output = this->GetOutput();
 
   // Delegate to the valued filter to find the minima
-  typename ValuedRegionalMinimaImageFilter<TInputImage, TInputImage>::Pointer regionalMin =
-    ValuedRegionalMinimaImageFilter<TInputImage, TInputImage>::New();
+  auto regionalMin = ValuedRegionalMinimaImageFilter<TInputImage, TInputImage>::New();
   regionalMin->SetInput(input);
   regionalMin->SetFullyConnected(m_FullyConnected);
   progress->RegisterInternalFilter(regionalMin, 0.67f);

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
@@ -46,8 +46,7 @@ WhiteTopHatImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   this->AllocateOutputs();
 
   // Delegate to an opening filter.
-  typename GrayscaleMorphologicalOpeningImageFilter<TInputImage, TInputImage, TKernel>::Pointer open =
-    GrayscaleMorphologicalOpeningImageFilter<TInputImage, TInputImage, TKernel>::New();
+  auto open = GrayscaleMorphologicalOpeningImageFilter<TInputImage, TInputImage, TKernel>::New();
 
   open->SetInput(this->GetInput());
   open->SetKernel(this->GetKernel());
@@ -62,8 +61,7 @@ WhiteTopHatImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   }
 
   // Need to subtract the opened image from the input
-  typename SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::Pointer subtract =
-    SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
+  auto subtract = SubtractImageFilter<TInputImage, TInputImage, TOutputImage>::New();
 
   subtract->SetInput1(this->GetInput());
   subtract->SetInput2(open->GetOutput());

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -118,7 +118,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateKernelImage()
     using KernelSizeType = typename GaussianImageSourceType::SizeType;
     using KernelMeanType = typename GaussianImageSourceType::ArrayType;
 
-    typename GaussianImageSourceType::Pointer kernelSource = GaussianImageSourceType::New();
+    auto kernelSource = GaussianImageSourceType::New();
 
     auto inputSpacing = this->GetInput()->GetSpacing();
     auto inputOrigin = this->GetInput()->GetOrigin();

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilterFactory.h
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilterFactory.h
@@ -72,7 +72,7 @@ public:
   static void
   RegisterOneFactory()
   {
-    FFTDiscreteGaussianImageFilterFactory::Pointer factory = FFTDiscreteGaussianImageFilterFactory::New();
+    auto factory = FFTDiscreteGaussianImageFilterFactory::New();
 
     ObjectFactoryBase::RegisterFactoryInternal(factory);
   }

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
@@ -49,8 +49,7 @@ KappaSigmaThresholdImageFilter<TInputImage, TMaskImage, TOutputImage>::GenerateD
 
   m_Threshold = thresholdImageCalculator->GetOutput();
 
-  typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::Pointer threshold =
-    BinaryThresholdImageFilter<TInputImage, TOutputImage>::New();
+  auto threshold = BinaryThresholdImageFilter<TInputImage, TOutputImage>::New();
 
   progress->RegisterInternalFilter(threshold, .5f);
   threshold->GraftOutput(this->GetOutput());

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -54,8 +54,7 @@ OtsuMultipleThresholdsImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   m_Thresholds = otsuHistogramThresholdCalculator->GetOutput();
 
-  typename ThresholdLabelerImageFilter<TInputImage, TOutputImage>::Pointer threshold =
-    ThresholdLabelerImageFilter<TInputImage, TOutputImage>::New();
+  auto threshold = ThresholdLabelerImageFilter<TInputImage, TOutputImage>::New();
 
   progress->RegisterInternalFilter(threshold, 1.0f);
   threshold->GraftOutput(this->GetOutput());

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -189,7 +189,7 @@ IPLCommonImageIO::ReadImageInformation()
   {
     *lastslash = '\0';
   }
-  itk::Directory::Pointer Dir = itk::Directory::New();
+  auto Dir = itk::Directory::New();
   if (Dir->Load(imagePath) == 0)
   {
     RAISE_EXCEPTION();

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -176,7 +176,7 @@ ArchetypeSeriesFileNames::Scan()
   StringVectorType::const_iterator regExpFileNameVectorItr = regExpFileNameVector.begin();
   while (regExpFileNameVectorItr != regExpFileNameVector.end())
   {
-    itk::RegularExpressionSeriesFileNames::Pointer fit = itk::RegularExpressionSeriesFileNames::New();
+    auto fit = itk::RegularExpressionSeriesFileNames::New();
     fit->SetDirectory(fileNamePath.c_str());
     fit->SetRegularExpression(regExpFileNameVectorItr->c_str());
     fit->SetSubMatch(1);

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -584,15 +584,13 @@ PhilipsRECImageIO::ReadImageInformation()
   }
 
   // Get rescale values associated with each scanning sequence.
-  ScanningSequenceImageTypeRescaleValuesContainerType::Pointer scanningSequenceImageTypeRescaleVector =
-    ScanningSequenceImageTypeRescaleValuesContainerType::New();
+  auto scanningSequenceImageTypeRescaleVector = ScanningSequenceImageTypeRescaleValuesContainerType::New();
   scanningSequenceImageTypeRescaleVector->clear();
   // Must match number of scanning sequences.
   scanningSequenceImageTypeRescaleVector->resize(par.num_scanning_sequences);
   for (int scanIndex = 0; scanIndex < par.num_scanning_sequences; ++scanIndex)
   {
-    ImageTypeRescaleValuesContainerType::Pointer imageTypeRescaleValuesVector =
-      ImageTypeRescaleValuesContainerType::New();
+    auto imageTypeRescaleValuesVector = ImageTypeRescaleValuesContainerType::New();
     if (!philipsPAR->GetRECRescaleValues(
           HeaderFileName, imageTypeRescaleValuesVector, par.scanning_sequences[scanIndex]))
     {

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -92,8 +92,7 @@ TxtTransformIOTemplate<TParametersValueType>::ReadComponentFile(std::string Valu
   std::string filePath = itksys::SystemTools::GetFilenamePath(this->GetFileName()) + "/";
 
   /* Use TransformFileReader to read each component file. */
-  typename TransformFileReaderTemplate<TParametersValueType>::Pointer reader =
-    TransformFileReaderTemplate<TParametersValueType>::New();
+  auto        reader = TransformFileReaderTemplate<TParametersValueType>::New();
   std::string componentFullPath = filePath + Value;
   reader->SetFileName(componentFullPath);
   try

--- a/Modules/IO/XML/include/itkDOMNodeXMLReader.h
+++ b/Modules/IO/XML/include/itkDOMNodeXMLReader.h
@@ -180,7 +180,7 @@ private:
 inline std::istream &
 operator>>(std::istream & is, itk::DOMNode & object)
 {
-  itk::DOMNodeXMLReader::Pointer reader = itk::DOMNodeXMLReader::New();
+  auto reader = itk::DOMNodeXMLReader::New();
   reader->SetDOMNodeXML(&object);
   reader->Update(is);
   return is;

--- a/Modules/IO/XML/include/itkDOMNodeXMLWriter.h
+++ b/Modules/IO/XML/include/itkDOMNodeXMLWriter.h
@@ -121,7 +121,7 @@ private:
 inline std::ostream &
 operator<<(std::ostream & os, const itk::DOMNode & object)
 {
-  itk::DOMNodeXMLWriter::Pointer writer = itk::DOMNodeXMLWriter::New();
+  auto writer = itk::DOMNodeXMLWriter::New();
   writer->SetInput(&object);
   writer->Update(os);
   return os;

--- a/Modules/IO/XML/include/itkDOMReader.h
+++ b/Modules/IO/XML/include/itkDOMReader.h
@@ -49,7 +49,7 @@ namespace itk
    \code
        itk::MyObjectType::Pointer output_object;
        const char* input_xml_file_name = ...
-       itk::MyObjectDOMReader::Pointer reader = itk::MyObjectDOMReader::New();
+       auto reader = itk::MyObjectDOMReader::New();
        reader->SetFileName( input_xml_file_name );
        reader->Update();
        output_object = reader->GetOutput();

--- a/Modules/IO/XML/include/itkDOMWriter.h
+++ b/Modules/IO/XML/include/itkDOMWriter.h
@@ -51,7 +51,7 @@ namespace itk
    \code
        itk::MyObjectType::Pointer input_object = ...
        const char* output_xml_file_name = ...
-       itk::MyObjectDOMWriter::Pointer writer = itk::MyObjectDOMWriter::New();
+       auto writer = itk::MyObjectDOMWriter::New();
        writer->SetInput( input_object );
        writer->SetFileName( output_xml_file_name );
        writer->Update();

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
@@ -49,8 +49,7 @@ RobustAutomaticThresholdImageFilter<TInputImage, TGradientImage, TOutputImage>::
 
   m_Threshold = thresholdCalculator->GetOutput();
 
-  typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::Pointer threshold =
-    BinaryThresholdImageFilter<TInputImage, TOutputImage>::New();
+  auto threshold = BinaryThresholdImageFilter<TInputImage, TOutputImage>::New();
 
   progress->RegisterInternalFilter(threshold, 1);
   threshold->GraftOutput(this->GetOutput());

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -129,7 +129,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
     {
       itkExceptionMacro("dynamic_cast failed.");
     }
-    fem::MaterialLinearElasticity::Pointer m = fem::MaterialLinearElasticity::New();
+    auto m = fem::MaterialLinearElasticity::New();
     m->SetGlobalNumber(mCopy->GetGlobalNumber());
     m->SetYoungsModulus(mCopy->GetYoungsModulus());
     m->SetPoissonsRatio(mCopy->GetPoissonsRatio());
@@ -180,7 +180,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
       {
         itkExceptionMacro("dynamic_cast failed.");
       }
-      fem::LoadNode::Pointer o1 = fem::LoadNode::New();
+      auto o1 = fem::LoadNode::New();
 
       o1->SetGlobalNumber(lCopy->GetGlobalNumber());
 
@@ -205,7 +205,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
         itkExceptionMacro("dynamic_cast failed.");
       }
 
-      fem::LoadBC::Pointer o1 = fem::LoadBC::New();
+      auto o1 = fem::LoadBC::New();
 
       o1->SetGlobalNumber(lCopy->GetGlobalNumber());
 
@@ -230,7 +230,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
         itkExceptionMacro("dynamic_cast failed.");
       }
 
-      fem::LoadBCMFC::Pointer o1 = fem::LoadBCMFC::New();
+      auto o1 = fem::LoadBCMFC::New();
       o1->SetGlobalNumber(lCopy->GetGlobalNumber());
 
       int   NumLHS;
@@ -268,7 +268,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
         itkExceptionMacro("dynamic_cast failed.");
       }
 
-      fem::LoadEdge::Pointer o1 = fem::LoadEdge::New();
+      auto o1 = fem::LoadEdge::New();
 
       o1->SetGlobalNumber(lCopy->GetGlobalNumber());
 
@@ -304,7 +304,7 @@ FEMObject<VDimension>::DeepCopy(FEMObject * Copy)
         itkExceptionMacro("dynamic_cast failed.");
       }
 
-      fem::LoadGravConst::Pointer o1 = fem::LoadGravConst::New();
+      auto o1 = fem::LoadGravConst::New();
 
       o1->SetGlobalNumber(lCopy->GetGlobalNumber());
       for (auto & i : lCopy->GetElementArray())

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -68,7 +68,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
 
     // create a new object of the correct class
     // a = FEMOF::Create(clID);
-    fem::Element::Node::Pointer o1 = fem::Element::Node::New();
+    auto o1 = fem::Element::Node::New();
     o1->SetGlobalNumber(node->m_GN);
     fem::Element::VectorType pt(node->m_Dim);
     for (unsigned int i = 0; i < node->m_Dim; ++i)
@@ -93,7 +93,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
   {
     FEMObjectMaterial * material = (*it_material);
 
-    fem::MaterialLinearElasticity::Pointer o1 = fem::MaterialLinearElasticity::New();
+    auto o1 = fem::MaterialLinearElasticity::New();
     o1->SetGlobalNumber(material->m_GN);
     o1->SetYoungsModulus(material->E); /* Young modulus */
     o1->SetPoissonsRatio(material->nu);
@@ -142,7 +142,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     std::string loadname(load->m_LoadName);
     if (loadname == "LoadNode")
     {
-      fem::LoadNode::Pointer o1 = fem::LoadNode::New();
+      auto o1 = fem::LoadNode::New();
       o1->SetGlobalNumber(load->m_GN);
 
       o1->SetElement(myFEMObject->GetElementWithGlobalNumber(load->m_ElementGN));
@@ -160,7 +160,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     else if (loadname == "LoadBC")
     {
-      fem::LoadBC::Pointer o1 = fem::LoadBC::New();
+      auto o1 = fem::LoadBC::New();
       o1->SetGlobalNumber(load->m_GN);
 
       o1->SetDegreeOfFreedom(load->m_DOF);
@@ -178,7 +178,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     else if (loadname == "LoadBCMFC")
     {
-      fem::LoadBCMFC::Pointer o1 = fem::LoadBCMFC::New();
+      auto o1 = fem::LoadBCMFC::New();
       o1->SetGlobalNumber(load->m_GN);
 
       int   NumLHS;
@@ -211,7 +211,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     else if (loadname == "LoadEdge")
     {
-      fem::LoadEdge::Pointer o1 = fem::LoadEdge::New();
+      auto o1 = fem::LoadEdge::New();
       o1->SetGlobalNumber(load->m_GN);
 
       int numRows;
@@ -241,7 +241,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     else if (loadname == "LoadGravConst")
     {
-      fem::LoadGravConst::Pointer o1 = fem::LoadGravConst::New();
+      auto o1 = fem::LoadGravConst::New();
       o1->SetGlobalNumber(load->m_GN);
 
       for (int i = 0; i < load->m_NumElements; ++i)
@@ -258,7 +258,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
     }
     else if (loadname == "LoadLandmark")
     {
-      fem::LoadLandmark::Pointer o1 = fem::LoadLandmark::New();
+      auto o1 = fem::LoadLandmark::New();
       o1->SetGlobalNumber(load->m_GN);
       o1->SetEta(load->m_Variance);
       o1->GetElementArray().resize(1);

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
@@ -169,9 +169,7 @@ Element2DC0QuadraticTriangular::GetLocalFromGlobalCoordinates(const VectorType &
   VectorType tempWeights(3);
   VectorType closest(3);
 
-  itk::fem::Element2DC0LinearTriangularMembrane::Pointer e1;
-
-  e1 = itk::fem::Element2DC0LinearTriangularMembrane::New();
+  itk::fem::Element2DC0LinearTriangularMembrane::Pointer e1 = itk::fem::Element2DC0LinearTriangularMembrane::New();
   // four linear triangles are used
   for (i = 0; i < 4; ++i)
   {

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
@@ -169,7 +169,7 @@ Element2DC0QuadraticTriangular::GetLocalFromGlobalCoordinates(const VectorType &
   VectorType tempWeights(3);
   VectorType closest(3);
 
-  itk::fem::Element2DC0LinearTriangularMembrane::Pointer e1 = itk::fem::Element2DC0LinearTriangularMembrane::New();
+  auto e1 = itk::fem::Element2DC0LinearTriangularMembrane::New();
   // four linear triangles are used
   for (i = 0; i < 4; ++i)
   {

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -64,8 +64,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointer
     MeasurementVectorType standardDeviation;
     NumericTraits<MeasurementVectorType>::SetLength(standardDeviation, this->GetMeasurementVectorSize());
     standardDeviation.Fill(ValueType{});
-    typename MeasurementVectorRealDecoratedType::Pointer decoratedStandardDeviation =
-      MeasurementVectorRealDecoratedType::New();
+    auto decoratedStandardDeviation = MeasurementVectorRealDecoratedType::New();
     decoratedStandardDeviation->Set(standardDeviation);
     return decoratedStandardDeviation.GetPointer();
   }
@@ -76,8 +75,7 @@ StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointer
     MeasurementVectorType mean;
     NumericTraits<MeasurementVectorType>::SetLength(mean, this->GetMeasurementVectorSize());
     mean.Fill(ValueType{});
-    typename MeasurementVectorRealDecoratedType::Pointer decoratedStandardDeviation =
-      MeasurementVectorRealDecoratedType::New();
+    auto decoratedStandardDeviation = MeasurementVectorRealDecoratedType::New();
     decoratedStandardDeviation->Set(mean);
     return decoratedStandardDeviation.GetPointer();
   }

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -39,8 +39,7 @@ public:
       return;
     }
     m_Registrator = ptr;
-    typename itk::SimpleMemberCommand<SimpleMultiResolutionImageRegistrationUI>::Pointer iterationCommand =
-      itk::SimpleMemberCommand<SimpleMultiResolutionImageRegistrationUI>::New();
+    auto iterationCommand = itk::SimpleMemberCommand<SimpleMultiResolutionImageRegistrationUI>::New();
 
     iterationCommand->SetCallbackFunction(this, &SimpleMultiResolutionImageRegistrationUI::StartNewLevel);
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -25,9 +25,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
   GPUDemonsRegistrationFilter()
 {
-  typename GPUDemonsRegistrationFunctionType::Pointer drfp;
-
-  drfp = GPUDemonsRegistrationFunctionType::New();
+  typename GPUDemonsRegistrationFunctionType::Pointer drfp = GPUDemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -25,7 +25,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 GPUDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
   GPUDemonsRegistrationFilter()
 {
-  typename GPUDemonsRegistrationFunctionType::Pointer drfp = GPUDemonsRegistrationFunctionType::New();
+  auto drfp = GPUDemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
@@ -33,7 +33,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::
   CurvatureRegistrationFilter()
 {
-  typename RegistrationFunctionType::Pointer drfp = RegistrationFunctionType::New();
+  auto drfp = RegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
@@ -33,8 +33,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 CurvatureRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TImageForceFunction>::
   CurvatureRegistrationFilter()
 {
-  typename RegistrationFunctionType::Pointer drfp;
-  drfp = RegistrationFunctionType::New();
+  typename RegistrationFunctionType::Pointer drfp = RegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -24,8 +24,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::DemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp;
-  drfp = DemonsRegistrationFunctionType::New();
+  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -24,7 +24,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::DemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
+  auto drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -28,7 +28,7 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   DiffeomorphicDemonsRegistrationFilter()
 
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
+  auto drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -28,8 +28,7 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   DiffeomorphicDemonsRegistrationFilter()
 
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp;
-  drfp = DemonsRegistrationFunctionType::New();
+  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
@@ -26,8 +26,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   FastSymmetricForcesDemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp;
-  drfp = DemonsRegistrationFunctionType::New();
+  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
@@ -26,7 +26,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   FastSymmetricForcesDemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
+  auto drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(drfp);
 

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
@@ -24,8 +24,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::LevelSetMotionRegistrationFilter()
 {
-  typename LevelSetMotionFunctionType::Pointer drfp;
-  drfp = LevelSetMotionFunctionType::New();
+  typename LevelSetMotionFunctionType::Pointer drfp = LevelSetMotionFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
@@ -24,7 +24,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::LevelSetMotionRegistrationFilter()
 {
-  typename LevelSetMotionFunctionType::Pointer drfp = LevelSetMotionFunctionType::New();
+  auto drfp = LevelSetMotionFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
@@ -25,7 +25,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   SymmetricForcesDemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
+  auto drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 }

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
@@ -25,8 +25,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 SymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
   SymmetricForcesDemonsRegistrationFilter()
 {
-  typename DemonsRegistrationFunctionType::Pointer drfp;
-  drfp = DemonsRegistrationFunctionType::New();
+  typename DemonsRegistrationFunctionType::Pointer drfp = DemonsRegistrationFunctionType::New();
 
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));
 }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -608,8 +608,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
       if (this->m_SmoothingSigmasPerLevel[level] > 0)
       {
         using FixedImageSmoothingFilterType = SmoothingRecursiveGaussianImageFilter<FixedImageType, FixedImageType>;
-        typename FixedImageSmoothingFilterType::Pointer fixedImageSmoothingFilter =
-          FixedImageSmoothingFilterType::New();
+        auto fixedImageSmoothingFilter = FixedImageSmoothingFilterType::New();
         typename FixedImageSmoothingFilterType::SigmaArrayType fixedImageSigmaArray(
           this->m_SmoothingSigmasPerLevel[level]);
 
@@ -629,8 +628,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
         fixedImageSmoothingFilter->GetOutput()->DisconnectPipeline();
 
         using MovingImageSmoothingFilterType = SmoothingRecursiveGaussianImageFilter<MovingImageType, MovingImageType>;
-        typename MovingImageSmoothingFilterType::Pointer movingImageSmoothingFilter =
-          MovingImageSmoothingFilterType::New();
+        auto movingImageSmoothingFilter = MovingImageSmoothingFilterType::New();
         typename MovingImageSmoothingFilterType::SigmaArrayType movingImageSigmaArray(
           this->m_SmoothingSigmasPerLevel[level]);
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -369,8 +369,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
           {
             using NearestNeighborInterpolatorType =
               NearestNeighborInterpolateImageFunction<FixedMaskImageType, RealType>;
-            typename NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-              NearestNeighborInterpolatorType::New();
+            auto nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
             nearestNeighborInterpolator->SetInputImage(
               dynamic_cast<ImageMaskSpatialObjectType *>(
                 const_cast<FixedImageMaskType *>(fixedImageMasks[n].GetPointer()))
@@ -399,8 +398,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
           {
             using NearestNeighborInterpolatorType =
               NearestNeighborInterpolateImageFunction<MovingMaskImageType, RealType>;
-            typename NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-              NearestNeighborInterpolatorType::New();
+            auto nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
             nearestNeighborInterpolator->SetInputImage(
               dynamic_cast<ImageMaskSpatialObjectType *>(
                 const_cast<MovingImageMaskType *>(movingImageMasks[n].GetPointer()))
@@ -502,8 +500,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
         if (fixedImageMasks[0])
         {
           using NearestNeighborInterpolatorType = NearestNeighborInterpolateImageFunction<FixedMaskImageType, RealType>;
-          typename NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-            NearestNeighborInterpolatorType::New();
+          auto nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
           nearestNeighborInterpolator->SetInputImage(
             dynamic_cast<ImageMaskSpatialObjectType *>(
               const_cast<FixedImageMaskType *>(fixedImageMasks[0].GetPointer()))
@@ -531,8 +528,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
         {
           using NearestNeighborInterpolatorType =
             NearestNeighborInterpolateImageFunction<MovingMaskImageType, RealType>;
-          typename NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-            NearestNeighborInterpolatorType::New();
+          auto nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
           nearestNeighborInterpolator->SetInputImage(
             dynamic_cast<ImageMaskSpatialObjectType *>(
               const_cast<MovingImageMaskType *>(movingImageMasks[0].GetPointer()))

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -391,8 +391,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
     inverseFieldDuplicator->SetInputImage(this->m_OutputTransform->GetInverseDisplacementField());
     inverseFieldDuplicator->Update();
 
-    typename DisplacementFieldTransformType::Pointer fixedDisplacementFieldTransform =
-      DisplacementFieldTransformType::New();
+    auto fixedDisplacementFieldTransform = DisplacementFieldTransformType::New();
     fixedDisplacementFieldTransform->SetDisplacementField(fieldDuplicator->GetOutput());
     fixedDisplacementFieldTransform->SetInverseDisplacementField(inverseFieldDuplicator->GetOutput());
 
@@ -422,8 +421,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
       this->m_OutputTransform->IntegrateVelocityField();
     }
 
-    typename DisplacementFieldTransformType::Pointer movingDisplacementFieldTransform =
-      DisplacementFieldTransformType::New();
+    auto movingDisplacementFieldTransform = DisplacementFieldTransformType::New();
     movingDisplacementFieldTransform->SetDisplacementField(this->m_OutputTransform->GetModifiableDisplacementField());
     movingDisplacementFieldTransform->SetInverseDisplacementField(
       this->m_OutputTransform->GetModifiableInverseDisplacementField());

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -73,8 +73,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
   auto identityTransform = IdentityTransformType::New();
   identityTransform->SetIdentity();
 
-  typename DisplacementFieldTransformType::Pointer identityDisplacementFieldTransform =
-    DisplacementFieldTransformType::New();
+  auto identityDisplacementFieldTransform = DisplacementFieldTransformType::New();
 
   // This transform gets used for the moving image
   auto fieldDuplicatorIdentity = DisplacementFieldDuplicatorType::New();
@@ -174,8 +173,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
       fieldDuplicator->SetInputImage(this->m_OutputTransform->GetDisplacementField());
       fieldDuplicator->Update();
 
-      typename DisplacementFieldTransformType::Pointer fixedDisplacementFieldTransform =
-        DisplacementFieldTransformType::New();
+      auto fixedDisplacementFieldTransform = DisplacementFieldTransformType::New();
       fixedDisplacementFieldTransform->SetDisplacementField(fieldDuplicator->GetOutput());
 
       // Get the moving transform
@@ -191,8 +189,7 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
         this->m_OutputTransform->IntegrateVelocityField();
       }
 
-      typename DisplacementFieldTransformType::Pointer movingDisplacementFieldTransform =
-        DisplacementFieldTransformType::New();
+      auto movingDisplacementFieldTransform = DisplacementFieldTransformType::New();
       movingDisplacementFieldTransform->SetDisplacementField(this->m_OutputTransform->GetModifiableDisplacementField());
 
       this->m_CompositeTransform->AddTransform(movingDisplacementFieldTransform);

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -175,9 +175,8 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
   }
 
   // Create gaussian membership functions.
-  auto                                                meanEstimatorsContainer = MeanEstimatorsContainerType::New();
-  typename CovarianceEstimatorsContainerType::Pointer covarianceEstimatorsContainer =
-    CovarianceEstimatorsContainerType::New();
+  auto meanEstimatorsContainer = MeanEstimatorsContainerType::New();
+  auto covarianceEstimatorsContainer = CovarianceEstimatorsContainerType::New();
   meanEstimatorsContainer->Reserve(m_NumberOfClasses);
   covarianceEstimatorsContainer->Reserve(m_NumberOfClasses);
 

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.hxx
@@ -40,14 +40,12 @@ template <typename TImageType, typename TFeatureImageType>
 void
 CannySegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateAdvectionImage()
 {
-  typename GradientImageFilter<ImageType, ScalarValueType, ScalarValueType>::Pointer gradient =
-    GradientImageFilter<ImageType, ScalarValueType, ScalarValueType>::New();
+  auto gradient = GradientImageFilter<ImageType, ScalarValueType, ScalarValueType>::New();
 
   using CovariantVectorImageType =
     typename GradientImageFilter<ImageType, ScalarValueType, ScalarValueType>::OutputImageType;
 
-  typename MultiplyImageFilter<CovariantVectorImageType, ImageType, CovariantVectorImageType>::Pointer multiply =
-    MultiplyImageFilter<CovariantVectorImageType, ImageType, CovariantVectorImageType>::New();
+  auto multiply = MultiplyImageFilter<CovariantVectorImageType, ImageType, CovariantVectorImageType>::New();
 
   // Create a distance transform to the canny edges
   this->CalculateDistanceImage();

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -38,8 +38,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 CollidingFrontsImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  typename FastMarchingUpwindGradientImageFilterType::Pointer fastMarchingFilter1 =
-    FastMarchingUpwindGradientImageFilterType::New();
+  auto fastMarchingFilter1 = FastMarchingUpwindGradientImageFilterType::New();
   fastMarchingFilter1->SetInput(this->GetInput());
   fastMarchingFilter1->SetTrialPoints(m_SeedPoints1);
   fastMarchingFilter1->SetTargetPoints(m_SeedPoints2);
@@ -58,8 +57,7 @@ CollidingFrontsImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
   fastMarchingFilter1->Update();
 
-  typename FastMarchingUpwindGradientImageFilterType::Pointer fastMarchingFilter2 =
-    FastMarchingUpwindGradientImageFilterType::New();
+  auto fastMarchingFilter2 = FastMarchingUpwindGradientImageFilterType::New();
   fastMarchingFilter2->SetInput(this->GetInput());
   fastMarchingFilter2->SetTrialPoints(m_SeedPoints2);
   fastMarchingFilter2->SetTargetPoints(m_SeedPoints1);

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.hxx
@@ -27,11 +27,9 @@ template <typename TImageType, typename TFeatureImageType>
 void
 LaplacianSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateSpeedImage()
 {
-  typename LaplacianImageFilter<ImageType, ImageType>::Pointer filter =
-    LaplacianImageFilter<ImageType, ImageType>::New();
+  auto filter = LaplacianImageFilter<ImageType, ImageType>::New();
 
-  typename CastImageFilter<FeatureImageType, ImageType>::Pointer caster =
-    CastImageFilter<FeatureImageType, ImageType>::New();
+  auto caster = CastImageFilter<FeatureImageType, ImageType>::New();
 
   caster->SetInput(this->GetFeatureImage());
   filter->SetInput(caster->GetOutput());

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -189,8 +189,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CopyInputToOu
   // keep a handle to the shifted output
   m_ShiftedImage = shiftScaleFilter->GetOutput();
 
-  typename ZeroCrossingImageFilter<OutputImageType, OutputImageType>::Pointer zeroCrossingFilter =
-    ZeroCrossingImageFilter<OutputImageType, OutputImageType>::New();
+  auto zeroCrossingFilter = ZeroCrossingImageFilter<OutputImageType, OutputImageType>::New();
   zeroCrossingFilter->SetInput(m_ShiftedImage);
   zeroCrossingFilter->GraftOutput(m_OutputImage);
   zeroCrossingFilter->SetBackgroundValue(m_ValueOne);

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -488,8 +488,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
   // keep a handle to the shifted output
   m_ShiftedImage = shiftScaleFilter->GetOutput();
 
-  typename ZeroCrossingImageFilter<OutputImageType, OutputImageType>::Pointer zeroCrossingFilter =
-    ZeroCrossingImageFilter<OutputImageType, OutputImageType>::New();
+  auto zeroCrossingFilter = ZeroCrossingImageFilter<OutputImageType, OutputImageType>::New();
   zeroCrossingFilter->SetInput(m_ShiftedImage);
   zeroCrossingFilter->GraftOutput(this->GetOutput());
   zeroCrossingFilter->SetBackgroundValue(m_ValueOne);

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -28,10 +28,8 @@ template <typename TImageType, typename TFeatureImageType>
 void
 ThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateSpeedImage()
 {
-  typename GradientAnisotropicDiffusionImageFilter<TFeatureImageType, TFeatureImageType>::Pointer diffusion =
-    GradientAnisotropicDiffusionImageFilter<TFeatureImageType, TFeatureImageType>::New();
-  typename LaplacianImageFilter<TFeatureImageType, TFeatureImageType>::Pointer laplacian =
-    LaplacianImageFilter<TFeatureImageType, TFeatureImageType>::New();
+  auto diffusion = GradientAnisotropicDiffusionImageFilter<TFeatureImageType, TFeatureImageType>::New();
+  auto laplacian = LaplacianImageFilter<TFeatureImageType, TFeatureImageType>::New();
 
   ImageRegionIterator<FeatureImageType>      lit;
   ImageRegionConstIterator<FeatureImageType> fit(this->GetFeatureImage(),


### PR DESCRIPTION
Two style commits:
- Replaced `T::Pointer var; var = x` with `T::Pointer var = x`, following pull request #4952
- Replaced `T::Pointer` with `auto` when initializing variables by `T::New()`, following pull request #2826
