### PR TITLE
Add `ITK_FUTURE_DEPRECATED` macro, use it in itkSingleton.h and for `CoordRepType`

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -91,8 +91,8 @@ public:
   using PointIdentifier = TPointIdentifier;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PointsContainer = TPointsContainer;
   using PointsContainerPointer = typename PointsContainer::Pointer;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -111,8 +111,8 @@ public:
   /** Save type information for this cell. */
   using CoordinateType = typename CellTraits::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = typename CellTraits::InterpolationWeightType;
   using PointIdentifier = typename CellTraits::PointIdentifier;
@@ -531,8 +531,8 @@ public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -58,8 +58,8 @@ public:
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Dimension of the Space */

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -71,8 +71,8 @@ public:
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = TInterpolationWeight;
 

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -69,8 +69,8 @@ public:
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = TInterpolationWeight;
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1373,6 +1373,14 @@ itkDynamicCastInDebugMode(TSource x)
 #endif
 }
 
+// ITK_FUTURE_DEPRECATED is only for internal use, within the implementation of ITK. It allows triggering "deprecated"
+// warnings when legacy support is removed, which warn that a specific feature may be removed in the future.
+#if defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT)
+#  define ITK_FUTURE_DEPRECATED(message) [[deprecated(message)]]
+#else
+#  define ITK_FUTURE_DEPRECATED(message)
+#endif
+
 #if __cplusplus >= 202002L
 #  define ITK_NODISCARD(message) [[nodiscard(message)]]
 #else

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -62,8 +62,8 @@ public:
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   using RealType = typename NumericTraits<ValueType>::RealType;

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -73,8 +73,8 @@ public:
   using PointType = typename TPointsContainer::Element;
   using CoordinateType = typename PointType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PointIdentifier = typename TPointsContainer::ElementIdentifier;
   using PointsContainer = TPointsContainer;

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -78,12 +78,12 @@ public:
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   template <typename T>
-  [[deprecated("Prefer calling the SetGlobalInstance(globalName, global, deleteFunc) overload (without the unused func "
-               "parameter)!")]] bool
-  SetGlobalInstance(const char *                globalName,
-                    T *                         global,
-                    std::function<void(void *)> itkNotUsed(func),
-                    std::function<void()>       deleteFunc)
+  ITK_FUTURE_DEPRECATED("Prefer calling the SetGlobalInstance(globalName, global, deleteFunc) overload (without the "
+                        "unused func parameter)!")
+  bool SetGlobalInstance(const char *                globalName,
+                         T *                         global,
+                         std::function<void(void *)> itkNotUsed(func),
+                         std::function<void()>       deleteFunc)
   {
     this->SetGlobalInstance(globalName, global, std::move(deleteFunc));
     // Just returns true for backward compatibility (legacy only).
@@ -148,8 +148,9 @@ Singleton(const char * globalName, std::function<void()> deleteFunc)
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 template <typename T>
-[[deprecated("Prefer calling the Singleton(globalName, deleteFunc) overload (without the unused func parameter)!")]] T *
-Singleton(const char * globalName, std::function<void(void *)> itkNotUsed(func), std::function<void()> deleteFunc)
+ITK_FUTURE_DEPRECATED(
+  "Prefer calling the Singleton(globalName, deleteFunc) overload (without the unused func parameter)!")
+T * Singleton(const char * globalName, std::function<void(void *)> itkNotUsed(func), std::function<void()> deleteFunc)
 {
   return Singleton<T>(globalName, std::move(deleteFunc));
 }

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -35,8 +35,8 @@ public:
   using PointType = TPoint;
   using CoordinateType = typename PointType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using VectorType = typename PointType::VectorType;
   using CrossVectorType = CrossHelper<VectorType>;

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -86,8 +86,8 @@ public:
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Index Type. */

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -88,8 +88,8 @@ public:
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Returns the interpolated image intensity at a

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -64,8 +64,8 @@ public:
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Type of the  transform. */

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -170,8 +170,8 @@ public:
   /** Convenient type alias obtained from TMeshTraits template parameter. */
   using CoordinateType = typename MeshTraits::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -58,8 +58,8 @@ public:
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   using InputMeshType = TInputMesh;

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -58,8 +58,8 @@ public:
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Type of the transform. */

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -59,8 +59,8 @@ public:
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Deformation field type alias support */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -52,8 +52,8 @@ public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -56,8 +56,8 @@ public:
   using PointType = typename MeshType::PointType;
   using CoordinateType = typename MeshType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using VectorType = typename MeshType::VectorType;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -72,8 +72,8 @@ public:
   /** Save the template parameters. */
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PixelType = TPixelType;
   using PrimalDataType = TPData;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -86,8 +86,8 @@ protected:
   // Mesh types
   using CoordinateType = typename MeshType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   // QE types
   using QEOriginType = typename QEType::OriginRefType;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -55,8 +55,8 @@ public:
   using CellPixelType = TPixel;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = TInterpolationWeight;
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -80,8 +80,8 @@ public:
   using InputImageType = TInputImage;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PixelType = typename InputImageType::PixelType;
   using RegionType = typename InputImageType::RegionType;

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -94,8 +94,8 @@ public:
   /** Typedef support for the interpolation function. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -130,8 +130,8 @@ public:
   /** Interpolator type alias support */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -133,8 +133,8 @@ public:
   /** Interpolator type alias support */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -119,8 +119,8 @@ public:
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
 #  ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #  endif
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -69,8 +69,8 @@ public:
   // using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Method for creation through the object factory. */

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -97,8 +97,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -192,8 +192,8 @@ public:
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -96,8 +96,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -97,8 +97,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -100,8 +100,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -74,8 +74,8 @@ public:
   using OutputType = TOutput;
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Typedef for points locator class to speed up finding neighboring points */

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -86,8 +86,8 @@ public:
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Set the input point set.

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -153,8 +153,8 @@ public:
   using PixelType = FixedPixelType;
   using CoordinateType = typename PointType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -142,8 +142,8 @@ public:
   using typename Superclass::PixelType;
   using CoordinateType = typename PointType::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -97,8 +97,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -130,8 +130,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -90,8 +90,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -100,8 +100,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -105,8 +105,8 @@ public:
   /** Interpolator type. */
   using CoordinateType = double;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordinateType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -78,8 +78,8 @@ public:
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
 
   /** Point type alias support */

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -77,8 +77,8 @@ public:
   using PixelType = typename MeshTraits::PixelType;
   using CoordinateType = typename MeshTraits::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -74,8 +74,8 @@ public:
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
   using CoordinateType = typename VDMesh::CoordinateType;
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  using CoordRepType [[deprecated("ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!")]] =
-    CoordinateType;
+  using CoordRepType ITK_FUTURE_DEPRECATED(
+    "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
   using VoronoiEdge = typename VDMesh::VoronoiEdge;
 


### PR DESCRIPTION
In general, `ITK_FUTURE_DEPRECATED` is intended to be used instead of `[[deprecated]]`, when a feature is marked `ITK_FUTURE_LEGACY_REMOVE`, and when such "deprecated" warnings may be disturbing to legacy users, who have intentionally enabled legacy support.

Used the macro for the deprecated `SetGlobalInstance` and `Singleton` overloads in itkSingleton.h (which were both already marked `ITK_FUTURE_LEGACY_REMOVE`), and the `CoordRepType` aliases.