### PR TITLE
PERF: readability container size empty

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
@@ -97,7 +97,7 @@ itkBinaryReconstructionLabelMapFilterTest(int argc, char * argv[])
                       obtainedAttributeSet.end(),
                       std::inserter(diff, diff.begin()));
 
-  if (diff.size() != 0)
+  if (!diff.empty())
   {
     std::cerr << "Error" << std::endl;
     std::cerr << " Obtained attribute set differs from expected atribute set" << std::endl;

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -61,7 +61,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
   itk::VTKPolyDataMeshIO::Pointer vtkPolyDataMeshIO = itk::VTKPolyDataMeshIO::New();
 
   // Supported read extensions are empty by default
-  ITK_TEST_EXPECT_TRUE(vtkPolyDataMeshIO->GetSupportedReadExtensions().size() == 0);
+  ITK_TEST_EXPECT_TRUE(vtkPolyDataMeshIO->GetSupportedReadExtensions().empty());
 
   const itk::MeshIOBase::ArrayOfExtensionsType supportedExtensions{ ".vtk" };
   ITK_TEST_EXPECT_TRUE(vtkPolyDataMeshIO->GetSupportedWriteExtensions() == supportedExtensions);

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -126,7 +126,7 @@ GetRootName(const std::string & filename)
 
   // Create a base filename
   // i.e Image.PAR --> Image
-  if (fileExt.length() > 0 && filename.length() > fileExt.length())
+  if (!fileExt.empty() && filename.length() > fileExt.length())
   {
     const std::string::size_type it = filename.find_last_of(fileExt);
     std::string                  baseName(filename, 0, it - (fileExt.length() - 1));

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -198,7 +198,7 @@ PolygonGroupSpatialObjectXMLFileWriter::WriteFile()
     std::string errmsg("No PolygonGroup to Write");
     RAISE_EXCEPTION(errmsg);
   }
-  if (m_Filename.length() == 0)
+  if (m_Filename.empty())
   {
     std::string errmsg("No filename given");
     RAISE_EXCEPTION(errmsg);

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -141,7 +141,7 @@ TxtTransformIOTemplate<TParametersValueType>::Read()
     line = trim(line);
     itkDebugMacro("Found line: \"" << line << '"');
 
-    if (line.length() == 0)
+    if (line.empty())
     {
       continue;
     }

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -95,7 +95,7 @@ VideoFileWriter<TInputVideoStream>::Write()
   }
 
   // Make sure FramesPerSecond and FourCC have been set
-  if (Math::ExactlyEquals(m_FramesPerSecond, TemporalRatioType{}) || m_FourCC.length() == 0)
+  if (Math::ExactlyEquals(m_FramesPerSecond, TemporalRatioType{}) || m_FourCC.empty())
   {
     itkExceptionMacro("Cannot write with FramesPerSecond or FourCC unset");
   }
@@ -270,7 +270,7 @@ template <typename TInputVideoStream>
 bool
 VideoFileWriter<TInputVideoStream>::InitializeVideoIO()
 {
-  if (m_FileName.length() != 0)
+  if (!m_FileName.empty())
   {
     m_VideoIO = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::WriteMode, m_FileName.c_str());
 


### PR DESCRIPTION
The emptiness of a container should be checked using the empty() method instead of the size() method. It is not guaranteed that size() is a constant-time function, and it is generally more efficient and also shows clearer intent to use empty(). Furthermore some containers may implement the empty() method but not implement the size() method. Using empty() whenever possible makes it easier to switch to another container in the future.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,readability-container-size-empty  -header-filter=.* -fix