### PR TITLE
STYLE: Replace `T var; var = x` with `T var = x`

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -30,9 +30,7 @@ template <typename TPixel, unsigned int TDimension, typename TAllocator>
 void
 AnnulusOperator<TPixel, TDimension, TAllocator>::CreateOperator()
 {
-  CoefficientVector coefficients;
-
-  coefficients = this->GenerateCoefficients();
+  CoefficientVector coefficients = this->GenerateCoefficients();
 
   this->Fill(coefficients);
 }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -409,8 +409,7 @@ inline ConstNeighborhoodIteratorWithOnlyIndex<TImage>
 operator+(const ConstNeighborhoodIteratorWithOnlyIndex<TImage> &                      it,
           const typename ConstNeighborhoodIteratorWithOnlyIndex<TImage>::OffsetType & ind)
 {
-  ConstNeighborhoodIteratorWithOnlyIndex<TImage> ret;
-  ret = it;
+  ConstNeighborhoodIteratorWithOnlyIndex<TImage> ret = it;
   ret += ind;
   return ret;
 }
@@ -428,8 +427,7 @@ inline ConstNeighborhoodIteratorWithOnlyIndex<TImage>
 operator-(const ConstNeighborhoodIteratorWithOnlyIndex<TImage> &                      it,
           const typename ConstNeighborhoodIteratorWithOnlyIndex<TImage>::OffsetType & ind)
 {
-  ConstNeighborhoodIteratorWithOnlyIndex<TImage> ret;
-  ret = it;
+  ConstNeighborhoodIteratorWithOnlyIndex<TImage> ret = it;
   ret -= ind;
   return ret;
 }

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -35,9 +35,7 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 void
 LaplacianOperator<TPixel, VDimension, TAllocator>::CreateOperator()
 {
-  CoefficientVector coefficients;
-
-  coefficients = this->GenerateCoefficients();
+  CoefficientVector coefficients = this->GenerateCoefficients();
 
   this->Fill(coefficients);
 }

--- a/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.hxx
@@ -73,9 +73,7 @@ GPUInPlaceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::AllocateOu
       {
         // if we cannot cast the input to an output type, then allocate
         // an output usual.
-        OutputImagePointer outputPtr;
-
-        outputPtr = this->GetOutput(0);
+        OutputImagePointer outputPtr = this->GetOutput(0);
         outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
         outputPtr->Allocate();
       }

--- a/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
@@ -124,9 +124,7 @@ public:
       return false;
     }
 
-    cl_int errid;
-
-    errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, sizeof(cl_mem), manager->GetGPUBufferPointer());
+    cl_int errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, sizeof(cl_mem), manager->GetGPUBufferPointer());
     OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
     m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -317,9 +317,7 @@ GPUKernelManager::SetKernelArg(int kernelIdx, cl_uint argIdx, size_t argSize, co
     return false;
   }
 
-  cl_int errid;
-
-  errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, argSize, argVal);
+  cl_int errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, argSize, argVal);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
   m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;
@@ -413,9 +411,7 @@ GPUKernelManager::SetKernelArgWithImage(int kernelIdx, cl_uint argIdx, GPUDataMa
     return false;
   }
 
-  cl_int errid;
-
-  errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, sizeof(cl_mem), manager->GetGPUBufferPointer());
+  cl_int errid = clSetKernelArg(m_KernelContainer[kernelIdx], argIdx, sizeof(cl_mem), manager->GetGPUBufferPointer());
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
   m_KernelArgumentReady[kernelIdx][argIdx].m_IsReady = true;
@@ -624,16 +620,15 @@ GPUKernelManager::LaunchKernel(int kernelIdx, int dim, size_t * globalWorkSize, 
   // localWorkSize[0] = localWorkSize[1] = localWorkSize[2] = 1;
   //
 
-  cl_int errid;
-  errid = clEnqueueNDRangeKernel(m_Manager->GetCommandQueue(m_CommandQueueId),
-                                 m_KernelContainer[kernelIdx],
-                                 (cl_uint)dim,
-                                 nullptr,
-                                 globalWorkSize,
-                                 localWorkSize,
-                                 0,
-                                 nullptr,
-                                 nullptr);
+  cl_int errid = clEnqueueNDRangeKernel(m_Manager->GetCommandQueue(m_CommandQueueId),
+                                        m_KernelContainer[kernelIdx],
+                                        (cl_uint)dim,
+                                        nullptr,
+                                        globalWorkSize,
+                                        localWorkSize,
+                                        0,
+                                        nullptr,
+                                        nullptr);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
   /*

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -54,9 +54,7 @@ OpenCLGetAvailableDevices(cl_platform_id platform, cl_device_type devType, cl_ui
   cl_uint        totalNumDevices;
 
   // get total # of devices
-  cl_int errid;
-
-  errid = clGetDeviceIDs(platform, devType, 0, nullptr, &totalNumDevices);
+  cl_int errid = clGetDeviceIDs(platform, devType, 0, nullptr, &totalNumDevices);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
   auto * totalDevices = (cl_device_id *)malloc(totalNumDevices * sizeof(cl_device_id));

--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -156,9 +156,7 @@ public:
   inline ExternalType
   Get(const ActualPixelType & input) const
   {
-    ExternalType output;
-
-    output = static_cast<ExternalType>(input[m_ElementNumber]);
+    ExternalType output = static_cast<ExternalType>(input[m_ElementNumber]);
     return output;
   }
 

--- a/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
@@ -74,9 +74,7 @@ public:
   inline ExternalType
   Get(const ActualPixelType & input) const
   {
-    ExternalType output;
-
-    output = input[m_ComponentIdx];
+    ExternalType output = input[m_ComponentIdx];
     return output;
   }
 

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -34,9 +34,7 @@ template <typename TInputImage, typename TCoordRep>
 auto
 MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  RealType sum;
-
-  sum = RealType{};
+  RealType sum = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
@@ -90,8 +90,7 @@ public:
   Evaluate(const PointType &) const override
   {
     std::cout << "NeighborhoodOperatorImageFunction::Evaluate(): Not implemented!" << std::endl;
-    TOutput out;
-    out = 0;
+    TOutput out = 0;
     return out;
   }
 
@@ -105,8 +104,7 @@ public:
   EvaluateAtContinuousIndex(const ContinuousIndexType &) const override
   {
     std::cout << "NeighborhoodOperatorImageFunction::EvaluateAtContinuousIndex():Not implemented!" << std::endl;
-    TOutput out;
-    out = 0;
+    TOutput out = 0;
     return out;
   }
 

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -35,9 +35,7 @@ template <typename TInputImage, typename TCoordRep>
 auto
 SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  RealType sumOfSquares;
-
-  sumOfSquares = RealType{};
+  RealType sumOfSquares = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -253,8 +253,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       }
 
       // get the cells using the closest point and use them as seeds
-      InputMeshCellLinksContainerConstPointer cellLinks;
-      cellLinks = input->GetCellLinks();
+      InputMeshCellLinksContainerConstPointer cellLinks = input->GetCellLinks();
 
       auto links = cellLinks->ElementAt(minId);
       for (auto citer = links.cbegin(); citer != links.cend(); ++citer)

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -105,8 +105,7 @@ ContourSpatialObject<TDimension>::SetControlPoints(const ContourPointListType & 
 {
   m_ControlPoints.clear();
 
-  typename ContourPointListType::const_iterator it;
-  it = points.begin();
+  typename ContourPointListType::const_iterator it = points.begin();
   while (it != points.end())
   {
     m_ControlPoints.push_back(*it);
@@ -219,8 +218,7 @@ ContourSpatialObject<TDimension>::Update()
             newPoint[d] = pnt[d] + i * step[d];
           }
         }
-        typename Superclass::SpatialObjectPointType newSOPoint;
-        newSOPoint = (*it);
+        typename Superclass::SpatialObjectPointType newSOPoint = (*it);
         newSOPoint.SetSpatialObject(this);
         newSOPoint.SetPositionInObjectSpace(newPoint);
         this->m_Points.push_back(newSOPoint);

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
@@ -198,9 +198,7 @@ QuaternionRigidTransform<TParametersValueType>::ComputeMatrix()
   VnlQuaternionType conjugateRotation = m_Rotation.conjugate();
   // this is done to compensate for the transposed representation
   // between VNL and ITK
-  MatrixType newMatrix;
-
-  newMatrix = conjugateRotation.rotation_matrix_transpose();
+  MatrixType newMatrix = conjugateRotation.rotation_matrix_transpose();
   this->SetVarMatrix(newMatrix);
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -111,8 +111,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::ComputePruneImage()
     {
       if (ot.GetCenterPixel())
       {
-        PixelType genus;
-        genus = ot.GetPixel(offset1) + ot.GetPixel(offset2);
+        PixelType genus = ot.GetPixel(offset1) + ot.GetPixel(offset2);
         genus += ot.GetPixel(offset3) + ot.GetPixel(offset4);
         genus += ot.GetPixel(offset5) + ot.GetPixel(offset6);
         genus += ot.GetPixel(offset7) + ot.GetPixel(offset8);

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -646,15 +646,13 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // is bigger than our input.
 
   // Cast away the constness so we can set the requested region.
-  InputImagePointer inputPtr;
-  inputPtr = const_cast<InputImageType *>(this->GetFixedImage());
+  InputImagePointer inputPtr = const_cast<InputImageType *>(this->GetFixedImage());
   inputPtr->SetRequestedRegion(this->GetFixedImage()->GetLargestPossibleRegion());
 
   inputPtr = const_cast<InputImageType *>(this->GetMovingImage());
   inputPtr->SetRequestedRegion(this->GetMovingImage()->GetLargestPossibleRegion());
 
-  MaskImagePointer maskPtr;
-  maskPtr = const_cast<MaskImageType *>(this->GetFixedImageMask());
+  MaskImagePointer maskPtr = const_cast<MaskImageType *>(this->GetFixedImageMask());
   if (maskPtr)
   {
     maskPtr->SetRequestedRegion(this->GetFixedImageMask()->GetLargestPossibleRegion());

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -404,8 +404,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
     return update;
   }
 
-  PixelType threshold;
-  threshold = this->ComputeThreshold(Dispatch<ImageDimension>(), it);
+  PixelType threshold = this->ComputeThreshold(Dispatch<ImageDimension>(), it);
 
   NeighborhoodInnerProduct<ImageType> innerProduct;
   PixelType                           avgValue = innerProduct(it, m_StencilOperator);

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -211,8 +211,7 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchRadiusInV
     thisPtr->m_InputImage = this->GetInput();
   }
   const typename InputImageType::SpacingType & spacing = this->m_InputImage->GetSpacing();
-  typename InputImageType::SpacingValueType    maxSpacing;
-  maxSpacing = spacing[0];
+  typename InputImageType::SpacingValueType    maxSpacing = spacing[0];
   for (unsigned int dim = 1; dim < ImageDimension; ++dim)
   {
     if (spacing[dim] > maxSpacing)

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -136,8 +136,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelSetImageType * 
   // set all output value to infinity
   using OutputIterator = ImageRegionIterator<LevelSetImageType>;
 
-  PixelType outputPixel;
-  outputPixel = m_LargeValue;
+  PixelType outputPixel = m_LargeValue;
 
   for (OutputIterator outIt(output, output->GetBufferedRegion()); !outIt.IsAtEnd(); ++outIt)
   {

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -53,8 +53,8 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
 
   // walk the region of eigen values and get the vesselness measure
   EigenValueArrayType                                 eigenValue;
-  ImageRegionConstIterator<EigenValueOutputImageType> it;
-  it = ImageRegionConstIterator<EigenValueOutputImageType>(eigenImage, eigenImage->GetRequestedRegion());
+  ImageRegionConstIterator<EigenValueOutputImageType> it =
+    ImageRegionConstIterator<EigenValueOutputImageType>(eigenImage, eigenImage->GetRequestedRegion());
   ImageRegionIterator<OutputImageType> oit;
   this->AllocateOutputs();
   oit = ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -318,9 +318,7 @@ protected:
   NonPCEvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
     unsigned int i, j;
-    TRealType    dx, sum, accum;
-
-    accum = TRealType{};
+    TRealType    dx, sum, accum = TRealType{};
     for (i = 0; i < ImageDimension; ++i)
     {
       sum = TRealType{};

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -114,8 +114,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetSplineOrder(ArrayT
 
     if (this->m_DoMultilevel)
     {
-      typename KernelType::MatrixType C;
-      C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
+      typename KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
 
       vnl_matrix<RealType> R;
       vnl_matrix<RealType> S;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -377,8 +377,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
    * OutputImage for direct writing into the final variable. */
 
   // The first time through the loop our input image is inputPtr
-  typename TInputImage::ConstPointer workingImage;
-  workingImage = inputPtr;
+  typename TInputImage::ConstPointer workingImage = inputPtr;
 
   unsigned int     count = scratchRegion.GetNumberOfPixels() * ImageDimension;
   ProgressReporter progress(this, 0, count, 10);
@@ -491,8 +490,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
   **/
 
   // The first time through the loop our input image is m_Image
-  typename TInputImage::ConstPointer workingImage;
-  workingImage = inputPtr;
+  typename TInputImage::ConstPointer workingImage = inputPtr;
 
   RegionType workingRegion = validRegion;
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -93,8 +93,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetSpli
 
     if (this->m_DoMultilevel)
     {
-      typename KernelType::MatrixType C;
-      C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
+      typename KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
 
       vnl_matrix<RealType> R;
       vnl_matrix<RealType> S;

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -310,8 +310,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->TransformContinuousIndexToPhysicalPoint(outputCenterIndex, outputCenterPoint);
 
   const typename TOutputImage::PointType & inputOrigin = inputPtr->GetOrigin();
-  typename TOutputImage::PointType         outputOrigin;
-  outputOrigin = inputOrigin + (inputCenterPoint - outputCenterPoint);
+  typename TOutputImage::PointType         outputOrigin = inputOrigin + (inputCenterPoint - outputCenterPoint);
   outputPtr->SetOrigin(outputOrigin);
 
   // Set region

--- a/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
@@ -155,9 +155,7 @@ public:
   void
   SetAccessor(AccessorType & accessor)
   {
-    FunctorType functor;
-
-    functor = this->GetFunctor();
+    FunctorType functor = this->GetFunctor();
     if (accessor != functor.GetAccessor())
     {
       functor.SetAccessor(accessor);

--- a/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
@@ -33,6 +33,10 @@ namespace Functor
  * allows an accessor to be used as functor in a UnaryFunctorImageFilter,
  * BinaryFunctorImageFilter, TernaryFunctorImageFilter, or
  * NaryFunctionImageFilter.
+ *
+ * \note AccessorFunctor does not have any user-declared "special member function", following the C++ Rule of Zero: the
+ * compiler will just generate any of them when necessary.
+ *
  * \ingroup ITKImageIntensity
  */
 template <typename TInput, typename TAccessor>
@@ -42,12 +46,6 @@ public:
   /** Standard class type aliases. */
   using Self = AccessorFunctor;
   using AccessorType = TAccessor;
-
-  /** Constructor and destructor. */
-  AccessorFunctor()
-    : m_Accessor()
-  {}
-  ~AccessorFunctor() = default;
 
   /** operator().  This is the "call" method of the functor. */
   using OutputType = typename TAccessor::ExternalType;
@@ -62,14 +60,6 @@ public:
   GetAccessor()
   {
     return m_Accessor;
-  }
-
-  /** Assignment operator */
-  AccessorFunctor &
-  operator=(const AccessorFunctor & functor)
-  {
-    m_Accessor = functor.m_Accessor;
-    return *this;
   }
 
   /** Set the accessor object. This replaces the current accessor with
@@ -93,7 +83,7 @@ public:
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
 private:
-  AccessorType m_Accessor;
+  AccessorType m_Accessor{};
 };
 } // namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -92,17 +92,14 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   itkDebugMacro("Normalized View vector" << nViewVector);
 
   // Orthogonalize nUpVector and nViewVector
-  TVector nOrthogonalVector;
-
-  nOrthogonalVector = nUpVector - (nViewVector * (nUpVector * nViewVector));
+  TVector nOrthogonalVector = nUpVector - (nViewVector * (nUpVector * nViewVector));
 
   itkDebugMacro("Up vector component orthogonal to View vector " << nOrthogonalVector);
 
   // Perform the cross product and determine a third coordinate axis
   // orthogonal to both nOrthogonalVector and nViewVector.
 
-  TVector nThirdAxis;
-  nThirdAxis = itk::CrossProduct(nOrthogonalVector, nViewVector);
+  TVector nThirdAxis = itk::CrossProduct(nOrthogonalVector, nViewVector);
 
   itkDebugMacro("Third basis vector" << nThirdAxis);
 
@@ -298,9 +295,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   projectionStart[1] = 0;
 
   ProjectionImageSizeType projectionSize;
-  IndexValueType          pad;
-
-  pad = 5;
+  IndexValueType          pad = 5;
 
   projectionSize[0] = (IndexValueType)(bounds[1] - bounds[0]) + pad;
   projectionSize[1] = (IndexValueType)(bounds[3] - bounds[2]) + pad;

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -426,8 +426,7 @@ protected:
       setConnectivityPrevious(&lnit, m_FullyConnected);
     }
 
-    typename LineNeighborhoodType::IndexListType ActiveIndexes;
-    ActiveIndexes = lnit.GetActiveIndexList();
+    typename LineNeighborhoodType::IndexListType ActiveIndexes = lnit.GetActiveIndexList();
 
     typename LineNeighborhoodType::IndexListType::const_iterator LI;
 

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
@@ -75,9 +75,7 @@ InPlaceLabelMapFilter<TInputImage>::AllocateOutputs()
     // If there are more than one outputs, allocate the remaining outputs
     for (unsigned int i = 1; i < this->GetNumberOfIndexedOutputs(); ++i)
     {
-      OutputImagePointer outputPtr;
-
-      outputPtr = this->GetOutput(i);
+      OutputImagePointer outputPtr = this->GetOutput(i);
       outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
       outputPtr->Allocate();
     }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -77,12 +77,10 @@ GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GenerateData()
   calculator->SetImage(inputImage);
   calculator->ComputeMaximum();
 
-  InputImagePixelType maxValue;
-  maxValue = calculator->GetMaximum();
+  InputImagePixelType maxValue = calculator->GetMaximum();
 
   // compare this maximum value to the value at the seed pixel.
-  InputImagePixelType seedValue;
-  seedValue = inputImage->GetPixel(m_Seed);
+  InputImagePixelType seedValue = inputImage->GetPixel(m_Seed);
 
   if (maxValue == seedValue)
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -77,12 +77,10 @@ GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
   calculator->SetImage(inputImage);
   calculator->ComputeMinimum();
 
-  InputImagePixelType minValue;
-  minValue = calculator->GetMinimum();
+  InputImagePixelType minValue = calculator->GetMinimum();
 
   // compare this minimum value to the value at the seed pixel.
-  InputImagePixelType seedValue;
-  seedValue = inputImage->GetPixel(m_Seed);
+  InputImagePixelType seedValue = inputImage->GetPixel(m_Seed);
 
   if (minValue == seedValue)
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -74,8 +74,7 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::GenerateData()
   calculator->SetImage(this->GetInput());
   calculator->ComputeMaximum();
 
-  InputImagePixelType maxValue;
-  maxValue = calculator->GetMaximum();
+  InputImagePixelType maxValue = calculator->GetMaximum();
 
   // allocate a marker image
   InputImagePointer markerPtr = InputImageType::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -84,8 +84,7 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::GenerateData()
   calculator->SetImage(this->GetInput());
   calculator->ComputeMinimum();
 
-  InputImagePixelType minValue;
-  minValue = calculator->GetMinimum();
+  InputImagePixelType minValue = calculator->GetMinimum();
 
   // allocate a marker image
   InputImagePointer markerPtr = InputImageType::New();

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -127,8 +127,7 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
     outIt.GoToBegin();
     // set up the stack and neighbor list
     IndexStack                              IS;
-    typename NOutputIterator::IndexListType IndexList;
-    IndexList = outNIt.GetActiveIndexList();
+    typename NOutputIterator::IndexListType IndexList = outNIt.GetActiveIndexList();
 
     while (!outIt.IsAtEnd())
     {

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -119,9 +119,7 @@ template <unsigned int VDimension>
 auto
 ParametricPath<VDimension>::EvaluateDerivative(const InputType & input) const -> VectorType
 {
-  InputType inputStepSize;
-
-  inputStepSize = m_DefaultInputStepSize;
+  InputType inputStepSize = m_DefaultInputStepSize;
   if ((input + inputStepSize) >= this->EndOfInput())
   {
     inputStepSize = this->EndOfInput() - input;

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -185,8 +185,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       DN = DN2 + beta * DN0;
       EN = EN2 + beta * EN0;
 
-      ScalarRealType alpha2;
-      alpha2 = EN * SD * SD - ED * SN * SD - 2 * DN * DD * SD + 2 * DD * DD * SN;
+      ScalarRealType alpha2 = EN * SD * SD - ED * SN * SD - 2 * DN * DD * SD + 2 * DD * DD * SN;
       alpha2 /= SD * SD * SD;
 
       this->m_N0 *= across_scale_normalization / alpha2;

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
@@ -37,8 +37,7 @@ ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Comp
 
   product = 1.;
 
-  ListPixelType L;
-  L = this->m_SharedData->m_NearestNeighborListImage->GetPixel(globalIndex);
+  ListPixelType L = this->m_SharedData->m_NearestNeighborListImage->GetPixel(globalIndex);
 
   InputPixelType hVal;
   InputIndexType otherIndex;

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -487,8 +487,7 @@ RobustSolver<VDimension>::UnselectLandmarks(unsigned int nUnselected)
 
   LoadVectorType & loadVector = container->CastToSTLContainer();
 
-  LoadVectorType::iterator it;
-  it = loadVector.begin();
+  LoadVectorType::iterator it = loadVector.begin();
   std::advance(it, nUnselected - 1);
   auto nth = it;
 
@@ -522,8 +521,7 @@ RobustSolver<VDimension>::DeleteFromLandmarkBeginning(unsigned int nDeleted)
 
   LoadVectorType & loadVector = container->CastToSTLContainer();
 
-  LoadVectorType::iterator it;
-  it = loadVector.begin();
+  LoadVectorType::iterator it = loadVector.begin();
   std::advance(it, nDeleted);
   auto nth = it;
   loadVector.erase(loadVector.begin(), nth);

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
@@ -199,8 +199,7 @@ LinearSystemWrapperDenseVNL::SwapMatrices(unsigned int MatrixIndex1, unsigned in
 void
 LinearSystemWrapperDenseVNL::SwapVectors(unsigned int VectorIndex1, unsigned int VectorIndex2)
 {
-  vnl_vector<Float> tmp;
-  tmp = *(*m_Vectors)[VectorIndex1];
+  vnl_vector<Float> tmp = *(*m_Vectors)[VectorIndex1];
   *(*m_Vectors)[VectorIndex1] = *(*m_Vectors)[VectorIndex2];
   *(*m_Vectors)[VectorIndex2] = tmp;
 }

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -152,8 +152,7 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Maximal number of iterations: " << this->m_MaximalNumberOfIterations << '\n';
   os << indent << "Number of generations with minimal improvement: ";
   os << this->m_NumberOfGenerationsWithMinimalImprovement << '\n';
-  ParameterBoundsType::const_iterator it, end;
-  end = this->m_ParameterBounds.end();
+  ParameterBoundsType::const_iterator it, end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
   for (it = this->m_ParameterBounds.begin(); it != end; ++it)
   {
@@ -180,8 +179,7 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 void
 ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
 {
-  std::vector<ParticleData>::const_iterator it, end;
-  end = this->m_Particles.end();
+  std::vector<ParticleData>::const_iterator it, end = this->m_Particles.end();
   os << indent << "[\n";
   for (it = this->m_Particles.begin(); it != end; ++it)
   {
@@ -427,8 +425,7 @@ ParticleSwarmOptimizerBase::Initialize()
 void
 ParticleSwarmOptimizerBase::RandomInitialization()
 {
-  unsigned int i, j, n;
-  n = GetInitialPosition().Size();
+  unsigned int                                                    i, j, n = GetInitialPosition().Size();
   ParameterBoundsType                                             parameterBounds(this->m_ParameterBounds);
   ParametersType                                                  mean = GetInitialPosition();
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
@@ -94,16 +94,14 @@ RegistrationParameterScalesFromIndexShift<TMetric>::TransformPointToContinuousIn
 
   if (this->GetTransformForward())
   {
-    MovingPointType mappedPoint;
-    mappedPoint = this->m_Metric->GetMovingTransform()->TransformPoint(point);
+    MovingPointType mappedPoint = this->m_Metric->GetMovingTransform()->TransformPoint(point);
     mappedIndex =
       this->m_Metric->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
         mappedPoint);
   }
   else
   {
-    FixedPointType mappedPoint;
-    mappedPoint = this->m_Metric->GetFixedTransform()->TransformPoint(point);
+    FixedPointType mappedPoint = this->m_Metric->GetFixedTransform()->TransformPoint(point);
     mappedIndex =
       this->m_Metric->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
         mappedPoint);

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
@@ -160,8 +160,7 @@ SampleClassifierFilter<TSample>::GenerateData()
 
   while (iter != end)
   {
-    typename TSample::MeasurementVectorType measurements;
-    measurements = iter.GetMeasurementVector();
+    typename TSample::MeasurementVectorType measurements = iter.GetMeasurementVector();
     for (unsigned int i = 0; i < this->m_NumberOfClasses; ++i)
     {
       discriminantScores[i] = membershipFunctionsWeightsArray[i] * membershipFunctions[i]->Evaluate(measurements);

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -395,9 +395,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(
   const TransformParametersType & parameters,
   DerivativeType &                derivative) const
 {
-  TransformParametersType testPoint;
-
-  testPoint = parameters;
+  TransformParametersType testPoint = parameters;
 
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   derivative = DerivativeType(numberOfParameters);

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -112,9 +112,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
   const TransformParametersType & parameters,
   DerivativeType &                derivative) const
 {
-  TransformParametersType testPoint;
-
-  testPoint = parameters;
+  TransformParametersType testPoint = parameters;
 
   const unsigned int numberOfParameters = this->GetNumberOfParameters();
   derivative = DerivativeType(numberOfParameters);

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1436,9 +1436,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::GetLandmark(unsign
                                                                           PointType &  target)
 {
   Element::VectorType localSource;
-  Element::VectorType localTarget;
-
-  localTarget = m_LandmarkArray[index]->GetTarget();
+  Element::VectorType localTarget = m_LandmarkArray[index]->GetTarget();
   localSource = m_LandmarkArray[index]->GetSource();
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -740,8 +740,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
 
   UnsignedIntVectorType remapLabelsVec(m_InitialNumberOfRegions, 0);
 
-  UnsignedIntVectorType::iterator uniqueLabelsVecIterator;
-  uniqueLabelsVecIterator = uniqueLabelsVec.begin();
+  UnsignedIntVectorType::iterator uniqueLabelsVecIterator = uniqueLabelsVec.begin();
 
   RegionLabelType newLabelValue = 1;
 

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -37,8 +37,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::ExtensionVe
 
   for (unsigned int k = 0; k < VAuxDimension; ++k)
   {
-    AuxImagePointer ptr;
-    ptr = AuxImageType::New();
+    AuxImagePointer ptr = AuxImageType::New();
     this->ProcessObject::SetNthOutput(k + 1, ptr.GetPointer());
   }
 }
@@ -187,8 +186,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
 
   for (unsigned int k = 0; k < VAuxDimension; ++k)
   {
-    AuxImagePointer ptr;
-    ptr = m_Marcher->GetAuxiliaryImage(k);
+    AuxImagePointer ptr = m_Marcher->GetAuxiliaryImage(k);
     auxTempIt[k] = AuxIteratorType(ptr, ptr->GetBufferedRegion());
   }
 
@@ -321,8 +319,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
   }
 
   // set all auxiliary images to zero
-  TAuxValue zeroPixel;
-  zeroPixel = 0.0;
+  TAuxValue zeroPixel = 0.0;
 
   using AuxIteratorType = ImageRegionIterator<AuxImageType>;
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -193,9 +193,7 @@ LevelSetNeighborhoodExtractor<TLevelSet>::CalculateDistance(IndexType & index)
   m_LastPointIsInside = false;
 
   typename LevelSetImageType::PixelType centerValue;
-  PixelType                             inputPixel;
-
-  inputPixel = m_InputLevelSet->GetPixel(index);
+  PixelType                             inputPixel = m_InputLevelSet->GetPixel(index);
   centerValue = static_cast<double>(inputPixel);
   centerValue -= m_LevelSetValue;
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -667,8 +667,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
   ValueType       value;
   StatusType      layer_number;
 
-  typename OutputImageType::IndexType upperBounds, lowerBounds;
-  lowerBounds = this->m_OutputImage->GetRequestedRegion().GetIndex();
+  typename OutputImageType::IndexType upperBounds, lowerBounds = this->m_OutputImage->GetRequestedRegion().GetIndex();
   upperBounds =
     this->m_OutputImage->GetRequestedRegion().GetIndex() + this->m_OutputImage->GetRequestedRegion().GetSize();
 

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -119,8 +119,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
               // ignore
               // If NeighborClass > 1   -> Found a new neighbor, but only if
               // it's minimum
-              OutputImagePixelType NeighborClass;
-              NeighborClass = outputImage->GetPixel(NeighborIndex);
+              OutputImagePixelType NeighborClass = outputImage->GetPixel(NeighborIndex);
               // See if we've already touched it
               if (NeighborClass != 1)
               {
@@ -180,8 +179,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
           Visited.push_back(SeedIndex);
           itkDebugMacro("Flood fill, looking at " << SeedIndex);
           // Look at the neighbors
-          InputImagePixelType SeedValue;
-          SeedValue = inputImage->GetPixel(SeedIndex);
+          InputImagePixelType SeedValue = inputImage->GetPixel(SeedIndex);
           for (Dimension = 0; Dimension < ImageDimension; ++Dimension)
           {
             for (t = -1; t <= 1; t = t + 2)

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -60,8 +60,7 @@ template <typename TScalar>
 bool
 SegmentTable<TScalar>::Add(IdentifierType a, const segment_t & t)
 {
-  std::pair<Iterator, bool> result;
-  result = m_HashMap.insert(ValueType(a, t));
+  std::pair<Iterator, bool> result = m_HashMap.insert(ValueType(a, t));
   if (result.second == false)
   {
     return false;


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^( [ ]+)([^ ][^=\r\n]*)([ ]+)(\w+);[\r\n]+\1\4\ =
    Replace with: $1$2$3$4 =
    Filters: itk*.* !+\test
    Directory: D:\src\ITK\Modules
    [v] Match case
    (*) Regular expression

Excluded a few cases where the syntax `T var; var = x` appears intentional (in ConceptChecking, ImageKmeansModelEstimator, MahalanobisDistanceThresholdImageFunction, QuasiNewtonOptimizerv4Template, and VariableSizeMatrix).

- Following pull request #4970 commit 89b5bd0e24dd1cb6dd268a32094f1b337bf25b39 "STYLE: Replace `Iterator it; it = x` with `Iterator it = x`" and other similar commits for different types of variables.

----

FYI, Just like in previous PRs, this regular expression also encountered some "false positives", for example, it matches the following lines of code, accidentally: 

    delete m_FaceSet;
    m_FaceSet = new IndexSetType();

Which is why I started by creating PRs that just deal with specific types of variables. To ease reviewability, and to avoid such "false positives". 