### PR TITLE
Deprecate `CoordRepType` and replace it with `CoordinateType`

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -89,7 +89,8 @@ public:
 
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using PointsContainer = TPointsContainer;
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using PointsContainerConstPointer = typename PointsContainer::ConstPointer;

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -95,8 +95,8 @@ public:
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using PointsContainerConstPointer = typename PointsContainer::ConstPointer;
 
-  using PointType = Point<CoordRepType, VPointDimension>;
-  using BoundsArrayType = FixedArray<CoordRepType, VPointDimension * 2>;
+  using PointType = Point<CoordinateType, VPointDimension>;
+  using BoundsArrayType = FixedArray<CoordinateType, VPointDimension * 2>;
 
   /** Hold on to the dimensions specified by the template parameters. */
   static constexpr unsigned int PointDimension = VPointDimension;
@@ -173,7 +173,7 @@ public:
   /** Get the length squared of the diagonal of the bounding box.
    * Returns zero if bounding box cannot be computed. Note that the
    * Accumulate type is used to represent the length. */
-  using AccumulateType = typename NumericTraits<CoordRepType>::AccumulateType;
+  using AccumulateType = typename NumericTraits<CoordinateType>::AccumulateType;
   AccumulateType
   GetDiagonalLength2() const;
 

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -90,7 +90,10 @@ public:
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PointsContainer = TPointsContainer;
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using PointsContainerConstPointer = typename PointsContainer::ConstPointer;

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -136,7 +136,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::C
   {
     if (this->GetMTime() > m_BoundsMTime)
     {
-      m_Bounds.Fill(CoordRepType{});
+      m_Bounds.Fill(CoordinateType{});
       m_BoundsMTime.Modified();
     }
     return false;
@@ -148,7 +148,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::C
     // start by initializing the values
     if (m_PointsContainer->Size() < 1)
     {
-      m_Bounds.Fill(CoordRepType{});
+      m_Bounds.Fill(CoordinateType{});
       m_BoundsMTime.Modified();
       return false;
     }
@@ -287,7 +287,7 @@ auto
 BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetDiagonalLength2() const
   -> AccumulateType
 {
-  typename NumericTraits<CoordRepType>::AccumulateType dist2 = CoordRepType{};
+  typename NumericTraits<CoordinateType>::AccumulateType dist2 = CoordinateType{};
 
   if (this->ComputeBoundingBox())
   {

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -110,7 +110,10 @@ public:
 
   /** Save type information for this cell. */
   using CoordinateType = typename CellTraits::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = typename CellTraits::InterpolationWeightType;
   using PointIdentifier = typename CellTraits::PointIdentifier;
   using PointIdIterator = typename CellTraits::PointIdIterator;
@@ -527,7 +530,10 @@ class ITK_TEMPLATE_EXPORT CellTraitsInfo
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -109,7 +109,8 @@ public:
   using CellTraits = TCellTraits;
 
   /** Save type information for this cell. */
-  using CoordRepType = typename CellTraits::CoordRepType;
+  using CoordinateType = typename CellTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename CellTraits::InterpolationWeightType;
   using PointIdentifier = typename CellTraits::PointIdentifier;
   using PointIdIterator = typename CellTraits::PointIdIterator;
@@ -525,7 +526,8 @@ class ITK_TEMPLATE_EXPORT CellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -62,7 +62,7 @@
   using typename Superclass::CellRawPointer;                           \
   using typename Superclass::CellConstRawPointer;                      \
   using typename Superclass::CellTraits;                               \
-  using typename Superclass::CoordRepType;                             \
+  using typename Superclass::CoordinateType;                           \
   using typename Superclass::InterpolationWeightType;                  \
   using typename Superclass::PointIdentifier;                          \
   using typename Superclass::PointIdIterator;                          \
@@ -109,7 +109,7 @@ public:
   using CellTraits = TCellTraits;
 
   /** Save type information for this cell. */
-  using CoordinateType = typename CellTraits::CoordRepType;
+  using CoordinateType = typename CellTraits::CoordinateType;
   using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename CellTraits::InterpolationWeightType;
   using PointIdentifier = typename CellTraits::PointIdentifier;
@@ -141,7 +141,7 @@ public:
   using CellFeatureCount = CellFeatureIdentifier;
 
   /** Types needed to contour the cells */
-  using ParametricCoordArrayType = Array<CoordRepType>;
+  using ParametricCoordArrayType = Array<CoordinateType>;
   using ShapeFunctionsArrayType = Array<InterpolationWeightType>;
 
   //  static int GetNextUserCellId(); // never return > MAX_INTERFACE
@@ -314,7 +314,7 @@ public:
    * topological dimension CellDimension-1.  If the "inside" pointer is not
    * nullptr, the flag is set to indicate whether the point is inside the cell. */
   virtual bool
-  GetClosestBoundary(CoordRepType[], bool *, CellAutoPointer &)
+  GetClosestBoundary(CoordinateType[], bool *, CellAutoPointer &)
   {
     return false;
   }
@@ -336,10 +336,10 @@ public:
    *  - Get the interpolation weights for the cell
    *     (Returns through pointer to array: weights[NumberOfPoints]). */
   virtual bool
-  EvaluatePosition(CoordRepType *,
+  EvaluatePosition(CoordinateType *,
                    PointsContainer *,
-                   CoordRepType *,
-                   CoordRepType[],
+                   CoordinateType *,
+                   CoordinateType[],
                    double *,
                    InterpolationWeightType *)
   {
@@ -369,12 +369,12 @@ public:
    *
    * Returns whether an intersection exists within the given tolerance. */
   virtual bool
-  IntersectWithLine(CoordRepType[PointDimension],
-                    CoordRepType[PointDimension],
-                    CoordRepType,
-                    CoordRepType[PointDimension],
-                    CoordRepType *,
-                    CoordRepType[])
+  IntersectWithLine(CoordinateType[PointDimension],
+                    CoordinateType[PointDimension],
+                    CoordinateType,
+                    CoordinateType[PointDimension],
+                    CoordinateType *,
+                    CoordinateType[])
   {
     return bool();
   }
@@ -383,13 +383,13 @@ public:
    * Array is ordered (xmin, xmax,  ymin, ymax, ....).  A pointer to the
    * array is returned for convenience.  This allows code like:
    * "CoordRep* bounds = cell->GetBoundingBox(new CoordRep[6]);". */
-  CoordRepType * GetBoundingBox(CoordRepType[PointDimension * 2]) { return nullptr; }
+  CoordinateType * GetBoundingBox(CoordinateType[PointDimension * 2]) { return nullptr; }
 
   /** Compute the square of the diagonal length of the bounding box. */
-  CoordRepType
+  CoordinateType
   GetBoundingBoxDiagonalLength2()
   {
-    return CoordRepType{};
+    return CoordinateType{};
   }
 
   /** Intersect the given bounding box (bounds[PointDimension*2]) with a line
@@ -404,11 +404,11 @@ public:
    *     (returned through "t" pointer).
    *
    * Returns whether an intersection exists. */
-  virtual bool IntersectBoundingBoxWithLine(CoordRepType[PointDimension * 2],
-                                            CoordRepType[PointDimension],
-                                            CoordRepType[PointDimension],
-                                            CoordRepType[PointDimension],
-                                            CoordRepType *)
+  virtual bool IntersectBoundingBoxWithLine(CoordinateType[PointDimension * 2],
+                                            CoordinateType[PointDimension],
+                                            CoordinateType[PointDimension],
+                                            CoordinateType[PointDimension],
+                                            CoordinateType *)
   {
     return bool();
   }
@@ -542,7 +542,7 @@ public:
 
 #define itkMakeCellTraitsMacro            \
   CellTraitsInfo<Self::PointDimension,    \
-                 CoordRepType,            \
+                 CoordinateType,          \
                  InterpolationWeightType, \
                  PointIdentifier,         \
                  CellIdentifier,          \

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -56,7 +56,8 @@ public:
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Dimension of the Space */
   static constexpr unsigned int IndexDimension = VIndexDimension;

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -57,7 +57,10 @@ public:
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Dimension of the Space */
   static constexpr unsigned int IndexDimension = VIndexDimension;

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -70,7 +70,10 @@ public:
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -69,7 +69,8 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -91,11 +91,11 @@ public:
   using CellFeatureIdentifier = IdentifierType;
 
   /** The type of point used by the mesh. */
-  using PointType = Point<CoordRepType, VPointDimension>;
+  using PointType = Point<CoordinateType, VPointDimension>;
 
   /** The type of point used for hashing.  This should never change from
    * this setting, regardless of the mesh type. */
-  using PointHashType = Point<CoordRepType, VPointDimension>;
+  using PointHashType = Point<CoordinateType, VPointDimension>;
 
   /** The container type for use in storing points.  It must conform to
    * the IndexedContainerInterface. */

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -89,11 +89,11 @@ public:
   using CellFeatureIdentifier = IdentifierType;
 
   /** The type of point used by the mesh. */
-  using PointType = Point<CoordRepType, VPointDimension>;
+  using PointType = Point<CoordinateType, VPointDimension>;
 
   /** The type of point used for hashing.  This should never change from
    * this setting, regardless of the mesh type. */
-  using PointHashType = Point<CoordRepType, VPointDimension>;
+  using PointHashType = Point<CoordinateType, VPointDimension>;
 
   /** The container type for use in storing points.  It must conform to
    * the IndexedContainer interface. */

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -67,7 +67,8 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -68,7 +68,10 @@ public:
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -141,10 +141,10 @@ public:
 
   /** Evaluate the position inside the cell */
   bool
-  EvaluatePosition(CoordRepType *,
+  EvaluatePosition(CoordinateType *,
                    PointsContainer *,
-                   CoordRepType *,
-                   CoordRepType[],
+                   CoordinateType *,
+                   CoordinateType[],
                    double *,
                    InterpolationWeightType *) override;
 
@@ -157,15 +157,15 @@ protected:
     NumericTraits<PointIdentifier>::max()) };
 
   void
-  InterpolationDerivs(CoordRepType pcoords[Self::CellDimension],
-                      CoordRepType derivs[Self::CellDimension * Self::NumberOfPoints]);
+  InterpolationDerivs(CoordinateType pcoords[Self::CellDimension],
+                      CoordinateType derivs[Self::CellDimension * Self::NumberOfPoints]);
   void
-  InterpolationFunctions(CoordRepType pcoords[Self::CellDimension], InterpolationWeightType sf[Self::NumberOfPoints]);
+  InterpolationFunctions(CoordinateType pcoords[Self::CellDimension], InterpolationWeightType sf[Self::NumberOfPoints]);
   void
   EvaluateLocation(int &                     itkNotUsed(subId),
                    PointsContainer *         points,
-                   CoordRepType              pcoords[Self::CellDimension],
-                   CoordRepType              x[Self::CellDimension],
+                   CoordinateType            pcoords[Self::CellDimension],
+                   CoordinateType            x[Self::CellDimension],
                    InterpolationWeightType * weights);
 
 public:

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -320,10 +320,10 @@ HexahedronCell<TCellInterface>::GetFace(CellFeatureIdentifier faceId, FaceAutoPo
 /** Evaluate the position inside the cell */
 template <typename TCellInterface>
 bool
-HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
+HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                                  PointsContainer *         points,
-                                                 CoordRepType *            closestPoint,
-                                                 CoordRepType              pcoord[],
+                                                 CoordinateType *          closestPoint,
+                                                 CoordinateType            pcoord[],
                                                  double *                  dist2,
                                                  InterpolationWeightType * weight)
 {
@@ -346,12 +346,12 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   double                  tcol[Self::PointDimension3D];
   double                  d;
   PointType               pt;
-  CoordRepType            derivs[CellDimension3D * Self::NumberOfPoints]{ 0 };
+  CoordinateType          derivs[CellDimension3D * Self::NumberOfPoints]{ 0 };
   InterpolationWeightType weights[Self::NumberOfPoints];
 
   //  set initial position for Newton's method
-  int          subId{ 0 };
-  CoordRepType pcoords[CellDimension3D]{ 0.5, 0.5, 0.5 };
+  int            subId{ 0 };
+  CoordinateType pcoords[CellDimension3D]{ 0.5, 0.5, 0.5 };
 
   // NOTE: Avoid compiler warning.  The code below only runs if PointType::Dimension == Self::PointDimension3D
   constexpr unsigned int PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS =
@@ -392,7 +392,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
     static_assert(Self::PointDimension3D == HARD_CODED_POINT_DIM,
                   "ERROR: Self::PointDimension3D does not equal HARD_CODED_POINT_DIM (i.e. 3).");
     //  compute determinants and generate improvements
-    vnl_matrix_fixed<CoordRepType, HARD_CODED_POINT_DIM, CellDimension3D> mat;
+    vnl_matrix_fixed<CoordinateType, HARD_CODED_POINT_DIM, CellDimension3D> mat;
     for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       mat.put(0, i, rcol[i]);
@@ -408,7 +408,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       return false;
     }
 
-    vnl_matrix_fixed<CoordRepType, HARD_CODED_POINT_DIM, CellDimension3D> mat1;
+    vnl_matrix_fixed<CoordinateType, HARD_CODED_POINT_DIM, CellDimension3D> mat1;
     for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       mat1.put(0, i, fcol[i]);
@@ -416,7 +416,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       mat1.put(2, i, tcol[i]);
     }
 
-    vnl_matrix_fixed<CoordRepType, HARD_CODED_POINT_DIM, CellDimension3D> mat2;
+    vnl_matrix_fixed<CoordinateType, HARD_CODED_POINT_DIM, CellDimension3D> mat2;
     for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       mat2.put(0, i, rcol[i]);
@@ -424,7 +424,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       mat2.put(2, i, tcol[i]);
     }
 
-    vnl_matrix_fixed<CoordRepType, HARD_CODED_POINT_DIM, CellDimension3D> mat3;
+    vnl_matrix_fixed<CoordinateType, HARD_CODED_POINT_DIM, CellDimension3D> mat3;
     for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       mat3.put(0, i, rcol[i]);
@@ -501,8 +501,8 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   }
   else
   {
-    CoordRepType pc[CellDimension3D];
-    CoordRepType w[Self::NumberOfPoints];
+    CoordinateType pc[CellDimension3D];
+    CoordinateType w[Self::NumberOfPoints];
     if (closestPoint)
     {
       for (unsigned int i = 0; i < CellDimension3D; ++i) // only approximate, not really true
@@ -536,7 +536,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 /** Compute iso-parametric interpolation functions */
 template <typename TCellInterface>
 void
-HexahedronCell<TCellInterface>::InterpolationFunctions(CoordRepType            pcoords[Self::CellDimension],
+HexahedronCell<TCellInterface>::InterpolationFunctions(CoordinateType          pcoords[Self::CellDimension],
                                                        InterpolationWeightType sf[Self::NumberOfPoints])
 {
   // Throw an exception if trying to EvaluatePosition for anything other than
@@ -548,7 +548,7 @@ HexahedronCell<TCellInterface>::InterpolationFunctions(CoordRepType            p
   }
   else
   {
-    CoordRepType pcoords3D[Self::CellDimension3D]{ 0 };
+    CoordinateType pcoords3D[Self::CellDimension3D]{ 0 };
     // NOTE: Avoid compiler warning.  The code below only runs if PointType::Dimension == Self::PointDimension3D
     constexpr unsigned int PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS =
       hexahedron_constexpr_min(PointType::Dimension, Self::PointDimension3D);
@@ -580,8 +580,8 @@ HexahedronCell<TCellInterface>::InterpolationFunctions(CoordRepType            p
 /** Compute iso-parametric interpolation functions */
 template <typename TCellInterface>
 void
-HexahedronCell<TCellInterface>::InterpolationDerivs(CoordRepType pcoords[Self::CellDimension],
-                                                    CoordRepType derivs[Self::CellDimension * Self::NumberOfPoints])
+HexahedronCell<TCellInterface>::InterpolationDerivs(CoordinateType pcoords[Self::CellDimension],
+                                                    CoordinateType derivs[Self::CellDimension * Self::NumberOfPoints])
 {
   // Throw an exception if trying to EvaluatePosition for anything other than
   // a 3D point or cell dimension. This implementation is hard-coded to 3D.
@@ -593,8 +593,8 @@ HexahedronCell<TCellInterface>::InterpolationDerivs(CoordRepType pcoords[Self::C
   else
   {
 
-    CoordRepType pcoords3D[Self::CellDimension3D]{ 0 };
-    CoordRepType derivs3D[Self::CellDimension3D * Self::NumberOfPoints]{ 0 };
+    CoordinateType pcoords3D[Self::CellDimension3D]{ 0 };
+    CoordinateType derivs3D[Self::CellDimension3D * Self::NumberOfPoints]{ 0 };
     // NOTE: Avoid compiler warning.  The code below only runs if PointType::Dimension == Self::PointDimension3D
     constexpr unsigned int PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS =
       hexahedron_constexpr_min(PointType::Dimension, Self::PointDimension3D);
@@ -658,8 +658,8 @@ template <typename TCellInterface>
 void
 HexahedronCell<TCellInterface>::EvaluateLocation(int &                     itkNotUsed(subId),
                                                  PointsContainer *         points,
-                                                 CoordRepType              pcoords[Self::CellDimension],
-                                                 CoordRepType              x[Self::CellDimension],
+                                                 CoordinateType            pcoords[Self::CellDimension],
+                                                 CoordinateType            x[Self::CellDimension],
                                                  InterpolationWeightType * weights)
 {
   // Throw an exception if trying to EvaluatePosition for anything other than
@@ -684,7 +684,7 @@ HexahedronCell<TCellInterface>::EvaluateLocation(int &                     itkNo
 
       for (unsigned int j = 0; j < PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS; ++j)
       {
-        const CoordRepType t = pt[j] * weights[i];
+        const CoordinateType t = pt[j] * weights[i];
         x[j] += t;
       }
     }

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -60,7 +60,8 @@ public:
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   using RealType = typename NumericTraits<ValueType>::RealType;
 

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -61,7 +61,10 @@ public:
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   using RealType = typename NumericTraits<ValueType>::RealType;
 

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -71,7 +71,8 @@ public:
 
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointIdentifier = typename TPointsContainer::ElementIdentifier;
   using PointsContainer = TPointsContainer;
 

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -71,13 +71,13 @@ public:
 
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
-  using CoordinateType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   using CoordRepType = CoordinateType;
   using PointIdentifier = typename TPointsContainer::ElementIdentifier;
   using PointsContainer = TPointsContainer;
 
   /** For improving Python support for PointSetBase and Meshes **/
-  using PointsVectorContainer = typename itk::VectorContainer<PointIdentifier, CoordRepType>;
+  using PointsVectorContainer = typename itk::VectorContainer<PointIdentifier, CoordinateType>;
   using PointsVectorContainerPointer = typename PointsVectorContainer::Pointer;
 
   /** Convenient constant, indirectly obtained from TPointsContainer template parameter. */
@@ -131,7 +131,7 @@ public:
 
   /** Sets the points by specifying its coordinates. */
   void
-  SetPointsByCoordinates(const std::vector<CoordRepType> & coordinates);
+  SetPointsByCoordinates(const std::vector<CoordinateType> & coordinates);
 
   /** Get the points container. */
   PointsContainer *

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -72,7 +72,10 @@ public:
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
   using CoordinateType = typename PointType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PointIdentifier = typename TPointsContainer::ElementIdentifier;
   using PointsContainer = TPointsContainer;
 

--- a/Modules/Core/Common/include/itkPointSetBase.hxx
+++ b/Modules/Core/Common/include/itkPointSetBase.hxx
@@ -79,7 +79,7 @@ PointSetBase<TPointsContainer>::SetPoints(PointsVectorContainer * points)
 
 template <typename TPointsContainer>
 void
-PointSetBase<TPointsContainer>::SetPointsByCoordinates(const std::vector<CoordRepType> & coordinates)
+PointSetBase<TPointsContainer>::SetPointsByCoordinates(const std::vector<CoordinateType> & coordinates)
 {
   itkDebugMacro("Setting the points to the specified coordinates");
 

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -121,7 +121,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
 
   using BoundingBoxType = BoundingBox<typename InputPointSetType::PointIdentifier,
                                       InputPointSetDimension,
-                                      typename InputPointSetType::CoordRepType,
+                                      typename InputPointSetType::CoordinateType,
                                       typename InputPointSetType::PointsContainer>;
   auto bb = BoundingBoxType::New();
   bb->SetPoints(InputPointSet->GetPoints());

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
@@ -225,7 +225,7 @@ void
 QuadraticEdgeCell<TCellInterface>::EvaluateShapeFunctions(const ParametricCoordArrayType & parametricCoordinates,
                                                           ShapeFunctionsArrayType &        weights) const
 {
-  CoordRepType x = parametricCoordinates[0]; // one-dimensional cell
+  CoordinateType x = parametricCoordinates[0]; // one-dimensional cell
 
   if (weights.Size() != this->GetNumberOfPoints())
   {

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -117,10 +117,10 @@ public:
 
   /** Evaluate the position inside the cell */
   bool
-  EvaluatePosition(CoordRepType *    x,
+  EvaluatePosition(CoordinateType *  x,
                    PointsContainer * points,
-                   CoordRepType *    closestPoint,
-                   CoordRepType[CellDimension],
+                   CoordinateType *  closestPoint,
+                   CoordinateType[CellDimension],
                    double *                  dist2,
                    InterpolationWeightType * weight) override;
 
@@ -137,15 +137,15 @@ protected:
     NumericTraits<PointIdentifier>::max()) };
 
   void
-  InterpolationDerivs(const CoordRepType pointCoords[CellDimension], CoordRepType derivs[NumberOfDerivatives]);
+  InterpolationDerivs(const CoordinateType pointCoords[CellDimension], CoordinateType derivs[NumberOfDerivatives]);
   void
-  InterpolationFunctions(const CoordRepType      pointCoords[CellDimension],
+  InterpolationFunctions(const CoordinateType    pointCoords[CellDimension],
                          InterpolationWeightType weights[NumberOfPoints]);
   void
   EvaluateLocation(int &                     itkNotUsed(subId),
                    const PointsContainer *   points,
-                   const CoordRepType        pointCoords[PointDimension],
-                   CoordRepType              x[PointDimension],
+                   const CoordinateType      pointCoords[PointDimension],
+                   CoordinateType            x[PointDimension],
                    InterpolationWeightType * weights);
 };
 } // end namespace itk

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -268,10 +268,10 @@ QuadrilateralCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAut
 /** Evaluate the position inside the cell */
 template <typename TCellInterface>
 bool
-QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
+QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                                     PointsContainer *         points,
-                                                    CoordRepType *            closestPoint,
-                                                    CoordRepType              pcoord[CellDimension],
+                                                    CoordinateType *          closestPoint,
+                                                    CoordinateType            pcoord[CellDimension],
                                                     double *                  dist2,
                                                     InterpolationWeightType * weight)
 {
@@ -287,12 +287,12 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   double                  scol[CellDimension];
   double                  d;
   PointType               pt;
-  CoordRepType            derivs[NumberOfDerivatives];
+  CoordinateType          derivs[NumberOfDerivatives];
   InterpolationWeightType weights[NumberOfPoints];
 
   //  set initial position for Newton's method
-  int          subId = 0;
-  CoordRepType pcoords[CellDimension];
+  int            subId = 0;
+  CoordinateType pcoords[CellDimension];
 
   pcoords[0] = pcoords[1] = params[0] = params[1] = 0.5;
 
@@ -333,7 +333,7 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
     }
 
     //  compute determinants and generate improvements
-    vnl_matrix_fixed<CoordRepType, CellDimension, CellDimension> mat;
+    vnl_matrix_fixed<CoordinateType, CellDimension, CellDimension> mat;
     for (unsigned int i = 0; i < CellDimension; ++i)
     {
       mat.put(0, i, rcol[i]);
@@ -347,14 +347,14 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       return false;
     }
 
-    vnl_matrix_fixed<CoordRepType, CellDimension, CellDimension> mat1;
+    vnl_matrix_fixed<CoordinateType, CellDimension, CellDimension> mat1;
     for (unsigned int i = 0; i < CellDimension; ++i)
     {
       mat1.put(0, i, fcol[i]);
       mat1.put(1, i, scol[i]);
     }
 
-    vnl_matrix_fixed<CoordRepType, CellDimension, CellDimension> mat2;
+    vnl_matrix_fixed<CoordinateType, CellDimension, CellDimension> mat2;
     for (unsigned int i = 0; i < CellDimension; ++i)
     {
       mat2.put(0, i, rcol[i]);
@@ -420,8 +420,8 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   }
   else
   {
-    CoordRepType pc[CellDimension];
-    CoordRepType w[NumberOfPoints];
+    CoordinateType pc[CellDimension];
+    CoordinateType w[NumberOfPoints];
     if (closestPoint)
     {
       for (unsigned int i = 0; i < CellDimension; ++i) // only approximate ??
@@ -454,7 +454,7 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 /** Compute iso-parametric interpolation functions */
 template <typename TCellInterface>
 void
-QuadrilateralCell<TCellInterface>::InterpolationFunctions(const CoordRepType      pointCoords[CellDimension],
+QuadrilateralCell<TCellInterface>::InterpolationFunctions(const CoordinateType    pointCoords[CellDimension],
                                                           InterpolationWeightType weights[NumberOfPoints])
 {
   const double rm = 1. - pointCoords[0];
@@ -469,8 +469,8 @@ QuadrilateralCell<TCellInterface>::InterpolationFunctions(const CoordRepType    
 /** Compute iso-parametric interpolation functions */
 template <typename TCellInterface>
 void
-QuadrilateralCell<TCellInterface>::InterpolationDerivs(const CoordRepType pointCoords[CellDimension],
-                                                       CoordRepType       derivs[NumberOfDerivatives])
+QuadrilateralCell<TCellInterface>::InterpolationDerivs(const CoordinateType pointCoords[CellDimension],
+                                                       CoordinateType       derivs[NumberOfDerivatives])
 {
   const double rm = 1. - pointCoords[0];
   const double sm = 1. - pointCoords[1];
@@ -492,15 +492,15 @@ template <typename TCellInterface>
 void
 QuadrilateralCell<TCellInterface>::EvaluateLocation(int &                     itkNotUsed(subId),
                                                     const PointsContainer *   points,
-                                                    const CoordRepType        pointCoords[PointDimension],
-                                                    CoordRepType              x[PointDimension],
+                                                    const CoordinateType      pointCoords[PointDimension],
+                                                    CoordinateType            x[PointDimension],
                                                     InterpolationWeightType * weights)
 {
   this->InterpolationFunctions(pointCoords, weights);
 
   for (unsigned int ii = 0; ii < PointDimension; ++ii)
   {
-    x[ii] = CoordRepType{};
+    x[ii] = CoordinateType{};
   }
 
   for (unsigned int ii = 0; ii < NumberOfPoints; ++ii)

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -164,10 +164,10 @@ public:
   itkCellVisitMacro(CellGeometryEnum::TETRAHEDRON_CELL);
 
   bool
-  EvaluatePosition(CoordRepType *,
+  EvaluatePosition(CoordinateType *,
                    PointsContainer *,
-                   CoordRepType *,
-                   CoordRepType[],
+                   CoordinateType *,
+                   CoordinateType[],
                    double *,
                    InterpolationWeightType *) override;
 

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -65,10 +65,10 @@ TetrahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) cons
 
 template <typename TCellInterface>
 bool
-TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
+TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                                   PointsContainer *         points,
-                                                  CoordRepType *            closestPoint,
-                                                  CoordRepType              pcoord[],
+                                                  CoordinateType *          closestPoint,
+                                                  CoordinateType            pcoord[],
                                                   double *                  minDist2,
                                                   InterpolationWeightType * weights)
 {
@@ -80,7 +80,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   double       det;
   double       p4;
 
-  CoordRepType pcoords[3];
+  CoordinateType pcoords[3];
 
   pcoords[0] = pcoords[1] = pcoords[2] = 0.0;
 
@@ -104,7 +104,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 
   // Create a vnl_matrix so that the determinant can be computed
   // for any PointDimension
-  vnl_matrix_fixed<CoordRepType, 3, PointDimension> mat;
+  vnl_matrix_fixed<CoordinateType, 3, PointDimension> mat;
   for (i = 0; i < PointDimension; ++i)
   {
     mat.put(0, i, c1[i]);
@@ -179,9 +179,9 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   }
   else
   { // could easily be sped up using parametric localization - next release
-    double       dist2;
-    CoordRepType closest[PointDimension];
-    CoordRepType pc[3];
+    double         dist2;
+    CoordinateType closest[PointDimension];
+    CoordinateType pc[3];
 
     if (closestPoint)
     {

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -157,10 +157,10 @@ public:
 
   /** Evaluate the position of a given point inside the cell */
   bool
-  EvaluatePosition(CoordRepType *,
+  EvaluatePosition(CoordinateType *,
                    PointsContainer *,
-                   CoordRepType *,
-                   CoordRepType[],
+                   CoordinateType *,
+                   CoordinateType[],
                    double *,
                    InterpolationWeightType *) override;
 
@@ -168,11 +168,11 @@ public:
   itkCellVisitMacro(CellGeometryEnum::TRIANGLE_CELL);
 
   /** Compute Area to a TriangleCell given a PointsContainer. */
-  CoordRepType
+  CoordinateType
   ComputeArea(PointsContainer *);
 
   PointType
-  ComputeBarycenter(CoordRepType *, PointsContainer *);
+  ComputeBarycenter(CoordinateType *, PointsContainer *);
 
   PointType
   ComputeCenterOfGravity(PointsContainer *);
@@ -193,7 +193,7 @@ private:
   /** Compute the squared distance between a point and a line segment defined by two other points. Returns the
    * parametric coordinate t and point location on line. */
   double
-  DistanceToLine(PointType x, PointType p1, PointType p2, double & t, CoordRepType * closestPoint);
+  DistanceToLine(PointType x, PointType p1, PointType p2, double & t, CoordinateType * closestPoint);
 
   double
   DistanceToLine(PointType x, PointType p1, PointType p2, double & t, PointType & closestPoint);

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -193,13 +193,13 @@ TriangleCell<TCellInterface>::GetEdge(CellFeatureIdentifier edgeId, EdgeAutoPoin
 
 template <typename TCellInterface>
 double
-TriangleCell<TCellInterface>::DistanceToLine(PointType      x,
-                                             PointType      p1,
-                                             PointType      p2,
-                                             double &       t,
-                                             CoordRepType * closestPoint)
+TriangleCell<TCellInterface>::DistanceToLine(PointType        x,
+                                             PointType        p1,
+                                             PointType        p2,
+                                             double &         t,
+                                             CoordinateType * closestPoint)
 {
-  // convert from CoordRepType * to PointType:
+  // convert from CoordinateType * to PointType:
   PointType temp(closestPoint);
   //   for (unsigned int i = 0; i < PointDimension; ++i)
   //     {
@@ -209,7 +209,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType      x,
   // Compute the squared distance to the line:
   const double distance2 = this->DistanceToLine(x, p1, p2, t, temp);
 
-  // convert from PointType to CoordRepType * :
+  // convert from PointType to CoordinateType * :
   for (unsigned int j = 0; j < PointDimension; ++j)
   {
     closestPoint[j] = temp[j];
@@ -264,7 +264,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType   x,
 
 template <typename TCellInterface>
 auto
-TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints) -> CoordRepType
+TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints) -> CoordinateType
 {
   PointType p[3];
 
@@ -273,21 +273,21 @@ TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints) -> CoordRep
     p[i] = iPoints->GetElement(m_PointIds[i]);
   }
 
-  CoordRepType a = p[1].EuclideanDistanceTo(p[2]);
-  CoordRepType b = p[0].EuclideanDistanceTo(p[2]);
-  CoordRepType c = p[1].EuclideanDistanceTo(p[0]);
+  CoordinateType a = p[1].EuclideanDistanceTo(p[2]);
+  CoordinateType b = p[0].EuclideanDistanceTo(p[2]);
+  CoordinateType c = p[1].EuclideanDistanceTo(p[0]);
 
-  CoordRepType s = 0.5 * (a + b + c);
+  CoordinateType s = 0.5 * (a + b + c);
   return std::sqrt(s * (s - a) * (s - b) * (s - c));
 }
 
 template <typename TCellInterface>
 auto
-TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsContainer * iPoints) -> PointType
+TriangleCell<TCellInterface>::ComputeBarycenter(CoordinateType * iWeights, PointsContainer * iPoints) -> PointType
 {
-  PointType    p[3];
-  CoordRepType sum_weights(0.);
-  unsigned int i(0);
+  PointType      p[3];
+  CoordinateType sum_weights(0.);
+  unsigned int   i(0);
 
   for (; i < 3; ++i)
   {
@@ -316,7 +316,7 @@ template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::ComputeCenterOfGravity(PointsContainer * iPoints) -> PointType
 {
-  std::vector<CoordRepType> weights(3, 1. / 3.);
+  std::vector<CoordinateType> weights(3, 1. / 3.);
   return ComputeBarycenter(&weights[0], iPoints);
 }
 
@@ -324,7 +324,7 @@ template <typename TCellInterface>
 auto
 TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> PointType
 {
-  std::vector<CoordRepType> weights(3, 0.);
+  std::vector<CoordinateType> weights(3, 0.);
 
   PointType    p[3];
   unsigned int i;
@@ -334,15 +334,15 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> 
     p[i] = iPoints->GetElement(m_PointIds[i]);
   }
 
-  CoordRepType a = p[1].SquaredEuclideanDistanceTo(p[2]);
-  CoordRepType b = p[0].SquaredEuclideanDistanceTo(p[2]);
-  CoordRepType c = p[1].SquaredEuclideanDistanceTo(p[0]);
+  CoordinateType a = p[1].SquaredEuclideanDistanceTo(p[2]);
+  CoordinateType b = p[0].SquaredEuclideanDistanceTo(p[2]);
+  CoordinateType c = p[1].SquaredEuclideanDistanceTo(p[0]);
 
   weights[0] = a * (b + c - a);
   weights[1] = b * (c + a - b);
   weights[2] = c * (a + b - c);
 
-  CoordRepType sum_weights = weights[0] + weights[1] + weights[2];
+  CoordinateType sum_weights = weights[0] + weights[1] + weights[2];
 
   if (sum_weights != 0.)
   {
@@ -363,10 +363,10 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> 
 
 template <typename TCellInterface>
 bool
-TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
+TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                                PointsContainer *         points,
-                                               CoordRepType *            closestPoint,
-                                               CoordRepType              pcoord[],
+                                               CoordinateType *          closestPoint,
+                                               CoordinateType            pcoord[],
                                                double *                  minDist2,
                                                InterpolationWeightType * weights)
 {

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -33,7 +33,7 @@ class ITK_TEMPLATE_EXPORT TriangleHelper
 public:
   using Self = TriangleHelper;
   using PointType = TPoint;
-  using CoordinateType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   using CoordRepType = CoordinateType;
   using VectorType = typename PointType::VectorType;
   using CrossVectorType = CrossHelper<VectorType>;
@@ -50,20 +50,20 @@ public:
   ComputeNormal(const PointType & iA, const PointType & iB, const PointType & iC);
 
   /** \brief Compute cotangent(iA,iB,iC)*/
-  static CoordRepType
+  static CoordinateType
   Cotangent(const PointType & iA, const PointType & iB, const PointType & iC);
 
   /** \brief Compute barycenter, with given weights*/
   static PointType
-  ComputeBarycenter(const CoordRepType & iA1,
-                    const PointType &    iP1,
-                    const CoordRepType & iA2,
-                    const PointType &    iP2,
-                    const CoordRepType & iA3,
-                    const PointType &    iP3);
+  ComputeBarycenter(const CoordinateType & iA1,
+                    const PointType &      iP1,
+                    const CoordinateType & iA2,
+                    const PointType &      iP2,
+                    const CoordinateType & iA3,
+                    const PointType &      iP3);
 
   /** \brief Compute angles (iA,iB,iC)*/
-  static CoordRepType
+  static CoordinateType
   ComputeAngle(const PointType & iP1, const PointType & iP2, const PointType & iP3);
 
   /** \brief Compute center of mass*/
@@ -79,10 +79,10 @@ public:
   ComputeConstrainedCircumCenter(const PointType & iP1, const PointType & iP2, const PointType & iP3);
 
   /** \brief Compute Area.*/
-  static CoordRepType
+  static CoordinateType
   ComputeArea(const PointType & iP1, const PointType & iP2, const PointType & iP3);
 
-  static CoordRepType
+  static CoordinateType
   ComputeMixedArea(const PointType & iP1, const PointType & iP2, const PointType & iP3);
 };
 } // namespace itk

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -34,7 +34,10 @@ public:
   using Self = TriangleHelper;
   using PointType = TPoint;
   using CoordinateType = typename PointType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using VectorType = typename PointType::VectorType;
   using CrossVectorType = CrossHelper<VectorType>;
 

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -33,7 +33,8 @@ class ITK_TEMPLATE_EXPORT TriangleHelper
 public:
   using Self = TriangleHelper;
   using PointType = TPoint;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VectorType = typename PointType::VectorType;
   using CrossVectorType = CrossHelper<VectorType>;
 

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -60,7 +60,7 @@ TriangleHelper<TPoint>::ComputeNormal(const PointType & iA, const PointType & iB
 {
   CrossVectorType cross;
   VectorType      w = cross(iB - iA, iC - iA);
-  CoordRepType    l2 = w.GetSquaredNorm();
+  CoordinateType  l2 = w.GetSquaredNorm();
 
   if (l2 != 0.0)
   {
@@ -72,55 +72,55 @@ TriangleHelper<TPoint>::ComputeNormal(const PointType & iA, const PointType & iB
 
 template <typename TPoint>
 auto
-TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, const PointType & iC) -> CoordRepType
+TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, const PointType & iC) -> CoordinateType
 {
   VectorType v21 = iA - iB;
 
-  CoordRepType v21_l2 = v21.GetSquaredNorm();
+  CoordinateType v21_l2 = v21.GetSquaredNorm();
 
-  if (Math::NotAlmostEquals(v21_l2, CoordRepType{}))
+  if (Math::NotAlmostEquals(v21_l2, CoordinateType{}))
   {
     v21 /= std::sqrt(v21_l2);
   }
 
-  VectorType   v23 = iC - iB;
-  CoordRepType v23_l2 = v23.GetSquaredNorm();
-  if (Math::NotAlmostEquals(v23_l2, CoordRepType{}))
+  VectorType     v23 = iC - iB;
+  CoordinateType v23_l2 = v23.GetSquaredNorm();
+  if (Math::NotAlmostEquals(v23_l2, CoordinateType{}))
   {
     v23 /= std::sqrt(v23_l2);
   }
 
-  CoordRepType bound(0.999999);
+  CoordinateType bound(0.999999);
 
-  CoordRepType cos_theta = std::clamp(v21 * v23, -bound, bound);
+  CoordinateType cos_theta = std::clamp(v21 * v23, -bound, bound);
 
   return 1.0 / std::tan(std::acos(cos_theta));
 }
 
 template <typename TPoint>
 auto
-TriangleHelper<TPoint>::ComputeBarycenter(const CoordRepType & iA1,
-                                          const PointType &    iP1,
-                                          const CoordRepType & iA2,
-                                          const PointType &    iP2,
-                                          const CoordRepType & iA3,
-                                          const PointType &    iP3) -> PointType
+TriangleHelper<TPoint>::ComputeBarycenter(const CoordinateType & iA1,
+                                          const PointType &      iP1,
+                                          const CoordinateType & iA2,
+                                          const PointType &      iP2,
+                                          const CoordinateType & iA3,
+                                          const PointType &      iP3) -> PointType
 {
   PointType oPt;
 
-  CoordRepType total = iA1 + iA2 + iA3;
+  CoordinateType total = iA1 + iA2 + iA3;
 
-  if (Math::AlmostEquals(total, CoordRepType{}))
+  if (Math::AlmostEquals(total, CoordinateType{}))
   {
     // in such case there is no barycenter;
     oPt.Fill(0.);
     return oPt;
   }
 
-  CoordRepType inv_total = 1. / total;
-  CoordRepType a1 = iA1 * inv_total;
-  CoordRepType a2 = iA2 * inv_total;
-  CoordRepType a3 = iA3 * inv_total;
+  CoordinateType inv_total = 1. / total;
+  CoordinateType a1 = iA1 * inv_total;
+  CoordinateType a2 = iA2 * inv_total;
+  CoordinateType a3 = iA3 * inv_total;
 
   for (unsigned int dim = 0; dim < PointDimension; ++dim)
   {
@@ -133,13 +133,13 @@ TriangleHelper<TPoint>::ComputeBarycenter(const CoordRepType & iA1,
 template <typename TPoint>
 auto
 TriangleHelper<TPoint>::ComputeAngle(const PointType & iP1, const PointType & iP2, const PointType & iP3)
-  -> CoordRepType
+  -> CoordinateType
 {
   VectorType v21 = iP1 - iP2;
   VectorType v23 = iP3 - iP2;
 
-  CoordRepType v21_l2 = v21.GetSquaredNorm();
-  CoordRepType v23_l2 = v23.GetSquaredNorm();
+  CoordinateType v21_l2 = v21.GetSquaredNorm();
+  CoordinateType v23_l2 = v23.GetSquaredNorm();
 
   if (v21_l2 != 0.0)
   {
@@ -150,9 +150,9 @@ TriangleHelper<TPoint>::ComputeAngle(const PointType & iP1, const PointType & iP
     v23 /= std::sqrt(v23_l2);
   }
 
-  CoordRepType bound(0.999999);
+  CoordinateType bound(0.999999);
 
-  CoordRepType cos_theta = std::clamp(v21 * v23, -bound, bound);
+  CoordinateType cos_theta = std::clamp(v21 * v23, -bound, bound);
 
   return std::acos(cos_theta);
 }
@@ -172,11 +172,11 @@ TriangleHelper<TPoint>::ComputeCircumCenter(const PointType & iP1, const PointTy
 {
   PointType oPt{};
 
-  CoordRepType a = iP2.SquaredEuclideanDistanceTo(iP3);
-  CoordRepType b = iP1.SquaredEuclideanDistanceTo(iP3);
-  CoordRepType c = iP2.SquaredEuclideanDistanceTo(iP1);
+  CoordinateType a = iP2.SquaredEuclideanDistanceTo(iP3);
+  CoordinateType b = iP1.SquaredEuclideanDistanceTo(iP3);
+  CoordinateType c = iP2.SquaredEuclideanDistanceTo(iP1);
 
-  CoordRepType Weight[3];
+  CoordinateType Weight[3];
   Weight[0] = a * (b + c - a);
   Weight[1] = b * (c + a - b);
   Weight[2] = c * (a + b - c);
@@ -190,11 +190,11 @@ TriangleHelper<TPoint>::ComputeConstrainedCircumCenter(const PointType & iP1,
                                                        const PointType & iP2,
                                                        const PointType & iP3) -> PointType
 {
-  const CoordRepType a = iP2.SquaredEuclideanDistanceTo(iP3);
-  const CoordRepType b = iP1.SquaredEuclideanDistanceTo(iP3);
-  const CoordRepType c = iP2.SquaredEuclideanDistanceTo(iP1);
+  const CoordinateType a = iP2.SquaredEuclideanDistanceTo(iP3);
+  const CoordinateType b = iP1.SquaredEuclideanDistanceTo(iP3);
+  const CoordinateType c = iP2.SquaredEuclideanDistanceTo(iP1);
 
-  CoordRepType Weight[3] = { a * (b + c - a), b * (c + a - b), c * (a + b - c) };
+  CoordinateType Weight[3] = { a * (b + c - a), b * (c + a - b), c * (a + b - c) };
 
   for (auto & i : Weight)
   {
@@ -209,39 +209,40 @@ TriangleHelper<TPoint>::ComputeConstrainedCircumCenter(const PointType & iP1,
 
 template <typename TPoint>
 auto
-TriangleHelper<TPoint>::ComputeArea(const PointType & iP1, const PointType & iP2, const PointType & iP3) -> CoordRepType
+TriangleHelper<TPoint>::ComputeArea(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+  -> CoordinateType
 {
-  CoordRepType a = iP2.EuclideanDistanceTo(iP3);
-  CoordRepType b = iP1.EuclideanDistanceTo(iP3);
-  CoordRepType c = iP2.EuclideanDistanceTo(iP1);
+  CoordinateType a = iP2.EuclideanDistanceTo(iP3);
+  CoordinateType b = iP1.EuclideanDistanceTo(iP3);
+  CoordinateType c = iP2.EuclideanDistanceTo(iP1);
 
-  CoordRepType s = 0.5 * (a + b + c);
+  CoordinateType s = 0.5 * (a + b + c);
 
-  return static_cast<CoordRepType>(std::sqrt(s * (s - a) * (s - b) * (s - c)));
+  return static_cast<CoordinateType>(std::sqrt(s * (s - a) * (s - b) * (s - c)));
 }
 
 template <typename TPoint>
 auto
 TriangleHelper<TPoint>::ComputeMixedArea(const PointType & iP1, const PointType & iP2, const PointType & iP3)
-  -> CoordRepType
+  -> CoordinateType
 {
   using TriangleType = TriangleHelper<TPoint>;
 
   if (!TriangleType::IsObtuse(iP1, iP2, iP3))
   {
-    auto sq_d01 = static_cast<CoordRepType>(iP1.SquaredEuclideanDistanceTo(iP2));
-    auto sq_d02 = static_cast<CoordRepType>(iP1.SquaredEuclideanDistanceTo(iP3));
+    auto sq_d01 = static_cast<CoordinateType>(iP1.SquaredEuclideanDistanceTo(iP2));
+    auto sq_d02 = static_cast<CoordinateType>(iP1.SquaredEuclideanDistanceTo(iP3));
 
-    CoordRepType cot_theta_210 = TriangleType::Cotangent(iP3, iP2, iP1);
-    CoordRepType cot_theta_021 = TriangleType::Cotangent(iP1, iP3, iP2);
+    CoordinateType cot_theta_210 = TriangleType::Cotangent(iP3, iP2, iP1);
+    CoordinateType cot_theta_021 = TriangleType::Cotangent(iP1, iP3, iP2);
 
     return 0.125 * (sq_d02 * cot_theta_210 + sq_d01 * cot_theta_021);
   }
   else
   {
-    auto area = static_cast<CoordRepType>(TriangleType::ComputeArea(iP1, iP2, iP3));
+    auto area = static_cast<CoordinateType>(TriangleType::ComputeArea(iP1, iP2, iP3));
 
-    if ((iP2 - iP1) * (iP3 - iP1) < CoordRepType{})
+    if ((iP2 - iP1) * (iP3 - iP1) < CoordinateType{})
     {
       return 0.5 * area;
     }

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -124,10 +124,10 @@ public:
 
   /** Evaluate the position of a given point */
   bool
-  EvaluatePosition(CoordRepType *,
+  EvaluatePosition(CoordinateType *,
                    PointsContainer *,
-                   CoordRepType *,
-                   CoordRepType[],
+                   CoordinateType *,
+                   CoordinateType[],
                    double *,
                    InterpolationWeightType *) override;
 

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -131,10 +131,10 @@ VertexCell<TCellInterface>::GetPointId() -> PointIdentifier
 
 template <typename TCellInterface>
 bool
-VertexCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
+VertexCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                              PointsContainer *         points,
-                                             CoordRepType *            closestPoint,
-                                             CoordRepType              pcoord[],
+                                             CoordinateType *          closestPoint,
+                                             CoordinateType            pcoord[],
                                              double *                  minDist2,
                                              InterpolationWeightType * weights)
 {

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -45,14 +45,14 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
 {
 
   { // Creating a local scope
-    using CoordRepType = double;
+    using CoordinateType = double;
     constexpr unsigned int SpaceDimension = 1;
     constexpr unsigned int SplineOrder = 2;
 
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
     std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
-    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
+    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordinateType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;
     using IndexType = FunctionType::IndexType;
     using WeightsType = FunctionType::WeightsType;
@@ -145,14 +145,14 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     std::cout << "Test passed. " << std::endl;
   }
   { // Creating a local scope
-    using CoordRepType = double;
+    using CoordinateType = double;
     constexpr unsigned int SpaceDimension = 1;
     constexpr unsigned int SplineOrder = 3;
 
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
     std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
-    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
+    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordinateType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;
     using IndexType = FunctionType::IndexType;
     using WeightsType = FunctionType::WeightsType;
@@ -234,13 +234,13 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
   }
 
   { // Creating a local scope
-    using CoordRepType = double;
+    using CoordinateType = double;
     constexpr unsigned int SpaceDimension = 3;
     constexpr unsigned int SplineOrder = 3;
     std::cout << "Testing SpaceDimension= " << SpaceDimension;
     std::cout << " and SplineOrder= " << SplineOrder << std::endl;
 
-    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordRepType, SpaceDimension, SplineOrder>;
+    using FunctionType = itk::BSplineInterpolationWeightFunction<CoordinateType, SpaceDimension, SplineOrder>;
     using ContinuousIndexType = FunctionType::ContinuousIndexType;
     using IndexType = FunctionType::IndexType;
     using WeightsType = FunctionType::WeightsType;

--- a/Modules/Core/Common/test/itkBoundingBoxTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxTest.cxx
@@ -40,7 +40,7 @@ itkBoundingBoxTest(int, char *[])
     const BB::BoundsArrayType & bounds = myBox->GetBounds();
     for (unsigned int i = 0; i < bounds.Size(); ++i)
     {
-      if (itk::Math::NotExactlyEquals(bounds[i], BB::CoordRepType{}))
+      if (itk::Math::NotExactlyEquals(bounds[i], BB::CoordinateType{}))
       {
         std::cerr << "Bounding Box initialization test failed" << std::endl;
         std::cerr << bounds << std::endl;
@@ -54,7 +54,7 @@ itkBoundingBoxTest(int, char *[])
     BB::PointType center = myBox->GetCenter();
     for (unsigned int i = 0; i < 1; ++i)
     {
-      if (itk::Math::NotExactlyEquals(center[i], BB::CoordRepType{}))
+      if (itk::Math::NotExactlyEquals(center[i], BB::CoordinateType{}))
       {
         std::cerr << "Empty Box GetCenter initialization test failed" << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkCrossHelperTest.cxx
+++ b/Modules/Core/Common/test/itkCrossHelperTest.cxx
@@ -28,11 +28,11 @@ itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   constexpr unsigned int Dimension3D = 3;
   constexpr unsigned int Dimension4D = 4;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using Vector2DType = itk::Vector<CoordRepType, Dimension2D>;
-  using Vector3DType = itk::Vector<CoordRepType, Dimension3D>;
-  using Vector4DType = itk::Vector<CoordRepType, Dimension4D>;
+  using Vector2DType = itk::Vector<CoordinateType, Dimension2D>;
+  using Vector3DType = itk::Vector<CoordinateType, Dimension3D>;
+  using Vector4DType = itk::Vector<CoordinateType, Dimension4D>;
 
   using Cross2DType = itk::CrossHelper<Vector2DType>;
   Cross2DType cross2d;

--- a/Modules/Core/Common/test/itkPointSetGTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetGTest.cxx
@@ -30,7 +30,7 @@ template <typename TPointSet>
 void
 TestSetPointsByCoordinates(TPointSet & pointSet)
 {
-  using CoordRepType = typename TPointSet::CoordRepType;
+  using CoordinateType = typename TPointSet::CoordinateType;
 
   static constexpr auto PointDimension = TPointSet::PointDimension;
 
@@ -38,15 +38,16 @@ TestSetPointsByCoordinates(TPointSet & pointSet)
   {
     // SetPointsByCoordinates is expected to throw an exception when the specified number of coordinates is not a
     // multiple of PointDimension.
-    EXPECT_THROW(pointSet.SetPointsByCoordinates(std::vector<CoordRepType>(numberOfCoordinates)), itk::ExceptionObject);
+    EXPECT_THROW(pointSet.SetPointsByCoordinates(std::vector<CoordinateType>(numberOfCoordinates)),
+                 itk::ExceptionObject);
   }
 
   for (const unsigned int numberOfPoints : { 2, 1, 0 })
   {
-    std::vector<CoordRepType> coordinates(numberOfPoints * PointDimension);
+    std::vector<CoordinateType> coordinates(numberOfPoints * PointDimension);
 
     // Just make sure that all coordinates have different values, for the purpose of the test.
-    std::iota(coordinates.begin(), coordinates.end(), CoordRepType());
+    std::iota(coordinates.begin(), coordinates.end(), CoordinateType());
     {
       const auto modifiedTime = pointSet.GetMTime();
       pointSet.SetPointsByCoordinates(coordinates);

--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -43,7 +43,7 @@ itkPointSetTest(int, char *[])
   /**
    * Define the 3d geometric positions for 8 points in a cube.
    */
-  PointSet::CoordRepType testPointCoords[3];
+  PointSet::CoordinateType testPointCoords[3];
 
   /**
    * Create the point set through its object factory.
@@ -67,9 +67,9 @@ itkPointSetTest(int, char *[])
   {
     for (int i = 0; i < numOfPoints; ++i)
     {
-      testPointCoords[0] = (PointSet::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-      testPointCoords[1] = (PointSet::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-      testPointCoords[2] = (PointSet::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
+      testPointCoords[0] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+      testPointCoords[1] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+      testPointCoords[2] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
       pset->SetPoint(i, PointType(testPointCoords));
     }
   }

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -83,7 +83,7 @@ public:
   /** OutputType type alias support */
   using OutputType = TOutput;
 
-  /** CoordRepType type alias support */
+  /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
   using CoordRepType = CoordinateType;
 

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -84,7 +84,8 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Index Type. */
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -85,7 +85,10 @@ public:
 
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Index Type. */
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Core/ImageFunction/include/itkImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.hxx
@@ -60,8 +60,8 @@ ImageFunction<TInputImage, TOutput, TCoordinate>::SetInputImage(const InputImage
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       m_EndIndex[j] = m_StartIndex[j] + static_cast<IndexValueType>(size[j]) - 1;
-      m_StartContinuousIndex[j] = static_cast<CoordRepType>(m_StartIndex[j] - 0.5);
-      m_EndContinuousIndex[j] = static_cast<CoordRepType>(m_EndIndex[j] + 0.5);
+      m_StartContinuousIndex[j] = static_cast<CoordinateType>(m_StartIndex[j] - 0.5);
+      m_EndContinuousIndex[j] = static_cast<CoordinateType>(m_EndIndex[j] + 0.5);
     }
   }
 }

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -87,7 +87,10 @@ public:
 
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Returns the interpolated image intensity at a
    * specified point position. No bounds checking is done.

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -86,7 +86,8 @@ public:
   using typename Superclass::OutputType;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Returns the interpolated image intensity at a
    * specified point position. No bounds checking is done.

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -35,7 +35,7 @@
 
 
 using InputPixelType = double;
-using CoordRepType = itk::SpacePrecisionType;
+using CoordinateType = itk::SpacePrecisionType;
 
 // Set up for 1D Images
 enum
@@ -46,7 +46,7 @@ enum
 using ImageType1D = itk::Image<InputPixelType, ImageDimension1D>;
 using ImageTypePtr1D = ImageType1D::Pointer;
 using SizeType1D = ImageType1D::SizeType;
-using InterpolatorType1D = itk::BSplineInterpolateImageFunction<ImageType1D, CoordRepType>;
+using InterpolatorType1D = itk::BSplineInterpolateImageFunction<ImageType1D, CoordinateType>;
 //  using IndexType1D = InterpolatorType1D::IndexType;
 using PointType1D = InterpolatorType1D::PointType;
 using ContinuousIndexType1D = InterpolatorType1D::ContinuousIndexType;
@@ -62,7 +62,7 @@ enum
 using ImageType2D = itk::Image<InputPixelType, ImageDimension2D>;
 using ImageTypePtr2D = ImageType2D::Pointer;
 using SizeType2D = ImageType2D::SizeType;
-using InterpolatorType2D = itk::BSplineInterpolateImageFunction<ImageType2D, CoordRepType>;
+using InterpolatorType2D = itk::BSplineInterpolateImageFunction<ImageType2D, CoordinateType>;
 //  using IndexType2D = InterpolatorType2D::IndexType;
 using PointType2D = InterpolatorType2D::PointType;
 using ContinuousIndexType2D = InterpolatorType2D::ContinuousIndexType;
@@ -78,13 +78,13 @@ enum
 using ImageType3D = itk::Image<InputPixelType, ImageDimension3D>;
 using ImageTypePtr3D = ImageType3D::Pointer;
 using SizeType3D = ImageType3D::SizeType;
-using InterpolatorType3D = itk::BSplineInterpolateImageFunction<ImageType3D, CoordRepType>;
+using InterpolatorType3D = itk::BSplineInterpolateImageFunction<ImageType3D, CoordinateType>;
 using IndexType3D = InterpolatorType3D::IndexType;
 using PointType3D = InterpolatorType3D::PointType;
 using ContinuousIndexType3D = InterpolatorType3D::ContinuousIndexType;
 
 using ImageIntegerType3D = itk::Image<unsigned int, ImageDimension3D>;
-using InterpolatorIntegerType3D = itk::BSplineInterpolateImageFunction<ImageIntegerType3D, CoordRepType>;
+using InterpolatorIntegerType3D = itk::BSplineInterpolateImageFunction<ImageIntegerType3D, CoordinateType>;
 using IndexIntegerType3D = InterpolatorIntegerType3D::IndexType;
 using PointIntegerType3D = InterpolatorIntegerType3D::PointType;
 using ContinuousIntegerIndexType3D = InterpolatorIntegerType3D::ContinuousIndexType;

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -64,10 +64,10 @@ itkCentralDifferenceImageFunctionOnVectorSpeedTestRun(char * argv[])
   }
 
   // set up central difference calculator
-  using CoordRepType = float;
+  using CoordinateType = float;
   using DerivativeType = itk::Matrix<double, vecLength, 2>;
 
-  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordRepType, DerivativeType>;
+  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordinateType, DerivativeType>;
   using OutputType = typename FunctionType::OutputType;
 
   auto function = FunctionType::New();

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -79,10 +79,10 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   }
 
   // set up central difference calculator
-  using CoordRepType = float;
+  using CoordinateType = float;
   using DerivativeType = itk::Matrix<double, VectorLength, ImageDimension>;
 
-  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordRepType, DerivativeType>;
+  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordinateType, DerivativeType>;
   using OutputType = typename FunctionType::OutputType;
   using OutputValueType = typename FunctionType::OutputValueType;
 
@@ -352,7 +352,7 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   // Test with incorrectly-sized output type
   using BadDerivativeType = itk::Matrix<double, 10, ImageDimension>;
 
-  using BadFunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordRepType, BadDerivativeType>;
+  using BadFunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordinateType, BadDerivativeType>;
 
   auto badFunction = BadFunctionType::New();
   ITK_TRY_EXPECT_EXCEPTION(badFunction->SetInputImage(image));

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
@@ -63,8 +63,8 @@ itkCentralDifferenceImageFunctionSpeedTest(int argc, char * argv[])
   }
 
   // set up central difference calculator
-  using CoordRepType = float;
-  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = float;
+  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordinateType>;
   using OutputType = FunctionType::OutputType;
 
   auto function = FunctionType::New();

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -51,8 +51,8 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
   }
 
   // set up central difference calculator
-  using CoordRepType = float;
-  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = float;
+  using FunctionType = itk::CentralDifferenceImageFunction<ImageType, CoordinateType>;
   using OutputType = FunctionType::OutputType;
   using OutputValueType = FunctionType::OutputValueType;
 

--- a/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
@@ -49,9 +49,9 @@ enum
 using ImageType = itk::Image<InputPixelType, ImageDimension>;
 using ImageAdaptorType = itk::ImageAdaptor<ImageType, RedChannelPixelAccessor>;
 
-using CoordRepType = itk::SpacePrecisionType;
+using CoordinateType = itk::SpacePrecisionType;
 
-using InterpolatorType = itk::LinearInterpolateImageFunction<ImageAdaptorType, CoordRepType>;
+using InterpolatorType = itk::LinearInterpolateImageFunction<ImageAdaptorType, CoordinateType>;
 using IndexType = InterpolatorType::IndexType;
 using PointType = ImageType::PointType;
 using ContinuousIndexType = InterpolatorType::ContinuousIndexType;

--- a/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
@@ -25,13 +25,13 @@
 
 using SizeType = itk::Size<3>;
 using ImageType = itk::Image<unsigned short, 3>;
-using CoordRepType = itk::SpacePrecisionType;
-using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+using CoordinateType = itk::SpacePrecisionType;
+using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
 using IndexType = InterpolatorType::IndexType;
 using PointType = InterpolatorType::PointType;
 using ContinuousIndexType = InterpolatorType::ContinuousIndexType;
 
-using NNInterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+using NNInterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
 namespace
 {
 

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -33,7 +33,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   using SizeType = RegionType::SizeType;
   using IndexType = ImageType::IndexType;
 
-  using CoordRepType = float;
+  using CoordinateType = float;
 
   // The ImageSizeToCompute
   constexpr double              FOV = 10.0;
@@ -84,7 +84,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
     }
   }
 
-  using InterpolatorType = itk::LabelImageGaussianInterpolateImageFunction<ImageType, CoordRepType>;
+  using InterpolatorType = itk::LabelImageGaussianInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
   interpolator->SetInputImage(small_image);
   {

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -40,17 +40,17 @@ RunLinearInterpolateTest()
   using SizeType = typename RegionType::SizeType;
   using IndexType = typename ImageType::IndexType;
 
-  using CoordRepType = float;
-  using ContinuousIndexType = typename itk::ContinuousIndex<CoordRepType, Dimensions>;
+  using CoordinateType = float;
+  using ContinuousIndexType = typename itk::ContinuousIndex<CoordinateType, Dimensions>;
 
   using AccumulatorType = typename ContinuousIndexType::ValueType;
 
-  using PointType = typename itk::Point<CoordRepType, Dimensions>;
+  using PointType = typename itk::Point<CoordinateType, Dimensions>;
 
-  using InterpolatorType = typename itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
-  using VectorInterpolatorType = typename itk::LinearInterpolateImageFunction<VectorImageType, CoordRepType>;
+  using InterpolatorType = typename itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
+  using VectorInterpolatorType = typename itk::LinearInterpolateImageFunction<VectorImageType, CoordinateType>;
   using VariableVectorInterpolatorType =
-    typename itk::LinearInterpolateImageFunction<VariableVectorImageType, CoordRepType>;
+    typename itk::LinearInterpolateImageFunction<VariableVectorImageType, CoordinateType>;
 
   using InterpolatedVectorType = typename VectorInterpolatorType::OutputType;
   using InterpolatedVariableVectorType = typename VariableVectorInterpolatorType::OutputType;

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -44,11 +44,11 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
 
   using PointType = itk::Point<float, 2>;
 
-  using CoordRepType = float;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
-  using VectorInterpolatorType = itk::NearestNeighborInterpolateImageFunction<VectorImageType, CoordRepType>;
+  using CoordinateType = float;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
+  using VectorInterpolatorType = itk::NearestNeighborInterpolateImageFunction<VectorImageType, CoordinateType>;
   using VariableVectorInterpolatorType =
-    itk::NearestNeighborInterpolateImageFunction<VariableVectorImageType, CoordRepType>;
+    itk::NearestNeighborInterpolateImageFunction<VariableVectorImageType, CoordinateType>;
 
   using InterpolatedVectorType = VectorInterpolatorType::OutputType;
   using InterpolatedVariableVectorType = VariableVectorInterpolatorType::OutputType;

--- a/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
@@ -34,8 +34,8 @@ enum
 }; // RGB is a vector of dimension 3
 using PixelType = itk::RGBPixel<unsigned short>;
 using ImageType = itk::Image<PixelType, ImageDimension>;
-using CoordRepType = itk::SpacePrecisionType;
-using InterpolatorType = itk::VectorLinearInterpolateImageFunction<ImageType, CoordRepType>;
+using CoordinateType = itk::SpacePrecisionType;
+using InterpolatorType = itk::VectorLinearInterpolateImageFunction<ImageType, CoordinateType>;
 using IndexType = InterpolatorType::IndexType;
 using PointType = InterpolatorType::PointType;
 using ContinuousIndexType = InterpolatorType::ContinuousIndexType;

--- a/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
@@ -30,8 +30,8 @@ enum
 };
 using PixelType = itk::Vector<unsigned short, VectorDimension>;
 using ImageType = itk::Image<PixelType, ImageDimension>;
-using CoordRepType = itk::SpacePrecisionType;
-using InterpolatorType = itk::VectorLinearInterpolateImageFunction<ImageType, CoordRepType>;
+using CoordinateType = itk::SpacePrecisionType;
+using InterpolatorType = itk::VectorLinearInterpolateImageFunction<ImageType, CoordinateType>;
 using IndexType = InterpolatorType::IndexType;
 using PointType = InterpolatorType::PointType;
 using ContinuousIndexType = InterpolatorType::ContinuousIndexType;

--- a/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -31,9 +31,9 @@ enum
 };
 using PixelType = itk::Vector<unsigned short, VectorDimension>;
 using ImageType = itk::Image<PixelType, ImageDimension>;
-using CoordRepType = itk::SpacePrecisionType;
+using CoordinateType = itk::SpacePrecisionType;
 
-using InterpolatorType = itk::VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>;
+using InterpolatorType = itk::VectorLinearInterpolateNearestNeighborExtrapolateImageFunction<ImageType, CoordinateType>;
 
 using IndexType = InterpolatorType::IndexType;
 using PointType = InterpolatorType::PointType;

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -37,12 +37,12 @@ enum
 
 using PixelType = unsigned char;
 using ImageType = itk::Image<PixelType, ImageDimension>;
-using CoordRepType = itk::SpacePrecisionType;
+using CoordinateType = itk::SpacePrecisionType;
 using WindowFunctionType = itk::Function::HammingWindowFunction<2>;
 using BoundaryConditionType = itk::ConstantBoundaryCondition<ImageType>;
 
 using InterpolatorType =
-  itk::WindowedSincInterpolateImageFunction<ImageType, 2, WindowFunctionType, BoundaryConditionType, CoordRepType>;
+  itk::WindowedSincInterpolateImageFunction<ImageType, 2, WindowFunctionType, BoundaryConditionType, CoordinateType>;
 
 using IndexType = InterpolatorType::IndexType;
 using PointType = InterpolatorType::PointType;
@@ -139,7 +139,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   using PointType = SincInterpolate::PointType;
   using OutputType = SincInterpolate::OutputType;
   using ContinuousIndexType = SincInterpolate::ContinuousIndexType;
-  using CoordRepType = SincInterpolate::CoordRepType;
+  using CoordinateType = SincInterpolate::CoordinateType;
 
   using InterpolatorType = SincInterpolate::InterpolatorType;
 
@@ -204,7 +204,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
 
   // an integer position inside the image
   {
-    CoordRepType darray[3] = { 10, 20, 40 };
+    CoordinateType darray[3] = { 10, 20, 40 };
     output = OutputType(70);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
@@ -225,7 +225,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
 
   // position at the image border
   {
-    CoordRepType darray[3] = { 0, 20, 40 };
+    CoordinateType darray[3] = { 0, 20, 40 };
     output = OutputType(60);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
@@ -246,8 +246,8 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
 
   // position near image border
   {
-    double       epsilon = 1.0e-10;
-    CoordRepType darray[3] = { 19 - epsilon, 20, 40 };
+    double         epsilon = 1.0e-10;
+    CoordinateType darray[3] = { 19 - epsilon, 20, 40 };
     output = OutputType(79);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
@@ -268,7 +268,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
 
   // position outside the image
   {
-    CoordRepType darray[3] = { 20, 20, 40 };
+    CoordinateType darray[3] = { 20, 20, 40 };
     output = OutputType(1);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, false, output);
@@ -289,7 +289,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
 
   // at non-integer position
   {
-    CoordRepType darray[3] = { 5.25, 12.5, 42.0 };
+    CoordinateType darray[3] = { 5.25, 12.5, 42.0 };
     output = OutputType(59.75);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
@@ -125,7 +125,7 @@ public:
   using PointType = typename MeshType::PointType;
   using CellType = typename MeshType::CellType;
   using MeshPointer = typename MeshType::Pointer;
-  using CoordinateType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   using CellAutoPointer = typename CellType::CellAutoPointer;
 
   /** Different kinds of cells. */

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -62,7 +62,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Type of the  transform. */
   using SpatialFunctionType = TSpatialFunction;

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -62,7 +62,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordRepType = CoordinateType;
 
   /** Type of the  transform. */

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -63,7 +63,10 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Type of the  transform. */
   using SpatialFunctionType = TSpatialFunction;

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -169,7 +169,10 @@ public:
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
   using CoordinateType = typename MeshTraits::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -168,7 +168,8 @@ public:
 #endif
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
-  using CoordRepType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -168,7 +168,7 @@ public:
 #endif
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
-  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordinateType;
   using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
@@ -189,7 +189,7 @@ public:
   using CellsVectorContainerPointer = typename CellsVectorContainer::Pointer;
 
   /** Used to support geometric operations on the toolkit. */
-  using BoundingBoxType = BoundingBox<PointIdentifier, Self::PointDimension, CoordRepType, PointsContainer>;
+  using BoundingBoxType = BoundingBox<PointIdentifier, Self::PointDimension, CoordinateType, PointsContainer>;
 
   /** Create types that are pointers to each of the container types. */
   using PointsContainerPointer = typename PointsContainer::Pointer;

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -56,7 +56,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Type for representing coordinates. */
-  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordRepType = CoordinateType;
 
   using InputMeshType = TInputMesh;

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -56,7 +56,8 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   using InputMeshType = TInputMesh;
   using OutputMeshType = TOutputMesh;

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -57,7 +57,10 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   using InputMeshType = TInputMesh;
   using OutputMeshType = TOutputMesh;

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -56,7 +56,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Type of the transform. */
   using TransformType = TTransform;

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -56,7 +56,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordRepType = CoordinateType;
 
   /** Type of the transform. */

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -57,7 +57,10 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Type of the transform. */
   using TransformType = TTransform;

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -57,7 +57,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Deformation field type alias support */
   using DisplacementFieldType = TDisplacementField;

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -58,7 +58,10 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Deformation field type alias support */
   using DisplacementFieldType = TDisplacementField;

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -57,7 +57,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordRepType = CoordinateType;
 
   /** Deformation field type alias support */

--- a/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
@@ -41,7 +41,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordinateType;
 
   /** Type of the transform. */
   using TransformType = TTransform;

--- a/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
@@ -41,8 +41,8 @@ itkMeshSpatialObjectIOTest(int argc, char * argv[])
   std::cout << "Creating Mesh File: ";
   auto mesh = MeshType::New();
 
-  MeshType::CoordRepType testPointCoords[8][3] = { { 0, 1, 2 }, { 1, 2, 3 }, { 2, 3, 4 }, { 3, 4, 5 },
-                                                   { 4, 5, 6 }, { 5, 6, 7 }, { 6, 7, 8 }, { 7, 8, 9 } };
+  MeshType::CoordinateType testPointCoords[8][3] = { { 0, 1, 2 }, { 1, 2, 3 }, { 2, 3, 4 }, { 3, 4, 5 },
+                                                     { 4, 5, 6 }, { 5, 6, 7 }, { 6, 7, 8 }, { 7, 8, 9 } };
 
 
   MeshType::PointIdentifier tetraPoints[4] = { 0, 1, 2, 3 };

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -148,8 +148,8 @@ itkMeshTest(int, char *[])
   /**
    * Define the 3d geometric positions for 8 points in a cube.
    */
-  MeshType::CoordRepType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
-                                                   { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
+  MeshType::CoordinateType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
+                                                     { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
 
   /**
    * List the points that the tetrahedron will use from the mesh.
@@ -688,7 +688,7 @@ itkMeshTest(int, char *[])
      */
     using BoundingBox = itk::BoundingBox<MeshType::PointIdentifier,
                                          MeshType::PointDimension,
-                                         MeshType::CoordRepType,
+                                         MeshType::CoordinateType,
                                          MeshType::PointsContainer>;
 
     BoundingBox::Pointer bbox(BoundingBox::New());

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -43,16 +43,16 @@ itkQuadrilateralCellTest(int, char *[])
   class QuadrilateralHelper : public QuadrilateralCellType
   {
     using Superclass = QuadrilateralCellType;
-    using CoordRepType = Superclass::CoordRepType;
+    using CoordinateType = Superclass::CoordinateType;
     using PointsContainer = Superclass::PointsContainer;
     using InterpolationWeightType = Superclass::InterpolationWeightType;
 
   public:
     bool
-    EvaluatePosition(CoordRepType *            inputPoint,
+    EvaluatePosition(CoordinateType *          inputPoint,
                      PointsContainer *         points,
-                     CoordRepType *            closestPoint,
-                     CoordRepType              pcoord[],
+                     CoordinateType *          closestPoint,
+                     CoordinateType            pcoord[],
                      double *                  distance,
                      InterpolationWeightType * weights) override
     {
@@ -88,8 +88,8 @@ itkQuadrilateralCellTest(int, char *[])
    */
   constexpr unsigned int Dimension = 3;
   // Test points are on a plane at an angle (3^2 + 4^2 = 5^2) with xy plane
-  MeshType::CoordRepType testPointCoords[numberOfPoints][Dimension] = { { 0, 0, 0 },  { 10, 0, 0 },  { 0, 8, 6 },
-                                                                        { 10, 8, 6 }, { 0, 16, 12 }, { 10, 16, 12 } };
+  MeshType::CoordinateType testPointCoords[numberOfPoints][Dimension] = { { 0, 0, 0 },  { 10, 0, 0 },  { 0, 8, 6 },
+                                                                          { 10, 8, 6 }, { 0, 16, 12 }, { 10, 16, 12 } };
 
   /**
    * Add our test points to the mesh.
@@ -147,10 +147,10 @@ itkQuadrilateralCellTest(int, char *[])
   //
   // Test the EvaluatePosition() method of the QuadrilateralCell
   //
-  QuadrilateralCellType::CoordRepType            inputPoint[3];
+  QuadrilateralCellType::CoordinateType          inputPoint[3];
   QuadrilateralCellType::PointsContainer *       points = mesh->GetPoints();
-  QuadrilateralCellType::CoordRepType            closestPoint[3];
-  QuadrilateralCellType::CoordRepType            pcoords[2]; // Quadrilateral has 2 parametric coordinates
+  QuadrilateralCellType::CoordinateType          closestPoint[3];
+  QuadrilateralCellType::CoordinateType          pcoords[2]; // Quadrilateral has 2 parametric coordinates
   double                                         distance;
   QuadrilateralCellType::InterpolationWeightType weights[4];
 

--- a/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
@@ -41,8 +41,8 @@ itkSimplexMeshTest(int, char *[])
   /**
    * Define the 3d geometric positions for 8 points in a cube.
    */
-  SimplexMeshType::CoordRepType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
-                                                          { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
+  SimplexMeshType::CoordinateType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
+                                                            { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
 
 
   /**

--- a/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
@@ -45,16 +45,16 @@ itkTriangleCellTest(int, char *[])
   class TriangleHelper : public TriangleCellType
   {
     using Superclass = TriangleCellType;
-    using CoordRepType = Superclass::CoordRepType;
+    using CoordinateType = Superclass::CoordinateType;
     using PointsContainer = Superclass::PointsContainer;
     using InterpolationWeightType = Superclass::InterpolationWeightType;
 
   public:
     bool
-    EvaluatePosition(CoordRepType *            inputPoint,
+    EvaluatePosition(CoordinateType *          inputPoint,
                      PointsContainer *         points,
-                     CoordRepType *            closestPoint,
-                     CoordRepType              pcoord[],
+                     CoordinateType *          closestPoint,
+                     CoordinateType            pcoord[],
                      double *                  distance,
                      InterpolationWeightType * weights) override
     {
@@ -88,7 +88,7 @@ itkTriangleCellTest(int, char *[])
   /**
    * Define the 3d geometric positions for 4 points in a square.
    */
-  MeshType::CoordRepType testPointCoords[numberOfPoints][3] = {
+  MeshType::CoordinateType testPointCoords[numberOfPoints][3] = {
     { 0, 0, 0 }, { 10, 0, 0 }, { 10, 10, 0 }, { 0, 10, 0 }
   };
 
@@ -152,10 +152,10 @@ itkTriangleCellTest(int, char *[])
   //
   // Exercise the EvaluatePosition() method of the TriangleCell
   //
-  TriangleCellType::CoordRepType            inputPoint[3];
+  TriangleCellType::CoordinateType          inputPoint[3];
   TriangleCellType::PointsContainer *       points = mesh->GetPoints();
-  TriangleCellType::CoordRepType            closestPoint[3];
-  TriangleCellType::CoordRepType            pcoords[3];
+  TriangleCellType::CoordinateType          closestPoint[3];
+  TriangleCellType::CoordinateType          pcoords[3];
   double                                    distance;
   TriangleCellType::InterpolationWeightType weights[3];
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -50,7 +50,8 @@ class QuadEdgeMeshCellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -51,7 +51,10 @@ class QuadEdgeMeshCellTraitsInfo
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -71,7 +71,7 @@ public:
 
   /** Types defined in superclass. */
   using typename Superclass::CellPixelType;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::PointIdentifier;
   using typename Superclass::PointHashType;
   using typename Superclass::PointType;
@@ -83,7 +83,7 @@ public:
   // Point section:
   using typename Superclass::PointsContainer;
   using typename Superclass::PointsContainerPointer;
-  using CoordRepArrayType = CoordRepType[Self::PointDimension];
+  using CoordRepArrayType = CoordinateType[Self::PointDimension];
 
   // Point data section:
   using typename Superclass::PointDataContainer;
@@ -410,7 +410,7 @@ public:
   FindEdgeCell(const PointIdentifier & pid0, const PointIdentifier & pid1) const;
 
   ///  Compute the euclidean length of argument edge
-  CoordRepType
+  CoordinateType
   ComputeEdgeLength(QEPrimal * e);
 
   PointIdentifier

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -1389,7 +1389,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ClearCellsContainer()
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
 auto
-QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeEdgeLength(QEPrimal * e) -> CoordRepType
+QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeEdgeLength(QEPrimal * e) -> CoordinateType
 {
   const PointsContainer * points = this->GetPoints();
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -55,7 +55,10 @@ public:
   using PointIdentifier = typename MeshType::PointIdentifier;
   using PointType = typename MeshType::PointType;
   using CoordinateType = typename MeshType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using VectorType = typename MeshType::VectorType;
 
   /** Evaluate at the specified input position */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -54,7 +54,8 @@ public:
 
   using PointIdentifier = typename MeshType::PointIdentifier;
   using PointType = typename MeshType::PointType;
-  using CoordRepType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VectorType = typename MeshType::VectorType;
 
   /** Evaluate at the specified input position */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -54,7 +54,7 @@ public:
 
   using PointIdentifier = typename MeshType::PointIdentifier;
   using PointType = typename MeshType::PointType;
-  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordinateType;
   using CoordRepType = CoordinateType;
   using VectorType = typename MeshType::VectorType;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
@@ -66,7 +66,7 @@ QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
     m_AssocBary[g] = pid;
     ++lit;
   } // rof
-  vec /= CoordRepType(sum);
+  vec /= CoordinateType(sum);
   PointType p;
   for (unsigned int i = 0; i < 3; ++i)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -49,16 +49,16 @@ std::vector<typename TMesh::PointType>
 GeneratePointCoordinates(const unsigned int iN)
 {
   using PointType = typename TMesh::PointType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   std::vector<PointType> oPt(iN * iN);
 
   for (unsigned int i = 0; i < iN; ++i)
   {
     for (unsigned int j = 0; j < iN; ++j)
     {
-      oPt[i * iN + j][0] = static_cast<CoordRepType>(j);
-      oPt[i * iN + j][1] = static_cast<CoordRepType>(i);
-      oPt[i * iN + j][2] = static_cast<CoordRepType>(0.);
+      oPt[i * iN + j][0] = static_cast<CoordinateType>(j);
+      oPt[i * iN + j][1] = static_cast<CoordinateType>(i);
+      oPt[i * iN + j][2] = static_cast<CoordinateType>(0.);
     }
   }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -113,9 +113,9 @@ public:
   /** The type of point used by the mesh. This should never change from
    * this setting, regardless of the mesh type. Points have an entry
    * in the Onext ring */
-  using PointType = QuadEdgeMeshPoint<CoordRepType, VPointDimension, QEPrimal>;
+  using PointType = QuadEdgeMeshPoint<CoordinateType, VPointDimension, QEPrimal>;
 
-  using PointHashType = Point<CoordRepType, VPointDimension>;
+  using PointHashType = Point<CoordinateType, VPointDimension>;
 
   /** The container type for use in storing points. It must conform to
    * the IndexedContainer interface. */
@@ -123,7 +123,7 @@ public:
 
   /** Standard itk cell interface. */
   using CellTraits = QuadEdgeMeshCellTraitsInfo<VPointDimension,
-                                                CoordRepType,
+                                                CoordinateType,
                                                 InterpolationWeightType,
                                                 PointIdentifier,
                                                 CellIdentifier,

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -71,7 +71,10 @@ public:
   using Self = QuadEdgeMeshExtendedTraits;
   /** Save the template parameters. */
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PixelType = TPixelType;
   using PrimalDataType = TPData;
   using DualDataType = TDData;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -70,7 +70,8 @@ class QuadEdgeMeshExtendedTraits
 public:
   using Self = QuadEdgeMeshExtendedTraits;
   /** Save the template parameters. */
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using PixelType = TPixelType;
   using PrimalDataType = TPData;
   using DualDataType = TDData;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -84,7 +84,8 @@ public:
 
 protected:
   // Mesh types
-  using CoordRepType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordRepType = CoordinateType;
   // QE types
   using QEOriginType = typename QEType::OriginRefType;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -84,7 +84,7 @@ public:
 
 protected:
   // Mesh types
-  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordinateType;
   using CoordRepType = CoordinateType;
   // QE types
   using QEOriginType = typename QEType::OriginRefType;
@@ -101,7 +101,7 @@ protected:
   class FrontAtom
   {
   public:
-    FrontAtom(QEType * e = (QEType *)0, const CoordRepType c = 0)
+    FrontAtom(QEType * e = (QEType *)0, const CoordinateType c = 0)
       : m_Edge(e)
       , m_Cost(c)
     {}
@@ -128,8 +128,8 @@ protected:
     }
 
   public:
-    QEType *     m_Edge;
-    CoordRepType m_Cost;
+    QEType *       m_Edge;
+    CoordinateType m_Cost;
   };
 
   /** The active front is simply a list of edges that can be sorted on
@@ -199,7 +199,7 @@ protected:
   /** The default cost associated to an edge is simply 1. This corresponds
    *  to the "topological metric" i.e. all edges have unit length.
    */
-  virtual CoordRepType
+  virtual CoordinateType
   GetCost(QEType * itkNotUsed(edge))
   {
     return (1);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -85,7 +85,10 @@ public:
 protected:
   // Mesh types
   using CoordinateType = typename MeshType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   // QE types
   using QEOriginType = typename QEType::OriginRefType;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -105,7 +105,7 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
       m_IsPointVisited->SetElement(oEdge->GetDestination(), true);
 
       // Compute the Cost of the new OriginType:
-      CoordRepType oCost = this->GetCost(oEdge) + fit->m_Cost;
+      CoordinateType oCost = this->GetCost(oEdge) + fit->m_Cost;
 
       // Push the Sym() on the front:
       m_Front->push_back(FrontAtom(oEdge->GetSym(), oCost));

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
@@ -62,7 +62,7 @@ public:
   using typename Superclass::CellRawPointer;
   using typename Superclass::CellConstRawPointer;
   using CellTraits = typename Superclass::CellTraits;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::InterpolationWeightType;
   using typename Superclass::PointIdentifier;
   using typename Superclass::CellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -45,7 +45,7 @@ public:
   static constexpr unsigned int PointDimension = VPointDimension;
 
   using typename Superclass::ValueType;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::RealType;
   using typename Superclass::Iterator;
   using typename Superclass::ConstIterator;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -58,7 +58,7 @@ public:
   using typename Superclass::CellRawPointer;
   using typename Superclass::CellConstRawPointer;
   using CellTraits = typename Superclass::CellTraits;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::InterpolationWeightType;
   using typename Superclass::PointIdentifier;
   using typename Superclass::CellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -49,7 +49,7 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEPrimal = typename InputMeshType::QEPrimal;
@@ -76,7 +76,7 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = typename OutputMeshType::CoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputQEPrimal = typename OutputMeshType::QEPrimal;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -53,7 +53,8 @@ public:
   using Self = QuadEdgeMeshTraits;
   using PixelType = TPixel;
   using CellPixelType = TPixel;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   static constexpr unsigned int PointDimension = VPointDimension;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -81,15 +81,15 @@ public:
 
   /** The type of point used for hashing.  This should never change from
    * this setting, regardless of the mesh type. */
-  using PointHashType = Point<CoordRepType, VPointDimension>;
+  using PointHashType = Point<CoordinateType, VPointDimension>;
 
   /** Points have an entry in the Onext ring */
-  using PointType = QuadEdgeMeshPoint<CoordRepType, VPointDimension, QEPrimal>;
+  using PointType = QuadEdgeMeshPoint<CoordinateType, VPointDimension, QEPrimal>;
   using PointsContainer = MapContainer<PointIdentifier, PointType>;
 
   /** Standard cell interface. */
   using CellTraits = QuadEdgeMeshCellTraitsInfo<VPointDimension,
-                                                CoordRepType,
+                                                CoordinateType,
                                                 InterpolationWeightType,
                                                 PointIdentifier,
                                                 CellIdentifier,

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -54,7 +54,10 @@ public:
   using PixelType = TPixel;
   using CellPixelType = TPixel;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = TInterpolationWeight;
 
   static constexpr unsigned int PointDimension = VPointDimension;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
@@ -70,7 +70,7 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
   constexpr int   NumPoints = 7;
   PointIdentifier pid[NumPoints];
 
-  PointType::CoordRepType a = std::sqrt(3.0) / 2.0;
+  PointType::CoordinateType a = std::sqrt(3.0) / 2.0;
 
   using ValueArrayType = PointType::ValueArrayType;
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -68,8 +68,8 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
   /**
    * Define the 3d geometric positions for 8 points in a cube.
    */
-  MeshType::CoordRepType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
-                                                   { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
+  MeshType::CoordinateType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
+                                                     { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
 
   /**
    * Add our test points to the mesh.

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -58,8 +58,8 @@ MeshSpatialObject<TMesh>::IsInsideInObjectSpace(const PointType & point) const
     typename MeshType::CellsContainer::ConstIterator it = cells->Begin();
     while (it != cells->End())
     {
-      using CoordRepType = typename MeshType::CoordRepType;
-      CoordRepType position[Dimension];
+      using CoordinateType = typename MeshType::CoordinateType;
+      CoordinateType position[Dimension];
       for (unsigned int i = 0; i < Dimension; ++i)
       {
         position[i] = point[i];

--- a/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
@@ -38,7 +38,7 @@ itkMeshSpatialObjectTest(int, char *[])
   // Create an itkMesh
   auto mesh = MeshType::New();
 
-  MeshType::CoordRepType testPointCoords[4][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 9, 0 }, { 0, 0, 9 } };
+  MeshType::CoordinateType testPointCoords[4][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 9, 0 }, { 0, 0, 9 } };
 
   MeshType::PointIdentifier tetraPoints[4] = { 0, 1, 2, 3 };
 
@@ -140,7 +140,7 @@ itkMeshSpatialObjectTest(int, char *[])
   // Create an itkMesh
   auto meshTriangle = MeshType::New();
 
-  MeshType::CoordRepType testTrianglePointCoords[4][3] = {
+  MeshType::CoordinateType testTrianglePointCoords[4][3] = {
     { 50, 50, 64 }, { 50, 100, 64 }, { 100, 50, 64 }, { 100, 100, 64 }
   };
 

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -63,7 +63,7 @@ public:
   using ImagePointer = typename ImageType::ConstPointer;
   using IndexType = typename ImageType::IndexType;
   using ImagePointType = typename ImageType::PointType;
-  using ImagePointCoordRepType = typename ImagePointType::CoordRepType;
+  using ImagePointCoordRepType = typename ImagePointType::CoordinateType;
 
   /** Types defined from transform traits. */
   using TransformPointer = typename TransformType::Pointer;

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -82,9 +82,9 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   // origin to determine these axes. Thus bitwise operators are used
   // throughout the code so that the initializer is generalized to n-dimensions.
 
-  using CoordRepType = typename ImagePointType::CoordRepType;
+  using CoordinateType = typename ImagePointType::CoordinateType;
 
-  using PointSetType = PointSet<CoordRepType, SpaceDimension>;
+  using PointSetType = PointSet<CoordinateType, SpaceDimension>;
   auto cornerPoints = PointSetType::New();
 
   using PointType = typename PointSetType::PointType;
@@ -92,7 +92,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   using RealType = typename PointType::RealType;
   using VectorType = typename PointType::VectorType;
 
-  using ContinuousIndexType = ContinuousIndex<CoordRepType, SpaceDimension>;
+  using ContinuousIndexType = ContinuousIndex<CoordinateType, SpaceDimension>;
 
   // We first convert the image corners into points which reside in physical
   // space and label them as indicated above.  Note that the corners reside
@@ -100,7 +100,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   // We also store the corners using the point set class which gives us easy
   // access to the bounding box.
 
-  const CoordRepType BSplineTransformDomainEpsilon = std::pow(2.0, -3);
+  const CoordinateType BSplineTransformDomainEpsilon = std::pow(2.0, -3);
 
   ContinuousIndexType startIndex;
   for (unsigned int i = 0; i < SpaceDimension; ++i)
@@ -113,7 +113,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
     ContinuousIndexType whichIndex;
     for (unsigned int i = 0; i < SpaceDimension; ++i)
     {
-      whichIndex[i] = startIndex[i] + static_cast<CoordRepType>(
+      whichIndex[i] = startIndex[i] + static_cast<CoordinateType>(
                                         ((d >> i) & 1) * (this->m_Image->GetLargestPossibleRegion().GetSize()[i] +
                                                           2.0 * BSplineTransformDomainEpsilon));
     }
@@ -129,7 +129,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
 
   using BoundingBoxType = BoundingBox<unsigned int,
                                       SpaceDimension,
-                                      typename PointSetType::CoordRepType,
+                                      typename PointSetType::CoordinateType,
                                       typename PointSetType::PointsContainer>;
   auto bbox = BoundingBoxType::New();
   bbox->SetPoints(cornerPoints->GetPoints());

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -55,17 +55,17 @@ TestKernelTransform(const char * name, KernelType *)
   sourceLandmarks->GetPoints()->Reserve(4);
 
   // Generate some random coordinates
-  typename KernelPointSetType::CoordRepType randomCoords[3];
+  typename KernelPointSetType::CoordinateType randomCoords[3];
   for (int i = 0; i < 4; ++i)
   {
-    randomCoords[0] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[1] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[2] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[0] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[1] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[2] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
     targetLandmarks->GetPoints()->SetElement(i, randomCoords);
 
-    randomCoords[0] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[1] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[2] = (typename KernelPointSetType::CoordRepType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[0] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[1] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    randomCoords[2] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
     sourceLandmarks->GetPoints()->SetElement(i, randomCoords);
   }
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -134,7 +134,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
     itkExceptionMacro("Output (B-spline) domain is undefined.");
   }
 
-  using ContinuousIndexType = ContinuousIndex<typename InputFieldPointType::CoordRepType, ImageDimension>;
+  using ContinuousIndexType = ContinuousIndex<typename InputFieldPointType::CoordinateType, ImageDimension>;
 
   // Create an output field based on the b-spline domain to determine boundary
   // points and whether or not specified points are inside or outside the domain.
@@ -239,7 +239,8 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
       inputField->TransformIndexToPhysicalPoint(index, physicalPoint);
       const ContinuousIndexType cidx =
         bsplinePhysicalDomainField
-          ->template TransformPhysicalPointToContinuousIndex<typename InputFieldPointType::CoordRepType>(physicalPoint);
+          ->template TransformPhysicalPointToContinuousIndex<typename InputFieldPointType::CoordinateType>(
+            physicalPoint);
       bsplineParametricDomainField->TransformContinuousIndexToPhysicalPoint(cidx, parametricPoint);
 
       bool isInside = true;
@@ -327,8 +328,8 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
         // to the boundary), we can ignore it.
         for (unsigned int d = 0; d < ImageDimension; ++d)
         {
-          if (cidx[d] < static_cast<typename ContinuousIndexType::CoordRepType>(startIndex[d]) + 0.5 ||
-              cidx[d] > static_cast<typename ContinuousIndexType::CoordRepType>(
+          if (cidx[d] < static_cast<typename ContinuousIndexType::CoordinateType>(startIndex[d]) + 0.5 ||
+              cidx[d] > static_cast<typename ContinuousIndexType::CoordinateType>(
                           startIndex[d] + static_cast<int>(this->m_BSplineDomainSize[d]) - 1) -
                           0.5)
           {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -92,12 +92,12 @@ public:
 
   /** Output type alias support */
   using OutputType = PixelType;
-  using GradientType = VariableSizeMatrix<CoordRepType>;
-  using HessianComponentType = VariableSizeMatrix<CoordRepType>;
+  using GradientType = VariableSizeMatrix<CoordinateType>;
+  using HessianComponentType = VariableSizeMatrix<CoordinateType>;
 
   /** Other type alias */
   using ArrayType = FixedArray<unsigned int, ImageDimension>;
-  using RealImageType = Image<CoordRepType, ImageDimension>;
+  using RealImageType = Image<CoordinateType, ImageDimension>;
   using RealImagePointer = typename RealImageType::Pointer;
   using typename Superclass::ContinuousIndexType;
   using RealType = float;
@@ -301,7 +301,7 @@ private:
   typename KernelOrder2Type::Pointer m_KernelOrder2{};
   typename KernelOrder3Type::Pointer m_KernelOrder3{};
 
-  CoordRepType m_BSplineEpsilon{};
+  CoordinateType m_BSplineEpsilon{};
 };
 
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -79,7 +79,10 @@ public:
   using ControlPointLatticeType = TInputImage;
   using InputImageType = TInputImage;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PixelType = typename InputImageType::PixelType;
   using RegionType = typename InputImageType::RegionType;
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -78,7 +78,8 @@ public:
   /** Image type alias support */
   using ControlPointLatticeType = TInputImage;
   using InputImageType = TInputImage;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
   using PixelType = typename InputImageType::PixelType;
   using RegionType = typename InputImageType::RegionType;
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -126,7 +126,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtParametric
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = (point[i] - this->m_Origin[i]) / (static_cast<CoordRepType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
+    params[i] =
+      (point[i] - this->m_Origin[i]) / (static_cast<CoordinateType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
   }
 
   return this->Evaluate(params);
@@ -139,7 +140,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(cons
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = static_cast<CoordRepType>(idx[i]) / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = static_cast<CoordinateType>(idx[i]) / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->Evaluate(params);
@@ -153,7 +154,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateAtContinuous
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = idx[i] / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = idx[i] / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->Evaluate(params);
@@ -163,32 +164,32 @@ template <typename TInputImage, typename TCoordinate>
 auto
 BSplineControlPointImageFunction<TInputImage, TCoordinate>::Evaluate(const PointType & params) const -> OutputType
 {
-  vnl_vector<CoordRepType> p(ImageDimension);
+  vnl_vector<CoordinateType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     p[i] = params[i];
-    if (itk::Math::abs(p[i] - NumericTraits<CoordRepType>::OneValue()) <= this->m_BSplineEpsilon)
+    if (itk::Math::abs(p[i] - NumericTraits<CoordinateType>::OneValue()) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
+      p[i] = NumericTraits<CoordinateType>::OneValue() - this->m_BSplineEpsilon;
     }
     if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
       p[i] = RealType{};
     }
 
-    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordinateType{} || p[i] >= NumericTraits<CoordinateType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }
-    auto numberOfSpans = static_cast<CoordRepType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
+    auto numberOfSpans = static_cast<CoordinateType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
     if (!this->m_CloseDimension[i])
     {
-      numberOfSpans -= static_cast<CoordRepType>(this->m_SplineOrder[i]);
+      numberOfSpans -= static_cast<CoordinateType>(this->m_SplineOrder[i]);
     }
-    p[i] = static_cast<CoordRepType>(p[i]) * numberOfSpans;
+    p[i] = static_cast<CoordinateType>(p[i]) * numberOfSpans;
   }
 
-  vnl_vector<CoordRepType> bsplineWeights[ImageDimension];
+  vnl_vector<CoordinateType> bsplineWeights[ImageDimension];
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -199,10 +200,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::Evaluate(const Point
   {
     for (unsigned int j = 0; j < bsplineWeights[i].size(); ++j)
     {
-      CoordRepType u = p[i] - static_cast<CoordRepType>(static_cast<unsigned int>(p[i]) + j) +
-                       0.5 * static_cast<CoordRepType>(this->m_SplineOrder[i] - 1);
+      CoordinateType u = p[i] - static_cast<CoordinateType>(static_cast<unsigned int>(p[i]) + j) +
+                         0.5 * static_cast<CoordinateType>(this->m_SplineOrder[i] - 1);
 
-      CoordRepType B = 1.0;
+      CoordinateType B = 1.0;
       switch (this->m_SplineOrder[i])
       {
         case 0:
@@ -242,7 +243,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::Evaluate(const Point
        !ItW.IsAtEnd();
        ++ItW)
   {
-    CoordRepType                      B = 1.0;
+    CoordinateType                    B = 1.0;
     typename RealImageType::IndexType idx = ItW.GetIndex();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
@@ -272,7 +273,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtPa
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = (point[i] - this->m_Origin[i]) / (static_cast<CoordRepType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
+    params[i] =
+      (point[i] - this->m_Origin[i]) / (static_cast<CoordinateType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
   }
 
   return this->EvaluateGradient(params);
@@ -286,7 +288,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtIn
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = static_cast<CoordRepType>(idx[i]) / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = static_cast<CoordinateType>(idx[i]) / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->EvaluateGradient(params);
@@ -300,7 +302,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradientAtCo
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = idx[i] / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = idx[i] / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->EvaluateGradient(params);
@@ -311,29 +313,29 @@ auto
 BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(const PointType & params) const
   -> GradientType
 {
-  vnl_vector<CoordRepType> p(ImageDimension);
+  vnl_vector<CoordinateType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     p[i] = params[i];
-    if (itk::Math::abs(p[i] - NumericTraits<CoordRepType>::OneValue()) <= this->m_BSplineEpsilon)
+    if (itk::Math::abs(p[i] - NumericTraits<CoordinateType>::OneValue()) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
+      p[i] = NumericTraits<CoordinateType>::OneValue() - this->m_BSplineEpsilon;
     }
     if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
       p[i] = RealType{};
     }
 
-    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordinateType{} || p[i] >= NumericTraits<CoordinateType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }
-    auto numberOfSpans = static_cast<CoordRepType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
+    auto numberOfSpans = static_cast<CoordinateType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
     if (!this->m_CloseDimension[i])
     {
-      numberOfSpans -= static_cast<CoordRepType>(this->m_SplineOrder[i]);
+      numberOfSpans -= static_cast<CoordinateType>(this->m_SplineOrder[i]);
     }
-    p[i] = static_cast<CoordRepType>(p[i]) * numberOfSpans;
+    p[i] = static_cast<CoordinateType>(p[i]) * numberOfSpans;
   }
 
   GradientType gradient;
@@ -343,7 +345,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(con
   ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
                                                   this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
 
-  vnl_vector<CoordRepType> bsplineWeights[ImageDimension];
+  vnl_vector<CoordinateType> bsplineWeights[ImageDimension];
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -356,10 +358,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(con
     {
       for (unsigned int j = 0; j < bsplineWeights[i].size(); ++j)
       {
-        CoordRepType u = p[i] - static_cast<CoordRepType>(static_cast<unsigned int>(p[i]) + j) +
-                         0.5 * static_cast<CoordRepType>(this->m_SplineOrder[i] - 1);
+        CoordinateType u = p[i] - static_cast<CoordinateType>(static_cast<unsigned int>(p[i]) + j) +
+                           0.5 * static_cast<CoordinateType>(this->m_SplineOrder[i] - 1);
 
-        CoordRepType B = 1.0;
+        CoordinateType B = 1.0;
         if (i == k)
         {
           B = this->m_Kernel[i]->EvaluateDerivative(u);
@@ -401,7 +403,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(con
 
     for (ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW)
     {
-      CoordRepType                      B = 1.0;
+      CoordinateType                    B = 1.0;
       typename RealImageType::IndexType idx = ItW.GetIndex();
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
@@ -437,7 +439,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtPar
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = (point[i] - this->m_Origin[i]) / (static_cast<CoordRepType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
+    params[i] =
+      (point[i] - this->m_Origin[i]) / (static_cast<CoordinateType>(this->m_Size[i] - 1) * this->m_Spacing[i]);
   }
 
   return this->EvaluateHessian(params, component);
@@ -452,7 +455,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtInd
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = static_cast<CoordRepType>(idx[i]) / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = static_cast<CoordinateType>(idx[i]) / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->EvaluateHessian(params, component);
@@ -467,7 +470,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessianAtCon
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    params[i] = idx[i] / static_cast<CoordRepType>(this->m_Size[i] - 1);
+    params[i] = idx[i] / static_cast<CoordinateType>(this->m_Size[i] - 1);
   }
 
   return this->EvaluateHessian(params, component);
@@ -479,32 +482,32 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(cons
                                                                             const unsigned int component) const
   -> HessianComponentType
 {
-  vnl_vector<CoordRepType> p(ImageDimension);
+  vnl_vector<CoordinateType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     p[i] = params[i];
-    if (itk::Math::abs(p[i] - NumericTraits<CoordRepType>::OneValue()) <= this->m_BSplineEpsilon)
+    if (itk::Math::abs(p[i] - NumericTraits<CoordinateType>::OneValue()) <= this->m_BSplineEpsilon)
     {
-      p[i] = NumericTraits<CoordRepType>::OneValue() - this->m_BSplineEpsilon;
+      p[i] = NumericTraits<CoordinateType>::OneValue() - this->m_BSplineEpsilon;
     }
     if (p[i] < RealType{} && itk::Math::abs(p[i]) <= this->m_BSplineEpsilon)
     {
       p[i] = RealType{};
     }
 
-    if (p[i] < CoordRepType{} || p[i] >= NumericTraits<CoordRepType>::OneValue())
+    if (p[i] < CoordinateType{} || p[i] >= NumericTraits<CoordinateType>::OneValue())
     {
       itkExceptionMacro("The specified point " << params << " is outside the reparameterized domain [0, 1).");
     }
-    auto numberOfSpans = static_cast<CoordRepType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
+    auto numberOfSpans = static_cast<CoordinateType>(this->GetInputImage()->GetLargestPossibleRegion().GetSize()[i]);
     if (!this->m_CloseDimension[i])
     {
-      numberOfSpans -= static_cast<CoordRepType>(this->m_SplineOrder[i]);
+      numberOfSpans -= static_cast<CoordinateType>(this->m_SplineOrder[i]);
     }
-    p[i] = static_cast<CoordRepType>(p[i]) * numberOfSpans;
+    p[i] = static_cast<CoordinateType>(p[i]) * numberOfSpans;
   }
 
-  CoordRepType         val;
+  CoordinateType       val;
   HessianComponentType hessian;
   hessian.SetSize(ImageDimension, ImageDimension);
   hessian.Fill(0.0);
@@ -512,7 +515,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(cons
   ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
                                                   this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
 
-  vnl_vector<CoordRepType> bsplineWeights[ImageDimension];
+  vnl_vector<CoordinateType> bsplineWeights[ImageDimension];
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -527,10 +530,10 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(cons
       {
         for (unsigned int h = 0; h < bsplineWeights[i].size(); ++h)
         {
-          CoordRepType u = p[i] - static_cast<CoordRepType>(static_cast<unsigned int>(p[i]) + h) +
-                           0.5 * static_cast<CoordRepType>(this->m_SplineOrder[i] - 1);
+          CoordinateType u = p[i] - static_cast<CoordinateType>(static_cast<unsigned int>(p[i]) + h) +
+                             0.5 * static_cast<CoordinateType>(this->m_SplineOrder[i] - 1);
 
-          CoordRepType B = 1.0;
+          CoordinateType B = 1.0;
           if (i == j && j == k)
           {
             B = this->m_Kernel[i]->EvaluateNthDerivative(u, 2);
@@ -575,7 +578,7 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(cons
       }
       for (ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW)
       {
-        CoordRepType                      B = 1.0;
+        CoordinateType                    B = 1.0;
         typename RealImageType::IndexType idx = ItW.GetIndex();
         for (unsigned int i = 0; i < ImageDimension; ++i)
         {

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -92,7 +92,8 @@ public:
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** Typedef support for the interpolation function. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -93,7 +93,10 @@ public:
 
   /** Typedef support for the interpolation function. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordinateType>;

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -94,9 +94,9 @@ public:
   /** Typedef support for the interpolation function. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordinateType>;
 
   /** Get/Set the interpolator function. */
   itkSetObjectMacro(Interpolator, InterpolatorType);

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -128,7 +128,8 @@ public:
   using DisplacementType = typename DisplacementFieldType::PixelType;
 
   /** Interpolator type alias support */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -130,12 +130,12 @@ public:
   /** Interpolator type alias support */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordinateType>;
 
   /** Point type */
-  using PointType = Point<CoordRepType, Self::ImageDimension>;
+  using PointType = Point<CoordinateType, Self::ImageDimension>;
 
   /** Type for representing the direction of the output image */
   using DirectionType = typename TOutputImage::DirectionType;

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -129,7 +129,10 @@ public:
 
   /** Interpolator type alias support */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordinateType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -131,7 +131,8 @@ public:
   using DisplacementType = typename DisplacementFieldType::PixelType;
 
   /** Interpolator type alias support */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -132,7 +132,10 @@ public:
 
   /** Interpolator type alias support */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -133,12 +133,12 @@ public:
   /** Interpolator type alias support */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
+  using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
-  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;
+  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>;
 
   /** Point type */
-  using PointType = Point<CoordRepType, Self::ImageDimension>;
+  using PointType = Point<CoordinateType, Self::ImageDimension>;
 
   /** Type for representing the direction of the output image */
   using DirectionType = typename TOutputImage::DirectionType;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -36,10 +36,10 @@ itkResampleImageTest(int, char *[])
   using ImagePointerType = ImageType::Pointer;
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
 
 
   // Create and configure an image

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -81,12 +81,12 @@ itkResampleImageTest2(int argc, char * argv[])
 
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, VDimension>;
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
-  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
-  using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
+  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
+  using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordinateType>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -76,12 +76,12 @@ itkResampleImageTest2Streaming(int argc, char * argv[])
 
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, VDimension>;
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
-  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
-  using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
+  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
+  using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordinateType>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
@@ -47,10 +47,10 @@ itkResampleImageTest3(int argc, char * argv[])
 
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, VDimension>;
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using TransformType = itk::IdentityTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using TransformType = itk::IdentityTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -37,11 +37,11 @@ itkResampleImageTest4(int argc, char * argv[])
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
 
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
 
 
   float scaling = 10.0;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -47,10 +47,10 @@ itkResampleImageTest5(int argc, char * argv[])
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   float scaling = std::stod(argv[1]);

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -50,10 +50,10 @@ itkResampleImageTest6(int argc, char * argv[])
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   float scaling = std::stod(argv[1]);

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -41,11 +41,11 @@ itkResampleImageTest7(int, char *[])
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
+  using AffineTransformType = itk::AffineTransform<CoordinateType, VDimension>;
 
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
 
   // Create and configure an image
   ImagePointerType image = ImageType::New();

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -133,10 +133,10 @@ itkResampleImageTest8(int, char *[])
   using OutputImageIndexType = OutputImageType::IndexType;
   using OutputImageSizeType = OutputImageType::SizeType;
 
-  using CoordRepType = double;
+  using CoordinateType = double;
 
   using TransformType = ProjectTransform;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<InputImageType, CoordRepType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<InputImageType, CoordinateType>;
 
   std::cout << "Input Image Type\n";
 

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -37,7 +37,7 @@ using ImagePointerType = ImageType::Pointer;
 using ImageRegionType = ImageType::RegionType;
 using ImageSizeType = ImageType::SizeType;
 using ImageIndexType = ImageType::IndexType;
-using CoordRepType = double;
+using CoordinateType = double;
 
 
 int

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -118,7 +118,10 @@ public:
 
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#  ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#  endif
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -119,9 +119,9 @@ public:
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
+  using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
-  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;
+  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>;
 
   /** Get/Set the interpolator function. */
   itkSetObjectMacro(Interpolator, InterpolatorType);

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -117,7 +117,8 @@ public:
   using ExpandFactorsArrayType = FixedArray<ExpandFactorsType, ImageDimension>;
 
   /** Typedef support for the interpolation function */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -264,7 +264,7 @@ private:
 
   struct VertexHash
   {
-    using CoordinateType = typename VertexType::CoordRepType;
+    using CoordinateType = typename VertexType::CoordinateType;
     inline size_t
     operator()(const VertexType & v) const noexcept
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
@@ -92,7 +92,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputTraits = typename InputMeshType::Traits;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -111,7 +111,7 @@ public:
 
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = typename OutputMeshType::CoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputTraits = typename OutputMeshType::Traits;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
@@ -49,7 +49,7 @@ public:
   /** Input types. */
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -73,7 +73,7 @@ public:
   /** Output types. */
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = typename OutputMeshType::CoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputCellType = typename OutputMeshType::CellType;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
@@ -51,7 +51,7 @@ public:
   using OutputPointsContainerPointer = typename OutputMeshType::PointsContainerPointer;
   using OutputPointsContainerIterator = typename OutputMeshType::PointsContainerIterator;
   using OutputPointType = typename OutputMeshType::PointType;
-  using OutputCoordType = typename OutputPointType::CoordRepType;
+  using OutputCoordType = typename OutputPointType::CoordinateType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputCellIdentifier = typename OutputMeshType::CellIdentifier;
   using OutputQEType = typename OutputMeshType::QEType;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
@@ -69,7 +69,7 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -98,7 +98,7 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = typename OutputMeshType::CoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputQEType = typename OutputMeshType::QEType;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -34,7 +34,7 @@ class QuadEdgeMeshDecimationQuadricElementHelper
 public:
   using Self = QuadEdgeMeshDecimationQuadricElementHelper;
   using PointType = TPoint;
-  using CoordType = typename PointType::CoordRepType;
+  using CoordType = typename PointType::CoordinateType;
 
   static constexpr unsigned int PointDimension = PointType::PointDimension;
   static constexpr unsigned int NumberOfCoefficients = PointDimension * (PointDimension + 1 / 2 + PointDimension + 1);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -34,7 +34,7 @@ class MatrixCoefficients
 {
 public:
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   MatrixCoefficients() = default;
@@ -58,7 +58,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   OnesMatrixCoefficients() = default;
@@ -87,7 +87,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -129,7 +129,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -183,7 +183,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -239,7 +239,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   InputCoordRepType m_Lambda;
@@ -274,7 +274,7 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = typename InputMeshType::CoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.h
@@ -53,7 +53,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputPointType = typename OutputMeshType::PointType;
-  using OutputCoordType = typename OutputPointType::CoordRepType;
+  using OutputCoordType = typename OutputPointType::CoordinateType;
   using OutputQEType = typename OutputMeshType::QEType;
   using OutputEdgeCellType = typename OutputMeshType::EdgeCellType;
   using OutputCellsContainerIterator = typename OutputMeshType::CellsContainerIterator;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
@@ -81,7 +81,7 @@ public:
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputVectorType = typename OutputPointType::VectorType;
-  using OutputCoordType = typename OutputPointType::CoordRepType;
+  using OutputCoordType = typename OutputPointType::CoordinateType;
   using OutputPointsContainer = typename OutputMeshType::PointsContainer;
   using OutputPointsContainerPointer = typename OutputMeshType::PointsContainerPointer;
   using OutputPointsContainerIterator = typename OutputMeshType::PointsContainerIterator;

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -97,7 +97,7 @@ public:
 
   /** Define output mesh types */
   using OutputMeshType = TOutputMesh;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = typename OutputMeshType::CoordinateType;
   using OutputPointPixelType = typename OutputMeshType::PixelType;
   using OutputCellPixelType = typename OutputMeshType::CellPixelType;
   using OutputPointType = typename OutputMeshType::PointType;

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
@@ -117,25 +117,25 @@ TEST(VTKPolyDataMeshIO, LosslessWriteAndReadOfPoints)
   // Generate various input points that have finite coordinate values.
   const auto inputPoints = [] {
     using PointType = typename MeshType::PointType;
-    using CoordRepType = typename MeshType::CoordRepType;
-    using NumericLimits = std::numeric_limits<MeshType::CoordRepType>;
+    using CoordinateType = typename MeshType::CoordinateType;
+    using NumericLimits = std::numeric_limits<MeshType::CoordinateType>;
 
     std::vector<PointType> points;
     std::mt19937           randomNumberEngine;
-    const auto             smallRandomValue = std::uniform_real_distribution<CoordRepType>{}(randomNumberEngine);
+    const auto             smallRandomValue = std::uniform_real_distribution<CoordinateType>{}(randomNumberEngine);
     const auto             largeRandomValue =
-      std::uniform_real_distribution<CoordRepType>{ CoordRepType{ 1 }, NumericLimits::max() }(randomNumberEngine);
+      std::uniform_real_distribution<CoordinateType>{ CoordinateType{ 1 }, NumericLimits::max() }(randomNumberEngine);
 
     // Include random and boundary values with the test input.
-    for (const CoordRepType coordValue : { smallRandomValue,
-                                           largeRandomValue,
-                                           CoordRepType{ 0 },
-                                           NumericLimits::denorm_min(),
-                                           NumericLimits::min(),
-                                           NumericLimits::epsilon(),
-                                           CoordRepType{ 1 },
-                                           NumericLimits::max(),
-                                           NumericLimits::infinity() })
+    for (const CoordinateType coordValue : { smallRandomValue,
+                                             largeRandomValue,
+                                             CoordinateType{ 0 },
+                                             NumericLimits::denorm_min(),
+                                             NumericLimits::min(),
+                                             NumericLimits::epsilon(),
+                                             CoordinateType{ 1 },
+                                             NumericLimits::max(),
+                                             NumericLimits::infinity() })
     {
       points.push_back(itk::MakeFilled<PointType>(coordValue));
       points.push_back(itk::MakeFilled<PointType>(-coordValue));
@@ -161,11 +161,11 @@ TEST(VTKPolyDataMeshIO, SupportWriteAndReadOfNaNCoordValues)
   {
     using MeshType = itk::Mesh<int>;
     using PointType = typename MeshType::PointType;
-    using CoordRepType = typename MeshType::CoordRepType;
+    using CoordinateType = typename MeshType::CoordinateType;
 
     Expect_lossless_writing_and_reading_of_points<MeshType>(
       "VTKPolyDataMeshIOGTest_SupportWriteAndReadOfNaNCoordValues.vtk",
-      { itk::MakeFilled<PointType>(std::numeric_limits<CoordRepType>::quiet_NaN()) },
+      { itk::MakeFilled<PointType>(std::numeric_limits<CoordinateType>::quiet_NaN()) },
       writeAsBinary);
   }
 }

--- a/Modules/Nonunit/IntegratedTest/test/itkPolygonCellTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkPolygonCellTest.cxx
@@ -65,8 +65,8 @@ itkPolygonCellTest(int, char *[])
   /**
    * Define the 3d geometric positions for 8 points in a cube.
    */
-  MeshType::CoordRepType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
-                                                   { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
+  MeshType::CoordinateType testPointCoords[8][3] = { { 0, 0, 0 }, { 9, 0, 0 }, { 9, 0, 9 }, { 0, 0, 9 },
+                                                     { 0, 9, 0 }, { 9, 9, 0 }, { 9, 9, 9 }, { 0, 9, 9 } };
 
   /**
    * Add our test points to the mesh.

--- a/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
@@ -23,8 +23,8 @@ int
 itkTriangleHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   constexpr unsigned int Dimension = 3;
-  using CoordRepType = double;
-  using PointType = itk::Point<CoordRepType, Dimension>;
+  using CoordinateType = double;
+  using PointType = itk::Point<CoordinateType, Dimension>;
   using VectorType = PointType::VectorType;
   using TriangleHelperType = itk::TriangleHelper<PointType>;
 
@@ -126,7 +126,7 @@ itkTriangleHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
     return EXIT_FAILURE;
   }
 
-  CoordRepType area = TriangleHelperType::ComputeArea(a, Org, b);
+  CoordinateType area = TriangleHelperType::ComputeArea(a, Org, b);
   if (itk::Math::abs(area - 0.25) > 1e-6)
   {
     std::cout << "TriangleHelperType::ComputeArea( a, Org, b ) FAILED" << std::endl;

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -68,7 +68,10 @@ public:
   /** Type for representing coordinates. */
   // using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -67,7 +67,8 @@ public:
 
   /** Type for representing coordinates. */
   // using CoordRepType = typename TInputMesh::CoordRepType;
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -66,7 +66,7 @@ public:
   using OutputPointType = typename OutputMeshType::PointType;
 
   /** Type for representing coordinates. */
-  // using CoordRepType = typename TInputMesh::CoordRepType;
+  // using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
 
@@ -123,8 +123,8 @@ protected:
   GenerateData() override;
 
 private:
-  using VectorCoordType = vnl_vector<CoordRepType>;
-  using SparseMatrixCoordType = vnl_sparse_matrix<CoordRepType>;
+  using VectorCoordType = vnl_vector<CoordinateType>;
+  using SparseMatrixCoordType = vnl_sparse_matrix<CoordinateType>;
 
   /** Cell Id  in which the point P, which is used
    * to define the mapping, lies in. */

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -180,7 +180,7 @@ public:
   using InputImageType = TInputImage;
   using InputImagePointer = typename InputImageType::Pointer;
   using InputPointType = typename InputImageType::PointType;
-  using InputCoordRepType = typename InputPointType::CoordRepType;
+  using InputCoordRepType = typename InputPointType::CoordinateType;
   using InputIndexType = typename InputImageType::IndexType;
   using InputIndexValueType = typename InputIndexType::IndexValueType;
   using InputSizeType = typename InputImageType::SizeType;

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -111,16 +111,16 @@ itkImageFunctionTest(int, char *[])
   using SizeType = RegionType::SizeType;
   using IndexType = ImageType::IndexType;
 
-  using CoordRepType = float;
-  using ContinuousIndexType = itk::ContinuousIndex<CoordRepType, Dimension>;
-  using PointType = itk::Point<CoordRepType, Dimension>;
+  using CoordinateType = float;
+  using ContinuousIndexType = itk::ContinuousIndex<CoordinateType, Dimension>;
+  using PointType = itk::Point<CoordinateType, Dimension>;
 
   using IndexNumericTraits = itk::NumericTraits<IndexType::IndexValueType>;
   using ContinuousIndexNumericTraits = itk::NumericTraits<ContinuousIndexType::ValueType>;
   using PointNumericTraits = itk::NumericTraits<PointType::ValueType>;
 
 
-  using FunctionType = itk::TestImageFunction<ImageType, CoordRepType>;
+  using FunctionType = itk::TestImageFunction<ImageType, CoordinateType>;
 
   auto image = ImageType::New();
 

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -98,8 +98,8 @@ WindowConvergenceMonitoringFunction<TScalar>::GetConvergenceValue() const -> Rea
   for (unsigned int n = 0; n < this->m_WindowSize; ++n)
   {
     ProfilePointType windowPoint;
-    windowPoint[0] = static_cast<typename ProfilePointType::CoordRepType>(n) /
-                     static_cast<typename ProfilePointType::CoordRepType>(this->m_WindowSize - 1);
+    windowPoint[0] = static_cast<typename ProfilePointType::CoordinateType>(n) /
+                     static_cast<typename ProfilePointType::CoordinateType>(this->m_WindowSize - 1);
     energyProfileWindow->SetPoint(n, windowPoint);
     energyProfileWindow->SetPointData(n, ProfilePointDataType(this->m_EnergyValues[n] / this->m_TotalEnergy));
   }

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -74,9 +74,9 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::InitializeT
 
     InputPointType centerFixedPoint;
 
-    using CoordRepType = typename InputPointType::ValueType;
+    using CoordinateType = typename InputPointType::ValueType;
 
-    using ContinuousIndexType = ContinuousIndex<CoordRepType, InputSpaceDimension>;
+    using ContinuousIndexType = ContinuousIndex<CoordinateType, InputSpaceDimension>;
 
     using ContinuousIndexValueType = typename ContinuousIndexType::ValueType;
 

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -245,11 +245,11 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -144,11 +144,11 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -243,11 +243,11 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -96,7 +96,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -97,10 +97,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -138,11 +138,11 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -238,11 +238,11 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -245,11 +245,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -430,11 +430,11 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -188,11 +188,11 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -331,11 +331,11 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
 
       // Get the gradient by NearestNeighborInterpolation:
       // which is equivalent to round up the point components.
-      using CoordRepType = typename OutputPointType::CoordRepType;
-      using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
+      using CoordinateType = typename OutputPointType::CoordinateType;
+      using MovingImageContinuousIndexType = ContinuousIndex<CoordinateType, MovingImageType::ImageDimension>;
 
       const MovingImageContinuousIndexType tempIndex =
-        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
+        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordinateType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -191,7 +191,10 @@ public:
 
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -190,7 +190,8 @@ public:
   using IndexSelectCasterType = itk::VectorIndexSelectionCastImageFilter<FieldType, FloatImageType>;
 
   /** Typedef support for the interpolation function */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -192,10 +192,10 @@ public:
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordRepType>;
+  using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 
-  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<FieldType, CoordRepType>;
+  using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<FieldType, CoordinateType>;
 
   using InterpolationGridType = typename itk::Image<Element::ConstPointer, ImageDimension>;
   using InterpolationGridSizeType = typename InterpolationGridType::SizeType;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -242,7 +242,7 @@ void
 FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::WarpImage(const MovingImageType * ImageToWarp)
 {
   auto warper = WarperType::New();
-  using WarperCoordRepType = typename WarperType::CoordRepType;
+  using WarperCoordRepType = typename WarperType::CoordinateType;
   using InterpolatorType1 = itk::LinearInterpolateImageFunction<MovingImageType, WarperCoordRepType>;
   auto interpolator = InterpolatorType1::New();
 
@@ -811,7 +811,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::EnforceDiffeomorph
   }
 
   auto warper = WarperType::New();
-  using WarperCoordRepType = typename WarperType::CoordRepType;
+  using WarperCoordRepType = typename WarperType::CoordinateType;
   using InterpolatorType1 = itk::LinearInterpolateImageFunction<MovingImageType, WarperCoordRepType>;
   auto interpolator = InterpolatorType1::New();
 
@@ -1043,7 +1043,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::SampleVectorFieldA
     InterpolatedType interpolatedValue;
     for (unsigned int jj = 0; jj < ImageDimension; ++jj)
     {
-      inputIndex[jj] = (CoordRepType)coord[jj];
+      inputIndex[jj] = (CoordinateType)coord[jj];
       interpolatedValue[jj] = 0.0;
     }
     if (m_Interpolator->IsInsideBuffer(inputIndex))

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -94,7 +94,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -95,7 +95,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -96,10 +96,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
 
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -96,7 +96,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
 
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -97,11 +97,11 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
 
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -99,7 +99,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -100,10 +100,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;
@@ -113,7 +113,7 @@ public:
   using GradientCalculatorPointer = typename GradientCalculatorType::Pointer;
 
   /** Moving image gradient calculator type. */
-  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordRepType>;
+  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordinateType>;
   using MovingImageGradientCalculatorPointer = typename MovingImageGradientCalculatorType::Pointer;
 
   /** GPU data pointer type. */

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -98,7 +98,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -239,8 +239,8 @@ itkGPUDemonsRegistrationFilterTest2(int argc, char * argv[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
   warper->SetInput(moving);

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -67,7 +67,7 @@ public:
   using typename Superclass::LocalDerivativeType;
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::PointIdentifier;
   using typename Superclass::NeighborsIdentifierType;
 
@@ -91,10 +91,10 @@ public:
    * which provides a sense of scale for determining the similarity between two
    * point sets.  Default = 1.0.
    */
-  itkSetMacro(PointSetSigma, CoordRepType);
+  itkSetMacro(PointSetSigma, CoordinateType);
 
   /** Get the point set sigma function */
-  itkGetConstMacro(PointSetSigma, CoordRepType);
+  itkGetConstMacro(PointSetSigma, CoordinateType);
 
   /**
    * Set the neighborhood size used to evaluate the measurement at each
@@ -134,10 +134,10 @@ private:
   using VectorType = typename PointType::VectorType;
   using NeighborsIterator = typename NeighborsIdentifierType::const_iterator;
 
-  CoordRepType m_PointSetSigma{};
-  MeasureType  m_PreFactor{};
-  MeasureType  m_Denominator{};
-  unsigned int m_EvaluationKNeighborhood{ 50 };
+  CoordinateType m_PointSetSigma{};
+  MeasureType    m_PreFactor{};
+  MeasureType    m_Denominator{};
+  unsigned int   m_EvaluationKNeighborhood{ 50 };
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -39,7 +39,7 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
 {
   Superclass::Initialize();
 
-  if (this->m_PointSetSigma <= NumericTraits<CoordRepType>::epsilon())
+  if (this->m_PointSetSigma <= NumericTraits<CoordinateType>::epsilon())
   {
     itkExceptionMacro("m_PointSetSigma is too small. <= epsilon");
   }

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -100,7 +100,7 @@ public:
   using typename Superclass::LocalDerivativeType;
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
   using typename Superclass::PointIdentifier;
   using typename Superclass::NeighborsIdentifierType;
   using typename Superclass::NumberOfParametersType;

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -148,7 +148,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 
       typename GaussianType::MeanVectorType mean = this->m_MovingDensityFunction->GetGaussian(neighbors[n])->GetMean();
 
-      Array<CoordRepType> diffMean(PointDimension);
+      Array<CoordinateType> diffMean(PointDimension);
       for (unsigned int i = 0; i < PointDimension; ++i)
       {
         diffMean[i] = mean[i] - samplePoint[i];

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -73,7 +73,10 @@ public:
   using RealType = TOutput;
   using OutputType = TOutput;
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Typedef for points locator class to speed up finding neighboring points */
   using PointsLocatorType = PointsLocator<PointsContainer>;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -72,7 +72,8 @@ public:
   /** Other type alias */
   using RealType = TOutput;
   using OutputType = TOutput;
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Typedef for points locator class to speed up finding neighboring points */
   using PointsLocatorType = PointsLocator<PointsContainer>;

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -83,7 +83,7 @@ public:
   /** OutputType type alias support */
   using OutputType = TOutput;
 
-  /** CoordRepType type alias support */
+  /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
   using CoordRepType = CoordinateType;
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -84,7 +84,8 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -85,7 +85,10 @@ public:
 
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -151,7 +151,7 @@ public:
 
   using PointType = FixedPointType;
   using PixelType = FixedPixelType;
-  using CoordinateType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -151,7 +151,8 @@ public:
 
   using PointType = FixedPointType;
   using PixelType = FixedPixelType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using PointIdentifier = typename PointsContainer::ElementIdentifier;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -152,7 +152,10 @@ public:
   using PointType = FixedPointType;
   using PixelType = FixedPixelType;
   using CoordinateType = typename PointType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using PointIdentifier = typename PointsContainer::ElementIdentifier;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -141,7 +141,10 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
   using CoordinateType = typename PointType::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using typename Superclass::PointIdentifier;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -140,7 +140,8 @@ public:
 
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using typename Superclass::PointIdentifier;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -140,7 +140,7 @@ public:
 
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
-  using CoordinateType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
   using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -75,7 +75,7 @@ itkEuclideanDistancePointSetMetricRegistrationTestRun(unsigned int              
 {
   using PointSetType = TPointSet;
   using PointType = typename PointSetType::PointType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordinateType;
 
   auto fixedPoints = PointSetType::New();
 
@@ -85,20 +85,20 @@ itkEuclideanDistancePointSetMetricRegistrationTestRun(unsigned int              
 
   float     theta = itk::Math::pi / static_cast<float>(180.0) * static_cast<float>(1.0);
   PointType fixedPoint;
-  fixedPoint[0] = static_cast<CoordRepType>(0.0);
-  fixedPoint[1] = static_cast<CoordRepType>(0.0);
+  fixedPoint[0] = static_cast<CoordinateType>(0.0);
+  fixedPoint[1] = static_cast<CoordinateType>(0.0);
   fixedPoints->SetPoint(0, fixedPoint);
   fixedPoint[0] = pointMax;
-  fixedPoint[1] = static_cast<CoordRepType>(0.0);
+  fixedPoint[1] = static_cast<CoordinateType>(0.0);
   fixedPoints->SetPoint(1, fixedPoint);
   fixedPoint[0] = pointMax;
   fixedPoint[1] = pointMax;
   fixedPoints->SetPoint(2, fixedPoint);
-  fixedPoint[0] = static_cast<CoordRepType>(0.0);
+  fixedPoint[0] = static_cast<CoordinateType>(0.0);
   fixedPoint[1] = pointMax;
   fixedPoints->SetPoint(3, fixedPoint);
-  fixedPoint[0] = pointMax / static_cast<CoordRepType>(2.0);
-  fixedPoint[1] = pointMax / static_cast<CoordRepType>(2.0);
+  fixedPoint[0] = pointMax / static_cast<CoordinateType>(2.0);
+  fixedPoint[1] = pointMax / static_cast<CoordinateType>(2.0);
   fixedPoints->SetPoint(4, fixedPoint);
   unsigned int numberOfPoints = fixedPoints->GetNumberOfPoints();
 

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -77,7 +77,7 @@ itkExpectationBasedPointSetMetricTestRun()
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(metric, ExpectationBasedPointSetToPointSetMetricv4, PointSetToPointSetMetricv4);
 
-  typename PointSetMetricType::CoordRepType pointSetSigma = 1.0;
+  typename PointSetMetricType::CoordinateType pointSetSigma = 1.0;
   metric->SetPointSetSigma(pointSetSigma);
   ITK_TEST_SET_GET_VALUE(pointSetSigma, metric->GetPointSetSigma());
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -627,8 +627,8 @@ itkImageToImageMetricv4Test(int, char ** const)
   using PointSetType = ImageToImageMetricv4TestMetricType::FixedSampledPointSetType;
 
   using PointType = PointSetType::PointType;
-  PointSetType::CoordRepType testPointCoords[2];
-  PointSetType::Pointer      pset(PointSetType::New());
+  PointSetType::CoordinateType testPointCoords[2];
+  PointSetType::Pointer        pset(PointSetType::New());
 
   std::cout << "Creating point set..." << std::endl;
   DimensionSizeType ind = 0;

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -97,10 +97,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;
@@ -110,7 +110,7 @@ public:
   using GradientCalculatorPointer = typename GradientCalculatorType::Pointer;
 
   /** Moving image gradient calculator type. */
-  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordRepType>;
+  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordinateType>;
   using MovingImageGradientCalculatorPointer = typename MovingImageGradientCalculatorType::Pointer;
 
   /** Set the moving image interpolator. */

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -96,7 +96,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -130,10 +130,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Warper type */
   using WarperType = WarpImageFilter<MovingImageType, MovingImageType, DisplacementFieldType>;
@@ -148,7 +148,7 @@ public:
   using GradientCalculatorPointer = typename GradientCalculatorType::Pointer;
 
   /** Moving image gradient (unwarped) calculator type. */
-  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordRepType>;
+  using MovingImageGradientCalculatorType = CentralDifferenceImageFunction<MovingImageType, CoordinateType>;
   using MovingImageGradientCalculatorPointer = typename MovingImageGradientCalculatorType::Pointer;
 
   /** Set the moving image interpolator. */

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -129,7 +129,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -128,7 +128,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -88,7 +88,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -90,10 +90,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Warper type */
   using WarperType = WarpImageFilter<MovingImageType, MovingImageType, DisplacementFieldType>;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -89,7 +89,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -100,10 +100,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Vector types. */
   using VectorType = Vector<double, Self::ImageDimension>;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -99,7 +99,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -98,7 +98,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -105,10 +105,10 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
   using CoordRepType = CoordinateType;
-  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;
-  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordinateType>;
 
   /** Covariant vector type. */
   using CovariantVectorType = CovariantVector<double, Self::ImageDimension>;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -104,7 +104,10 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -103,7 +103,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -198,8 +198,8 @@ itkCurvatureRegistrationFilterTest(int, char *[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -251,8 +251,8 @@ itkDemonsRegistrationFilterTest(int, char *[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -276,8 +276,8 @@ itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
@@ -180,8 +180,8 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
   const ImageType * fixed = fixedReader->GetOutput();

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -244,8 +244,8 @@ itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -254,8 +254,8 @@ itkLevelSetMotionRegistrationFilterTest(int argc, char * argv[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
   warper->SetInput(moving);

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -305,8 +305,8 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -207,8 +207,8 @@ itkSymmetricForcesDemonsRegistrationFilterTest(int, char *[])
   using WarperType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
   auto warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   auto interpolator = InterpolatorType::New();
 
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
@@ -154,7 +154,7 @@ public:
   using DisplacementFieldType = typename OutputTransformType::DisplacementFieldType;
   using DisplacementFieldPointType = typename DisplacementFieldType::PointType;
 
-  using ContinuousIndexType = ContinuousIndex<typename DisplacementFieldPointType::CoordRepType, ImageDimension>;
+  using ContinuousIndexType = ContinuousIndex<typename DisplacementFieldPointType::CoordinateType, ImageDimension>;
 
   using TimeVaryingVelocityFieldControlPointLatticeType =
     typename OutputTransformType::TimeVaryingVelocityFieldControlPointLatticeType;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -801,7 +801,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<
     ContinuousIndexType cidx;
     for (SizeValueType d = 0; d < ImageDimension; ++d)
     {
-      cidx[d] = static_cast<typename ContinuousIndexType::CoordRepType>(index[d]);
+      cidx[d] = static_cast<typename ContinuousIndexType::CoordinateType>(index[d]);
     }
     DisplacementFieldPointType parametricPoint;
     bsplineParametricDomainField->TransformContinuousIndexToPhysicalPoint(cidx, parametricPoint);

--- a/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepTest.cxx
@@ -24,8 +24,8 @@ itkSimplexMeshWithFloatCoordRepTest(int, char *[])
   constexpr unsigned int Dimension = 3;
 
   using PixelType = float;
-  using CoordRepType = float;
-  using MeshTraits = itk::DefaultDynamicMeshTraits<PixelType, Dimension, Dimension, CoordRepType>;
+  using CoordinateType = float;
+  using MeshTraits = itk::DefaultDynamicMeshTraits<PixelType, Dimension, Dimension, CoordinateType>;
   using MeshType = itk::SimplexMesh<PixelType, Dimension, MeshTraits>;
   using DeformType = itk::DeformableSimplexMesh3DFilter<MeshType, MeshType>;
 

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
@@ -87,7 +87,7 @@ public:
   static constexpr unsigned int SpaceDimension = Superclass::SpaceDimension;
 
   /** CoordRep type alias support */
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
 
   /** InputType type alias support */
   using typename Superclass::InputType;
@@ -107,20 +107,20 @@ public:
   using ImagePointerVector = std::vector<ImagePointer>;
 
   /** Transform type alias support */
-  using TransformType = Transform<CoordRepType, Self::SpaceDimension, Self::SpaceDimension>;
+  using TransformType = Transform<CoordinateType, Self::SpaceDimension, Self::SpaceDimension>;
 
   /** Interpolator type alias support */
-  using InterpolatorType = InterpolateImageFunction<ImageType, CoordRepType>;
+  using InterpolatorType = InterpolateImageFunction<ImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using InterpolatorPointerVector = std::vector<InterpolatorPointer>;
 
   /** extrapolator type alias support */
-  using ExtrapolatorType = ExtrapolateImageFunction<ImageType, CoordRepType>;
+  using ExtrapolatorType = ExtrapolateImageFunction<ImageType, CoordinateType>;
   using ExtrapolatorPointer = typename ExtrapolatorType::Pointer;
   using ExtrapolatorPointerVector = std::vector<ExtrapolatorPointer>;
 
   /** function type alias support */
-  using FunctionType = ImageFunction<ImageType, double, CoordRepType>;
+  using FunctionType = ImageFunction<ImageType, double, CoordinateType>;
   using FunctionPointer = typename FunctionType::Pointer;
   using FunctionPointerVector = std::vector<FunctionPointer>;
 

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
@@ -141,19 +141,19 @@ PCAShapeSignedDistanceFunction<TCoordinate, VSpaceDimension, TImage>::Initialize
   m_Extrapolators.resize(m_NumberOfPrincipalComponents + 1);
 
   // interpolator/extrapolator for mean image
-  m_Interpolators[0] = LinearInterpolateImageFunction<ImageType, CoordRepType>::New();
+  m_Interpolators[0] = LinearInterpolateImageFunction<ImageType, CoordinateType>::New();
   m_Interpolators[0]->SetInputImage(m_MeanImage);
 
-  m_Extrapolators[0] = NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>::New();
+  m_Extrapolators[0] = NearestNeighborExtrapolateImageFunction<ImageType, CoordinateType>::New();
   m_Extrapolators[0]->SetInputImage(m_MeanImage);
 
   // interpolators/extrapolators for pc images
   for (unsigned int k = 1; k <= m_NumberOfPrincipalComponents; ++k)
   {
-    m_Interpolators[k] = LinearInterpolateImageFunction<ImageType, CoordRepType>::New();
+    m_Interpolators[k] = LinearInterpolateImageFunction<ImageType, CoordinateType>::New();
     m_Interpolators[k]->SetInputImage(m_PrincipalComponentImages[k - 1]);
 
-    m_Extrapolators[k] = NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>::New();
+    m_Extrapolators[k] = NearestNeighborExtrapolateImageFunction<ImageType, CoordinateType>::New();
     m_Extrapolators[k]->SetInputImage(m_PrincipalComponentImages[k - 1]);
   }
 }

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -76,7 +76,8 @@ public:
   static constexpr unsigned int SpaceDimension = VSpaceDimension;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordinate;
+  using CoordinateType = TCoordinate;
+  using CoordRepType = CoordinateType;
 
   /** Point type alias support */
   using PointType = InputType;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -77,7 +77,10 @@ public:
 
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
 
   /** Point type alias support */
   using PointType = InputType;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
@@ -70,7 +70,7 @@ public:
   static constexpr unsigned int SpaceDimension = Superclass::SpaceDimension;
 
   /** CoordRep type alias support */
-  using typename Superclass::CoordRepType;
+  using typename Superclass::CoordinateType;
 
   /** Point type alias support */
   using typename Superclass::PointType;
@@ -106,7 +106,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  using VectorType = Vector<CoordRepType, Self::SpaceDimension>;
+  using VectorType = Vector<CoordinateType, Self::SpaceDimension>;
 
   VectorType m_Translation{};
   double     m_Radius{};

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -75,7 +75,8 @@ public:
 
   /** Typedefs from itkMesh */
   using PixelType = typename MeshTraits::PixelType;
-  using CoordRepType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -75,7 +75,7 @@ public:
 
   /** Typedefs from itkMesh */
   using PixelType = typename MeshTraits::PixelType;
-  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordinateType;
   using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
@@ -90,7 +90,7 @@ public:
   using PointDataContainer = typename MeshTraits::PointDataContainer;
   using CellDataContainer = typename MeshTraits::CellDataContainer;
   using genericCellPointer = typename MeshTraits::CellAutoPointer;
-  using BoundingBoxType = BoundingBox<PointIdentifier, Self::PointDimension, CoordRepType, PointsContainer>;
+  using BoundingBoxType = BoundingBox<PointIdentifier, Self::PointDimension, CoordinateType, PointsContainer>;
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using CellsContainerPointer = typename CellsContainer::Pointer;
   using CellLinksContainerPointer = typename CellLinksContainer::Pointer;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -76,7 +76,10 @@ public:
   /** Typedefs from itkMesh */
   using PixelType = typename MeshTraits::PixelType;
   using CoordinateType = typename MeshTraits::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -72,7 +72,7 @@ public:
   using SeedsType = typename VDMesh::SeedsType;
   using EdgeInfo = typename VDMesh::EdgeInfo;
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
-  using CoordinateType = typename VDMesh::CoordRepType;
+  using CoordinateType = typename VDMesh::CoordinateType;
   using CoordRepType = CoordinateType;
   using VoronoiEdge = typename VDMesh::VoronoiEdge;
 
@@ -166,7 +166,7 @@ private:
     FortuneSite()
       : m_Sitenbr(NumericTraits<int>::max())
     {
-      m_Coord.Fill(NumericTraits<CoordRepType>::max());
+      m_Coord.Fill(NumericTraits<CoordinateType>::max());
     }
 
     ~FortuneSite() = default;
@@ -248,7 +248,7 @@ private:
   differentPoint(PointType p1, PointType p2);
 
   bool
-  almostsame(CoordRepType p1, CoordRepType p2);
+  almostsame(CoordinateType p1, CoordinateType p2);
 
   unsigned char
   Pointonbnd(int VertID);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -72,7 +72,8 @@ public:
   using SeedsType = typename VDMesh::SeedsType;
   using EdgeInfo = typename VDMesh::EdgeInfo;
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
-  using CoordRepType = typename VDMesh::CoordRepType;
+  using CoordinateType = typename VDMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VoronoiEdge = typename VDMesh::VoronoiEdge;
 
   /** Get the number of seed points. */

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -73,7 +73,10 @@ public:
   using EdgeInfo = typename VDMesh::EdgeInfo;
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
   using CoordinateType = typename VDMesh::CoordinateType;
-  using CoordRepType = CoordinateType;
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
+    CoordinateType;
+#endif
   using VoronoiEdge = typename VDMesh::VoronoiEdge;
 
   /** Get the number of seed points. */

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -49,8 +49,8 @@ VoronoiDiagram2DGenerator<TCoordinateType>::SetRandomSeeds(int num)
   double xmax{ m_VorBoundary[0] };
   for (int i = 0; i < num; ++i)
   {
-    curr[0] = (CoordRepType)(vnl_sample_uniform(0, xmax));
-    curr[1] = (CoordRepType)(vnl_sample_uniform(0, ymax));
+    curr[0] = (CoordinateType)(vnl_sample_uniform(0, xmax));
+    curr[1] = (CoordinateType)(vnl_sample_uniform(0, ymax));
     m_Seeds.push_back(curr);
   }
   m_NumberOfSeeds = num;
@@ -184,7 +184,7 @@ VoronoiDiagram2DGenerator<TCoordinateType>::differentPoint(PointType p1, PointTy
 
 template <typename TCoordinateType>
 bool
-VoronoiDiagram2DGenerator<TCoordinateType>::almostsame(CoordRepType p1, CoordRepType p2)
+VoronoiDiagram2DGenerator<TCoordinateType>::almostsame(CoordinateType p1, CoordinateType p2)
 {
   double diff = p1 - p2;
   bool   save = ((diff < -DIFF_TOLERENCE) || (diff > DIFF_TOLERENCE));

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -530,8 +530,8 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   m_Size = this->GetInput()->GetRequestedRegion().GetSize();
 
   VoronoiDiagram::PointType VDsize;
-  VDsize[0] = (VoronoiDiagram::CoordRepType)(m_Size[0] - 0.1);
-  VDsize[1] = (VoronoiDiagram::CoordRepType)(m_Size[1] - 0.1);
+  VDsize[0] = (VoronoiDiagram::CoordinateType)(m_Size[0] - 0.1);
+  VDsize[1] = (VoronoiDiagram::CoordinateType)(m_Size[1] - 0.1);
   m_VDGenerator->SetBoundary(VDsize);
   m_VDGenerator->SetRandomSeeds(m_NumberOfSeeds);
 

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
@@ -39,10 +39,10 @@ struct OpenCVBasicTypeBridge
 {};
 
 template <typename TPoint>
-struct OpenCVBasicTypeBridge<TPoint, cv::Point_<typename TPoint::CoordRepType>>
+struct OpenCVBasicTypeBridge<TPoint, cv::Point_<typename TPoint::CoordinateType>>
 {
   using ITKDataType = TPoint;
-  using CoordinateType = typename TPoint::CoordRepType;
+  using CoordinateType = typename TPoint::CoordinateType;
   using OpenCVDataType = cv::Point_<CoordinateType>;
 
   static ITKDataType
@@ -68,10 +68,10 @@ struct OpenCVBasicTypeBridge<TPoint, cv::Point_<typename TPoint::CoordRepType>>
 };
 
 template <typename TPoint>
-struct OpenCVBasicTypeBridge<TPoint, cv::Point3_<typename TPoint::CoordRepType>>
+struct OpenCVBasicTypeBridge<TPoint, cv::Point3_<typename TPoint::CoordinateType>>
 {
   using ITKDataType = TPoint;
-  using CoordinateType = typename TPoint::CoordRepType;
+  using CoordinateType = typename TPoint::CoordinateType;
   using OpenCVDataType = cv::Point3_<CoordinateType>;
 
   static ITKDataType


### PR DESCRIPTION
"CoordinateType" appears more readable than "CoordRepType".

Using Notepad++, Replace in Files, doing:

    Find what: ( [ ]+)using CoordRepType = (\w+);
    Replace with: $1using CoordinateType = $2;\r\n$1using CoordRepType = CoordinateType;
    Filters: itk*.h
    Directory: D:\src\ITK\Modules
    [v] Match case
    (*) Regular expression

- Follow-up to pull request #4995