### PR TITLE
COMP: Replace "CoordRep" with "Coordinate" in Examples

### DIFF
--- a/Examples/DataRepresentation/Mesh/MeshTraits.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshTraits.cxx
@@ -83,7 +83,7 @@ main(int, char *[])
   //  \item[PixelType.] The value type associated with every point.
   //  \item[PointDimension.] The dimension of the space in which the mesh is
   //  embedded. \item[MaxTopologicalDimension.] The highest dimension of the
-  //  mesh cells. \item[CoordRepType.] The type used to represent spacial
+  //  mesh cells. \item[CoordinateType.] The type used to represent spacial
   //  coordinates. \item[InterpolationWeightType.]  The type used to represent
   //  interpolation weights. \item[CellPixelType.] The value type associated
   //  with every cell. \end{description}

--- a/Examples/SpatialObjects/MeshSpatialObject.cxx
+++ b/Examples/SpatialObjects/MeshSpatialObject.cxx
@@ -63,7 +63,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   auto myMesh = MeshType::New();
 
-  MeshType::CoordRepType testPointCoords[4][3] = {
+  MeshType::CoordinateType testPointCoords[4][3] = {
     { 0, 0, 0 }, { 9, 0, 0 }, { 9, 9, 0 }, { 0, 0, 9 }
   };
 

--- a/Examples/Statistics/PointSetToListSampleAdaptor.cxx
+++ b/Examples/Statistics/PointSetToListSampleAdaptor.cxx
@@ -80,7 +80,7 @@ main()
   // dimension, we have to modify the \code{TMeshTraits} (one of the optional
   // template arguments for the \code{PointSet} class). The easiest way of
   // creating a custom mesh traits instance is to specialize the existing
-  // \doxygen{DefaultStaticMeshTraits}. By specifying the \code{TCoordRep}
+  // \doxygen{DefaultStaticMeshTraits}. By specifying the \code{TCoordinate}
   // template argument, we can change the coordinate value type of a point.
   // By specifying the \code{VPointDimension} template argument, we can
   // change the dimension of the point. As mentioned earlier, a


### PR DESCRIPTION
Addressed a compile error at Mac12.x-AppleClang-dbg-Universal saying:

> MeshSpatialObject.cxx:66:13: error: no type named 'CoordRepType' in
> 'itk::Mesh<float, 3, itk::DefaultDynamicMeshTraits<float, 3>>'

Reported by Jon Haitz Legarreta Gorroño (@jhlegarreta) at https://github.com/InsightSoftwareConsortium/ITK/pull/4997#issuecomment-2508979579

- Follow-up to pull request #4997 commit 15d189f513ac63e3cafc77a58b39c8862ce6e844
"STYLE: Replace CoordRepType with CoordinateType in ITK implementation"