### PR TITLE
Add CoordinateType aliases to release 5.4

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -89,7 +89,8 @@ public:
 
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using PointsContainer = TPointsContainer;
   using PointsContainerPointer = typename PointsContainer::Pointer;
   using PointsContainerConstPointer = typename PointsContainer::ConstPointer;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -108,7 +108,8 @@ public:
   using CellTraits = TCellTraits;
 
   /** Save type information for this cell. */
-  using CoordRepType = typename CellTraits::CoordRepType;
+  using CoordinateType = typename CellTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename CellTraits::InterpolationWeightType;
   using PointIdentifier = typename CellTraits::PointIdentifier;
   using PointIdIterator = typename CellTraits::PointIdIterator;
@@ -524,7 +525,8 @@ class ITK_TEMPLATE_EXPORT CellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -56,7 +56,8 @@ public:
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
   using ValueType = TCoordRep;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Dimension of the Space */
   static constexpr unsigned int IndexDimension = VIndexDimension;

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -69,7 +69,8 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -67,7 +67,8 @@ public:
   /** Just save all the template parameters. */
   using PixelType = TPixelType;
   using CellPixelType = TCellPixelType;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   /** Just save all the template parameters. */

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -60,7 +60,8 @@ public:
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
   using ValueType = TCoordRep;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   using RealType = typename NumericTraits<ValueType>::RealType;
 

--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -101,7 +101,8 @@ public:
   using PixelType = typename MeshTraits::PixelType;
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
-  using CoordRepType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using PointType = typename MeshTraits::PointType;
   using PointsContainer = typename MeshTraits::PointsContainer;

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -33,7 +33,8 @@ class ITK_TEMPLATE_EXPORT TriangleHelper
 public:
   using Self = TriangleHelper;
   using PointType = TPoint;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VectorType = typename PointType::VectorType;
   using CrossVectorType = CrossHelper<VectorType>;
 

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -84,7 +84,8 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Index Type. */
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -86,7 +86,8 @@ public:
   using typename Superclass::OutputType;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Returns the interpolated image intensity at a
    * specified point position. No bounds checking is done.

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -62,7 +62,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Type of the  transform. */
   using SpatialFunctionType = TSpatialFunction;

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -168,7 +168,8 @@ public:
 #endif
 
   /** Convenient type alias obtained from TMeshTraits template parameter. */
-  using CoordRepType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -56,7 +56,8 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   using InputMeshType = TInputMesh;
   using OutputMeshType = TOutputMesh;

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -56,7 +56,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Type of the transform. */
   using TransformType = TTransform;

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -57,7 +57,8 @@ public:
   using OutputMeshPointer = typename OutputMeshType::Pointer;
 
   /** Type for representing coordinates. */
-  using CoordRepType = typename TInputMesh::CoordRepType;
+  using CoordinateType = typename TInputMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
 
   /** Deformation field type alias support */
   using DisplacementFieldType = TDisplacementField;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -50,7 +50,8 @@ class QuadEdgeMeshCellTraitsInfo
 {
 public:
   static constexpr unsigned int PointDimension = VPointDimension;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
   using PointIdentifier = TPointIdentifier;
   using CellIdentifier = TCellIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -54,7 +54,8 @@ public:
 
   using PointIdentifier = typename MeshType::PointIdentifier;
   using PointType = typename MeshType::PointType;
-  using CoordRepType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VectorType = typename MeshType::VectorType;
 
   /** Evaluate at the specified input position */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -70,7 +70,8 @@ class QuadEdgeMeshExtendedTraits
 public:
   using Self = QuadEdgeMeshExtendedTraits;
   /** Save the template parameters. */
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using PixelType = TPixelType;
   using PrimalDataType = TPData;
   using DualDataType = TDData;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -85,7 +85,8 @@ public:
 
 protected:
   // Mesh types
-  using CoordRepType = typename MeshType::CoordRepType;
+  using CoordinateType = typename MeshType::CoordRepType;
+  using CoordRepType = CoordinateType;
   // QE types
   using QEOriginType = typename QEType::OriginRefType;
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -49,7 +49,8 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEPrimal = typename InputMeshType::QEPrimal;
@@ -76,7 +77,8 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordinateType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = OutputCoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputQEPrimal = typename OutputMeshType::QEPrimal;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -53,7 +53,8 @@ public:
   using Self = QuadEdgeMeshTraits;
   using PixelType = TPixel;
   using CellPixelType = TPixel;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = TInterpolationWeight;
 
   static constexpr unsigned int PointDimension = VPointDimension;

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -63,7 +63,8 @@ public:
   using ImagePointer = typename ImageType::ConstPointer;
   using IndexType = typename ImageType::IndexType;
   using ImagePointType = typename ImageType::PointType;
-  using ImagePointCoordRepType = typename ImagePointType::CoordRepType;
+  using ImagePointCoordinateType = typename ImagePointType::CoordRepType;
+  using ImagePointCoordRepType = ImagePointCoordinateType;
 
   /** Types defined from transform traits. */
   using TransformPointer = typename TransformType::Pointer;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -78,7 +78,8 @@ public:
   /** Image type alias support */
   using ControlPointLatticeType = TInputImage;
   using InputImageType = TInputImage;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
   using PixelType = typename InputImageType::PixelType;
   using RegionType = typename InputImageType::RegionType;
   using IndexType = typename InputImageType::IndexType;

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -92,7 +92,8 @@ public:
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** Typedef support for the interpolation function. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -128,7 +128,8 @@ public:
   using DisplacementType = typename DisplacementFieldType::PixelType;
 
   /** Interpolator type alias support */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = LinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -131,7 +131,8 @@ public:
   using DisplacementType = typename DisplacementFieldType::PixelType;
 
   /** Interpolator type alias support */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -117,7 +117,8 @@ public:
   using ExpandFactorsArrayType = FixedArray<ExpandFactorsType, ImageDimension>;
 
   /** Typedef support for the interpolation function */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<InputImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using DefaultInterpolatorType = VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
@@ -92,7 +92,8 @@ public:
 
   using InputMeshType = TInputMesh;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputTraits = typename InputMeshType::Traits;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -111,7 +112,8 @@ public:
 
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordinateType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = OutputCoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputTraits = typename OutputMeshType::Traits;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
@@ -49,7 +49,8 @@ public:
   /** Input types. */
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -73,7 +74,8 @@ public:
   /** Output types. */
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordinateType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = OutputCoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputCellType = typename OutputMeshType::CellType;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
@@ -69,7 +69,8 @@ public:
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
   using InputMeshConstPointer = typename InputMeshType::ConstPointer;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
@@ -98,7 +99,8 @@ public:
   using OutputMeshType = TOutputMesh;
   using OutputMeshPointer = typename OutputMeshType::Pointer;
   using OutputMeshConstPointer = typename OutputMeshType::ConstPointer;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordinateType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = OutputCoordinateType;
   using OutputPointType = typename OutputMeshType::PointType;
   using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
   using OutputQEType = typename OutputMeshType::QEType;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -34,7 +34,8 @@ class MatrixCoefficients
 {
 public:
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   MatrixCoefficients() = default;
@@ -58,7 +59,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   OnesMatrixCoefficients() = default;
@@ -87,7 +89,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -129,7 +132,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -183,7 +187,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;
   using InputQEType = typename InputMeshType::QEType;
@@ -239,7 +244,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputQEType = typename InputMeshType::QEType;
 
   InputCoordRepType m_Lambda;
@@ -274,7 +280,8 @@ public:
   using Superclass = MatrixCoefficients<TInputMesh>;
 
   using InputMeshType = TInputMesh;
-  using InputCoordRepType = typename InputMeshType::CoordRepType;
+  using InputCoordinateType = typename InputMeshType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputPointType = typename InputMeshType::PointType;
   using InputVectorType = typename InputPointType::VectorType;
   using InputPointIdentifier = typename InputMeshType::PointIdentifier;

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -97,7 +97,8 @@ public:
 
   /** Define output mesh types */
   using OutputMeshType = TOutputMesh;
-  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputCoordinateType = typename OutputMeshType::CoordRepType;
+  using OutputCoordRepType = OutputCoordinateType;
   using OutputPointPixelType = typename OutputMeshType::PixelType;
   using OutputCellPixelType = typename OutputMeshType::CellPixelType;
   using OutputPointType = typename OutputMeshType::PointType;

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -67,7 +67,8 @@ public:
 
   /** Type for representing coordinates. */
   // using CoordRepType = typename TInputMesh::CoordRepType;
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -180,7 +180,8 @@ public:
   using InputImageType = TInputImage;
   using InputImagePointer = typename InputImageType::Pointer;
   using InputPointType = typename InputImageType::PointType;
-  using InputCoordRepType = typename InputPointType::CoordRepType;
+  using InputCoordinateType = typename InputPointType::CoordRepType;
+  using InputCoordRepType = InputCoordinateType;
   using InputIndexType = typename InputImageType::IndexType;
   using InputIndexValueType = typename InputIndexType::IndexValueType;
   using InputSizeType = typename InputImageType::SizeType;

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -190,7 +190,8 @@ public:
   using IndexSelectCasterType = itk::VectorIndexSelectionCastImageFilter<FieldType, FloatImageType>;
 
   /** Typedef support for the interpolation function */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = VectorInterpolateImageFunction<FieldType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
 

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -94,7 +94,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
 
   using InterpolatorPointer = typename InterpolatorType::Pointer;

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -98,7 +98,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -71,7 +71,8 @@ public:
   /** Other type alias */
   using RealType = TOutput;
   using OutputType = TOutput;
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Typedef for points locator class to speed up finding neighboring points */
   using PointsLocatorType = PointsLocator<PointsContainer>;

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -84,7 +84,8 @@ public:
   using OutputType = TOutput;
 
   /** CoordRepType type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -151,7 +151,8 @@ public:
 
   using PointType = FixedPointType;
   using PixelType = FixedPixelType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using PointIdentifier = typename PointsContainer::ElementIdentifier;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -140,7 +140,8 @@ public:
 
   using typename Superclass::PointType;
   using typename Superclass::PixelType;
-  using CoordRepType = typename PointType::CoordRepType;
+  using CoordinateType = typename PointType::CoordRepType;
+  using CoordRepType = CoordinateType;
   using PointsContainer = FixedPointsContainer;
   using PointsConstIterator = typename PointsContainer::ConstIterator;
   using typename Superclass::PointIdentifier;

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -95,7 +95,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -128,7 +128,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -88,7 +88,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -98,7 +98,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -103,7 +103,8 @@ public:
   using typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  using CoordRepType = double;
+  using CoordinateType = double;
+  using CoordRepType = CoordinateType;
   using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
   using InterpolatorPointer = typename InterpolatorType::Pointer;
   using PointType = typename InterpolatorType::PointType;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -76,7 +76,8 @@ public:
   static constexpr unsigned int SpaceDimension = VSpaceDimension;
 
   /** CoordRep type alias support */
-  using CoordRepType = TCoordRep;
+  using CoordinateType = TCoordRep;
+  using CoordRepType = CoordinateType;
 
   /** Point type alias support */
   using PointType = InputType;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -75,7 +75,8 @@ public:
 
   /** Typedefs from itkMesh */
   using PixelType = typename MeshTraits::PixelType;
-  using CoordRepType = typename MeshTraits::CoordRepType;
+  using CoordinateType = typename MeshTraits::CoordRepType;
+  using CoordRepType = CoordinateType;
   using InterpolationWeightType = typename MeshTraits::InterpolationWeightType;
   using PointIdentifier = typename MeshTraits::PointIdentifier;
   using CellIdentifier = typename MeshTraits::CellIdentifier;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -72,7 +72,8 @@ public:
   using SeedsType = typename VDMesh::SeedsType;
   using EdgeInfo = typename VDMesh::EdgeInfo;
   using EdgeInfoDQ = typename VDMesh::EdgeInfoDQ;
-  using CoordRepType = typename VDMesh::CoordRepType;
+  using CoordinateType = typename VDMesh::CoordRepType;
+  using CoordRepType = CoordinateType;
   using VoronoiEdge = typename VDMesh::VoronoiEdge;
 
   /** Get the number of seed points. */


### PR DESCRIPTION
Aims to make it easier for users to gradually upgrade their code to ITK 6. Allows them to simply replace their uses of `CoordRepType` with `CoordinateType`, without adding `#if`'s to the user code