### PR TITLE
Revert "BUG: Reduce tolerance for same slice checks"

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -27,7 +27,6 @@
 #include "itkMetaDataObject.h"
 #include <cstddef> // For ptrdiff_t.
 #include <iomanip>
-#include "itkImageBase.h"
 
 namespace itk
 {
@@ -433,8 +432,9 @@ ImageSeriesReader<TOutputImage>::GenerateData()
         SpacingScalarType dirNnorm = dirN.GetNorm();
 
         if (this->m_SpacingDefined &&
-            std::abs(dirNnorm - outputSpacing[this->m_NumberOfDimensionsInImage]) >
-              itk::DefaultImageCoordinateTolerance) // either non-uniform sampling or missing slice
+            !Math::AlmostEquals(
+              dirNnorm,
+              outputSpacing[this->m_NumberOfDimensionsInImage])) // either non-uniform sampling or missing slice
         {
           nonUniformSampling = true;
           spacingDeviation = itk::Math::abs(outputSpacing[this->m_NumberOfDimensionsInImage] - dirNnorm);


### PR DESCRIPTION
This reverts commit 916a40cb3cebf817f91b69ef80a428b346c46fef.

The strict tolerance is required for backward compatibility.

The commit 916a40cb3cebf817f91b69ef80a428b346c46fef caused an undesirable regression in end-user application, and was not necessary for fixing the problem described in #4955 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)


