### PR TITLE
STYLE: Remove support for 10+ year old GDCM

### DIFF
--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -35,10 +35,9 @@
 #include <string>
 
 
-#if !defined(ITK_LEGACY_REMOVE)
-#  define ITKIO_DEPRECATED_GDCM1_API
+#if GDCM_MAJOR_VERSION == 2 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION <= 12
+#  error "GDCM versions less or equeal to 2.0.12 are no longer supported"
 #endif
-
 
 namespace itk
 {
@@ -191,61 +190,6 @@ public:
   itkGetConstMacro(ReadYBRtoRGB, bool);
   itkBooleanMacro(ReadYBRtoRGB);
 
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-  /** Convenience methods to query patient information and scanner
-   * information. These methods are here for compatibility with the
-   * DICOMImageIO2 class and as such should not be used in any new code.
-   * They rely on properly preallocated buffer, which is not a good practice.
-   * Instead user is encouraged to use directly the GetValueFromTag function. */
-  void
-  GetPatientName(char * name, size_t len = 512);
-
-  void
-  GetPatientID(char * name, size_t len = 512);
-
-  void
-  GetPatientSex(char * name, size_t len = 512);
-
-  void
-  GetPatientAge(char * name, size_t len = 512);
-
-  void
-  GetStudyID(char * name, size_t len = 512);
-
-  void
-  GetPatientDOB(char * name, size_t len = 512);
-
-  void
-  GetStudyDescription(char * name, size_t len = 512);
-
-  void
-  GetBodyPart(char * name, size_t len = 512);
-
-  void
-  GetNumberOfSeriesInStudy(char * name, size_t len = 512);
-
-  void
-  GetNumberOfStudyRelatedSeries(char * name, size_t len = 512);
-
-  void
-  GetStudyDate(char * name, size_t len = 512);
-
-  void
-  GetModality(char * name, size_t len = 512);
-
-  void
-  GetManufacturer(char * name, size_t len = 512);
-
-  void
-  GetInstitution(char * name, size_t len = 512);
-
-  void
-  GetModel(char * name, size_t len = 512);
-
-  void
-  GetScanOptions(char * name, size_t len = 512);
-#endif
-
   /** More general method to retrieve an arbitrary DICOM value based
    * on a DICOM Tag (eg "0123|45ef"). */
   bool
@@ -259,82 +203,6 @@ public:
    * tagkey is returned in the variable labelId. */
   static bool
   GetLabelFromTag(const std::string & tag, std::string & labelId);
-
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-  /** A DICOM file can contains multiple binary stream that can be very long.
-   * For example an Overlay on the image. Most of the time user do not want to load
-   * this binary structure in memory since it can consume lot of memory. Therefore
-   * any field that is bigger than the default value 0xfff is discarded and just seek'd.
-   * This method allow advanced user to force the reading of such field.
-   * \warning this is a GDCM 1.x only option, no effect on GDCM 2.x */
-  virtual void
-  SetMaxSizeLoadEntry(const long)
-  {}
-
-  /** Parse any sequences in the DICOM file. Defaults to the value of
-   * LoadSequencesDefault. Loading DICOM files is faster when
-   * sequences are not needed.
-   * \warning this is a GDCM 1.x only option, no effect on GDCM 2.x */
-  virtual void
-  SetLoadSequences(const bool)
-  {}
-  virtual bool
-  GetLoadSequences() const
-  {
-    return true;
-  }
-  virtual void
-  LoadSequencesOn()
-  {}
-  virtual void
-  LoadSequencesOff()
-  {}
-
-  /** Global method to define the default value for
-   * LoadSequences. When instances of GDCMImageIO are created, the
-   * ivar LoadSequences is initialized to the value of
-   * LoadSequencesDefault. This method is useful when relying on the
-   * IO factory mechanism to load images rather than specifying a
-   * particular ImageIO object on the readers. Default is false.
-   * \warning this is a GDCM 1.x only option, no effect on GDCM 2.x */
-  static void
-  SetLoadSequencesDefault(bool)
-  {}
-  static void
-  LoadSequencesDefaultOn()
-  {}
-  static void
-  LoadSequencesDefaultOff()
-  {}
-  static bool
-  GetLoadSequencesDefault()
-  {
-    return true;
-  }
-
-  /** Global method to define the default value for
-   * LoadPrivateTags. When instances of GDCMImageIO are created, the
-   * ivar LoadPrivateTags is initialized to the value of
-   * LoadPrivateTagsDefault. This method is useful when relying on the
-   * IO factory mechanism to load images rather than specifying a
-   * particular ImageIO object on the readers. Default is false.
-   * \warning this is a GDCM 1.x only option, no effect on GDCM 2.x */
-  static void
-  SetLoadPrivateTagsDefault(bool)
-  {}
-  static void
-  LoadPrivateTagsDefaultOn()
-  {}
-  static void
-  LoadPrivateTagsDefaultOff()
-  {}
-  static bool
-  GetLoadPrivateTagsDefault()
-  {
-    return true;
-  }
-#endif
-
 
   using CompressionEnum = GDCMImageIOEnums::Compression;
 #if !defined(ITK_LEGACY_REMOVE)
@@ -380,40 +248,6 @@ protected:
   bool m_ReadYBRtoRGB{};
 
 private:
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-  std::string m_PatientName{};
-
-  std::string m_PatientID{};
-
-  std::string m_PatientDOB{};
-
-  std::string m_StudyID{};
-
-  std::string m_StudyDescription{};
-
-  std::string m_BodyPart{};
-
-  std::string m_NumberOfSeriesInStudy{};
-
-  std::string m_NumberOfStudyRelatedSeries{};
-
-  std::string m_PatientSex{};
-
-  std::string m_PatientAge{};
-
-  std::string m_StudyDate{};
-
-  std::string m_Modality{};
-
-  std::string m_Manufacturer{};
-
-  std::string m_Institution{};
-
-  std::string m_Model{};
-
-  std::string m_ScanOptions{};
-#endif
-
   unsigned int m_GlobalNumberOfDimensions{};
 
   CompressionEnum m_CompressionType{};

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -787,27 +787,6 @@ GDCMImageIO::InternalReadImageInformation()
       }
     }
   }
-
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-  // Now is a good time to fill in the class member:
-  char name[512];
-  this->GetPatientName(name, 512);
-  this->GetPatientID(name, 512);
-  this->GetPatientSex(name, 512);
-  this->GetPatientAge(name, 512);
-  this->GetStudyID(name, 512);
-  this->GetPatientDOB(name, 512);
-  this->GetStudyDescription(name, 512);
-  this->GetBodyPart(name, 512);
-  this->GetNumberOfSeriesInStudy(name, 512);
-  this->GetNumberOfStudyRelatedSeries(name, 512);
-  this->GetStudyDate(name, 512);
-  this->GetModality(name, 512);
-  this->GetManufacturer(name, 512);
-  this->GetInstitution(name, 512);
-  this->GetModel(name, 512);
-  this->GetScanOptions(name, 512);
-#endif
 }
 
 void
@@ -934,11 +913,6 @@ GDCMImageIO::Write(const void * buffer)
           {
             de.SetVR(dictEntry.GetVR());
           }
-#if GDCM_MAJOR_VERSION == 2 && GDCM_MINOR_VERSION == 0 && GDCM_BUILD_VERSION <= 12
-          // This will not work in the vast majority of cases but to get at
-          // least something working in GDCM 2.0.12
-          de.SetByteValue(value.c_str(), static_cast<uint32_t>(value.size()));
-#else
           // Even padding string with space. If string is not even, SetByteValue() will
           // pad it with '\0' which is not what is expected except for VR::UI
           // (see standard section 6.2).
@@ -952,7 +926,6 @@ GDCMImageIO::Write(const void * buffer)
             const gdcm::String<> si = sf.FromString(tag, value.c_str(), value.size());
             de.SetByteValue(si.c_str(), static_cast<uint32_t>(si.size()));
           }
-#endif
           if (tag.GetGroup() == 0x2)
           {
             fmi.Insert(de);
@@ -1416,170 +1389,6 @@ GDCMImageIO::Write(const void * buffer)
   }
 }
 
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-// Convenience methods to query patient and scanner information. These
-// methods are here for compatibility with the DICOMImageIO2 class.
-void
-GDCMImageIO::GetPatientName(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0010|0010", m_PatientName);
-  strncpy(name, m_PatientName.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetPatientID(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0010|0020", m_PatientID);
-  strncpy(name, m_PatientID.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetPatientSex(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0010|0040", m_PatientSex);
-  strncpy(name, m_PatientSex.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetPatientAge(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0010|1010", m_PatientAge);
-  strncpy(name, m_PatientAge.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetStudyID(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0020|0010", m_StudyID);
-  strncpy(name, m_StudyID.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetPatientDOB(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0010|0030", m_PatientDOB);
-  strncpy(name, m_PatientDOB.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetStudyDescription(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|1030", m_StudyDescription);
-  strncpy(name, m_StudyDescription.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetBodyPart(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0018|0015", m_BodyPart);
-  strncpy(name, m_BodyPart.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetNumberOfSeriesInStudy(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0020|1000", m_NumberOfSeriesInStudy);
-  strncpy(name, m_NumberOfSeriesInStudy.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetNumberOfStudyRelatedSeries(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0020|1206", m_NumberOfStudyRelatedSeries);
-  strncpy(name, m_NumberOfStudyRelatedSeries.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetStudyDate(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|0020", m_StudyDate);
-  strncpy(name, m_StudyDate.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetModality(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|0060", m_Modality);
-  strncpy(name, m_Modality.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetManufacturer(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|0070", m_Manufacturer);
-  strncpy(name, m_Manufacturer.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetInstitution(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|0080", m_Institution);
-  strncpy(name, m_Institution.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetModel(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0008|1090", m_Model);
-  strncpy(name, m_Model.c_str(), len);
-  name[len - 1] = '\0';
-}
-
-void
-GDCMImageIO::GetScanOptions(char * name, size_t len)
-{
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-
-  ExposeMetaData<std::string>(dict, "0018|0022", m_ScanOptions);
-  strncpy(name, m_ScanOptions.c_str(), len);
-  name[len - 1] = '\0';
-}
-#endif
-
 bool
 GDCMImageIO::GetValueFromTag(const std::string & tag, std::string & value)
 {
@@ -1649,25 +1458,6 @@ GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
   {
     os << m_DICOMHeader << std::endl;
   }
-
-#if defined(ITKIO_DEPRECATED_GDCM1_API)
-  os << indent << "PatientName: " << m_PatientName << std::endl;
-  os << indent << "PatientID: " << m_PatientID << std::endl;
-  os << indent << "PatientSex: " << m_PatientSex << std::endl;
-  os << indent << "PatientAge: " << m_PatientAge << std::endl;
-  os << indent << "StudyID: " << m_StudyID << std::endl;
-  os << indent << "PatientDOB: " << m_PatientDOB << std::endl;
-  os << indent << "StudyDescription: " << m_StudyDescription << std::endl;
-  os << indent << "BodyPart: " << m_BodyPart << std::endl;
-  os << indent << "NumberOfSeriesInStudy: " << m_NumberOfSeriesInStudy << std::endl;
-  os << indent << "NumberOfStudyRelatedSeries: " << m_NumberOfStudyRelatedSeries << std::endl;
-  os << indent << "StudyDate: " << m_StudyDate << std::endl;
-  os << indent << "Modality: " << m_Modality << std::endl;
-  os << indent << "Manufacturer: " << m_Manufacturer << std::endl;
-  os << indent << "InstitutionName: " << m_Institution << std::endl;
-  os << indent << "Model: " << m_Model << std::endl;
-  os << indent << "ScanOptions: " << m_ScanOptions << std::endl;
-#endif
 }
 
 std::ostream &

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -146,26 +146,9 @@ GDCMSeriesFileNames::GetFileNames(const std::string serie)
     ProgressReporter progress(this, 0, static_cast<itk::SizeValueType>(flist->size()), 10);
     for (it = flist->begin(); it != flist->end(); ++it)
     {
-#if GDCM_MAJOR_VERSION < 2
-      gdcm::File * header = *it;
-      if (!header)
-      {
-        itkWarningMacro("GDCMSeriesFileNames got nullptr header, "
-                        "this is a serious bug");
-        continue;
-      }
-      if (!header->IsReadable())
-      {
-        itkWarningMacro("GDCMSeriesFileNames got a non DICOM file:" << header->GetFileName());
-        continue;
-      }
-      m_InputFileNames.push_back(header->GetFileName());
-      progress.CompletedPixel();
-#else
       gdcm::FileWithName * header = *it;
       m_InputFileNames.push_back(header->filename);
       progress.CompletedPixel();
-#endif
     }
   }
   else

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -74,9 +74,6 @@ itkGDCMImageIONoCrashTest(int argc, char * argv[])
   std::cout << "SeriesInstanceUID: " << gdcmImageIO->GetSeriesInstanceUID() << std::endl;
   std::cout << "FrameOfReferenceInstanceUID: " << gdcmImageIO->GetFrameOfReferenceInstanceUID() << std::endl;
   std::cout << "KeepOriginalUID: " << gdcmImageIO->GetKeepOriginalUID() << std::endl;
-#ifndef ITK_LEGACY_REMOVE
-  std::cout << "LoadSequences: " << gdcmImageIO->GetLoadSequences() << std::endl;
-#endif
   std::cout << "LoadPrivateTags: " << gdcmImageIO->GetLoadPrivateTags() << std::endl;
   std::cout << "CompressionType: " << gdcmImageIO->GetCompressionType() << std::endl;
 


### PR DESCRIPTION
Remove support for system installed versions of GDCM that are more than 10 years old.

This simplifies the codebase for code that has likely not been explicitly tested in a very long time.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
