### PR TITLE
COMP: GDCM: fix CMake Deprecation Warning

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
@@ -1,14 +1,7 @@
-cmake_minimum_required(VERSION 3.9.2 FATAL_ERROR)
+set(GDCM_MAX_VALIDATED_CMAKE_VERSION "3.13.4")
 
-set(GDCM_MAX_VALIDATED_CMAKE_VERSION "3.13.1")
-if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "${GDCM_MAX_VALIDATED_CMAKE_VERSION}")
-  # As of 2018-12-04 GDCM has been validated to build with cmake version 3.13.1 new policies.
-  # Set and use the newest cmake policies that are validated to work
-  set(GDCM_CMAKE_POLICY_VERSION "${CMAKE_VERSION}")
-else()
-  set(GDCM_CMAKE_POLICY_VERSION "${GDCM_MAX_VALIDATED_CMAKE_VERSION}")
-endif()
-cmake_policy(VERSION ${GDCM_CMAKE_POLICY_VERSION})
+# Set minimum required version of CMake, and policy version
+cmake_minimum_required(VERSION 3.9.2...${GDCM_MAX_VALIDATED_CMAKE_VERSION} FATAL_ERROR) # travis-ci wants 3.9.2
 
 # GDCM version 3.0.0 will only support C++11 and greater
 if(CMAKE_CXX_STANDARD EQUAL "98" )


### PR DESCRIPTION
Use cmake_minimum_required to set min and policy_max

    CMake version >3.30 produce a deprecated awarning when only, a min
    argument less that 3.10 is pass to cmake_minimum_required. Using the
    additional policy_max version range specified the max policy setting
    at the same time.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
