### PR TITLE
COMP: Improve path management for python package install

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -83,10 +83,14 @@ macro(WRAP_ITK_PYTHON_BINDINGS_INSTALL path wrapper_library_name)
       set(_component_module "${wrapper_library_name}")
     endif()
   endif()
+  set(_ORIG_DESTINATION "${PY_SITE_PACKAGES_PATH}/${path}")
+  cmake_path(NORMAL_PATH _ORIG_DESTINATION OUTPUT_VARIABLE _NORMALIZED_DESTINATION)
   install(
     FILES ${ARGN}
-    DESTINATION "${PY_SITE_PACKAGES_PATH}/${path}"
+    DESTINATION "${_NORMALIZED_DESTINATION}"
     COMPONENT ${_component_module}${WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER}RuntimeLibraries)
+  unset(_ORIG_DESTINATION)
+  unset(_NORMALIZED_DESTINATION)
   unset(_component_module)
 endmacro()
 


### PR DESCRIPTION
cmake 3.31 does an implicit conversion of paths like:
   /myvenv/site-packages//itk --> /myvenv/site-packages/itk
                        ^^                             ^

which produces many warnings like:

```txt
ITKCommon: Creating itkAnatomicalOrientation submodule.
 CMake Warning (dev) at Wrapping/Generators/Python/CMakeLists.txt:88 (install):
   Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
   "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
   command to set the policy and suppress this warning.
 Call Stack (most recent call first):
   Wrapping/Generators/Python/CMakeLists.txt:305 (wrap_itk_python_bindings_install)
   Wrapping/Generators/Python/CMakeLists.txt:380 (itk_setup_swig_python)
   Wrapping/macro_files/itk_auto_load_submodules.cmake:328 (itk_end_wrap_submodule_python)
   Wrapping/TypedefMacros.cmake:1331 (itk_auto_load_submodules)
   Modules/Core/Common/wrapping/CMakeLists.txt:63 (itk_auto_load_and_end_wrap_submodules)
```

Explicitly normalizing the path before calling the install command suppresses the message.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
