### PR TITLE
STYLE: Remove `p->Initialize()` calls directly after `p = T::New()`

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -86,7 +86,6 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
 
   using PointSetType = PointSet<CoordRepType, SpaceDimension>;
   auto cornerPoints = PointSetType::New();
-  cornerPoints->Initialize();
 
   using PointType = typename PointSetType::PointType;
   using PointIdentifier = typename PointSetType::PointIdentifier;

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -499,14 +499,12 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateB
   const typename ImporterType::OutputImageType * parametricFieldEstimate = importer->GetOutput();
 
   PointSetPointer fieldPoints = PointSetType::New();
-  fieldPoints->Initialize();
-  auto & pointSTLContainer = fieldPoints->GetPoints()->CastToSTLContainer();
+  auto &          pointSTLContainer = fieldPoints->GetPoints()->CastToSTLContainer();
   pointSTLContainer.reserve(numberOfIncludedPixels);
   auto & pointDataSTLContainer = fieldPoints->GetPointData()->CastToSTLContainer();
   pointDataSTLContainer.reserve(numberOfIncludedPixels);
 
-  auto weights = BSplineFilterType::WeightsContainerType::New();
-  weights->Initialize();
+  auto   weights = BSplineFilterType::WeightsContainerType::New();
   auto & weightSTLContainer = weights->CastToSTLContainer();
   weightSTLContainer.reserve(numberOfIncludedPixels);
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -122,7 +122,6 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
   }
 
   auto fieldPoints = InputPointSetType::New();
-  fieldPoints->Initialize();
 
   auto weights = WeightsContainerType::New();
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -126,7 +126,6 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::SetPointsF
   if (iLabel == Traits::Alive || iLabel == Traits::InitialTrial || iLabel == Traits::Forbidden)
   {
     NodePairContainerPointer nodes = NodePairContainerType::New();
-    nodes->Initialize();
 
     using IteratorType = ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType it(image, image->GetBufferedRegion());

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -94,7 +94,6 @@ WindowConvergenceMonitoringFunction<TScalar>::GetConvergenceValue() const -> Rea
   bspliner->SetNumberOfWorkUnits(1);
 
   auto energyProfileWindow = EnergyProfileType::New();
-  energyProfileWindow->Initialize();
 
   for (unsigned int n = 0; n < this->m_WindowSize; ++n)
   {

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -121,7 +121,6 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
 
   // Set a pointSet from the input landmarks.
   auto pointSet = PointSetType::New();
-  pointSet->Initialize();
 
   PointsContainerConstIterator fixedIt = this->m_FixedLandmarks.begin();
   PointsContainerConstIterator movingIt = this->m_MovingLandmarks.begin();

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -130,7 +130,6 @@ typename LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
     GetLabeledFixedPointSet(const LabelType label) const
 {
   auto fixedPointSet = FixedPointSetType::New();
-  fixedPointSet->Initialize();
 
   typename FixedPointSetType::PointIdentifier count{};
 
@@ -156,7 +155,6 @@ typename LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
     GetLabeledMovingPointSet(const LabelType label) const
 {
   auto movingPointSet = MovingPointSetType::New();
-  movingPointSet->Initialize();
 
   typename MovingPointSetType::PointIdentifier count{};
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
@@ -279,7 +279,6 @@ typename BSplineSyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTra
     }
 
     auto gradientPointSet = BSplinePointSetType::New();
-    gradientPointSet->Initialize();
 
     if (fixedPointSets[0]->GetNumberOfPoints() > 0)
     {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -938,7 +938,6 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   for (SizeValueType n = 0; n < numberOfLocalMetrics; ++n)
   {
     auto samplePointSet = MetricSamplePointSetType::New();
-    samplePointSet->Initialize();
 
     using SamplePointType = typename MetricSamplePointSetType::PointType;
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -150,13 +150,10 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
 
   // Keep track of velocityFieldPointSet from the previous iteration
   VelocityFieldPointSetPointer velocityFieldPointSetFromPreviousIteration = VelocityFieldPointSetType::New();
-  velocityFieldPointSetFromPreviousIteration->Initialize();
 
   VelocityFieldPointSetPointer velocityFieldPointSet = VelocityFieldPointSetType::New();
-  velocityFieldPointSet->Initialize();
 
   auto velocityFieldWeights = WeightsContainerType::New();
-  velocityFieldWeights->Initialize();
 
   // Monitor the convergence
   using ConvergenceMonitoringType = itk::Function::WindowConvergenceMonitoringFunction<RealType>;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -181,7 +181,6 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
   covarianceEstimatorsContainer->Reserve(m_NumberOfClasses);
 
   m_MembershipFunctionContainer = MembershipFunctionContainerType::New();
-  m_MembershipFunctionContainer->Initialize(); // Clear elements
   for (unsigned int i = 0; i < m_NumberOfClasses; ++i)
   {
     meanEstimatorsContainer->InsertElement(i, new typename GaussianMembershipFunctionType::MeanVectorType(1));


### PR DESCRIPTION
For any ITK type `T`, `T::New()` does already initialize the object it returns.

Using Notepad++, Replace in Files, doing:

    Find what:  (\w+)([ ]+= .+::New\(\);)\r\n[\r\n]* [ ]+\1->Initialize\(\);
    Replace with:  $1$2
    Filters: itk*.* !+\test
    Directory: D:\src\ITK\Modules
    [v] Match case
    (*) Regular expression

Manually removed an obsolete comment saying `Clear elements`.