### PR TITLE
STYLE: One declaration per line for readability

### DIFF
--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -147,7 +147,9 @@ main(int argc, char * argv[])
 
   for (; itKey != imgMetaKeys.end(); ++itKey)
   {
-    double x, y, z;
+    double x;
+    double y;
+    double z;
 
     itk::ExposeMetaData<std::string>(imgMetaDictionary, *itKey, metaString);
     if (itKey->find("DWMRI_gradient") != std::string::npos)

--- a/Examples/IO/ImageReadDicomSeriesWrite.cxx
+++ b/Examples/IO/ImageReadDicomSeriesWrite.cxx
@@ -97,7 +97,8 @@ main(int argc, char * argv[])
   auto namesGenerator = NamesGeneratorType::New();
 
   itk::MetaDataDictionary & dict = gdcmIO->GetMetaDataDictionary();
-  std::string               tagkey, value;
+  std::string               tagkey;
+  std::string               value;
   tagkey = "0008|0060"; // Modality
   value = "MR";
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -169,7 +169,8 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   auto projectionDirection = static_cast<unsigned int>(std::stoi(argv[3]));
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   unsigned int direction[2];
   for (i = 0, j = 0; i < 3; ++i)
   {

--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -59,7 +59,9 @@ auto
 AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   // Determine the initial kernel values...
-  double interiorV, annulusV, exteriorV;
+  double interiorV;
+  double annulusV;
+  double exteriorV;
 
   if (m_Normalize)
   {
@@ -80,7 +82,8 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
 
   // Compute the size of the kernel in pixels
   SizeType     r;
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   double       outerRadius = m_InnerRadius + m_Thickness;
   for (i = 0; i < TDimension; ++i)
   {

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -59,7 +59,8 @@ BSplineInterpolationWeightFunction<TCoordinate, VSpaceDimension, VSplineOrder>::
     return table;
   }();
 
-  unsigned int j, k;
+  unsigned int j;
+  unsigned int k;
 
   // Find the starting index of the support region
   for (j = 0; j < SpaceDimension; ++j)

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -52,7 +52,8 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> 
 
   OffsetArray result(length);
 
-  IndexType m_CurrentImageIndex, LastIndex;
+  IndexType m_CurrentImageIndex;
+  IndexType LastIndex;
 
   Direction.Normalize();
   // we are going to start at 0

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -229,8 +229,11 @@ ColorTable<TComponent>::UseRandomColors(unsigned int n)
   m_NumberOfColors = n;
   m_Color.resize(m_NumberOfColors);
   m_ColorName.resize(m_NumberOfColors);
-  TComponent r, g, b;
-  TComponent minimum, maximum;
+  TComponent r;
+  TComponent g;
+  TComponent b;
+  TComponent minimum;
+  TComponent maximum;
   if (NumericTraits<TComponent>::is_integer)
   {
     minimum = NumericTraits<TComponent>::NonpositiveMin();

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -165,7 +165,8 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetPixel(NeighborIndexTyp
   else
   {
     bool       flag;
-    OffsetType offset, internalIndex;
+    OffsetType offset;
+    OffsetType internalIndex;
 
     flag = this->IndexInBounds(n, internalIndex, offset);
     if (flag)
@@ -267,7 +268,10 @@ template <typename TImage, typename TBoundaryCondition>
 auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const -> NeighborhoodType
 {
-  OffsetType OverlapLow, OverlapHigh, temp, offset;
+  OffsetType OverlapLow;
+  OffsetType OverlapHigh;
+  OffsetType temp;
+  OffsetType offset;
 
   const ConstIterator _end = this->End();
   NeighborhoodType    ans;

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -69,7 +69,8 @@ template <unsigned int VDimension, typename TInput>
 void
 EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -167,7 +167,8 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI0(double y)
 {
-  double d, accumulator;
+  double d;
+  double accumulator;
   double m;
 
   if ((d = itk::Math::abs(y)) < 3.75)
@@ -196,7 +197,8 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(double y)
 {
-  double d, accumulator;
+  double d;
+  double accumulator;
   double m;
 
   if ((d = itk::Math::abs(y)) < 3.75)
@@ -233,7 +235,10 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int 
 {
   constexpr double DIGITS = 10.0;
   int              j;
-  double           qim, qi, qip, toy;
+  double           qim;
+  double           qi;
+  double           qip;
+  double           toy;
   double           accumulator;
 
   if (n < 2)

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -145,7 +145,10 @@ GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int n, double 
 {
   constexpr double ACCURACY = 40.0;
   int              j;
-  double           qim, qi, qip, toy;
+  double           qim;
+  double           qi;
+  double           qip;
+  double           toy;
   double           accumulator;
 
   if (n < 2)

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -501,7 +501,8 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   }
   else
   {
-    CoordRepType pc[CellDimension3D], w[Self::NumberOfPoints];
+    CoordRepType pc[CellDimension3D];
+    CoordRepType w[Self::NumberOfPoints];
     if (closestPoint)
     {
       for (unsigned int i = 0; i < CellDimension3D; ++i) // only approximate, not really true

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -210,7 +210,9 @@ ImageSink<TInputImage>::VerifyInputInformation() const
           !inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
                                                              this->m_DirectionTolerance))
       {
-        std::ostringstream originString, spacingString, directionString;
+        std::ostringstream originString;
+        std::ostringstream spacingString;
+        std::ostringstream directionString;
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
         {
           originString.setf(std::ios::scientific);

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -186,7 +186,9 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 
       if (!inputPtr1->IsCongruentImageGeometry(inputPtrN, m_CoordinateTolerance, m_DirectionTolerance))
       {
-        std::ostringstream originString, spacingString, directionString;
+        std::ostringstream originString;
+        std::ostringstream spacingString;
+        std::ostringstream directionString;
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
         {
           originString.setf(std::ios::scientific);

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -64,7 +64,8 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 auto
 LaplacianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
-  unsigned int i, w;
+  unsigned int i;
+  unsigned int w;
 
   // Here we set the radius to 1's, here the
   // operator is 3x3 for 2D, 3x3x3 for 3D.

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -500,7 +500,8 @@ MersenneTwisterRandomVariateGenerator::GetIntegerVariate(const IntegerType & n)
 inline double
 MersenneTwisterRandomVariateGenerator::Get53BitVariate()
 {
-  IntegerType a = GetIntegerVariate() >> 5, b = GetIntegerVariate() >> 6;
+  IntegerType a = GetIntegerVariate() >> 5;
+  IntegerType b = GetIntegerVariate() >> 6;
 
   return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0); // by Isaku
                                                             // Wada

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -42,7 +42,8 @@ Neighborhood<TPixel, VDimension, TContainer>::ComputeNeighborhoodOffsetTable()
   m_OffsetTable.clear();
   m_OffsetTable.reserve(this->Size());
   OffsetType         o;
-  DimensionValueType i, j;
+  DimensionValueType i;
+  DimensionValueType j;
   for (j = 0; j < VDimension; ++j)
   {
     o[j] = -(static_cast<OffsetValueType>(this->GetRadius(j)));

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
@@ -100,7 +100,8 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetPixel(const unsigned int n,
   unsigned int i;
   OffsetType   temp;
 
-  typename OffsetType::OffsetValueType OverlapLow, OverlapHigh;
+  typename OffsetType::OffsetValueType OverlapLow;
+  typename OffsetType::OffsetValueType OverlapHigh;
 
   if (this->m_NeedToUseBoundaryCondition == false)
   {
@@ -148,7 +149,9 @@ void
 NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const NeighborhoodType & N)
 {
   unsigned int i;
-  OffsetType   OverlapLow, OverlapHigh, temp;
+  OffsetType   OverlapLow;
+  OffsetType   OverlapHigh;
+  OffsetType   temp;
   bool         flag;
 
   const Iterator _end = this->End();

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -123,7 +123,9 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::GetValue(const unsigned int
   // Define CurrentOctreeNode at the Octree head Node
   OctreeNode * CurrentOctreeNode = &m_Tree;
   // Define the origin of current OctreeNode
-  unsigned int ox = 0, oy = 0, oz = 0;
+  unsigned int ox = 0;
+  unsigned int oy = 0;
+  unsigned int oz = 0;
   // Define the halfwidth, this will be changed inside of while loop
   unsigned int halfwidth = this->m_Width;
 

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -279,7 +279,8 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   static constexpr double ITK_QUAD_CONVERGED = 1.e-03;
   static constexpr double ITK_DIVERGED = 1.e6;
 
-  int                     iteration, converged;
+  int                     iteration;
+  int                     converged;
   double                  params[CellDimension];
   double                  fcol[CellDimension];
   double                  rcol[CellDimension];
@@ -419,7 +420,8 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   }
   else
   {
-    CoordRepType pc[CellDimension], w[NumberOfPoints];
+    CoordRepType pc[CellDimension];
+    CoordRepType w[NumberOfPoints];
     if (closestPoint)
     {
       for (unsigned int i = 0; i < CellDimension; ++i) // only approximate ??

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -51,7 +51,8 @@ auto
 SparseFieldLayer<TNodeType>::SplitRegions(int num) const -> RegionListType
 {
   std::vector<RegionType> regionlist;
-  unsigned int            size, regionsize;
+  unsigned int            size;
+  unsigned int            regionsize;
   size = Size();
   regionsize = static_cast<unsigned int>(std::ceil(static_cast<float>(size) / static_cast<float>(num)));
   ConstIterator position = Begin();

--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -151,7 +151,8 @@ StreamingImageFilter<TInputImage, TOutputImage>::UpdateOutputData(DataObject * i
    * minimum of what the user specified via SetNumberOfStreamDivisions()
    * and what the Splitter thinks is a reasonable value.
    */
-  unsigned int numDivisions, numDivisionsFromSplitter;
+  unsigned int numDivisions;
+  unsigned int numDivisionsFromSplitter;
 
   numDivisions = m_NumberOfStreamDivisions;
   numDivisionsFromSplitter = m_RegionSplitter->GetNumberOfSplits(outputRegion, m_NumberOfStreamDivisions);

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -142,8 +142,13 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
   double d__1;
 
   // Local variables
-  double f, g, h;
-  int    i, j, k, l;
+  double f;
+  double g;
+  double h;
+  int    i;
+  int    j;
+  int    k;
+  int    l;
   double scale;
 
   for (i = 0; i < static_cast<int>(m_Order); ++i)
@@ -259,9 +264,15 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
   double d__1;
 
   // Local variables
-  double       f, g, h;
-  unsigned int i, j, k, l;
-  double       scale, hh;
+  double       f;
+  double       g;
+  double       h;
+  unsigned int i;
+  unsigned int j;
+  unsigned int k;
+  unsigned int l;
+  double       scale;
+  double       hh;
 
   for (i = 0; i < m_Order; ++i)
   {
@@ -420,12 +431,24 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
   constexpr double c_b10 = 1.0;
 
   // Local variables
-  double       c, f, g, h;
-  unsigned int i, j, l, m;
-  double       p, r, s, c2, c3 = 0.0;
+  double       c;
+  double       f;
+  double       g;
+  double       h;
+  unsigned int i;
+  unsigned int j;
+  unsigned int l;
+  unsigned int m;
+  double       p;
+  double       r;
+  double       s;
+  double       c2;
+  double       c3 = 0.0;
   double       s2 = 0.0;
-  double       dl1, el1;
-  double       tst1, tst2;
+  double       dl1;
+  double       el1;
+  double       tst1;
+  double       tst2;
 
   unsigned int ierr = 0;
 
@@ -566,12 +589,25 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   constexpr double c_b10 = 1.0;
 
   // Local variables
-  double       c, f, g, h;
-  unsigned int i, j, k, l, m;
-  double       p, r, s, c2, c3 = 0.0;
+  double       c;
+  double       f;
+  double       g;
+  double       h;
+  unsigned int i;
+  unsigned int j;
+  unsigned int k;
+  unsigned int l;
+  unsigned int m;
+  double       p;
+  double       r;
+  double       s;
+  double       c2;
+  double       c3 = 0.0;
   double       s2 = 0.0;
-  double       dl1, el1;
-  double       tst1, tst2;
+  double       dl1;
+  double       el1;
+  double       tst1;
+  double       tst2;
 
   unsigned int ierr = 0;
 

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -180,7 +180,8 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   else
   { // could easily be sped up using parametric localization - next release
     double       dist2;
-    CoordRepType closest[PointDimension], pc[3];
+    CoordRepType closest[PointDimension];
+    CoordRepType pc[3];
 
     if (closestPoint)
     {

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -54,7 +54,10 @@ ITKCommon_EXPORT std::istream &
 
     // Get name
     std::istringstream stream(headerline);
-    std::string        address, perms, offset, device;
+    std::string        address;
+    std::string        perms;
+    std::string        offset;
+    std::string        device;
     int                inode = -1;
     // the header is defined with the following expression: "address permissions
     // offset device inode [name]"

--- a/Modules/Core/Common/test/itkByteSwapTest.cxx
+++ b/Modules/Core/Common/test/itkByteSwapTest.cxx
@@ -27,13 +27,20 @@ itkByteSwapTest(int, char *[])
 
   std::cout << "Starting test" << std::endl;
 
-  unsigned char      uc = 'a', uc1 = 'a';
-  unsigned short     us = 1, us1 = 1;
-  unsigned int       ui = 1, ui1 = 1;
-  unsigned long      ul = 1, ul1 = 1;
-  unsigned long long ull = 1, ull1 = 1;
-  float              f = 1.0, f1 = 1.0;
-  double             d = 1.0, d1 = 1.0;
+  unsigned char      uc = 'a';
+  unsigned char      uc1 = 'a';
+  unsigned short     us = 1;
+  unsigned short     us1 = 1;
+  unsigned int       ui = 1;
+  unsigned int       ui1 = 1;
+  unsigned long      ul = 1;
+  unsigned long      ul1 = 1;
+  unsigned long long ull = 1;
+  unsigned long long ull1 = 1;
+  float              f = 1.0;
+  float              f1 = 1.0;
+  double             d = 1.0;
+  double             d1 = 1.0;
 
 
   // Try to swap a char

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -39,7 +39,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x, y, i = 0;
+  unsigned int x;
+  unsigned int y;
+  unsigned int i = 0;
   for (y = 0; y < p.GetSize()[1]; ++y)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -133,7 +133,8 @@ itkExceptionObjectTest(int, char *[])
   bool OneShouldFail = true;
   try
   {
-    human          john, jane;
+    human          john;
+    human          jane;
     naked_mole_rat hal;
     OneShouldFail &= (john == john); // OK
     OneShouldFail &= (jane == john); // OK

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -98,7 +98,9 @@ itkImageTest(int, char *[])
 
   std::cout << "Test transform to/from physical vector." << std::endl;
   using GradientType = itk::FixedArray<float, 2>;
-  GradientType truthGradient, outputGradient, testGradient;
+  GradientType truthGradient;
+  GradientType outputGradient;
+  GradientType testGradient;
   truthGradient[0] = 1.0;
   truthGradient[1] = 1.0;
   image->TransformLocalVectorToPhysicalVector(truthGradient, outputGradient);

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -59,7 +59,8 @@ itkIteratorTests(int, char *[])
 
   // extra variables
   double        elapsedTime;
-  clock_t       start, end;
+  clock_t       start;
+  clock_t       end;
   unsigned long num = 190 * 190 * 190;
 
   bool passed = true;
@@ -98,7 +99,10 @@ itkIteratorTests(int, char *[])
     }
   }
   // 3 nested loops
-  unsigned long ii, jj, kk, len = 190;
+  unsigned long ii;
+  unsigned long jj;
+  unsigned long kk;
+  unsigned long len = 190;
   start = clock();
   {
     unsigned int i = 0;

--- a/Modules/Core/Common/test/itkModifiedTimeTest.cxx
+++ b/Modules/Core/Common/test/itkModifiedTimeTest.cxx
@@ -27,7 +27,9 @@ itkModifiedTimeTest(int, char *[])
   using PointsContainer = itk::VectorContainer<Point>;
   using BoundingBox = itk::BoundingBox<unsigned long, 3, double, PointsContainer>;
 
-  Point p, q, r;
+  Point p;
+  Point q;
+  Point r;
 
   p.Fill(0);
   q.Fill(0);

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -81,7 +81,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   it3.SetLocation(loc);
 
   it3.Print(std::cout);
-  unsigned int x, y, i;
+  unsigned int x;
+  unsigned int y;
+  unsigned int i;
   for (y = 0, i = 0; y < 5; ++y)
   {
     for (x = 0; x < 5; ++x, ++i)

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -39,7 +39,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x, y, i = 0;
+  unsigned int x;
+  unsigned int y;
+  unsigned int i = 0;
   for (y = 0; y < p.GetSize()[1]; ++y)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -401,7 +401,8 @@ ASSERT(v[0] == 13.0 && v[1] == 18.0 && v[2] == 23.0, "On-the-fly conversion fail
   FloatVariableLengthVectorType v2 = v1;
   v1 = v2;
 
-  FloatVariableLengthVectorType v3, v4;
+  FloatVariableLengthVectorType v3;
+  FloatVariableLengthVectorType v4;
   v1 = 2 * v2 + (v3 - v4) / 6;
 
   v1.SetSize(0, FloatVariableLengthVectorType::DontShrinkToFit(), FloatVariableLengthVectorType::KeepOldValues());

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -208,7 +208,9 @@ itkVectorTest(int, char *[])
   }
 
   using RealVector3 = itk::Vector<float, 3>;
-  RealVector3 a, b, c;
+  RealVector3 a;
+  RealVector3 b;
+  RealVector3 c;
   a[0] = 1.0;
   a[1] = 0.0;
   a[2] = 0.0;
@@ -219,7 +221,9 @@ itkVectorTest(int, char *[])
   std::cout << '(' << a << ") cross (" << b << ") : (" << c << ')' << std::endl;
 
   using DoubleVector3 = itk::Vector<double, 3>;
-  DoubleVector3 aa, bb, cc;
+  DoubleVector3 aa;
+  DoubleVector3 bb;
+  DoubleVector3 cc;
   aa[0] = 1.0;
   aa[1] = 0.0;
   aa[2] = 0.0;
@@ -228,7 +232,9 @@ itkVectorTest(int, char *[])
   bb[2] = 0.0;
   cc = itk::CrossProduct(aa, bb);
   std::cout << '(' << aa << ") cross (" << bb << ") : (" << cc << ')' << std::endl;
-  DoubleVector3 ia, ib, ic;
+  DoubleVector3 ia;
+  DoubleVector3 ib;
+  DoubleVector3 ic;
   ia[0] = 1;
   ia[1] = 0;
   ia[2] = 0;

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -38,7 +38,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x, y, i = 0;
+  unsigned int x;
+  unsigned int y;
+  unsigned int i = 0;
   for (y = 0; y < p.GetSize()[1]; ++y)
   {
     for (x = 0; x < p.GetSize()[0]; ++x, ++i)

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -90,7 +90,9 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::ApplyUpdateThreaderCallback(void * arg)
 {
   FDThreadStruct * str;
-  ThreadIdType     total, workUnitID, workUnitCount;
+  ThreadIdType     total;
+  ThreadIdType     workUnitID;
+  ThreadIdType     workUnitCount;
 
   workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
@@ -182,7 +184,9 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChangeThreaderCallback(void * arg)
 {
   FDThreadStruct * str;
-  ThreadIdType     total, workUnitID, workUnitCount;
+  ThreadIdType     total;
+  ThreadIdType     workUnitID;
+  ThreadIdType     workUnitCount;
 
   workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
@@ -211,7 +215,9 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Prec
   void * arg)
 {
   FDThreadStruct * str;
-  ThreadIdType     total, workUnitID, workUnitCount;
+  ThreadIdType     total;
+  ThreadIdType     workUnitID;
+  ThreadIdType     workUnitCount;
 
   workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -317,7 +317,8 @@ template <typename TImage, typename TAccessor>
 ModifiedTimeType
 ImageAdaptor<TImage, TAccessor>::GetMTime() const
 {
-  ModifiedTimeType mtime1, mtime2;
+  ModifiedTimeType mtime1;
+  ModifiedTimeType mtime2;
 
   mtime1 = Superclass::GetMTime();
   mtime2 = m_Image->GetMTime();

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -179,7 +179,9 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
 {
   // See Unser, 1999, Box 2 for explanation
   CoeffType                           sum;
-  double                              zn, z2n, iz;
+  double                              zn;
+  double                              z2n;
+  double                              iz;
   typename TInputImage::SizeValueType horizon;
 
   // Yhis initialization corresponds to mirror boundaries

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -175,7 +175,12 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
   // For speed improvements we could make each case a separate function and use
   // function pointers to reference the correct weight order.
   // Left as is for now for readability.
-  double w, w2, w4, t, t0, t1;
+  double w;
+  double w2;
+  double w4;
+  double t;
+  double t0;
+  double t1;
 
   switch (splineOrder)
   {
@@ -291,7 +296,16 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
   // the number
   // of switch statement executions to one per routine call.
   // Left as is for now for readability.
-  double w, w1, w2, w3, w4, w5, t, t0, t1, t2;
+  double w;
+  double w1;
+  double w2;
+  double w3;
+  double w4;
+  double w5;
+  double t;
+  double t0;
+  double t1;
+  double t2;
   int    derivativeSplineOrder = static_cast<int>(splineOrder) - 1;
 
   switch (derivativeSplineOrder)
@@ -550,10 +564,14 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::
 
   unsigned int indx;
   double       tmpV;
-  double       w, w1, tmpW;
+  double       w;
+  double       w1;
+  double       tmpW;
   IndexType    coefficientIndex;
   value = 0.0;
-  unsigned int p, n, n1;
+  unsigned int p;
+  unsigned int n;
+  unsigned int n1;
   derivativeValue[0] = 0.0;
   for (p = 0; p < m_MaxNumberInterpolationPoints; ++p)
   {

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -368,7 +368,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcPl
 
   // find the equations of the planes
 
-  int c1 = 0, c2 = 0, c3 = 0;
+  int c1 = 0;
+  int c2 = 0;
+  int c3 = 0;
 
   for (j = 0; j < 6; ++j)
   { // loop around for planes
@@ -406,8 +408,12 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcPl
         break;
     }
 
-    double line1x, line1y, line1z;
-    double line2x, line2y, line2z;
+    double line1x;
+    double line1y;
+    double line1z;
+    double line2x;
+    double line2y;
+    double line2z;
 
     // lines from one corner to another in x,y,z dirns
     line1x = m_BoundingCorner[c1][0] - m_BoundingCorner[c2][0];
@@ -419,7 +425,10 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcPl
     line1z = m_BoundingCorner[c1][2] - m_BoundingCorner[c2][2];
     line2z = m_BoundingCorner[c1][2] - m_BoundingCorner[c3][2];
 
-    double A, B, C, D;
+    double A;
+    double B;
+    double C;
+    double D;
 
     // take cross product
     A = line1y * line2z - line2y * line1z;
@@ -758,7 +767,9 @@ template <typename TInputImage, typename TCoordinate>
 void
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcDirnVector()
 {
-  double xNum, yNum, zNum;
+  double xNum;
+  double yNum;
+  double zNum;
 
   // Calculate the number of voxels in each direction
 
@@ -906,7 +917,8 @@ template <typename TInputImage, typename TCoordinate>
 bool
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::AdjustRayLength()
 {
-  bool startOK, endOK;
+  bool startOK;
+  bool endOK;
 
   int Istart[3];
   int Idirn[3];
@@ -1048,7 +1060,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Initia
 {
   IndexType index;
 
-  int Ix, Iy, Iz;
+  int Ix;
+  int Iy;
+  int Iz;
 
   Ix = static_cast<int>(m_RayVoxelStartPosition[0]);
   Iy = static_cast<int>(m_RayVoxelStartPosition[1]);
@@ -1210,8 +1224,12 @@ template <typename TInputImage, typename TCoordinate>
 double
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::GetCurrentIntensity() const
 {
-  double a, b, c, d;
-  double y, z;
+  double a;
+  double b;
+  double c;
+  double d;
+  double y;
+  double z;
 
   if (!m_ValidRay)
   {

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -776,7 +776,9 @@ set3DDerivativeData(ImageType3D::Pointer imgPtr)
   // df(y)/dy = 5
   // df(z)/dz = -4z - 6
   double      value;
-  double      slice1, row1, col1;
+  double      slice1;
+  double      row1;
+  double      col1;
   IndexType3D index;
   for (unsigned int slice = 0; slice < size[2]; ++slice)
   {

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -281,7 +281,9 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier  
     auto foundIt2 = std::find(list->begin(), list->end(), neighborArray[1]);
     auto foundIt3 = std::find(list->begin(), list->end(), neighborArray[2]);
     auto endIt = list->end();
-    bool found1 = false, found2 = false, found3 = false;
+    bool found1 = false;
+    bool found2 = false;
+    bool found3 = false;
 
     if (foundIt1 != endIt)
     {
@@ -390,7 +392,10 @@ template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier idx) const -> CovariantVectorType
 {
-  PointType p, n1, n2, n3;
+  PointType p;
+  PointType n1;
+  PointType n2;
+  PointType n3;
 
   p.Fill(0);
   n1.Fill(0);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -183,7 +183,9 @@ public:
     double
     ComputeArea(PointIdentifier p1, PointIdentifier p2, PointIdentifier p3)
     {
-      InputPointType v1, v2, v3;
+      InputPointType v1;
+      InputPointType v2;
+      InputPointType v3;
 
       v1.Fill(0);
       v2.Fill(0);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -182,8 +182,10 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
       PointIdentifier secondNewIndex = newPointId + 1;
 
       // create first new point
-      InputPointType newMidPoint, helperPoint;
-      InputPointType p1, p2;
+      InputPointType newMidPoint;
+      InputPointType helperPoint;
+      InputPointType p1;
+      InputPointType p2;
       p1.Fill(0);
       p2.Fill(0);
       outputMesh->GetPoint(lineOneFirstIdx, &p1);
@@ -399,7 +401,8 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(Input
   InputPolygonPointIdIterator pointIt = simplexCell->PointIdsBegin();
 
   InputVectorType tmp;
-  InputPointType  p1, cellCenter;
+  InputPointType  p1;
+  InputPointType  cellCenter;
 
   p1.Fill(0);
   cellCenter.Fill(0);

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -49,7 +49,9 @@ void
 SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::CreateTriangles()
 {
   auto                                   meshSource = AutoMeshSourceType::New();
-  typename AutoMeshSourceType::PointType p1, p2, p3;
+  typename AutoMeshSourceType::PointType p1;
+  typename AutoMeshSourceType::PointType p2;
+  typename AutoMeshSourceType::PointType p3;
 
   typename TInputMesh::ConstPointer                 inputMesh = this->GetInput(0);
   typename InputPointsContainer::ConstPointer       points = inputMesh->GetPoints();

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -121,7 +121,8 @@ public:
     {
       using PointIdIterator = typename SimplexPolygonType::PointIdIterator;
       PointIdIterator it = poly->PointIdsBegin();
-      InputPointType  center, p;
+      InputPointType  center;
+      InputPointType  p;
       center.Fill(0);
       p.Fill(0.0);
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -98,10 +98,22 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
                                                                  InputPointType p3)
 {
   double area;
-  double a, b, c, s;
-  double i[3], j[3], k[3], u[3], absu[3], length;
-  double ii[3], jj[3], kk[3];
-  double xavg, yavg, zavg;
+  double a;
+  double b;
+  double c;
+  double s;
+  double i[3];
+  double j[3];
+  double k[3];
+  double u[3];
+  double absu[3];
+  double length;
+  double ii[3];
+  double jj[3];
+  double kk[3];
+  double xavg;
+  double yavg;
+  double zavg;
 
   // Get i j k vectors ...
   //
@@ -216,7 +228,9 @@ SimplexMeshVolumeCalculator<TInputMesh>::Compute()
 {
   this->Initialize();
 
-  InputPointType p1, p2, p3;
+  InputPointType p1;
+  InputPointType p2;
+  InputPointType p3;
   p1.Fill(0.0);
   p2.Fill(0.0);
   p3.Fill(0.0);

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -49,9 +49,19 @@ template <typename TOutputMesh>
 void
 SphereMeshSource<TOutputMesh>::GenerateData()
 {
-  IdentifierType i, j, jn, p, numpts;
-  double         ustep, vstep, ubeg, vbeg, u, v;
-  int            signu, signv;
+  IdentifierType i;
+  IdentifierType j;
+  IdentifierType jn;
+  IdentifierType p;
+  IdentifierType numpts;
+  double         ustep;
+  double         vstep;
+  double         ubeg;
+  double         vbeg;
+  double         u;
+  double         v;
+  int            signu;
+  int            signv;
 
   // calculate the number os cells and points
   numpts = m_ResolutionX * m_ResolutionY + 2;

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -76,8 +76,13 @@ template <typename TInputMesh>
 void
 TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMeshType * inputMesh)
 {
-  MeshPointType e0, e1, e2;
-  double        A, alpha0, alpha1, alpha2;
+  MeshPointType e0;
+  MeshPointType e1;
+  MeshPointType e2;
+  double        A;
+  double        alpha0;
+  double        alpha1;
+  double        alpha2;
 
   const unsigned int numberOfPoints = inputMesh->GetNumberOfPoints();
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -73,7 +73,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::Initialize()
 
   m_FaceSet = new IndexSetType();
 
-  InputPointType v1, v2, v3;
+  InputPointType v1;
+  InputPointType v2;
+  InputPointType v3;
 
   for (unsigned int idx1 = 0; idx1 < m_IdOffset; ++idx1)
   {
@@ -159,7 +161,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateSimplexNeighbors
   OutputPointsContainerPointer  outputPointsContainer = output->GetPoints();
   OutputPointsContainerIterator points = outputPointsContainer->Begin();
 
-  CellIdentifier tp0, tp1, tp2;
+  CellIdentifier tp0;
+  CellIdentifier tp1;
+  CellIdentifier tp2;
 
   InputBoundaryAssignmentsContainerPointer cntlines = this->GetInput(0)->GetBoundaryAssignments(1);
 
@@ -312,7 +316,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
     auto iterator1 = vertexNeighbors.begin();
 
     auto           tmpMap = MapType::New();
-    CellIdentifier startIdx = NumericTraits<CellIdentifier>::max(), lastIdx = 0, wrongIdx = 0;
+    CellIdentifier startIdx = NumericTraits<CellIdentifier>::max();
+    CellIdentifier lastIdx = 0;
+    CellIdentifier wrongIdx = 0;
 
     while (lastIdx != startIdx)
     {
@@ -403,7 +409,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::ComputeFaceCenter(Cell
                                                                             const InputMeshType * inputMesh)
   -> InputPointType
 {
-  InputPointType v1, v2, v3;
+  InputPointType v1;
+  InputPointType v2;
+  InputPointType v3;
 
   CellAutoPointer cellPointer;
 

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -61,7 +61,10 @@ SimplexMeshGeometry::~SimplexMeshGeometry()
 void
 SimplexMeshGeometry::ComputeGeometry()
 {
-  VectorType b, c, cXb, tmp;
+  VectorType b;
+  VectorType c;
+  VectorType cXb;
+  VectorType tmp;
 
   // compute the circum circle (center and radius)
   b = this->neighbors[2] - this->neighbors[0];
@@ -81,7 +84,10 @@ SimplexMeshGeometry::ComputeGeometry()
   circleCenter = this->neighbors[0] + tmp;
 
   // Compute the circum sphere (center and radius) of a point
-  VectorType d, dXc, bXd, sphereTmp;
+  VectorType d;
+  VectorType dXc;
+  VectorType bXd;
+  VectorType sphereTmp;
 
   d = pos - this->neighbors[0];
   dXc.SetVnlVector(vnl_cross_3d<double>(d.GetVnlVector(), c.GetVnlVector()));

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -89,7 +89,10 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   image->Allocate();
   image->FillBuffer(backgroundValue);
 
-  unsigned int i, j, k, l;
+  unsigned int i;
+  unsigned int j;
+  unsigned int k;
+  unsigned int l;
 
   for (unsigned char counter = 0; counter < 18; ++counter)
   {

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -112,7 +112,8 @@ itkQuadrilateralCellTest(int, char *[])
    * pointer to a cell; in this example it ends up pointing to
    * different types of cells.
    */
-  CellAutoPointer testCell1, testCell2;
+  CellAutoPointer testCell1;
+  CellAutoPointer testCell2;
   testCell1.TakeOwnership(new QuadrilateralHelper); // polymorphism
   testCell2.TakeOwnership(new QuadrilateralHelper); // polymorphism
   // List the points that the polygon will use from the mesh.

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
@@ -64,7 +64,8 @@ QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
   // that are incident to g->GetDestination().(This prevents the operation
   // from collapsing a volume into two facets glued together with opposite
   // orientations, such as would happen with any vertex of a tetrahedron.)
-  PointIdentifier PointId1, PointId2;
+  PointIdentifier PointId1;
+  PointIdentifier PointId2;
   PointId1 = pList.back();
   pList.pop_back();
   PointId2 = pList.back();

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
@@ -28,7 +28,12 @@ itkQuadEdgeMeshDeleteEdgeTest(int, char *[])
   auto mesh = MeshType::New();
 
   // Points
-  MeshType::PointType p0, p1, p2, p3, p4, p5;
+  MeshType::PointType p0;
+  MeshType::PointType p1;
+  MeshType::PointType p2;
+  MeshType::PointType p3;
+  MeshType::PointType p4;
+  MeshType::PointType p5;
   p0[0] = 0.00000000000000;
   p0[1] = 0.00000000000000;
   p0[2] = 5.0;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -100,8 +100,10 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
   }
   else
   {
-    PointType                               p1, p2;
-    DerivativeVectorType                    v1, v2;
+    PointType                               p1;
+    PointType                               p2;
+    DerivativeVectorType                    v1;
+    DerivativeVectorType                    v2;
     typename DerivativeVectorType::Iterator it = value.Begin();
     auto                                    it_v1 = v1.cbegin();
     auto                                    it_v2 = v2.cbegin();

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -61,7 +61,9 @@ SpatialObjectDuplicator<TInputSpatialObject>::Update()
   }
 
   // Update only if the input SpatialObject has been modified
-  ModifiedTimeType t, t1, t2;
+  ModifiedTimeType t;
+  ModifiedTimeType t1;
+  ModifiedTimeType t2;
   t1 = m_Input->GetPipelineMTime();
   t2 = m_Input->GetMTime();
   t = (t1 > t2 ? t1 : t2);

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -41,8 +41,10 @@ itkDTITubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  Vector axis, translation;
-  Point  in, out;
+  Vector axis;
+  Vector translation;
+  Point  in;
+  Point  out;
   double angle;
   bool   passed = true;
 
@@ -316,7 +318,8 @@ itkDTITubeSpatialObjectTest(int, char *[])
   in.Fill(25);
   out.Fill(15);
 
-  Point p1, p2;
+  Point p1;
+  Point p2;
   p1.Fill(15);
   p1[2] = 5;
   p2.Fill(15);
@@ -364,7 +367,8 @@ itkDTITubeSpatialObjectTest(int, char *[])
   TubePointer  tube = TubeType::New();
   GroupPointer net = GroupType::New();
 
-  unsigned int tubeCount, netCount;
+  unsigned int tubeCount;
+  unsigned int netCount;
   tubeCount = tube->GetReferenceCount();
   netCount = net->GetReferenceCount();
 

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -41,8 +41,10 @@ itkTubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  Vector axis, translation;
-  Point  in, out;
+  Vector axis;
+  Vector translation;
+  Point  in;
+  Point  out;
   double angle;
   bool   passed = true;
 
@@ -327,7 +329,8 @@ itkTubeSpatialObjectTest(int, char *[])
   in.Fill(25);
   out.Fill(15);
 
-  Point p1, p2;
+  Point p1;
+  Point p2;
   p1.Fill(15);
   p1[2] = 5;
   p2.Fill(15);
@@ -375,7 +378,8 @@ itkTubeSpatialObjectTest(int, char *[])
   TubePointer  tube = TubeType::New();
   GroupPointer net = GroupType::New();
 
-  unsigned int tubeCount, netCount;
+  unsigned int tubeCount;
+  unsigned int netCount;
   tubeCount = tube->GetReferenceCount();
   netCount = net->GetReferenceCount();
 

--- a/Modules/Core/TestKernel/include/itkTestDriverBeforeTest.inc
+++ b/Modules/Core/TestKernel/include/itkTestDriverBeforeTest.inc
@@ -23,7 +23,8 @@
   try
     {
     std::ofstream redirectStream;
-    std::streambuf *redirectBuf, *oldCoutBuf = nullptr;
+    std::streambuf *redirectBuf;
+    std::streambuf *oldCoutBuf = nullptr;
     RedirectOutputParameters& redirectOutputParameters = GetRedirectOutputParameters();
     if (redirectOutputParameters.redirect)
       {

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -91,7 +91,8 @@ void
 AffineTransform<TParametersValueType, VDimension>::Scale(const OutputVectorType & factor, bool pre)
 {
   MatrixType   trans;
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   for (i = 0; i < VDimension; ++i)
   {
@@ -120,7 +121,8 @@ void
 AffineTransform<TParametersValueType, VDimension>::Rotate(int axis1, int axis2, TParametersValueType angle, bool pre)
 {
   MatrixType   trans;
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   for (i = 0; i < VDimension; ++i)
   {
@@ -179,8 +181,14 @@ AffineTransform<TParametersValueType, VDimension>::Rotate3D(const OutputVectorTy
                                                             bool                     pre)
 {
   MatrixType trans;
-  ScalarType r, x1, x2, x3;
-  ScalarType q0, q1, q2, q3;
+  ScalarType r;
+  ScalarType x1;
+  ScalarType x2;
+  ScalarType x3;
+  ScalarType q0;
+  ScalarType q1;
+  ScalarType q2;
+  ScalarType q3;
 
   // Convert the axis to a unit vector
   r = std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
@@ -225,7 +233,8 @@ void
 AffineTransform<TParametersValueType, VDimension>::Shear(int axis1, int axis2, TParametersValueType coef, bool pre)
 {
   MatrixType   trans;
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   for (i = 0; i < VDimension; ++i)
   {
@@ -268,7 +277,8 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const -> ScalarType
 {
-  ScalarType result = 0.0, term;
+  ScalarType result = 0.0;
+  ScalarType term;
 
   for (unsigned int i = 0; i < VDimension; ++i)
   {
@@ -287,7 +297,8 @@ template <typename TParametersValueType, unsigned int VDimension>
 auto
 AffineTransform<TParametersValueType, VDimension>::Metric() const -> ScalarType
 {
-  ScalarType result = 0.0, term;
+  ScalarType result = 0.0;
+  ScalarType term;
 
   for (unsigned int i = 0; i < VDimension; ++i)
   {

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -122,8 +122,10 @@ itkAffineTransformTest(int, char *[])
 
   int any = 0; // Any errors detected in testing?
 
-  Matrix2Type matrix2, matrix2Truth;
-  Vector2Type vector2, vector2Truth;
+  Matrix2Type matrix2;
+  Matrix2Type matrix2Truth;
+  Vector2Type vector2;
+  Vector2Type vector2Truth;
 
   /* Create a 2D identity transformation and show its parameters */
   using Affine2DType = itk::AffineTransform<double, 2>;
@@ -348,7 +350,9 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Transform a point */
-  itk::Point<double, 2> u2, v2, v2T;
+  itk::Point<double, 2> u2;
+  itk::Point<double, 2> v2;
+  itk::Point<double, 2> v2T;
   u2[0] = 3;
   u2[1] = 5;
   v2 = aff2->TransformPoint(u2);
@@ -368,7 +372,9 @@ itkAffineTransformTest(int, char *[])
   // << v2[0] << " , " << v2[1] << std::endl;
 
   /* Transform a vnl_vector */
-  vnl_vector_fixed<double, 2> x2, y2, y2T;
+  vnl_vector_fixed<double, 2> x2;
+  vnl_vector_fixed<double, 2> y2;
+  vnl_vector_fixed<double, 2> y2T;
   x2[0] = 1;
   x2[1] = 2;
   y2 = aff2->TransformVector(x2);
@@ -388,7 +394,9 @@ itkAffineTransformTest(int, char *[])
   // << y2[0] << " , " << y2[1] << std::endl;
 
   /* Transform a vector */
-  itk::Vector<double, 2> u3, v3, v3T;
+  itk::Vector<double, 2> u3;
+  itk::Vector<double, 2> v3;
+  itk::Vector<double, 2> v3T;
   u3[0] = 3;
   u3[1] = 5;
   v3 = aff2->TransformVector(u3);
@@ -414,7 +422,9 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Transform a variable length vector */
-  itk::VariableLengthVector<double> l3, m3, m3T;
+  itk::VariableLengthVector<double> l3;
+  itk::VariableLengthVector<double> m3;
+  itk::VariableLengthVector<double> m3T;
   l3.SetSize(2);
   m3T.SetSize(2);
   l3[0] = 3;
@@ -436,7 +446,9 @@ itkAffineTransformTest(int, char *[])
   // << v3[0] << " , " << v3[1] << std::endl;
 
   /* Transform a Covariant vector */
-  itk::CovariantVector<double, 2> u4, v4, v4T;
+  itk::CovariantVector<double, 2> u4;
+  itk::CovariantVector<double, 2> v4;
+  itk::CovariantVector<double, 2> v4T;
   u4[0] = 3;
   u4[1] = 5;
   v4 = aff2->TransformCovariantVector(u4);
@@ -451,7 +463,9 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Transform a variable length vector as covariant vector */
-  itk::VariableLengthVector<double> l4, m4, m4T;
+  itk::VariableLengthVector<double> l4;
+  itk::VariableLengthVector<double> m4;
+  itk::VariableLengthVector<double> m4T;
   l4.SetSize(2);
   m4T.SetSize(2);
   l4[0] = 3;

--- a/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
@@ -152,7 +152,8 @@ itkCenteredAffineTransformTest(int, char *[])
   aff2->Print(std::cout);
 
   /* Transform a point */
-  itk::Point<double, 2> u2, v2;
+  itk::Point<double, 2> u2;
+  itk::Point<double, 2> v2;
   u2[0] = 3;
   u2[1] = 5;
   v2 = aff2->TransformPoint(u2);
@@ -164,7 +165,8 @@ itkCenteredAffineTransformTest(int, char *[])
   // << v2[0] << " , " << v2[1] << std::endl;
 
   /* Transform a vnl_vector */
-  vnl_vector_fixed<double, 2> x2, y2;
+  vnl_vector_fixed<double, 2> x2;
+  vnl_vector_fixed<double, 2> y2;
   x2[0] = 1;
   x2[1] = 2;
   y2 = aff2->TransformVector(x2);
@@ -176,7 +178,8 @@ itkCenteredAffineTransformTest(int, char *[])
   // << y2[0] << " , " << y2[1] << std::endl;
 
   /* Transform a vector */
-  itk::Vector<double, 2> u3, v3;
+  itk::Vector<double, 2> u3;
+  itk::Vector<double, 2> v3;
   u3[0] = 3;
   u3[1] = 5;
   v3 = aff2->TransformVector(u3);
@@ -188,7 +191,8 @@ itkCenteredAffineTransformTest(int, char *[])
   // << v3[0] << " , " << v3[1] << std::endl;
 
   /* Transform a Covariant vector */
-  itk::Vector<double, 2> u4, v4;
+  itk::Vector<double, 2> u4;
+  itk::Vector<double, 2> v4;
   u4[0] = 3;
   u4[1] = 5;
   v4 = aff2->TransformVector(u4);

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -203,7 +203,8 @@ itkCompositeTransformTest(int, char *[])
   /* Get parameters with single transform.
    * Should be same as GetParameters from affine transform. */
   std::cout << "Get Parameters: " << std::endl;
-  CompositeType::ParametersType parametersTest, parametersTruth;
+  CompositeType::ParametersType parametersTest;
+  CompositeType::ParametersType parametersTruth;
   parametersTest = compositeTransform->GetParameters();
   parametersTruth = affine->GetParameters();
   std::cout << "affine parametersTruth: " << std::endl
@@ -218,7 +219,8 @@ itkCompositeTransformTest(int, char *[])
   }
 
   /* Set parameters with single transform. */
-  CompositeType::ParametersType parametersNew(6), parametersReturned;
+  CompositeType::ParametersType parametersNew(6);
+  CompositeType::ParametersType parametersReturned;
   parametersNew[0] = 0;
   parametersNew[1] = 10;
   parametersNew[2] = 20;
@@ -282,7 +284,8 @@ itkCompositeTransformTest(int, char *[])
 
   /* Setup test point and truth value for tests */
   CompositeType::InputPointType  inputPoint;
-  CompositeType::OutputPointType outputPoint, affineTruth;
+  CompositeType::OutputPointType outputPoint;
+  CompositeType::OutputPointType affineTruth;
   inputPoint[0] = 2;
   inputPoint[1] = 3;
   affineTruth[0] = 13;
@@ -308,7 +311,8 @@ itkCompositeTransformTest(int, char *[])
 
   /* Test inverse */
   auto                           inverseTransform = CompositeType::New();
-  CompositeType::OutputPointType inverseTruth, inverseOutput;
+  CompositeType::OutputPointType inverseTruth;
+  CompositeType::OutputPointType inverseOutput;
   if (!compositeTransform->GetInverse(inverseTransform))
   {
     std::cout << "ERROR: GetInverse() failed." << std::endl;
@@ -328,7 +332,8 @@ itkCompositeTransformTest(int, char *[])
 
   /* Test ComputeJacobianWithRespectToParameters */
 
-  CompositeType::JacobianType   jacComposite, jacSingle;
+  CompositeType::JacobianType   jacComposite;
+  CompositeType::JacobianType   jacSingle;
   CompositeType::InputPointType jacPoint;
   jacPoint[0] = 1;
   jacPoint[1] = 2;
@@ -724,7 +729,10 @@ itkCompositeTransformTest(int, char *[])
    * Remember that the point gets transformed by preceding transforms
    * before its used for individual Jacobian. */
   std::cout << "Test ComputeJacobianWithRespectToParameters with three transforms: " << std::endl;
-  CompositeType::JacobianType   jacTruth, jacComposite2, jacAffine, jacAffine3;
+  CompositeType::JacobianType   jacTruth;
+  CompositeType::JacobianType   jacComposite2;
+  CompositeType::JacobianType   jacAffine;
+  CompositeType::JacobianType   jacAffine3;
   CompositeType::InputPointType jacPoint2;
   jacPoint2[0] = 1;
   jacPoint2[1] = 2;

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -271,7 +271,9 @@ itkEuler2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5, p6, p7;
+    TransformType::InputPointType p5;
+    TransformType::InputPointType p6;
+    TransformType::InputPointType p7;
     p5 = t1->TransformPoint(p1);
     p6 = t4->TransformPoint(p5);
     p7 = t5->TransformPoint(p1);
@@ -368,7 +370,8 @@ itkEuler2DTransformTest(int, char *[])
     ip[0] = 8.0;
     ip[1] = 9.0;
 
-    TransformType::OutputPointType op1, op2;
+    TransformType::OutputPointType op1;
+    TransformType::OutputPointType op2;
     op1 = t1->TransformPoint(ip);
     op2 = t23->TransformPoint(ip);
 

--- a/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
@@ -130,7 +130,8 @@ itkEuler3DTransformTest(int, char *[])
   std::cout << "Testing Rotation Change from ZXY to ZYX consistency:";
 
   auto                                eulerTransform2 = EulerTransformType::New();
-  EulerTransformType::OutputPointType r1, r2;
+  EulerTransformType::OutputPointType r1;
+  EulerTransformType::OutputPointType r2;
 
   // rotation angles already set above
   eulerTransform->SetComputeZYX(true);
@@ -215,7 +216,9 @@ itkEuler3DTransformTest(int, char *[])
 
   // Testing fixed parameters
   std::cout << "Testing Set/Get Fixed Parameters: ";
-  EulerTransformType::FixedParametersType oldVersion(3), newVersion(4), res(4);
+  EulerTransformType::FixedParametersType oldVersion(3);
+  EulerTransformType::FixedParametersType newVersion(4);
+  EulerTransformType::FixedParametersType res(4);
   oldVersion.Fill(0);
   newVersion.Fill(0);
   eulerTransform->SetFixedParameters(oldVersion);

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -196,7 +196,8 @@ itkMultiTransformTest(int, char *[])
   /* Get parameters with single transform.
    * Should be same as GetParameters from affine transform. */
   std::cout << "Get Parameters: " << std::endl;
-  Superclass::ParametersType parametersTest, parametersTruth;
+  Superclass::ParametersType parametersTest;
+  Superclass::ParametersType parametersTruth;
   parametersTest = multiTransform->GetParameters();
   parametersTruth = affine->GetParameters();
   std::cout << "affine parametersTruth: " << std::endl
@@ -211,7 +212,8 @@ itkMultiTransformTest(int, char *[])
   }
 
   /* Set parameters with single transform. */
-  Superclass::ParametersType parametersNew(6), parametersReturned;
+  Superclass::ParametersType parametersNew(6);
+  Superclass::ParametersType parametersReturned;
   parametersNew[0] = 0;
   parametersNew[1] = 10;
   parametersNew[2] = 20;

--- a/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
@@ -559,7 +559,9 @@ itkRigid2DTransformTest(int, char *[])
       t1->CloneTo(t5);
       t5->Compose(t4, false);
 
-      TransformType::InputPointType p5, p6, p7;
+      TransformType::InputPointType p5;
+      TransformType::InputPointType p6;
+      TransformType::InputPointType p7;
       p5 = t1->TransformPoint(p1);
       p6 = t4->TransformPoint(p5);
       p7 = t5->TransformPoint(p1);

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -354,7 +354,9 @@ itkSimilarity2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5, p6, p7;
+    TransformType::InputPointType p5;
+    TransformType::InputPointType p6;
+    TransformType::InputPointType p7;
     p5 = t1->TransformPoint(p1);
     p6 = t4->TransformPoint(p5);
     p7 = t5->TransformPoint(p1);
@@ -513,7 +515,9 @@ itkSimilarity2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5, p6, p7;
+    TransformType::InputPointType p5;
+    TransformType::InputPointType p6;
+    TransformType::InputPointType p7;
     p5 = t1->TransformPoint(p1);
     p6 = t4->TransformPoint(p5);
     p7 = t5->TransformPoint(p1);
@@ -610,7 +614,8 @@ itkSimilarity2DTransformTest(int, char *[])
     ip[0] = 8.0;
     ip[1] = 9.0;
 
-    TransformType::OutputPointType op1, op2;
+    TransformType::OutputPointType op1;
+    TransformType::OutputPointType op2;
     op1 = t1->TransformPoint(ip);
     op2 = t2->TransformPoint(ip);
 

--- a/Modules/Core/Transform/test/itkTransformCloneTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformCloneTest.cxx
@@ -60,7 +60,8 @@ itkTransformCloneTest(int, char *[])
   using AffineTransformType = itk::AffineTransform<double, 3>;
   using Transform3DType = itk::Transform<double, 3, 3>;
   auto                                  affineXfrm = AffineTransformType::New();
-  AffineTransformType::OutputVectorType axis, offset;
+  AffineTransformType::OutputVectorType axis;
+  AffineTransformType::OutputVectorType offset;
   axis[0] = -1.0;
   axis[1] = 1.0;
   axis[2] = 0.0;

--- a/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
@@ -107,7 +107,8 @@ itkTranslationTransformTest(int, char *[])
   std::cout << "Result of a translation:" << std::endl << aff2;
 
   /* Transform a point */
-  itk::Point<double, 2> u2, v2;
+  itk::Point<double, 2> u2;
+  itk::Point<double, 2> v2;
   u2[0] = 3;
   u2[1] = 5;
   v2 = aff2->TransformPoint(u2);
@@ -118,7 +119,8 @@ itkTranslationTransformTest(int, char *[])
   std::cout << "Back transform a point:" << std::endl << v2[0] << " , " << v2[1] << std::endl;
 
   /* Transform a vnl_vector */
-  vnl_vector_fixed<double, 2> x2, y2;
+  vnl_vector_fixed<double, 2> x2;
+  vnl_vector_fixed<double, 2> y2;
   x2[0] = 1;
   x2[1] = 2;
   y2 = aff2->TransformVector(x2);
@@ -129,7 +131,8 @@ itkTranslationTransformTest(int, char *[])
   std::cout << "Back transform a vnl_vector:" << std::endl << y2[0] << " , " << y2[1] << std::endl;
 
   /* Transform a vector */
-  itk::Vector<double, 2> u3, v3;
+  itk::Vector<double, 2> u3;
+  itk::Vector<double, 2> v3;
   u3[0] = 3;
   u3[1] = 5;
   v3 = aff2->TransformVector(u3);
@@ -140,7 +143,8 @@ itkTranslationTransformTest(int, char *[])
   std::cout << "Back transform a vector :" << std::endl << v3[0] << " , " << v3[1] << std::endl;
 
   /* Transform a Covariant vector */
-  itk::Vector<double, 2> u4, v4;
+  itk::Vector<double, 2> u4;
+  itk::Vector<double, 2> v4;
   u4[0] = 3;
   u4[1] = 5;
   v4 = aff2->TransformVector(u4);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -28,7 +28,8 @@ template <typename TImage>
 CurvatureNDAnisotropicDiffusionFunction<TImage>::CurvatureNDAnisotropicDiffusionFunction()
   : m_K(0.0)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   RadiusType   r;
 
   for (i = 0; i < ImageDimension; ++i)
@@ -75,10 +76,18 @@ CurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhoo
                                                                void *                   itkNotUsed(globalData),
                                                                const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
-  unsigned int i, j;
-  double       speed, dx_forward_Cn, dx_backward_Cn, propagation_gradient;
-  double       grad_mag_sq, grad_mag_sq_d, grad_mag, grad_mag_d;
-  double       Cx, Cxd;
+  unsigned int i;
+  unsigned int j;
+  double       speed;
+  double       dx_forward_Cn;
+  double       dx_backward_Cn;
+  double       propagation_gradient;
+  double       grad_mag_sq;
+  double       grad_mag_sq_d;
+  double       grad_mag;
+  double       grad_mag_d;
+  double       Cx;
+  double       Cxd;
   double       dx_forward[ImageDimension];
   double       dx_backward[ImageDimension];
   double       dx[ImageDimension];

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -29,7 +29,8 @@ template <typename TImage>
 GradientNDAnisotropicDiffusionFunction<TImage>::GradientNDAnisotropicDiffusionFunction()
   : m_K(0.0)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   RadiusType   r;
 
   for (i = 0; i < ImageDimension; ++i)
@@ -79,7 +80,8 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
                                                               void *,
                                                               const FloatOffsetType &) -> PixelType
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   double accum;
   double accum_d;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -33,7 +33,8 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   using SNI_type = ConstNeighborhoodIterator<TImage>;
   using BFC_type = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TImage>;
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   //  ZeroFluxNeumannBoundaryCondition<TImage>  bc;
   double                                    accumulator;
   PixelType                                 val;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -28,7 +28,8 @@ template <typename TImage>
 VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::VectorCurvatureNDAnisotropicDiffusionFunction()
 
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   RadiusType   r;
 
   for (i = 0; i < ImageDimension; ++i)
@@ -78,7 +79,9 @@ VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neigh
                                                                      void *,
                                                                      const FloatOffsetType &) -> PixelType
 {
-  unsigned int i, j, k;
+  unsigned int i;
+  unsigned int j;
+  unsigned int k;
   double       speed;
   double       dx_forward_Cn[ImageDimension][VectorDimension];
   double       dx_backward_Cn[ImageDimension][VectorDimension];

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
@@ -28,7 +28,8 @@ template <typename TImage>
 VectorGradientNDAnisotropicDiffusionFunction<TImage>::VectorGradientNDAnisotropicDiffusionFunction()
   : m_K(0.0)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   RadiusType   r;
 
   for (i = 0; i < ImageDimension; ++i)
@@ -78,7 +79,9 @@ VectorGradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighb
                                                                     void *,
                                                                     const FloatOffsetType &) -> PixelType
 {
-  unsigned int i, j, k;
+  unsigned int i;
+  unsigned int j;
+  unsigned int k;
   PixelType    delta;
 
   double GradMag;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -294,7 +294,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::SetSchedule
   }
 
   this->Modified();
-  unsigned int level, dim;
+  unsigned int level;
+  unsigned int dim;
   for (level = 0; level < m_NumberOfLevels; ++level)
   {
     for (dim = 0; dim < ImageDimension; ++dim)
@@ -321,7 +322,8 @@ bool
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::IsScheduleDownwardDivisible(
   const ScheduleType & schedule)
 {
-  unsigned int ilevel, idim;
+  unsigned int ilevel;
+  unsigned int idim;
 
   for (ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
   {

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -53,7 +53,9 @@ CompositeValleyFunction::~CompositeValleyFunction() = default;
 void
 CompositeValleyFunction::Initialize()
 {
-  SizeValueType i, low, high;
+  SizeValueType i;
+  SizeValueType low;
+  SizeValueType high;
 
   // build table
   // when using valley-func then the table values run from

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -41,7 +41,8 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {
   this->AllocateOutputs();
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   // Retrieve input and output pointers
   typename OutputImageType::Pointer     output = this->GetOutput();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -41,7 +41,8 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {
   this->AllocateOutputs();
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   // Retrieve input and output pointers
   typename OutputImageType::Pointer     output = this->GetOutput();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -56,7 +56,8 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
 
   std::vector<unsigned int> kernelOnElements;
 
-  IndexValueType i, k;
+  IndexValueType i;
+  IndexValueType k;
 
   // **************************
   // Structuring element ( SE ) coding

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -116,7 +116,9 @@ itkCustomColormapFunctionTest(int argc, char * argv[])
   using RGBPixelType = itk::RGBPixel<unsigned char>;
 
   double              value;
-  std::vector<double> redChannel, greenChannel, blueChannel;
+  std::vector<double> redChannel;
+  std::vector<double> greenChannel;
+  std::vector<double> blueChannel;
 
   std::ifstream str(argv[1]);
   std::string   line;

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -167,7 +167,8 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
   using InputPadFilterType = PadImageFilter<InputImageType, InputImageType>;
   using PadSizeType = typename InputPadFilterType::SizeType;
 
-  PadSizeType    lowerPad, upperPad;
+  PadSizeType    lowerPad;
+  PadSizeType    upperPad;
   bool           needsKernelPadding = false;
   KernelSizeType kernelRadius = this->GetKernelRadius();
   for (unsigned int dim = 0; dim < ImageDimension; ++dim)

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -607,7 +607,8 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // We need a few additional checks.
   // Check that the image sizes are the same as their corresponding
   // masks.
-  std::ostringstream fixedSizeString, movingSizeString;
+  std::ostringstream fixedSizeString;
+  std::ostringstream movingSizeString;
   if (this->GetFixedImageMask() && this->GetFixedImage()->GetLargestPossibleRegion().GetSize() !=
                                      this->GetFixedImageMask()->GetLargestPossibleRegion().GetSize())
   {

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -57,7 +57,8 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   PixelRealType  crossderiv[ImageDimension][ImageDimension] = {};
   IdentifierType center;
   IdentifierType stride[ImageDimension];
-  unsigned int   i, j;
+  unsigned int   i;
+  unsigned int   j;
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -853,7 +853,10 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
   // I3 = det(D) = DxxDyyDzz + 2DxyDxzDyz - (Dzz(Dxy)^2 + Dyy(Dxz)^2 +
   // Dxx(Dyz)^2)
 
-  RealTensorValueT I1, I2, I3, I1div3;
+  RealTensorValueT I1;
+  RealTensorValueT I2;
+  RealTensorValueT I3;
+  RealTensorValueT I1div3;
   I1 = D0 + D3 + D5;
   I2 = D0 * D3 + D0 * D5 + D3 * D5 - (DSq1 + DSq2 + DSq4);
   I3 = D0 * D3 * D5 + 2 * D1 * D2 * D4 - (D5 * DSq1 + D3 * DSq2 + D0 * DSq4);
@@ -863,7 +866,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
   // n = (I1/3)^2 - I2/3
   // s = (I1/3)^3 - I1*I2/6 + I3/2
 
-  RealTensorValueT n, sqrtn, s;
+  RealTensorValueT n;
+  RealTensorValueT sqrtn;
+  RealTensorValueT s;
   n = I1div3 * I1div3 - I2 / 3;
   s = I1div3 * I1div3 * I1div3 - I1 * I2 / 6 + I3 / 2;
   sqrtn = std::sqrt(n);
@@ -903,7 +908,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
   // Due to trace invariance,
   // lambda3 also = I1 - lambda1 - lambda2
 
-  RealTensorValueT lambda1, lambda2, lambda3;
+  RealTensorValueT lambda1;
+  RealTensorValueT lambda2;
+  RealTensorValueT lambda3;
   lambda1 = I1div3 + 2 * sqrtn * std::cos(phi);
   lambda2 = I1div3 - 2 * sqrtn * std::cos(itk::Math::pi / 3 + phi);
   lambda3 = I1 - lambda1 - lambda2;
@@ -926,7 +933,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
     // Ai = Dxx - eigenVals[i]
     // Bi = Dyy - eigenVals[i]
     // Ci = Dzz - eigenVals[i]
-    RealTensorValueT A, B, C;
+    RealTensorValueT A;
+    RealTensorValueT B;
+    RealTensorValueT C;
     A = D0 - eigenVals[i];
     B = D3 - eigenVals[i];
     C = D5 - eigenVals[i];
@@ -939,8 +948,12 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
     // eix = term1 * term2
     // eiy = term2 * term3
     // eiz = term1 * term3
-    RealTensorValueT term1, term2, term3;
-    RealTensorValueT ex, ey, ez;
+    RealTensorValueT term1;
+    RealTensorValueT term2;
+    RealTensorValueT term3;
+    RealTensorValueT ex;
+    RealTensorValueT ey;
+    RealTensorValueT ez;
     term1 = D1 * D4 - B * D2;
     term2 = D2 * D4 - C * D1;
     term3 = D2 * D1 - A * D4;
@@ -951,7 +964,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
     // Now normalize the vector
     // e = [ex ey ez]
     // eigenVec = e / sqrt(e'e)
-    RealTensorValueT norm, sqrtnorm;
+    RealTensorValueT norm;
+    RealTensorValueT sqrtnorm;
     norm = ex * ex + ey * ey + ez * ez;
     sqrtnorm = std::sqrt(norm);
     eigenVecs(i, 0) = ex / sqrtnorm;

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -95,10 +95,12 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
   else
   {
     // calculate the inverted field
-    InputImagePointType         mappedPoint, newPoint;
+    InputImagePointType         mappedPoint;
+    InputImagePointType         newPoint;
     OutputImagePointType        originalPoint;
     OutputImageIndexType        index;
-    OutputImagePixelType        displacement, outputValue;
+    OutputImagePixelType        displacement;
+    OutputImagePixelType        outputValue;
     FieldInterpolatorOutputType forwardVector;
     double                      spacing = inputPtr->GetSpacing()[0];
     double                      smallestError = 0;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -381,7 +381,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   // Test ComputeJacobianWithRespectToParameters: should return identity
 
-  DisplacementTransformType::JacobianType identity(Dimensions, Dimensions), testIdentity;
+  DisplacementTransformType::JacobianType identity(Dimensions, Dimensions);
+  DisplacementTransformType::JacobianType testIdentity;
 
   identity.Fill(0);
   for (unsigned int i = 0; i < Dimensions; ++i)
@@ -415,7 +416,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   // Test transforming of points
   //
 
-  DisplacementTransformType::OutputPointType deformOutput, deformTruth;
+  DisplacementTransformType::OutputPointType deformOutput;
+  DisplacementTransformType::OutputPointType deformTruth;
 
   // Test a point with non-zero displacement
   FieldType::IndexType idx = field->TransformPhysicalPointToIndex(testPoint);
@@ -431,7 +433,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   }
 
   DisplacementTransformType::InputVectorType  testVector;
-  DisplacementTransformType::OutputVectorType deformVector, deformVectorTruth;
+  DisplacementTransformType::OutputVectorType deformVector;
+  DisplacementTransformType::OutputVectorType deformVectorTruth;
   testVector[0] = 0.5;
   testVector[1] = 0.5;
 
@@ -451,8 +454,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   // Test VectorTransform for variable length vector
   DisplacementTransformType::InputVectorPixelType  testVVector(DisplacementTransformType::Dimension);
-  DisplacementTransformType::OutputVectorPixelType deformVVector,
-    deformVVectorTruth(DisplacementTransformType::Dimension);
+  DisplacementTransformType::OutputVectorPixelType deformVVector;
+  DisplacementTransformType::OutputVectorPixelType deformVVectorTruth(DisplacementTransformType::Dimension);
   testVVector[0] = 0.5;
   testVVector[1] = 0.5;
 
@@ -472,7 +475,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
 
   DisplacementTransformType::InputCovariantVectorType  testcVector;
-  DisplacementTransformType::OutputCovariantVectorType deformcVector, deformcVectorTruth;
+  DisplacementTransformType::OutputCovariantVectorType deformcVector;
+  DisplacementTransformType::OutputCovariantVectorType deformcVectorTruth;
   testcVector[0] = 0.5;
   testcVector[1] = 0.5;
 
@@ -493,8 +497,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
 
   DisplacementTransformType::InputVectorPixelType  testcVVector(DisplacementTransformType::Dimension);
-  DisplacementTransformType::OutputVectorPixelType deformcVVector,
-    deformcVVectorTruth(DisplacementTransformType::Dimension);
+  DisplacementTransformType::OutputVectorPixelType deformcVVector;
+  DisplacementTransformType::OutputVectorPixelType deformcVVectorTruth(DisplacementTransformType::Dimension);
   testcVVector[0] = 0.5;
   testcVVector[1] = 0.5;
 
@@ -514,7 +518,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
 
   DisplacementTransformType::InputDiffusionTensor3DType  testTensor;
-  DisplacementTransformType::OutputDiffusionTensor3DType deformTensor, deformTensorTruth;
+  DisplacementTransformType::OutputDiffusionTensor3DType deformTensor;
+  DisplacementTransformType::OutputDiffusionTensor3DType deformTensorTruth;
   testTensor[0] = 3;
   testTensor[1] = 0.01;
   testTensor[2] = 0.01;

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -110,7 +110,8 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   unsigned int       n;
   float              val[ImageDimension];
   PixelType          center_value;
-  int                neighbor_start, neighbor_end;
+  int                neighbor_start;
+  int                neighbor_end;
   BandNodeType       node;
 
   /** 1st Scan , using neighbors from center_voxel+1 to it.Size()-1 */

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -87,7 +87,8 @@ test(int testIdx)
   {
     std::cout << "Compute with a 9x9 image, with a 5x5 square at the center set to ON." << std::endl << std::endl;
     // Test the signed Danielsson Output for the a 5x5 square in a 9x9 image
-    int i, j;
+    int i;
+    int j;
     for (i = 2; i <= 6; ++i)
     {
       for (j = 2; j <= 6; ++j)

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -151,7 +151,9 @@ FastMarchingImageFilterBase<TInput, TOutput>::UpdateNeighbors(OutputImageType * 
 
   unsigned char label;
 
-  typename NodeType::IndexValueType v, start, last;
+  typename NodeType::IndexValueType v;
+  typename NodeType::IndexValueType start;
+  typename NodeType::IndexValueType last;
 
   int s;
 
@@ -215,7 +217,10 @@ FastMarchingImageFilterBase<TInput, TOutput>::GetInternalNodesUsed(OutputImageTy
   InternalNodeStructure temp_node;
   temp_node.m_Node = iNode;
 
-  typename NodeType::IndexValueType v, start, last, temp;
+  typename NodeType::IndexValueType v;
+  typename NodeType::IndexValueType start;
+  typename NodeType::IndexValueType last;
+  typename NodeType::IndexValueType temp;
 
   int s;
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -278,7 +278,10 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::Solve(OutputMeshType *     
     }
     else
     {
-      OutputVectorRealType      sq_norm3, norm3, dot1, dot2;
+      OutputVectorRealType      sq_norm3;
+      OutputVectorRealType      norm3;
+      OutputVectorRealType      dot1;
+      OutputVectorRealType      dot2;
       OutputPointIdentifierType new_id;
 
       bool unfolded =

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -54,7 +54,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   const double min_rms_error = 1.0e-14; // 7 digits of precision
 
-  unsigned int                                  i, iter;
+  unsigned int                                  i;
+  unsigned int                                  iter;
   ProcessObject::DataObjectPointerArraySizeType number_of_input_files;
 
   // Allocate the output "fuzzy" image.
@@ -129,7 +130,10 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
   g_t = (g_t / N) * m_ConfidenceWeight;
 
-  double p_num, p_denom, q_num, q_denom;
+  double p_num;
+  double p_denom;
+  double q_num;
+  double q_denom;
 
   for (iter = 0; iter < m_MaximumIterations; ++iter)
   {
@@ -171,7 +175,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
     // Need an iterator on each D
     // const double g_t = 0.1;  // prior likelihood that a pixel is incl.in
     // segmentation
-    double alpha1, beta1;
+    double alpha1;
+    double beta1;
 
     for (i = 0; i < number_of_input_files; ++i)
     {

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -113,7 +113,9 @@ void
 SimilarityIndexImageFilter<TInputImage1, TInputImage2>::AfterThreadedGenerateData()
 {
   ThreadIdType  i;
-  SizeValueType countImage1, countImage2, countIntersect;
+  SizeValueType countImage1;
+  SizeValueType countImage2;
+  SizeValueType countIntersect;
 
   ThreadIdType numberOfWorkUnits = this->GetNumberOfWorkUnits();
 

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -248,7 +248,13 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     fC(this->GetInput(), outputRegionForThread, m_GaussianKernel.GetRadius());
 
   OutputPixelRealType centerPixel;
-  OutputPixelRealType val, tableArg, normFactor, rangeGaussian, rangeDistance, pixel, gaussianProduct;
+  OutputPixelRealType val;
+  OutputPixelRealType tableArg;
+  OutputPixelRealType normFactor;
+  OutputPixelRealType rangeGaussian;
+  OutputPixelRealType rangeDistance;
+  OutputPixelRealType pixel;
+  OutputPixelRealType gaussianProduct;
 
   const double distanceToTableIndex = static_cast<double>(m_NumberOfRangeGaussianSamples) / m_DynamicRangeUsed;
 

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -85,7 +85,8 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::InitIn
 {
   unsigned int i;
   double       b;
-  PixelType    c_vec, m_vec;
+  PixelType    c_vec;
+  PixelType    m_vec;
 
   m_IntermediateImage = TInputImage::New();
   m_IntermediateImage->SetLargestPossibleRegion(this->GetInput()->GetLargestPossibleRegion());

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -111,7 +111,10 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  InputImagePixelType this_one, that, abs_this_one, abs_that;
+  InputImagePixelType this_one;
+  InputImagePixelType that;
+  InputImagePixelType abs_this_one;
+  InputImagePixelType abs_that;
   InputImagePixelType zero{};
 
   FixedArray<OffsetValueType, 2 * ImageDimension> offset;

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -138,7 +138,8 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
     // histogram to update and the direction in which to push
     // it. Then we need to copy that histogram to the relevant
     // places
-    OffsetType LineOffset, Changes;
+    OffsetType LineOffset;
+    OffsetType Changes;
     // Figure out which stored histogram to move and in
     // which direction
     int LineDirection = 0;

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -317,8 +317,11 @@ protected:
   TRealType
   NonPCEvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
-    unsigned int i, j;
-    TRealType    dx, sum, accum = TRealType{};
+    unsigned int i;
+    unsigned int j;
+    TRealType    dx;
+    TRealType    sum;
+    TRealType    accum = TRealType{};
     for (i = 0; i < ImageDimension; ++i)
     {
       sum = TRealType{};
@@ -336,7 +339,8 @@ protected:
   EvaluateAtNeighborhood3D(const ConstNeighborhoodIteratorType & it) const
   {
     // WARNING:  ONLY CALL THIS METHOD WHEN PROCESSING A 3D IMAGE
-    unsigned int i, j;
+    unsigned int i;
+    unsigned int j;
     double       Lambda[3];
     double       CharEqn[3];
     double       ans;
@@ -449,7 +453,8 @@ protected:
   TRealType
   EvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
-    unsigned int i, j;
+    unsigned int i;
+    unsigned int j;
 
     vnl_matrix<TRealType>                        g(ImageDimension, ImageDimension);
     vnl_vector_fixed<TRealType, VectorDimension> d_phi_du[TInputImage::ImageDimension];

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
@@ -229,9 +229,11 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage
                                                                                  unsigned int       inTraverseSize,
                                                                                  ProgressReporter & progress)
 {
-  IndexValueType i1, i2;
+  IndexValueType i1;
+  IndexValueType i2;
 
-  SizeValueType outK, inK;
+  SizeValueType outK;
+  SizeValueType inK;
   SizeValueType outTraverseSize = inTraverseSize / 2;
 
   inTraverseSize = outTraverseSize * 2; // ensures that an even number is used.
@@ -295,7 +297,8 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage
                                                                                  unsigned int       inTraverseSize,
                                                                                  ProgressReporter & progress)
 {
-  IndexValueType i1, i2;
+  IndexValueType i1;
+  IndexValueType i2;
 
   IndexValueType inK;
   SizeValueType  outTraverseSize = inTraverseSize * 2;
@@ -305,7 +308,8 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage
   inModK = outTraverseSize;
   IndexValueType k0 = (this->m_HSize / 2) * 2 - 1L;
 
-  double outVal, outVal2;
+  double outVal;
+  double outVal2;
 
   for (inK = 0; inK < (IndexValueType)inTraverseSize; ++inK)
   {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -191,9 +191,11 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage(const s
                                                                          unsigned int                inTraverseSize,
                                                                          ProgressReporter &          progress)
 {
-  int i1, i2;
+  int i1;
+  int i2;
 
-  unsigned int outK, inK;
+  unsigned int outK;
+  unsigned int inK;
   unsigned int outTraverseSize = inTraverseSize / 2;
 
   inTraverseSize = outTraverseSize * 2; // ensures that an even number is used.
@@ -270,7 +272,8 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
                                                                          unsigned int                inTraverseSize,
                                                                          ProgressReporter &          progress)
 {
-  int i1, i2;
+  int i1;
+  int i2;
 
   int          outK;
   unsigned int inK;

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -110,7 +110,9 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   ImageScanlineConstIterator inputIterator(inputPtr, inputPtr->GetRequestedRegion());
 
   // Set up shaped neighbor hood by defining the offsets
-  OutputOffsetType negativeOffset, positiveOffset, iOffset;
+  OutputOffsetType negativeOffset;
+  OutputOffsetType positiveOffset;
+  OutputOffsetType iOffset;
 
   negativeOffset[0] = 0;
   positiveOffset[0] = 0;

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -182,8 +182,10 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::ConvertOutputIndexToInputIndex(
                                                                                 double &                outDecayFactor)
 {
   unsigned int dimCtr;
-  long         a, b, c; // Output region goes from a to a+b-1
-                        // Input region goes from c to c+b-1
+  long         a;
+  long         b;
+  long         c; // Output region goes from a to a+b-1
+                  // Input region goes from c to c+b-1
   OutputImageIndexType outputRegionStart = outputRegion.GetIndex();
   InputImageIndexType  inputRegionStart = inputRegion.GetIndex();
   InputImageSizeType   inputSizes = inputRegion.GetSize();
@@ -488,8 +490,11 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   // can handle other blockings imposed by the mirror and wrap algorithms.
   long              inRegLimit[ImageDimension];
   long              outRegLimit[ImageDimension];
-  long              minIndex[ImageDimension], maxIndex[ImageDimension];
-  int               numPre[ImageDimension], numPost[ImageDimension], numIn[ImageDimension];
+  long              minIndex[ImageDimension];
+  long              maxIndex[ImageDimension];
+  int               numPre[ImageDimension];
+  int               numPost[ImageDimension];
+  int               numIn[ImageDimension];
   std::vector<long> outputRegionStart[ImageDimension];
   std::vector<long> outputRegionSizes[ImageDimension];
   std::vector<long> inputRegionStart[ImageDimension];
@@ -621,10 +626,12 @@ void
 MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  unsigned int dimCtr, i;
+  unsigned int dimCtr;
+  unsigned int i;
   int          regCtr;
   int          numRegions = 1; // number of regions in our decomposed space.
-  int          goodInput, goodOutput;
+  int          goodInput;
+  int          goodOutput;
 
   // Are the regions non-empty?
   itkDebugMacro("MirrorPadImageFilter::DynamicThreadedGenerateData");
@@ -650,7 +657,9 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   long              inRegLimit[ImageDimension];
   long              outRegIndices[ImageDimension];
   long              outRegLimit[ImageDimension];
-  int               numPre[ImageDimension], numPost[ImageDimension], numIn[ImageDimension];
+  int               numPre[ImageDimension];
+  int               numPost[ImageDimension];
+  int               numIn[ImageDimension];
   std::vector<long> outputRegionStart[ImageDimension];
   std::vector<long> outputRegionSizes[ImageDimension];
   std::vector<long> inputRegionStart[ImageDimension];

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -132,7 +132,8 @@ PermuteAxesImageFilter<TImage>::GenerateOutputInformation()
   typename TImage::SizeType      outputSize;
   typename TImage::IndexType     outputStartIndex;
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   for (j = 0; j < ImageDimension; ++j)
   {
     // origin does not change by a Permute.  But spacing, directions,

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -202,7 +202,8 @@ ShrinkImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   }
 
   OutputIndexType  outputIndex;
-  InputIndexType   inputIndex, inputRequestedRegionIndex;
+  InputIndexType   inputIndex;
+  InputIndexType   inputRequestedRegionIndex;
   OutputOffsetType offsetIndex;
 
   typename TInputImage::SizeType   inputRequestedRegionSize;

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -255,7 +255,8 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   ImageLinearConstIteratorWithIndex<TileImageType> tit(m_TileImage, m_TileImage->GetRequestedRegion());
   int                                              value;
 
-  std::vector<std::vector<int>> sizes, offsets;
+  std::vector<std::vector<int>> sizes;
+  std::vector<std::vector<int>> offsets;
 
   sizes.resize(OutputImageDimension);
   offsets.resize(OutputImageDimension);

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -27,7 +27,8 @@ using ImagePointer = ImageType::Pointer;
 void
 PrintInformation(ImagePointer image1, ImagePointer image2)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   std::cout << "Input  "
             << "      Output" << std::endl;
   std::cout << "Origin"
@@ -63,7 +64,8 @@ PrintInformation(ImagePointer image1, ImagePointer image2)
 void
 PrintInformation3(ImagePointer image1, ImagePointer image2, ImagePointer image3)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   std::cout << "Input  "
             << "      Output"
             << "      Reference" << std::endl;

--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -36,7 +36,8 @@ itkConstantPadImageTest(int, char *[])
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
   ShortImage::RegionType region;
-  int                    row, column;
+  int                    row;
+  int                    column;
   region.SetSize(size);
   region.SetIndex(index);
   image->SetLargestPossibleRegion(region);

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
@@ -106,7 +106,8 @@ itkMirrorPadImageTest(int, char *[])
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
   ShortImage::RegionType region;
-  int                    row, column;
+  int                    row;
+  int                    column;
   region.SetSize(size);
   region.SetIndex(index);
   if2->SetLargestPossibleRegion(region);

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -94,7 +94,8 @@ itkOrientImageFilterTest(int argc, char * argv[])
 
   ImageType::RegionType::SizeType originalSize = randImage->GetLargestPossibleRegion().GetSize();
   ImageType::RegionType::SizeType transformedSize = SLA->GetLargestPossibleRegion().GetSize();
-  ImageType::IndexType            originalIndex, transformedIndex;
+  ImageType::IndexType            originalIndex;
+  ImageType::IndexType            transformedIndex;
 
   for (originalIndex[2] = transformedIndex[2] = 0;
        originalIndex[2] < static_cast<ImageType::IndexType::IndexValueType>(originalSize[2]);

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -57,7 +57,10 @@ CreateAxialImage()
   img->SetRegions(region);
   img->Allocate();
 
-  std::string row, column, slice, label;
+  std::string row;
+  std::string column;
+  std::string slice;
+  std::string label;
   for (imageIndex[2] = 0; imageIndex[2] < 4; imageIndex[2]++)
   {
     if (imageIndex[2] < 2)
@@ -120,7 +123,10 @@ CreateCoronalImage()
   imageDirection[1][2] = 1;
   imageDirection[2][2] = 0;
   img->SetDirection(imageDirection);
-  std::string row, column, slice, label;
+  std::string row;
+  std::string column;
+  std::string slice;
+  std::string label;
   for (imageIndex[2] = 0; imageIndex[2] < 4; imageIndex[2]++)
   {
     if (imageIndex[2] < 2)

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -136,8 +136,8 @@ itkResampleImageTest7(int, char *[])
   ImagePointerType outputSDI = streamer->GetOutput();
   outputSDI->DisconnectPipeline();
 
-  itk::ImageRegionIterator<ImageType> itNoSDI(outputNoSDI, outputNoSDI->GetLargestPossibleRegion()),
-    itSDI(outputSDI, outputSDI->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> itNoSDI(outputNoSDI, outputNoSDI->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> itSDI(outputSDI, outputSDI->GetLargestPossibleRegion());
   for (itNoSDI.GoToBegin(), itSDI.GoToBegin(); !itNoSDI.IsAtEnd() && !itSDI.IsAtEnd(); ++itNoSDI, ++itSDI)
   {
     if (itk::Math::NotAlmostEquals(itNoSDI.Value(), itSDI.Value()))

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -125,8 +125,8 @@ itkWarpImageFilterTest2(int, char *[])
   filter->Modified();
   filter->Update();
   ImageType::Pointer                  result2 = filter->GetOutput();
-  itk::ImageRegionIterator<ImageType> it1(result1, result1->GetLargestPossibleRegion()),
-    it2(result2, result1->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> it1(result1, result1->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> it2(result2, result1->GetLargestPossibleRegion());
   for (it1.GoToBegin(), it2.GoToBegin(); !it1.IsAtEnd() && !it2.IsAtEnd(); ++it1, ++it2)
   {
     if (itk::Math::NotAlmostEquals(it1.Value(), it2.Value()))

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
@@ -50,7 +50,8 @@ IntensityWindowingImageFilter<TInputImage, TOutputImage>::SetWindowLevel(const I
                                                                          const InputPixelType & level)
 {
   using InputRealType = typename NumericTraits<InputPixelType>::RealType;
-  InputRealType tmp1, tmp2;
+  InputRealType tmp1;
+  InputRealType tmp2;
 
   tmp1 = static_cast<InputRealType>(level) - (static_cast<InputRealType>(window) / 2.0);
   if (tmp1 < NumericTraits<InputPixelType>::NonpositiveMin())

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -173,7 +173,9 @@ itkNaryAddImageFilterTest(int, char *[])
   auto vectorImageB = VectorImageType::New();
   auto vectorImageC = VectorImageType::New();
 
-  VectorPixelType vectorImageValueA, vectorImageValueB, vectorImageValueC;
+  VectorPixelType vectorImageValueA;
+  VectorPixelType vectorImageValueB;
+  VectorPixelType vectorImageValueC;
 
   constexpr VectorImageType::PixelType::ValueType vectorValueA = 12;
   vectorImageValueA.Fill(vectorValueA);

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -50,7 +50,8 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
   using inputPolylineType = itk::PolyLineParametricPath<pDimension>;
 
   // Create up and viewing direction vectors
-  inputVectorType inputUpVector, inputViewVector;
+  inputVectorType inputUpVector;
+  inputVectorType inputViewVector;
 
   // Create polyline
   auto inputPolyline = inputPolylineType::New();

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -157,7 +157,9 @@ protected:
   {
     m_UnionFind = UnionFindType(numberOfLabels + 1);
 
-    typename LineMapType::iterator MapBegin, MapEnd, LineIt;
+    typename LineMapType::iterator MapBegin;
+    typename LineMapType::iterator MapEnd;
+    typename LineMapType::iterator LineIt;
     MapBegin = m_LineMap.begin();
     MapEnd = m_LineMap.end();
     LineIt = MapBegin;
@@ -287,7 +289,9 @@ protected:
       offset = 1;
     }
 
-    LineEncodingConstIterator nIt, mIt, cIt;
+    LineEncodingConstIterator nIt;
+    LineEncodingConstIterator mIt;
+    LineEncodingConstIterator cIt;
 
     mIt = Neighbour.begin(); // out marker iterator
 

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -287,7 +287,8 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   }
 
   // compute some projections!
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3, proj4;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4;
   decomposer->SetImage(image3);
   ITK_TEST_SET_GET_VALUE(image3, decomposer->GetImage());
 
@@ -308,7 +309,8 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   basis.push_back(image7);
   decomposer->SetBasisImages(basis);
 
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_2, proj4_2;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_2;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_2;
   // decomposer->SetImage(image4); // DON'T set image4 -- it should still
   // be cached with the decomposer. Test that this works between basis changes.
   decomposer->Compute();
@@ -318,7 +320,8 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   decomposer->Compute();
   proj3_2 = decomposer->GetProjection();
 
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_3, proj4_3;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_3;
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_3;
   // now test it with a mean image set
   decomposer->SetMeanImage(image8);
   ITK_TEST_SET_GET_VALUE(image8, decomposer->GetMeanImage());

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -64,8 +64,10 @@ AnchorErodeDilateLine<TInputPix, TCompare>::DoLine(std::vector<TInputPix> & buff
 
   int middle = static_cast<int>(m_Size) / 2;
 
-  int                 outLeftP = 0, outRightP = static_cast<int>(bufflength) - 1;
-  int                 inLeftP = 0, inRightP = static_cast<int>(bufflength) - 1;
+  int                 outLeftP = 0;
+  int                 outRightP = static_cast<int>(bufflength) - 1;
+  int                 inLeftP = 0;
+  int                 inRightP = static_cast<int>(bufflength) - 1;
   InputImagePixelType Extreme;
   HistogramType       histo;
   if (bufflength <= m_Size)

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -196,7 +196,9 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DoFaceOpen(
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int               start, end, len;
+    unsigned int               start;
+    unsigned int               end;
+    unsigned int               len;
     if (FillLineBuffer<TImage, BresType, KernelLType>(
           input, Ind, NormLine, tol, LineOffsets, AllImage, outbuffer, start, end))
     {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -62,7 +62,8 @@ AnchorOpenCloseLine<TInputPix, TCompare>::DoLine(std::vector<InputImagePixelType
 
   // start the real work - everything here will be done with index
   // arithmetic rather than pointer arithmetic
-  unsigned int outLeftP = 0, outRightP = bufflength - 1;
+  unsigned int outLeftP = 0;
+  unsigned int outRightP = bufflength - 1;
   // left side
   while ((outLeftP < outRightP) && Compare1(buffer[outLeftP], buffer[outLeftP + 1]))
   {
@@ -120,7 +121,8 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
   // code, and false to indicate finishLine
   Extreme = buffer[outLeftP];
   unsigned int currentP = outLeftP + 1;
-  unsigned int sentinel, endP;
+  unsigned int sentinel;
+  unsigned int endP;
 
   while ((currentP < outRightP) && Compare2(buffer[currentP], Extreme))
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
@@ -66,7 +66,8 @@ DoAnchorFace(const TImage *                            input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int               start, end;
+    unsigned int               start;
+    unsigned int               end;
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, inbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -334,7 +334,9 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
-        LType3 L, A, B;
+        LType3 L;
+        LType3 A;
+        LType3 B;
         A = FacetArray[j].P2 - FacetArray[j].P1;
         B = FacetArray[j].P3 - FacetArray[j].P1;
         L[0] = A[1] * B[2] - B[1] * A[2];
@@ -700,7 +702,9 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
-        LType3 L, A, B;
+        LType3 L;
+        LType3 A;
+        LType3 B;
         A = FacetArray[j].P2 - FacetArray[j].P1;
         B = FacetArray[j].P3 - FacetArray[j].P1;
         L[0] = A[1] * B[2] - B[1] * A[2];
@@ -733,7 +737,12 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       FacetArray.resize(facets);
 
       // original corners of octahedron
-      LType3 P0{}, P1{}, P2{}, P3{}, P4{}, P5{};
+      LType3 P0{};
+      LType3 P1{};
+      LType3 P2{};
+      LType3 P3{};
+      LType3 P4{};
+      LType3 P5{};
       P0[0] = 0;
       P0[1] = 0;
       P0[2] = 1;
@@ -753,7 +762,14 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       P5[1] = 1 / sqrt2;
       P5[2] = 0;
 
-      FacetType3 F0, F1, F2, F3, F4, F5, F6, F7;
+      FacetType3 F0;
+      FacetType3 F1;
+      FacetType3 F2;
+      FacetType3 F3;
+      FacetType3 F4;
+      FacetType3 F5;
+      FacetType3 F6;
+      FacetType3 F7;
       F0.P1 = P0;
       F0.P2 = P3;
       F0.P3 = P4;
@@ -795,7 +811,9 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
         unsigned int ntold = pos;
         for (unsigned int i = 0; i < ntold; ++i)
         {
-          LType3 Pa, Pb, Pc;
+          LType3 Pa;
+          LType3 Pb;
+          LType3 Pc;
           for (unsigned int d = 0; d < 3; ++d)
           {
             Pa[d] = (FacetArray[i].P1[d] + FacetArray[i].P2[d]) / 2;
@@ -826,7 +844,9 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
-        LType3 L, A, B;
+        LType3 L;
+        LType3 A;
+        LType3 B;
         A = FacetArray[j].P2 - FacetArray[j].P1;
         B = FacetArray[j].P3 - FacetArray[j].P1;
         L[0] = A[1] * B[2] - B[1] * A[2];

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -294,7 +294,9 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   typename NeighborhoodIteratorType::OffsetValueType i;
   typename NeighborhoodIteratorType::OffsetType      offset;
 
-  MarkerImagePixelType value, dilateValue, maskValue;
+  MarkerImagePixelType value;
+  MarkerImagePixelType dilateValue;
+  MarkerImagePixelType maskValue;
 
   // Iterate over the faces
   for (const auto & face : faceList)

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -290,7 +290,9 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   typename NeighborhoodIteratorType::OffsetValueType i;
   typename NeighborhoodIteratorType::OffsetType      offset;
 
-  MarkerImagePixelType value, erodeValue, maskValue;
+  MarkerImagePixelType value;
+  MarkerImagePixelType erodeValue;
+  MarkerImagePixelType maskValue;
 
   // Iterate over the faces
   //

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -245,7 +245,8 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     // histogram to update and the direction in which to push
     // it. Then we need to copy that histogram to the relevant
     // places
-    OffsetType LineOffset, Changes;
+    OffsetType LineOffset;
+    OffsetType Changes;
     // Figure out which stored histogram to move and in
     // which direction
     int LineDirection = 0;

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -231,8 +231,10 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
   setConnectivityLater(&mskNIt, m_FullyConnected);
   mskNIt.OverrideBoundaryCondition(&iBC);
 
-  typename NOutputIterator::IndexListType                 oIndexList, mIndexList;
-  typename NOutputIterator::IndexListType::const_iterator oLIt, mLIt;
+  typename NOutputIterator::IndexListType                 oIndexList;
+  typename NOutputIterator::IndexListType                 mIndexList;
+  typename NOutputIterator::IndexListType::const_iterator oLIt;
+  typename NOutputIterator::IndexListType::const_iterator mLIt;
 
   oIndexList = outNIt.GetActiveIndexList();
   mIndexList = mskNIt.GetActiveIndexList();

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -95,7 +95,8 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
   float                      Tfar = NumericTraits<float>::max();
   float                      Tnear = NumericTraits<float>::NonpositiveMin();
   float                      domdir = NumericTraits<float>::NonpositiveMin();
-  int                        sPos, ePos;
+  int                        sPos;
+  int                        ePos;
   unsigned int               perpdir = 0;
   for (unsigned int i = 0; i < TImage::RegionType::ImageDimension; ++i)
   {
@@ -305,7 +306,8 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
 
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
-    RegionType R1, R2;
+    RegionType R1;
+    RegionType R2;
     SizeType   S1 = AllImage.GetSize();
     IndexType  I2 = AllImage.GetIndex();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -150,7 +150,8 @@ DoFace(typename TImage::ConstPointer             input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int               start, end;
+    unsigned int               start;
+    unsigned int               end;
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -147,7 +147,10 @@ ContourExtractor2DImageFilter<TInputImage>::CreateSingleContour(InputPixelType  
     // 01    is numbered as    45
     // 23                      78
 
-    InputPixelType v0, v1, v2, v3;
+    InputPixelType v0;
+    InputPixelType v1;
+    InputPixelType v2;
+    InputPixelType v3;
     unsigned char  squareCase{ 0 };
     if (m_LabelContours)
     {

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -47,7 +47,8 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // current swath column (all previous columns have been fully processed)
   unsigned int x;
   // current first row and last row of the swath.
-  unsigned int F, L;
+  unsigned int F;
+  unsigned int L;
   // index used to access the processed swath image; filled in with x, F, & L
   IndexType index;
 
@@ -117,8 +118,10 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // end of triple for-loop covering x & F & L
 
   // Find the best starting and ending points (F & L) for the path
-  int    bestF = 0, bestL = 0;
-  double meritTemp, meritMax = NumericTraits<double>::NonpositiveMin();
+  int    bestF = 0;
+  int    bestL = 0;
+  double meritTemp;
+  double meritMax = NumericTraits<double>::NonpositiveMin();
   for (F = 0; F < m_SwathSize[1]; ++F)
   {
     for (L = 0; L < m_SwathSize[1]; ++L)

--- a/Modules/Filtering/Path/include/itkPathFunctions.h
+++ b/Modules/Filtering/Path/include/itkPathFunctions.h
@@ -36,7 +36,9 @@ MakeChainCodeTracePath(TChainCodePath & chainPath, const TPathInput & inPath, bo
   using ChainInputType = typename TChainCodePath::InputType;
   using InPathInputType = typename TPathInput::InputType;
 
-  OffsetType      offset, tempOffset, zeroOffset;
+  OffsetType      offset;
+  OffsetType      tempOffset;
+  OffsetType      zeroOffset;
   InPathInputType inPathInput;
   int             dimension = OffsetType::GetOffsetDimension();
 

--- a/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
+++ b/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
@@ -29,7 +29,9 @@ OrthogonallyCorrected2DParametricPath::Evaluate(const InputType & inputValue) co
   OutputType                        output;
   OrthogonalCorrectionTableSizeType numOrthogonalCorrections;
   double                            softOrthogonalCorrectionTableIndex;
-  double                            Correction, Correction1, Correction2;
+  double                            Correction;
+  double                            Correction1;
+  double                            Correction2;
   VectorType                        originalDerivative;
 
   numOrthogonalCorrections = m_OrthogonalCorrectionTable->Size();

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -33,7 +33,8 @@ itkFourierSeriesPathTest(int, char *[])
 
   InputType  input;
   OffsetType offset;
-  VectorType cosV, sinV;
+  VectorType cosV;
+  VectorType sinV;
 
   auto path = PathType::New();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -107,7 +107,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder() -> Inp
     itkGenericExceptionMacro("This filter requires at least one boundary");
   }
 
-  InputCoordRepType max_length(0.0), length(0.0);
+  InputCoordRepType max_length(0.0);
+  InputCoordRepType length(0.0);
   auto              oborder_it = list->begin();
 
   for (auto b_it = list->begin(); b_it != list->end(); ++b_it)
@@ -260,7 +261,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare() -> InputCoo
 
   InputPointType center = this->GetMeshBarycentre();
 
-  InputCoordRepType oRmax(0.), r;
+  InputCoordRepType oRmax(0.);
+  InputCoordRepType r;
 
   for (auto BoundaryPtIterator = this->m_BoundaryPtMap.begin(); BoundaryPtIterator != this->m_BoundaryPtMap.end();
        ++BoundaryPtIterator)
@@ -355,10 +357,14 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ArcLengthSquareTransform()
 
   std::vector<InputCoordRepType> Length(NbBoundaryPt + 1, 0.0);
 
-  InputCoordRepType TotalLength(0.0), distance;
+  InputCoordRepType TotalLength(0.0);
+  InputCoordRepType distance;
 
-  InputPointIdentifier i(0), org(0), dest(0);
-  InputPointType       PtOrg, PtDest;
+  InputPointIdentifier i(0);
+  InputPointIdentifier org(0);
+  InputPointIdentifier dest(0);
+  InputPointType       PtOrg;
+  InputPointType       PtDest;
 
   for (InputIteratorGeom it = bdryEdge->BeginGeomLnext(); it != bdryEdge->EndGeomLnext(); ++it, ++i)
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
@@ -91,7 +91,8 @@ protected:
       OutputQEType * qe_it = qe;
       OutputQEType * qe_it2;
 
-      OutputPointType q0, q1;
+      OutputPointType q0;
+      OutputPointType q1;
 
       OutputCurvatureType sum_theta = 0.;
       OutputCurvatureType area = 0.;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -106,7 +106,8 @@ protected:
         OutputCurvatureType temp_area;
         OutputCoordType     temp_coeff;
 
-        OutputPointType  q0, q1;
+        OutputPointType  q0;
+        OutputPointType  q1;
         OutputVectorType face_normal;
 
         do

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -96,14 +96,16 @@ protected:
 
       OutputQEType * qe_it = qe;
 
-      OutputCurvatureType area(0.), sum_theta(0.);
+      OutputCurvatureType area(0.);
+      OutputCurvatureType sum_theta(0.);
 
       if (qe_it != qe_it->GetOnext())
       {
         qe_it = qe;
         OutputQEType * qe_it2;
 
-        OutputPointType  q0, q1;
+        OutputPointType  q0;
+        OutputPointType  q1;
         OutputVectorType face_normal;
 
         OutputVectorType normal{};

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -221,7 +221,9 @@ protected:
     OutputMeshPointer           output = this->GetOutput();
     OutputCellsContainerPointer cells = output->GetCells();
 
-    std::list<OutputCellIdentifier> r1, r2, elements_to_be_tested;
+    std::list<OutputCellIdentifier> r1;
+    std::list<OutputCellIdentifier> r2;
+    std::list<OutputCellIdentifier> elements_to_be_tested;
     OutputQEType *                  qe = iEdge;
     OutputQEType *                  qe_it = qe->GetOnext();
 
@@ -255,10 +257,12 @@ protected:
     OutputPolygonType *   poly;
     OutputPointIdentifier p_id;
 
-    int             k(0), replace_k(0);
+    int             k(0);
+    int             replace_k(0);
     OutputPointType pt[3];
 
-    OutputVectorType n_bef, n_aft;
+    OutputVectorType n_bef;
+    OutputVectorType n_aft;
 
     while ((it != elements_to_be_tested.end()) && orientation_ok)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -485,7 +485,9 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::NumberOfCommonVer
   OutputQEType * qe = m_Element;
   OutputQEType * e_it = qe->GetOnext();
 
-  std::list<OutputPointIdentifier> dir_list, sym_list, intersection_list;
+  std::list<OutputPointIdentifier> dir_list;
+  std::list<OutputPointIdentifier> sym_list;
+  std::list<OutputPointIdentifier> intersection_list;
   do
   {
     dir_list.push_back(e_it->GetDestination());

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -198,7 +198,8 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
 
   OutputPointIdentifier vId;
   unsigned int          degree;
-  OutputQEPrimal *      qe, *temp;
+  OutputQEPrimal *      qe;
+  OutputQEPrimal *      temp;
 
   while (!todo.empty())
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
@@ -139,7 +139,9 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
 
     MatrixType A(Mt * M);
 
-    VectorType Cx, Cy, Cz;
+    VectorType Cx;
+    VectorType Cy;
+    VectorType Cz;
     Mt.mult(Bx, Cx);
     Mt.mult(By, Cy);
     Mt.mult(Bz, Cz);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -137,9 +137,11 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdent
       // this test should be removed...
       if (poly->GetNumberOfPoints() == 3)
       {
-        int              internal_id(0), k(0);
+        int              internal_id(0);
+        int              k(0);
         OutputPointType  pt[3];
-        OutputVectorType u, v;
+        OutputVectorType u;
+        OutputVectorType v;
 
         OutputQEType * edge = poly->GetEdgeRingEntry();
         OutputQEType * temp = edge;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
@@ -93,8 +93,10 @@ ParameterizationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::Fill
 
   InputMapPointIdentifierIterator it;
 
-  InputPointIdentifier id1, id2;
-  InputPointIdentifier InternalId1, InternalId2;
+  InputPointIdentifier id1;
+  InputPointIdentifier id2;
+  InputPointIdentifier InternalId1;
+  InputPointIdentifier InternalId2;
 
   OutputPointType pt2;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -182,7 +182,9 @@ public:
   void
   AddPoint(const PointType & iP, const VectorType & iN, const CoordType & iWeight = static_cast<CoordType>(1.))
   {
-    unsigned int k(0), dim1, dim2;
+    unsigned int k(0);
+    unsigned int dim1;
+    unsigned int dim2;
 
     CoordType d = -iN * iP.GetVectorFromOrigin();
 
@@ -262,7 +264,9 @@ protected:
   void
   ComputeAMatrixAndBVector()
   {
-    unsigned int k(0), dim1, dim2;
+    unsigned int k(0);
+    unsigned int dim1;
+    unsigned int dim2;
 
     for (dim1 = 0; dim1 < PointDimension; ++dim1)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -120,7 +120,8 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
 
   it = constraints.begin();
 
-  MeshType::PointType  iPt, oPt;
+  MeshType::PointType  iPt;
+  MeshType::PointType  oPt;
   MeshType::VectorType displacement;
 
   while (it != constraints.end())

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -129,7 +129,8 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
 
   it = constraints.begin();
 
-  MeshType::PointType  iPt, oPt;
+  MeshType::PointType  iPt;
+  MeshType::PointType  oPt;
   MeshType::VectorType displacement;
 
   while (it != constraints.end())

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -140,7 +140,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   typename TTempImage::IndexType indexShift;
 
   // Temporary pixel storage
-  double pixelA, pixelB;
+  double pixelA;
+  double pixelB;
 
   // walk the output image forwards and compute blur
   for (unsigned int rep = 0; rep < m_Repetitions; ++rep)

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -117,9 +117,13 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
   A2[2] = static_cast<ScalarRealType>(0.3446);
   B2[2] = static_cast<ScalarRealType>(-2.2355);
 
-  ScalarRealType SD, DD, ED;
+  ScalarRealType SD;
+  ScalarRealType DD;
+  ScalarRealType ED;
   this->ComputeDCoefficients(sigmad, W1, L1, W2, L2, SD, DD, ED);
-  ScalarRealType SN, DN, EN;
+  ScalarRealType SN;
+  ScalarRealType DN;
+  ScalarRealType EN;
 
   switch (m_Order)
   {
@@ -169,10 +173,20 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       }
       // Approximation of convolution with the second derivative of a
       // Gaussian.
-      ScalarRealType N0_0, N1_0, N2_0, N3_0;
-      ScalarRealType N0_2, N1_2, N2_2, N3_2;
-      ScalarRealType SN0, DN0, EN0;
-      ScalarRealType SN2, DN2, EN2;
+      ScalarRealType N0_0;
+      ScalarRealType N1_0;
+      ScalarRealType N2_0;
+      ScalarRealType N3_0;
+      ScalarRealType N0_2;
+      ScalarRealType N1_2;
+      ScalarRealType N2_2;
+      ScalarRealType N3_2;
+      ScalarRealType SN0;
+      ScalarRealType DN0;
+      ScalarRealType EN0;
+      ScalarRealType SN2;
+      ScalarRealType DN2;
+      ScalarRealType EN2;
       ComputeNCoefficients(sigmad, A1[0], B1[0], W1, L1, A2[0], B2[0], W2, L2, N0_0, N1_0, N2_0, N3_0, SN0, DN0, EN0);
       ComputeNCoefficients(sigmad, A1[2], B1[2], W1, L1, A2[2], B2[2], W2, L2, N0_2, N1_2, N2_2, N3_2, SN2, DN2, EN2);
 

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
@@ -44,7 +44,8 @@ MaximumEntropyThresholdCalculator<THistogram, TOutput>::GenerateData()
   unsigned int size = histogram->GetSize(0);
 
   typename HistogramType::InstanceIdentifier threshold = 0;
-  int                                        ih, it;
+  int                                        ih;
+  int                                        it;
   int                                        first_bin;
   int                                        last_bin;
   double                                     tot_ent;          // total entropy

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
@@ -44,8 +44,17 @@ MomentsThresholdCalculator<THistogram, TOutput>::GenerateData()
   unsigned int size = histogram->GetSize(0);
 
   double                                     total = histogram->GetTotalFrequency();
-  double                                     m0 = 1.0, m1 = 0.0, m2 = 0.0, m3 = 0.0, sum = 0.0, p0 = 0.0;
-  double                                     cd, c0, c1, z0, z1; // auxiliary variables
+  double                                     m0 = 1.0;
+  double                                     m1 = 0.0;
+  double                                     m2 = 0.0;
+  double                                     m3 = 0.0;
+  double                                     sum = 0.0;
+  double                                     p0 = 0.0;
+  double                                     cd;
+  double                                     c0;
+  double                                     c1;
+  double                                     z0;
+  double                                     z1; // auxiliary variables
   typename HistogramType::InstanceIdentifier threshold = 0;
 
   std::vector<double> histo(size);

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
@@ -45,7 +45,8 @@ ShanbhagThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   const double                               tolerance = 2.220446049250313E-16;
   typename HistogramType::InstanceIdentifier threshold = 0;
-  int                                        ih, it;
+  int                                        ih;
+  int                                        it;
   int                                        first_bin;
   int                                        last_bin;
   double                                     term;

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
@@ -70,7 +70,8 @@ TriangleThresholdCalculator<THistogram, TOutput>::GenerateData()
     cumSum[j] = histogram->GetFrequency(j, 0) + cumSum[j - 1];
   }
 
-  typename HistogramType::MeasurementVectorType onePC(1), nnPC(1);
+  typename HistogramType::MeasurementVectorType onePC(1);
+  typename HistogramType::MeasurementVectorType nnPC(1);
   onePC.Fill(histogram->Quantile(0, 0.01));
   typename HistogramType::IndexType localIndex;
   histogram->GetIndex(onePC, localIndex);

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
@@ -44,7 +44,8 @@ YenThresholdCalculator<THistogram, TOutput>::GenerateData()
   unsigned int size = histogram->GetSize(0);
 
   typename HistogramType::InstanceIdentifier threshold = 0;
-  int                                        ih, it;
+  int                                        ih;
+  int                                        it;
   double                                     crit;
   double                                     max_crit;
   std::vector<double>                        norm_histo(size); // normalized histogram

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -82,7 +82,8 @@ BMPImageIO::CanReadFile(const char * filename)
     return false;
   }
 
-  char magic_number1, magic_number2;
+  char magic_number1;
+  char magic_number2;
   inputStream.read((char *)&magic_number1, sizeof(char));
   inputStream.read((char *)&magic_number2, sizeof(char));
 
@@ -341,7 +342,8 @@ BMPImageIO::Read(void * buffer)
 void
 BMPImageIO::ReadImageInformation()
 {
-  int   xsize, ysize;
+  int   xsize;
+  int   ysize;
   long  tmp;
   short stmp;
   long  infoSize;
@@ -351,7 +353,8 @@ BMPImageIO::ReadImageInformation()
   // Now check the content
   this->OpenFileForReading(m_Ifstream, m_FileName);
 
-  char magic_number1, magic_number2;
+  char magic_number1;
+  char magic_number2;
   m_Ifstream.read((char *)&magic_number1, sizeof(char));
   m_Ifstream.read((char *)&magic_number2, sizeof(char));
 

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -204,7 +204,8 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
   this->OpenFileForReading(file, m_FileName);
 
   // Find info...
-  bioradheader h, *p;
+  bioradheader   h;
+  bioradheader * p;
   p = &h;
   if (sizeof(h) != BIORAD_HEADER_LENGTH)
   {

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -708,7 +708,8 @@ GDCMImageIO::InternalReadImageInformation()
   }
 
   const double *     dircos = image.GetDirectionCosines();
-  vnl_vector<double> rowDirection(3), columnDirection(3);
+  vnl_vector<double> rowDirection(3);
+  vnl_vector<double> columnDirection(3);
   rowDirection[0] = dircos[0];
   rowDirection[1] = dircos[1];
   rowDirection[2] = dircos[2];

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -59,7 +59,10 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   // reader->GetOutput()->Print(std::cout);
 
   itk::MetaDataDictionary & dict = dicomIO->GetMetaDataDictionary();
-  std::string               tagkey, value, commatagkey, commavalue;
+  std::string               tagkey;
+  std::string               value;
+  std::string               commatagkey;
+  std::string               commavalue;
   tagkey = "0002|0002";
   value = "1.2.840.10008.5.1.4.1.1.4"; // Media Storage SOP Class UID
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -66,7 +66,8 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   auto namesGenerator = NamesGeneratorType::New();
 
   itk::MetaDataDictionary & dict = gdcmIO->GetMetaDataDictionary();
-  std::string               tagkey, value;
+  std::string               tagkey;
+  std::string               value;
   tagkey = "0008|0060"; // Modality
   value = "MR";
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -452,7 +452,9 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
 void
 GE5ImageIO::ModifyImageInformation()
 {
-  vnl_vector<double> dirx(3), diry(3), dirz(3);
+  vnl_vector<double> dirx(3);
+  vnl_vector<double> diry(3);
+  vnl_vector<double> dirz(3);
 
   // NOTE: itk use LPS coordinates while the GE system uses RAS
   // coordinates. Consequently, the R and A coordinates must be negated
@@ -509,7 +511,8 @@ GE5ImageIO::ModifyImageInformation()
     const std::unique_ptr<const GEImageHeader> hdr1{ this->ReadHeader(file1.c_str()) };
     const std::unique_ptr<const GEImageHeader> hdr2{ this->ReadHeader(file2.c_str()) };
 
-    float origin1[3], origin2[3];
+    float origin1[3];
+    float origin2[3];
     origin1[0] = hdr1->tlhcR;
     origin1[1] = hdr1->tlhcA;
     origin1[2] = hdr1->tlhcS;

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -1101,7 +1101,8 @@ HDF5ImageIO::WriteImageInformation()
     //
     // MetaData.
     MetaDataDictionary & metaDict = this->GetMetaDataDictionary();
-    auto                 it = metaDict.Begin(), end = metaDict.End();
+    auto                 it = metaDict.Begin();
+    auto                 end = metaDict.End();
     for (; it != end; ++it)
     {
       MetaDataObjectBase * metaObj = it->second.GetPointer();

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -258,7 +258,9 @@ IPLCommonImageIO::ReadImageInformation()
   // set direction cosines
   AnatomicalOrientation::DirectionType dir =
     AnatomicalOrientation(m_ImageHeader->coordinateOrientation).GetAsDirection();
-  std::vector<double> dirx(3, 0), diry(3, 0), dirz(3, 0);
+  std::vector<double> dirx(3, 0);
+  std::vector<double> diry(3, 0);
+  std::vector<double> dirz(3, 0);
   dirx[0] = dir[0][0];
   dirx[1] = dir[1][0];
   dirx[2] = dir[2][0];

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -448,7 +448,8 @@ JPEG2000ImageIO::Read(void * buffer)
                                                               << "Reason: opj_setup_decoder returns false");
   }
 
-  OPJ_INT32 l_tile_x0, l_tile_y0;
+  OPJ_INT32 l_tile_x0;
+  OPJ_INT32 l_tile_y0;
 
   OPJ_UINT32 l_tile_width;
   OPJ_UINT32 l_tile_height;
@@ -814,7 +815,8 @@ JPEG2000ImageIO::Write(const void * buffer)
 
   //--------------------------------------------------------
   // Copy the contents into the image structure
-  int w, h;
+  int w;
+  int h;
   w = this->m_Dimensions[0];
   h = this->m_Dimensions[1];
 

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -234,7 +234,10 @@ LSMImageIO::Write(const void * buffer)
 {
   const auto * outPtr = (const unsigned char *)buffer;
 
-  unsigned int width, height, page, pages = 1;
+  unsigned int width;
+  unsigned int height;
+  unsigned int page;
+  unsigned int pages = 1;
   if (this->GetNumberOfDimensions() < 2)
   {
     itkExceptionMacro("TIFF requires images to have at least 2 dimensions");

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -409,7 +409,8 @@ MINCImageIO::ReadImageInformation()
   }
 
   // voxel valid range
-  double valid_min, valid_max;
+  double valid_min;
+  double valid_max;
   // get the voxel valid range
   if (miget_volume_valid_range(m_MINCPImpl->m_Volume, &valid_max, &valid_min) < 0)
   {
@@ -417,7 +418,8 @@ MINCImageIO::ReadImageInformation()
   }
 
   // real volume range, only awailable when slice scaling is off
-  double volume_min = 0.0, volume_max = 1.0;
+  double volume_min = 0.0;
+  double volume_max = 1.0;
   if (!slice_scaling_flag)
   {
     if (miget_volume_range(m_MINCPImpl->m_Volume, &volume_max, &volume_min) < 0)
@@ -458,7 +460,8 @@ MINCImageIO::ReadImageInformation()
   Matrix<double, 3, 3> dir_cos{};
   dir_cos.SetIdentity();
 
-  Vector<double, 3> origin, sep;
+  Vector<double, 3> origin;
+  Vector<double, 3> sep;
   Vector<double, 3> o_origin;
   origin.Fill(0.0);
   o_origin.Fill(0.0);
@@ -478,7 +481,8 @@ MINCImageIO::ReadImageInformation()
       miget_dimension_size(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
 
       std::vector<double> _dir(3);
-      double              _sep, _start;
+      double              _sep;
+      double              _start;
 
       miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_sep);
       miget_dimension_cosines(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_dir[0]);
@@ -684,7 +688,8 @@ MINCImageIO::ReadImageInformation()
   if (m_MINCPImpl->m_DimensionIndices[4] != -1) // have time dimension
   {
     // store time dimension start and step in metadata for preservation
-    double _sep, _start;
+    double _sep;
+    double _start;
     miget_dimension_separation(
       m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_sep);
     miget_dimension_start(m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_start);
@@ -1126,7 +1131,8 @@ MINCImageIO::WriteImageInformation()
           if (!positive && dimension_order[i * 2 + 1] != 'V' &&
               dimension_order[i * 2 + 1] != 'v') // Vector dimension is always positive
           {
-            double   _sep, _start;
+            double   _sep;
+            double   _start;
             misize_t _sz;
 
             miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_sep);
@@ -1226,7 +1232,8 @@ MINCImageIO::WriteImageInformation()
     itkExceptionMacro("Could not set slice scaling flag");
   }
 
-  double valid_min, valid_max;
+  double valid_min;
+  double valid_max;
   miget_volume_valid_range(m_MINCPImpl->m_Volume, &valid_max, &valid_min);
 
   // by default valid range will be equal to range, to avoid scaling
@@ -1359,7 +1366,8 @@ MINCImageIO::Write(const void * buffer)
     buffer_length *= nComp;
   }
 
-  double   buffer_min, buffer_max;
+  double   buffer_min;
+  double   buffer_max;
   mitype_t volume_data_type = MI_TYPE_UBYTE;
 
   switch (this->GetComponentType())

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -737,7 +737,8 @@ MINCReadWriteTestVector(const char * fileName,
   }
 
   itk::ImageRegionIterator<ImageType> it2(im2, im2->GetLargestPossibleRegion());
-  InternalPixelType                   pix1, pix2;
+  InternalPixelType                   pix1;
+  InternalPixelType                   pix2;
   if (tolerance == 0.0)
   {
     for (it.GoToBegin(), it2.GoToBegin(); !it.IsAtEnd() && !it2.IsAtEnd(); ++it, ++it2)

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -808,7 +808,9 @@ MetaImageIO::Write(const void * buffer)
 
   if (numberOfDimensions == 3)
   {
-    std::vector<double>                  dirx, diry, dirz;
+    std::vector<double>                  dirx;
+    std::vector<double>                  diry;
+    std::vector<double>                  dirz;
     AnatomicalOrientation::DirectionType dir;
     dirx = this->GetDirection(0);
     diry = this->GetDirection(1);

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -433,7 +433,8 @@ TestImageOfSymMats(const std::string & fname)
               for (int k = 0; k < dims[0]; ++k)
               {
                 _index[0] = k;
-                PixelType p1, p2;
+                PixelType p1;
+                PixelType p2;
                 for (unsigned int q = 0; q < VDimension; ++q)
                 {
                   index[q] = _index[q];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -263,7 +263,8 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
               for (size_t k = 0; k < dims[0]; ++k)
               {
                 _index[0] = k;
-                FieldPixelType p1, p2;
+                FieldPixelType p1;
+                FieldPixelType p2;
                 for (size_t q = 0; q < TDimension; ++q)
                 {
                   index[q] = _index[q];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
@@ -77,7 +77,8 @@ itkNiftiImageIOTest6(int argc, char * argv[])
   itk::ImageRegionIterator<VectorImageType> readbackIt(readback, readback->GetLargestPossibleRegion());
   for (it.GoToBegin(), readbackIt.GoToBegin(); !it.IsAtEnd() && !readbackIt.IsAtEnd(); ++it, ++readbackIt)
   {
-    VectorImageType::PixelType p(vecLength), readbackP(vecLength);
+    VectorImageType::PixelType p(vecLength);
+    VectorImageType::PixelType readbackP(vecLength);
     p = it.Get();
     readbackP = readbackIt.Get();
     if (p != readbackP)

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -340,7 +340,10 @@ NrrdImageIO::ReadImageInformation()
     this->SetComponentType(cmpType);
 
     // Set the number of image dimensions and bail if needed
-    unsigned int domainAxisNum, domainAxisIdx[NRRD_DIM_MAX], rangeAxisNum, rangeAxisIdx[NRRD_DIM_MAX];
+    unsigned int domainAxisNum;
+    unsigned int domainAxisIdx[NRRD_DIM_MAX];
+    unsigned int rangeAxisNum;
+    unsigned int rangeAxisIdx[NRRD_DIM_MAX];
     domainAxisNum = nrrdDomainAxesGet(nrrd, domainAxisIdx);
     rangeAxisNum = nrrdRangeAxesGet(nrrd, rangeAxisIdx);
     if (nrrd->spaceDim && nrrd->spaceDim != domainAxisNum)
@@ -776,7 +779,8 @@ NrrdImageIO::Read(void * buffer)
   FloatingPointExceptions::SetEnabled(saveFPEState);
 #endif
 
-  unsigned int rangeAxisNum, rangeAxisIdx[NRRD_DIM_MAX];
+  unsigned int rangeAxisNum;
+  unsigned int rangeAxisIdx[NRRD_DIM_MAX];
   rangeAxisNum = nrrdRangeAxesGet(nrrd, rangeAxisIdx);
 
   if (rangeAxisNum > 1)
@@ -815,7 +819,9 @@ NrrdImageIO::Read(void * buffer)
         IOPixelEnum::SYMMETRICSECONDRANKTENSOR == this->GetPixelType())
     {
       // we crop out the mask and put the output in ITK-allocated "buffer"
-      size_t size[NRRD_DIM_MAX], minIdx[NRRD_DIM_MAX], maxIdx[NRRD_DIM_MAX];
+      size_t size[NRRD_DIM_MAX];
+      size_t minIdx[NRRD_DIM_MAX];
+      size_t maxIdx[NRRD_DIM_MAX];
       for (unsigned int axi = 0; axi < nrrd->dim; ++axi)
       {
         minIdx[axi] = (0 == axi) ? 1 : 0;
@@ -892,7 +898,9 @@ NrrdImageIO::Write(const void * buffer)
   NrrdIoState * nio = nrrdIoStateNew();
   int           kind[NRRD_DIM_MAX];
   size_t        size[NRRD_DIM_MAX];
-  unsigned int  nrrdDim, baseDim, spaceDim;
+  unsigned int  nrrdDim;
+  unsigned int  baseDim;
+  unsigned int  spaceDim;
   double        spaceDir[NRRD_DIM_MAX][NRRD_SPACE_DIM_MAX];
   double        origin[NRRD_DIM_MAX];
 
@@ -972,7 +980,8 @@ NrrdImageIO::Write(const void * buffer)
   MetaDataDictionary &                     thisDic = this->GetMetaDataDictionary();
   std::vector<std::string>                 keys = thisDic.GetKeys();
   std::vector<std::string>::const_iterator keyIt;
-  const char *                             keyField, *field;
+  const char *                             keyField;
+  const char *                             field;
   for (keyIt = keys.begin(); keyIt != keys.end(); ++keyIt)
   {
     if (!strncmp(KEY_PREFIX, keyIt->c_str(), strlen(KEY_PREFIX)))

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -174,9 +174,13 @@ PNGImageIO::Read(void * buffer)
 
   png_read_info(png_ptr, info_ptr);
 
-  png_uint_32 width, height;
-  int         bitDepth, colorType, interlaceType;
-  int         compression_type, filter_method;
+  png_uint_32 width;
+  png_uint_32 height;
+  int         bitDepth;
+  int         colorType;
+  int         interlaceType;
+  int         compression_type;
+  int         filter_method;
   png_get_IHDR(
     png_ptr, info_ptr, &width, &height, &bitDepth, &colorType, &interlaceType, &compression_type, &filter_method);
 
@@ -365,9 +369,13 @@ PNGImageIO::ReadImageInformation()
 
   png_read_info(png_ptr, info_ptr);
 
-  png_uint_32 width, height;
-  int         bitDepth, colorType, interlaceType;
-  int         compression_type, filter_method;
+  png_uint_32 width;
+  png_uint_32 height;
+  int         bitDepth;
+  int         colorType;
+  int         interlaceType;
+  int         compression_type;
+  int         filter_method;
   png_get_IHDR(
     png_ptr, info_ptr, &width, &height, &bitDepth, &colorType, &interlaceType, &compression_type, &filter_method);
 
@@ -593,8 +601,10 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
       break;
   }
 
-  png_uint_32 width, height;
-  double      rowSpacing, colSpacing;
+  png_uint_32 width;
+  png_uint_32 height;
+  double      rowSpacing;
+  double      colSpacing;
   width = this->GetDimensions(0);
   colSpacing = m_Spacing[0];
 

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -553,7 +553,9 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
     {
       struct image_info_defV3 tempInfo;
       struct image_info_defV3 tempInfo1;
-      float                   fovAP, fovFH, fovRL;
+      float                   fovAP;
+      float                   fovFH;
+      float                   fovRL;
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
       strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));
@@ -1045,7 +1047,9 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
     {
       struct image_info_defV4 tempInfo;
       struct image_info_defV4 tempInfo1;
-      float                   fovAP, fovFH, fovRL;
+      float                   fovAP;
+      float                   fovFH;
+      float                   fovRL;
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
       strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -744,7 +744,8 @@ PhilipsRECImageIO::ReadImageInformation()
 
   AffineMatrix direction;
   direction.SetIdentity();
-  int rows, columns;
+  int rows;
+  int columns;
   for (rows = 0; rows < 3; ++rows)
   {
     for (columns = 0; columns < 3; ++columns)
@@ -827,8 +828,10 @@ PhilipsRECImageIO::ReadImageInformation()
   std::cout << "Final direction cosines after rotation = " << direction << std::endl;
 #endif
 
-  std::vector<double> dirx(numberOfDimensions, 0), diry(numberOfDimensions, 0), dirz(numberOfDimensions, 0),
-    dirBlock(numberOfDimensions, 0);
+  std::vector<double> dirx(numberOfDimensions, 0);
+  std::vector<double> diry(numberOfDimensions, 0);
+  std::vector<double> dirz(numberOfDimensions, 0);
+  std::vector<double> dirBlock(numberOfDimensions, 0);
   dirBlock[numberOfDimensions - 1] = 1;
   dirx[0] = direction[0][0];
   dirx[1] = direction[1][0];

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -116,7 +116,12 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   hdr->name[HDR_PAT_NAME_LEN] = '\0';
   DB(hdr->name);
 
-  int year, month, day, hour, minute, second;
+  int year;
+  int month;
+  int day;
+  int hour;
+  int minute;
+  int second;
 
   this->GetIntAt(f, HDR_REG_YEAR, &year);
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -119,7 +119,9 @@ TIFFImageIO::GetFormat()
         {
           for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
           {
-            uint16_t red, green, blue;
+            uint16_t red;
+            uint16_t green;
+            uint16_t blue;
             this->GetColor(cc, &red, &green, &blue);
             if (red != green || red != blue)
             {
@@ -301,7 +303,9 @@ TIFFImageIO::InitializeColors()
     return;
   }
 
-  unsigned short *red_orig, *green_orig, *blue_orig;
+  unsigned short * red_orig;
+  unsigned short * green_orig;
+  unsigned short * blue_orig;
   if (!TIFFGetField(m_InternalImage->m_Image, TIFFTAG_COLORMAP, &red_orig, &green_orig, &blue_orig))
   {
     return;
@@ -466,7 +470,9 @@ TIFFImageIO::ReadImageInformation()
     // detect if palette appears to be 8-bit or 16-bit
     for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
     {
-      uint16_t red, green, blue;
+      uint16_t red;
+      uint16_t green;
+      uint16_t blue;
       this->GetColor(cc, &red, &green, &blue);
       if (red > 255 || green > 255 || blue > 255)
       {
@@ -566,7 +572,8 @@ TIFFImageIO::InternalWrite(const void * buffer)
 {
   const auto * outPtr = static_cast<const char *>(buffer);
 
-  uint16_t page, pages = 1;
+  uint16_t page;
+  uint16_t pages = 1;
 
   const SizeValueType width = m_Dimensions[0];
   const SizeValueType height = m_Dimensions[1];
@@ -967,7 +974,9 @@ TIFFImageIO::PopulateColorPalette()
     m_ColorPalette.resize(m_TotalColors);
     for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
     {
-      uint16_t red, green, blue;
+      uint16_t red;
+      uint16_t green;
+      uint16_t blue;
       this->GetColor(cc, &red, &green, &blue);
 
       RGBPixelType p;

--- a/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
@@ -36,7 +36,8 @@ itkIOEuler3DTransformTxtTest(int argc, char * argv[])
   itk::ObjectFactoryBase::RegisterFactory(itk::TxtTransformIOFactory::New());
 
   using TransformType = itk::Euler3DTransform<double>;
-  TransformType::Pointer oldStyleInput, newStyleInput;
+  TransformType::Pointer oldStyleInput;
+  TransformType::Pointer newStyleInput;
 
   using ReaderType = itk::TransformFileReaderTemplate<double>;
   auto reader = ReaderType::New();

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -57,7 +57,9 @@ InitializationBiasedParticleSwarmOptimizer::UpdateSwarm()
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {
     ParticleData &            p = m_Particles[j];
-    ParametersType::ValueType phi1, phi2, phi3;
+    ParametersType::ValueType phi1;
+    ParametersType::ValueType phi2;
+    ParametersType::ValueType phi3;
     phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
     phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
     phi3 = randomGenerator->GetVariateWithClosedRange() * initializationCoefficient;

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -201,7 +201,8 @@ LevenbergMarquardtOptimizer::GetOptimizer() const
 std::string
 LevenbergMarquardtOptimizer::GetStopConditionDescription() const
 {
-  std::ostringstream reason, outcome;
+  std::ostringstream reason;
+  std::ostringstream outcome;
 
   outcome.str("");
   if (GetOptimizer())

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -54,7 +54,8 @@ ParticleSwarmOptimizer::UpdateSwarm()
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {
     ParticleData &            p = m_Particles[j];
-    ParametersType::ValueType phi1, phi2;
+    ParametersType::ValueType phi1;
+    ParametersType::ValueType phi2;
     phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
     phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
     for (unsigned int k = 0; k < n; ++k)

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -152,7 +152,8 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Maximal number of iterations: " << this->m_MaximalNumberOfIterations << '\n';
   os << indent << "Number of generations with minimal improvement: ";
   os << this->m_NumberOfGenerationsWithMinimalImprovement << '\n';
-  ParameterBoundsType::const_iterator it, end = this->m_ParameterBounds.end();
+  ParameterBoundsType::const_iterator it;
+  ParameterBoundsType::const_iterator end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
   for (it = this->m_ParameterBounds.begin(); it != end; ++it)
   {
@@ -179,7 +180,8 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 void
 ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
 {
-  std::vector<ParticleData>::const_iterator it, end = this->m_Particles.end();
+  std::vector<ParticleData>::const_iterator it;
+  std::vector<ParticleData>::const_iterator end = this->m_Particles.end();
   os << indent << "[\n";
   for (it = this->m_Particles.begin(); it != end; ++it)
   {
@@ -342,7 +344,8 @@ ParticleSwarmOptimizerBase::ValidateSettings()
     {
       itkExceptionMacro("cost function and particle data dimensions mismatch");
     }
-    std::vector<ParticleData>::iterator it, end = this->m_Particles.end();
+    std::vector<ParticleData>::iterator it;
+    std::vector<ParticleData>::iterator end = this->m_Particles.end();
     for (it = this->m_Particles.begin(); it != end; ++it)
     {
       ParticleData & p = (*it);

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -431,9 +431,15 @@ PowellOptimizer::StartOptimization()
   pt = p;
 
   unsigned int ibig;
-  double       fp, del, fptt;
-  double       ax, xx, bx;
-  double       fa, fx, fb;
+  double       fp;
+  double       del;
+  double       fptt;
+  double       ax;
+  double       xx;
+  double       bx;
+  double       fa;
+  double       fx;
+  double       fb;
 
   xx = 0;
   this->SetLine(p, xit);

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -502,7 +502,8 @@ AmoebaTest2()
   itkOptimizer->SetInitialSimplexDelta(initialSimplexDelta);
   ITK_TEST_SET_GET_VALUE(initialSimplexDelta, itkOptimizer->GetInitialSimplexDelta());
 
-  OptimizerType::ParametersType initialParameters(1), finalParameters;
+  OptimizerType::ParametersType initialParameters(1);
+  OptimizerType::ParametersType finalParameters;
   // starting position
   initialParameters[0] = -100;
 

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -81,9 +81,12 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
     initalizationBasedTestVerboseFlag = std::stoi(argv[5]) ? true : false;
   }
 
-  unsigned int i, allIterations = 10;
+  unsigned int i;
+  unsigned int allIterations = 10;
   double       threshold = 0.8;
-  unsigned int success1, success2, success3;
+  unsigned int success1;
+  unsigned int success2;
+  unsigned int success3;
 
   std::cout << "Initialization Biased Particle Swarm Optimizer Test \n \n";
 
@@ -168,7 +171,8 @@ IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
   unsigned int                  maxIterations = 200;
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
-  OptimizerType::ParametersType initialParameters(1), finalParameters;
+  OptimizerType::ParametersType initialParameters(1);
+  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -295,7 +299,8 @@ IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
   unsigned int                  maxIterations = 200;
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
-  OptimizerType::ParametersType initialParameters(2), finalParameters;
+  OptimizerType::ParametersType initialParameters(2);
+  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -394,7 +399,8 @@ IBPSOTest3(typename OptimizerType::CoefficientType inertiaCoefficient,
   unsigned int                  maxIterations = 1000;
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.01;
-  OptimizerType::ParametersType initialParameters(2), finalParameters;
+  OptimizerType::ParametersType initialParameters(2);
+  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -66,9 +66,12 @@ itkParticleSwarmOptimizerTest(int argc, char * argv[])
     verboseFlag = std::stoi(argv[1]) ? true : false;
   }
 
-  unsigned int i, allIterations = 10;
+  unsigned int i;
+  unsigned int allIterations = 10;
   double       threshold = 0.8;
-  unsigned int success1, success2, success3;
+  unsigned int success1;
+  unsigned int success2;
+  unsigned int success3;
 
   std::cout << "Particle Swarm Optimizer Test \n \n";
 
@@ -125,7 +128,8 @@ PSOTest1()
   unsigned int                  maxIterations = 100;
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
-  OptimizerType::ParametersType initialParameters(1), finalParameters;
+  OptimizerType::ParametersType initialParameters(1);
+  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -224,7 +228,8 @@ PSOTest2()
   unsigned int                  maxIterations = 100;
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
-  OptimizerType::ParametersType initialParameters(2), finalParameters;
+  OptimizerType::ParametersType initialParameters(2);
+  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -511,7 +511,9 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
       !this->GetVirtualSpacing().GetVnlVector().is_equal(field->GetSpacing().GetVnlVector(), coordinateTol) ||
       !this->GetVirtualDirection().GetVnlMatrix().is_equal(field->GetDirection().GetVnlMatrix(), directionTol))
   {
-    std::ostringstream originString, spacingString, directionString;
+    std::ostringstream originString;
+    std::ostringstream spacingString;
+    std::ostringstream directionString;
     originString << "Virtual Origin: " << this->GetVirtualOrigin()
                  << ", DisplacementField Origin: " << field->GetOrigin() << std::endl;
     spacingString << "Virtual Spacing: " << this->GetVirtualSpacing()

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -425,9 +425,15 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
   pt = p;
 
   unsigned int ibig;
-  double       fp, del, fptt;
-  double       ax, xx, bx;
-  double       fa, fx, fb;
+  double       fp;
+  double       del;
+  double       fptt;
+  double       ax;
+  double       xx;
+  double       bx;
+  double       fa;
+  double       fx;
+  double       fb;
 
   xx = 0;
   this->SetLine(p, xit);

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -444,7 +444,9 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex() ->
   VirtualRegionType   region = this->m_Metric->GetVirtualRegion();
   const SizeValueType dim = this->GetDimension();
 
-  VirtualIndexType lowerIndex, upperIndex, centralIndex;
+  VirtualIndexType lowerIndex;
+  VirtualIndexType upperIndex;
+  VirtualIndexType centralIndex;
   lowerIndex = region.GetIndex();
   upperIndex = region.GetUpperIndex();
 
@@ -465,7 +467,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion() -
   VirtualRegionType   region = this->m_Metric->GetVirtualRegion();
   const SizeValueType dim = this->GetDimension();
 
-  VirtualIndexType lowerIndex, upperIndex;
+  VirtualIndexType lowerIndex;
+  VirtualIndexType upperIndex;
   lowerIndex = region.GetIndex();
   upperIndex = region.GetUpperIndex();
 

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -499,7 +499,8 @@ AmoebaTest2()
   itkOptimizer->SetInitialSimplexDelta(initialSimplexDelta);
   ITK_TEST_SET_GET_VALUE(initialSimplexDelta, itkOptimizer->GetInitialSimplexDelta());
 
-  OptimizerType::ParametersType initialParameters(1), finalParameters;
+  OptimizerType::ParametersType initialParameters(1);
+  OptimizerType::ParametersType finalParameters;
   // starting position
   initialParameters[0] = -100;
 

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -214,7 +214,8 @@ MultivariateLegendrePolynomial::LegendreSum(const double x, int n, const Coeffic
     return coef[offset];
   }
 
-  double ykp2 = 0, ykp1 = coef[n + offset];
+  double ykp2 = 0;
+  double ykp1 = coef[n + offset];
 
   for (int k = n - 1; k > 0; k--)
   {

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
@@ -38,7 +38,8 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     measurementVectorSize,
     "EuclideanSquareDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp, distance = 0.0;
+  double temp;
+  double distance = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
@@ -61,7 +62,8 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     itkExceptionMacro("EuclideanSquareDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp, distance = 0.0;
+  double temp;
+  double distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     temp = x1[i] - x2[i];

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -285,7 +285,8 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::UpdateProportions()
   size_t numberOfComponents = m_ComponentVector.size();
   size_t sampleSize = m_Sample->Size();
   auto   totalFrequency = static_cast<double>(m_Sample->GetTotalFrequency());
-  size_t i, j;
+  size_t i;
+  size_t j;
   double tempSum;
   bool   updated = false;
 

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
@@ -88,7 +88,8 @@ GaussianMixtureModelComponent<TSample>::SetParameters(const ParametersType & par
   Superclass::SetParameters(parameters);
 
   unsigned int paramIndex = 0;
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   bool changed = false;
 
@@ -137,7 +138,8 @@ template <typename TSample>
 double
 GaussianMixtureModelComponent<TSample>::CalculateParametersChange()
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   typename MeanVectorType::MeasurementVectorType meanEstimate = m_MeanEstimator->GetMean();
 
@@ -192,7 +194,8 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
   m_MeanEstimator->SetWeights(weights);
   m_MeanEstimator->Update();
 
-  MeasurementVectorSizeType i, j;
+  MeasurementVectorSizeType i;
+  MeasurementVectorSizeType j;
   double                    temp;
   double                    changes;
   bool                      changed = false;

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -605,7 +605,9 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
   double             cumulated = 0;
   auto               totalFrequency = static_cast<double>(this->GetTotalFrequency());
   double             binProportion;
-  double             min, max, interval;
+  double             min;
+  double             max;
+  double             interval;
 
   if (p < 0.5)
   {

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -230,7 +230,8 @@ protected:
     void
     UpdateCentroids()
     {
-      unsigned int i, j;
+      unsigned int i;
+      unsigned int j;
 
       for (i = 0; i < static_cast<unsigned int>(this->Size()); ++i)
       {

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -136,7 +136,8 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
                                             MeasurementVectorType & lowerBound,
                                             MeasurementVectorType & upperBound)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   typename TKdTree::InstanceIdentifier tempId;
   int                                  closest;
@@ -258,7 +259,8 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(ParametersType & source, InternalParametersType & target)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   int          index = 0;
 
   for (i = 0; i < static_cast<unsigned int>(source.size() / m_MeasurementVectorSize); ++i)
@@ -275,7 +277,8 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(InternalParametersType & source, ParametersType & target)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   int          index = 0;
 
   for (i = 0; i < static_cast<unsigned int>(source.size()); ++i)
@@ -292,7 +295,8 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(InternalParametersType & source, InternalParametersType & target)
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   for (i = 0; i < static_cast<unsigned int>(source.size()); ++i)
   {

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
@@ -37,7 +37,8 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x) cons
                                   measurementVectorSize,
                                   "ManhattanDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp, distance = 0.0;
+  double temp;
+  double distance = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
@@ -58,7 +59,8 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
     itkExceptionMacro("ManhattanDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp, distance = 0.0;
+  double temp;
+  double distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     temp = itk::Math::abs(x1[i] - x2[i]);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -120,7 +120,8 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
 
   // For each offset, calculate each feature
   typename OffsetVector::ConstIterator offsetIt;
-  size_t                               offsetNum, featureNum;
+  size_t                               offsetNum;
+  size_t                               featureNum;
   using InternalRunLengthFeatureName = itk::Statistics::RunLengthFeatureEnum;
 
   for (offsetIt = this->m_Offsets->Begin(), offsetNum = 0; offsetIt != this->m_Offsets->End(); ++offsetIt, offsetNum++)

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -120,7 +120,8 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
 
   // For each offset, calculate each feature
   typename OffsetVector::ConstIterator offsetIt;
-  size_t                               offsetNum, featureNum;
+  size_t                               offsetNum;
+  size_t                               featureNum;
   using InternalTextureFeatureName = itk::Statistics::HistogramToTextureFeaturesFilterEnums::TextureFeature;
 
   for (offsetIt = m_Offsets->Begin(), offsetNum = 0; offsetIt != m_Offsets->End(); ++offsetIt, offsetNum++)

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -208,7 +208,11 @@ GaussianDistribution::CDF(double x, const ParametersType & p)
 double
 GaussianDistribution::InverseCDF(double p)
 {
-  double dp, dx, dt, ddq, dq;
+  double dp;
+  double dx;
+  double dt;
+  double ddq;
+  double dq;
   int    newt;
 
   dp = (p <= 0.5) ? (p) : (1.0 - p); /* make between 0 and 0.5 */

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -61,7 +61,8 @@ MaximumRatioDecisionRule::SetPriorProbabilities(const PriorProbabilityVectorType
   }
   else
   {
-    PriorProbabilityVectorType::const_iterator pit, it;
+    PriorProbabilityVectorType::const_iterator pit;
+    PriorProbabilityVectorType::const_iterator it;
 
     for (pit = p.begin(), it = m_PriorProbabilities.begin(); pit != p.end(); ++pit, ++it)
     {
@@ -93,7 +94,8 @@ MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScor
   if (uniformPrior)
   {
     // find the maximum discriminant score. if list is empty, return 0.
-    ClassIdentifierType i, besti = 0;
+    ClassIdentifierType i;
+    ClassIdentifierType besti = 0;
     MembershipValueType best = NumericTraits<MembershipValueType>::NonpositiveMin();
     for (i = 0; i < discriminantScores.size(); ++i)
     {
@@ -108,7 +110,8 @@ MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScor
 
   // Non-uniform prior case
   // find the maximum p(x|i)*p(i)
-  ClassIdentifierType i, besti = 0;
+  ClassIdentifierType i;
+  ClassIdentifierType besti = 0;
   MembershipValueType best = NumericTraits<MembershipValueType>::NonpositiveMin();
   MembershipValueType temp = NumericTraits<MembershipValueType>::NonpositiveMin();
 

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -100,7 +100,8 @@ double
 TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
 {
   double bx;
-  double pin, qin;
+  double pin;
+  double qin;
   double dof;
 
   // Based on Abramowitz and Stegun 26.7.1, which gives the probability
@@ -166,8 +167,15 @@ TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   }
 
   double x;
-  double dof, dof2, dof3, dof4;
-  double gaussX, gaussX3, gaussX5, gaussX7, gaussX9;
+  double dof;
+  double dof2;
+  double dof3;
+  double dof4;
+  double gaussX;
+  double gaussX3;
+  double gaussX5;
+  double gaussX7;
+  double gaussX9;
 
   // Based on Abramowitz and Stegun 26.7.5
   dof = static_cast<double>(degreesOfFreedom);

--- a/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
@@ -42,7 +42,8 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
   }
 
 
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
   char *       dataFileName = argv[1];
   int          dataSize = 2000;
   int          maximumIteration = 200;

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -203,7 +203,11 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
     two_two[0] = 2;
     two_two[1] = 2;
 
-    float ooF, otF, toF, ttF, totalF;
+    float ooF;
+    float otF;
+    float toF;
+    float ttF;
+    float totalF;
     ooF = hist->GetFrequency(one_one);
     otF = hist->GetFrequency(one_two);
     toF = hist->GetFrequency(two_one);
@@ -335,7 +339,8 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
     one_zero[0] = 1;
     one_zero[1] = 0;
 
-    float zoF, ozF;
+    float zoF;
+    float ozF;
     zzF = hist3->GetFrequency(zero_zero);
     zoF = hist3->GetFrequency(zero_one);
     ozF = hist3->GetFrequency(one_zero);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -162,7 +162,11 @@ itkScalarImageToCooccurrenceMatrixFilterTest2(int, char *[])
     two_two[0] = 2;
     two_two[1] = 2;
 
-    float ooF, otF, toF, ttF, totalF;
+    float ooF;
+    float otF;
+    float toF;
+    float ttF;
+    float totalF;
     ooF = hist->GetFrequency(one_one);
     otF = hist->GetFrequency(one_two);
     toF = hist->GetFrequency(two_one);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -196,7 +196,8 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       passed = false;
     }
 
-    RunLengthFilterType::FeatureValueVectorPointer means, stds;
+    RunLengthFilterType::FeatureValueVectorPointer means;
+    RunLengthFilterType::FeatureValueVectorPointer stds;
     means = texFilter->GetFeatureMeans();
     stds = texFilter->GetFeatureStandardDeviations();
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -195,7 +195,8 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       passed = false;
     }
 
-    TextureFilterType::FeatureValueVectorPointer means, stds;
+    TextureFilterType::FeatureValueVectorPointer means;
+    TextureFilterType::FeatureValueVectorPointer stds;
     means = texFilter->GetFeatureMeans();
     stds = texFilter->GetFeatureStandardDeviations();
 

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -233,7 +233,9 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreaderCallback(void * arg)
 {
   ThreadStruct * str;
-  ThreadIdType   total, workUnitID, workUnitCount;
+  ThreadIdType   total;
+  ThreadIdType   workUnitID;
+  ThreadIdType   workUnitCount;
 
   workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -151,7 +151,8 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetSchedule(const 
   }
 
   this->Modified();
-  unsigned int level, dim;
+  unsigned int level;
+  unsigned int dim;
   for (level = 0; level < m_NumberOfLevels; ++level)
   {
     for (dim = 0; dim < ImageDimension; ++dim)
@@ -177,7 +178,8 @@ template <typename TInputImage, typename TOutputImage>
 bool
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::IsScheduleDownwardDivisible(const ScheduleType & schedule)
 {
-  unsigned int ilevel, idim;
+  unsigned int ilevel;
+  unsigned int idim;
 
   for (ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
   {
@@ -245,7 +247,8 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   shrinkerFilter->SetInput(smoother->GetOutput());
 
-  unsigned int ilevel, idim;
+  unsigned int ilevel;
+  unsigned int idim;
   unsigned int factors[ImageDimension];
   double       variance[ImageDimension];
 
@@ -393,7 +396,8 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
     itkExceptionMacro("Could not cast refOutput to TOutputImage*.");
   }
 
-  unsigned int ilevel, idim;
+  unsigned int ilevel;
+  unsigned int idim;
 
   if (ptr->GetRequestedRegion() == ptr->GetLargestPossibleRegion())
   {

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -237,7 +237,8 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   using IndexType = typename OutputImageType::IndexType;
   using RegionType = typename OutputImageType::RegionType;
 
-  int          ilevel, idim;
+  int          ilevel;
+  int          idim;
   unsigned int factors[ImageDimension];
 
   typename TInputImage::SizeType radius;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -167,7 +167,8 @@ itkImageRegistrationMethodTest_14(int, char *[])
   }
 
   itk::Point<double, dimension>  p;
-  itk::Vector<double, dimension> d, d2;
+  itk::Vector<double, dimension> d;
+  itk::Vector<double, dimension> d2;
 
   MovingImageIterator mIter(movingImage, region);
   FixedImageIterator  fIter(fixedImage, region);

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
@@ -176,7 +176,16 @@ DoRegistration()
 int
 itkImageRegistrationMethodTest_16(int itkNotUsed(argc), char *[] itkNotUsed(argv))
 {
-  bool result_uc, result_c, result_us, result_s, result_ui, result_i, result_ul, result_l, result_f, result_d;
+  bool result_uc;
+  bool result_c;
+  bool result_us;
+  bool result_s;
+  bool result_ui;
+  bool result_i;
+  bool result_ul;
+  bool result_l;
+  bool result_f;
+  bool result_d;
   result_uc = DoRegistration<unsigned char>();
   result_c = DoRegistration<char>();
   result_us = DoRegistration<unsigned short>();

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -380,7 +380,8 @@ itkLandmarkBasedTransformInitializerTest(int, char *[])
 
       for (unsigned int i = 0; i < numWorkingLandmark; ++i)
       {
-        TransformInitializerType::LandmarkPointType fixedPoint, movingPoint;
+        TransformInitializerType::LandmarkPointType fixedPoint;
+        TransformInitializerType::LandmarkPointType movingPoint;
 
         for (unsigned int j = 0; j < 3; ++j)
         {
@@ -409,7 +410,8 @@ itkLandmarkBasedTransformInitializerTest(int, char *[])
 
       for (unsigned int i = 0; i < numDummyLandmark; ++i)
       {
-        TransformInitializerType::LandmarkPointType fixedPoint, movingPoint;
+        TransformInitializerType::LandmarkPointType fixedPoint;
+        TransformInitializerType::LandmarkPointType movingPoint;
 
         for (unsigned int j = 0; j < 3; ++j)
         {

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -332,7 +332,8 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   // for parameters[4] = {-10,10} (arbitrary choice)
   //---------------------------------------------------------
 
-  typename MetricType::MeasureType    measure, measure2;
+  typename MetricType::MeasureType    measure;
+  typename MetricType::MeasureType    measure2;
   typename MetricType::DerivativeType derivative(numberOfParameters);
 
   std::cout << "param[4]\tMI\tMI2\tdMI/dparam[4]" << std::endl;
@@ -599,7 +600,8 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   // for parameters between {-10,10} (arbitrary choice)
   //---------------------------------------------------------
 
-  typename MetricType::MeasureType    measure, measure2;
+  typename MetricType::MeasureType    measure;
+  typename MetricType::MeasureType    measure2;
   typename MetricType::DerivativeType derivative(numberOfParameters);
   unsigned int                        q = numberOfParameters / 4;
 

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -140,7 +140,8 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   }
 
   itk::Point<double, dimension>  p;
-  itk::Vector<double, dimension> d, d2;
+  itk::Vector<double, dimension> d;
+  itk::Vector<double, dimension> d2;
 
   MovingImageIterator mIter(movingImage, region);
   FixedImageIterator  fIter(fixedImage, region);

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -183,7 +183,8 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   // set image origin to be center of the image
   double       transCenter[3];
-  unsigned int j, k;
+  unsigned int j;
+  unsigned int k;
   for (j = 0; j < 3; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]) * spacing[j];

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -160,7 +160,8 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   // check the schedule
   ScheduleType schedule(numLevels, ImageDimension);
-  unsigned int j, k;
+  unsigned int j;
+  unsigned int k;
 
   for (k = 0; k < numLevels; ++k)
   {

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -164,7 +164,8 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
     for (SizeValueType indct = i; indct < hoodlen; indct += (diameter + NumericTraits<SizeValueType>::OneValue()))
     {
-      typename ScanIteratorType::OffsetType internalIndex, offset;
+      typename ScanIteratorType::OffsetType internalIndex;
+      typename ScanIteratorType::OffsetType offset;
       bool                                  isInBounds = scanIt.IndexInBounds(indct, internalIndex, offset);
       if (!isInBounds)
       {
@@ -248,7 +249,8 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
   for (SizeValueType indct = diameter; indct < hoodlen; indct += (diameter + NumericTraits<SizeValueType>::OneValue()))
   {
-    typename ScanIteratorType::OffsetType internalIndex, offset;
+    typename ScanIteratorType::OffsetType internalIndex;
+    typename ScanIteratorType::OffsetType offset;
     bool                                  isInBounds = scanIt.IndexInBounds(indct, internalIndex, offset);
 
     if (!isInBounds)

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -132,7 +132,8 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
   /* For global transforms, compute the derivatives by combining values from each region. */
   if (this->m_CorrelationAssociate->GetComputeDerivative())
   {
-    DerivativeType fdm, mdm;
+    DerivativeType fdm;
+    DerivativeType mdm;
     fdm.SetSize(globalDerivativeSize);
     mdm.SetSize(globalDerivativeSize);
 

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -350,7 +350,9 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   2- The MI energy is bounded in the range of [0  min(H(x),H(y))].
   3- The ComputeMutualInformation() iterator range should cover the entire PDF.
   4- The normalization is done based on NumberOfHistogramBins-1 instead of NumberOfHistogramBins. */
-  TInternalComputationValueType                       px, py, pxy;
+  TInternalComputationValueType                       px;
+  TInternalComputationValueType                       py;
+  TInternalComputationValueType                       pxy;
   CompensatedSummation<TInternalComputationValueType> total_mi;
   TInternalComputationValueType                       local_mi;
   TInternalComputationValueType                       eps = NumericTraits<TInternalComputationValueType>::epsilon();

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -366,7 +366,8 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   DisplacementTransformType::ParametersType parameters(transformMdisplacement->GetNumberOfParameters());
   parameters.Fill(static_cast<DisplacementTransformType::ParametersValueType>(1000.0));
   transformMdisplacement->SetParameters(parameters);
-  MetricType::MeasureType expectedMetricMax, valueReturn;
+  MetricType::MeasureType expectedMetricMax;
+  MetricType::MeasureType valueReturn;
   expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
   metric->GetValueAndDerivative(valueReturn, derivativeReturn);

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -66,7 +66,8 @@ itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(TMetricPointer &  me
   }
 
   // Evaluate with GetValueAndDerivative
-  typename MetricType::MeasureType    valueReturn1, valueReturn2;
+  typename MetricType::MeasureType    valueReturn1;
+  typename MetricType::MeasureType    valueReturn2;
   typename MetricType::DerivativeType derivativeReturn;
 
   try
@@ -213,8 +214,10 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   metric->SetFixedTransform(fixedTransform);
   metric->SetMovingTransform(movingTransform);
 
-  MetricType::MeasureType    value1, value2;
-  MetricType::DerivativeType derivative1, derivative2;
+  MetricType::MeasureType    value1;
+  MetricType::MeasureType    value2;
+  MetricType::DerivativeType derivative1;
+  MetricType::DerivativeType derivative2;
   int                        ret;
   int                        result = EXIT_SUCCESS;
 
@@ -257,7 +260,8 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   MovingTransformType::ParametersType parameters(imageDimensionality);
   parameters.Fill(static_cast<MovingTransformType::ParametersValueType>(1000));
   movingTransform->SetParameters(parameters);
-  MetricType::MeasureType    expectedMetricMax, valueReturn;
+  MetricType::MeasureType    expectedMetricMax;
+  MetricType::MeasureType    valueReturn;
   MetricType::DerivativeType derivativeReturn;
   expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -206,7 +206,8 @@ itkDemonsImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   {
     using PointType = PointSetType::PointType;
     PointSetType::Pointer                             pset(PointSetType::New());
-    unsigned long                                     ind = 0, ct = 0;
+    unsigned long                                     ind = 0;
+    unsigned long                                     ct = 0;
     itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
     for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -136,7 +136,8 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   }
 
   // Evaluate with GetValueAndDerivative
-  MetricType::MeasureType    valueReturn1, valueReturn2;
+  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
 
   try

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -80,8 +80,10 @@ itkEuclideanDistancePointSetMetricTestRun()
   metric->SetMovingTransform(translationTransform);
   metric->Initialize();
 
-  typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-  typename PointSetMetricType::DerivativeType derivative, derivative2;
+  typename PointSetMetricType::MeasureType    value = metric->GetValue();
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
   metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -136,8 +136,10 @@ itkEuclideanDistancePointSetMetricTest2Run()
   metric->Initialize();
 
   // test
-  typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-  typename PointSetMetricType::DerivativeType derivative, derivative2;
+  typename PointSetMetricType::MeasureType    value = metric->GetValue();
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
   metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -122,8 +122,10 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
   metric->Initialize();
 
   // test
-  typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-  typename PointSetMetricType::DerivativeType derivative, derivative2;
+  typename PointSetMetricType::MeasureType    value = metric->GetValue();
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
   metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -90,8 +90,10 @@ itkExpectationBasedPointSetMetricTestRun()
   metric->SetMovingTransform(translationTransform);
   metric->Initialize();
 
-  typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-  typename PointSetMetricType::DerivativeType derivative, derivative2;
+  typename PointSetMetricType::MeasureType    value = metric->GetValue();
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
   metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -129,7 +129,8 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
     using PointSetType = typename TMetric::FixedSampledPointSetType;
     using PointType = typename PointSetType::PointType;
     typename PointSetType::Pointer            pset(PointSetType::New());
-    itk::SizeValueType                        ind = 0, ct = 0;
+    itk::SizeValueType                        ind = 0;
+    itk::SizeValueType                        ct = 0;
     itk::ImageRegionIteratorWithIndex<TImage> itS(fixedImage, fixedImage->GetLargestPossibleRegion());
     for (itS.GoToBegin(); !itS.IsAtEnd(); ++itS)
     {

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -316,7 +316,8 @@ ImageToImageMetricv4TestRunSingleTest(const ImageToImageMetricv4TestMetricPointe
 {
   int result = EXIT_SUCCESS;
 
-  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn1, valueReturn2;
+  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn1;
+  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn2;
   ImageToImageMetricv4TestMetricType::DerivativeType derivativeReturn;
 
   // Initialize.

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -129,8 +129,10 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
 
     metric->Initialize();
 
-    typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-    typename PointSetMetricType::DerivativeType derivative, derivative2;
+    typename PointSetMetricType::MeasureType    value = metric->GetValue();
+    typename PointSetMetricType::MeasureType    value2;
+    typename PointSetMetricType::DerivativeType derivative;
+    typename PointSetMetricType::DerivativeType derivative2;
     metric->GetDerivative(derivative);
     metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -114,7 +114,8 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
 
 
   // Evaluate
-  MetricType::MeasureType    valueReturn1, valueReturn2;
+  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
 
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn1 = metric->GetValue());

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -243,7 +243,8 @@ itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, char * 
 
   using PointType = PointSetType::PointType;
   PointSetType::Pointer                             pset(PointSetType::New());
-  unsigned long                                     ind = 0, ct = 0;
+  unsigned long                                     ind = 0;
+  unsigned long                                     ct = 0;
   itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
   {

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -102,8 +102,10 @@ itkLabeledPointSetMetricTestRun()
   metric->SetMovingTransform(translationTransform);
   metric->Initialize();
 
-  typename PointSetMetricType::MeasureType    value = metric->GetValue(), value2;
-  typename PointSetMetricType::DerivativeType derivative, derivative2;
+  typename PointSetMetricType::MeasureType    value = metric->GetValue();
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
   metric->GetValueAndDerivative(value2, derivative2);
 

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
@@ -154,7 +154,8 @@ itkMattesMutualInformationImageToImageMetricv4RegistrationTest(int argc, char * 
   {
     using PointType = PointSetType::PointType;
     PointSetType::Pointer                             pset(PointSetType::New());
-    unsigned long                                     ind = 0, ct = 0;
+    unsigned long                                     ind = 0;
+    unsigned long                                     ct = 0;
     itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
     for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -131,7 +131,8 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   std::cout << "Initialized" << std::endl;
 
   /* Evaluate with GetValueAndDerivative */
-  MetricType::MeasureType    valueReturn1, valueReturn2;
+  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
 
   try

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -143,7 +143,8 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char * argv[])
 
   using PointType = PointSetType::PointType;
   PointSetType::Pointer                             pset(PointSetType::New());
-  unsigned long                                     ind = 0, ct = 0;
+  unsigned long                                     ind = 0;
+  unsigned long                                     ct = 0;
   itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
 
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -116,7 +116,8 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   }
 
   // Evaluate with GetValueAndDerivative
-  MetricType::MeasureType    valueReturn1, valueReturn2;
+  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
 
   try
@@ -168,7 +169,8 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   // Test that using floating point correction produces
   // a different result
   std::cout << "Testing with different floating point correction settings." << std::endl;
-  MetricType::DerivativeType derivativeWithFPC, derivativeWithOutFPC;
+  MetricType::DerivativeType derivativeWithFPC;
+  MetricType::DerivativeType derivativeWithOutFPC;
   metric->SetMaximumNumberOfWorkUnits(1);
   metric->SetUseFloatingPointCorrection(false); // default
   metric->GetValueAndDerivative(valueReturn1, derivativeWithOutFPC);

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -151,7 +151,8 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
 
   using PointType = PointSetType::PointType;
   PointSetType::Pointer                             pset(PointSetType::New());
-  unsigned long                                     ind = 0, ct = 0;
+  unsigned long                                     ind = 0;
+  unsigned long                                     ct = 0;
   itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
 
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)

--- a/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
@@ -127,7 +127,8 @@ itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   {
     using PointType = PointSetType::PointType;
     PointSetType::Pointer                             pset(PointSetType::New());
-    unsigned long                                     ind = 0, ct = 0;
+    unsigned long                                     ind = 0;
+    unsigned long                                     ct = 0;
     itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
     for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -153,7 +153,8 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   //  metric->SetNumberOfHistogramBins(20);
   using PointType = PointSetType::PointType;
   PointSetType::Pointer                                pset(PointSetType::New());
-  unsigned long                                        ind = 0, ct = 0;
+  unsigned long                                        ind = 0;
+  unsigned long                                        ct = 0;
   itk::ImageRegionIteratorWithIndex<InternalImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
   {

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -210,7 +210,8 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
   translationTransform->SetIdentity();
 
   // create images
-  ImageType::Pointer    fixedImage = nullptr, movingImage = nullptr;
+  ImageType::Pointer    fixedImage = nullptr;
+  ImageType::Pointer    movingImage = nullptr;
   ImageType::OffsetType imageShift{};
   ObjectToObjectMultiMetricv4RegistrationTestCreateImages<ImageType>(fixedImage, movingImage, imageShift);
 

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -472,8 +472,12 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
   // Test that we get the same scales/step estimation
   // with a single metric and the same metric twice in a multimetric
   //
-  ScalesEstimatorMultiType::ScalesType singleScales, multiSingleScales, multiDoubleScales;
-  ScalesEstimatorMultiType::FloatType  singleStep, multiSingleStep, multiDoubleStep;
+  ScalesEstimatorMultiType::ScalesType singleScales;
+  ScalesEstimatorMultiType::ScalesType multiSingleScales;
+  ScalesEstimatorMultiType::ScalesType multiDoubleScales;
+  ScalesEstimatorMultiType::FloatType  singleStep;
+  ScalesEstimatorMultiType::FloatType  multiSingleStep;
+  ScalesEstimatorMultiType::FloatType  multiDoubleStep;
   step.SetSize(m1->GetNumberOfParameters());
   step.Fill(itk::NumericTraits<ScalesEstimatorMultiType::ParametersType::ValueType>::OneValue());
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -150,7 +150,8 @@ itkQuasiNewtonOptimizerv4RegistrationTestMain(int argc, char * argv[])
     miMetric->SetNumberOfHistogramBins(20);
     using PointType = typename PointSetType::PointType;
     typename PointSetType::Pointer                    pset(PointSetType::New());
-    unsigned long                                     ind = 0, ct = 0;
+    unsigned long                                     ind = 0;
+    unsigned long                                     ct = 0;
     itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
     for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -124,7 +124,8 @@ template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 {
-  SizeValueType initCodebookSize, finalCodebookSize;
+  SizeValueType initCodebookSize;
+  SizeValueType finalCodebookSize;
 
   m_VectorDimension = InputImagePixelType::GetVectorDimension();
 
@@ -282,7 +283,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
   // First pass requires very large distortion
 
   double olddistortion = m_DoubleMaximum;
-  double distortion, tempdistortion;
+  double distortion;
+  double tempdistortion;
   int    pass = 0; // no empty cells have been found yet
   int    emptycells;
   int    bestcodeword;
@@ -399,7 +401,9 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
 {
   // itkDebugMacro(<<"Start nearest_neighbor_search_basic()");
 
-  double bestdistortion, tempdistortion, diff;
+  double bestdistortion;
+  double tempdistortion;
+  double diff;
   int    bestcodeword;
 
   // unused: double *centroidVecTemp = ( double * ) new double[m_VectorDimension];

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -182,7 +182,8 @@ itkKmeansModelEstimatorTest(int, char *[])
 
   vnl_matrix<double> inCDBK(NCODEWORDS, NUMBANDS);
   // There are 4 entries to the code book
-  int r, c;
+  int r;
+  int c;
   r = 0;
   c = 0;
   inCDBK.put(r, c, 10);

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -33,8 +33,11 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
   // create an equivalency table
   auto eqTable = EquivalencyTable::New();
 
-  InputPixelType        value, neighborValue;
-  OutputPixelType       label, originalLabel, neighborLabel;
+  InputPixelType        value;
+  InputPixelType        neighborValue;
+  OutputPixelType       label;
+  OutputPixelType       originalLabel;
+  OutputPixelType       neighborLabel;
   OutputPixelType       maxLabel{};
   const OutputPixelType maxPossibleLabel = NumericTraits<OutputPixelType>::max();
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -70,7 +70,8 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low, threshold_hi;
+  InternalPixelType threshold_low;
+  InternalPixelType threshold_hi;
   threshold_low = std::stoi(argv[3]);
   threshold_hi = std::stoi(argv[4]);
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -66,7 +66,8 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low, threshold_hi;
+  InternalPixelType threshold_low;
+  InternalPixelType threshold_hi;
   threshold_low = std::stoi(argv[3]);
   threshold_hi = std::stoi(argv[4]);
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -56,7 +56,8 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   inputimg->SetRegions(region);
   inputimg->Allocate();
 
-  int       row, col;
+  int       row;
+  int       col;
   IndexType myIndex;
   for (row = 0; row < 20; ++row)
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -68,7 +68,8 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low, threshold_hi;
+  InternalPixelType threshold_low;
+  InternalPixelType threshold_hi;
   threshold_low = std::stoi(argv[3]);
   threshold_hi = std::stoi(argv[4]);
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -101,7 +101,8 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
   change->ChangeSpacingOn();
 
   // Create a binary input image to label
-  InternalPixelType threshold_low, threshold_hi;
+  InternalPixelType threshold_low;
+  InternalPixelType threshold_hi;
   threshold_low = std::stoi(argv[3]);
   threshold_hi = std::stoi(argv[4]);
 

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
@@ -57,8 +57,15 @@ DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::ComputeExter
   SimplexMeshGeometry *     data,
   const GradientImageType * gradientImage)
 {
-  PointType         vec_for, tmp_vec_1, tmp_vec_2, tmp_vec_3;
-  GradientIndexType coord, coord2, tmp_co_1, tmp_co_2, tmp_co_3;
+  PointType         vec_for;
+  PointType         tmp_vec_1;
+  PointType         tmp_vec_2;
+  PointType         tmp_vec_3;
+  GradientIndexType coord;
+  GradientIndexType coord2;
+  GradientIndexType tmp_co_1;
+  GradientIndexType tmp_co_2;
+  GradientIndexType tmp_co_3;
 
   coord[0] = static_cast<GradientIndexValueType>(data->pos[0]);
   coord[1] = static_cast<GradientIndexValueType>(data->pos[1]);

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -363,8 +363,15 @@ void
 DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeExternalForce(SimplexMeshGeometry *     data,
                                                                              const GradientImageType * gradientImage)
 {
-  PointType         vec_for, tmp_vec_1, tmp_vec_2, tmp_vec_3;
-  GradientIndexType coord, coord2, tmp_co_1, tmp_co_2, tmp_co_3;
+  PointType         vec_for;
+  PointType         tmp_vec_1;
+  PointType         tmp_vec_2;
+  PointType         tmp_vec_3;
+  GradientIndexType coord;
+  GradientIndexType coord2;
+  GradientIndexType tmp_co_1;
+  GradientIndexType tmp_co_2;
+  GradientIndexType tmp_co_3;
 
   coord[0] = static_cast<GradientIndexValueType>(data->pos[0]);
   coord[1] = static_cast<GradientIndexValueType>(data->pos[1]);
@@ -498,7 +505,8 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::UpdateReferenceMetrics()
     // deltaH[1] = (H_N2 - H_Mean)/H;
     // deltaH[2] = (H_N3 - H_Mean)/H;
 
-    PointType eps, eps_opt;
+    PointType eps;
+    PointType eps_opt;
     // compute optimal reference metrics
     eps_opt[0] = (1.0 / 3.0) + m_Gamma * deltaH[0];
     eps_opt[1] = (1.0 / 3.0) + m_Gamma * deltaH[1];
@@ -560,7 +568,10 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeBarycentricCoordi
   const PointType b = data->neighbors[1];
   const PointType c = data->neighbors[2];
 
-  VectorType n, na, nb, nc;
+  VectorType n;
+  VectorType na;
+  VectorType nb;
+  VectorType nc;
   n.SetVnlVector(vnl_cross_3d((b - a).GetVnlVector(), (c - a).GetVnlVector()));
   na.SetVnlVector(vnl_cross_3d((c - b).GetVnlVector(), (p - b).GetVnlVector()));
   nb.SetVnlVector(vnl_cross_3d((a - c).GetVnlVector(), (p - c).GetVnlVector()));

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -114,7 +114,10 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::N
                                                                                          double *       y,
                                                                                          double *       z)
 {
-  double d, dlx, dly, dlz;
+  double d;
+  double dlx;
+  double dly;
+  double dlz;
   double dp[3];
 
   dp[0] = pp[0];
@@ -206,7 +209,9 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
   // image coordinate
   int               ic[3];
   GradientIndexType coord;
-  double            x, y, z;
+  double            x;
+  double            y;
+  double            z;
 
   coord[0] = static_cast<ImageIndexValueType>(data->pos[0]);
   coord[1] = static_cast<ImageIndexValueType>(data->pos[1]);
@@ -392,8 +397,10 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
 
   // now fun begins try to use all the above
   std::vector<ImageVoxel *>::iterator it;
-  double                              mag, max = 0;
-  GradientIndexType                   coord3, coord2{};
+  double                              mag;
+  double                              max = 0;
+  GradientIndexType                   coord3;
+  GradientIndexType                   coord2{};
   for (it = m_Positive.begin(); it != m_Positive.end(); ++it)
   {
     coord3[0] = static_cast<GradientIndexValueType>((*it)->GetX());

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -125,7 +125,9 @@ LevelSetFunction<TImageType>::Compute3DMinimalCurvature(const NeighborhoodType &
 {
   ScalarValueType mean_curve = this->ComputeMeanCurvature(neighborhood, offset, gd);
 
-  int             i0 = 0, i1 = 1, i2 = 2;
+  int             i0 = 0;
+  int             i1 = 1;
+  int             i2 = 2;
   ScalarValueType gauss_curve =
     (2 *
        (gd->m_dx[i0] * gd->m_dx[i1] * (gd->m_dxy[i2][i0] * gd->m_dxy[i1][i2] - gd->m_dxy[i0][i1] * gd->m_dxy[i2][i2]) +
@@ -288,9 +290,14 @@ LevelSetFunction<TImageType>::ComputeUpdate(const NeighborhoodType & it,
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
 
-  ScalarValueType laplacian, x_energy, laplacian_term, propagation_term, curvature_term, advection_term,
-    propagation_gradient;
-  VectorType advection_field;
+  ScalarValueType laplacian;
+  ScalarValueType x_energy;
+  ScalarValueType laplacian_term;
+  ScalarValueType propagation_term;
+  ScalarValueType curvature_term;
+  ScalarValueType advection_term;
+  ScalarValueType propagation_gradient;
+  VectorType      advection_field;
 
   // Global data structure
   auto * gd = (GlobalDataStruct *)globalData;

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -71,10 +71,14 @@ auto
 LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
   const NeighborhoodType & neighborhood) const -> ScalarValueType
 {
-  unsigned int              j, k;
-  unsigned int              counterN, counterP;
-  NeighborhoodSizeValueType positionN, positionP, stride[TImageType::ImageDimension],
-    indicator[TImageType::ImageDimension];
+  unsigned int              j;
+  unsigned int              k;
+  unsigned int              counterN;
+  unsigned int              counterP;
+  NeighborhoodSizeValueType positionN;
+  NeighborhoodSizeValueType positionP;
+  NeighborhoodSizeValueType stride[TImageType::ImageDimension];
+  NeighborhoodSizeValueType indicator[TImageType::ImageDimension];
 
   constexpr NeighborhoodSizeValueType one = 1;
   const NeighborhoodSizeValueType     center = neighborhood.Size() / 2;
@@ -155,7 +159,9 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::PropagationSpeed(co
 {
   IndexType       idx = neighborhood.GetIndex();
   NodeType *      targetnode = m_SparseTargetImage->GetPixel(idx);
-  ScalarValueType refitterm, cv, tcv;
+  ScalarValueType refitterm;
+  ScalarValueType cv;
+  ScalarValueType tcv;
 
   if ((targetnode == nullptr) || (targetnode->m_CurvatureFlag == false))
   {

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -58,7 +58,9 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
   const NormalVectorType CenterPixel = CenterNode->m_Data;
 
   Vector<NodeValueType, ImageDimension> gradient[ImageDimension];
-  NormalVectorType                      PositiveSidePixel[2], NegativeSidePixel[2], flux;
+  NormalVectorType                      PositiveSidePixel[2];
+  NormalVectorType                      NegativeSidePixel[2];
+  NormalVectorType                      flux;
   SizeValueType                         stride[ImageDimension];
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -473,7 +473,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeAct
 
   const NeighborhoodScalesType neighborhoodScales = this->GetDifferenceFunction()->ComputeNeighborhoodScales();
 
-  ValueType dx_forward, dx_backward, length, distance;
+  ValueType dx_forward;
+  ValueType dx_backward;
+  ValueType length;
+  ValueType distance;
 
   // For all indices in the active layer...
   for (activeIt = m_Layers[0]->Begin(); activeIt != m_Layers[0]->End(); ++activeIt)
@@ -826,7 +829,8 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedIniti
 {
   // divide the lists based on the boundaries
 
-  LayerNodeType *nodePtr, *nodeTempPtr;
+  LayerNodeType * nodePtr;
+  LayerNodeType * nodeTempPtr;
 
   for (unsigned int i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
   {
@@ -1226,7 +1230,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
   -> TimeStepType
 {
   typename FiniteDifferenceFunctionType::Pointer df = this->GetDifferenceFunction();
-  ValueType                                      centerValue = 0.0, forwardValue, backwardValue;
+  ValueType                                      centerValue = 0.0;
+  ValueType                                      forwardValue;
+  ValueType                                      backwardValue;
   ValueType                                      MIN_NORM = 1.0e-6;
   if (this->GetUseImageSpacing())
   {
@@ -1360,9 +1366,12 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedApply
 
   this->SignalNeighborsAndWait(ThreadId);
 
-  StatusType    up_to = 1, up_search = 5;
-  StatusType    down_to = 2, down_search = 6;
-  unsigned char j = 0, k = 1;
+  StatusType    up_to = 1;
+  StatusType    up_search = 5;
+  StatusType    down_to = 2;
+  StatusType    down_search = 6;
+  unsigned char j = 0;
+  unsigned char k = 1;
 
   // The 3D case: this loop is executed at least once
   while (down_search < 2 * m_NumberOfLayers + 1)
@@ -1652,7 +1661,8 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedProce
   ThreadIdType       ThreadId)
 {
   unsigned int     neighbor_Size = m_NeighborList.GetSize();
-  LayerPointerType InputList, OutputList;
+  LayerPointerType InputList;
+  LayerPointerType OutputList;
 
   // InOrOut == 1, inside, more negative, uplist
   // InOrOut == 0, outside
@@ -1801,9 +1811,11 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedProce
   LayerNodeType * nodePtr;
   StatusType      neighbor_status;
 
-  IndexType center_index, n_index;
+  IndexType center_index;
+  IndexType n_index;
 
-  LayerPointerType InputList, OutputList;
+  LayerPointerType InputList;
+  LayerPointerType OutputList;
 
   // Push each index in the input list into its appropriate status layer
   // (ChangeToStatus) and update the status image value at that index.
@@ -1962,7 +1974,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedPropa
   unsigned int       InOrOut,
   ThreadIdType       ThreadId)
 {
-  ValueType value, value_temp, delta;
+  ValueType value;
+  ValueType value_temp;
+  ValueType delta;
   bool      found_neighbor_flag;
 
   typename LayerType::Iterator toIt;
@@ -1985,8 +1999,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedPropa
   toIt = m_Data[ThreadId].m_Layers[to]->Begin();
   toEnd = m_Data[ThreadId].m_Layers[to]->End();
 
-  IndexType  centerIndex, nIndex;
-  StatusType centerStatus, nStatus;
+  IndexType  centerIndex;
+  IndexType  nIndex;
+  StatusType centerStatus;
+  StatusType nStatus;
 
   while (toIt != toEnd)
   {
@@ -2070,7 +2086,8 @@ template <typename TInputImage, typename TOutputImage>
 void
 ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CheckLoadBalance()
 {
-  unsigned int i, j;
+  unsigned int i;
+  unsigned int j;
 
   // This parameter defines a degree of unbalancedness of the load among
   // threads.

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -85,7 +85,9 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
   SparseImageIteratorType & it) const -> ValueType
 {
   unsigned int            counter;
-  SizeValueType           position, stride[ImageDimension], indicator[ImageDimension];
+  SizeValueType           position;
+  SizeValueType           stride[ImageDimension];
+  SizeValueType           indicator[ImageDimension];
   constexpr SizeValueType one = 1;
   const SizeValueType     center = it.Size() / 2;
   NormalVectorType        normalvector;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -643,7 +643,8 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
   NeighborhoodIterator<StatusImageType> statusIt(
     m_NeighborList.GetRadius(), m_StatusImage, this->m_OutputImage->GetRequestedRegion());
 
-  typename OutputImageType::IndexType upperBounds, lowerBounds = this->m_OutputImage->GetRequestedRegion().GetIndex();
+  typename OutputImageType::IndexType upperBounds;
+  typename OutputImageType::IndexType lowerBounds = this->m_OutputImage->GetRequestedRegion().GetIndex();
   upperBounds =
     this->m_OutputImage->GetRequestedRegion().GetIndex() + this->m_OutputImage->GetRequestedRegion().GetSize();
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -55,7 +55,8 @@ circle(unsigned int x, unsigned int y)
 float
 square(unsigned int x, unsigned int y)
 {
-  float X, Y;
+  float X;
+  float Y;
   X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -59,7 +59,9 @@ sphere(unsigned int x, unsigned int y, unsigned int z)
 float
 cube(unsigned int x, unsigned int y, unsigned int z)
 {
-  float X, Y, Z;
+  float X;
+  float Y;
+  float Z;
   X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   Z = itk::Math::abs(z - static_cast<float>(DEPTH) / 2.0);

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -50,7 +50,8 @@ const unsigned int WIDTH = (128);
 float
 square(unsigned int x, unsigned int y)
 {
-  float X, Y;
+  float X;
+  float Y;
   X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -28,7 +28,8 @@ const unsigned int WIDTH = (128);
 float
 square(unsigned int x, unsigned int y)
 {
-  float X, Y;
+  float X;
+  float Y;
   X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
   Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -75,7 +75,8 @@ itkMRFImageFilterTest(int, char *[])
   using DataVector = VecImageType::PixelType;
   DataVector dblVec;
 
-  int i, k;
+  int i;
+  int k;
   int halfWidth = static_cast<int>(vecImgSize[0]) / 2;
   int halfHeight = static_cast<int>(vecImgSize[1]) / 2;
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -305,7 +305,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     secondFunction->SetInputImage(outputImage);
     secondFunction->ThresholdBetween(m_ReplaceValue, m_ReplaceValue);
 
-    typename NumericTraits<typename InputImageType::PixelType>::RealType sum, sumOfSquares;
+    typename NumericTraits<typename InputImageType::PixelType>::RealType sum;
+    typename NumericTraits<typename InputImageType::PixelType>::RealType sumOfSquares;
     sum = InputRealType{};
     sumOfSquares = InputRealType{};
     typename TOutputImage::SizeValueType numberOfSamples = 0;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -816,7 +816,10 @@ VoronoiDiagram2DGenerator<TCoordinateType>::clip_line(FortuneEdge * task)
   // Clip line
   FortuneSite * s1;
   FortuneSite * s2;
-  double        x1, y1, x2, y2;
+  double        x1;
+  double        y1;
+  double        x2;
+  double        y2;
 
   if (((task->m_A) == 1.0) && ((task->m_B) >= 0.0))
   {

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -57,7 +57,8 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Te
     addpp = addpp + getp * getp;
   }
 
-  double savemean, saveSTD;
+  double savemean;
+  double saveSTD;
   if (num > 1)
   {
     savemean = addp / num;
@@ -104,7 +105,10 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Ta
   float addpp = 0;
   float currp;
 
-  unsigned int minx = 0, miny = 0, maxx = 0, maxy = 0;
+  unsigned int minx = 0;
+  unsigned int miny = 0;
+  unsigned int maxx = 0;
+  unsigned int maxy = 0;
   bool         status = false;
   for (unsigned int i = 0; i < this->m_Size[1]; ++i)
   {

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -124,7 +124,8 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   double rightendy = rightP[1];
   double beginx = currP[0];
   double endx = currP[0];
-  double leftDx, rightDx;
+  double leftDx;
+  double rightDx;
   double offset;
   double leftheadx = beginx;
   double rightheadx = endx;
@@ -676,7 +677,8 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   double rightendy = rightP[1];
   double beginx = currP[0];
   double endx = currP[0];
-  double leftDx, rightDx;
+  double leftDx;
+  double rightDx;
   double offset;
   double leftheadx = beginx;
   double rightheadx = endx;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -151,7 +151,8 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TestHomogeneity(In
     }
   }
 
-  double savemean[6], saveSTD[6];
+  double savemean[6];
+  double saveSTD[6];
   if (num > 1)
   {
     for (int i = 0; i < 6; ++i)
@@ -169,7 +170,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TestHomogeneity(In
     }
   }
 
-  for(int j =0;  j < 3; ++j)
+  for (int j = 0; j < 3; ++j)
   {
     const double savem = savemean[m_TestMean[j]] - m_Mean[m_TestMean[j]];
     const double savev = saveSTD[m_TestSTD[j]] - m_STD[m_TestSTD[j]];
@@ -194,7 +195,10 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
   itk::ImageRegionConstIteratorWithIndex<BinaryObjectImage> ait(aprior, region);
   itk::ImageRegionIteratorWithIndex<RGBHCVImage>            iit(m_WorkingImage, region);
 
-  unsigned int minx = 0, miny = 0, maxx = 0, maxy = 0;
+  unsigned int minx = 0;
+  unsigned int miny = 0;
+  unsigned int maxx = 0;
+  unsigned int maxy = 0;
   bool         status = false;
   for (unsigned int i = 0; i < this->GetSize()[1]; ++i)
   {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -208,7 +208,8 @@ SegmentTreeGenerator<TScalar>::ExtractMergeHierarchy(SegmentTableTypePointer seg
   using MergeComparison = typename SegmentTreeType::merge_comp;
   typename SegmentTableType::DataType * toSeg;
   typename SegmentTreeType::ValueType   tempMerge;
-  IdentifierType                        toSegLabel, fromSegLabel;
+  IdentifierType                        toSegLabel;
+  IdentifierType                        fromSegLabel;
 
   if (heap->Empty())
   {
@@ -297,9 +298,12 @@ SegmentTreeGenerator<TScalar>::PruneMergeSegments(SegmentTableTypePointer       
                                                   const IdentifierType              TO,
                                                   ScalarType)
 {
-  typename SegmentTableType::edge_list_t::iterator edgeTOi, edgeFROMi, edgeTEMPi;
+  typename SegmentTableType::edge_list_t::iterator edgeTOi;
+  typename SegmentTableType::edge_list_t::iterator edgeFROMi;
+  typename SegmentTableType::edge_list_t::iterator edgeTEMPi;
   HashMapType                                      seen_table;
-  IdentifierType                                   labelTO, labelFROM;
+  IdentifierType                                   labelTO;
+  IdentifierType                                   labelFROM;
 
   // Lookup both entries.
   typename SegmentTableType::segment_t * from_seg = segments->Lookup(FROM);
@@ -434,9 +438,12 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
                                              const IdentifierType              FROM,
                                              const IdentifierType              TO)
 {
-  typename SegmentTableType::edge_list_t::iterator edgeTOi, edgeFROMi, edgeTEMPi;
+  typename SegmentTableType::edge_list_t::iterator edgeTOi;
+  typename SegmentTableType::edge_list_t::iterator edgeFROMi;
+  typename SegmentTableType::edge_list_t::iterator edgeTEMPi;
   HashMapType                                      seen_table;
-  IdentifierType                                   labelTO, labelFROM;
+  IdentifierType                                   labelTO;
+  IdentifierType                                   labelFROM;
 
   // Lookup both entries.
   typename SegmentTableType::segment_t * from_seg = segments->Lookup(FROM);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -167,7 +167,8 @@ Segmenter<TInputImage>::GenerateData()
   // for local minima without requiring expensive boundary conditions.
   //
   //
-  InputPixelType minimum, maximum;
+  InputPixelType minimum;
+  InputPixelType maximum;
   Self::MinMax(input, regionToProcess, minimum, maximum);
   // cap the maximum in the image so that we can always define a pixel
   // value that is one greater than the maximum value in the image.
@@ -430,7 +431,10 @@ Segmenter<TInputImage>::AnalyzeBoundaryFlow(InputImageTypePointer thresholdImage
   // NOTE: For ease of initial implementation, this method does
   // not support arbitrary connectivity across boundaries (yet). 10-8-01 jc
   //
-  unsigned int nCenter, i, nPos, cPos;
+  unsigned int nCenter;
+  unsigned int i;
+  unsigned int nPos;
+  unsigned int cPos;
   bool         isSteepest;
 
   ConstNeighborhoodIterator<InputImageType>          searchIt;
@@ -621,7 +625,11 @@ template <typename TInputImage>
 void
 Segmenter<TInputImage>::GenerateConnectivity()
 {
-  unsigned int i, j, nSize, nCenter, stride;
+  unsigned int i;
+  unsigned int j;
+  unsigned int nSize;
+  unsigned int nCenter;
+  unsigned int stride;
   int          d;
 
   //
@@ -675,8 +683,12 @@ Segmenter<TInputImage>::LabelMinima(InputImageTypePointer                img,
                                     typename Self::flat_region_table_t & flatRegions,
                                     InputPixelType                       Max)
 {
-  unsigned int   i, nSize, nCenter, nPos = 0;
-  bool           foundSinglePixelMinimum, foundFlatRegion;
+  unsigned int   i;
+  unsigned int   nSize;
+  unsigned int   nCenter;
+  unsigned int   nPos = 0;
+  bool           foundSinglePixelMinimum;
+  bool           foundFlatRegion;
   InputPixelType maxValue = Max;
 
   flat_region_t tempFlatRegion;
@@ -829,7 +841,8 @@ Segmenter<TInputImage>::GradientDescent(InputImageTypePointer img, ImageRegionTy
   typename OutputImageType::Pointer output = this->GetOutputImage();
 
   InputPixelType                      minVal;
-  unsigned int                        i, nPos;
+  unsigned int                        i;
+  unsigned int                        nPos;
   typename InputImageType::OffsetType moveIndex;
   IdentifierType                      newLabel;
   std::stack<IdentifierType *>        updateStack;
@@ -920,7 +933,8 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
   typename edge_table_hash_t::iterator edge_table_entry_ptr;
   typename edge_table_t::iterator      edge_ptr;
 
-  unsigned int                                               i, nPos;
+  unsigned int                                               i;
+  unsigned int                                               nPos;
   typename NeighborhoodIterator<OutputImageType>::RadiusType hoodRadius;
   typename SegmentTableType::segment_t *                     segment_ptr;
   typename SegmentTableType::segment_t                       temp_segment;
@@ -1123,7 +1137,8 @@ Segmenter<TInputImage>::MergeFlatRegions(flat_region_table_t & regions, Equivale
   // format with its Flatten() method.
   eqTable->Flatten();
 
-  typename flat_region_table_t::iterator a, b;
+  typename flat_region_table_t::iterator a;
+  typename flat_region_table_t::iterator b;
   for (EquivalencyTable::ConstIterator it = eqTable->Begin(); it != eqTable->End(); ++it)
   {
     if (((a = regions.find(it->first)) == regions.end()) || ((b = regions.find(it->second)) == regions.end()))

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -65,7 +65,8 @@ itkIsolatedWatershedImageFilterTest(int argc, char * argv[])
   filter->SetInput(reader->GetOutput());
 
 
-  FilterType::IndexType seed1, seed2;
+  FilterType::IndexType seed1;
+  FilterType::IndexType seed2;
   seed1.Fill(0);
   seed2.Fill(0);
 

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -344,7 +344,9 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 VideoSource<TOutputVideoStream>::ThreaderCallback(void * arg)
 {
   ThreadStruct * str;
-  int            total, workUnitID, threadCount;
+  int            total;
+  int            workUnitID;
+  int            threadCount;
 
   workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;


### PR DESCRIPTION
Multiple declarations in a single statement reduce readability.

Detect local variable declaration statements and update to have only one statement per declaration.

The clang-tidy readability-isolate-declaration check with fix options automatically identified these changes.

This is a pre-cursor to the larger work to be done in 4991

As a stand-alone commit, this has very little value to the toolkit, but it provides a significant improvement for identifying places where updates need to be considered.   Regular-expression tools work much better on this simplified code layout.

NOTE:  This is unmodified output of the clang-tidy check and fixes.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)