### PR TITLE
COMP: Slow down removal of the `CoordRepType` aliases

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -90,7 +90,7 @@ public:
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -110,7 +110,7 @@ public:
 
   /** Save type information for this cell. */
   using CoordinateType = typename CellTraits::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif
@@ -530,7 +530,7 @@ class ITK_TEMPLATE_EXPORT CellTraitsInfo
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -57,7 +57,7 @@ public:
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -70,7 +70,7 @@ public:
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -68,7 +68,7 @@ public:
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -61,7 +61,7 @@ public:
    * as a data element held in an Point.   */
   using ValueType = TCoordinate;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -72,7 +72,7 @@ public:
   /** Convenient type alias obtained from TPointsContainer template parameter. */
   using PointType = typename TPointsContainer::Element;
   using CoordinateType = typename PointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -34,7 +34,7 @@ public:
   using Self = TriangleHelper;
   using PointType = TPoint;
   using CoordinateType = typename PointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -85,7 +85,7 @@ public:
 
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -87,7 +87,7 @@ public:
 
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -63,7 +63,7 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -169,7 +169,7 @@ public:
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
   using CoordinateType = typename MeshTraits::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -57,7 +57,7 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -57,7 +57,7 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -58,7 +58,7 @@ public:
 
   /** Type for representing coordinates. */
   using CoordinateType = typename TInputMesh::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -51,7 +51,7 @@ class QuadEdgeMeshCellTraitsInfo
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -55,7 +55,7 @@ public:
   using PointIdentifier = typename MeshType::PointIdentifier;
   using PointType = typename MeshType::PointType;
   using CoordinateType = typename MeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -71,7 +71,7 @@ public:
   using Self = QuadEdgeMeshExtendedTraits;
   /** Save the template parameters. */
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -85,7 +85,7 @@ public:
 protected:
   // Mesh types
   using CoordinateType = typename MeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -50,7 +50,7 @@ public:
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -81,7 +81,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
   using OutputCoordinateType = typename OutputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using OutputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `OutputCoordRepType`. Please use `OutputCoordinateType` instead!") = OutputCoordinateType;
 #endif

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -54,7 +54,7 @@ public:
   using PixelType = TPixel;
   using CellPixelType = TPixel;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -64,7 +64,7 @@ public:
   using IndexType = typename ImageType::IndexType;
   using ImagePointType = typename ImageType::PointType;
   using ImagePointCoordinateType = typename ImagePointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using ImagePointCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `ImagePointCoordRepType`. Please use `ImagePointCoordinateType` instead!") =
     ImagePointCoordinateType;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -79,7 +79,7 @@ public:
   using ControlPointLatticeType = TInputImage;
   using InputImageType = TInputImage;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -93,7 +93,7 @@ public:
 
   /** Typedef support for the interpolation function. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -129,7 +129,7 @@ public:
 
   /** Interpolator type alias support */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -132,7 +132,7 @@ public:
 
   /** Interpolator type alias support */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -118,7 +118,7 @@ public:
 
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
-#  ifndef ITK_FUTURE_LEGACY_REMOVE
+#  ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #  endif

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
@@ -93,7 +93,7 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -116,7 +116,7 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputCoordinateType = typename OutputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using OutputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `OutputCoordRepType`. Please use `OutputCoordinateType` instead!") = OutputCoordinateType;
 #endif

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
@@ -50,7 +50,7 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -78,7 +78,7 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputCoordinateType = typename OutputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using OutputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `OutputCoordRepType`. Please use `OutputCoordinateType` instead!") = OutputCoordinateType;
 #endif

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
@@ -70,7 +70,7 @@ public:
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -103,7 +103,7 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
   using OutputCoordinateType = typename OutputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using OutputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `OutputCoordRepType`. Please use `OutputCoordinateType` instead!") = OutputCoordinateType;
 #endif

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -35,7 +35,7 @@ class MatrixCoefficients
 public:
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -63,7 +63,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -96,7 +96,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -142,7 +142,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -200,7 +200,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -260,7 +260,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif
@@ -299,7 +299,7 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputCoordinateType = typename InputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -98,7 +98,7 @@ public:
   /** Define output mesh types */
   using OutputMeshType = TOutputMesh;
   using OutputCoordinateType = typename OutputMeshType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using OutputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `OutputCoordRepType`. Please use `OutputCoordinateType` instead!") = OutputCoordinateType;
 #endif

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -68,7 +68,7 @@ public:
   /** Type for representing coordinates. */
   // using CoordinateType = typename TInputMesh::CoordinateType;
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -181,7 +181,7 @@ public:
   using InputImagePointer = typename InputImageType::Pointer;
   using InputPointType = typename InputImageType::PointType;
   using InputCoordinateType = typename InputPointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using InputCoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `InputCoordRepType`. Please use `InputCoordinateType` instead!") = InputCoordinateType;
 #endif

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -96,7 +96,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -191,7 +191,7 @@ public:
 
   /** Typedef support for the interpolation function */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -95,7 +95,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -96,7 +96,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -99,7 +99,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -73,7 +73,7 @@ public:
   using RealType = TOutput;
   using OutputType = TOutput;
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -85,7 +85,7 @@ public:
 
   /** CoordinateType type alias support */
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -152,7 +152,7 @@ public:
   using PointType = FixedPointType;
   using PixelType = FixedPixelType;
   using CoordinateType = typename PointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -141,7 +141,7 @@ public:
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
   using CoordinateType = typename PointType::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -96,7 +96,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -129,7 +129,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -89,7 +89,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -99,7 +99,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -104,7 +104,7 @@ public:
 
   /** Interpolator type. */
   using CoordinateType = double;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -77,7 +77,7 @@ public:
 
   /** CoordRep type alias support */
   using CoordinateType = TCoordinate;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -76,7 +76,7 @@ public:
   /** Typedefs from itkMesh */
   using PixelType = typename MeshTraits::PixelType;
   using CoordinateType = typename MeshTraits::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -73,7 +73,7 @@ public:
   using EdgeInfo = typename VDMesh::EdgeInfo;
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
   using CoordinateType = typename VDMesh::CoordinateType;
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef ITK_REMOVE_COORD_REP_TYPES
   using CoordRepType ITK_FUTURE_DEPRECATED(
     "ITK 6 discourages using `CoordRepType`. Please use `CoordinateType` instead!") = CoordinateType;
 #endif


### PR DESCRIPTION
For now, only remove those aliases when explicitly requested by defining `ITK_REMOVE_COORD_REP_TYPES`. The aim is to put them in `#ifndef ITK_FUTURE_LEGACY_REMOVE` with ITK 6.1.