### PR TITLE
STYLE: Rename `TCoordRep` template parameters to `TCoordinate`

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup Functions ImageInterpolators
  * \ingroup ITKCommon
  */
-template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
+template <typename TCoordinate = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationWeightFunction
-  : public FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>,
+  : public FunctionBase<ContinuousIndex<TCoordinate, VSpaceDimension>,
                         FixedArray<double, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>>
 {
 public:
@@ -54,7 +54,7 @@ public:
 
   /** Standard class type aliases. */
   using Self = BSplineInterpolationWeightFunction;
-  using Superclass = FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>,
+  using Superclass = FunctionBase<ContinuousIndex<TCoordinate, VSpaceDimension>,
                                   FixedArray<double, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>>;
 
   using Pointer = SmartPointer<Self>;
@@ -83,7 +83,7 @@ public:
   using SizeType = Size<VSpaceDimension>;
 
   /** ContinuousIndex type alias support. */
-  using ContinuousIndexType = ContinuousIndex<TCoordRep, VSpaceDimension>;
+  using ContinuousIndexType = ContinuousIndex<TCoordinate, VSpaceDimension>;
 
   /** The support region size: a hypercube of length SplineOrder + 1 */
   static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -26,9 +26,9 @@
 namespace itk
 {
 /** Compute weights for interpolation at continuous index position */
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordinate, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 auto
-BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
+BSplineInterpolationWeightFunction<TCoordinate, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & index) const -> WeightsType
 {
   WeightsType weights;
@@ -40,9 +40,9 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
 }
 
 /** Compute weights for interpolation at continuous index position */
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+template <typename TCoordinate, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 void
-BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
+BSplineInterpolationWeightFunction<TCoordinate, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & index,
   WeightsType &               weights,
   IndexType &                 startIndex) const

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -55,7 +55,7 @@ namespace itk
  * Template parameters for BoundingBox:
  *
  * \tparam TPointIdentifier The type used to access a particular point (i.e., a point's id)
- * \tparam TCoordRep Numerical type with which to represent each coordinate value.
+ * \tparam TCoordinate Numerical type with which to represent each coordinate value.
  * \tparam VPointDimension Geometric dimension of space.
  *
  * \ingroup DataRepresentation
@@ -65,8 +65,8 @@ namespace itk
  */
 template <typename TPointIdentifier = IdentifierType,
           unsigned int VPointDimension = 3,
-          typename TCoordRep = float,
-          typename TPointsContainer = VectorContainer<TPointIdentifier, Point<TCoordRep, VPointDimension>>>
+          typename TCoordinate = float,
+          typename TPointsContainer = VectorContainer<TPointIdentifier, Point<TCoordinate, VPointDimension>>>
 class ITK_TEMPLATE_EXPORT BoundingBox : public Object
 {
 public:
@@ -89,7 +89,7 @@ public:
 
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using PointsContainer = TPointsContainer;
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using PointsContainerConstPointer = typename PointsContainer::ConstPointer;

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -35,10 +35,10 @@ namespace itk
 /**
  * Print out the bounding box.
  */
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 void
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PrintSelf(std::ostream & os,
-                                                                                       Indent         indent) const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::PrintSelf(std::ostream & os,
+                                                                                         Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -53,9 +53,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Pri
 /**
  * Access routine to set the points container.
  */
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 void
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::SetPoints(const PointsContainer * points)
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::SetPoints(const PointsContainer * points)
 {
   itkDebugMacro("setting Points container to " << points);
   if (m_PointsContainer != points)
@@ -66,9 +66,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Set
 }
 
 /** Access routine to get the points container. */
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetPoints() const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetPoints() const
   -> const PointsContainer *
 {
   itkDebugMacro("returning Points container of " << m_PointsContainer);
@@ -77,9 +77,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
 }
 
 /** Compute and get the corners of the bounding box */
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::ComputeCorners() const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::ComputeCorners() const
   -> std::array<PointType, NumberOfCorners>
 {
   std::array<PointType, NumberOfCorners> result;
@@ -110,9 +110,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
 
 #if !defined(ITK_LEGACY_REMOVE)
 /** Compute and get the corners of the bounding box */
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCorners() -> const PointsContainer *
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetCorners() -> const PointsContainer *
 {
   m_CornersContainer->clear();
   m_CornersContainer->Reserve(NumberOfCorners);
@@ -128,9 +128,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
 #endif
 
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 bool
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::ComputeBoundingBox() const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::ComputeBoundingBox() const
 {
   if (!m_PointsContainer)
   {
@@ -153,8 +153,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
       return false;
     }
 
-    PointsContainerConstIterator      ci = m_PointsContainer->Begin();
-    Point<TCoordRep, VPointDimension> point = ci->Value(); // point value
+    PointsContainerConstIterator        ci = m_PointsContainer->Begin();
+    Point<TCoordinate, VPointDimension> point = ci->Value(); // point value
     for (unsigned int i = 0; i < PointDimension; ++i)
     {
       m_Bounds[2 * i] = point[i];
@@ -187,9 +187,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
   return true;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCenter() const -> PointType
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetCenter() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -202,9 +202,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   return center;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMinimum() const -> PointType
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetMinimum() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -217,9 +217,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   return minimum;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 void
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::SetMinimum(const PointType & point)
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::SetMinimum(const PointType & point)
 {
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
@@ -229,9 +229,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Set
   m_BoundsMTime.Modified();
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMaximum() const -> PointType
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetMaximum() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -244,9 +244,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   return maximum;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 void
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::SetMaximum(const PointType & point)
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::SetMaximum(const PointType & point)
 {
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
@@ -256,9 +256,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Set
   m_BoundsMTime.Modified();
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 void
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::ConsiderPoint(const PointType & point)
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::ConsiderPoint(const PointType & point)
 {
   bool changed = false;
 
@@ -282,9 +282,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Con
   }
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetDiagonalLength2() const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetDiagonalLength2() const
   -> AccumulateType
 {
   typename NumericTraits<CoordRepType>::AccumulateType dist2 = CoordRepType{};
@@ -300,9 +300,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   return dist2;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 bool
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::IsInside(const PointType & point) const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::IsInside(const PointType & point) const
 {
   unsigned int j = 0;
   unsigned int i = 0;
@@ -322,9 +322,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::IsI
   return true;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 ModifiedTimeType
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMTime() const
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetMTime() const
 {
   ModifiedTimeType latestTime = Object::GetMTime();
 
@@ -335,9 +335,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   return latestTime;
 }
 
-template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
+template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordinate, typename TPointsContainer>
 auto
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::DeepCopy() const -> Pointer
+BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::DeepCopy() const -> Pointer
 {
   Pointer clone = Self::New();
 

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -513,7 +513,7 @@ protected:
  * \ingroup ITKCommon
  */
 template <int VPointDimension,
-          typename TCoordRep,
+          typename TCoordinate,
           typename TInterpolationWeight,
           typename TPointIdentifier,
           typename TCellIdentifier,
@@ -525,7 +525,7 @@ class ITK_TEMPLATE_EXPORT CellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -30,7 +30,7 @@ namespace itk
  *
  * ContinuousIndex is a templated class that holds a set of coordinates
  * (components).
- * The template parameter TCoordRep can be any floating point type (float, double).
+ * The template parameter TCoordinate can be any floating point type (float, double).
  * The VIndexDimension defines the number of  components in the continuous
  * index array.
  *
@@ -42,21 +42,21 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TCoordRep = double, unsigned int VIndexDimension = 2>
-class ITK_TEMPLATE_EXPORT ContinuousIndex : public Point<TCoordRep, VIndexDimension>
+template <typename TCoordinate = double, unsigned int VIndexDimension = 2>
+class ITK_TEMPLATE_EXPORT ContinuousIndex : public Point<TCoordinate, VIndexDimension>
 {
-  static_assert(std::is_floating_point_v<TCoordRep>,
+  static_assert(std::is_floating_point_v<TCoordinate>,
                 "The coordinates of a continuous index must be represented by floating point numbers.");
 
 public:
   /** Standard class type aliases. */
   using Self = ContinuousIndex;
-  using Superclass = Point<TCoordRep, VIndexDimension>;
+  using Superclass = Point<TCoordinate, VIndexDimension>;
 
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
-  using ValueType = TCoordRep;
-  using CoordRepType = TCoordRep;
+  using ValueType = TCoordinate;
+  using CoordRepType = TCoordinate;
 
   /** Dimension of the Space */
   static constexpr unsigned int IndexDimension = VIndexDimension;
@@ -83,7 +83,7 @@ public:
   {
     for (unsigned int i = 0; i < VIndexDimension; ++i)
     {
-      (*this)[i] = static_cast<TCoordRep>(index[i]);
+      (*this)[i] = static_cast<TCoordinate>(index[i]);
     }
   }
 };

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -245,9 +245,9 @@ public:
 
   /** Copy from another CovariantVector with a different representation type.
    *  Casting is done with C-Like rules  */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   void
-  CastFrom(const CovariantVector<TCoordRepB, VVectorDimension> & pa)
+  CastFrom(const CovariantVector<TCoordinateB, VVectorDimension> & pa)
   {
     for (unsigned int i = 0; i < VVectorDimension; ++i)
     {

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -46,7 +46,7 @@ namespace itk
  * \tparam VMaxTopologicalDimension Max topological dimension of a cell
  * that can be inserted into this mesh.
  *
- * \tparam TCoordRep Numerical type to store each coordinate value.
+ * \tparam TCoordinate Numerical type to store each coordinate value.
  *
  * \tparam TInterpolationWeight Numerical type to store interpolation
  * weights.
@@ -57,7 +57,7 @@ namespace itk
 template <typename TPixelType,
           unsigned int VPointDimension = 3,
           unsigned int VMaxTopologicalDimension = VPointDimension,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TInterpolationWeight = float,
           typename TCellPixelType = TPixelType>
 class DefaultDynamicMeshTraits
@@ -69,7 +69,7 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -43,7 +43,7 @@ namespace itk
  * VMaxTopologicalDimension =
  *    Max topological dimension of a cell that can be inserted into this mesh.
  *
- * TCoordRep =
+ * TCoordinate =
  *    Numerical type with which to represent each coordinate value.
  *
  * TInterpolationWeight =
@@ -55,7 +55,7 @@ namespace itk
 template <typename TPixelType,
           unsigned int VPointDimension = 3,
           unsigned int VMaxTopologicalDimension = VPointDimension,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TInterpolationWeight = float,
           typename TCellPixelType = TPixelType>
 class ITK_TEMPLATE_EXPORT DefaultStaticMeshTraits
@@ -67,7 +67,7 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.h
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.h
@@ -103,8 +103,8 @@ public:
   DiffusionTensor3D(const ComponentArrayType r);
 
   /** Constructor to enable casting...  */
-  template <typename TCoordRepB>
-  DiffusionTensor3D(const DiffusionTensor3D<TCoordRepB> & pa)
+  template <typename TCoordinateB>
+  DiffusionTensor3D(const DiffusionTensor3D<TCoordinateB> & pa)
     : SymmetricSecondRankTensor<TComponent, 3>(pa)
   {}
 
@@ -119,14 +119,14 @@ public:
   operator=(const ComponentArrayType r);
 
   /** Templated Pass-through assignment for the Array base class. */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   Self &
-  operator=(const DiffusionTensor3D<TCoordRepB> & pa)
+  operator=(const DiffusionTensor3D<TCoordinateB> & pa)
   {
     // NOTE (this != &pa ) because they are different pointer types
     // if this templated function is called
     // ComponentType 'itk::DiffusionTensor3D<double> *'
-    // TCoordRepB   'const DiffusionTensor3D<float> *')
+    // TCoordinateB   'const DiffusionTensor3D<float> *')
     SymmetricSecondRankTensor<TComponent, 3>::operator=(pa);
     return *this;
   }

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -455,15 +455,15 @@ public:
       if (image->TransformPhysicalPointToIndex(point, index)) // Et cetera...
      \endcode
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   [[nodiscard]] IndexType
-  TransformPhysicalPointToIndex(const Point<TCoordRep, VImageDimension> & point) const
+  TransformPhysicalPointToIndex(const Point<TCoordinate, VImageDimension> & point) const
   {
     IndexType index;
 
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
-      TCoordRep sum{};
+      TCoordinate sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += this->m_PhysicalPointToIndex[i][j] * (point[j] - this->m_Origin[j]);
@@ -481,9 +481,9 @@ public:
    * overload instead, which has only one parameter (the point), and returns the index.
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToIndex(const Point<TCoordRep, VImageDimension> & point, IndexType & index) const
+  bool TransformPhysicalPointToIndex(const Point<TCoordinate, VImageDimension> & point, IndexType & index) const
   {
     index = TransformPhysicalPointToIndex(point);
 
@@ -507,9 +507,9 @@ public:
      if (image->TransformPhysicalPointToContinuousIndex(point, index)) // Et cetera...
      \endcode
    * \sa Transform */
-  template <typename TIndexRep, typename TCoordRep>
+  template <typename TIndexRep, typename TCoordinate>
   [[nodiscard]] ContinuousIndex<TIndexRep, VImageDimension>
-  TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, VImageDimension> & point) const
+  TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, VImageDimension> & point) const
   {
     ContinuousIndex<TIndexRep, VImageDimension> index;
     Vector<SpacePrecisionType, VImageDimension> cvector;
@@ -534,9 +534,9 @@ public:
    * overload instead, which has only one parameter (the point), and returns the continuous index.
    *
    * \sa Transform */
-  template <typename TCoordRep, typename TIndexRep>
+  template <typename TCoordinate, typename TIndexRep>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, VImageDimension> &     point,
+  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, VImageDimension> &   point,
                                                ContinuousIndex<TIndexRep, VImageDimension> & index) const
   {
     index = TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
@@ -550,14 +550,14 @@ public:
    * the origin and spacing information comes from)
    * from a continuous index (in the index space)
    * \sa Transform */
-  template <typename TCoordRep, typename TIndexRep>
+  template <typename TCoordinate, typename TIndexRep>
   void
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, VImageDimension> & index,
-                                          Point<TCoordRep, VImageDimension> &                 point) const
+                                          Point<TCoordinate, VImageDimension> &               point) const
   {
     for (unsigned int r = 0; r < VImageDimension; ++r)
     {
-      TCoordRep sum{};
+      TCoordinate sum{};
       for (unsigned int c = 0; c < VImageDimension; ++c)
       {
         sum += this->m_IndexToPhysicalPoint(r, c) * index[c];
@@ -570,11 +570,11 @@ public:
    * the origin and spacing information comes from)
    * from a continuous index (in the index space)
    * \sa Transform */
-  template <typename TCoordRep, typename TIndexRep>
-  [[nodiscard]] Point<TCoordRep, VImageDimension>
+  template <typename TCoordinate, typename TIndexRep>
+  [[nodiscard]] Point<TCoordinate, VImageDimension>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, VImageDimension> & index) const
   {
-    Point<TCoordRep, VImageDimension> point;
+    Point<TCoordinate, VImageDimension> point;
     TransformContinuousIndexToPhysicalPoint(index, point);
     return point;
   }
@@ -584,9 +584,9 @@ public:
    * from a discrete index (in the index space)
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordRep, VImageDimension> & point) const
+  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordinate, VImageDimension> & point) const
   {
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
@@ -603,11 +603,11 @@ public:
    * from a discrete index (in the index space)
    *
    * \sa Transform */
-  template <typename TCoordRep>
-  [[nodiscard]] Point<TCoordRep, VImageDimension>
+  template <typename TCoordinate>
+  [[nodiscard]] Point<TCoordinate, VImageDimension>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
-    Point<TCoordRep, VImageDimension> point;
+    Point<TCoordinate, VImageDimension> point;
     TransformIndexToPhysicalPoint(index, point);
     return point;
   }
@@ -626,10 +626,10 @@ public:
    *
    * \sa Image
    */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformLocalVectorToPhysicalVector(const FixedArray<TCoordRep, VImageDimension> & inputGradient,
-                                       FixedArray<TCoordRep, VImageDimension> &       outputGradient) const
+  TransformLocalVectorToPhysicalVector(const FixedArray<TCoordinate, VImageDimension> & inputGradient,
+                                       FixedArray<TCoordinate, VImageDimension> &       outputGradient) const
   {
     const DirectionType & direction = this->GetDirection();
 
@@ -637,13 +637,13 @@ public:
 
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
-      using CoordSumType = typename NumericTraits<TCoordRep>::AccumulateType;
+      using CoordSumType = typename NumericTraits<TCoordinate>::AccumulateType;
       CoordSumType sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += direction[i][j] * inputGradient[j];
       }
-      outputGradient[i] = static_cast<TCoordRep>(sum);
+      outputGradient[i] = static_cast<TCoordinate>(sum);
     }
   }
 
@@ -675,10 +675,10 @@ public:
    * same data.
    *
    */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordRep, VImageDimension> & inputGradient,
-                                       FixedArray<TCoordRep, VImageDimension> &       outputGradient) const
+  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordinate, VImageDimension> & inputGradient,
+                                       FixedArray<TCoordinate, VImageDimension> &       outputGradient) const
   {
     const DirectionType & inverseDirection = this->GetInverseDirection();
 
@@ -686,13 +686,13 @@ public:
 
     for (unsigned int i = 0; i < VImageDimension; ++i)
     {
-      using CoordSumType = typename NumericTraits<TCoordRep>::AccumulateType;
+      using CoordSumType = typename NumericTraits<TCoordinate>::AccumulateType;
       CoordSumType sum{};
       for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += inverseDirection[i][j] * inputGradient[j];
       }
-      outputGradient[i] = static_cast<TCoordRep>(sum);
+      outputGradient[i] = static_cast<TCoordinate>(sum);
     }
   }
 

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -280,11 +280,11 @@ public:
    * We take into account the fact that each voxel has its
    * center at the integer coordinate and extends half way
    * to the next integer coordinate, inclusive on all sides. */
-  template <typename TCoordRepType>
+  template <typename TCoordinateType>
   bool
-  IsInside(const ContinuousIndex<TCoordRepType, VImageDimension> & index) const
+  IsInside(const ContinuousIndex<TCoordinateType, VImageDimension> & index) const
   {
-    constexpr TCoordRepType half = 0.5;
+    constexpr TCoordinateType half = 0.5;
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       // Use negation of tests so that index[i]==NaN leads to returning false.

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -288,9 +288,9 @@ public:
   alignas(IndexValueType) IndexValueType m_InternalArray[VDimension];
 
   /** Copy values from a FixedArray by rounding each one of the components */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   inline void
-  CopyWithRound(const FixedArray<TCoordRep, VDimension> & point)
+  CopyWithRound(const FixedArray<TCoordinate, VDimension> & point)
   {
     for (unsigned int i = 0; i < VDimension; ++i)
     {
@@ -299,9 +299,9 @@ public:
   }
 
   /** Copy values from a FixedArray by casting each one of the components */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   inline void
-  CopyWithCast(const FixedArray<TCoordRep, VDimension> & point)
+  CopyWithCast(const FixedArray<TCoordinate, VDimension> & point)
   {
     for (unsigned int i = 0; i < VDimension; ++i)
     {

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -239,9 +239,9 @@ public:
   alignas(OffsetValueType) OffsetValueType m_InternalArray[VDimension];
 
   /** Copy values from a FixedArray by rounding each one of the components */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   inline void
-  CopyWithRound(const FixedArray<TCoordRep, VDimension> & point)
+  CopyWithRound(const FixedArray<TCoordinate, VDimension> & point)
   {
     for (unsigned int i = 0; i < VDimension; ++i)
     {
@@ -250,9 +250,9 @@ public:
   }
 
   /** Copy values from a FixedArray by casting each one of the components */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   inline void
-  CopyWithCast(const FixedArray<TCoordRep, VDimension> & point)
+  CopyWithCast(const FixedArray<TCoordinate, VDimension> & point)
   {
     for (unsigned int i = 0; i < VDimension; ++i)
     {

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -182,29 +182,29 @@ public:
   using PixelContainerConstPointer = typename PixelContainer::ConstPointer;
 
   /** Returns the continuous index from a physical point */
-  template <typename TIndexRep, typename TCoordRep>
+  template <typename TIndexRep, typename TCoordinate>
   [[nodiscard]] ContinuousIndex<TIndexRep, 3>
-  TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, 3> & point) const
+  TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, 3> & point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
     const double     maxAzimuth = region.GetSize(0) - 1;
     const double     maxElevation = region.GetSize(1) - 1;
 
     // Convert Cartesian coordinates into angular coordinates
-    TCoordRep azimuth = Math::pi_over_2;
-    TCoordRep elevation = Math::pi_over_2;
+    TCoordinate azimuth = Math::pi_over_2;
+    TCoordinate elevation = Math::pi_over_2;
     if (point[2] != 0.0)
     {
       azimuth = std::atan(point[0] / point[2]);
       elevation = std::atan(point[1] / point[2]);
     }
-    const TCoordRep radius = std::sqrt(point[0] * point[0] + point[1] * point[1] + point[2] * point[2]);
+    const TCoordinate radius = std::sqrt(point[0] * point[0] + point[1] * point[1] + point[2] * point[2]);
 
     // Convert the "proper" angular coordinates into index format
     ContinuousIndex<TIndexRep, 3> index;
-    index[0] = static_cast<TCoordRep>((azimuth / m_AzimuthAngularSeparation) + (maxAzimuth / 2.0));
-    index[1] = static_cast<TCoordRep>((elevation / m_ElevationAngularSeparation) + (maxElevation / 2.0));
-    index[2] = static_cast<TCoordRep>(((radius - m_FirstSampleDistance) / m_RadiusSampleSize));
+    index[0] = static_cast<TCoordinate>((azimuth / m_AzimuthAngularSeparation) + (maxAzimuth / 2.0));
+    index[1] = static_cast<TCoordinate>((elevation / m_ElevationAngularSeparation) + (maxElevation / 2.0));
+    index[2] = static_cast<TCoordinate>(((radius - m_FirstSampleDistance) / m_RadiusSampleSize));
     return index;
   }
 
@@ -216,9 +216,9 @@ public:
    * overload instead, which has only one parameter (the point), and returns the continuous index.
    *
    * \sa Transform */
-  template <typename TCoordRep, typename TIndexRep>
+  template <typename TCoordinate, typename TIndexRep>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, 3> &     point,
+  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, 3> &   point,
                                                ContinuousIndex<TIndexRep, 3> & index) const
   {
     index = this->TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
@@ -232,23 +232,23 @@ public:
   /** Returns the index (discrete) from a physical point.
    * Floating point index results are truncated to integers.
    */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   [[nodiscard]] IndexType
-  TransformPhysicalPointToIndex(const Point<TCoordRep, 3> & point) const
+  TransformPhysicalPointToIndex(const Point<TCoordinate, 3> & point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
     const double     maxAzimuth = region.GetSize(0) - 1;
     const double     maxElevation = region.GetSize(1) - 1;
 
     // Convert Cartesian coordinates into angular coordinates
-    TCoordRep azimuth = Math::pi_over_2;
-    TCoordRep elevation = Math::pi_over_2;
+    TCoordinate azimuth = Math::pi_over_2;
+    TCoordinate elevation = Math::pi_over_2;
     if (point[2] != 0.0)
     {
       azimuth = std::atan(point[0] / point[2]);
       elevation = std::atan(point[1] / point[2]);
     }
-    const TCoordRep radius = std::sqrt(point[0] * point[0] + point[1] * point[1] + point[2] * point[2]);
+    const TCoordinate radius = std::sqrt(point[0] * point[0] + point[1] * point[1] + point[2] * point[2]);
 
     // Convert the "proper" angular coordinates into index format
     IndexType index;
@@ -266,9 +266,9 @@ public:
    * overload instead, which has only one parameter (the point), and returns the index.
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToIndex(const Point<TCoordRep, 3> & point, IndexType & index) const
+  bool TransformPhysicalPointToIndex(const Point<TCoordinate, 3> & point, IndexType & index) const
   {
     index = this->TransformPhysicalPointToIndex(point);
 
@@ -282,36 +282,36 @@ public:
    * the origin and spacing information comes from)
    * from a continuous index (in the index space)
    * \sa Transform */
-  template <typename TCoordRep, typename TIndexRep>
+  template <typename TCoordinate, typename TIndexRep>
   void
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, 3> & index,
-                                          Point<TCoordRep, 3> &                 point) const
+                                          Point<TCoordinate, 3> &               point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
     const double     maxAzimuth = region.GetSize(0) - 1;
     const double     maxElevation = region.GetSize(1) - 1;
 
     // Convert the index into proper angular coordinates
-    const TCoordRep azimuth = (index[0] - (maxAzimuth / 2.0)) * m_AzimuthAngularSeparation;
-    const TCoordRep elevation = (index[1] - (maxElevation / 2.0)) * m_ElevationAngularSeparation;
-    const TCoordRep radius = (index[2] * m_RadiusSampleSize) + m_FirstSampleDistance;
+    const TCoordinate azimuth = (index[0] - (maxAzimuth / 2.0)) * m_AzimuthAngularSeparation;
+    const TCoordinate elevation = (index[1] - (maxElevation / 2.0)) * m_ElevationAngularSeparation;
+    const TCoordinate radius = (index[2] * m_RadiusSampleSize) + m_FirstSampleDistance;
 
     // Convert the angular coordinates into Cartesian coordinates
-    const TCoordRep tanOfAzimuth = std::tan(azimuth);
-    const TCoordRep tanOfElevation = std::tan(elevation);
+    const TCoordinate tanOfAzimuth = std::tan(azimuth);
+    const TCoordinate tanOfElevation = std::tan(elevation);
 
     point[2] =
-      static_cast<TCoordRep>(radius / std::sqrt(1 + tanOfAzimuth * tanOfAzimuth + tanOfElevation * tanOfElevation));
-    point[1] = static_cast<TCoordRep>(point[2] * tanOfElevation);
-    point[0] = static_cast<TCoordRep>(point[2] * tanOfAzimuth);
+      static_cast<TCoordinate>(radius / std::sqrt(1 + tanOfAzimuth * tanOfAzimuth + tanOfElevation * tanOfElevation));
+    point[1] = static_cast<TCoordinate>(point[2] * tanOfElevation);
+    point[0] = static_cast<TCoordinate>(point[2] * tanOfAzimuth);
   }
 
   /** Returns a physical point from a continuous index. */
-  template <typename TCoordRep, typename TIndexRep>
-  [[nodiscard]] Point<TCoordRep, 3>
+  template <typename TCoordinate, typename TIndexRep>
+  [[nodiscard]] Point<TCoordinate, 3>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, 3> & index) const
   {
-    Point<TCoordRep, 3> point;
+    Point<TCoordinate, 3> point;
     this->TransformContinuousIndexToPhysicalPoint(index, point);
     return point;
   }
@@ -321,35 +321,35 @@ public:
    * from a discrete index (in the index space)
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordRep, 3> & point) const
+  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordinate, 3> & point) const
   {
     const RegionType region = this->GetLargestPossibleRegion();
     const double     maxAzimuth = region.GetSize(0) - 1;
     const double     maxElevation = region.GetSize(1) - 1;
 
     // Convert the index into proper angular coordinates
-    const TCoordRep azimuth = (static_cast<double>(index[0]) - (maxAzimuth / 2.0)) * m_AzimuthAngularSeparation;
-    const TCoordRep elevation = (static_cast<double>(index[1]) - (maxElevation / 2.0)) * m_ElevationAngularSeparation;
-    const TCoordRep radius = (static_cast<double>(index[2]) * m_RadiusSampleSize) + m_FirstSampleDistance;
+    const TCoordinate azimuth = (static_cast<double>(index[0]) - (maxAzimuth / 2.0)) * m_AzimuthAngularSeparation;
+    const TCoordinate elevation = (static_cast<double>(index[1]) - (maxElevation / 2.0)) * m_ElevationAngularSeparation;
+    const TCoordinate radius = (static_cast<double>(index[2]) * m_RadiusSampleSize) + m_FirstSampleDistance;
 
     // Convert the angular coordinates into Cartesian coordinates
-    const TCoordRep tanOfAzimuth = std::tan(azimuth);
-    const TCoordRep tanOfElevation = std::tan(elevation);
+    const TCoordinate tanOfAzimuth = std::tan(azimuth);
+    const TCoordinate tanOfElevation = std::tan(elevation);
 
     point[2] =
-      static_cast<TCoordRep>(radius / std::sqrt(1.0 + tanOfAzimuth * tanOfAzimuth + tanOfElevation * tanOfElevation));
-    point[1] = static_cast<TCoordRep>(point[2] * tanOfElevation);
-    point[0] = static_cast<TCoordRep>(point[2] * tanOfAzimuth);
+      static_cast<TCoordinate>(radius / std::sqrt(1.0 + tanOfAzimuth * tanOfAzimuth + tanOfElevation * tanOfElevation));
+    point[1] = static_cast<TCoordinate>(point[2] * tanOfElevation);
+    point[0] = static_cast<TCoordinate>(point[2] * tanOfAzimuth);
   }
 
   /** Returns a physical point from a discrete index. */
-  template <typename TCoordRep>
-  [[nodiscard]] Point<TCoordRep, 3>
+  template <typename TCoordinate>
+  [[nodiscard]] Point<TCoordinate, 3>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
-    Point<TCoordRep, 3> point;
+    Point<TCoordinate, 3> point;
     this->TransformIndexToPhysicalPoint(index, point);
     return point;
   }
@@ -366,13 +366,13 @@ public:
   /**  Set the distance to add to the radius. */
   itkSetMacro(FirstSampleDistance, double);
 
-  template <typename TCoordRep>
-  void TransformLocalVectorToPhysicalVector(FixedArray<TCoordRep, 3> &) const
+  template <typename TCoordinate>
+  void TransformLocalVectorToPhysicalVector(FixedArray<TCoordinate, 3> &) const
   {}
 
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordRep, 3> &, FixedArray<TCoordRep, 3> &) const
+  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordinate, 3> &, FixedArray<TCoordinate, 3> &) const
   {}
 
   /** Return the Pixel Accessor object */

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -49,18 +49,18 @@ namespace itk
  * \sphinxexample{Core/Common/DistanceBetweenIndices,Distance between two indices}
  * \endsphinx
  */
-template <typename TCoordRep, unsigned int VPointDimension = 3>
-class ITK_TEMPLATE_EXPORT Point : public FixedArray<TCoordRep, VPointDimension>
+template <typename TCoordinate, unsigned int VPointDimension = 3>
+class ITK_TEMPLATE_EXPORT Point : public FixedArray<TCoordinate, VPointDimension>
 {
 public:
   /** Standard class type aliases. */
   using Self = Point;
-  using Superclass = FixedArray<TCoordRep, VPointDimension>;
+  using Superclass = FixedArray<TCoordinate, VPointDimension>;
 
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
-  using ValueType = TCoordRep;
-  using CoordRepType = TCoordRep;
+  using ValueType = TCoordinate;
+  using CoordRepType = TCoordinate;
 
   using RealType = typename NumericTraits<ValueType>::RealType;
 
@@ -68,7 +68,7 @@ public:
   static constexpr unsigned int PointDimension = VPointDimension;
 
   /** The Array type from which this Vector is derived. */
-  using BaseArray = FixedArray<TCoordRep, VPointDimension>;
+  using BaseArray = FixedArray<TCoordinate, VPointDimension>;
   using Iterator = typename BaseArray::Iterator;
   using ConstIterator = typename BaseArray::ConstIterator;
 
@@ -167,11 +167,11 @@ public:
   GetVectorFromOrigin() const;
 
   /** Get a vnl_vector_ref referencing the same memory block */
-  vnl_vector_ref<TCoordRep>
+  vnl_vector_ref<TCoordinate>
   GetVnlVector();
 
   /** Get a vnl_vector with a copy of the internal memory block. */
-  vnl_vector<TCoordRep>
+  vnl_vector<TCoordinate>
   GetVnlVector() const;
 
   /** Set to median point between the two points
@@ -252,13 +252,13 @@ public:
 
   /** Copy from another Point with a different representation type.
    *  Casting is done with C-Like rules  */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   void
-  CastFrom(const Point<TCoordRepB, VPointDimension> & pa)
+  CastFrom(const Point<TCoordinateB, VPointDimension> & pa)
   {
     for (unsigned int i = 0; i < VPointDimension; ++i)
     {
-      (*this)[i] = static_cast<TCoordRep>(pa[i]);
+      (*this)[i] = static_cast<TCoordinate>(pa[i]);
     }
   }
 
@@ -266,9 +266,9 @@ public:
    * with a different representation type.  Casting is done with
    * C-Like rules */
 
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   RealType
-  SquaredEuclideanDistanceTo(const Point<TCoordRepB, VPointDimension> & pa) const
+  SquaredEuclideanDistanceTo(const Point<TCoordinateB, VPointDimension> & pa) const
   {
     RealType sum{};
 
@@ -284,9 +284,9 @@ public:
   /** Compute the Euclidean Distance from this point to another point
    * with a different representation type.  Casting is done with
    * C-Like rules */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   RealType
-  EuclideanDistanceTo(const Point<TCoordRepB, VPointDimension> & pa) const
+  EuclideanDistanceTo(const Point<TCoordinateB, VPointDimension> & pa) const
   {
     const double distance = std::sqrt(static_cast<double>(this->SquaredEuclideanDistanceTo(pa)));
 
@@ -343,9 +343,9 @@ public:
 };
 
 
-template <typename TCoordRep, unsigned int VPointDimension>
+template <typename TCoordinate, unsigned int VPointDimension>
 inline void
-swap(Point<TCoordRep, VPointDimension> & a, Point<TCoordRep, VPointDimension> & b)
+swap(Point<TCoordinate, VPointDimension> & a, Point<TCoordinate, VPointDimension> & b)
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
@@ -303,25 +303,25 @@ public:
   /* It is ILLEGAL in C++ to make a templated member function virtual! */
   /* Therefore, we must just let templates take care of everything.    */
   /*
-  template<typename TCoordRep>
+  template<typename TCoordinate>
   virtual bool TransformPhysicalPointToContinuousIndex(
-              const Point<TCoordRep, VImageDimension>& point,
-              ContinuousIndex<TCoordRep, VImageDimension>& index   ) const = 0;
+              const Point<TCoordinate, VImageDimension>& point,
+              ContinuousIndex<TCoordinate, VImageDimension>& index   ) const = 0;
 
-  template<typename TCoordRep>
+  template<typename TCoordinate>
   virtual bool TransformPhysicalPointToIndex(
-            const Point<TCoordRep, VImageDimension>&,
+            const Point<TCoordinate, VImageDimension>&,
             IndexType & index                                ) const = 0;
 
-  template<typename TCoordRep>
+  template<typename TCoordinate>
   virtual void TransformContinuousIndexToPhysicalPoint(
-            const ContinuousIndex<TCoordRep, VImageDimension>& index,
-            Point<TCoordRep, VImageDimension>& point        ) const = 0;
+            const ContinuousIndex<TCoordinate, VImageDimension>& index,
+            Point<TCoordinate, VImageDimension>& point        ) const = 0;
 
-  template<typename TCoordRep>
+  template<typename TCoordinate>
   virtual void TransformIndexToPhysicalPoint(
                       const IndexType & index,
-                      Point<TCoordRep, VImageDimension>& point ) const = 0;
+                      Point<TCoordinate, VImageDimension>& point ) const = 0;
   */
 
 protected:

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -113,8 +113,8 @@ public:
   SymmetricSecondRankTensor(const ComponentType & r) { this->Fill(r); }
 
   /** Constructor to enable casting...  */
-  template <typename TCoordRepB>
-  SymmetricSecondRankTensor(const SymmetricSecondRankTensor<TCoordRepB, VDimension> & pa)
+  template <typename TCoordinateB>
+  SymmetricSecondRankTensor(const SymmetricSecondRankTensor<TCoordinateB, VDimension> & pa)
     : BaseArray(pa)
   {}
 
@@ -126,9 +126,9 @@ public:
   {}
 
   /** Templated Pass-through assignment  for the Array base class. */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   Self &
-  operator=(const SymmetricSecondRankTensor<TCoordRepB, VDimension> & pa)
+  operator=(const SymmetricSecondRankTensor<TCoordinateB, VDimension> & pa)
   {
     BaseArray::operator=(pa);
     return *this;

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -269,9 +269,9 @@ public:
 
   /** Copy from another Vector with a different representation type.
    *  Casting is done with C-Like rules  */
-  template <typename TCoordRepB>
+  template <typename TCoordinateB>
   void
-  CastFrom(const Vector<TCoordRepB, VVectorDimension> & pa)
+  CastFrom(const Vector<TCoordinateB, VVectorDimension> & pa)
   {
     for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
@@ -279,13 +279,13 @@ public:
     }
   }
 
-  template <typename TCoordRepB>
-  operator Vector<TCoordRepB, VVectorDimension>()
+  template <typename TCoordinateB>
+  operator Vector<TCoordinateB, VVectorDimension>()
   {
-    Vector<TCoordRepB, VVectorDimension> r;
+    Vector<TCoordinateB, VVectorDimension> r;
     for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
-      r[i] = static_cast<TCoordRepB>((*this)[i]);
+      r[i] = static_cast<TCoordinateB>((*this)[i]);
     }
     return r;
   }

--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -85,8 +85,8 @@ IO  const Self & operator-=(const OffsetType & offset)
 IO  const Self operator-(const OffsetType & off) const
 
 IO  const OffsetType operator-(const Self & vec) const
-IO  inline void CopyWithRound(const FixedArray<TCoordRep, VDimension> & point)
-IO  inline void CopyWithCast(const FixedArray<TCoordRep, VDimension> & point)
+IO  inline void CopyWithRound(const FixedArray<TCoordinate, VDimension> & point)
+IO  inline void CopyWithCast(const FixedArray<TCoordinate, VDimension> & point)
 
 Index
 I  void SetIndex(const IndexValueType val[VDimension])

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -20,7 +20,7 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkTestingMacros.h"
 
-// Test template instantiation for TCoordRep = float and VSplineOrder = 1.
+// Test template instantiation for TCoordinate = float and VSplineOrder = 1.
 // Note that this particular template instantiation would take forever to
 // compile on VS2015 Update 3 64-bit Release when using ITK 4.13, but
 // itkBSplineInterpolationWeightFunction.hxx can now handle this Visual C++

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -26,12 +26,12 @@ itkImageRegionTest(int, char *[])
 
   constexpr unsigned int dimension = 3;
 
-  using TCoordRepType = double;
+  using TCoordinateType = double;
   using RegionType = itk::ImageRegion<dimension>;
   using IndexType = RegionType::IndexType;
   using SizeType = RegionType::SizeType;
   using SliceRegionType = RegionType::SliceRegion;
-  using ContinuousIndexType = itk::ContinuousIndex<TCoordRepType, dimension>;
+  using ContinuousIndexType = itk::ContinuousIndex<TCoordinateType, dimension>;
 
   using IndexNumericTraits = itk::NumericTraits<IndexType::IndexValueType>;
   using ContinuousIndexNumericTraits = itk::NumericTraits<ContinuousIndexType::ValueType>;
@@ -273,21 +273,21 @@ itkImageRegionTest(int, char *[])
     std::cout << "NaN < -1 = " << (indexC[0] < -1.0) << std::endl;
     std::cout << "NaN > -1 = " << (indexC[0] > -1.0) << std::endl;
 
-    TCoordRepType NaN = ContinuousIndexNumericTraits::quiet_NaN();
-    std::cout << "RoundHalfIntegerUp(NaN): " << itk::Math::RoundHalfIntegerUp<TCoordRepType>(NaN) << std::endl;
-    std::cout << "RoundHalfIntegerUp< TCoordRepType >(NaN) < static_cast<TCoordRepType> (0): "
-              << (itk::Math::RoundHalfIntegerUp<TCoordRepType>(NaN) < static_cast<TCoordRepType>(0)) << std::endl;
-    std::cout << "RoundHalfIntegerUp< TCoordRepType >(NaN) > static_cast<TCoordRepType> (0): "
-              << (itk::Math::RoundHalfIntegerUp<TCoordRepType>(NaN) > static_cast<TCoordRepType>(0)) << std::endl;
-    auto rf = itk::Math::RoundHalfIntegerUp<TCoordRepType>(NaN);
-    std::cout << "TCoordRepType = RoundHalfIntegerUp(NaN): " << rf << std::endl;
-    auto rl = itk::Math::RoundHalfIntegerUp<RegionType::IndexValueType, TCoordRepType>(NaN);
+    TCoordinateType NaN = ContinuousIndexNumericTraits::quiet_NaN();
+    std::cout << "RoundHalfIntegerUp(NaN): " << itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) << std::endl;
+    std::cout << "RoundHalfIntegerUp< TCoordinateType >(NaN) < static_cast<TCoordinateType> (0): "
+              << (itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) < static_cast<TCoordinateType>(0)) << std::endl;
+    std::cout << "RoundHalfIntegerUp< TCoordinateType >(NaN) > static_cast<TCoordinateType> (0): "
+              << (itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) > static_cast<TCoordinateType>(0)) << std::endl;
+    auto rf = itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN);
+    std::cout << "TCoordinateType = RoundHalfIntegerUp(NaN): " << rf << std::endl;
+    auto rl = itk::Math::RoundHalfIntegerUp<RegionType::IndexValueType, TCoordinateType>(NaN);
     std::cout << "RegionType::IndexValueType type = RoundHalfIntegerUp(NaN): " << rl << std::endl;
     std::cout << "static_cast<RegionType::IndexValueType>( NaN ): " << static_cast<RegionType::IndexValueType>(NaN)
               << std::endl;
     std::cout << "NumericTraits<RegionType::IndexValueType>::min(): "
               << itk::NumericTraits<RegionType::IndexValueType>::min() << std::endl;
-    std::cout << "TCoordRepType min(): " << ContinuousIndexNumericTraits::min() << std::endl;
+    std::cout << "TCoordinateType min(): " << ContinuousIndexNumericTraits::min() << std::endl;
     std::cout << "...end NaN tests." << std::endl << std::endl;
   }
 

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -384,9 +384,9 @@ public:
   VerifyRequestedRegion() override;
 
   /** Returns the continuous index from a physical point. */
-  template <typename TIndexRep, typename TCoordRep>
+  template <typename TIndexRep, typename TCoordinate>
   [[nodiscard]] ContinuousIndex<TIndexRep, TImage::ImageDimension>
-  TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, TImage::ImageDimension> & point) const
+  TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, TImage::ImageDimension> & point) const
   {
     return m_Image->template TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
   }
@@ -399,18 +399,18 @@ public:
    * overload instead, which has only one parameter (the point), and returns the continuous index.
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, Self::ImageDimension> &     point,
-                                               ContinuousIndex<TCoordRep, Self::ImageDimension> & index) const
+  bool TransformPhysicalPointToContinuousIndex(const Point<TCoordinate, Self::ImageDimension> &     point,
+                                               ContinuousIndex<TCoordinate, Self::ImageDimension> & index) const
   {
     return m_Image->TransformPhysicalPointToContinuousIndex(point, index);
   }
 
   /** Returns the index (discrete) of a voxel from a physical point. */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   [[nodiscard]] IndexType
-  TransformPhysicalPointToIndex(const Point<TCoordRep, Self::ImageDimension> & point) const
+  TransformPhysicalPointToIndex(const Point<TCoordinate, Self::ImageDimension> & point) const
   {
     return m_Image->TransformPhysicalPointToIndex(point);
   }
@@ -423,9 +423,9 @@ public:
    * overload instead, which has only one parameter (the point), and returns the index.
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   ITK_NODISCARD("Call the overload which has the point as the only parameter and returns the index")
-  bool TransformPhysicalPointToIndex(const Point<TCoordRep, Self::ImageDimension> & point, IndexType & index) const
+  bool TransformPhysicalPointToIndex(const Point<TCoordinate, Self::ImageDimension> & point, IndexType & index) const
   {
     return m_Image->TransformPhysicalPointToIndex(point, index);
   }
@@ -434,17 +434,17 @@ public:
    * the origin and spacing information comes from)
    * from a continuous index (in the index space)
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TCoordRep, Self::ImageDimension> & index,
-                                          Point<TCoordRep, Self::ImageDimension> &                 point) const
+  TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TCoordinate, Self::ImageDimension> & index,
+                                          Point<TCoordinate, Self::ImageDimension> &                 point) const
   {
     m_Image->TransformContinuousIndexToPhysicalPoint(index, point);
   }
 
   /** Returns a physical point from a continuous index (in the index space) */
-  template <typename TCoordRep, typename TIndexRep>
-  [[nodiscard]] Point<TCoordRep, TImage::ImageDimension>
+  template <typename TCoordinate, typename TIndexRep>
+  [[nodiscard]] Point<TCoordinate, TImage::ImageDimension>
   TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, Self::ImageDimension> & index) const
   {
     return m_Image->template TransformContinuousIndexToPhysicalPoint<TIndexRep>(index);
@@ -455,25 +455,25 @@ public:
    * from a discrete index (in the index space)
    *
    * \sa Transform */
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordRep, Self::ImageDimension> & point) const
+  TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordinate, Self::ImageDimension> & point) const
   {
     m_Image->TransformIndexToPhysicalPoint(index, point);
   }
 
   /** Returns a physical point from a discrete index (in the index space) */
-  template <typename TCoordRep>
-  [[nodiscard]] Point<TCoordRep, Self::ImageDimension>
+  template <typename TCoordinate>
+  [[nodiscard]] Point<TCoordinate, Self::ImageDimension>
   TransformIndexToPhysicalPoint(const IndexType & index) const
   {
-    return m_Image->template TransformIndexToPhysicalPoint<TCoordRep>(index);
+    return m_Image->template TransformIndexToPhysicalPoint<TCoordinate>(index);
   }
 
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformLocalVectorToPhysicalVector(const FixedArray<TCoordRep, Self::ImageDimension> & inputGradient,
-                                       FixedArray<TCoordRep, Self::ImageDimension> &       outputGradient) const
+  TransformLocalVectorToPhysicalVector(const FixedArray<TCoordinate, Self::ImageDimension> & inputGradient,
+                                       FixedArray<TCoordinate, Self::ImageDimension> &       outputGradient) const
   {
     m_Image->TransformLocalVectorToPhysicalVector(inputGradient, outputGradient);
   }
@@ -487,10 +487,10 @@ public:
     return outputGradient;
   }
 
-  template <typename TCoordRep>
+  template <typename TCoordinate>
   void
-  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordRep, Self::ImageDimension> & inputGradient,
-                                       FixedArray<TCoordRep, Self::ImageDimension> &       outputGradient) const
+  TransformPhysicalVectorToLocalVector(const FixedArray<TCoordinate, Self::ImageDimension> & inputGradient,
+                                       FixedArray<TCoordinate, Self::ImageDimension> &       outputGradient) const
   {
     m_Image->TransformPhysicalVectorToLocalVector(inputGradient, outputGradient);
   }

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
@@ -60,12 +60,12 @@ Expect_same_type_and_equal_value(T1 && value1, T2 && value2)
 }
 
 
-template <typename TImage, typename TAccessor, typename TCoordRep>
+template <typename TImage, typename TAccessor, typename TCoordinate>
 void
 Expect_TransformPhysicalPoint_member_functions_return_the_same_for_ImageAdapter_as_for_image(
-  const itk::ImageAdaptor<TImage, TAccessor> &          imageAdaptor,
-  const TImage &                                        image,
-  const itk::Point<TCoordRep, TImage::ImageDimension> & point)
+  const itk::ImageAdaptor<TImage, TAccessor> &            imageAdaptor,
+  const TImage &                                          image,
+  const itk::Point<TCoordinate, TImage::ImageDimension> & point)
 {
   Expect_same_type_and_equal_value(imageAdaptor.TransformPhysicalPointToIndex(point),
                                    image.TransformPhysicalPointToIndex(point));

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -79,15 +79,15 @@ namespace itk
  * \ingroup ITKImageFunction
  *
  */
-template <typename TImageType, typename TCoordRep = double, typename TCoefficientType = double>
-class ITK_TEMPLATE_EXPORT BSplineInterpolateImageFunction : public InterpolateImageFunction<TImageType, TCoordRep>
+template <typename TImageType, typename TCoordinate = double, typename TCoefficientType = double>
+class ITK_TEMPLATE_EXPORT BSplineInterpolateImageFunction : public InterpolateImageFunction<TImageType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = BSplineInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TImageType, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TImageType, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -144,7 +144,7 @@ public:
   Evaluate(const PointType & point) const override
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     // No thread info passed in, so call method that doesn't need thread ID.
     return (this->EvaluateAtContinuousIndex(index));
   }
@@ -153,7 +153,7 @@ public:
   Evaluate(const PointType & point, ThreadIdType threadId) const
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     return (this->EvaluateAtContinuousIndex(index, threadId));
   }
 
@@ -181,7 +181,7 @@ public:
   EvaluateDerivative(const PointType & point) const
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
 
     // No thread info passed in, so call method that doesn't need thread ID.
     return (this->EvaluateDerivativeAtContinuousIndex(index));
@@ -191,7 +191,7 @@ public:
   EvaluateDerivative(const PointType & point, ThreadIdType threadId) const
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     return (this->EvaluateDerivativeAtContinuousIndex(index, threadId));
   }
 
@@ -223,7 +223,7 @@ public:
   EvaluateValueAndDerivative(const PointType & point, OutputType & value, CovariantVectorType & deriv) const
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
 
     // No thread info passed in, so call method that doesn't need thread ID.
     this->EvaluateValueAndDerivativeAtContinuousIndex(index, value, deriv);
@@ -236,7 +236,7 @@ public:
                              ThreadIdType          threadId) const
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     this->EvaluateValueAndDerivativeAtContinuousIndex(index, value, deriv, threadId);
   }
 

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -40,8 +40,8 @@
 namespace itk
 {
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplineInterpolateImageFunction()
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::BSplineInterpolateImageFunction()
 {
   m_NumberOfWorkUnits = 1;
 
@@ -53,10 +53,10 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplin
   this->SetSplineOrder(SplineOrder);
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,
-                                                                                    Indent         indent) const
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::PrintSelf(std::ostream & os,
+                                                                                      Indent         indent) const
 {
   using namespace print_helper;
 
@@ -112,9 +112,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintS
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInputImage(const TImageType * inputData)
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetInputImage(const TImageType * inputData)
 {
   if (inputData)
   {
@@ -135,9 +135,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInp
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetSplineOrder(unsigned int SplineOrder)
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetSplineOrder(unsigned int SplineOrder)
 {
   if (SplineOrder == m_SplineOrder)
   {
@@ -155,18 +155,18 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetSpl
   this->GeneratePointsToIndex();
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetNumberOfWorkUnits(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetNumberOfWorkUnits(
   ThreadIdType numWorkUnits)
 {
   m_NumberOfWorkUnits = numWorkUnits;
   this->GeneratePointsToIndex();
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInterpolationWeights(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetInterpolationWeights(
   const ContinuousIndexType & x,
   const vnl_matrix<long> &    EvaluateIndex,
   vnl_matrix<double> &        weights,
@@ -277,9 +277,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInt
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetDerivativeWeights(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetDerivativeWeights(
   const ContinuousIndexType & x,
   const vnl_matrix<long> &    EvaluateIndex,
   vnl_matrix<double> &        weights,
@@ -404,9 +404,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetDer
 }
 
 // Generates m_PointsToIndex;
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::GeneratePointsToIndex()
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::GeneratePointsToIndex()
 {
   // m_PointsToIndex is used to convert a sequential location to an N-dimension
   // index vector.  This is precomputed to save time during the interpolation
@@ -439,9 +439,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::Genera
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::DetermineRegionOfSupport(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::DetermineRegionOfSupport(
   vnl_matrix<long> &          evaluateIndex,
   const ContinuousIndexType & x,
   unsigned int                splineOrder) const
@@ -457,9 +457,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::Determ
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::ApplyMirrorBoundaryConditions(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::ApplyMirrorBoundaryConditions(
   vnl_matrix<long> & evaluateIndex,
   unsigned int       splineOrder) const
 {
@@ -494,9 +494,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::ApplyM
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 auto
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndexInternal(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::EvaluateAtContinuousIndexInternal(
   const ContinuousIndexType & x,
   vnl_matrix<long> &          evaluateIndex,
   vnl_matrix<double> &        weights) const -> OutputType
@@ -529,9 +529,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::Evalua
   return (interpolated);
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::
   EvaluateValueAndDerivativeAtContinuousIndexInternal(const ContinuousIndexType & x,
                                                       OutputType &                value,
                                                       CovariantVectorType &       derivativeValue,
@@ -606,9 +606,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 auto
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateDerivativeAtContinuousIndexInternal(
+BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::EvaluateDerivativeAtContinuousIndexInternal(
   const ContinuousIndexType & x,
   vnl_matrix<long> &          evaluateIndex,
   vnl_matrix<double> &        weights,

--- a/Modules/Core/ImageFunction/include/itkBSplineResampleImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineResampleImageFunction.h
@@ -53,16 +53,16 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TImageType, typename TCoordRep = float>
+template <typename TImageType, typename TCoordinate = float>
 class BSplineResampleImageFunction
-  : public BSplineInterpolateImageFunction<TImageType, TCoordRep, typename TImageType::PixelType>
+  : public BSplineInterpolateImageFunction<TImageType, TCoordinate, typename TImageType::PixelType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineResampleImageFunction);
 
   /** Standard class type aliases. */
   using Self = BSplineResampleImageFunction;
-  using Superclass = BSplineInterpolateImageFunction<TImageType, TCoordRep, typename TImageType::PixelType>;
+  using Superclass = BSplineInterpolateImageFunction<TImageType, TCoordinate, typename TImageType::PixelType>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -78,7 +78,7 @@ public:
   SetInputImage(const TImageType * inputData) override
   {
     // bypass my superclass
-    this->InterpolateImageFunction<TImageType, TCoordRep>::SetInputImage(inputData);
+    this->InterpolateImageFunction<TImageType, TCoordinate>::SetInputImage(inputData);
     this->m_Coefficients = inputData;
     if (this->m_Coefficients.IsNotNull())
     {

--- a/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.h
@@ -40,15 +40,15 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
-class ITK_TEMPLATE_EXPORT BinaryThresholdImageFunction : public ImageFunction<TInputImage, bool, TCoordRep>
+template <typename TInputImage, typename TCoordinate = float>
+class ITK_TEMPLATE_EXPORT BinaryThresholdImageFunction : public ImageFunction<TInputImage, bool, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryThresholdImageFunction);
 
   /** Standard class type aliases. */
   using Self = BinaryThresholdImageFunction;
-  using Superclass = ImageFunction<TInputImage, bool, TCoordRep>;
+  using Superclass = ImageFunction<TInputImage, bool, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.hxx
@@ -22,8 +22,8 @@
 
 namespace itk
 {
-template <typename TInputImage, typename TCoordRep>
-BinaryThresholdImageFunction<TInputImage, TCoordRep>::BinaryThresholdImageFunction()
+template <typename TInputImage, typename TCoordinate>
+BinaryThresholdImageFunction<TInputImage, TCoordinate>::BinaryThresholdImageFunction()
 {
   m_Lower = NumericTraits<PixelType>::NonpositiveMin();
   m_Upper = NumericTraits<PixelType>::max();
@@ -32,9 +32,9 @@ BinaryThresholdImageFunction<TInputImage, TCoordRep>::BinaryThresholdImageFuncti
 /**
  * Values greater than or equal to the value are inside
  */
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdAbove(PixelType thresh)
+BinaryThresholdImageFunction<TInputImage, TCoordinate>::ThresholdAbove(PixelType thresh)
 {
   if (Math::NotExactlyEquals(m_Lower, thresh) || Math::NotExactlyEquals(m_Upper, NumericTraits<PixelType>::max()))
   {
@@ -47,9 +47,9 @@ BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdAbove(PixelType t
 /**
  * The values less than or equal to the value are inside
  */
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdBelow(PixelType thresh)
+BinaryThresholdImageFunction<TInputImage, TCoordinate>::ThresholdBelow(PixelType thresh)
 {
   if (Math::NotExactlyEquals(m_Lower, NumericTraits<PixelType>::NonpositiveMin()) ||
       Math::NotExactlyEquals(m_Upper, thresh))
@@ -63,9 +63,9 @@ BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdBelow(PixelType t
 /**
  * The values less than or equal to the value are inside
  */
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdBetween(PixelType lower, PixelType upper)
+BinaryThresholdImageFunction<TInputImage, TCoordinate>::ThresholdBetween(PixelType lower, PixelType upper)
 {
   if (Math::NotExactlyEquals(m_Lower, lower) || Math::NotExactlyEquals(m_Upper, upper))
   {
@@ -75,9 +75,9 @@ BinaryThresholdImageFunction<TInputImage, TCoordRep>::ThresholdBetween(PixelType
   }
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BinaryThresholdImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+BinaryThresholdImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
@@ -71,9 +71,9 @@ namespace itk
  * \ingroup ITKImageFunction
  */
 template <typename TInputImage,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TOutputType = CovariantVector<double, TInputImage::ImageDimension>>
-class ITK_TEMPLATE_EXPORT CentralDifferenceImageFunction : public ImageFunction<TInputImage, TOutputType, TCoordRep>
+class ITK_TEMPLATE_EXPORT CentralDifferenceImageFunction : public ImageFunction<TInputImage, TOutputType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CentralDifferenceImageFunction);
@@ -83,7 +83,7 @@ public:
 
   /** Standard class type aliases. */
   using Self = CentralDifferenceImageFunction;
-  using Superclass = ImageFunction<TInputImage, TOutputType, TCoordRep>;
+  using Superclass = ImageFunction<TInputImage, TOutputType, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -127,7 +127,7 @@ public:
   using SpacingType = typename TInputImage::SpacingType;
 
   /** Interpolator type alias support */
-  using InterpolatorType = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using InterpolatorType = InterpolateImageFunction<TInputImage, TCoordinate>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 
   /** Set the input image.  This must be set by the user. */

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::CentralDifferenceImageFunction()
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::CentralDifferenceImageFunction()
 {
-  using LinearInterpolatorType = LinearInterpolateImageFunction<TInputImage, TCoordRep>;
+  using LinearInterpolatorType = LinearInterpolateImageFunction<TInputImage, TCoordinate>;
   this->m_Interpolator = LinearInterpolatorType::New();
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInputImage(const TInputImage * inputData)
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::SetInputImage(const TInputImage * inputData)
 {
   if (inputData != this->m_Image)
   {
@@ -60,9 +60,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInputIma
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInterpolator(InterpolatorType * interpolator)
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::SetInterpolator(InterpolatorType * interpolator)
 {
   if (interpolator != this->m_Interpolator)
   {
@@ -75,9 +75,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInterpol
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(std::ostream & os, Indent indent) const
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -86,9 +86,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(s
   itkPrintSelfObjectMacro(Interpolator);
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 auto
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtIndex(const IndexType & index) const
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtIndex(const IndexType & index) const
   -> OutputType
 {
   OutputType derivative;
@@ -102,10 +102,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   return derivative;
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtIndexSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtIndexSpecialized(
   const IndexType & index,
   OutputType &      orientedDerivative,
   OutputTypeSpecializationStructType<OutputType>) const
@@ -155,10 +155,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtIndexSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtIndexSpecialized(
   const IndexType & index,
   OutputType &      derivative,
   OutputTypeSpecializationStructType<Type>) const
@@ -236,9 +236,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 auto
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::Evaluate(const PointType & point) const
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::Evaluate(const PointType & point) const
   -> OutputType
 {
   OutputType derivative;
@@ -252,10 +252,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::Evaluate(co
   return derivative;
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateSpecialized(
   const PointType & point,
   OutputType &      orientedDerivative,
   OutputTypeSpecializationStructType<OutputType>) const
@@ -318,10 +318,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateSpecialized(
   const PointType & point,
   OutputType &      derivative,
   OutputTypeSpecializationStructType<Type>) const
@@ -428,9 +428,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateSpe
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 auto
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtContinuousIndex(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & cindex) const -> OutputType
 {
   OutputType derivative;
@@ -442,10 +442,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
   return derivative;
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtContinuousIndexSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtContinuousIndexSpecialized(
   const ContinuousIndexType & cindex,
   OutputType &                orientedDerivative,
   OutputTypeSpecializationStructType<OutputType>) const
@@ -496,10 +496,10 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtC
   }
 }
 
-template <typename TInputImage, typename TCoordRep, typename TOutputType>
+template <typename TInputImage, typename TCoordinate, typename TOutputType>
 template <typename Type>
 void
-CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtContinuousIndexSpecialized(
+CentralDifferenceImageFunction<TInputImage, TCoordinate, TOutputType>::EvaluateAtContinuousIndexSpecialized(
   const ContinuousIndexType & cindex,
   OutputType &                derivative,
   OutputTypeSpecializationStructType<Type>) const

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
@@ -41,11 +41,11 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT CovarianceImageFunction
   : public ImageFunction<TInputImage,
                          vnl_matrix<typename NumericTraits<typename TInputImage::PixelType::ValueType>::RealType>,
-                         TCoordRep>
+                         TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CovarianceImageFunction);
@@ -55,7 +55,7 @@ public:
   using Superclass =
     ImageFunction<TInputImage,
                   vnl_matrix<typename NumericTraits<typename TInputImage::PixelType::ValueType>::RealType>,
-                  TCoordRep>;
+                  TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -24,14 +24,14 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-CovarianceImageFunction<TInputImage, TCoordRep>::CovarianceImageFunction()
+template <typename TInputImage, typename TCoordinate>
+CovarianceImageFunction<TInputImage, TCoordinate>::CovarianceImageFunction()
 
   = default;
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+CovarianceImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   using PixelType = typename TInputImage::PixelType;
   using PixelComponentType = typename PixelType::ValueType;
@@ -102,9 +102,9 @@ CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType
   return (covariance);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-CovarianceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+CovarianceImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
@@ -40,9 +40,9 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ExtrapolateImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ExtrapolateImageFunction);
@@ -50,7 +50,7 @@ public:
   /** Standard class type aliases. */
   using Self = ExtrapolateImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -87,7 +87,7 @@ public:
   Evaluate(const PointType & point) const override
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
@@ -50,15 +50,15 @@ namespace itk
  * \ingroup ITKImageFunction
  */
 
-template <typename TInputImage, typename TCoordRep = double>
-class ITK_TEMPLATE_EXPORT GaussianInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
+template <typename TInputImage, typename TCoordinate = double>
+class ITK_TEMPLATE_EXPORT GaussianInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaussianInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = GaussianInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -35,8 +35,8 @@
 namespace itk
 {
 
-template <typename TImageType, typename TCoordRep>
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::GaussianInterpolateImageFunction()
+template <typename TImageType, typename TCoordinate>
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::GaussianInterpolateImageFunction()
   : m_Alpha(1.0)
 {
   this->m_Sigma.Fill(1.0);
@@ -47,9 +47,9 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::GaussianInterpolateImag
   this->m_CutOffDistance.Fill(1.0);
 }
 
-template <typename TImageType, typename TCoordRep>
+template <typename TImageType, typename TCoordinate>
 void
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeBoundingBox()
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::ComputeBoundingBox()
 {
   if (!this->GetInputImage())
   {
@@ -71,17 +71,17 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeBoundingBox()
 }
 
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-GaussianInterpolateImageFunction<TInputImage, TCoordRep>::ComputeInterpolationRegion(
+GaussianInterpolateImageFunction<TInputImage, TCoordinate>::ComputeInterpolationRegion(
   const ContinuousIndexType & cindex) const -> RegionType
 {
   RegionType region = this->GetInputImage()->GetBufferedRegion();
   for (unsigned int d = 0; d < ImageDimension; ++d)
   {
-    TCoordRep      cBegin = cindex[d] + 0.5 - this->m_CutOffDistance[d];
+    TCoordinate    cBegin = cindex[d] + 0.5 - this->m_CutOffDistance[d];
     IndexValueType begin = std::max(region.GetIndex()[d], static_cast<IndexValueType>(std::floor(cBegin)));
-    TCoordRep      cEnd = cindex[d] + 0.5 + this->m_CutOffDistance[d];
+    TCoordinate    cEnd = cindex[d] + 0.5 + this->m_CutOffDistance[d];
     SizeValueType  end =
       std::min(region.GetIndex()[d] + region.GetSize()[d], static_cast<SizeValueType>(std::ceil(cEnd)));
     region.SetIndex(d, begin);
@@ -90,10 +90,10 @@ GaussianInterpolateImageFunction<TInputImage, TCoordRep>::ComputeInterpolationRe
   return region;
 }
 
-template <typename TImageType, typename TCoordRep>
+template <typename TImageType, typename TCoordinate>
 auto
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::EvaluateAtContinuousIndex(const ContinuousIndexType & cindex,
-                                                                                   OutputType * grad) const
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::EvaluateAtContinuousIndex(const ContinuousIndexType & cindex,
+                                                                                     OutputType * grad) const
   -> OutputType
 {
   vnl_vector<RealType> erfArray[ImageDimension];
@@ -174,14 +174,14 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::EvaluateAtContinuousInd
   return rc;
 }
 
-template <typename TImageType, typename TCoordRep>
+template <typename TImageType, typename TCoordinate>
 void
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeErrorFunctionArray(const RegionType &     region,
-                                                                                   unsigned int           dimension,
-                                                                                   RealType               cindex,
-                                                                                   vnl_vector<RealType> & erfArray,
-                                                                                   vnl_vector<RealType> & gerfArray,
-                                                                                   bool evaluateGradient) const
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::ComputeErrorFunctionArray(const RegionType &     region,
+                                                                                     unsigned int           dimension,
+                                                                                     RealType               cindex,
+                                                                                     vnl_vector<RealType> & erfArray,
+                                                                                     vnl_vector<RealType> & gerfArray,
+                                                                                     bool evaluateGradient) const
 {
   erfArray.set_size(region.GetSize()[dimension]);
   gerfArray.set_size(region.GetSize()[dimension]);
@@ -212,9 +212,9 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeErrorFunctionArr
 }
 
 
-template <typename TImageType, typename TCoordRep>
+template <typename TImageType, typename TCoordinate>
 auto
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::GetRadius() const -> SizeType
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::GetRadius() const -> SizeType
 {
   SizeType radius;
 
@@ -234,9 +234,9 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::GetRadius() const -> Si
 }
 
 
-template <typename TImageType, typename TCoordRep>
+template <typename TImageType, typename TCoordinate>
 void
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+GaussianInterpolateImageFunction<TImageType, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -51,8 +51,8 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TOutput, typename TCoordRep = float>
-class ITK_TEMPLATE_EXPORT ImageFunction : public FunctionBase<Point<TCoordRep, TInputImage::ImageDimension>, TOutput>
+template <typename TInputImage, typename TOutput, typename TCoordinate = float>
+class ITK_TEMPLATE_EXPORT ImageFunction : public FunctionBase<Point<TCoordinate, TInputImage::ImageDimension>, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ImageFunction);
@@ -63,7 +63,7 @@ public:
   /** Standard class type aliases. */
   using Self = ImageFunction;
 
-  using Superclass = FunctionBase<Point<TCoordRep, Self::ImageDimension>, TOutput>;
+  using Superclass = FunctionBase<Point<TCoordinate, Self::ImageDimension>, TOutput>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -84,17 +84,17 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
 
   /** Index Type. */
   using IndexType = typename InputImageType::IndexType;
   using IndexValueType = typename InputImageType::IndexValueType;
 
   /** ContinuousIndex Type. */
-  using ContinuousIndexType = ContinuousIndex<TCoordRep, Self::ImageDimension>;
+  using ContinuousIndexType = ContinuousIndex<TCoordinate, Self::ImageDimension>;
 
   /** Point Type. */
-  using PointType = Point<TCoordRep, Self::ImageDimension>;
+  using PointType = Point<TCoordinate, Self::ImageDimension>;
 
   /** Set the input image.
    * \warning this method caches BufferedRegion information.
@@ -171,7 +171,7 @@ public:
   virtual bool
   IsInsideBuffer(const PointType & point) const
   {
-    const ContinuousIndexType index = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+    const ContinuousIndexType index = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     /* Call IsInsideBuffer to test against BufferedRegion bounds.
      * TransformPhysicalPointToContinuousIndex tests against
      * LargestPossibleRegion */
@@ -183,7 +183,7 @@ public:
   void
   ConvertPointToNearestIndex(const PointType & point, IndexType & index) const
   {
-    const ContinuousIndexType cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+    const ContinuousIndexType cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     this->ConvertContinuousIndexToNearestIndex(cindex, index);
   }
 
@@ -191,7 +191,7 @@ public:
   void
   ConvertPointToContinuousIndex(const PointType & point, ContinuousIndexType & cindex) const
   {
-    cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+    cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
   }
 
   /** Convert continuous index to nearest index. */

--- a/Modules/Core/ImageFunction/include/itkImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.hxx
@@ -22,8 +22,8 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TOutput, typename TCoordRep>
-ImageFunction<TInputImage, TOutput, TCoordRep>::ImageFunction()
+template <typename TInputImage, typename TOutput, typename TCoordinate>
+ImageFunction<TInputImage, TOutput, TCoordinate>::ImageFunction()
 {
   m_Image = nullptr;
   m_StartIndex.Fill(0);
@@ -33,9 +33,9 @@ ImageFunction<TInputImage, TOutput, TCoordRep>::ImageFunction()
 }
 
 
-template <typename TInputImage, typename TOutput, typename TCoordRep>
+template <typename TInputImage, typename TOutput, typename TCoordinate>
 void
-ImageFunction<TInputImage, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+ImageFunction<TInputImage, TOutput, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "InputImage: " << m_Image.GetPointer() << std::endl;
@@ -45,9 +45,9 @@ ImageFunction<TInputImage, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Ind
   os << indent << "EndContinuousIndex: " << m_EndContinuousIndex << std::endl;
 }
 
-template <typename TInputImage, typename TOutput, typename TCoordRep>
+template <typename TInputImage, typename TOutput, typename TCoordinate>
 void
-ImageFunction<TInputImage, TOutput, TCoordRep>::SetInputImage(const InputImageType * ptr)
+ImageFunction<TInputImage, TOutput, TCoordinate>::SetInputImage(const InputImageType * ptr)
 {
   // set the input image
   m_Image = ptr;

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -41,9 +41,9 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT InterpolateImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(InterpolateImageFunction);
@@ -51,7 +51,7 @@ public:
   /** Standard class type aliases. */
   using Self = InterpolateImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -96,7 +96,7 @@ public:
   Evaluate(const PointType & point) const override
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
@@ -66,17 +66,17 @@ namespace itk
  */
 
 template <typename TInputImage,
-          typename TCoordRep = double,
+          typename TCoordinate = double,
           typename TPixelCompare = std::less<typename itk::NumericTraits<typename TInputImage::PixelType>::RealType>>
 class ITK_TEMPLATE_EXPORT LabelImageGaussianInterpolateImageFunction
-  : public GaussianInterpolateImageFunction<TInputImage, TCoordRep>
+  : public GaussianInterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LabelImageGaussianInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = LabelImageGaussianInterpolateImageFunction;
-  using Superclass = GaussianInterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = GaussianInterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   using InputPixelType = typename TInputImage::PixelType;

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -33,9 +33,9 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep, typename TPixelCompare>
+template <typename TInputImage, typename TCoordinate, typename TPixelCompare>
 auto
-LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordRep, TPixelCompare>::EvaluateAtContinuousIndex(
+LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordinate, TPixelCompare>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & cindex,
   OutputType *                itkNotUsed(grad)) const -> OutputType
 {

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -47,15 +47,15 @@ namespace itk
  * \sphinxexample{Core/ImageFunction/LinearlyInterpolatePositionInImage,Linearly Interpolate Position In Image}
  * \endsphinx
  */
-template <typename TInputImage, typename TCoordRep = double>
-class ITK_TEMPLATE_EXPORT LinearInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
+template <typename TInputImage, typename TCoordinate = double>
+class ITK_TEMPLATE_EXPORT LinearInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LinearInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = LinearInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
@@ -25,9 +25,9 @@
 
 namespace itk
 {
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-LinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateUnoptimized(const ContinuousIndexType & index) const
+LinearInterpolateImageFunction<TInputImage, TCoordinate>::EvaluateUnoptimized(const ContinuousIndexType & index) const
   -> OutputType
 {
   // Avoid the smartpointer de-reference in the loop for
@@ -97,9 +97,9 @@ LinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateUnoptimized(cons
   return (static_cast<OutputType>(value));
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-LinearInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+LinearInterpolateImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.h
@@ -46,15 +46,16 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
-class ITK_TEMPLATE_EXPORT MahalanobisDistanceThresholdImageFunction : public ImageFunction<TInputImage, bool, TCoordRep>
+template <typename TInputImage, typename TCoordinate = float>
+class ITK_TEMPLATE_EXPORT MahalanobisDistanceThresholdImageFunction
+  : public ImageFunction<TInputImage, bool, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MahalanobisDistanceThresholdImageFunction);
 
   /** Standard class type aliases. */
   using Self = MahalanobisDistanceThresholdImageFunction;
-  using Superclass = ImageFunction<TInputImage, bool, TCoordRep>;
+  using Superclass = ImageFunction<TInputImage, bool, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
@@ -21,15 +21,15 @@
 
 namespace itk
 {
-template <typename TInputImage, typename TCoordRep>
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::MahalanobisDistanceThresholdImageFunction()
+template <typename TInputImage, typename TCoordinate>
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::MahalanobisDistanceThresholdImageFunction()
   : m_Threshold(0.0)
   , m_MahalanobisDistanceMembershipFunction(MahalanobisDistanceFunctionType::New())
 {}
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::SetMean(const MeanVectorType & mean)
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::SetMean(const MeanVectorType & mean)
 {
   // Cache the mean
   m_Mean = mean;
@@ -44,9 +44,9 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::SetMean(const
   m_MahalanobisDistanceMembershipFunction->SetMean(m);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::SetCovariance(
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::SetCovariance(
   const CovarianceMatrixType & covariance)
 {
   // Cache the covariance
@@ -58,9 +58,9 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::SetCovariance
   m_MahalanobisDistanceMembershipFunction->SetCovariance(c);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::Evaluate(const PointType & point) const
 {
   IndexType index;
 
@@ -68,9 +68,9 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::Evaluate(cons
   return (this->EvaluateAtIndex(index));
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & index) const
 {
   IndexType nindex;
@@ -79,18 +79,18 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateAtCon
   return this->EvaluateAtIndex(nindex);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const
 {
   double mahalanobisDistance = this->EvaluateDistanceAtIndex(index);
 
   return (mahalanobisDistance <= m_Threshold);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 double
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateDistance(const PointType & point) const
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::EvaluateDistance(const PointType & point) const
 {
   IndexType index;
 
@@ -99,9 +99,9 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateDista
   return mahalanobisDistance;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 double
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateDistanceAtIndex(
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::EvaluateDistanceAtIndex(
   const IndexType & index) const
 {
   double mahalanobisDistanceSquared =
@@ -125,9 +125,9 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::EvaluateDista
   return mahalanobisDistance;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
@@ -45,9 +45,9 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT MeanImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MeanImageFunction);
@@ -55,7 +55,7 @@ public:
   /** Standard class type aliases. */
   using Self = MeanImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -25,14 +25,14 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-MeanImageFunction<TInputImage, TCoordRep>::MeanImageFunction()
+template <typename TInputImage, typename TCoordinate>
+MeanImageFunction<TInputImage, TCoordinate>::MeanImageFunction()
 
   = default;
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+MeanImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sum = RealType{};
 
@@ -60,9 +60,9 @@ MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & ind
 }
 
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MeanImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigned int radius)
+MeanImageFunction<TInputImage, TCoordinate>::SetNeighborhoodRadius(const unsigned int radius)
 {
   if (m_NeighborhoodRadius != radius)
   {
@@ -73,9 +73,9 @@ MeanImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigned 
 }
 
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MeanImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+MeanImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
@@ -45,16 +45,16 @@ namespace itk
  * \sphinxexample{Core/ImageFunction/ComputeMedianOfImageAtPixel,Compute Median Of Image At Pixel}
  * \endsphinx
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT MedianImageFunction
-  : public ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordRep>
+  : public ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MedianImageFunction);
 
   /** Standard class type aliases. */
   using Self = MedianImageFunction;
-  using Superclass = ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordRep>;
+  using Superclass = ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -27,12 +27,12 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-MedianImageFunction<TInputImage, TCoordRep>::MedianImageFunction() = default;
+template <typename TInputImage, typename TCoordinate>
+MedianImageFunction<TInputImage, TCoordinate>::MedianImageFunction() = default;
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MedianImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigned int radius)
+MedianImageFunction<TInputImage, TCoordinate>::SetNeighborhoodRadius(const unsigned int radius)
 {
   if (m_NeighborhoodRadius != radius)
   {
@@ -42,17 +42,17 @@ MedianImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigne
   }
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-MedianImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+MedianImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> OutputType
+MedianImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> OutputType
 {
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
@@ -38,16 +38,16 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT NearestNeighborExtrapolateImageFunction
-  : public ExtrapolateImageFunction<TInputImage, TCoordRep>
+  : public ExtrapolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NearestNeighborExtrapolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = NearestNeighborExtrapolateImageFunction;
-  using Superclass = ExtrapolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = ExtrapolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
@@ -35,16 +35,16 @@ namespace itk
  * \ingroup ImageFunctions ImageInterpolators
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT NearestNeighborInterpolateImageFunction
-  : public InterpolateImageFunction<TInputImage, TCoordRep>
+  : public InterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NearestNeighborInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = NearestNeighborInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.h
@@ -38,16 +38,16 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT NeighborhoodBinaryThresholdImageFunction
-  : public BinaryThresholdImageFunction<TInputImage, TCoordRep>
+  : public BinaryThresholdImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NeighborhoodBinaryThresholdImageFunction);
 
   /** Standard class type aliases. */
   using Self = NeighborhoodBinaryThresholdImageFunction;
-  using Superclass = BinaryThresholdImageFunction<TInputImage, TCoordRep>;
+  using Superclass = BinaryThresholdImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
@@ -24,24 +24,24 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::NeighborhoodBinaryThresholdImageFunction()
+template <typename TInputImage, typename TCoordinate>
+NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordinate>::NeighborhoodBinaryThresholdImageFunction()
 {
   m_Radius.Fill(1);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "Radius: " << m_Radius << std::endl;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+NeighborhoodBinaryThresholdImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const
 {
   if (!this->GetInputImage())
   {

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
@@ -37,15 +37,15 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
-class ITK_TEMPLATE_EXPORT RayCastInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
+template <typename TInputImage, typename TCoordinate = double>
+class ITK_TEMPLATE_EXPORT RayCastInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(RayCastInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = RayCastInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -56,7 +56,7 @@ public:
    * Type of the Transform Base class
    * The fixed image should be a 3D image
    */
-  using TransformType = Transform<TCoordRep, 3, 3>;
+  using TransformType = Transform<TCoordinate, 3, 3>;
 
   using TransformPointer = typename TransformType::Pointer;
   using InputPointType = typename TransformType::InputPointType;
@@ -68,10 +68,10 @@ public:
 
   using SizeType = typename TInputImage::SizeType;
 
-  using DirectionType = Vector<TCoordRep, 3>;
+  using DirectionType = Vector<TCoordinate, 3>;
 
   /**  Type of the Interpolator Base class */
-  using InterpolatorType = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using InterpolatorType = InterpolateImageFunction<TInputImage, TCoordinate>;
 
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 
@@ -202,7 +202,7 @@ private:
  * \brief Contains all enum classes used by RayCastHelper class.
  * \ingroup ITKImageFunction
  * @tparam TInputImage
- * @tparam TCoordRep
+ * @tparam TCoordinate
  */
 class RayCastHelperEnums
 {

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -28,15 +28,15 @@ namespace itk
  * \class Helper class to maintain state when casting a ray.
  *  This helper class keeps the RayCastInterpolateImageFunction thread safe.
  */
-template <typename TInputImage, typename TCoordRep>
-class RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper
+template <typename TInputImage, typename TCoordinate>
+class RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper
 {
 public:
   /**
    * Type of the Transform Base class
    * The fixed image should be a 3D image
    */
-  using TransformType = itk::Transform<TCoordRep, 3, 3>;
+  using TransformType = itk::Transform<TCoordinate, 3, 3>;
 
   using TransformPointer = typename TransformType::Pointer;
   using InputPointType = typename TransformType::InputPointType;
@@ -45,8 +45,8 @@ public:
   using TransformJacobianType = typename TransformType::JacobianType;
 
   using SizeType = typename TInputImage::SizeType;
-  using DirectionType = itk::Vector<TCoordRep, 3>;
-  using PointType = itk::Point<TCoordRep, 3>;
+  using DirectionType = itk::Vector<TCoordinate, 3>;
+  using PointType = itk::Point<TCoordinate, 3>;
 
   using InputImageType = TInputImage;
   using PixelType = typename InputImageType::PixelType;
@@ -298,9 +298,9 @@ protected:
    Initialise() - Initialise the object
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Initialise()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Initialise()
 {
   // Save the dimensions of the volume and calculate the bounding box
   this->RecordVolumeDimensions();
@@ -314,9 +314,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Initiali
    RecordVolumeDimensions() - Record volume dimensions and resolution
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::RecordVolumeDimensions()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::RecordVolumeDimensions()
 {
   typename InputImageType::SpacingType spacing = this->m_Image->GetSpacing();
   SizeType                             dim = this->m_Image->GetLargestPossibleRegion().GetSize();
@@ -334,9 +334,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::RecordVo
    DefineCorners() - Define the corners of the volume
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::DefineCorners()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::DefineCorners()
 {
   // Define corner positions as if at the origin
 
@@ -360,9 +360,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::DefineCo
    CalcPlanesAndCorners() - Calculate the planes and corners of the volume.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcPlanesAndCorners()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcPlanesAndCorners()
 {
   int j;
 
@@ -450,9 +450,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcPlan
    CalcRayIntercepts() - Calculate the ray intercepts with the volume.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcRayIntercepts()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcRayIntercepts()
 {
   bool   noInterceptFlag[6];
   double cubeIntercepts[6][3];
@@ -671,10 +671,10 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcRayI
    SetRay() - Set the position and direction of the ray
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::SetRay(const OutputPointType & rayPosition,
-                                                                               const DirectionType &   rayDirection)
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::SetRay(const OutputPointType & rayPosition,
+                                                                                 const DirectionType &   rayDirection)
 {
   // Store the position and direction of the ray
   typename TInputImage::SpacingType spacing = this->m_Image->GetSpacing();
@@ -737,9 +737,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::SetRay(c
    EndPointsInVoxels() - Convert the endpoints to voxels
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::EndPointsInVoxels()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::EndPointsInVoxels()
 {
   m_RayVoxelStartPosition[0] = m_RayStartCoordInMM[0] / m_VoxelDimensionInX;
   m_RayVoxelStartPosition[1] = m_RayStartCoordInMM[1] / m_VoxelDimensionInY;
@@ -754,9 +754,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::EndPoint
    CalcDirnVector() - Calculate the incremental direction vector in voxels.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcDirnVector()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcDirnVector()
 {
   double xNum, yNum, zNum;
 
@@ -902,9 +902,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::CalcDirn
    AdjustRayLength() - Ensure that the ray lies within the volume
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::AdjustRayLength()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::AdjustRayLength()
 {
   bool startOK, endOK;
 
@@ -988,9 +988,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::AdjustRa
    Reset() - Reset the iterator to the start of the ray.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Reset()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset()
 {
   int i;
 
@@ -1042,9 +1042,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Reset()
    InitialiseVoxelPointers() - Obtain pointers to the first four voxels
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::InitialiseVoxelPointers()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::InitialiseVoxelPointers()
 {
   IndexType index;
 
@@ -1174,9 +1174,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Initiali
    IncrementVoxelPointers() - Increment the voxel pointers
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::IncrementVoxelPointers()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::IncrementVoxelPointers()
 {
   double xBefore = m_Position3Dvox[0].GetSum();
   double yBefore = m_Position3Dvox[1].GetSum();
@@ -1206,9 +1206,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Incremen
    GetCurrentIntensity() - Get the intensity of the current ray point.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 double
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::GetCurrentIntensity() const
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::GetCurrentIntensity() const
 {
   double a, b, c, d;
   double y, z;
@@ -1259,10 +1259,10 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::GetCurre
    IntegrateAboveThreshold() - Integrate intensities above a threshold.
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 bool
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::IntegrateAboveThreshold(double & integral,
-                                                                                                double   threshold)
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::IntegrateAboveThreshold(double & integral,
+                                                                                                  double   threshold)
 {
   double intensity;
 
@@ -1304,9 +1304,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::Integrat
    ZeroState() - Set the default (zero) state of the object
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::ZeroState()
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroState()
 {
   int i;
 
@@ -1368,8 +1368,8 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper::ZeroStat
    Constructor
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastInterpolateImageFunction()
+template <typename TInputImage, typename TCoordinate>
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastInterpolateImageFunction()
 {
   m_Threshold = 0.;
 
@@ -1382,9 +1382,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastInterpolateImage
    PrintSelf
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -1398,9 +1398,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream 
    Evaluate at image index position
    ----------------------------------------------------------------------- */
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const -> OutputType
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::Evaluate(const PointType & point) const -> OutputType
 {
   double integral = 0;
 
@@ -1408,7 +1408,7 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTyp
 
   DirectionType direction = transformedFocalPoint - point;
 
-  RayCastInterpolateImageFunction<TInputImage, TCoordRep>::RayCastHelper ray;
+  RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper ray;
   ray.SetImage(this->m_Image);
   ray.ZeroState();
   ray.Initialise();
@@ -1429,9 +1429,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTyp
   return (static_cast<OutputType>(integral));
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
+RayCastInterpolateImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & index) const -> OutputType
 {
   OutputPointType point;

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
@@ -41,11 +41,11 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT ScatterMatrixImageFunction
   : public ImageFunction<TInputImage,
                          vnl_matrix<typename NumericTraits<typename TInputImage::PixelType::ValueType>::RealType>,
-                         TCoordRep>
+                         TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ScatterMatrixImageFunction);
@@ -55,7 +55,7 @@ public:
   using Superclass =
     ImageFunction<TInputImage,
                   vnl_matrix<typename NumericTraits<typename TInputImage::PixelType::ValueType>::RealType>,
-                  TCoordRep>;
+                  TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -23,23 +23,23 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-ScatterMatrixImageFunction<TInputImage, TCoordRep>::ScatterMatrixImageFunction()
+template <typename TInputImage, typename TCoordinate>
+ScatterMatrixImageFunction<TInputImage, TCoordinate>::ScatterMatrixImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-ScatterMatrixImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+ScatterMatrixImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+ScatterMatrixImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType covariance;
 

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
@@ -43,9 +43,9 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT SumOfSquaresImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SumOfSquaresImageFunction);
@@ -53,7 +53,7 @@ public:
   /** Standard class type aliases. */
   using Self = SumOfSquaresImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -24,16 +24,16 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-SumOfSquaresImageFunction<TInputImage, TCoordRep>::SumOfSquaresImageFunction()
+template <typename TInputImage, typename TCoordinate>
+SumOfSquaresImageFunction<TInputImage, TCoordinate>::SumOfSquaresImageFunction()
 {
   this->m_NeighborhoodRadius = 1;
   this->m_NeighborhoodSize = 1;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+SumOfSquaresImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sumOfSquares = RealType{};
 
@@ -61,9 +61,9 @@ SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexTy
   return (sumOfSquares);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-SumOfSquaresImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+SumOfSquaresImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
@@ -39,9 +39,9 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT VarianceImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VarianceImageFunction);
@@ -49,7 +49,7 @@ public:
   /** Standard class type aliases. */
   using Self = VarianceImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -24,23 +24,23 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-VarianceImageFunction<TInputImage, TCoordRep>::VarianceImageFunction()
+template <typename TInputImage, typename TCoordinate>
+VarianceImageFunction<TInputImage, TCoordinate>::VarianceImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-VarianceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+VarianceImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+VarianceImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sum;
   RealType sumOfSquares;

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -43,9 +43,9 @@ namespace itk
  * \ingroup ImageFunctions ImageInterpolators
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT VectorInterpolateImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorInterpolateImageFunction);
@@ -59,7 +59,7 @@ public:
   /** Standard class type aliases. */
   using Self = VectorInterpolateImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -86,7 +86,7 @@ public:
   using typename Superclass::OutputType;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
 
   /** Returns the interpolated image intensity at a
    * specified point position. No bounds checking is done.
@@ -97,7 +97,7 @@ public:
   Evaluate(const PointType & point) const override
   {
     const ContinuousIndexType index =
-      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordinate>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
@@ -39,16 +39,16 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT VectorLinearInterpolateImageFunction
-  : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
+  : public VectorInterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorLinearInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = VectorLinearInterpolateImageFunction;
-  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -25,14 +25,14 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-const unsigned long VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::m_Neighbors =
+template <typename TInputImage, typename TCoordinate>
+const unsigned long VectorLinearInterpolateImageFunction<TInputImage, TCoordinate>::m_Neighbors =
   1 << TInputImage::ImageDimension;
 
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-VectorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
+VectorLinearInterpolateImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & index) const -> OutputType
 {
   //

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
@@ -50,16 +50,16 @@ namespace itk
  * \ingroup ITKImageFunction
  *
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT VectorLinearInterpolateNearestNeighborExtrapolateImageFunction
-  : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
+  : public VectorInterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorLinearInterpolateNearestNeighborExtrapolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = VectorLinearInterpolateNearestNeighborExtrapolateImageFunction;
-  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
@@ -26,13 +26,14 @@ namespace itk
 /**
  * Define the number of neighbors
  */
-template <typename TInputImage, typename TCoordRep>
-const unsigned int VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::m_Neighbors =
-  1 << TInputImage::ImageDimension;
+template <typename TInputImage, typename TCoordinate>
+const unsigned int
+  VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordinate>::m_Neighbors =
+    1 << TInputImage::ImageDimension;
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
+VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & index) const -> OutputType
 {
   unsigned int dim; // index over dimension
@@ -125,9 +126,9 @@ VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoo
 /**
  * Evaluate at image index position
  */
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(
+VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(
   const IndexType & index) const -> OutputType
 {
   // Find the index that is closest to the requested one

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
@@ -41,9 +41,9 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = float>
+template <typename TInputImage, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT VectorMeanImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorMeanImageFunction);
@@ -51,7 +51,7 @@ public:
   /** Standard class type aliases. */
   using Self = VectorMeanImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -23,23 +23,23 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-VectorMeanImageFunction<TInputImage, TCoordRep>::VectorMeanImageFunction()
+template <typename TInputImage, typename TCoordinate>
+VectorMeanImageFunction<TInputImage, TCoordinate>::VectorMeanImageFunction()
 {
   m_NeighborhoodRadius = 1;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-VectorMeanImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+VectorMeanImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "NeighborhoodRadius: " << m_NeighborhoodRadius << std::endl;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-VectorMeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
+VectorMeanImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
 
   using PixelType = typename TInputImage::PixelType;

--- a/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
@@ -39,16 +39,16 @@ namespace itk
  *
  * \ingroup ITKImageFunction
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT VectorNearestNeighborInterpolateImageFunction
-  : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
+  : public VectorInterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorNearestNeighborInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = VectorNearestNeighborInterpolateImageFunction;
-  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -228,7 +228,7 @@ private:
  * classes.
  *
  * \par
- * The fifth (TCoordRep) is again standard for interpolating functions,
+ * The fifth (TCoordinate) is again standard for interpolating functions,
  * and should be float or double.
  *
  * \par CAVEATS
@@ -262,15 +262,16 @@ template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction = Function::HammingWindowFunction<VRadius>,
           class TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TInputImage, TInputImage>,
-          class TCoordRep = double>
-class ITK_TEMPLATE_EXPORT WindowedSincInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
+          class TCoordinate = double>
+class ITK_TEMPLATE_EXPORT WindowedSincInterpolateImageFunction
+  : public InterpolateImageFunction<TInputImage, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(WindowedSincInterpolateImageFunction);
 
   /** Standard class type aliases. */
   using Self = WindowedSincInterpolateImageFunction;
-  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -50,9 +50,9 @@ template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,
           typename TBoundaryCondition,
-          typename TCoordRep>
+          typename TCoordinate>
 void
-WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
+WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordinate>::
   SetInputImage(const ImageType * image)
 {
   // Call the parent implementation
@@ -111,9 +111,9 @@ template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,
           typename TBoundaryCondition,
-          typename TCoordRep>
+          typename TCoordinate>
 void
-WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::PrintSelf(
+WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordinate>::PrintSelf(
   std::ostream & os,
   Indent         indent) const
 {
@@ -127,9 +127,9 @@ template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,
           typename TBoundaryCondition,
-          typename TCoordRep>
+          typename TCoordinate>
 auto
-WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordRep>::
+WindowedSincInterpolateImageFunction<TInputImage, VRadius, TWindowFunction, TBoundaryCondition, TCoordinate>::
   EvaluateAtContinuousIndex(const ContinuousIndexType & index) const -> OutputType
 {
   IndexType baseIndex;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -37,12 +37,12 @@ namespace itk
  * \ingroup ITKQuadEdgeMesh
  */
 template <int VPointDimension,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TInterpolationWeight = float,
           typename TPointIdentifier = IdentifierType,
           typename TCellIdentifier = IdentifierType,
           typename TCellFeatureIdentifier = unsigned char,
-          typename TPoint = QuadEdgeMeshPoint<TCoordRep, VPointDimension>,
+          typename TPoint = QuadEdgeMeshPoint<TCoordinate, VPointDimension>,
           typename TPointsContainer = MapContainer<TPointIdentifier, TPoint>,
           typename TUsingCellsContainer = std::set<TPointIdentifier>,
           typename TQE = GeometricalQuadEdge<unsigned long, unsigned long, bool, bool, true>>
@@ -50,7 +50,7 @@ class QuadEdgeMeshCellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -34,7 +34,7 @@ namespace itk
  * of many template parameters while still enjoying the benefits of generic
  * programming.
  *
- * \tparam TCoordRep
+ * \tparam TCoordinate
  *    Numerical type with which to represent each coordinate value.
  *
  * \tparam VPointDimension
@@ -60,7 +60,7 @@ namespace itk
 template <typename TPixelType = float,
           unsigned int VPointDimension = 3,
           unsigned int VMaxTopologicalDimension = VPointDimension,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TInterpolationWeightType = float,
           typename TCellPixelType = TPixelType,
           typename TPData = bool,
@@ -70,7 +70,7 @@ class QuadEdgeMeshExtendedTraits
 public:
   using Self = QuadEdgeMeshExtendedTraits;
   /** Save the template parameters. */
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using PixelType = TPixelType;
   using PrimalDataType = TPData;
   using DualDataType = TDData;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -31,15 +31,15 @@ namespace itk
  * to an entry in the edge ring.
  * \ingroup ITKQuadEdgeMesh
  */
-template <typename TCoordRep,
+template <typename TCoordinate,
           unsigned int VPointDimension,
           typename TQuadEdge = GeometricalQuadEdge<unsigned long, unsigned long, bool, bool, true>>
-class ITK_TEMPLATE_EXPORT QuadEdgeMeshPoint : public Point<TCoordRep, VPointDimension>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshPoint : public Point<TCoordinate, VPointDimension>
 {
 public:
   /** Standard type alias. */
   using Self = QuadEdgeMeshPoint;
-  using Superclass = Point<TCoordRep, VPointDimension>;
+  using Superclass = Point<TCoordinate, VPointDimension>;
 
   /** Types & values defined in superclass. */
   static constexpr unsigned int PointDimension = VPointDimension;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
@@ -23,26 +23,26 @@ namespace itk
 {
 // ---------------------------------------------------------------------
 // ResetEdge would be a better name than Initialize.
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 void
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::Initialize()
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::Initialize()
 {
   m_Edge = static_cast<TQuadEdge *>(nullptr);
 }
 
 
 // ---------------------------------------------------------------------
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::QuadEdgeMeshPoint(const Superclass & r)
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::QuadEdgeMeshPoint(const Superclass & r)
   : Superclass(r)
 {
   this->Initialize();
 }
 
 // ---------------------------------------------------------------------
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge> &
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::operator=(const Superclass & r)
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge> &
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::operator=(const Superclass & r)
 {
   this->Superclass::operator=(r);
   this->Initialize();
@@ -50,18 +50,18 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::operator=(const Superc
 }
 
 // ---------------------------------------------------------------------
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge> &
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::operator=(const ValueType r[VPointDimension])
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge> &
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::operator=(const ValueType r[VPointDimension])
 {
   this->Superclass::operator=(r);
   this->Initialize();
   return (*this);
 }
 
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 bool
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::IsInternal() const
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::IsInternal() const
 {
   if (this->GetEdge())
   {
@@ -75,9 +75,9 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::IsInternal() const
  *  @return the valence when an entry in the Onext ring is present,
  *          and -1 otherwise.
  */
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 int
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetValence() const
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::GetValence() const
 {
   int valence = -1; // error code by default
 
@@ -92,9 +92,9 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetValence() const
 /** Set Edge
  *
  */
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 void
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::SetEdge(TQuadEdge * inputEdge)
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::SetEdge(TQuadEdge * inputEdge)
 {
   m_Edge = inputEdge;
 }
@@ -102,9 +102,9 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::SetEdge(TQuadEdge * in
 /** Get Edge
  *
  */
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 TQuadEdge *
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetEdge() const
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::GetEdge() const
 {
   return m_Edge;
 }
@@ -112,9 +112,9 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetEdge() const
 /** Get Edge non-const version
  *
  */
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 TQuadEdge *
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetEdge()
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::GetEdge()
 {
   return (m_Edge);
 }
@@ -122,9 +122,9 @@ QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::GetEdge()
 /** Set Point Coordinates
  *
  */
-template <typename TCoordRep, unsigned int VPointDimension, typename TQuadEdge>
+template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>
 void
-QuadEdgeMeshPoint<TCoordRep, VPointDimension, TQuadEdge>::SetPoint(const Superclass & point)
+QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::SetPoint(const Superclass & point)
 {
   this->Superclass::operator=(point);
 }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -44,7 +44,7 @@ template <typename TPixel,
           unsigned int VPointDimension,
           typename TPData,
           typename TDData,
-          typename TCoordRep = float,
+          typename TCoordinate = float,
           typename TInterpolationWeight = float>
 class QuadEdgeMeshTraits
 {
@@ -53,7 +53,7 @@ public:
   using Self = QuadEdgeMeshTraits;
   using PixelType = TPixel;
   using CellPixelType = TPixel;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using InterpolationWeightType = TInterpolationWeight;
 
   static constexpr unsigned int PointDimension = VPointDimension;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -54,15 +54,15 @@ namespace itk
  *
  * \ingroup ITKImageGrid
  */
-template <typename TInputImage, typename TCoordRep = double>
+template <typename TInputImage, typename TCoordinate = double>
 class ITK_TEMPLATE_EXPORT BSplineControlPointImageFunction
-  : public ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordRep>
+  : public ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineControlPointImageFunction);
 
   using Self = BSplineControlPointImageFunction;
-  using Superclass = ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordRep>;
+  using Superclass = ImageFunction<TInputImage, typename TInputImage::PixelType, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -78,7 +78,7 @@ public:
   /** Image type alias support */
   using ControlPointLatticeType = TInputImage;
   using InputImageType = TInputImage;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
   using PixelType = typename InputImageType::PixelType;
   using RegionType = typename InputImageType::RegionType;
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -25,8 +25,8 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep>
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::BSplineControlPointImageFunction()
+template <typename TInputImage, typename TCoordinate>
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::BSplineControlPointImageFunction()
 {
   this->m_SplineOrder.Fill(3);
   this->m_Origin.Fill(0.0);
@@ -51,17 +51,17 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::BSplineControlPointIma
   this->m_BSplineEpsilon = 1e-3;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetSplineOrder(const unsigned int order)
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::SetSplineOrder(const unsigned int order)
 {
   this->m_SplineOrder.Fill(order);
   this->SetSplineOrder(this->m_SplineOrder);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetSplineOrder(const ArrayType & order)
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::SetSplineOrder(const ArrayType & order)
 {
   itkDebugMacro("Setting m_SplineOrder to " << order);
 
@@ -79,9 +79,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetSplineOrder(const A
   this->Modified();
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetInputImage(const InputImageType * image)
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::SetInputImage(const InputImageType * image)
 {
   Superclass::SetInputImage(image);
 
@@ -118,9 +118,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetInputImage(const In
   this->m_NeighborhoodWeightImage->Allocate();
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtParametricPoint(const PointType & point) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtParametricPoint(const PointType & point) const
   -> OutputType
 {
   PointType params;
@@ -132,9 +132,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtParametricPo
   return this->Evaluate(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & idx) const -> OutputType
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & idx) const -> OutputType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -145,9 +145,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const 
   return this->Evaluate(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIndex(
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & idx) const -> OutputType
 {
   PointType params;
@@ -159,9 +159,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIn
   return this->Evaluate(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & params) const -> OutputType
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::Evaluate(const PointType & params) const -> OutputType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -264,9 +264,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTy
   return data;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtParametricPoint(
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtParametricPoint(
   const PointType & point) const -> GradientType
 {
   PointType params;
@@ -278,9 +278,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtPara
   return this->EvaluateGradient(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtIndex(const IndexType & idx) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtIndex(const IndexType & idx) const
   -> GradientType
 {
   PointType params;
@@ -292,9 +292,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtInde
   return this->EvaluateGradient(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtContinuousIndex(
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtContinuousIndex(
   const ContinuousIndexType & idx) const -> GradientType
 {
   PointType params;
@@ -306,9 +306,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtCont
   return this->EvaluateGradient(params);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradient(const PointType & params) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(const PointType & params) const
   -> GradientType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
@@ -428,9 +428,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradient(const
   return gradient;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtParametricPoint(
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtParametricPoint(
   const PointType &  point,
   const unsigned int component) const -> HessianComponentType
 {
@@ -443,10 +443,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtParam
   return this->EvaluateHessian(params, component);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtIndex(const IndexType &  idx,
-                                                                                 const unsigned int component) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtIndex(const IndexType &  idx,
+                                                                                   const unsigned int component) const
   -> HessianComponentType
 {
   PointType params;
@@ -458,9 +458,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtIndex
   return this->EvaluateHessian(params, component);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtContinuousIndex(
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtContinuousIndex(
   const ContinuousIndexType & idx,
   const unsigned int          component) const -> HessianComponentType
 {
@@ -473,10 +473,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessianAtConti
   return this->EvaluateHessian(params, component);
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 auto
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessian(const PointType &  params,
-                                                                          const unsigned int component) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(const PointType &  params,
+                                                                            const unsigned int component) const
   -> HessianComponentType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
@@ -609,9 +609,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateHessian(const 
   return hessian;
 }
 
-template <typename TInputImage, typename TCoordRep>
+template <typename TInputImage, typename TCoordinate>
 void
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+BSplineControlPointImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -49,7 +49,7 @@ namespace itk
  * number of tissue types.  For such an image, one does not want to
  * interpolate between different pixel values, and so
  * NearestNeighborInterpolateImageFunction< InputImageType,
- * TCoordRep > would be a better choice.
+ * TCoordinate > would be a better choice.
  *
  * If an sample is taken from outside the image domain, the default behavior is
  * to use a default pixel value.  If different behavior is desired, an

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -33,13 +33,13 @@
 namespace
 {
 
-template <typename TCoordRepType, unsigned int VDimension>
-class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, VDimension>
+template <typename TCoordinateType, unsigned int VDimension>
+class NonlinearAffineTransform : public itk::AffineTransform<TCoordinateType, VDimension>
 {
 public:
   /** Standard class type aliases.   */
   using Self = NonlinearAffineTransform;
-  using Superclass = itk::AffineTransform<TCoordRepType, VDimension>;
+  using Superclass = itk::AffineTransform<TCoordinateType, VDimension>;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -34,13 +34,13 @@
 namespace
 {
 
-template <typename TCoordRepType, unsigned int VDimension>
-class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, VDimension>
+template <typename TCoordinateType, unsigned int VDimension>
+class NonlinearAffineTransform : public itk::AffineTransform<TCoordinateType, VDimension>
 {
 public:
   /** Standard class type aliases.   */
   using Self = NonlinearAffineTransform;
-  using Superclass = itk::AffineTransform<TCoordRepType, VDimension>;
+  using Superclass = itk::AffineTransform<TCoordinateType, VDimension>;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
@@ -51,10 +51,10 @@ public:
   itkOverrideGetNameOfClassMacro(NonlinearAffineTransform);
 
   /** Override this so not linear. See test below. */
-  typename itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryEnum
+  typename itk::TransformBaseTemplate<TCoordinateType>::TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryEnum::UnknownTransformCategory;
+    return itk::TransformBaseTemplate<TCoordinateType>::TransformCategoryEnum::UnknownTransformCategory;
   }
 };
 } // namespace

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -595,13 +595,13 @@ public:
     this->SetPixelType(IOPixelEnum::VECTOR);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-  template <typename TCoordRep, unsigned int VPointDimension>
+  template <typename TCoordinate, unsigned int VPointDimension>
   void
-  SetPixelTypeInfo(const Point<TCoordRep, VPointDimension> *)
+  SetPixelTypeInfo(const Point<TCoordinate, VPointDimension> *)
   {
     this->SetNumberOfComponents(VPointDimension);
     this->SetPixelType(IOPixelEnum::POINT);
-    this->SetComponentType(MapPixelType<TCoordRep>::CType);
+    this->SetComponentType(MapPixelType<TCoordinate>::CType);
   }
   template <typename TPixel, unsigned int VLength>
   void

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
@@ -40,9 +40,9 @@ namespace itk
  * \ingroup ImageInterpolators
  * \ingroup ITKReview
  */
-template <typename TImageType, typename TCoordRep = double, typename TCoefficientType = double>
+template <typename TImageType, typename TCoordinate = double, typename TCoefficientType = double>
 class ITK_TEMPLATE_EXPORT ComplexBSplineInterpolateImageFunction
-  : public InterpolateImageFunction<TImageType, TCoordRep>
+  : public InterpolateImageFunction<TImageType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ComplexBSplineInterpolateImageFunction);
@@ -50,7 +50,7 @@ public:
   /** Standard class type alias. */
   using Self = ComplexBSplineInterpolateImageFunction;
   /** Standard class type alias. */
-  using Superclass = InterpolateImageFunction<TImageType, TCoordRep>;
+  using Superclass = InterpolateImageFunction<TImageType, TCoordinate>;
   /** Standard class type alias. */
   using Pointer = SmartPointer<Self>;
   /** Standard class type alias. */
@@ -91,7 +91,7 @@ public:
   using ImaginaryFilterType = ComplexToImaginaryImageFilter<InputImageType, InternalImageType>;
 
   /** Underlying real BSpline interpolator */
-  using InterpolatorType = BSplineInterpolateImageFunction<InternalImageType, TCoordRep, TCoefficientType>;
+  using InterpolatorType = BSplineInterpolateImageFunction<InternalImageType, TCoordinate, TCoefficientType>;
 
   /** Evaluate the function at a ContinuousIndex position.
    *

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
@@ -22,8 +22,8 @@
 namespace itk
 {
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
+ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::
   ComplexBSplineInterpolateImageFunction()
 {
   m_RealInterpolator = InterpolatorType::New();
@@ -35,10 +35,10 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
   this->SetSplineOrder(3);
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::PrintSelf(std::ostream & os,
-                                                                                           Indent         indent) const
+ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::PrintSelf(std::ostream & os,
+                                                                                             Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -50,9 +50,9 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
   itkPrintSelfObjectMacro(ImaginaryFilter);
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInputImage(
+ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetInputImage(
   const TImageType * inputData)
 {
   if (inputData)
@@ -67,9 +67,9 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
   }
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 void
-ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetSplineOrder(
+ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetSplineOrder(
   unsigned int SplineOrder)
 {
   m_SplineOrder = SplineOrder;
@@ -77,15 +77,15 @@ ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>:
   m_ImaginaryInterpolator->SetSplineOrder(SplineOrder);
 }
 
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
+template <typename TImageType, typename TCoordinate, typename TCoefficientType>
 auto
-ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndex(
+ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::EvaluateAtContinuousIndex(
   const ContinuousIndexType & x) const -> OutputType
 {
   typename InterpolatorType::OutputType realPart = m_RealInterpolator->EvaluateAtContinuousIndex(x);
   typename InterpolatorType::OutputType imagPart = m_ImaginaryInterpolator->EvaluateAtContinuousIndex(x);
   using ReturnType =
-    typename ComplexBSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::OutputType;
+    typename ComplexBSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::OutputType;
 
   return ReturnType(realPart, imagPart);
 }

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -25,9 +25,9 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TCoordRep = SpacePrecisionType>
+template <typename TInputImage, typename TCoordinate = SpacePrecisionType>
 class TestImageFunction
-  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
+  : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TestImageFunction);
@@ -35,7 +35,7 @@ public:
   /** Standard class type aliases. */
   using Self = TestImageFunction;
   using Superclass =
-    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>;
+    ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordinate>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
@@ -38,7 +38,10 @@ namespace itk
  *
  * \ingroup ITKMetricsv4
  */
-template <typename TFixedImageType, typename TMovingImageType, typename TVirtualImageType, typename TCoordRep = double>
+template <typename TFixedImageType,
+          typename TMovingImageType,
+          typename TVirtualImageType,
+          typename TCoordinate = double>
 class DefaultImageToImageMetricTraitsv4
 {
 public:
@@ -52,7 +55,7 @@ public:
   using FixedImagePixelType = typename FixedImageType::PixelType;
   using MovingImagePixelType = typename MovingImageType::PixelType;
 
-  using CoordinateRepresentationType = TCoordRep;
+  using CoordinateRepresentationType = TCoordinate;
 
   /* Image dimension accessors */
   using ImageDimensionType = unsigned int;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -42,14 +42,15 @@ namespace itk
  *
  * \ingroup ITKMetricsv4
  */
-template <typename TPointSet, typename TOutput = double, typename TCoordRep = double>
-class ITK_TEMPLATE_EXPORT ManifoldParzenWindowsPointSetFunction : public PointSetFunction<TPointSet, TOutput, TCoordRep>
+template <typename TPointSet, typename TOutput = double, typename TCoordinate = double>
+class ITK_TEMPLATE_EXPORT ManifoldParzenWindowsPointSetFunction
+  : public PointSetFunction<TPointSet, TOutput, TCoordinate>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ManifoldParzenWindowsPointSetFunction);
 
   using Self = ManifoldParzenWindowsPointSetFunction;
-  using Superclass = PointSetFunction<TPointSet, TOutput, TCoordRep>;
+  using Superclass = PointSetFunction<TPointSet, TOutput, TCoordinate>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -71,7 +72,7 @@ public:
   /** Other type alias */
   using RealType = TOutput;
   using OutputType = TOutput;
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
 
   /** Typedef for points locator class to speed up finding neighboring points */
   using PointsLocatorType = PointsLocator<PointsContainer>;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -25,8 +25,8 @@
 namespace itk
 {
 
-template <typename TPointSet, typename TOutput, typename TCoordRep>
-ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::ManifoldParzenWindowsPointSetFunction()
+template <typename TPointSet, typename TOutput, typename TCoordinate>
+ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::ManifoldParzenWindowsPointSetFunction()
   : m_PointsLocator(nullptr)
   , m_RegularizationSigma(1.0)
   , m_KernelSigma(1.0)
@@ -35,9 +35,9 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::ManifoldPa
   m_MultiThreader = MultiThreaderBase::New();
 }
 
-template <typename TPointSet, typename TOutput, typename TCoordRep>
+template <typename TPointSet, typename TOutput, typename TCoordinate>
 void
-ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::SetInputPointSet(const InputPointSetType * ptr)
+ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::SetInputPointSet(const InputPointSetType * ptr)
 {
   this->m_PointSet = ptr;
 
@@ -142,9 +142,9 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::SetInputPo
     nullptr);
 }
 
-template <typename TPointSet, typename TOutput, typename TCoordRep>
+template <typename TPointSet, typename TOutput, typename TCoordinate>
 TOutput
-ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::Evaluate(const InputPointType & point) const
+ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::Evaluate(const InputPointType & point) const
 {
   if (this->GetInputPointSet() == nullptr)
   {
@@ -176,9 +176,9 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::Evaluate(c
   return static_cast<OutputType>(sum.GetSum() / static_cast<OutputType>(this->m_Gaussians.size()));
 }
 
-template <typename TPointSet, typename TOutput, typename TCoordRep>
+template <typename TPointSet, typename TOutput, typename TCoordinate>
 auto
-ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::GetGaussian(PointIdentifier i) const
+ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::GetGaussian(PointIdentifier i) const
   -> GaussianConstPointer
 {
   if (i < this->m_Gaussians.size())
@@ -194,9 +194,10 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::GetGaussia
 /**
  * Standard "PrintSelf" method
  */
-template <typename TPointSet, typename TOutput, typename TCoordRep>
+template <typename TPointSet, typename TOutput, typename TCoordinate>
 void
-ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::PrintSelf(std::ostream & os,
+                                                                                  Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -52,7 +52,7 @@ namespace itk
  *
  * \ingroup ITKMetricsv4
  */
-template <typename TInputPointSet, typename TOutput, typename TCoordRep = float>
+template <typename TInputPointSet, typename TOutput, typename TCoordinate = float>
 class ITK_TEMPLATE_EXPORT PointSetFunction : public FunctionBase<typename TInputPointSet::PointType, TOutput>
 {
 public:
@@ -84,7 +84,7 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
@@ -22,24 +22,24 @@
 namespace itk
 {
 
-template <typename TInputPointSet, typename TOutput, typename TCoordRep>
-PointSetFunction<TInputPointSet, TOutput, TCoordRep>::PointSetFunction()
+template <typename TInputPointSet, typename TOutput, typename TCoordinate>
+PointSetFunction<TInputPointSet, TOutput, TCoordinate>::PointSetFunction()
 {
   this->m_PointSet = nullptr;
 }
 
-template <typename TInputPointSet, typename TOutput, typename TCoordRep>
+template <typename TInputPointSet, typename TOutput, typename TCoordinate>
 void
-PointSetFunction<TInputPointSet, TOutput, TCoordRep>::PrintSelf(std::ostream & os, Indent indent) const
+PointSetFunction<TInputPointSet, TOutput, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfObjectMacro(PointSet);
 }
 
-template <typename TInputPointSet, typename TOutput, typename TCoordRep>
+template <typename TInputPointSet, typename TOutput, typename TCoordinate>
 void
-PointSetFunction<TInputPointSet, TOutput, TCoordRep>::SetInputPointSet(const InputPointSetType * ptr)
+PointSetFunction<TInputPointSet, TOutput, TCoordinate>::SetInputPointSet(const InputPointSetType * ptr)
 {
   this->m_PointSet = ptr;
 }

--- a/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
@@ -43,7 +43,7 @@ template <typename TFixedImageType,
           typename TMovingImageType,
           typename TVirtualImageType,
           unsigned int VNumberOfComponents,
-          typename TCoordRep = typename ObjectToObjectMetricBase::CoordinateRepresentationType>
+          typename TCoordinate = typename ObjectToObjectMetricBase::CoordinateRepresentationType>
 class VectorImageToImageMetricTraitsv4
 {
 public:
@@ -57,7 +57,7 @@ public:
   using FixedImagePixelType = typename FixedImageType::PixelType;
   using MovingImagePixelType = typename MovingImageType::PixelType;
 
-  using CoordinateRepresentationType = TCoordRep;
+  using CoordinateRepresentationType = TCoordinate;
 
   /* Image dimension accessors */
   using ImageDimensionType = unsigned int;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
@@ -63,16 +63,16 @@ namespace itk
  *
  * \ingroup ITKSignedDistanceFunction
  */
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage = Image<double, VSpaceDimension>>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage = Image<double, VSpaceDimension>>
 class ITK_TEMPLATE_EXPORT PCAShapeSignedDistanceFunction
-  : public ShapeSignedDistanceFunction<TCoordRep, VSpaceDimension>
+  : public ShapeSignedDistanceFunction<TCoordinate, VSpaceDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(PCAShapeSignedDistanceFunction);
 
   /** Standard class type aliases. */
   using Self = PCAShapeSignedDistanceFunction;
-  using Superclass = ShapeSignedDistanceFunction<TCoordRep, VSpaceDimension>;
+  using Superclass = ShapeSignedDistanceFunction<TCoordinate, VSpaceDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
@@ -25,8 +25,8 @@
 namespace itk
 {
 // Constructor with default arguments
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::PCAShapeSignedDistanceFunction()
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::PCAShapeSignedDistanceFunction()
 {
   m_NumberOfPrincipalComponents = 0;
   m_NumberOfTransformParameters = 0;
@@ -35,7 +35,7 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::PCAShapeSign
   m_PrincipalComponentImages.resize(0);
   m_PrincipalComponentStandardDeviations.SetSize(0);
 
-  m_Transform = TranslationTransform<TCoordRep, SpaceDimension>::New();
+  m_Transform = TranslationTransform<TCoordinate, SpaceDimension>::New();
   m_Interpolators.resize(0);
   m_Extrapolators.resize(0);
 
@@ -45,9 +45,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::PCAShapeSign
 }
 
 // Set the number of principal components
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
 void
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::SetNumberOfPrincipalComponents(unsigned int n)
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::SetNumberOfPrincipalComponents(unsigned int n)
 {
   m_NumberOfPrincipalComponents = n;
 
@@ -59,9 +59,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::SetNumberOfP
 }
 
 // Set the parameters
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
 void
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::SetParameters(const ParametersType & parameters)
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::SetParameters(const ParametersType & parameters)
 {
   this->m_Parameters = parameters;
 
@@ -85,9 +85,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::SetParameter
 }
 
 // Print self
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
 void
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::PrintSelf(std::ostream & os, Indent indent) const
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -102,9 +102,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::PrintSelf(st
 }
 
 // Initialize the function
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
 void
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Initialize()
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::Initialize()
 {
   // verify mean image
   if (!m_MeanImage)
@@ -159,9 +159,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Initialize()
 }
 
 // Evaluate the signed distance
-template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
+template <typename TCoordinate, unsigned int VSpaceDimension, typename TImage>
 auto
-PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Evaluate(const PointType & point) const
+PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::Evaluate(const PointType & point) const
   -> OutputType
 {
   // transform the point into the shape model space

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -49,16 +49,16 @@ namespace itk
  *
  * \ingroup ITKSignedDistanceFunction
  */
-template <typename TCoordRep, unsigned int VSpaceDimension>
+template <typename TCoordinate, unsigned int VSpaceDimension>
 class ITK_TEMPLATE_EXPORT ShapeSignedDistanceFunction
-  : public SpatialFunction<double, VSpaceDimension, Point<TCoordRep, VSpaceDimension>>
+  : public SpatialFunction<double, VSpaceDimension, Point<TCoordinate, VSpaceDimension>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ShapeSignedDistanceFunction);
 
   /** Standard class type aliases. */
   using Self = ShapeSignedDistanceFunction;
-  using Superclass = SpatialFunction<double, VSpaceDimension, Point<TCoordRep, VSpaceDimension>>;
+  using Superclass = SpatialFunction<double, VSpaceDimension, Point<TCoordinate, VSpaceDimension>>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -76,7 +76,7 @@ public:
   static constexpr unsigned int SpaceDimension = VSpaceDimension;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordRepType = TCoordinate;
 
   /** Point type alias support */
   using PointType = InputType;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
@@ -41,15 +41,16 @@ namespace itk
  *
  * \ingroup ITKSignedDistanceFunction
  */
-template <typename TCoordRep, unsigned int VSpaceDimension>
-class ITK_TEMPLATE_EXPORT SphereSignedDistanceFunction : public ShapeSignedDistanceFunction<TCoordRep, VSpaceDimension>
+template <typename TCoordinate, unsigned int VSpaceDimension>
+class ITK_TEMPLATE_EXPORT SphereSignedDistanceFunction
+  : public ShapeSignedDistanceFunction<TCoordinate, VSpaceDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SphereSignedDistanceFunction);
 
   /** Standard class type aliases. */
   using Self = SphereSignedDistanceFunction;
-  using Superclass = ShapeSignedDistanceFunction<TCoordRep, VSpaceDimension>;
+  using Superclass = ShapeSignedDistanceFunction<TCoordinate, VSpaceDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 // Constructor with default arguments
-template <typename TCoordRep, unsigned int VSpaceDimension>
-SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::SphereSignedDistanceFunction()
+template <typename TCoordinate, unsigned int VSpaceDimension>
+SphereSignedDistanceFunction<TCoordinate, VSpaceDimension>::SphereSignedDistanceFunction()
 {
   this->GetParameters().SetSize(SpaceDimension + 1);
   this->GetParameters().Fill(0.0);
@@ -34,9 +34,9 @@ SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::SphereSignedDistanceFu
 }
 
 // Set the parameters
-template <typename TCoordRep, unsigned int VSpaceDimension>
+template <typename TCoordinate, unsigned int VSpaceDimension>
 void
-SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::SetParameters(const ParametersType & parameters)
+SphereSignedDistanceFunction<TCoordinate, VSpaceDimension>::SetParameters(const ParametersType & parameters)
 {
   if (parameters != this->GetParameters())
   {
@@ -54,9 +54,9 @@ SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::SetParameters(const Pa
 }
 
 // Print self
-template <typename TCoordRep, unsigned int VSpaceDimension>
+template <typename TCoordinate, unsigned int VSpaceDimension>
 void
-SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::PrintSelf(std::ostream & os, Indent indent) const
+SphereSignedDistanceFunction<TCoordinate, VSpaceDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -65,9 +65,9 @@ SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::PrintSelf(std::ostream
 }
 
 // Evaluate the signed distance
-template <typename TCoordRep, unsigned int VSpaceDimension>
+template <typename TCoordinate, unsigned int VSpaceDimension>
 auto
-SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::Evaluate(const PointType & point) const -> OutputType
+SphereSignedDistanceFunction<TCoordinate, VSpaceDimension>::Evaluate(const PointType & point) const -> OutputType
 {
   using RealType = typename NumericTraits<OutputType>::RealType;
   RealType output = 0.0;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
@@ -23,15 +23,15 @@
 namespace itk
 {
 
-template <typename TCoordRepType>
-VoronoiDiagram2D<TCoordRepType>::VoronoiDiagram2D()
+template <typename TCoordinateType>
+VoronoiDiagram2D<TCoordinateType>::VoronoiDiagram2D()
 {
   m_NumberOfSeeds = 0;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::PrintSelf(std::ostream & os, Indent indent) const
+VoronoiDiagram2D<TCoordinateType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Number Of Seeds: " << m_NumberOfSeeds << std::endl;
@@ -39,9 +39,9 @@ VoronoiDiagram2D<TCoordRepType>::PrintSelf(std::ostream & os, Indent indent) con
 
 
 /* Set the seed points, specify the number of seeds as "num". */
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::SetSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2D<TCoordinateType>::SetSeeds(int num, SeedsIterator begin)
 {
   m_Seeds.clear();
   auto ii(begin);
@@ -54,43 +54,43 @@ VoronoiDiagram2D<TCoordRepType>::SetSeeds(int num, SeedsIterator begin)
 
 
 /* Set the rectangle that encloses the Voronoi Diagram. */
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::SetBoundary(PointType vorsize)
+VoronoiDiagram2D<TCoordinateType>::SetBoundary(PointType vorsize)
 {
   m_VoronoiBoundary[0] = vorsize[0];
   m_VoronoiBoundary[1] = vorsize[1];
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::SetOrigin(PointType vorsize)
+VoronoiDiagram2D<TCoordinateType>::SetOrigin(PointType vorsize)
 {
   m_VoronoiBoundaryOrigin[0] = vorsize[0];
   m_VoronoiBoundaryOrigin[1] = vorsize[1];
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::GetPoint(int pId, PointType * answer)
+VoronoiDiagram2D<TCoordinateType>::GetPoint(int pId, PointType * answer)
 {
   *answer = this->m_PointsContainer->ElementAt(pId);
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::GetCellId(CellIdentifier cellId, CellAutoPointer & cellPtr)
+VoronoiDiagram2D<TCoordinateType>::GetCellId(CellIdentifier cellId, CellAutoPointer & cellPtr)
 {
   cellPtr.TakeNoOwnership(m_VoronoiRegions[cellId]);
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> EdgeInfo
+VoronoiDiagram2D<TCoordinateType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> EdgeInfo
 {
   EdgeInfo answer;
 
@@ -100,57 +100,57 @@ VoronoiDiagram2D<TCoordRepType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> Edg
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::EdgeBegin() -> VoronoiEdgeIterator
+VoronoiDiagram2D<TCoordinateType>::EdgeBegin() -> VoronoiEdgeIterator
 {
   return m_EdgeList.begin();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::EdgeEnd() -> VoronoiEdgeIterator
+VoronoiDiagram2D<TCoordinateType>::EdgeEnd() -> VoronoiEdgeIterator
 {
   return m_EdgeList.end();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::NeighborIdsBegin(int seeds) -> NeighborIdIterator
+VoronoiDiagram2D<TCoordinateType>::NeighborIdsBegin(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].begin();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::NeighborIdsEnd(int seeds) -> NeighborIdIterator
+VoronoiDiagram2D<TCoordinateType>::NeighborIdsEnd(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].end();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::VertexBegin() -> VertexIterator
+VoronoiDiagram2D<TCoordinateType>::VertexBegin() -> VertexIterator
 {
   return this->m_PointsContainer->Begin();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::VertexEnd() -> VertexIterator
+VoronoiDiagram2D<TCoordinateType>::VertexEnd() -> VertexIterator
 {
   return this->m_PointsContainer->End();
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2D<TCoordRepType>::GetSeed(int SeedID) -> PointType
+VoronoiDiagram2D<TCoordinateType>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 
@@ -160,9 +160,9 @@ VoronoiDiagram2D<TCoordRepType>::GetSeed(int SeedID) -> PointType
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::Reset()
+VoronoiDiagram2D<TCoordinateType>::Reset()
 {
   m_VoronoiRegions.clear();
   m_VoronoiRegions.resize(m_NumberOfSeeds);
@@ -176,9 +176,9 @@ VoronoiDiagram2D<TCoordRepType>::Reset()
 }
 
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2D<TCoordRepType>::InsertCells()
+VoronoiDiagram2D<TCoordinateType>::InsertCells()
 {
   genericCellPointer cellPtr;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -29,8 +29,8 @@ namespace itk
 const double     NUMERIC_TOLERENCE = 1.0e-10;
 constexpr double DIFF_TOLERENCE = 0.001;
 
-template <typename TCoordRepType>
-VoronoiDiagram2DGenerator<TCoordRepType>::VoronoiDiagram2DGenerator()
+template <typename TCoordinateType>
+VoronoiDiagram2DGenerator<TCoordinateType>::VoronoiDiagram2DGenerator()
   : m_OutputVD(Self::GetOutput())
   , m_BottomSite(nullptr)
 
@@ -38,9 +38,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::VoronoiDiagram2DGenerator()
   m_VorBoundary.Fill(0.0);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::SetRandomSeeds(int num)
+VoronoiDiagram2DGenerator<TCoordinateType>::SetRandomSeeds(int num)
 {
   PointType curr;
 
@@ -56,9 +56,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::SetRandomSeeds(int num)
   m_NumberOfSeeds = num;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::SetSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2DGenerator<TCoordinateType>::SetSeeds(int num, SeedsIterator begin)
 {
   m_Seeds.clear();
   SeedsIterator ii(begin);
@@ -69,27 +69,27 @@ VoronoiDiagram2DGenerator<TCoordRepType>::SetSeeds(int num, SeedsIterator begin)
   m_NumberOfSeeds = num;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::SetBoundary(PointType vorsize)
+VoronoiDiagram2DGenerator<TCoordinateType>::SetBoundary(PointType vorsize)
 {
   m_VorBoundary[0] = vorsize[0];
   m_VorBoundary[1] = vorsize[1];
   m_OutputVD->SetBoundary(vorsize);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::SetOrigin(PointType vorsize)
+VoronoiDiagram2DGenerator<TCoordinateType>::SetOrigin(PointType vorsize)
 {
   m_Pxmin = vorsize[0];
   m_Pymin = vorsize[1];
   m_OutputVD->SetOrigin(vorsize);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 bool
-VoronoiDiagram2DGenerator<TCoordRepType>::comp(PointType arg1, PointType arg2)
+VoronoiDiagram2DGenerator<TCoordinateType>::comp(PointType arg1, PointType arg2)
 {
   if (arg1[1] < arg2[1])
   {
@@ -115,16 +115,16 @@ VoronoiDiagram2DGenerator<TCoordRepType>::comp(PointType arg1, PointType arg2)
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::SortSeeds()
+VoronoiDiagram2DGenerator<TCoordinateType>::SortSeeds()
 {
   std::sort(m_Seeds.begin(), m_Seeds.end(), comp);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::AddSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2DGenerator<TCoordinateType>::AddSeeds(int num, SeedsIterator begin)
 {
   auto ii(begin);
 
@@ -135,17 +135,17 @@ VoronoiDiagram2DGenerator<TCoordRepType>::AddSeeds(int num, SeedsIterator begin)
   m_NumberOfSeeds += num;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::AddOneSeed(PointType inputSeed)
+VoronoiDiagram2DGenerator<TCoordinateType>::AddOneSeed(PointType inputSeed)
 {
   m_Seeds.push_back(inputSeed);
   ++m_NumberOfSeeds;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::GetSeed(int SeedID) -> PointType
+VoronoiDiagram2DGenerator<TCoordinateType>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 
@@ -154,9 +154,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GetSeed(int SeedID) -> PointType
   return answer;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::GenerateData()
+VoronoiDiagram2DGenerator<TCoordinateType>::GenerateData()
 {
   SortSeeds();
   m_OutputVD->SetSeeds(m_NumberOfSeeds, m_Seeds.begin());
@@ -164,16 +164,16 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateData()
   this->ConstructDiagram();
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::UpdateDiagram()
+VoronoiDiagram2DGenerator<TCoordinateType>::UpdateDiagram()
 {
   this->GenerateData();
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 bool
-VoronoiDiagram2DGenerator<TCoordRepType>::differentPoint(PointType p1, PointType p2)
+VoronoiDiagram2DGenerator<TCoordinateType>::differentPoint(PointType p1, PointType p2)
 {
   double diffx = p1[0] - p2[0];
   double diffy = p1[1] - p2[1];
@@ -182,18 +182,18 @@ VoronoiDiagram2DGenerator<TCoordRepType>::differentPoint(PointType p1, PointType
           (diffy > DIFF_TOLERENCE));
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 bool
-VoronoiDiagram2DGenerator<TCoordRepType>::almostsame(CoordRepType p1, CoordRepType p2)
+VoronoiDiagram2DGenerator<TCoordinateType>::almostsame(CoordRepType p1, CoordRepType p2)
 {
   double diff = p1 - p2;
   bool   save = ((diff < -DIFF_TOLERENCE) || (diff > DIFF_TOLERENCE));
   return (!save);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 unsigned char
-VoronoiDiagram2DGenerator<TCoordRepType>::Pointonbnd(int VertID)
+VoronoiDiagram2DGenerator<TCoordinateType>::Pointonbnd(int VertID)
 {
   PointType currVert = m_OutputVD->GetVertex(VertID);
 
@@ -219,9 +219,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::Pointonbnd(int VertID)
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
+VoronoiDiagram2DGenerator<TCoordinateType>::ConstructDiagram()
 {
   const auto rawEdges = make_unique_for_overwrite<EdgeInfoDQ[]>(m_NumberOfSeeds);
 
@@ -416,9 +416,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ConstructDiagram()
   m_OutputVD->InsertCells();
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 bool
-VoronoiDiagram2DGenerator<TCoordRepType>::right_of(FortuneHalfEdge * el, PointType * p)
+VoronoiDiagram2DGenerator<TCoordinateType>::right_of(FortuneHalfEdge * el, PointType * p)
 {
   FortuneEdge * e = el->m_Edge;
   FortuneSite * topsite = e->m_Reg[1];
@@ -478,9 +478,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::right_of(FortuneHalfEdge * el, PointTy
   return (el->m_RorL ? (!above) : above);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::createHalfEdge(FortuneHalfEdge * task, FortuneEdge * e, bool pm)
+VoronoiDiagram2DGenerator<TCoordinateType>::createHalfEdge(FortuneHalfEdge * task, FortuneEdge * e, bool pm)
 {
   task->m_Edge = e;
   task->m_RorL = pm;
@@ -488,9 +488,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::createHalfEdge(FortuneHalfEdge * task,
   task->m_Vert = nullptr;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::PQshowMin(PointType * answer)
+VoronoiDiagram2DGenerator<TCoordinateType>::PQshowMin(PointType * answer)
 {
   while ((m_PQHash[m_PQmin].m_Next) == nullptr)
   {
@@ -500,9 +500,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::PQshowMin(PointType * answer)
   (*answer)[1] = m_PQHash[m_PQmin].m_Next->m_Ystar;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::deletePQ(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinateType>::deletePQ(FortuneHalfEdge * task)
 {
   FortuneHalfEdge * last;
 
@@ -519,18 +519,18 @@ VoronoiDiagram2DGenerator<TCoordRepType>::deletePQ(FortuneHalfEdge * task)
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::deleteEdgeList(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinateType>::deleteEdgeList(FortuneHalfEdge * task)
 {
   (task->m_Left)->m_Right = task->m_Right;
   (task->m_Right)->m_Left = task->m_Left;
   task->m_Edge = &(m_DELETED);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 int
-VoronoiDiagram2DGenerator<TCoordRepType>::PQbucket(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinateType>::PQbucket(FortuneHalfEdge * task)
 {
   int bucket = static_cast<int>((task->m_Ystar - m_Pymin) / m_Deltay * m_PQhashsize);
   if (bucket < 0)
@@ -548,9 +548,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::PQbucket(FortuneHalfEdge * task)
   return (bucket);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::insertPQ(FortuneHalfEdge * he, FortuneSite * v, double offset)
+VoronoiDiagram2DGenerator<TCoordinateType>::insertPQ(FortuneHalfEdge * he, FortuneSite * v, double offset)
 {
   he->m_Vert = v;
   he->m_Ystar = (v->m_Coord[1]) + offset;
@@ -568,9 +568,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::insertPQ(FortuneHalfEdge * he, Fortune
   m_PQcount += 1;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 double
-VoronoiDiagram2DGenerator<TCoordRepType>::dist(FortuneSite * s1, FortuneSite * s2)
+VoronoiDiagram2DGenerator<TCoordinateType>::dist(FortuneSite * s1, FortuneSite * s2)
 {
   double dx = (s1->m_Coord[0]) - (s2->m_Coord[0]);
   double dy = (s1->m_Coord[1]) - (s2->m_Coord[1]);
@@ -578,9 +578,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::dist(FortuneSite * s1, FortuneSite * s
   return (std::sqrt(dx * dx + dy * dy));
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::ELgethash(int b) -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinateType>::ELgethash(int b) -> FortuneHalfEdge *
 {
   if ((b < 0) || (b >= static_cast<int>(m_ELhashsize)))
   {
@@ -604,9 +604,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ELgethash(int b) -> FortuneHalfEdge *
   return (nullptr);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::findLeftHE(PointType * p) -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinateType>::findLeftHE(PointType * p) -> FortuneHalfEdge *
 {
   int  i;
   auto bucket = static_cast<int>((((*p)[0]) - m_Pxmin) / m_Deltax * m_ELhashsize);
@@ -658,9 +658,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::findLeftHE(PointType * p) -> FortuneHa
   return (he);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::getRightReg(FortuneHalfEdge * he) -> FortuneSite *
+VoronoiDiagram2DGenerator<TCoordinateType>::getRightReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -676,9 +676,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::getRightReg(FortuneHalfEdge * he) -> F
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::getLeftReg(FortuneHalfEdge * he) -> FortuneSite *
+VoronoiDiagram2DGenerator<TCoordinateType>::getLeftReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -694,9 +694,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::getLeftReg(FortuneHalfEdge * he) -> Fo
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::insertEdgeList(FortuneHalfEdge * lbase, FortuneHalfEdge * lnew)
+VoronoiDiagram2DGenerator<TCoordinateType>::insertEdgeList(FortuneHalfEdge * lbase, FortuneHalfEdge * lnew)
 {
   lnew->m_Left = lbase;
   lnew->m_Right = lbase->m_Right;
@@ -704,9 +704,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::insertEdgeList(FortuneHalfEdge * lbase
   lbase->m_Right = lnew;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::bisect(FortuneEdge * answer, FortuneSite * s1, FortuneSite * s2)
+VoronoiDiagram2DGenerator<TCoordinateType>::bisect(FortuneEdge * answer, FortuneSite * s1, FortuneSite * s2)
 {
   answer->m_Reg[0] = s1;
   answer->m_Reg[1] = s2;
@@ -739,9 +739,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::bisect(FortuneEdge * answer, FortuneSi
   m_OutputVD->AddLine(outline);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::intersect(FortuneSite * newV, FortuneHalfEdge * el1, FortuneHalfEdge * el2)
+VoronoiDiagram2DGenerator<TCoordinateType>::intersect(FortuneSite * newV, FortuneHalfEdge * el1, FortuneHalfEdge * el2)
 {
   FortuneEdge *     e1 = el1->m_Edge;
   FortuneEdge *     e2 = el2->m_Edge;
@@ -798,9 +798,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::intersect(FortuneSite * newV, FortuneH
   newV->m_Sitenbr = -5;
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 auto
-VoronoiDiagram2DGenerator<TCoordRepType>::getPQmin() -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinateType>::getPQmin() -> FortuneHalfEdge *
 {
   FortuneHalfEdge * curr = m_PQHash[m_PQmin].m_Next;
 
@@ -809,9 +809,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::getPQmin() -> FortuneHalfEdge *
   return (curr);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::clip_line(FortuneEdge * task)
+VoronoiDiagram2DGenerator<TCoordinateType>::clip_line(FortuneEdge * task)
 {
   // Clip line
   FortuneSite * s1;
@@ -1005,9 +1005,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::clip_line(FortuneEdge * task)
   m_OutputVD->AddEdge(newInfo);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::makeEndPoint(FortuneEdge * task, bool lr, FortuneSite * ends)
+VoronoiDiagram2DGenerator<TCoordinateType>::makeEndPoint(FortuneEdge * task, bool lr, FortuneSite * ends)
 {
   task->m_Ep[lr] = ends;
   if ((task->m_Ep[1 - lr]) == nullptr)
@@ -1018,9 +1018,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::makeEndPoint(FortuneEdge * task, bool 
   clip_line(task);
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
+VoronoiDiagram2DGenerator<TCoordinateType>::GenerateVDFortune()
 {
   // Build seed sites
   m_SeedSites.resize(m_NumberOfSeeds);
@@ -1226,9 +1226,9 @@ VoronoiDiagram2DGenerator<TCoordRepType>::GenerateVDFortune()
   }
 }
 
-template <typename TCoordRepType>
+template <typename TCoordinateType>
 void
-VoronoiDiagram2DGenerator<TCoordRepType>::PrintSelf(std::ostream & os, Indent indent) const
+VoronoiDiagram2DGenerator<TCoordinateType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 


### PR DESCRIPTION
Aims to make template parameter names for coordinate types clearer.

Following the ITKSoftwareGuide/CodingStyleGuide guideline on Naming Conventions, saying, "Names are generally spelled out; use of abbreviations is discouraged".

----

I think `CoordRep` was an abbreviation of "coordinate representation". But if I understand correctly, that is a specific mathematical term, for example used in https://en.wikipedia.org/wiki/Coordinate_vector as:

> We can mechanize the above transformation by defining a function ..., called the standard representation of V with respect to B, that takes every vector to its coordinate representation

It seems to me that ITK just used the term "representation" here as an equivalent to _type_. (Please correct me if I'm wrong.) But then it appears redundant for a template parameter named "TCoordRep", as its initial `T` already specifies that it is a type.