### PR TITLE
ENH: Force python 3.9 or greater compliance.

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -8,26 +8,22 @@
 # implementation gives preference to active virtualenvs.
 
 cmake_policy(SET CMP0094 NEW) # makes FindPython3 prefer activated virtualenv Python to latest version
-set(PYTHON_REQUIRED_VERSION 3.8)
-set(Python_ADDITIONAL_VERSIONS
-    3.12
-    3.11
-    3.10
-    3.9
-    3.8)
+set(PYTHON_VERSION_MIN 3.9)
+set(PYTHON_VERSION_MAX 3.999)
+
 if(PYTHON_DEVELOPMENT_REQUIRED)
   if(DEFINED Python3_EXECUTABLE) # if already specified
     set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
   endif()
   # set(Python3_FIND_REGISTRY LAST) # default is FIRST. Do we need/want this?
-  find_package(Python3 ${PYTHON_REQUIRED_VERSION} COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
+  find_package(Python3 ${PYTHON_VERSION_MIN}...${PYTHON_VERSION_MAX} COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
   if(DEFINED _specified_Python3_EXECUTABLE)
     set(Python3_EXECUTABLE
         ${_specified_Python3_EXECUTABLE}
         CACHE INTERNAL "Path to the Python interpreter" FORCE)
   endif()
 else() # if not PYTHON_DEVELOPMENT_REQUIRED, just find some version of Python (don't need to be as specific)
-  find_package(Python3 ${PYTHON_REQUIRED_VERSION} COMPONENTS Interpreter)
+  find_package(Python3 ${PYTHON_VERSION_MIN}...${PYTHON_VERSION_MAX} COMPONENTS Interpreter)
 endif()
 if(ITK_WRAP_PYTHON)
   set(ITK_WRAP_PYTHON_VERSION "${Python3_VERSION}")

--- a/Documentation/docs/contributing/python_packaging.md
+++ b/Documentation/docs/contributing/python_packaging.md
@@ -20,7 +20,7 @@ Building ITK Python wheels requires the following:
 - CMake >= 3.16
 - Git
 - C++ Compiler (see [scikit-build platform specific requirements](https://scikit-build.readthedocs.io/en/latest/generators.html))
-- Python >= 3.8
+- Python >= 3.9
 
 ## Automated Platform Scripts
 

--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -401,7 +401,7 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
     if(ITK_USE_PYTHON_LIMITED_API)
       set(development_component "Development.SABIModule")
     endif()
-    find_package(Python3 COMPONENTS Interpreter ${development_component} REQUIRED)
+    find_package(Python3 ${PYTHON_VERSION_MIN}...${PYTHON_VERSION_MAX} COMPONENTS Interpreter ${development_component} REQUIRED)
     add_library(${lib} MODULE ${cpp_file} ${ITK_WRAP_PYTHON_CXX_FILES} ${WRAPPER_LIBRARY_CXX_SOURCES})
     set_target_properties(${lib} PROPERTIES PREFIX "_")
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -5890,7 +5890,7 @@ packages:
   sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
   md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
-  - python >=3.8
+  - python >=3.9
   license: Apache-2.0
   license_family: APACHE
   size: 50290
@@ -5905,7 +5905,7 @@ packages:
   sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
   md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
   depends:
-  - python >=3.8
+  - python >=3.9
   license: MIT
   license_family: MIT
   size: 23815
@@ -5941,7 +5941,7 @@ packages:
   - iniconfig
   - packaging
   - pluggy <2,>=1.5
-  - python >=3.8
+  - python >=3.9
   - tomli >=1
   constrains:
   - pytest-faulthandler >=2


### PR DESCRIPTION
Python 3.8 has reached it's end-of-life.

Use cmake find_package version range limits for
valid versions of python to enforce the lower
bound of 3.9.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
