### PR TITLE
STYLE: Drop Visual C++ 2013 compiler support from itktiff/libtiff

### DIFF
--- a/Modules/ThirdParty/TIFF/src/itktiff/libtiff/tif_config.h.in
+++ b/Modules/ThirdParty/TIFF/src/itktiff/libtiff/tif_config.h.in
@@ -417,14 +417,6 @@ the sizes can be different.*/
 /* Define to empty if `const' does not conform to ANSI C. */
 #cmakedefine const
 
-/* MSVC does not support C99 inline, so just make the inline keyword
-   disappear for C.  */
-#ifndef __cplusplus
-#  if defined(_MSC_VER) && _MSC_VER < 1900
-#    define inline
-#  endif
-#endif
-
 /* Define to `long int' if <sys/types.h> does not define. */
 #cmakedefine off_t
 


### PR DESCRIPTION
ITK already dropped Visual C++ 2013 in 2018, with commit 0067eee541994d6f977490bee521b9f6f0adfc64 "COMP: Require MSVC VS14 2015 for C++11 compatibility", by Bradley Lowekamp (@blowekamp).

----

For the record, Microsoft also dropped VS2013: https://learn.microsoft.com/en-us/lifecycle/products/visual-studio-2013