### PR TITLE
COMP: Fix 'itkPyCommand.h' file not found

### DIFF
--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.wrap
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.wrap
@@ -1,1 +1,2 @@
+itk_wrap_include("${CMAKE_CURRENT_LIST_DIR}/itkPyCommand.h")
 itk_wrap_simple_class("itk::PyCommand" POINTER)


### PR DESCRIPTION
This is appearing again, which means that previous solution was not thorough enough: https://github.com/InsightSoftwareConsortium/ITK/pull/4829

Sample error message:
```log
28>------ Build started: Project: ITKPyUtilsCastXML, Configuration: RelWithDebInfo x64 ------ 28>Generating ../../../castxml_inputs/itkPyCommand.xml 28>C:/Dev/ITK-py22/Wrapping/castxml_inputs/itkPyCommand.cxx:16:10: fatal error: 'itkPyCommand.h' file not found
28>   16 | #include "itkPyCommand.h"
28>      |          ^~~~~~~~~~~~~~~~
28>1 error generated.
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
