### PR TITLE
Remove "Type" from `TCoordinateType` template parameters, remove initial "T" from `TCoordinateType` alias

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -280,11 +280,11 @@ public:
    * We take into account the fact that each voxel has its
    * center at the integer coordinate and extends half way
    * to the next integer coordinate, inclusive on all sides. */
-  template <typename TCoordinateType>
+  template <typename TCoordinate>
   bool
-  IsInside(const ContinuousIndex<TCoordinateType, VImageDimension> & index) const
+  IsInside(const ContinuousIndex<TCoordinate, VImageDimension> & index) const
   {
-    constexpr TCoordinateType half = 0.5;
+    constexpr TCoordinate half = 0.5;
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       // Use negation of tests so that index[i]==NaN leads to returning false.

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -26,12 +26,12 @@ itkImageRegionTest(int, char *[])
 
   constexpr unsigned int dimension = 3;
 
-  using TCoordinateType = double;
+  using CoordinateType = double;
   using RegionType = itk::ImageRegion<dimension>;
   using IndexType = RegionType::IndexType;
   using SizeType = RegionType::SizeType;
   using SliceRegionType = RegionType::SliceRegion;
-  using ContinuousIndexType = itk::ContinuousIndex<TCoordinateType, dimension>;
+  using ContinuousIndexType = itk::ContinuousIndex<CoordinateType, dimension>;
 
   using IndexNumericTraits = itk::NumericTraits<IndexType::IndexValueType>;
   using ContinuousIndexNumericTraits = itk::NumericTraits<ContinuousIndexType::ValueType>;
@@ -273,21 +273,21 @@ itkImageRegionTest(int, char *[])
     std::cout << "NaN < -1 = " << (indexC[0] < -1.0) << std::endl;
     std::cout << "NaN > -1 = " << (indexC[0] > -1.0) << std::endl;
 
-    TCoordinateType NaN = ContinuousIndexNumericTraits::quiet_NaN();
-    std::cout << "RoundHalfIntegerUp(NaN): " << itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) << std::endl;
-    std::cout << "RoundHalfIntegerUp< TCoordinateType >(NaN) < static_cast<TCoordinateType> (0): "
-              << (itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) < static_cast<TCoordinateType>(0)) << std::endl;
-    std::cout << "RoundHalfIntegerUp< TCoordinateType >(NaN) > static_cast<TCoordinateType> (0): "
-              << (itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN) > static_cast<TCoordinateType>(0)) << std::endl;
-    auto rf = itk::Math::RoundHalfIntegerUp<TCoordinateType>(NaN);
-    std::cout << "TCoordinateType = RoundHalfIntegerUp(NaN): " << rf << std::endl;
-    auto rl = itk::Math::RoundHalfIntegerUp<RegionType::IndexValueType, TCoordinateType>(NaN);
+    CoordinateType NaN = ContinuousIndexNumericTraits::quiet_NaN();
+    std::cout << "RoundHalfIntegerUp(NaN): " << itk::Math::RoundHalfIntegerUp<CoordinateType>(NaN) << std::endl;
+    std::cout << "RoundHalfIntegerUp< CoordinateType >(NaN) < static_cast<CoordinateType> (0): "
+              << (itk::Math::RoundHalfIntegerUp<CoordinateType>(NaN) < static_cast<CoordinateType>(0)) << std::endl;
+    std::cout << "RoundHalfIntegerUp< CoordinateType >(NaN) > static_cast<CoordinateType> (0): "
+              << (itk::Math::RoundHalfIntegerUp<CoordinateType>(NaN) > static_cast<CoordinateType>(0)) << std::endl;
+    auto rf = itk::Math::RoundHalfIntegerUp<CoordinateType>(NaN);
+    std::cout << "CoordinateType = RoundHalfIntegerUp(NaN): " << rf << std::endl;
+    auto rl = itk::Math::RoundHalfIntegerUp<RegionType::IndexValueType, CoordinateType>(NaN);
     std::cout << "RegionType::IndexValueType type = RoundHalfIntegerUp(NaN): " << rl << std::endl;
     std::cout << "static_cast<RegionType::IndexValueType>( NaN ): " << static_cast<RegionType::IndexValueType>(NaN)
               << std::endl;
     std::cout << "NumericTraits<RegionType::IndexValueType>::min(): "
               << itk::NumericTraits<RegionType::IndexValueType>::min() << std::endl;
-    std::cout << "TCoordinateType min(): " << ContinuousIndexNumericTraits::min() << std::endl;
+    std::cout << "CoordinateType min(): " << ContinuousIndexNumericTraits::min() << std::endl;
     std::cout << "...end NaN tests." << std::endl << std::endl;
   }
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -54,7 +54,7 @@ namespace itk
  * Limitations:  The coordinates must be in an image of the same dimension as the
  *       input image.  There is no reason why this should be the case and future
  *       revisions should look at eliminating this limitation.
- *    Currently TCoordType must be the same as the input pixel type (TInputImage).
+ *    Currently TCoordinate must be the same as the input pixel type (TInputImage).
  *       Again future revisions should look at eliminating this limitation.
  *    Though the output generation may be streamed the entire input image,
  *       must be supplied. The coordinates may be streamed in smaller blocks.
@@ -75,8 +75,8 @@ namespace itk
 
 template <typename TInputImage,
           typename TOutputImage,
-          typename TCoordType = typename TInputImage::PixelType,
-          typename InterpolatorType = BSplineInterpolateImageFunction<TInputImage, TCoordType>>
+          typename TCoordinate = typename TInputImage::PixelType,
+          typename InterpolatorType = BSplineInterpolateImageFunction<TInputImage, TCoordinate>>
 class ITK_TEMPLATE_EXPORT InterpolateImagePointsFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
@@ -115,7 +115,7 @@ public:
   using ContinuousIndexType = typename InterpolatorType::ContinuousIndexType;
 
   /** Typedefs to describe and access coordinate images */
-  using CoordImageType = Image<TCoordType, Self::ImageDimension>;
+  using CoordImageType = Image<TCoordinate, Self::ImageDimension>;
 
   /** Typedef for region copier */
   using RegionCopierType = ImageToImageFilterDetail::ImageRegionCopier<Self::ImageDimension, Self::ImageDimension>;

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
@@ -33,8 +33,8 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::InterpolateImagePointsFilter()
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::InterpolateImagePointsFilter()
 {
   m_Interpolator = InterpolatorType::New();
   m_DefaultPixelValue = 0;
@@ -44,9 +44,9 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   this->ThreaderUpdateProgressOff();
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::SetInputImage(
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::SetInputImage(
   const TInputImage * inputImage)
 {
   this->SetInput(0, inputImage); // This is a data filter input
@@ -55,9 +55,9 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   m_Interpolator->SetInputImage(inputImage);
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::SetInterpolationCoordinate(
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::SetInterpolationCoordinate(
   const CoordImageType * coordinate,
   unsigned int           setDimension)
 {
@@ -65,9 +65,9 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   this->SetInput(setDimension + 1, coordinate); // This is a data filter input
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::DynamicThreadedGenerateData(
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
   OutputImagePointer outputPtr = this->GetOutput();
@@ -120,9 +120,9 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   }
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::GenerateInputRequestedRegion()
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::GenerateInputRequestedRegion()
 {
   // Call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();
@@ -139,9 +139,9 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   inputPtr->SetRequestedRegionToLargestPossibleRegion();
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::GenerateOutputInformation()
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::GenerateOutputInformation()
 {
   // Call the superclass' implementation of this method
   Superclass::GenerateOutputInformation();
@@ -169,10 +169,10 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }
 
-template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
+template <typename TInputImage, typename TOutputImage, typename TCoordinate, typename InterpolatorType>
 void
-InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, InterpolatorType>::PrintSelf(std::ostream & os,
-                                                                                                 Indent indent) const
+InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordinate, InterpolatorType>::PrintSelf(std::ostream & os,
+                                                                                                  Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -37,7 +37,7 @@ namespace itk
  *
  * Template parameters for VoronoiDiagram2D:
  *
- * TCoordType = The type associated with the coordination of the seeds and
+ * TCoordinate = The type associated with the coordination of the seeds and
  * the resulting vertices.
  *
  * \ingroup MeshObjects
@@ -47,16 +47,16 @@ namespace itk
  * \sphinxexample{Segmentation/Voronoi/VoronoiDiagram,Voronoi Diagram}
  * \endsphinx
  */
-template <typename TCoordType>
+template <typename TCoordinate>
 class ITK_TEMPLATE_EXPORT VoronoiDiagram2D
-  : public Mesh<TCoordType, 2, DefaultDynamicMeshTraits<TCoordType, 2, 2, TCoordType>>
+  : public Mesh<TCoordinate, 2, DefaultDynamicMeshTraits<TCoordinate, 2, 2, TCoordinate>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VoronoiDiagram2D);
 
   /** Standard class type aliases. */
   using Self = VoronoiDiagram2D;
-  using Superclass = Mesh<TCoordType, 2, DefaultDynamicMeshTraits<TCoordType, 2, 2, TCoordType>>;
+  using Superclass = Mesh<TCoordinate, 2, DefaultDynamicMeshTraits<TCoordinate, 2, 2, TCoordinate>>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -67,7 +67,7 @@ public:
   itkOverrideGetNameOfClassMacro(VoronoiDiagram2D);
 
   /** Define the mesh traits. */
-  using MeshTraits = DefaultDynamicMeshTraits<TCoordType, 2, 2, TCoordType>;
+  using MeshTraits = DefaultDynamicMeshTraits<TCoordinate, 2, 2, TCoordinate>;
 
   /** Dimensions of the points and topology. */
   static constexpr unsigned int PointDimension = MeshTraits::PointDimension;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
@@ -23,15 +23,15 @@
 namespace itk
 {
 
-template <typename TCoordinateType>
-VoronoiDiagram2D<TCoordinateType>::VoronoiDiagram2D()
+template <typename TCoordinate>
+VoronoiDiagram2D<TCoordinate>::VoronoiDiagram2D()
 {
   m_NumberOfSeeds = 0;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::PrintSelf(std::ostream & os, Indent indent) const
+VoronoiDiagram2D<TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Number Of Seeds: " << m_NumberOfSeeds << std::endl;
@@ -39,9 +39,9 @@ VoronoiDiagram2D<TCoordinateType>::PrintSelf(std::ostream & os, Indent indent) c
 
 
 /* Set the seed points, specify the number of seeds as "num". */
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::SetSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2D<TCoordinate>::SetSeeds(int num, SeedsIterator begin)
 {
   m_Seeds.clear();
   auto ii(begin);
@@ -54,43 +54,43 @@ VoronoiDiagram2D<TCoordinateType>::SetSeeds(int num, SeedsIterator begin)
 
 
 /* Set the rectangle that encloses the Voronoi Diagram. */
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::SetBoundary(PointType vorsize)
+VoronoiDiagram2D<TCoordinate>::SetBoundary(PointType vorsize)
 {
   m_VoronoiBoundary[0] = vorsize[0];
   m_VoronoiBoundary[1] = vorsize[1];
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::SetOrigin(PointType vorsize)
+VoronoiDiagram2D<TCoordinate>::SetOrigin(PointType vorsize)
 {
   m_VoronoiBoundaryOrigin[0] = vorsize[0];
   m_VoronoiBoundaryOrigin[1] = vorsize[1];
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::GetPoint(int pId, PointType * answer)
+VoronoiDiagram2D<TCoordinate>::GetPoint(int pId, PointType * answer)
 {
   *answer = this->m_PointsContainer->ElementAt(pId);
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::GetCellId(CellIdentifier cellId, CellAutoPointer & cellPtr)
+VoronoiDiagram2D<TCoordinate>::GetCellId(CellIdentifier cellId, CellAutoPointer & cellPtr)
 {
   cellPtr.TakeNoOwnership(m_VoronoiRegions[cellId]);
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> EdgeInfo
+VoronoiDiagram2D<TCoordinate>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> EdgeInfo
 {
   EdgeInfo answer;
 
@@ -100,57 +100,57 @@ VoronoiDiagram2D<TCoordinateType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> E
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::EdgeBegin() -> VoronoiEdgeIterator
+VoronoiDiagram2D<TCoordinate>::EdgeBegin() -> VoronoiEdgeIterator
 {
   return m_EdgeList.begin();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::EdgeEnd() -> VoronoiEdgeIterator
+VoronoiDiagram2D<TCoordinate>::EdgeEnd() -> VoronoiEdgeIterator
 {
   return m_EdgeList.end();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::NeighborIdsBegin(int seeds) -> NeighborIdIterator
+VoronoiDiagram2D<TCoordinate>::NeighborIdsBegin(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].begin();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::NeighborIdsEnd(int seeds) -> NeighborIdIterator
+VoronoiDiagram2D<TCoordinate>::NeighborIdsEnd(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].end();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::VertexBegin() -> VertexIterator
+VoronoiDiagram2D<TCoordinate>::VertexBegin() -> VertexIterator
 {
   return this->m_PointsContainer->Begin();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::VertexEnd() -> VertexIterator
+VoronoiDiagram2D<TCoordinate>::VertexEnd() -> VertexIterator
 {
   return this->m_PointsContainer->End();
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2D<TCoordinateType>::GetSeed(int SeedID) -> PointType
+VoronoiDiagram2D<TCoordinate>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 
@@ -160,9 +160,9 @@ VoronoiDiagram2D<TCoordinateType>::GetSeed(int SeedID) -> PointType
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::Reset()
+VoronoiDiagram2D<TCoordinate>::Reset()
 {
   m_VoronoiRegions.clear();
   m_VoronoiRegions.resize(m_NumberOfSeeds);
@@ -176,9 +176,9 @@ VoronoiDiagram2D<TCoordinateType>::Reset()
 }
 
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2D<TCoordinateType>::InsertCells()
+VoronoiDiagram2D<TCoordinate>::InsertCells()
 {
   genericCellPointer cellPtr;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -37,7 +37,7 @@ namespace itk
  * (1) Size of the region.
  * (2) Seed points coordinates. These coordinates can also be randomly set.
  *
- * \tparam TCoordType The type associated with the coordination of the seeds
+ * \tparam TCoordinate The type associated with the coordination of the seeds
  * and the resulting vertices.
  *
  * \ingroup ITKVoronoi
@@ -46,14 +46,14 @@ namespace itk
  * \sphinxexample{Segmentation/Voronoi/VoronoiDiagram,Voronoi Diagram}
  * \endsphinx
  */
-template <typename TCoordType>
-class ITK_TEMPLATE_EXPORT VoronoiDiagram2DGenerator : public MeshSource<VoronoiDiagram2D<TCoordType>>
+template <typename TCoordinate>
+class ITK_TEMPLATE_EXPORT VoronoiDiagram2DGenerator : public MeshSource<VoronoiDiagram2D<TCoordinate>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VoronoiDiagram2DGenerator);
 
   using Self = VoronoiDiagram2DGenerator;
-  using Superclass = MeshSource<VoronoiDiagram2D<TCoordType>>;
+  using Superclass = MeshSource<VoronoiDiagram2D<TCoordinate>>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -64,7 +64,7 @@ public:
   itkOverrideGetNameOfClassMacro(VoronoiDiagram2DGenerator);
 
   /** Convenient type alias. */
-  using VoronoidDiagramType = VoronoiDiagram2D<TCoordType>;
+  using VoronoidDiagramType = VoronoiDiagram2D<TCoordinate>;
   using VDMesh = VoronoidDiagramType;
   using SeedsIterator = typename VDMesh::SeedsIterator;
   using OutputType = typename VDMesh::Pointer;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -29,8 +29,8 @@ namespace itk
 const double     NUMERIC_TOLERENCE = 1.0e-10;
 constexpr double DIFF_TOLERENCE = 0.001;
 
-template <typename TCoordinateType>
-VoronoiDiagram2DGenerator<TCoordinateType>::VoronoiDiagram2DGenerator()
+template <typename TCoordinate>
+VoronoiDiagram2DGenerator<TCoordinate>::VoronoiDiagram2DGenerator()
   : m_OutputVD(Self::GetOutput())
   , m_BottomSite(nullptr)
 
@@ -38,9 +38,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::VoronoiDiagram2DGenerator()
   m_VorBoundary.Fill(0.0);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::SetRandomSeeds(int num)
+VoronoiDiagram2DGenerator<TCoordinate>::SetRandomSeeds(int num)
 {
   PointType curr;
 
@@ -56,9 +56,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::SetRandomSeeds(int num)
   m_NumberOfSeeds = num;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::SetSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2DGenerator<TCoordinate>::SetSeeds(int num, SeedsIterator begin)
 {
   m_Seeds.clear();
   SeedsIterator ii(begin);
@@ -69,27 +69,27 @@ VoronoiDiagram2DGenerator<TCoordinateType>::SetSeeds(int num, SeedsIterator begi
   m_NumberOfSeeds = num;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::SetBoundary(PointType vorsize)
+VoronoiDiagram2DGenerator<TCoordinate>::SetBoundary(PointType vorsize)
 {
   m_VorBoundary[0] = vorsize[0];
   m_VorBoundary[1] = vorsize[1];
   m_OutputVD->SetBoundary(vorsize);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::SetOrigin(PointType vorsize)
+VoronoiDiagram2DGenerator<TCoordinate>::SetOrigin(PointType vorsize)
 {
   m_Pxmin = vorsize[0];
   m_Pymin = vorsize[1];
   m_OutputVD->SetOrigin(vorsize);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 bool
-VoronoiDiagram2DGenerator<TCoordinateType>::comp(PointType arg1, PointType arg2)
+VoronoiDiagram2DGenerator<TCoordinate>::comp(PointType arg1, PointType arg2)
 {
   if (arg1[1] < arg2[1])
   {
@@ -115,16 +115,16 @@ VoronoiDiagram2DGenerator<TCoordinateType>::comp(PointType arg1, PointType arg2)
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::SortSeeds()
+VoronoiDiagram2DGenerator<TCoordinate>::SortSeeds()
 {
   std::sort(m_Seeds.begin(), m_Seeds.end(), comp);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::AddSeeds(int num, SeedsIterator begin)
+VoronoiDiagram2DGenerator<TCoordinate>::AddSeeds(int num, SeedsIterator begin)
 {
   auto ii(begin);
 
@@ -135,17 +135,17 @@ VoronoiDiagram2DGenerator<TCoordinateType>::AddSeeds(int num, SeedsIterator begi
   m_NumberOfSeeds += num;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::AddOneSeed(PointType inputSeed)
+VoronoiDiagram2DGenerator<TCoordinate>::AddOneSeed(PointType inputSeed)
 {
   m_Seeds.push_back(inputSeed);
   ++m_NumberOfSeeds;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::GetSeed(int SeedID) -> PointType
+VoronoiDiagram2DGenerator<TCoordinate>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 
@@ -154,9 +154,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::GetSeed(int SeedID) -> PointType
   return answer;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::GenerateData()
+VoronoiDiagram2DGenerator<TCoordinate>::GenerateData()
 {
   SortSeeds();
   m_OutputVD->SetSeeds(m_NumberOfSeeds, m_Seeds.begin());
@@ -164,16 +164,16 @@ VoronoiDiagram2DGenerator<TCoordinateType>::GenerateData()
   this->ConstructDiagram();
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::UpdateDiagram()
+VoronoiDiagram2DGenerator<TCoordinate>::UpdateDiagram()
 {
   this->GenerateData();
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 bool
-VoronoiDiagram2DGenerator<TCoordinateType>::differentPoint(PointType p1, PointType p2)
+VoronoiDiagram2DGenerator<TCoordinate>::differentPoint(PointType p1, PointType p2)
 {
   double diffx = p1[0] - p2[0];
   double diffy = p1[1] - p2[1];
@@ -182,18 +182,18 @@ VoronoiDiagram2DGenerator<TCoordinateType>::differentPoint(PointType p1, PointTy
           (diffy > DIFF_TOLERENCE));
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 bool
-VoronoiDiagram2DGenerator<TCoordinateType>::almostsame(CoordinateType p1, CoordinateType p2)
+VoronoiDiagram2DGenerator<TCoordinate>::almostsame(CoordinateType p1, CoordinateType p2)
 {
   double diff = p1 - p2;
   bool   save = ((diff < -DIFF_TOLERENCE) || (diff > DIFF_TOLERENCE));
   return (!save);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 unsigned char
-VoronoiDiagram2DGenerator<TCoordinateType>::Pointonbnd(int VertID)
+VoronoiDiagram2DGenerator<TCoordinate>::Pointonbnd(int VertID)
 {
   PointType currVert = m_OutputVD->GetVertex(VertID);
 
@@ -219,9 +219,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::Pointonbnd(int VertID)
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::ConstructDiagram()
+VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
 {
   const auto rawEdges = make_unique_for_overwrite<EdgeInfoDQ[]>(m_NumberOfSeeds);
 
@@ -416,9 +416,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::ConstructDiagram()
   m_OutputVD->InsertCells();
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 bool
-VoronoiDiagram2DGenerator<TCoordinateType>::right_of(FortuneHalfEdge * el, PointType * p)
+VoronoiDiagram2DGenerator<TCoordinate>::right_of(FortuneHalfEdge * el, PointType * p)
 {
   FortuneEdge * e = el->m_Edge;
   FortuneSite * topsite = e->m_Reg[1];
@@ -478,9 +478,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::right_of(FortuneHalfEdge * el, Point
   return (el->m_RorL ? (!above) : above);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::createHalfEdge(FortuneHalfEdge * task, FortuneEdge * e, bool pm)
+VoronoiDiagram2DGenerator<TCoordinate>::createHalfEdge(FortuneHalfEdge * task, FortuneEdge * e, bool pm)
 {
   task->m_Edge = e;
   task->m_RorL = pm;
@@ -488,9 +488,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::createHalfEdge(FortuneHalfEdge * tas
   task->m_Vert = nullptr;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::PQshowMin(PointType * answer)
+VoronoiDiagram2DGenerator<TCoordinate>::PQshowMin(PointType * answer)
 {
   while ((m_PQHash[m_PQmin].m_Next) == nullptr)
   {
@@ -500,9 +500,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::PQshowMin(PointType * answer)
   (*answer)[1] = m_PQHash[m_PQmin].m_Next->m_Ystar;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::deletePQ(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinate>::deletePQ(FortuneHalfEdge * task)
 {
   FortuneHalfEdge * last;
 
@@ -519,18 +519,18 @@ VoronoiDiagram2DGenerator<TCoordinateType>::deletePQ(FortuneHalfEdge * task)
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::deleteEdgeList(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinate>::deleteEdgeList(FortuneHalfEdge * task)
 {
   (task->m_Left)->m_Right = task->m_Right;
   (task->m_Right)->m_Left = task->m_Left;
   task->m_Edge = &(m_DELETED);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 int
-VoronoiDiagram2DGenerator<TCoordinateType>::PQbucket(FortuneHalfEdge * task)
+VoronoiDiagram2DGenerator<TCoordinate>::PQbucket(FortuneHalfEdge * task)
 {
   int bucket = static_cast<int>((task->m_Ystar - m_Pymin) / m_Deltay * m_PQhashsize);
   if (bucket < 0)
@@ -548,9 +548,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::PQbucket(FortuneHalfEdge * task)
   return (bucket);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::insertPQ(FortuneHalfEdge * he, FortuneSite * v, double offset)
+VoronoiDiagram2DGenerator<TCoordinate>::insertPQ(FortuneHalfEdge * he, FortuneSite * v, double offset)
 {
   he->m_Vert = v;
   he->m_Ystar = (v->m_Coord[1]) + offset;
@@ -568,9 +568,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::insertPQ(FortuneHalfEdge * he, Fortu
   m_PQcount += 1;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 double
-VoronoiDiagram2DGenerator<TCoordinateType>::dist(FortuneSite * s1, FortuneSite * s2)
+VoronoiDiagram2DGenerator<TCoordinate>::dist(FortuneSite * s1, FortuneSite * s2)
 {
   double dx = (s1->m_Coord[0]) - (s2->m_Coord[0]);
   double dy = (s1->m_Coord[1]) - (s2->m_Coord[1]);
@@ -578,9 +578,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::dist(FortuneSite * s1, FortuneSite *
   return (std::sqrt(dx * dx + dy * dy));
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::ELgethash(int b) -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinate>::ELgethash(int b) -> FortuneHalfEdge *
 {
   if ((b < 0) || (b >= static_cast<int>(m_ELhashsize)))
   {
@@ -604,9 +604,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::ELgethash(int b) -> FortuneHalfEdge 
   return (nullptr);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::findLeftHE(PointType * p) -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinate>::findLeftHE(PointType * p) -> FortuneHalfEdge *
 {
   int  i;
   auto bucket = static_cast<int>((((*p)[0]) - m_Pxmin) / m_Deltax * m_ELhashsize);
@@ -658,9 +658,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::findLeftHE(PointType * p) -> Fortune
   return (he);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::getRightReg(FortuneHalfEdge * he) -> FortuneSite *
+VoronoiDiagram2DGenerator<TCoordinate>::getRightReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -676,9 +676,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::getRightReg(FortuneHalfEdge * he) ->
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::getLeftReg(FortuneHalfEdge * he) -> FortuneSite *
+VoronoiDiagram2DGenerator<TCoordinate>::getLeftReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -694,9 +694,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::getLeftReg(FortuneHalfEdge * he) -> 
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::insertEdgeList(FortuneHalfEdge * lbase, FortuneHalfEdge * lnew)
+VoronoiDiagram2DGenerator<TCoordinate>::insertEdgeList(FortuneHalfEdge * lbase, FortuneHalfEdge * lnew)
 {
   lnew->m_Left = lbase;
   lnew->m_Right = lbase->m_Right;
@@ -704,9 +704,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::insertEdgeList(FortuneHalfEdge * lba
   lbase->m_Right = lnew;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::bisect(FortuneEdge * answer, FortuneSite * s1, FortuneSite * s2)
+VoronoiDiagram2DGenerator<TCoordinate>::bisect(FortuneEdge * answer, FortuneSite * s1, FortuneSite * s2)
 {
   answer->m_Reg[0] = s1;
   answer->m_Reg[1] = s2;
@@ -739,9 +739,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::bisect(FortuneEdge * answer, Fortune
   m_OutputVD->AddLine(outline);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::intersect(FortuneSite * newV, FortuneHalfEdge * el1, FortuneHalfEdge * el2)
+VoronoiDiagram2DGenerator<TCoordinate>::intersect(FortuneSite * newV, FortuneHalfEdge * el1, FortuneHalfEdge * el2)
 {
   FortuneEdge *     e1 = el1->m_Edge;
   FortuneEdge *     e2 = el2->m_Edge;
@@ -798,9 +798,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::intersect(FortuneSite * newV, Fortun
   newV->m_Sitenbr = -5;
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 auto
-VoronoiDiagram2DGenerator<TCoordinateType>::getPQmin() -> FortuneHalfEdge *
+VoronoiDiagram2DGenerator<TCoordinate>::getPQmin() -> FortuneHalfEdge *
 {
   FortuneHalfEdge * curr = m_PQHash[m_PQmin].m_Next;
 
@@ -809,9 +809,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::getPQmin() -> FortuneHalfEdge *
   return (curr);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::clip_line(FortuneEdge * task)
+VoronoiDiagram2DGenerator<TCoordinate>::clip_line(FortuneEdge * task)
 {
   // Clip line
   FortuneSite * s1;
@@ -1008,9 +1008,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::clip_line(FortuneEdge * task)
   m_OutputVD->AddEdge(newInfo);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::makeEndPoint(FortuneEdge * task, bool lr, FortuneSite * ends)
+VoronoiDiagram2DGenerator<TCoordinate>::makeEndPoint(FortuneEdge * task, bool lr, FortuneSite * ends)
 {
   task->m_Ep[lr] = ends;
   if ((task->m_Ep[1 - lr]) == nullptr)
@@ -1021,9 +1021,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::makeEndPoint(FortuneEdge * task, boo
   clip_line(task);
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::GenerateVDFortune()
+VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
 {
   // Build seed sites
   m_SeedSites.resize(m_NumberOfSeeds);
@@ -1229,9 +1229,9 @@ VoronoiDiagram2DGenerator<TCoordinateType>::GenerateVDFortune()
   }
 }
 
-template <typename TCoordinateType>
+template <typename TCoordinate>
 void
-VoronoiDiagram2DGenerator<TCoordinateType>::PrintSelf(std::ostream & os, Indent indent) const
+VoronoiDiagram2DGenerator<TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 


### PR DESCRIPTION
The postfix `Type` is unnecessary for a template parameter `TCoordinateType`, because its initial `T` already indicates that it is a type.

On the other hand, a type alias (typedef) "typically" has a `Type` postfix, but should _not_ have a `T` initial.

Triggered by a comment from Jon (@jhlegarreta) at https://github.com/InsightSoftwareConsortium/ITK/pull/4995#issuecomment-2504978482