### PR TITLE
ENH: Initialize variables in smallest scope

### DIFF
--- a/Examples/IO/ImageReadDicomSeriesWrite.cxx
+++ b/Examples/IO/ImageReadDicomSeriesWrite.cxx
@@ -97,10 +97,9 @@ main(int argc, char * argv[])
   auto namesGenerator = NamesGeneratorType::New();
 
   itk::MetaDataDictionary & dict = gdcmIO->GetMetaDataDictionary();
-  std::string               tagkey;
-  std::string               value;
-  tagkey = "0008|0060"; // Modality
-  value = "MR";
+
+  std::string tagkey = "0008|0060"; // Modality
+  std::string value = "MR";
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);
   tagkey = "0008|0008"; // Image Type
   value = "DERIVED\\SECONDARY";

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -169,10 +169,8 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   auto projectionDirection = static_cast<unsigned int>(std::stoi(argv[3]));
 
-  unsigned int i;
-  unsigned int j;
   unsigned int direction[2];
-  for (i = 0, j = 0; i < 3; ++i)
+  for (unsigned int i = 0, j = 0; i < 3; ++i)
   {
     if (i != projectionDirection)
     {

--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -65,7 +65,7 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
 
   if (m_Normalize)
   {
-    double bright = (m_BrightCenter ? 1.0 : -1.0);
+    const double bright = (m_BrightCenter ? 1.0 : -1.0);
 
     // Initial values for a normalized kernel
     interiorV = bright;
@@ -81,15 +81,16 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
   }
 
   // Compute the size of the kernel in pixels
-  SizeType     r;
-  unsigned int i;
-  unsigned int j;
-  double       outerRadius = m_InnerRadius + m_Thickness;
-  for (i = 0; i < TDimension; ++i)
   {
-    r[i] = Math::Ceil<SizeValueType>(outerRadius / m_Spacing[i]);
+    SizeType r;
+
+    double outerRadius = m_InnerRadius + m_Thickness;
+    for (unsigned int i = 0; i < TDimension; ++i)
+    {
+      r[i] = Math::Ceil<SizeValueType>(outerRadius / m_Spacing[i]);
+    }
+    this->SetRadius(r);
   }
-  this->SetRadius(r);
 
   // Use a couple of sphere spatial functions...
   using SphereType = SphereSpatialFunction<TDimension>;
@@ -112,13 +113,13 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
   OffsetType                     offset;
   typename SphereType::InputType point;
 
-  for (i = 0; i < w; ++i)
+  for (unsigned int i = 0; i < w; ++i)
   {
     // get the offset from the center pixel
     offset = this->GetOffset(i);
 
     // convert to a position
-    for (j = 0; j < TDimension; ++j)
+    for (unsigned int j = 0; j < TDimension; ++j)
     {
       point[j] = m_Spacing[j] * offset[j];
     }
@@ -174,7 +175,7 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
     // elements that are not exterior to the annulus.  This forces the
     // kernel to have mean zero and norm 1 AND forces the region
     // outside the annulus to have no influence.
-    for (i = 0; i < w; ++i)
+    for (unsigned int i = 0; i < w; ++i)
     {
       // normalize the coefficient if it is inside the outer circle
       // (exterior to outer circle is already zero)

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -59,11 +59,8 @@ BSplineInterpolationWeightFunction<TCoordinate, VSpaceDimension, VSplineOrder>::
     return table;
   }();
 
-  unsigned int j;
-  unsigned int k;
-
   // Find the starting index of the support region
-  for (j = 0; j < SpaceDimension; ++j)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     // Note that the expression passed to Math::Floor is adapted to work around
     // a compiler bug which caused endless compilations (apparently), by
@@ -73,22 +70,22 @@ BSplineInterpolationWeightFunction<TCoordinate, VSpaceDimension, VSplineOrder>::
 
   // Compute the weights
   Matrix<double, SpaceDimension, SplineOrder + 1> weights1D;
-  for (j = 0; j < SpaceDimension; ++j)
+  for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
     double x = index[j] - static_cast<double>(startIndex[j]);
 
-    for (k = 0; k <= SplineOrder; ++k)
+    for (unsigned int k = 0; k <= SplineOrder; ++k)
     {
       weights1D[j][k] = BSplineKernelFunction<SplineOrder>::FastEvaluate(x);
       x -= 1.0;
     }
   }
 
-  for (k = 0; k < Self::NumberOfWeights; ++k)
+  for (unsigned int k = 0; k < Self::NumberOfWeights; ++k)
   {
     weights[k] = 1.0;
 
-    for (j = 0; j < SpaceDimension; ++j)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       weights[k] *= weights1D[j][offsetToIndexTable[k][j]];
     }

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -222,16 +222,12 @@ template <typename TComponent>
 void
 ColorTable<TComponent>::UseRandomColors(unsigned int n)
 {
-  unsigned int i;
-
   this->DeleteColors();
 
   m_NumberOfColors = n;
   m_Color.resize(m_NumberOfColors);
   m_ColorName.resize(m_NumberOfColors);
-  TComponent r;
-  TComponent g;
-  TComponent b;
+
   TComponent minimum;
   TComponent maximum;
   if (NumericTraits<TComponent>::is_integer)
@@ -244,13 +240,13 @@ ColorTable<TComponent>::UseRandomColors(unsigned int n)
     minimum = TComponent{};
     maximum = NumericTraits<TComponent>::OneValue();
   }
-  for (i = 0; i < n; ++i)
+  for (unsigned int i = 0; i < n; ++i)
   {
-    r = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    TComponent r = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][0] = r;
-    g = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    TComponent g = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][1] = g;
-    b = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    TComponent b = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][2] = b;
     std::ostringstream name;
     name << "Random(" << std::fixed << std::setprecision(2) << static_cast<float>(r) << ',' << static_cast<float>(g)

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -164,11 +164,9 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetPixel(NeighborIndexTyp
   }
   else
   {
-    bool       flag;
     OffsetType offset;
     OffsetType internalIndex;
-
-    flag = this->IndexInBounds(n, internalIndex, offset);
+    bool       flag = this->IndexInBounds(n, internalIndex, offset);
     if (flag)
     {
       IsInBounds = true;
@@ -268,35 +266,31 @@ template <typename TImage, typename TBoundaryCondition>
 auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const -> NeighborhoodType
 {
-  OffsetType OverlapLow;
-  OffsetType OverlapHigh;
-  OffsetType temp;
-  OffsetType offset;
-
   const ConstIterator _end = this->End();
-  NeighborhoodType    ans;
 
-  typename NeighborhoodType::Iterator ansIt;
-  ConstIterator                       thisIt;
-
+  NeighborhoodType ans;
   ans.SetRadius(this->GetRadius());
-
   if (m_NeedToUseBoundaryCondition == false)
   {
-    for (ansIt = ans.Begin(), thisIt = this->Begin(); thisIt < _end; ++ansIt, ++thisIt)
+    ConstIterator thisIt = this->Begin();
+    for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
     {
       *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
     }
   }
   else if (InBounds())
   {
-    for (ansIt = ans.Begin(), thisIt = this->Begin(); thisIt < _end; ++ansIt, ++thisIt)
+    ConstIterator thisIt = this->Begin();
+    for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
     {
       *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
     }
   }
   else
   {
+    OffsetType temp;
+    OffsetType OverlapHigh;
+    OffsetType OverlapLow;
     // Calculate overlap & initialize index
     for (DimensionValueType i = 0; i < Dimension; ++i)
     {
@@ -306,11 +300,13 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const -
     }
 
     // Iterate through neighborhood
-    for (ansIt = ans.Begin(), thisIt = this->Begin(); thisIt < _end; ++ansIt, ++thisIt)
+    ConstIterator thisIt = this->Begin();
+    for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
     {
       bool flag = true;
 
       // Is this pixel in bounds?
+      OffsetType offset;
       for (DimensionValueType i = 0; i < Dimension; ++i)
       {
         if (m_InBounds[i])
@@ -490,7 +486,6 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition> &
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
 {
-  Iterator       it;
   const Iterator _end = Superclass::End();
 
   // Repositioning neighborhood, previous bounds check on neighborhood
@@ -498,7 +493,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
   m_IsInBoundsValid = false;
 
   // Increment pointers.
-  for (it = Superclass::Begin(); it < _end; ++it)
+  for (Iterator it = Superclass::Begin(); it < _end; ++it)
   {
     (*it)++;
   }
@@ -510,7 +505,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
     if (m_Loop[i] == m_Bound[i])
     {
       m_Loop[i] = m_BeginIndex[i];
-      for (it = Superclass::Begin(); it < _end; ++it)
+      for (Iterator it = Superclass::Begin(); it < _end; ++it)
       {
         (*it) += m_WrapOffset[i];
       }
@@ -527,7 +522,6 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition> &
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
 {
-  Iterator       it;
   const Iterator _end = Superclass::End();
 
   // Repositioning neighborhood, previous bounds check on neighborhood
@@ -535,7 +529,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
   m_IsInBoundsValid = false;
 
   // Decrement pointers.
-  for (it = Superclass::Begin(); it < _end; ++it)
+  for (Iterator it = Superclass::Begin(); it < _end; ++it)
   {
     (*it)--;
   }
@@ -546,7 +540,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
     if (m_Loop[i] == m_BeginIndex[i])
     {
       m_Loop[i] = m_Bound[i] - 1;
-      for (it = Superclass::Begin(); it < _end; ++it)
+      for (Iterator it = Superclass::Begin(); it < _end; ++it)
       {
         (*it) -= m_WrapOffset[i];
       }
@@ -566,45 +560,43 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  DimensionValueType i;
-
   os << indent;
   os << "ConstNeighborhoodIterator {this= " << this;
   os << ", m_Region = { Start = {";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_Region.GetIndex()[i] << ' ';
   }
   os << "}, Size = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_Region.GetSize()[i] << ' ';
   }
   os << "} }";
   os << ", m_BeginIndex = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_BeginIndex[i] << ' ';
   }
   os << "} , m_EndIndex = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_EndIndex[i] << ' ';
   }
   os << "} , m_Loop = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_Loop[i] << ' ';
   }
   os << "}, m_Bound = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_Bound[i] << ' ';
   }
   os << "}, m_IsInBounds = {" << m_IsInBounds;
   os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
   os << "}, m_WrapOffset = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_WrapOffset[i] << ' ';
   }
@@ -613,12 +605,12 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
   os << '}' << std::endl;
 
   os << indent << ",  m_InnerBoundsLow = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsLow[i] << ' ';
   }
   os << "}, m_InnerBoundsHigh = { ";
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsHigh[i] << ' ';
   }
@@ -654,35 +646,28 @@ void
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::SetPixelPointers(const IndexType & pos)
 {
   const Iterator          _end = Superclass::End();
-  InternalPixelType *     Iit;
   auto *                  ptr = const_cast<ImageType *>(m_ConstImage.GetPointer());
   const SizeType          size = this->GetSize();
   const OffsetValueType * OffsetTable = m_ConstImage->GetOffsetTable();
   const SizeType          radius = this->GetRadius();
 
-  DimensionValueType i;
-  Iterator           Nit;
-  SizeType           loop;
-
-  for (i = 0; i < Dimension; ++i)
-  {
-    loop[i] = 0;
-  }
+  SizeType loop;
+  loop.Fill(0);
 
   // Find first "upper-left-corner"  pixel address of neighborhood
-  Iit = ptr->GetBufferPointer() + ptr->ComputeOffset(pos);
+  InternalPixelType * Iit = ptr->GetBufferPointer() + ptr->ComputeOffset(pos);
 
-  for (i = 0; i < Dimension; ++i)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     Iit -= radius[i] * OffsetTable[i];
   }
 
   // Compute the rest of the pixel addresses
-  for (Nit = Superclass::Begin(); Nit != _end; ++Nit)
+  for (Iterator Nit = Superclass::Begin(); Nit != _end; ++Nit)
   {
     *Nit = Iit;
     ++Iit;
-    for (i = 0; i < Dimension; ++i)
+    for (DimensionValueType i = 0; i < Dimension; ++i)
     {
       loop[i]++;
       if (loop[i] == size[i])
@@ -706,7 +691,6 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition> &
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator+=(const OffsetType & idx)
 {
-  Iterator                it;
   const Iterator          _end = this->End();
   OffsetValueType         accumulator = 0;
   const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
@@ -729,7 +713,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator+=(const OffsetTy
   }
 
   // Increment pointers.
-  for (it = this->Begin(); it < _end; ++it)
+  for (Iterator it = this->Begin(); it < _end; ++it)
   {
     (*it) += accumulator;
   }
@@ -744,7 +728,6 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition> &
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator-=(const OffsetType & idx)
 {
-  Iterator                it;
   const Iterator          _end = this->End();
   OffsetValueType         accumulator = 0;
   const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
@@ -767,7 +750,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator-=(const OffsetTy
   }
 
   // Increment pointers.
-  for (it = this->Begin(); it < _end; ++it)
+  for (Iterator it = this->Begin(); it < _end; ++it)
   {
     (*it) -= accumulator;
   }

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -26,21 +26,19 @@ template <unsigned int VDimension, typename TInput>
 auto
 EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
-  double distanceSquared = 0;
-
-  Vector<double, VDimension> orientationVector;
-  Vector<double, VDimension> pointVector;
-
   // Project the position onto each of the axes, normalize by axis length,
   // and determine whether position is inside ellipsoid. The length of axis0,
   // m_Axis[0] is orientated in the direction of m_Orientations[0].
+  Vector<double, VDimension> pointVector;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     pointVector[i] = position[i] - m_Center[i];
   }
 
+  double distanceSquared = 0;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
+    Vector<double, VDimension> orientationVector;
     for (unsigned int j = 0; j < VDimension; ++j)
     {
       orientationVector[j] = m_Orientations[i][j];
@@ -69,17 +67,14 @@ template <unsigned int VDimension, typename TInput>
 void
 EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  unsigned int i;
-  unsigned int j;
-
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Lengths of Ellipsoid Axes: " << m_Axes << std::endl;
   os << indent << "Origin of Ellipsoid: " << m_Center << std::endl;
   os << indent << "Orientations: " << std::endl;
-  for (i = 0; i < VDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < VDimension; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       os << indent << indent << m_Orientations[i][j] << ' ';
     }

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -103,20 +103,19 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 auto
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoefficients() const -> CoefficientVector
 {
-
-  CoefficientVector coeff;
-
   // Use image spacing to modify variance
   const double pixelVariance = m_Variance / (m_Spacing * m_Spacing);
 
   // Now create coefficients as if they were zero order coeffs
-  const double                 et = std::exp(-pixelVariance);
-  const double                 cap = 1.0 - m_MaximumError;
-  CompensatedSummation<double> sum;
+  const double et = std::exp(-pixelVariance);
+  const double cap = 1.0 - m_MaximumError;
+
 
   // Create the kernel coefficients as a std::vector
+  CoefficientVector coeff;
   coeff.push_back(et * ModifiedBesselI0(pixelVariance));
-  sum += coeff[0];
+
+  CompensatedSummation<double> sum = coeff[0];
   coeff.push_back(et * ModifiedBesselI1(pixelVariance));
   sum += coeff[1] * 2.0;
 
@@ -167,20 +166,19 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI0(double y)
 {
-  double d;
   double accumulator;
-  double m;
 
-  if ((d = itk::Math::abs(y)) < 3.75)
+  double d = itk::Math::abs(y);
+  if (d < 3.75)
   {
-    m = y / 3.75;
+    double m = y / 3.75;
     m *= m;
     accumulator =
       1.0 + m * (3.5156229 + m * (3.0899424 + m * (1.2067492 + m * (0.2659732 + m * (0.360768e-1 + m * 0.45813e-2)))));
   }
   else
   {
-    m = 3.75 / d;
+    double m = 3.75 / d;
     accumulator =
       (std::exp(d) / std::sqrt(d)) *
       (0.39894228 +
@@ -197,13 +195,11 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(double y)
 {
-  double d;
   double accumulator;
-  double m;
-
-  if ((d = itk::Math::abs(y)) < 3.75)
+  double d = itk::Math::abs(y);
+  if (d < 3.75)
   {
-    m = y / 3.75;
+    double m = y / 3.75;
     m *= m;
     accumulator =
       d * (0.5 + m * (0.87890594 +
@@ -211,7 +207,7 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(dou
   }
   else
   {
-    m = 3.75 / d;
+    double m = 3.75 / d;
     accumulator = 0.2282967e-1 + m * (-0.2895312e-1 + m * (0.1787654e-1 - m * 0.420059e-2));
     accumulator =
       0.39894228 + m * (-0.3988024e-1 + m * (-0.362018e-2 + m * (0.163801e-2 + m * (-0.1031555e-1 + m * accumulator))));
@@ -234,30 +230,26 @@ double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int n, double y)
 {
   constexpr double DIGITS = 10.0;
-  int              j;
-  double           qim;
-  double           qi;
-  double           qip;
-  double           toy;
-  double           accumulator;
 
   if (n < 2)
   {
     throw ExceptionObject(__FILE__, __LINE__, "Order of modified bessel is > 2.", ITK_LOCATION); //
                                                                                                  // placeholder
   }
+
+  double accumulator;
   if (y == 0.0)
   {
     return 0.0;
   }
   else
   {
-    toy = 2.0 / itk::Math::abs(y);
-    qip = accumulator = 0.0;
-    qi = 1.0;
-    for (j = 2 * (n + static_cast<int>(DIGITS * std::sqrt(static_cast<double>(n)))); j > 0; j--)
+    double toy = 2.0 / itk::Math::abs(y);
+    double qip = accumulator = 0.0;
+    double qi = 1.0;
+    for (int j = 2 * (n + static_cast<int>(DIGITS * std::sqrt(static_cast<double>(n)))); j > 0; j--)
     {
-      qim = qip + j * toy * qi;
+      double qim = qip + j * toy * qi;
       qip = qi;
       qi = qim;
       if (itk::Math::abs(qi) > 1.0e10)

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -25,24 +25,18 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 auto
 GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
-  CoefficientVector coeff;
-  double            sum;
-  int               i;
-  int               j;
-
-  typename CoefficientVector::iterator it;
-
   const double et = std::exp(-m_Variance);
-  const double cap = 1.0 - m_MaximumError;
 
   // Create the kernel coefficients as a std::vector
-  sum = 0.0;
+  double            sum = 0.0;
+  CoefficientVector coeff;
   coeff.push_back(et * ModifiedBesselI0(m_Variance));
   sum += coeff[0];
   coeff.push_back(et * ModifiedBesselI1(m_Variance));
   sum += coeff[1] * 2.0;
 
-  for (i = 2; sum < cap; ++i)
+  const double cap = 1.0 - m_MaximumError;
+  for (int i = 2; sum < cap; ++i)
   {
     coeff.push_back(et * ModifiedBesselI(i, m_Variance));
     sum += coeff[i] * 2.0;
@@ -59,19 +53,21 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coef
     }
   }
   // Normalize the coefficients so that their sum is one.
-  for (it = coeff.begin(); it < coeff.end(); ++it)
+  for (typename CoefficientVector::iterator it = coeff.begin(); it < coeff.end(); ++it)
   {
     *it /= sum;
   }
 
   // Make symmetric
-  j = static_cast<int>(coeff.size()) - 1;
+  int j = static_cast<int>(coeff.size()) - 1;
   coeff.insert(coeff.begin(), j, 0);
-  for (i = 0, it = coeff.end() - 1; i < j; --it, ++i)
   {
-    coeff[i] = *it;
+    int i = 0;
+    for (typename CoefficientVector::iterator it = coeff.end() - 1; i < j; --it, ++i)
+    {
+      coeff[i] = *it;
+    }
   }
-
   return coeff;
 }
 
@@ -144,12 +140,6 @@ double
 GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int n, double y)
 {
   constexpr double ACCURACY = 40.0;
-  int              j;
-  double           qim;
-  double           qi;
-  double           qip;
-  double           toy;
-  double           accumulator;
 
   if (n < 2)
   {
@@ -164,13 +154,14 @@ GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int n, double 
   }
   else
   {
-    toy = 2.0 / itk::Math::abs(y);
-    qip = accumulator = 0.0;
-    qi = 1.0;
+    double toy = 2.0 / itk::Math::abs(y);
+    double qip = 0.0;
+    double accumulator = 0.0;
+    double qi = 1.0;
 
-    for (j = 2 * (n + static_cast<int>(std::sqrt(ACCURACY * n))); j > 0; j--)
+    for (int j = 2 * (n + static_cast<int>(std::sqrt(ACCURACY * n))); j > 0; j--)
     {
-      qim = qip + j * toy * qi;
+      double qim = qip + j * toy * qi;
       qip = qi;
       qi = qim;
       if (itk::Math::abs(qi) > 1.0e10)

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -339,13 +339,6 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
   static constexpr double ITK_HEX_CONVERGED = 1.e-03;
   static constexpr double ITK_DIVERGED = 1.e6;
 
-  double                  params[Self::CellDimension3D]{ 0.5, 0.5, 0.5 };
-  double                  fcol[Self::PointDimension3D];
-  double                  rcol[Self::PointDimension3D];
-  double                  scol[Self::PointDimension3D];
-  double                  tcol[Self::PointDimension3D];
-  double                  d;
-  PointType               pt;
   CoordinateType          derivs[CellDimension3D * Self::NumberOfPoints]{ 0 };
   InterpolationWeightType weights[Self::NumberOfPoints];
 
@@ -366,14 +359,18 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     this->InterpolationDerivs(pcoords, derivs);
 
     //  calculate newton functions
+    double fcol[Self::PointDimension3D];
+    double rcol[Self::PointDimension3D];
+    double scol[Self::PointDimension3D];
+    double tcol[Self::PointDimension3D];
     for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       fcol[i] = rcol[i] = scol[i] = tcol[i] = 0.0;
     }
+
     for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
     {
-
-      pt = points->GetElement(m_PointIds[i]);
+      PointType pt = points->GetElement(m_PointIds[i]);
       for (unsigned int j = 0; j < PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS; ++j)
       {
         fcol[j] += pt[j] * weights[i];
@@ -401,7 +398,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
 
     // ONLY 3x3 determinants are supported.
-    d = vnl_determinant(mat);
+    double d = vnl_determinant(mat);
     // d=vtkMath::Determinant3x3(rcol,scol,tcol);
     if (itk::Math::abs(d) < 1.e-20)
     {
@@ -431,7 +428,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
       mat3.put(1, i, scol[i]);
       mat3.put(2, i, fcol[i]);
     }
-
+    double params[Self::CellDimension3D]{ 0.5, 0.5, 0.5 };
     pcoords[0] = params[0] - vnl_determinant(mat1) / d;
     pcoords[1] = params[1] - vnl_determinant(mat2) / d;
     pcoords[2] = params[2] - vnl_determinant(mat3) / d;
@@ -502,7 +499,6 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
   else
   {
     CoordinateType pc[CellDimension3D];
-    CoordinateType w[Self::NumberOfPoints];
     if (closestPoint)
     {
       for (unsigned int i = 0; i < CellDimension3D; ++i) // only approximate, not really true
@@ -521,6 +517,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
           pc[i] = pcoords[i];
         }
       }
+      CoordinateType w[Self::NumberOfPoints];
       this->EvaluateLocation(subId, points, pc, closestPoint, (InterpolationWeightType *)w);
 
       *dist2 = 0;

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -211,8 +211,6 @@ ImageSink<TInputImage>::VerifyInputInformation() const
                                                              this->m_DirectionTolerance))
       {
         std::ostringstream originString;
-        std::ostringstream spacingString;
-        std::ostringstream directionString;
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
         {
           originString.setf(std::ios::scientific);
@@ -221,6 +219,7 @@ ImageSink<TInputImage>::VerifyInputInformation() const
                        << " Origin: " << inputPtrN->GetOrigin() << std::endl;
           originString << "\tTolerance: " << coordinateTol << std::endl;
         }
+        std::ostringstream spacingString;
         if (!inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol))
         {
           spacingString.setf(std::ios::scientific);
@@ -229,6 +228,7 @@ ImageSink<TInputImage>::VerifyInputInformation() const
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
+        std::ostringstream directionString;
         if (!inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
                                                                this->m_DirectionTolerance))
         {

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -187,8 +187,6 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
       if (!inputPtr1->IsCongruentImageGeometry(inputPtrN, m_CoordinateTolerance, m_DirectionTolerance))
       {
         std::ostringstream originString;
-        std::ostringstream spacingString;
-        std::ostringstream directionString;
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
         {
           originString.setf(std::ios::scientific);
@@ -197,6 +195,7 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
                        << " Origin: " << inputPtrN->GetOrigin() << std::endl;
           originString << "\tTolerance: " << coordinateTol << std::endl;
         }
+        std::ostringstream spacingString;
         if (!inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol))
         {
           spacingString.setf(std::ios::scientific);
@@ -205,6 +204,7 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
+        std::ostringstream directionString;
         if (!inputPtr1->GetDirection().GetVnlMatrix().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
                                                                this->m_DirectionTolerance))
         {

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -64,21 +64,18 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 auto
 LaplacianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
-  unsigned int i;
-  unsigned int w;
-
   // Here we set the radius to 1's, here the
   // operator is 3x3 for 2D, 3x3x3 for 3D.
   constexpr auto r = SizeType::Filled(1);
   this->SetRadius(r);
 
   // Create a vector of the correct size to hold the coefficients.
-  w = this->Size();
+  unsigned int      w = this->Size();
   CoefficientVector coeffP(w);
 
   // Set the coefficients
   double sum = 0.0;
-  for (i = 0; i < 2 * VDimension; i += 2)
+  for (unsigned int i = 0; i < 2 * VDimension; i += 2)
   {
     OffsetValueType stride = this->GetStride(i / 2);
 

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -372,13 +372,12 @@ MersenneTwisterRandomVariateGenerator::reload()
   constexpr auto index = int{ M } - int{ MersenneTwisterRandomVariateGenerator::StateVectorLength };
 
   IntegerType * p = state;
-  int           i;
 
-  for (i = MersenneTwisterRandomVariateGenerator::StateVectorLength - M; i--; ++p)
+  for (int i = MersenneTwisterRandomVariateGenerator::StateVectorLength - M; i--; ++p)
   {
     *p = twist(p[M], p[0], p[1]);
   }
-  for (i = M; --i; ++p)
+  for (int i = M; --i; ++p)
   {
     *p = twist(p[index], p[0], p[1]);
   }

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -41,18 +41,17 @@ Neighborhood<TPixel, VDimension, TContainer>::ComputeNeighborhoodOffsetTable()
 {
   m_OffsetTable.clear();
   m_OffsetTable.reserve(this->Size());
-  OffsetType         o;
-  DimensionValueType i;
-  DimensionValueType j;
-  for (j = 0; j < VDimension; ++j)
+
+  OffsetType o;
+  for (DimensionValueType j = 0; j < VDimension; ++j)
   {
     o[j] = -(static_cast<OffsetValueType>(this->GetRadius(j)));
   }
 
-  for (i = 0; i < this->Size(); ++i)
+  for (DimensionValueType i = 0; i < this->Size(); ++i)
   {
     m_OffsetTable.push_back(o);
-    for (j = 0; j < VDimension; ++j)
+    for (DimensionValueType j = 0; j < VDimension; ++j)
     {
       o[j] = o[j] + 1;
       if (o[j] > static_cast<OffsetValueType>(this->GetRadius(j)))

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
@@ -97,11 +97,7 @@ template <typename TImage, typename TBoundaryCondition>
 void
 NeighborhoodIterator<TImage, TBoundaryCondition>::SetPixel(const unsigned int n, const PixelType & v, bool & status)
 {
-  unsigned int i;
-  OffsetType   temp;
 
-  typename OffsetType::OffsetValueType OverlapLow;
-  typename OffsetType::OffsetValueType OverlapHigh;
 
   if (this->m_NeedToUseBoundaryCondition == false)
   {
@@ -118,18 +114,18 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetPixel(const unsigned int n,
   }
   else
   {
-    temp = this->ComputeInternalIndex(n);
+    OffsetType temp = this->ComputeInternalIndex(n);
 
     // Calculate overlap.
     // Here, we are checking whether the particular pixel in the
     // neighborhood is within the bounds (when the neighborhood is not
     // completely in bounds, it is usually partly in bounds)
-    for (i = 0; i < Superclass::Dimension; ++i)
+    for (unsigned int i = 0; i < Superclass::Dimension; ++i)
     {
       if (!this->m_InBounds[i]) // Part of dimension spills out of bounds
       {
-        OverlapLow = this->m_InnerBoundsLow[i] - this->m_Loop[i];
-        OverlapHigh =
+        typename OffsetType::OffsetValueType OverlapLow = this->m_InnerBoundsLow[i] - this->m_Loop[i];
+        typename OffsetType::OffsetValueType OverlapHigh =
           static_cast<OffsetValueType>(this->GetSize(i) - ((this->m_Loop[i] + 2) - this->m_InnerBoundsHigh[i]));
         if (temp[i] < OverlapLow || OverlapHigh < temp[i])
         {
@@ -148,27 +144,22 @@ template <typename TImage, typename TBoundaryCondition>
 void
 NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const NeighborhoodType & N)
 {
-  unsigned int i;
-  OffsetType   OverlapLow;
-  OffsetType   OverlapHigh;
-  OffsetType   temp;
-  bool         flag;
-
   const Iterator _end = this->End();
-  Iterator       this_it;
 
   typename NeighborhoodType::ConstIterator N_it;
 
   if (this->m_NeedToUseBoundaryCondition == false)
   {
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++this_it, ++N_it)
+    Iterator this_it = this->Begin();
+    for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
     {
       this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
     }
   }
   else if (this->InBounds())
   {
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++this_it, ++N_it)
+    Iterator this_it = this->Begin();
+    for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
     {
       this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
     }
@@ -176,19 +167,22 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const Neighbor
   else
   {
     // Calculate overlap & initialize index
-    for (i = 0; i < Superclass::Dimension; ++i)
+    OffsetType OverlapLow;
+    OffsetType OverlapHigh;
+    OffsetType temp{ 0 };
+    for (unsigned int i = 0; i < Superclass::Dimension; ++i)
     {
       OverlapLow[i] = this->m_InnerBoundsLow[i] - this->m_Loop[i];
       OverlapHigh[i] =
         static_cast<OffsetValueType>(this->GetSize(i) - (this->m_Loop[i] - this->m_InnerBoundsHigh[i]) - 1);
-      temp[i] = 0;
     }
 
     // Iterate through neighborhood
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++N_it, ++this_it)
+    Iterator this_it = this->Begin();
+    for (N_it = N.Begin(); this_it < _end; ++N_it, ++this_it)
     {
-      flag = true;
-      for (i = 0; i < Superclass::Dimension; ++i)
+      bool flag = true;
+      for (unsigned int i = 0; i < Superclass::Dimension; ++i)
       {
         if (!this->m_InBounds[i] && ((temp[i] < OverlapLow[i]) || (temp[i] >= OverlapHigh[i])))
         {
@@ -202,7 +196,7 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const Neighbor
         this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
       }
 
-      for (i = 0; i < Superclass::Dimension; ++i) // Update index
+      for (unsigned int i = 0; i < Superclass::Dimension; ++i) // Update index
       {
         temp[i]++;
         if (static_cast<unsigned int>(temp[i]) == this->GetSize(i))

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -50,14 +50,13 @@ template <typename TNodeType>
 auto
 SparseFieldLayer<TNodeType>::SplitRegions(int num) const -> RegionListType
 {
-  std::vector<RegionType> regionlist;
-  unsigned int            size;
-  unsigned int            regionsize;
-  size = Size();
-  regionsize = static_cast<unsigned int>(std::ceil(static_cast<float>(size) / static_cast<float>(num)));
+  unsigned int  size = Size();
+  unsigned int  regionsize = static_cast<unsigned int>(std::ceil(static_cast<float>(size) / static_cast<float>(num)));
   ConstIterator position = Begin();
   ConstIterator last = End();
 
+  std::vector<RegionType> regionlist;
+  regionlist.reserve(num);
   for (int i = 0; i < num; ++i)
   {
     unsigned int j = 0;

--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -151,11 +151,8 @@ StreamingImageFilter<TInputImage, TOutputImage>::UpdateOutputData(DataObject * i
    * minimum of what the user specified via SetNumberOfStreamDivisions()
    * and what the Splitter thinks is a reasonable value.
    */
-  unsigned int numDivisions;
-  unsigned int numDivisionsFromSplitter;
-
-  numDivisions = m_NumberOfStreamDivisions;
-  numDivisionsFromSplitter = m_RegionSplitter->GetNumberOfSplits(outputRegion, m_NumberOfStreamDivisions);
+  unsigned int numDivisions = m_NumberOfStreamDivisions;
+  unsigned int numDivisionsFromSplitter = m_RegionSplitter->GetNumberOfSplits(outputRegion, m_NumberOfStreamDivisions);
   if (numDivisionsFromSplitter < numDivisions)
   {
     numDivisions = numDivisionsFromSplitter;

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -139,39 +139,28 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
                                                                                   double * e,
                                                                                   double * e2) const
 {
-  double d__1;
-
   // Local variables
-  double f;
-  double g;
-  double h;
-  int    i;
-  int    j;
-  int    k;
-  int    l;
-  double scale;
-
-  for (i = 0; i < static_cast<int>(m_Order); ++i)
+  for (int i = 0; i < static_cast<int>(m_Order); ++i)
   {
     d[i] = a[m_Order - 1 + i * m_Dimension];
     a[m_Order - 1 + i * m_Dimension] = a[i + i * m_Dimension];
   }
 
-  for (i = m_Order - 1; i >= 0; --i)
+  for (int i = m_Order - 1; i >= 0; --i)
   {
-    l = i - 1;
-    h = 0.;
-    scale = 0.;
+    int    l = i - 1;
+    double h = 0.;
+    double scale = 0.;
 
     // Scale row (algol tol then not needed)
-    for (k = 0; k <= l; ++k)
+    for (int k = 0; k <= l; ++k)
     {
       scale += itk::Math::abs(d[k]);
     }
 
     if (scale == 0.)
     {
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         d[j] = a[l + j * m_Dimension];
         a[l + j * m_Dimension] = a[i + j * m_Dimension];
@@ -181,33 +170,33 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
       e2[i] = 0.;
       continue;
     }
-    for (k = 0; k <= l; ++k)
+    for (int k = 0; k <= l; ++k)
     {
       d[k] /= scale;
       h += d[k] * d[k];
     }
 
     e2[i] = scale * scale * h;
-    f = d[l];
-    d__1 = std::sqrt(h);
-    g = (-1.0) * itk::Math::sgn0(f) * itk::Math::abs(d__1);
+    double f = d[l];
+    double d__1 = std::sqrt(h);
+    double g = (-1.0) * itk::Math::sgn0(f) * itk::Math::abs(d__1);
     e[i] = scale * g;
     h -= f * g;
     d[l] = f - g;
     if (l != 0)
     {
       // Form a*u
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         e[j] = 0.;
       }
 
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         f = d[j];
         g = e[j] + a[j + j * m_Dimension] * f;
 
-        for (k = j + 1; k <= l; ++k)
+        for (int k = j + 1; k <= l; ++k)
         {
           g += a[k + j * m_Dimension] * d[k];
           e[k] += a[k + j * m_Dimension] * f;
@@ -218,7 +207,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
       // Form p
       f = 0.;
 
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         e[j] /= h;
         f += e[j] * d[j];
@@ -226,25 +215,25 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
 
       h = f / (h + h);
       // Form q
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         e[j] -= h * d[j];
       }
 
       // Form reduced a
-      for (j = 0; j <= l; ++j)
+      for (int j = 0; j <= l; ++j)
       {
         f = d[j];
         g = e[j];
 
-        for (k = j; k <= l; ++k)
+        for (int k = j; k <= l; ++k)
         {
           a[k + j * m_Dimension] = a[k + j * m_Dimension] - f * e[k] - g * d[k];
         }
       }
     }
 
-    for (j = 0; j <= l; ++j)
+    for (int j = 0; j <= l; ++j)
     {
       f = d[j];
       d[j] = a[l + j * m_Dimension];
@@ -261,36 +250,24 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
                                                                                                       double *       e,
                                                                                                       double * z) const
 {
-  double d__1;
-
   // Local variables
-  double       f;
-  double       g;
-  double       h;
-  unsigned int i;
-  unsigned int j;
-  unsigned int k;
-  unsigned int l;
-  double       scale;
-  double       hh;
-
-  for (i = 0; i < m_Order; ++i)
+  for (unsigned int i = 0; i < m_Order; ++i)
   {
-    for (j = i; j < m_Order; ++j)
+    for (unsigned int j = i; j < m_Order; ++j)
     {
       z[j + i * m_Dimension] = a[j + i * m_Dimension];
     }
     d[i] = a[m_Order - 1 + i * m_Dimension];
   }
 
-  for (i = m_Order - 1; i > 0; --i)
+  for (unsigned int i = m_Order - 1; i > 0; --i)
   {
-    l = i - 1;
-    h = 0.0;
-    scale = 0.0;
+    unsigned int l = i - 1;
+    double       h = 0.0;
+    double       scale = 0.0;
 
     // Scale row (algol tol then not needed)
-    for (k = 0; k <= l; ++k)
+    for (unsigned int k = 0; k <= l; ++k)
     {
       scale += itk::Math::abs(d[k]);
     }
@@ -299,7 +276,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
     {
       e[i] = d[l];
 
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         d[j] = z[l + j * m_Dimension];
         z[i + j * m_Dimension] = 0.0;
@@ -308,32 +285,32 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
     }
     else
     {
-      for (k = 0; k <= l; ++k)
+      for (unsigned int k = 0; k <= l; ++k)
       {
         d[k] /= scale;
         h += d[k] * d[k];
       }
 
-      f = d[l];
-      d__1 = std::sqrt(h);
-      g = (-1.0) * itk::Math::sgn0(f) * itk::Math::abs(d__1);
+      double f = d[l];
+      double d__1 = std::sqrt(h);
+      double g = (-1.0) * itk::Math::sgn0(f) * itk::Math::abs(d__1);
       e[i] = scale * g;
       h -= f * g;
       d[l] = f - g;
 
       // Form a*u
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         e[j] = 0.0;
       }
 
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         f = d[j];
         z[j + i * m_Dimension] = f;
         g = e[j] + z[j + j * m_Dimension] * f;
 
-        for (k = j + 1; k <= l; ++k)
+        for (unsigned int k = j + 1; k <= l; ++k)
         {
           g += z[k + j * m_Dimension] * d[k];
           e[k] += z[k + j * m_Dimension] * f;
@@ -345,27 +322,27 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
       // Form p
       f = 0.0;
 
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         e[j] /= h;
         f += e[j] * d[j];
       }
 
-      hh = f / (h + h);
+      double hh = f / (h + h);
 
       // Form q
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         e[j] -= hh * d[j];
       }
 
       // Form reduced a
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
         f = d[j];
         g = e[j];
 
-        for (k = j; k <= l; ++k)
+        for (unsigned int k = j; k <= l; ++k)
         {
           z[k + j * m_Dimension] = z[k + j * m_Dimension] - f * e[k] - g * d[k];
         }
@@ -379,42 +356,42 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
   }
 
   // Accumulation of transformation matrices
-  for (i = 1; i < m_Order; ++i)
+  for (unsigned int i = 1; i < m_Order; ++i)
   {
-    l = i - 1;
+    unsigned int l = i - 1;
     z[m_Order - 1 + l * m_Dimension] = z[l + l * m_Dimension];
     z[l + l * m_Dimension] = 1.0;
-    h = d[i];
+    double h = d[i];
     if (h != 0.0)
     {
-      for (k = 0; k <= l; ++k)
+      for (unsigned int k = 0; k <= l; ++k)
       {
         d[k] = z[k + i * m_Dimension] / h;
       }
 
-      for (j = 0; j <= l; ++j)
+      for (unsigned int j = 0; j <= l; ++j)
       {
-        g = 0.0;
+        double g = 0.0;
 
-        for (k = 0; k <= l; ++k)
+        for (unsigned int k = 0; k <= l; ++k)
         {
           g += z[k + i * m_Dimension] * z[k + j * m_Dimension];
         }
 
-        for (k = 0; k <= l; ++k)
+        for (unsigned int k = 0; k <= l; ++k)
         {
           z[k + j * m_Dimension] -= g * d[k];
         }
       }
     }
 
-    for (k = 0; k <= l; ++k)
+    for (unsigned int k = 0; k <= l; ++k)
     {
       z[k + i * m_Dimension] = 0.0;
     }
   }
 
-  for (i = 0; i < m_Order; ++i)
+  for (unsigned int i = 0; i < m_Order; ++i)
   {
     d[i] = z[m_Order - 1 + i * m_Dimension];
     z[m_Order - 1 + i * m_Dimension] = 0.0;
@@ -431,45 +408,26 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
   constexpr double c_b10 = 1.0;
 
   // Local variables
-  double       c;
-  double       f;
-  double       g;
-  double       h;
-  unsigned int i;
-  unsigned int j;
-  unsigned int l;
-  unsigned int m;
-  double       p;
-  double       r;
-  double       s;
-  double       c2;
-  double       c3 = 0.0;
-  double       s2 = 0.0;
-  double       dl1;
-  double       el1;
-  double       tst1;
-  double       tst2;
-
   unsigned int ierr = 0;
 
   if (m_Order == 1)
   {
     return 1;
   }
-
-  for (i = 1; i < m_Order; ++i)
+  unsigned int m;
+  for (unsigned int i = 1; i < m_Order; ++i)
   {
     e[i - 1] = e[i];
   }
 
-  f = 0.;
-  tst1 = 0.;
+  double f = 0.;
+  double tst1 = 0.;
   e[m_Order - 1] = 0.;
 
-  for (l = 0; l < m_Order; ++l)
+  for (unsigned int l = 0; l < m_Order; ++l)
   {
-    j = 0;
-    h = itk::Math::abs(d[l]) + itk::Math::abs(e[l]);
+    unsigned int j = 0;
+    double       h = itk::Math::abs(d[l]) + itk::Math::abs(e[l]);
     if (tst1 < h)
     {
       tst1 = h;
@@ -477,7 +435,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
     // Look for small sub-diagonal element
     for (m = l; m < m_Order - 1; ++m)
     {
-      tst2 = tst1 + itk::Math::abs(e[m]);
+      double tst2 = tst1 + itk::Math::abs(e[m]);
       if (tst2 == tst1)
       {
         break;
@@ -487,6 +445,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
 
     if (m != l)
     {
+      double tst2;
       do
       {
         if (j == 30)
@@ -497,15 +456,15 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
         }
         ++j;
         // Form shift
-        g = d[l];
-        p = (d[l + 1] - g) / (e[l] * 2.);
-        r = itk::Math::hypot(p, c_b10);
+        double g = d[l];
+        double p = (d[l + 1] - g) / (e[l] * 2.);
+        double r = itk::Math::hypot(p, c_b10);
         d[l] = e[l] / (p + itk::Math::sgn0(p) * itk::Math::abs(r));
         d[l + 1] = e[l] * (p + itk::Math::sgn0(p) * itk::Math::abs(r));
-        dl1 = d[l + 1];
+        double dl1 = d[l + 1];
         h = g - d[l];
 
-        for (i = l + 2; i < m_Order; ++i)
+        for (unsigned int i = l + 2; i < m_Order; ++i)
         {
           d[i] -= h;
         }
@@ -513,11 +472,13 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
         f += h;
         // ql transformation
         p = d[m];
-        c = 1.;
-        c2 = c;
-        el1 = e[l + 1];
-        s = 0.;
-        for (i = m - 1; i >= l; --i)
+        double       c = 1.;
+        double       c2 = c;
+        double const el1 = e[l + 1];
+        double       s = 0.;
+        double       s2 = 0;
+        double       c3 = c2;
+        for (unsigned int i = m - 1; i >= l; --i)
         {
           c3 = c2;
           c2 = c;
@@ -543,11 +504,12 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
       } while (tst2 > tst1);
     }
 
-    p = d[l] + f;
+    double p = d[l] + f;
 
     if (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue)
     {
       // Order by value
+      unsigned int i;
       for (i = l; i > 0; --i)
       {
         if (p >= d[i - 1])
@@ -561,6 +523,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
     else if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       // Order by magnitude. Make eigenvalues positive
+      unsigned int i;
       for (i = l; i > 0; --i)
       {
         if (itk::Math::abs(p) >= itk::Math::abs(d[i - 1]))
@@ -587,54 +550,36 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
                                                                                             double * z) const
 {
   constexpr double c_b10 = 1.0;
-
-  // Local variables
-  double       c;
-  double       f;
-  double       g;
-  double       h;
-  unsigned int i;
-  unsigned int j;
-  unsigned int k;
-  unsigned int l;
-  unsigned int m;
-  double       p;
-  double       r;
-  double       s;
-  double       c2;
-  double       c3 = 0.0;
-  double       s2 = 0.0;
-  double       dl1;
-  double       el1;
-  double       tst1;
-  double       tst2;
-
-  unsigned int ierr = 0;
-
   if (m_Order == 1)
   {
     return 1;
   }
 
-  for (i = 1; i < m_Order; ++i)
+  unsigned int ierr = 0;
+  double       c3 = 0.0;
+  double       s2 = 0.0;
+  for (unsigned int i = 1; i < m_Order; ++i)
   {
     e[i - 1] = e[i];
   }
 
-  f = 0.0;
-  tst1 = 0.;
+
+  double f = 0.0;
+  double tst1 = 0.;
   e[m_Order - 1] = 0.;
 
-  for (l = 0; l < m_Order; ++l)
+  for (unsigned int l = 0; l < m_Order; ++l)
   {
-    j = 0;
-    h = itk::Math::abs(d[l]) + itk::Math::abs(e[l]);
+    unsigned int j = 0;
+    double       h = itk::Math::abs(d[l]) + itk::Math::abs(e[l]);
     if (tst1 < h)
     {
       tst1 = h;
     }
 
     // Look for small sub-diagonal element
+    unsigned int m;
+    double       tst2;
     for (m = l; m < m_Order - 1; ++m)
     {
       tst2 = tst1 + itk::Math::abs(e[m]);
@@ -658,15 +603,15 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
         }
         ++j;
         // Form shift
-        g = d[l];
-        p = (d[l + 1] - g) / (e[l] * 2.);
-        r = itk::Math::hypot(p, c_b10);
+        double g = d[l];
+        double p = (d[l + 1] - g) / (e[l] * 2.);
+        double r = itk::Math::hypot(p, c_b10);
         d[l] = e[l] / (p + itk::Math::sgn0(p) * itk::Math::abs(r));
         d[l + 1] = e[l] * (p + itk::Math::sgn0(p) * itk::Math::abs(r));
-        dl1 = d[l + 1];
+        double dl1 = d[l + 1];
         h = g - d[l];
 
-        for (i = l + 2; i < m_Order; ++i)
+        for (unsigned int i = l + 2; i < m_Order; ++i)
         {
           d[i] -= h;
         }
@@ -674,12 +619,12 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
         f += h;
         // ql transformation
         p = d[m];
-        c = 1.0;
-        c2 = c;
-        el1 = e[l + 1];
-        s = 0.;
+        double c = 1.0;
+        double c2 = c;
+        double el1 = e[l + 1];
+        double s = 0.;
 
-        for (i = m - 1; i >= l; --i)
+        for (unsigned int i = m - 1; i >= l; --i)
         {
           c3 = c2;
           c2 = c;
@@ -694,7 +639,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
           d[i + 1] = h + s * (c * g + s * d[i]);
 
           // Form vector
-          for (k = 0; k < m_Order; ++k)
+          for (unsigned int k = 0; k < m_Order; ++k)
           {
             h = z[k + (i + 1) * m_Dimension];
             z[k + (i + 1) * m_Dimension] = s * z[k + i * m_Dimension] + c * h;
@@ -720,12 +665,12 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   if (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue)
   {
     // Order by value
-    for (i = 0; i < m_Order - 1; ++i)
+    for (unsigned int i = 0; i < m_Order - 1; ++i)
     {
-      k = i;
-      p = d[i];
+      unsigned int k = i;
+      double       p = d[i];
 
-      for (j = i + 1; j < m_Order; ++j)
+      for (unsigned int j = i + 1; j < m_Order; ++j)
       {
         if (d[j] >= p)
         {
@@ -742,7 +687,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
       d[k] = d[i];
       d[i] = p;
 
-      for (j = 0; j < m_Order; ++j)
+      for (unsigned int j = 0; j < m_Order; ++j)
       {
         p = z[j + i * m_Dimension];
         z[j + i * m_Dimension] = z[j + k * m_Dimension];
@@ -753,12 +698,12 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   else if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
   {
     // Order by magnitude
-    for (i = 0; i < m_Order - 1; ++i)
+    for (unsigned int i = 0; i < m_Order - 1; ++i)
     {
-      k = i;
-      p = d[i];
+      unsigned int k = i;
+      double       p = d[i];
 
-      for (j = i + 1; j < m_Order; ++j)
+      for (unsigned int j = i + 1; j < m_Order; ++j)
       {
         if (itk::Math::abs(d[j]) >= itk::Math::abs(p))
         {
@@ -776,7 +721,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
       d[k] = d[i];
       d[i] = p;
 
-      for (j = 0; j < m_Order; ++j)
+      for (unsigned int j = 0; j < m_Order; ++j)
       {
         p = z[j + i * m_Dimension];
         z[j + i * m_Dimension] = z[j + k * m_Dimension];

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -54,28 +54,30 @@ ITKCommon_EXPORT std::istream &
 
     // Get name
     std::istringstream stream(headerline);
-    std::string        address;
-    std::string        perms;
-    std::string        offset;
-    std::string        device;
-    int                inode = -1;
+
+    int inode = -1;
     // the header is defined with the following expression: "address permissions
     // offset device inode [name]"
+    std::string address;
+
     stream >> address;
     if (!stream.good())
     {
       itkGenericExceptionMacro("bad address: " << address);
     }
+    std::string perms;
     stream >> perms;
     if (!stream.good())
     {
       itkGenericExceptionMacro("bad perms: " << perms);
     }
+    std::string offset;
     stream >> offset;
     if (!stream.good())
     {
       itkGenericExceptionMacro("bad offset: " << offset);
     }
+    std::string device;
     stream >> device;
     if (!stream.good())
     {

--- a/Modules/Core/Common/test/itkByteSwapTest.cxx
+++ b/Modules/Core/Common/test/itkByteSwapTest.cxx
@@ -27,22 +27,6 @@ itkByteSwapTest(int, char *[])
 
   std::cout << "Starting test" << std::endl;
 
-  unsigned char      uc = 'a';
-  unsigned char      uc1 = 'a';
-  unsigned short     us = 1;
-  unsigned short     us1 = 1;
-  unsigned int       ui = 1;
-  unsigned int       ui1 = 1;
-  unsigned long      ul = 1;
-  unsigned long      ul1 = 1;
-  unsigned long long ull = 1;
-  unsigned long long ull1 = 1;
-  float              f = 1.0;
-  float              f1 = 1.0;
-  double             d = 1.0;
-  double             d1 = 1.0;
-
-
   // Try to swap a char
 
   if constexpr (itk::ByteSwapper<int>::SystemIsBigEndian() == itk::ByteSwapper<int>::SystemIsLE())
@@ -54,6 +38,8 @@ itkByteSwapTest(int, char *[])
     return EXIT_FAILURE;
   }
 
+  unsigned char uc = 'a';
+  unsigned char uc1 = 'a';
   if constexpr (itk::ByteSwapper<int>::SystemIsBigEndian())
   {
     itk::ByteSwapper<unsigned char>::SwapFromSystemToLittleEndian(&uc);
@@ -70,6 +56,8 @@ itkByteSwapTest(int, char *[])
   }
   std::cout << "Passed unsigned char: " << uc << std::endl;
 
+  unsigned short us = 1;
+  unsigned short us1 = 1;
   if constexpr (itk::ByteSwapper<int>::SystemIsBE())
   {
     itk::ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&us);
@@ -85,7 +73,8 @@ itkByteSwapTest(int, char *[])
     return EXIT_FAILURE;
   }
   std::cout << "Passed unsigned short: " << us << std::endl;
-
+  unsigned int ui = 1;
+  unsigned int ui1 = 1;
   if constexpr (itk::ByteSwapper<int>::SystemIsBigEndian())
   {
     itk::ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(&ui);
@@ -102,7 +91,8 @@ itkByteSwapTest(int, char *[])
   }
   std::cout << "Passed unsigned int: " << ui << std::endl;
 
-
+  unsigned long ul = 1;
+  unsigned long ul1 = 1;
   try
   {
     if constexpr (itk::ByteSwapper<long>::SystemIsBigEndian())
@@ -127,7 +117,8 @@ itkByteSwapTest(int, char *[])
     err.Print(std::cerr);
   }
 
-
+  unsigned long long ull = 1;
+  unsigned long long ull1 = 1;
   try
   {
     if constexpr (itk::ByteSwapper<long>::SystemIsBigEndian())
@@ -152,6 +143,8 @@ itkByteSwapTest(int, char *[])
     err.Print(std::cerr);
   }
 
+  float f = 1.0;
+  float f1 = 1.0;
   try
   {
     if constexpr (itk::ByteSwapper<int>::SystemIsBigEndian())
@@ -177,6 +170,8 @@ itkByteSwapTest(int, char *[])
     return EXIT_FAILURE;
   }
 
+  double d = 1.0;
+  double d1 = 1.0;
   try
   {
     if constexpr (itk::ByteSwapper<int>::SystemIsBigEndian())

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -39,12 +39,10 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x;
-  unsigned int y;
-  unsigned int i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+
+  for (unsigned int y = 0, i = 0; y < p.GetSize()[1]; ++y)
   {
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       std::cout << p.GetPixel(i) << ' ';
     }
@@ -54,10 +52,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *, "
             << "const NeighborhoodAccessorFunctorType &) const" << std::endl;
 
-  i = 0;
-  for (y = 0; y < v.GetSize()[1]; ++y)
+  for (unsigned int y = 0, i = 0; y < v.GetSize()[1]; ++y)
   {
-    for (x = 0; x < v.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
       std::cout << v.GetPixel(i)[0] << ' ';
     }
@@ -66,12 +63,11 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from GetPixel( const IndexType & index, const TImage * image ) const" << std::endl;
 
-  i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+  for (unsigned int y = 0, i = 0; y < p.GetSize()[1]; ++y)
   {
     itk::Index<2> index;
     index[1] = p.GetIndex()[1] - p.GetRadius()[1] + y;
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       index[0] = p.GetIndex()[0] - p.GetRadius()[0] + x;
 
@@ -126,9 +122,9 @@ itkConstantBoundaryConditionTest(int, char *[])
 {
   // Test an image to cover one operator() method.
   auto       image = ImageType::New();
-  RegionType imageRegion;
   SizeType   imageSize = { { 5, 5 } };
   IndexType  imageIndex = { { 0, 0 } };
+  RegionType imageRegion;
   imageRegion.SetSize(imageSize);
   imageRegion.SetIndex(imageIndex);
   image->SetRegions(imageRegion);
@@ -221,26 +217,20 @@ itkConstantBoundaryConditionTest(int, char *[])
   }
 
   // Now test the input region calculation
-  IndexType  requestIndex;
-  SizeType   requestSize;
-  RegionType requestRegion;
-
-  IndexType  expectedIndex;
-  SizeType   expectedSize;
-  RegionType expectedRegion;
-
-  RegionType inputRegion;
 
   // Test 1
   std::cout << "GetInputRequestedRegion() Test 1" << std::endl;
+  IndexType requestIndex;
   requestIndex.Fill(0);
+  SizeType requestSize;
   requestSize.Fill(2);
+  RegionType requestRegion;
   requestRegion.SetIndex(requestIndex);
   requestRegion.SetSize(requestSize);
 
-  expectedRegion = requestRegion;
+  RegionType expectedRegion = requestRegion;
 
-  inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
+  RegionType inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
   if (!CheckInputRequestedRegion(imageRegion, inputRegion, expectedRegion))
   {
     std::cerr << "[FAILED]" << std::endl;
@@ -257,11 +247,11 @@ itkConstantBoundaryConditionTest(int, char *[])
   requestRegion.SetIndex(requestIndex);
   requestRegion.SetSize(requestSize);
 
-  expectedIndex[0] = 0;
-  expectedIndex[1] = 0;
+  auto expectedIndex = itk::MakeFilled<IndexType>(0);
+  expectedRegion.SetIndex(expectedIndex);
+  SizeType expectedSize = { 1, 2 };
   expectedSize[0] = 1;
   expectedSize[1] = 2;
-  expectedRegion.SetIndex(expectedIndex);
   expectedRegion.SetSize(expectedSize);
 
   inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -133,14 +133,14 @@ itkExceptionObjectTest(int, char *[])
   bool OneShouldFail = true;
   try
   {
-    human          john;
-    human          jane;
-    naked_mole_rat hal;
+    human john;
     OneShouldFail &= (john == john); // OK
+    human jane;
     OneShouldFail &= (jane == john); // OK
     // NOTE:  (hal == john) throws an exception, and does not actually return false!
     //       This means that the &= operator below is never executed, and
     //       the OneShouldFail variable is never actually set to false!
+    naked_mole_rat hal;
     OneShouldFail &= (hal == john); // ERROR
   }
   catch (const itk::IncompatibleOperandsError & e)

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -99,11 +99,11 @@ itkImageTest(int, char *[])
   std::cout << "Test transform to/from physical vector." << std::endl;
   using GradientType = itk::FixedArray<float, 2>;
   GradientType truthGradient;
-  GradientType outputGradient;
-  GradientType testGradient;
   truthGradient[0] = 1.0;
   truthGradient[1] = 1.0;
+  GradientType outputGradient;
   image->TransformLocalVectorToPhysicalVector(truthGradient, outputGradient);
+  GradientType testGradient;
   image->TransformPhysicalVectorToLocalVector(outputGradient, testGradient);
   if (itk::Math::abs(truthGradient[0] - testGradient[0]) > eps ||
       itk::Math::abs(truthGradient[1] - testGradient[1]) > eps)

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -58,19 +58,15 @@ itkIteratorTests(int, char *[])
   o3->Allocate();
 
   // extra variables
-  double        elapsedTime;
-  clock_t       start;
-  clock_t       end;
   unsigned long num = 190 * 190 * 190;
 
   bool passed = true;
-
   // memset
-  start = clock();
+  clock_t          start = clock();
   unsigned short * ptr = o3->GetBufferPointer();
   memset(ptr, 0, num * sizeof(unsigned short));
-  end = clock();
-  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
+  clock_t end = clock();
+  double  elapsedTime = (end - start) / static_cast<double>(CLOCKS_PER_SEC);
 
   std::cout << "Raw pointer using memset" << std::endl;
   std::cout << "\tTime   = " << elapsedTime << std::endl;
@@ -99,17 +95,14 @@ itkIteratorTests(int, char *[])
     }
   }
   // 3 nested loops
-  unsigned long ii;
-  unsigned long jj;
-  unsigned long kk;
   unsigned long len = 190;
   start = clock();
   {
     unsigned int i = 0;
     ptr = o3->GetBufferPointer();
-    for (ii = 0; ii < len; ++ii)
-      for (jj = 0; jj < len; ++jj)
-        for (kk = 0; kk < len; ++kk)
+    for (unsigned long ii = 0; ii < len; ++ii)
+      for (unsigned long jj = 0; jj < len; ++jj)
+        for (unsigned long kk = 0; kk < len; ++kk)
         {
           *ptr = 5;
           ++ptr;

--- a/Modules/Core/Common/test/itkModifiedTimeTest.cxx
+++ b/Modules/Core/Common/test/itkModifiedTimeTest.cxx
@@ -22,36 +22,27 @@
 int
 itkModifiedTimeTest(int, char *[])
 {
-
   using Point = itk::Point<double, 3>;
   using PointsContainer = itk::VectorContainer<Point>;
   using BoundingBox = itk::BoundingBox<unsigned long, 3, double, PointsContainer>;
 
-  Point p;
-  Point q;
-  Point r;
-
-  p.Fill(0);
-  q.Fill(0);
-  r.Fill(0);
-
-  auto bb = BoundingBox::New();
-
-  auto pc = PointsContainer::New();
-
+  auto  pc = PointsContainer::New();
+  Point p{};
   pc->InsertElement(0, p);
+  Point q{};
   pc->InsertElement(1, q);
   pc->Modified();
 
+  auto bb = BoundingBox::New();
   bb->SetPoints(pc);
 
   const itk::ModifiedTimeType bbBeforeTime = bb->GetMTime();
   const itk::ModifiedTimeType pcBeforeTime = pc->GetMTime();
 
-
   std::cout << "BB time before modification: " << bbBeforeTime << std::endl;
   std::cout << "PC time before modification: " << pcBeforeTime << std::endl;
 
+  Point r{};
   pc->InsertElement(2, r);
   pc->Modified(); // call the Modified function to update the modified time of the container
 
@@ -60,7 +51,6 @@ itkModifiedTimeTest(int, char *[])
 
   std::cout << "BB time after modification: " << bbAfterTime << std::endl;
   std::cout << "PC time after modification: " << pcAfterTime << std::endl;
-
 
   if (pcAfterTime == pcBeforeTime)
   {
@@ -75,7 +65,6 @@ itkModifiedTimeTest(int, char *[])
     std::cout << "updated by changes in the points" << std::endl;
     return EXIT_FAILURE;
   }
-
 
   if (bbAfterTime < pcAfterTime)
   {

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -31,8 +31,8 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   itk::NeighborhoodIterator<TestImageType>::IndexType zeroIDX{};
 
-  itk::NeighborhoodIterator<TestImageType>::RadiusType radius;
-  radius[0] = radius[1] = radius[2] = radius[3] = 1;
+  auto radius = itk::MakeFilled<itk::NeighborhoodIterator<TestImageType>::RadiusType>(1);
+
 
   println("Creating NeighborhoodIterator");
   itk::NeighborhoodIterator<TestImageType> it(radius, img, img->GetRequestedRegion());
@@ -81,12 +81,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   it3.SetLocation(loc);
 
   it3.Print(std::cout);
-  unsigned int x;
-  unsigned int y;
-  unsigned int i;
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -101,9 +98,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   z[3] = 0;
   it3.SetNext(0, 2, z);
 
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -112,9 +109,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(1, 2, [0,0,0,0])");
   it3.SetNext(1, 2, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -123,9 +120,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(0, [0,0,0,0])");
   it3.SetNext(0, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -134,9 +131,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(1, [0,0,0,0])");
   it3.SetNext(1, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -147,9 +144,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   println("Testing SetPrevious(0, 2, [0,0,0,0])");
   it3.SetPrevious(0, 2, z);
 
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -158,9 +155,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(1, 2, [0,0,0,0])");
   it3.SetPrevious(1, 2, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -169,9 +166,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(0, [0,0,0,0])");
   it3.SetPrevious(0, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }
@@ -180,9 +177,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(1, [0,0,0,0])");
   it3.SetPrevious(1, z);
-  for (y = 0, i = 0; y < 5; ++y)
+  for (unsigned int y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; ++x, ++i)
+    for (unsigned int x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << ' ';
     }

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -39,12 +39,10 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x;
-  unsigned int y;
   unsigned int i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < p.GetSize()[1]; ++y)
   {
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       std::cout << p.GetPixel(i) << ' ';
     }
@@ -55,9 +53,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
             << "const NeighborhoodAccessorFunctorType &) const" << std::endl;
 
   i = 0;
-  for (y = 0; y < v.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < v.GetSize()[1]; ++y)
   {
-    for (x = 0; x < v.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
       std::cout << v.GetPixel(i)[0] << ' ';
     }
@@ -67,11 +65,11 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   std::cout << "Output from GetPixel( const IndexType & index, const TImage * image ) const" << std::endl;
 
   i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < p.GetSize()[1]; ++y)
   {
     itk::Index<2> index;
     index[1] = p.GetIndex()[1] - p.GetRadius()[1] + y;
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       index[0] = p.GetIndex()[0] - p.GetRadius()[0] + x;
 
@@ -124,12 +122,11 @@ int
 itkPeriodicBoundaryConditionTest(int, char *[])
 {
   // Test an image to cover one operator() method.
-  auto       image = ImageType::New();
-  RegionType imageRegion;
+  auto image = ImageType::New();
+
   SizeType   imageSize = { { 5, 5 } };
   IndexType  imageIndex = { { 0, 0 } };
-  imageRegion.SetSize(imageSize);
-  imageRegion.SetIndex(imageIndex);
+  RegionType imageRegion(imageIndex, imageSize);
   image->SetRegions(imageRegion);
   image->Allocate();
 
@@ -154,15 +151,15 @@ itkPeriodicBoundaryConditionTest(int, char *[])
   }
 
   RadiusType radius;
-  RadiusType radiusTwo;
   radius[0] = radius[1] = 1;
-  IteratorType       it(radius, image, image->GetRequestedRegion());
-  VectorIteratorType vit(radius, vectorImage, vectorImage->GetRequestedRegion());
+  IteratorType it(radius, image, image->GetRequestedRegion());
 
-  itk::PeriodicBoundaryCondition<ImageType>       bc;
-  itk::PeriodicBoundaryCondition<VectorImageType> vbc;
 
+  itk::PeriodicBoundaryCondition<ImageType> bc;
   it.OverrideBoundaryCondition(&bc);
+
+  itk::PeriodicBoundaryCondition<VectorImageType> vbc;
+  VectorIteratorType                              vit(radius, vectorImage, vectorImage->GetRequestedRegion());
   vit.OverrideBoundaryCondition(&vbc);
 
   pos[0] = pos[1] = 0;
@@ -177,7 +174,7 @@ itkPeriodicBoundaryConditionTest(int, char *[])
       return EXIT_FAILURE;
     }
   }
-
+  RadiusType radiusTwo;
   radiusTwo[0] = radiusTwo[1] = 2;
   IteratorType       it2(radiusTwo, image, image->GetRequestedRegion());
   VectorIteratorType vit2(radiusTwo, vectorImage, vectorImage->GetRequestedRegion());
@@ -200,26 +197,16 @@ itkPeriodicBoundaryConditionTest(int, char *[])
   }
 
   // Now test the input region calculation
-  IndexType  requestIndex;
-  SizeType   requestSize;
-  RegionType requestRegion;
-
-  IndexType  expectedIndex;
-  SizeType   expectedSize;
-  RegionType expectedRegion;
-
-  RegionType inputRegion;
-
   // Test 1
   std::cout << "GetInputRequestedRegion() Test 1" << std::endl;
-  requestIndex.Fill(0);
-  requestSize.Fill(2);
-  requestRegion.SetIndex(requestIndex);
-  requestRegion.SetSize(requestSize);
+  auto       requestIndex = itk::MakeFilled<IndexType>(0);
+  auto       requestSize = itk::MakeFilled<SizeType>(2);
+  RegionType requestRegion(requestIndex, requestSize);
 
-  expectedRegion = requestRegion;
 
-  inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
+  RegionType expectedRegion = requestRegion;
+
+  RegionType inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
   if (!CheckInputRequestedRegion(imageRegion, inputRegion, expectedRegion))
   {
     std::cerr << "[FAILED]" << std::endl;
@@ -236,8 +223,10 @@ itkPeriodicBoundaryConditionTest(int, char *[])
   requestRegion.SetIndex(requestIndex);
   requestRegion.SetSize(requestSize);
 
+  IndexType expectedIndex;
   expectedIndex[0] = 0;
   expectedIndex[1] = 0;
+  SizeType expectedSize;
   expectedSize[0] = 5;
   expectedSize[1] = 2;
   expectedRegion.SetIndex(expectedIndex);

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -209,39 +209,38 @@ itkVectorTest(int, char *[])
 
   using RealVector3 = itk::Vector<float, 3>;
   RealVector3 a;
-  RealVector3 b;
-  RealVector3 c;
+
   a[0] = 1.0;
   a[1] = 0.0;
   a[2] = 0.0;
+  RealVector3 b;
   b[0] = 0.0;
   b[1] = 1.0;
   b[2] = 0.0;
-  c = itk::CrossProduct(a, b);
+  RealVector3 c = itk::CrossProduct(a, b);
   std::cout << '(' << a << ") cross (" << b << ") : (" << c << ')' << std::endl;
 
   using DoubleVector3 = itk::Vector<double, 3>;
   DoubleVector3 aa;
-  DoubleVector3 bb;
-  DoubleVector3 cc;
+
   aa[0] = 1.0;
   aa[1] = 0.0;
   aa[2] = 0.0;
+  DoubleVector3 bb;
   bb[0] = 0.0;
   bb[1] = 1.0;
   bb[2] = 0.0;
-  cc = itk::CrossProduct(aa, bb);
+  DoubleVector3 cc = itk::CrossProduct(aa, bb);
   std::cout << '(' << aa << ") cross (" << bb << ") : (" << cc << ')' << std::endl;
   DoubleVector3 ia;
-  DoubleVector3 ib;
-  DoubleVector3 ic;
   ia[0] = 1;
   ia[1] = 0;
   ia[2] = 0;
+  DoubleVector3 ib;
   ib[0] = 0;
   ib[1] = 1;
   ib[2] = 0;
-  ic = itk::CrossProduct(ia, ib);
+  DoubleVector3 ic = itk::CrossProduct(ia, ib);
   std::cout << '(' << ia << ") cross (" << ib << ") : (" << ic << ')' << std::endl;
   if (passed)
   {

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -38,12 +38,10 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
   std::cout << "Output from operator()(const OffsetType &, const OffsetType &, const NeighborhoodType *) const"
             << std::endl;
-  unsigned int x;
-  unsigned int y;
   unsigned int i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < p.GetSize()[1]; ++y)
   {
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       std::cout << p.GetPixel(i) << ' ';
     }
@@ -54,9 +52,9 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
             << "const NeighborhoodAccessorFunctorType &) const" << std::endl;
 
   i = 0;
-  for (y = 0; y < v.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < v.GetSize()[1]; ++y)
   {
-    for (x = 0; x < v.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < v.GetSize()[0]; ++x, ++i)
     {
       std::cout << v.GetPixel(i)[0] << ' ';
     }
@@ -66,11 +64,11 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
   std::cout << "Output from GetPixel( const IndexType & index, const TImage * image ) const" << std::endl;
 
   i = 0;
-  for (y = 0; y < p.GetSize()[1]; ++y)
+  for (unsigned int y = 0; y < p.GetSize()[1]; ++y)
   {
     itk::Index<2> index;
     index[1] = p.GetIndex()[1] - p.GetRadius()[1] + y;
-    for (x = 0; x < p.GetSize()[0]; ++x, ++i)
+    for (unsigned int x = 0; x < p.GetSize()[0]; ++x, ++i)
     {
       index[0] = p.GetIndex()[0] - p.GetRadius()[0] + x;
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -89,21 +89,16 @@ template <typename TInputImageType, typename TSparseOutputImageType>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::ApplyUpdateThreaderCallback(void * arg)
 {
-  FDThreadStruct * str;
-  ThreadIdType     total;
-  ThreadIdType     workUnitID;
-  ThreadIdType     workUnitCount;
-
-  workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-  str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  ThreadIdType     workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  ThreadIdType     workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  FDThreadStruct * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
   // Use GetSplitRegion to access partition previously computed by
   // the SplitRegions function in the SparseFieldLayer class.
   ThreadRegionType splitRegion;
-  total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
+  ThreadIdType     total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
 
   if (workUnitID < total)
   {
@@ -183,22 +178,17 @@ template <typename TInputImageType, typename TSparseOutputImageType>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChangeThreaderCallback(void * arg)
 {
-  FDThreadStruct * str;
-  ThreadIdType     total;
-  ThreadIdType     workUnitID;
-  ThreadIdType     workUnitCount;
+  ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-
-  str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  FDThreadStruct * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
   // Use GetSplitRegion to access partition previously computed by
   // the SplitRegions function in the SparseFieldLayer class.
   ThreadRegionType splitRegion;
-  total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
+  ThreadIdType     total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
 
   if (workUnitID < total)
   {
@@ -214,22 +204,17 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::PrecalculateChangeThreaderCallback(
   void * arg)
 {
-  FDThreadStruct * str;
-  ThreadIdType     total;
-  ThreadIdType     workUnitID;
-  ThreadIdType     workUnitCount;
+  ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-
-  str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  FDThreadStruct * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
   // Use GetSplitRegion to access partition previously computed by
   // the SplitRegions function in the SparseFieldLayer class.
   ThreadRegionType splitRegion;
-  total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
+  ThreadIdType     total = str->Filter->GetSplitRegion(workUnitID, workUnitCount, splitRegion);
 
   if (workUnitID < total)
   {
@@ -249,22 +234,18 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Thre
 
   typename SparseOutputImageType::Pointer output = this->GetOutput();
 
-  TimeStepType timeStep;
-  void *       globalData;
-
   const SizeType radius = m_SparseFunction->GetRadius();
 
   // Ask the function object for a pointer to a data structure it will use to
   // manage any global values it needs.  We'll pass this back to the function
   // object at each calculation so that the function object can use it to
   // determine a time step for this iteration.
-  globalData = m_SparseFunction->GetGlobalDataPointer();
+  void * globalData = m_SparseFunction->GetGlobalDataPointer();
 
-  typename NodeListType::Iterator bandIt;
-  NeighborhoodIteratorType        outputIt(radius, output, output->GetRequestedRegion());
+  NeighborhoodIteratorType outputIt(radius, output, output->GetRequestedRegion());
 
   // compute the update variables
-  for (bandIt = regionToProcess.first; bandIt != regionToProcess.last; ++bandIt)
+  for (typename NodeListType::Iterator bandIt = regionToProcess.first; bandIt != regionToProcess.last; ++bandIt)
   {
     outputIt.SetLocation(bandIt->m_Index);
     outputIt.GetCenterPixel()->m_Update = m_SparseFunction->ComputeSparseUpdate(outputIt, globalData);
@@ -273,7 +254,7 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Thre
   // Ask the finite difference function to compute the time step for
   // this iteration.  We give it the global data pointer to use, then
   // ask it to free the global data memory.
-  timeStep = m_SparseFunction->ComputeGlobalTimeStep(globalData);
+  TimeStepType timeStep = m_SparseFunction->ComputeGlobalTimeStep(globalData);
   m_SparseFunction->ReleaseGlobalDataPointer(globalData);
 
   return timeStep;
@@ -291,13 +272,12 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Thre
 
   const SizeType radius = m_SparseFunction->GetRadius();
 
-  typename NodeListType::Iterator bandIt;
-  NeighborhoodIteratorType        outputIt(radius, output, output->GetRequestedRegion());
+  NeighborhoodIteratorType outputIt(radius, output, output->GetRequestedRegion());
 
   // the step for computing the flux variables
   // these are used for computing the update in diffusion processes
   // can disable these lines for non-diffusion processes
-  for (bandIt = regionToProcess.first; bandIt != regionToProcess.last; ++bandIt)
+  for (typename NodeListType::Iterator bandIt = regionToProcess.first; bandIt != regionToProcess.last; ++bandIt)
   {
     outputIt.SetLocation(bandIt->m_Index);
     m_SparseFunction->PrecomputeSparseUpdate(outputIt);

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -317,11 +317,8 @@ template <typename TImage, typename TAccessor>
 ModifiedTimeType
 ImageAdaptor<TImage, TAccessor>::GetMTime() const
 {
-  ModifiedTimeType mtime1;
-  ModifiedTimeType mtime2;
-
-  mtime1 = Superclass::GetMTime();
-  mtime2 = m_Image->GetMTime();
+  const ModifiedTimeType mtime1 = Superclass::GetMTime();
+  const ModifiedTimeType mtime2 = m_Image->GetMTime();
 
   return (mtime1 >= mtime2 ? mtime1 : mtime2);
 }

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -178,15 +178,10 @@ void
 BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoefficient(double z)
 {
   // See Unser, 1999, Box 2 for explanation
-  CoeffType                           sum;
-  double                              zn;
-  double                              z2n;
-  double                              iz;
-  typename TInputImage::SizeValueType horizon;
 
   // Yhis initialization corresponds to mirror boundaries
-  horizon = m_DataLength[m_IteratorDirection];
-  zn = z;
+  typename TInputImage::SizeValueType horizon = m_DataLength[m_IteratorDirection];
+  double                              zn = z;
   if (m_Tolerance > 0.0)
   {
     horizon = (typename TInputImage::SizeValueType)std::ceil(std::log(m_Tolerance) / std::log(itk::Math::abs(z)));
@@ -194,7 +189,7 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
   if (horizon < m_DataLength[m_IteratorDirection])
   {
     // Accelerated loop
-    sum = m_Scratch[0]; // verify this
+    CoeffType sum = m_Scratch[0]; // verify this
     for (unsigned int n = 1; n < horizon; ++n)
     {
       sum += zn * m_Scratch[n];
@@ -205,9 +200,9 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
   else
   {
     // Full loop
-    iz = 1.0 / z;
-    z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1L));
-    sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1L];
+    double    iz = 1.0 / z;
+    double    z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1L));
+    CoeffType sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1L];
     z2n *= z2n * iz;
     for (unsigned int n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); ++n)
     {

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -175,20 +175,13 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
   // For speed improvements we could make each case a separate function and use
   // function pointers to reference the correct weight order.
   // Left as is for now for readability.
-  double w;
-  double w2;
-  double w4;
-  double t;
-  double t0;
-  double t1;
-
   switch (splineOrder)
   {
     case 3:
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] - static_cast<double>(EvaluateIndex[n][1]);
+        double w = x[n] - static_cast<double>(EvaluateIndex[n][1]);
         weights[n][3] = (1.0 / 6.0) * w * w * w;
         weights[n][0] = (1.0 / 6.0) + 0.5 * w * (w - 1.0) - weights[n][3];
         weights[n][2] = w + weights[n][0] - 2.0 * weights[n][3];
@@ -208,7 +201,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] - static_cast<double>(EvaluateIndex[n][0]);
+        double w = x[n] - static_cast<double>(EvaluateIndex[n][0]);
         weights[n][1] = w;
         weights[n][0] = 1.0 - w;
       }
@@ -219,7 +212,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         /* x */
-        w = x[n] - static_cast<double>(EvaluateIndex[n][1]);
+        double w = x[n] - static_cast<double>(EvaluateIndex[n][1]);
         weights[n][1] = 0.75 - w * w;
         weights[n][2] = 0.5 * (w - weights[n][1] + 1.0);
         weights[n][0] = 1.0 - weights[n][1] - weights[n][2];
@@ -231,14 +224,14 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         /* x */
-        w = x[n] - static_cast<double>(EvaluateIndex[n][2]);
-        w2 = w * w;
-        t = (1.0 / 6.0) * w2;
+        double w = x[n] - static_cast<double>(EvaluateIndex[n][2]);
+        double w2 = w * w;
+        double t = (1.0 / 6.0) * w2;
         weights[n][0] = 0.5 - w;
         weights[n][0] *= weights[n][0];
         weights[n][0] *= (1.0 / 24.0) * weights[n][0];
-        t0 = w * (t - 11.0 / 24.0);
-        t1 = 19.0 / 96.0 + w2 * (0.25 - t);
+        double t0 = w * (t - 11.0 / 24.0);
+        double t1 = 19.0 / 96.0 + w2 * (0.25 - t);
         weights[n][1] = t1 + t0;
         weights[n][3] = t1 - t0;
         weights[n][4] = weights[n][0] + t0 + 0.5 * w;
@@ -251,16 +244,16 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetI
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         /* x */
-        w = x[n] - static_cast<double>(EvaluateIndex[n][2]);
-        w2 = w * w;
+        double w = x[n] - static_cast<double>(EvaluateIndex[n][2]);
+        double w2 = w * w;
         weights[n][5] = (1.0 / 120.0) * w * w2 * w2;
         w2 -= w;
-        w4 = w2 * w2;
+        double w4 = w2 * w2;
         w -= 0.5;
-        t = w2 * (w2 - 3.0);
+        double t = w2 * (w2 - 3.0);
         weights[n][0] = (1.0 / 24.0) * (1.0 / 5.0 + w2 + w4) - weights[n][5];
-        t0 = (1.0 / 24.0) * (w2 * (w2 - 5.0) + 46.0 / 5.0);
-        t1 = (-1.0 / 12.0) * w * (t + 4.0);
+        double t0 = (1.0 / 24.0) * (w2 * (w2 - 5.0) + 46.0 / 5.0);
+        double t1 = (-1.0 / 12.0) * w * (t + 4.0);
         weights[n][2] = t0 + t1;
         weights[n][3] = t0 - t1;
         t0 = (1.0 / 16.0) * (9.0 / 5.0 - t);
@@ -296,17 +289,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
   // the number
   // of switch statement executions to one per routine call.
   // Left as is for now for readability.
-  double w;
-  double w1;
-  double w2;
-  double w3;
-  double w4;
-  double w5;
-  double t;
-  double t0;
-  double t1;
-  double t2;
-  int    derivativeSplineOrder = static_cast<int>(splineOrder) - 1;
+  int derivativeSplineOrder = static_cast<int>(splineOrder) - 1;
 
   switch (derivativeSplineOrder)
   {
@@ -334,9 +317,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] + 0.5 - static_cast<double>(EvaluateIndex[n][1]);
+        double w = x[n] + 0.5 - static_cast<double>(EvaluateIndex[n][1]);
         // w2 = w;
-        w1 = 1.0 - w;
+        double w1 = 1.0 - w;
 
         weights[n][0] = 0.0 - w1;
         weights[n][1] = w1 - w;
@@ -348,10 +331,10 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] + .5 - static_cast<double>(EvaluateIndex[n][2]);
-        w2 = 0.75 - w * w;
-        w3 = 0.5 * (w - w2 + 1.0);
-        w1 = 1.0 - w2 - w3;
+        double w = x[n] + .5 - static_cast<double>(EvaluateIndex[n][2]);
+        double w2 = 0.75 - w * w;
+        double w3 = 0.5 * (w - w2 + 1.0);
+        double w1 = 1.0 - w2 - w3;
 
         weights[n][0] = 0.0 - w1;
         weights[n][1] = w1 - w2;
@@ -364,11 +347,11 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] + 0.5 - static_cast<double>(EvaluateIndex[n][2]);
-        w4 = (1.0 / 6.0) * w * w * w;
-        w1 = (1.0 / 6.0) + 0.5 * w * (w - 1.0) - w4;
-        w3 = w + w1 - 2.0 * w4;
-        w2 = 1.0 - w1 - w3 - w4;
+        double w = x[n] + 0.5 - static_cast<double>(EvaluateIndex[n][2]);
+        double w4 = (1.0 / 6.0) * w * w * w;
+        double w1 = (1.0 / 6.0) + 0.5 * w * (w - 1.0) - w4;
+        double w3 = w + w1 - 2.0 * w4;
+        double w2 = 1.0 - w1 - w3 - w4;
 
         weights[n][0] = 0.0 - w1;
         weights[n][1] = w1 - w2;
@@ -382,18 +365,18 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::SetD
     {
       for (unsigned int n = 0; n < ImageDimension; ++n)
       {
-        w = x[n] + .5 - static_cast<double>(EvaluateIndex[n][3]);
-        t2 = w * w;
-        t = (1.0 / 6.0) * t2;
-        w1 = 0.5 - w;
+        double w = x[n] + .5 - static_cast<double>(EvaluateIndex[n][3]);
+        double t2 = w * w;
+        double t = (1.0 / 6.0) * t2;
+        double w1 = 0.5 - w;
         w1 *= w1;
         w1 *= (1.0 / 24.0) * w1;
-        t0 = w * (t - 11.0 / 24.0);
-        t1 = 19.0 / 96.0 + t2 * (0.25 - t);
-        w2 = t1 + t0;
-        w4 = t1 - t0;
-        w5 = w1 + t0 + 0.5 * w;
-        w3 = 1.0 - w1 - w2 - w4 - w5;
+        double t0 = w * (t - 11.0 / 24.0);
+        double t1 = 19.0 / 96.0 + t2 * (0.25 - t);
+        double w2 = t1 + t0;
+        double w4 = t1 - t0;
+        double w5 = w1 + t0 + 0.5 * w;
+        double w3 = 1.0 - w1 - w2 - w4 - w5;
 
         weights[n][0] = 0.0 - w1;
         weights[n][1] = w1 - w2;
@@ -562,45 +545,37 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::
   // Modify EvaluateIndex at the boundaries using mirror boundary conditions
   this->ApplyMirrorBoundaryConditions((evaluateIndex), m_SplineOrder);
 
-  unsigned int indx;
-  double       tmpV;
-  double       w;
-  double       w1;
-  double       tmpW;
-  IndexType    coefficientIndex;
   value = 0.0;
-  unsigned int p;
-  unsigned int n;
-  unsigned int n1;
   derivativeValue[0] = 0.0;
-  for (p = 0; p < m_MaxNumberInterpolationPoints; ++p)
+  IndexType coefficientIndex;
+  for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
   {
-    indx = m_PointsToIndex[p][0];
+    unsigned int indx = m_PointsToIndex[p][0];
     coefficientIndex[0] = (evaluateIndex)[0][indx];
-    w = (weights)[0][indx];
-    w1 = (weightsDerivative)[0][indx];
-    for (n = 1; n < ImageDimension; ++n)
+    double w = (weights)[0][indx];
+    double w1 = (weightsDerivative)[0][indx];
+    for (unsigned int n = 1; n < ImageDimension; ++n)
     {
       indx = m_PointsToIndex[p][n];
       coefficientIndex[n] = (evaluateIndex)[n][indx];
-      tmpW = (weights)[n][indx];
+      double tmpW = (weights)[n][indx];
       w *= tmpW;
       w1 *= tmpW;
     }
-    tmpV = m_Coefficients->GetPixel(coefficientIndex);
+    double tmpV = m_Coefficients->GetPixel(coefficientIndex);
     value += w * tmpV;
     derivativeValue[0] += w1 * tmpV;
   }
   derivativeValue[0] /= this->GetInputImage()->GetSpacing()[0];
-  for (n = 1; n < ImageDimension; ++n)
+  for (unsigned int n = 1; n < ImageDimension; ++n)
   {
     derivativeValue[n] = 0.0;
-    for (p = 0; p < m_MaxNumberInterpolationPoints; ++p)
+    for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
     {
-      w1 = 1.0;
-      for (n1 = 0; n1 < ImageDimension; ++n1)
+      double w1 = 1.0;
+      for (unsigned int n1 = 0; n1 < ImageDimension; ++n1)
       {
-        indx = m_PointsToIndex[p][n1];
+        unsigned int indx = m_PointsToIndex[p][n1];
         coefficientIndex[n1] = (evaluateIndex)[n1][indx];
 
         if (n1 == n)
@@ -646,14 +621,14 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::Eval
 
   // Calculate derivative
   CovariantVectorType derivativeValue;
-  double              tempValue;
-  IndexType           coefficientIndex;
+
+  IndexType coefficientIndex;
   for (unsigned int n = 0; n < ImageDimension; ++n)
   {
     derivativeValue[n] = 0.0;
     for (unsigned int p = 0; p < m_MaxNumberInterpolationPoints; ++p)
     {
-      tempValue = 1.0;
+      double tempValue = 1.0;
       for (unsigned int n1 = 0; n1 < ImageDimension; ++n1)
       {
         unsigned int indx = m_PointsToIndex[p][n1];

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -408,35 +408,23 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcPl
         break;
     }
 
-    double line1x;
-    double line1y;
-    double line1z;
-    double line2x;
-    double line2y;
-    double line2z;
-
     // lines from one corner to another in x,y,z dirns
-    line1x = m_BoundingCorner[c1][0] - m_BoundingCorner[c2][0];
-    line2x = m_BoundingCorner[c1][0] - m_BoundingCorner[c3][0];
+    double line1x = m_BoundingCorner[c1][0] - m_BoundingCorner[c2][0];
+    double line2x = m_BoundingCorner[c1][0] - m_BoundingCorner[c3][0];
 
-    line1y = m_BoundingCorner[c1][1] - m_BoundingCorner[c2][1];
-    line2y = m_BoundingCorner[c1][1] - m_BoundingCorner[c3][1];
+    double line1y = m_BoundingCorner[c1][1] - m_BoundingCorner[c2][1];
+    double line2y = m_BoundingCorner[c1][1] - m_BoundingCorner[c3][1];
 
-    line1z = m_BoundingCorner[c1][2] - m_BoundingCorner[c2][2];
-    line2z = m_BoundingCorner[c1][2] - m_BoundingCorner[c3][2];
-
-    double A;
-    double B;
-    double C;
-    double D;
+    double line1z = m_BoundingCorner[c1][2] - m_BoundingCorner[c2][2];
+    double line2z = m_BoundingCorner[c1][2] - m_BoundingCorner[c3][2];
 
     // take cross product
-    A = line1y * line2z - line2y * line1z;
-    B = line2x * line1z - line1x * line2z;
-    C = line1x * line2y - line2x * line1y;
+    double A = line1y * line2z - line2y * line1z;
+    double B = line2x * line1z - line1x * line2z;
+    double C = line1x * line2y - line2x * line1y;
 
     // find constant
-    D = -(A * m_BoundingCorner[c1][0] + B * m_BoundingCorner[c1][1] + C * m_BoundingCorner[c1][2]);
+    double D = -(A * m_BoundingCorner[c1][0] + B * m_BoundingCorner[c1][1] + C * m_BoundingCorner[c1][2]);
 
     // initialise plane value and normalise
     m_BoundingPlane[j][0] = A / std::sqrt(A * A + B * B + C * C);
@@ -463,15 +451,13 @@ template <typename TInputImage, typename TCoordinate>
 bool
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcRayIntercepts()
 {
-  bool   noInterceptFlag[6];
-  double cubeIntercepts[6][3];
-
   constexpr unsigned int numSides = 6; // =6 to allow truncation: =4 to remove truncated rays
 
   // Calculate intercept of ray with planes
   double interceptx[6];
   double intercepty[6];
   double interceptz[6];
+  bool   noInterceptFlag[6];
   for (unsigned int j = 0; j < numSides; ++j)
   {
     const double denom =
@@ -497,6 +483,7 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcRa
     }
   }
 
+  double       cubeIntercepts[6][3];
   unsigned int nSidesCrossed = 0;
   for (unsigned int j = 0; j < numSides; ++j)
   {
@@ -767,15 +754,10 @@ template <typename TInputImage, typename TCoordinate>
 void
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcDirnVector()
 {
-  double xNum;
-  double yNum;
-  double zNum;
-
   // Calculate the number of voxels in each direction
-
-  xNum = itk::Math::abs(m_RayVoxelStartPosition[0] - m_RayVoxelEndPosition[0]);
-  yNum = itk::Math::abs(m_RayVoxelStartPosition[1] - m_RayVoxelEndPosition[1]);
-  zNum = itk::Math::abs(m_RayVoxelStartPosition[2] - m_RayVoxelEndPosition[2]);
+  double xNum = itk::Math::abs(m_RayVoxelStartPosition[0] - m_RayVoxelEndPosition[0]);
+  double yNum = itk::Math::abs(m_RayVoxelStartPosition[1] - m_RayVoxelEndPosition[1]);
+  double zNum = itk::Math::abs(m_RayVoxelStartPosition[2] - m_RayVoxelEndPosition[2]);
 
   // The direction iterated in is that with the greatest number of voxels
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -917,12 +899,9 @@ template <typename TInputImage, typename TCoordinate>
 bool
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::AdjustRayLength()
 {
-  bool startOK;
-  bool endOK;
 
-  int Istart[3];
+
   int Idirn[3];
-
   if (m_TraversalDirection == TraversalDirectionEnum::TRANSVERSE_IN_X)
   {
     Idirn[0] = 0;
@@ -951,6 +930,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Adjust
     return false;
   }
 
+  int  Istart[3];
+  bool startOK;
+  bool endOK;
   do
   {
     startOK = false;
@@ -1004,15 +986,13 @@ template <typename TInputImage, typename TCoordinate>
 void
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset()
 {
-  int i;
-
   m_NumVoxelPlanesTraversed = -1;
 
   // If this is a valid ray...
 
   if (m_ValidRay)
   {
-    for (i = 0; i < 3; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       m_Position3Dvox[i] = m_RayVoxelStartPosition[i];
     }
@@ -1023,15 +1003,15 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset(
 
   else
   {
-    for (i = 0; i < 3; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       m_RayVoxelStartPosition[i] = 0.;
     }
-    for (i = 0; i < 3; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       m_RayVoxelEndPosition[i] = 0.;
     }
-    for (i = 0; i < 3; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       m_VoxelIncrement[i] = 0.;
     }
@@ -1039,11 +1019,11 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset(
 
     m_TotalRayVoxelPlanes = 0;
 
-    for (i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
       m_RayIntersectionVoxels[i] = nullptr;
     }
-    for (i = 0; i < 3; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       m_RayIntersectionVoxelIndex[i] = 0;
     }
@@ -1058,20 +1038,15 @@ template <typename TInputImage, typename TCoordinate>
 void
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::InitialiseVoxelPointers()
 {
-  IndexType index;
-
-  int Ix;
-  int Iy;
-  int Iz;
-
-  Ix = static_cast<int>(m_RayVoxelStartPosition[0]);
-  Iy = static_cast<int>(m_RayVoxelStartPosition[1]);
-  Iz = static_cast<int>(m_RayVoxelStartPosition[2]);
+  int Ix = static_cast<int>(m_RayVoxelStartPosition[0]);
+  int Iy = static_cast<int>(m_RayVoxelStartPosition[1]);
+  int Iz = static_cast<int>(m_RayVoxelStartPosition[2]);
 
   m_RayIntersectionVoxelIndex[0] = Ix;
   m_RayIntersectionVoxelIndex[1] = Iy;
   m_RayIntersectionVoxelIndex[2] = Iz;
 
+  IndexType index;
   switch (m_TraversalDirection)
   {
     case TraversalDirectionEnum::TRANSVERSE_IN_X:
@@ -1224,22 +1199,17 @@ template <typename TInputImage, typename TCoordinate>
 double
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::GetCurrentIntensity() const
 {
-  double a;
-  double b;
-  double c;
-  double d;
-  double y;
-  double z;
-
   if (!m_ValidRay)
   {
     return 0;
   }
-  a = static_cast<double>(*m_RayIntersectionVoxels[0]);
-  b = static_cast<double>(*m_RayIntersectionVoxels[1] - a);
-  c = static_cast<double>(*m_RayIntersectionVoxels[2] - a);
-  d = static_cast<double>(*m_RayIntersectionVoxels[3] - a - b - c);
+  double a = static_cast<double>(*m_RayIntersectionVoxels[0]);
+  double b = static_cast<double>(*m_RayIntersectionVoxels[1] - a);
+  double c = static_cast<double>(*m_RayIntersectionVoxels[2] - a);
+  double d = static_cast<double>(*m_RayIntersectionVoxels[3] - a - b - c);
 
+  double y;
+  double z;
   switch (m_TraversalDirection)
   {
     case TraversalDirectionEnum::TRANSVERSE_IN_X:
@@ -1282,8 +1252,6 @@ bool
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::IntegrateAboveThreshold(double & integral,
                                                                                                   double   threshold)
 {
-  double intensity;
-
   //  double posn3D_x, posn3D_y, posn3D_z;
 
   CompensatedSummationType sum;
@@ -1299,7 +1267,7 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Integr
 
   for (m_NumVoxelPlanesTraversed = 0; m_NumVoxelPlanesTraversed < m_TotalRayVoxelPlanes; ++m_NumVoxelPlanesTraversed)
   {
-    intensity = this->GetCurrentIntensity();
+    double intensity = this->GetCurrentIntensity();
 
     if (intensity > threshold)
     {
@@ -1326,8 +1294,6 @@ template <typename TInputImage, typename TCoordinate>
 void
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroState()
 {
-  int i;
-
   m_ValidRay = false;
 
   m_NumberOfVoxelsInX = 0;
@@ -1338,23 +1304,23 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
   m_VoxelDimensionInY = 0;
   m_VoxelDimensionInZ = 0;
 
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_CurrentRayPositionInMM[i] = 0.;
   }
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_RayDirectionInMM[i] = 0.;
   }
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_RayVoxelStartPosition[i] = 0.;
   }
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_RayVoxelEndPosition[i] = 0.;
   }
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_VoxelIncrement[i] = 0.;
   }
@@ -1363,11 +1329,11 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
   m_TotalRayVoxelPlanes = 0;
   m_NumVoxelPlanesTraversed = -1;
 
-  for (i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
   {
     m_RayIntersectionVoxels[i] = nullptr;
   }
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     m_RayIntersectionVoxelIndex[i] = 0;
   }

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -780,24 +780,21 @@ set3DDerivativeData(ImageType3D::Pointer imgPtr)
   // df(x)/dx = 0.4x^3 - 1.5x^2 + 2
   // df(y)/dy = 5
   // df(z)/dz = -4z - 6
-  double      value;
-  double      slice1;
-  double      row1;
-  double      col1;
+
   IndexType3D index;
   for (unsigned int slice = 0; slice < size[2]; ++slice)
   {
     index[2] = slice;
-    slice1 = slice - 20.0; // Center offset
+    double slice1 = slice - 20.0; // Center offset
     for (unsigned int row = 0; row < size[1]; ++row)
     {
       index[1] = row;
-      row1 = row - 20.0; // Center
+      double row1 = row - 20.0; // Center
       for (unsigned int col = 0; col < size[0]; ++col)
       {
         index[0] = col;
-        col1 = col - 20.0; // Center
-        value = 0.1 * col1 * col1 * col1 * col1 - 0.5 * col1 * col1 * col1 + 2.0 * col1 - 43.0;
+        double col1 = col - 20.0; // Center
+        double value = 0.1 * col1 * col1 * col1 * col1 - 0.5 * col1 * col1 * col1 + 2.0 * col1 - 43.0;
         value += 5.0 * row1 + 7.0;
         value += -2.0 * slice1 * slice1 - 6.0 * slice1 + 10.0;
         imgPtr->SetPixel(index, value);

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -282,17 +282,16 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier  
     auto foundIt3 = std::find(list->begin(), list->end(), neighborArray[2]);
     auto endIt = list->end();
     bool found1 = false;
-    bool found2 = false;
-    bool found3 = false;
-
     if (foundIt1 != endIt)
     {
       found1 = true;
     }
+    bool found2 = false;
     if (foundIt2 != endIt)
     {
       found2 = true;
     }
+    bool found3 = false;
     if (foundIt3 != endIt)
     {
       found3 = true;
@@ -365,11 +364,10 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SwapNeighbors(PointIdentifier 
                                                                 PointIdentifier secondIdx)
 {
   SimplexMeshGeometry * data = m_GeometryData->GetElement(pointIdx);
-  int                   i;
   int                   firstFound = -1;
   int                   secondFound = -1;
 
-  for (i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     if (data->neighborIndices[i] == firstIdx)
     {
@@ -393,13 +391,12 @@ auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier idx) const -> CovariantVectorType
 {
   PointType p;
-  PointType n1;
-  PointType n2;
-  PointType n3;
-
   p.Fill(0);
+  PointType n1;
   n1.Fill(0);
+  PointType n2;
   n2.Fill(0);
+  PointType n3;
   n3.Fill(0);
 
   IndexArray neighbors = this->GetNeighbors(idx);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -138,15 +138,13 @@ public:
       val = mesh->GetMeanCurvature(*it++);
       meanCurvature += itk::Math::abs(val);
 
-      PointIdentifier id2;
-
       double area = 0;
 
       int cnt = 0;
 
       while (it != poly->PointIdsEnd())
       {
-        id2 = *it;
+        PointIdentifier id2 = *it;
         area += ComputeArea(refPoint, id1, id2);
         id1 = id2;
         val = mesh->GetMeanCurvature(*it);
@@ -184,11 +182,10 @@ public:
     ComputeArea(PointIdentifier p1, PointIdentifier p2, PointIdentifier p3)
     {
       InputPointType v1;
-      InputPointType v2;
-      InputPointType v3;
-
       v1.Fill(0);
+      InputPointType v2;
       v2.Fill(0);
+      InputPointType v3;
       v3.Fill(0);
 
       mesh->GetPoint(p1, &v1);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -182,16 +182,16 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
       PointIdentifier secondNewIndex = newPointId + 1;
 
       // create first new point
-      InputPointType newMidPoint;
-      InputPointType helperPoint;
       InputPointType p1;
-      InputPointType p2;
       p1.Fill(0);
+      InputPointType p2;
       p2.Fill(0);
       outputMesh->GetPoint(lineOneFirstIdx, &p1);
       outputMesh->GetPoint(lineOneSecondIdx, &p2);
 
+      InputPointType helperPoint;
       helperPoint.SetToMidPoint(p1, p2);
+      InputPointType newMidPoint;
       newMidPoint.SetToMidPoint(helperPoint, cellCenter);
 
       outputMesh->SetPoint(firstNewIndex, newMidPoint);
@@ -400,11 +400,9 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(Input
   OutputMeshPointer           outputMesh = this->GetOutput();
   InputPolygonPointIdIterator pointIt = simplexCell->PointIdsBegin();
 
-  InputVectorType tmp;
-  InputPointType  p1;
-  InputPointType  cellCenter;
-
+  InputPointType p1;
   p1.Fill(0);
+  InputPointType cellCenter;
   cellCenter.Fill(0);
 
   // compute the cell center first
@@ -415,6 +413,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(Input
     ++pointIt;
   }
 
+  InputVectorType tmp;
   tmp.SetVnlVector(cellCenter.GetVnlVector() / simplexCell->GetNumberOfPoints());
   cellCenter.Fill(0.0);
   cellCenter += tmp;

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -48,10 +48,7 @@ template <typename TInputMesh, typename TOutputMesh>
 void
 SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::CreateTriangles()
 {
-  auto                                   meshSource = AutoMeshSourceType::New();
-  typename AutoMeshSourceType::PointType p1;
-  typename AutoMeshSourceType::PointType p2;
-  typename AutoMeshSourceType::PointType p3;
+  auto meshSource = AutoMeshSourceType::New();
 
   typename TInputMesh::ConstPointer                 inputMesh = this->GetInput(0);
   typename InputPointsContainer::ConstPointer       points = inputMesh->GetPoints();
@@ -67,9 +64,12 @@ SimplexMeshToTriangleMeshFilter<TInputMesh, TOutputMesh>::CreateTriangles()
     CellIdentifier newId2 = FindCellId(n[1], pointsIt.Index(), n[2]);
     CellIdentifier newId3 = FindCellId(n[2], pointsIt.Index(), n[0]);
 
-    bool b1 = m_Centers->GetElementIfIndexExists(newId1, &p1);
-    bool b2 = m_Centers->GetElementIfIndexExists(newId2, &p2);
-    bool b3 = m_Centers->GetElementIfIndexExists(newId3, &p3);
+    typename AutoMeshSourceType::PointType p1;
+    bool                                   b1 = m_Centers->GetElementIfIndexExists(newId1, &p1);
+    typename AutoMeshSourceType::PointType p2;
+    bool                                   b2 = m_Centers->GetElementIfIndexExists(newId2, &p2);
+    typename AutoMeshSourceType::PointType p3;
+    bool                                   b3 = m_Centers->GetElementIfIndexExists(newId3, &p3);
 
     meshSource->AddTriangle(p1, p2, p3);
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -122,8 +122,8 @@ public:
       using PointIdIterator = typename SimplexPolygonType::PointIdIterator;
       PointIdIterator it = poly->PointIdsBegin();
       InputPointType  center;
-      InputPointType  p;
       center.Fill(0);
+      InputPointType p;
       p.Fill(0.0);
 
       while (it != poly->PointIdsEnd())

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -97,26 +97,11 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
                                                                  InputPointType p2,
                                                                  InputPointType p3)
 {
-  double area;
-  double a;
-  double b;
-  double c;
-  double s;
+  // Get i j k vectors ...
+  //
   double i[3];
   double j[3];
   double k[3];
-  double u[3];
-  double absu[3];
-  double length;
-  double ii[3];
-  double jj[3];
-  double kk[3];
-  double xavg;
-  double yavg;
-  double zavg;
-
-  // Get i j k vectors ...
-  //
   i[0] = (p2[0] - p1[0]);
   j[0] = (p2[1] - p1[1]);
   k[0] = (p2[2] - p1[2]);
@@ -129,13 +114,14 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
 
   // Cross product between two vectors, to determine normal vector
   //
+  double u[3];
   u[0] = (j[0] * k[1] - k[0] * j[1]);
   u[1] = (k[0] * i[1] - i[0] * k[1]);
   u[2] = (i[0] * j[1] - j[0] * i[1]);
 
   // Normalize normal
   //
-  length = std::sqrt(u[0] * u[0] + u[1] * u[1] + u[2] * u[2]);
+  double length = std::sqrt(u[0] * u[0] + u[1] * u[1] + u[2] * u[2]);
   if (length != 0.0)
   {
     u[0] /= length;
@@ -149,6 +135,8 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
 
   // Determine max unit normal component...
   //
+
+  double absu[3];
   absu[0] = itk::Math::abs(u[0]);
   absu[1] = itk::Math::abs(u[1]);
   absu[2] = itk::Math::abs(u[2]);
@@ -188,6 +176,10 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
 
   // This is reduced to ...
   //
+
+  double ii[3];
+  double jj[3];
+  double kk[3];
   ii[0] = i[0] * i[0];
   ii[1] = i[1] * i[1];
   ii[2] = i[2] * i[2];
@@ -200,17 +192,17 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
 
   // Area of a triangle using Heron's formula...
   //
-  a = std::sqrt(ii[1] + jj[1] + kk[1]);
-  b = std::sqrt(ii[0] + jj[0] + kk[0]);
-  c = std::sqrt(ii[2] + jj[2] + kk[2]);
-  s = 0.5 * (a + b + c);
-  area = std::sqrt(itk::Math::abs(s * (s - a) * (s - b) * (s - c)));
+  double a = std::sqrt(ii[1] + jj[1] + kk[1]);
+  double b = std::sqrt(ii[0] + jj[0] + kk[0]);
+  double c = std::sqrt(ii[2] + jj[2] + kk[2]);
+  double s = 0.5 * (a + b + c);
+  double area = std::sqrt(itk::Math::abs(s * (s - a) * (s - b) * (s - c)));
 
   // Volume elements ...
   //
-  zavg = (p1[2] + p2[2] + p3[2]) / 3.0;
-  yavg = (p1[1] + p2[1] + p3[1]) / 3.0;
-  xavg = (p1[0] + p2[0] + p3[0]) / 3.0;
+  double zavg = (p1[2] + p2[2] + p3[2]) / 3.0;
+  double yavg = (p1[1] + p2[1] + p3[1]) / 3.0;
+  double xavg = (p1[0] + p2[0] + p3[0]) / 3.0;
 
   m_VolumeX += (area * static_cast<double>(u[2]) * static_cast<double>(zavg));
   m_VolumeY += (area * static_cast<double>(u[1]) * static_cast<double>(yavg));
@@ -228,10 +220,10 @@ SimplexMeshVolumeCalculator<TInputMesh>::Compute()
   this->Initialize();
 
   InputPointType p1;
-  InputPointType p2;
-  InputPointType p3;
   p1.Fill(0.0);
+  InputPointType p2;
   p2.Fill(0.0);
+  InputPointType p3;
   p3.Fill(0.0);
 
   InputPointsContainerPointer  Points = m_SimplexMesh->GetPoints();

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -49,28 +49,14 @@ template <typename TOutputMesh>
 void
 SphereMeshSource<TOutputMesh>::GenerateData()
 {
-  IdentifierType i;
-  IdentifierType j;
-  IdentifierType jn;
-  IdentifierType p;
-  IdentifierType numpts;
-  double         ustep;
-  double         vstep;
-  double         ubeg;
-  double         vbeg;
-  double         u;
-  double         v;
-  int            signu;
-  int            signv;
-
   // calculate the number os cells and points
-  numpts = m_ResolutionX * m_ResolutionY + 2;
+  IdentifierType numpts = m_ResolutionX * m_ResolutionY + 2;
 
   // calculate the steps using resolution
-  ustep = itk::Math::pi / (m_ResolutionX + 1);
-  vstep = 2.0 * itk::Math::pi / m_ResolutionY;
-  ubeg = (-itk::Math::pi / 2.0) + ustep;
-  vbeg = -itk::Math::pi;
+  double ustep = itk::Math::pi / (m_ResolutionX + 1);
+  double vstep = 2.0 * itk::Math::pi / m_ResolutionY;
+  double ubeg = (-itk::Math::pi / 2.0) + ustep;
+  double vbeg = -itk::Math::pi;
 
   ///////////////////////////////////////////////////////////////////////////
   // nodes allocation
@@ -93,10 +79,13 @@ SphereMeshSource<TOutputMesh>::GenerateData()
   // calculate all regular nodes
   while (point != myPoints->End())
   {
-    for (u = ubeg, i = 0; i < m_ResolutionX; u += ustep, i++)
+    double u = ubeg;
+    for (IdentifierType i = 0; i < m_ResolutionX; u += ustep, i++)
     {
-      for (v = vbeg, j = 0; j < m_ResolutionY; v += vstep, j++)
+      double v = vbeg;
+      for (IdentifierType j = 0; j < m_ResolutionY; v += vstep, j++)
       {
+        int signu;
         if (std::cos(u) > 0)
         {
           signu = 1;
@@ -105,6 +94,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
         {
           signu = -1;
         }
+        int signv;
         if (std::cos(v) > 0)
         {
           signv = 1;
@@ -178,7 +168,8 @@ SphereMeshSource<TOutputMesh>::GenerateData()
 
   ///////////////////////////////////////////////////////////////////////////
   // cells allocation
-  p = 0;
+
+  IdentifierType p = 0;
 
   // store all regular cells
   CellAutoPointer testCell;
@@ -186,7 +177,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
   {
     for (unsigned int jj = 0; jj < m_ResolutionY; ++jj)
     {
-      jn = (jj + 1) % m_ResolutionY;
+      IdentifierType jn = (jj + 1) % m_ResolutionY;
       tripoints[0] = ii * m_ResolutionY + jj;
       tripoints[1] = tripoints[0] - jj + jn;
       tripoints[2] = tripoints[0] + m_ResolutionY;
@@ -208,7 +199,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
   // store cells containing the south pole nodes
   for (unsigned int jj = 0; jj < m_ResolutionY; ++jj)
   {
-    jn = (jj + 1) % m_ResolutionY;
+    IdentifierType jn = (jj + 1) % m_ResolutionY;
     tripoints[0] = numpts - 2;
     tripoints[1] = jn;
     tripoints[2] = jj;
@@ -222,7 +213,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
   // store cells containing the north pole nodes
   for (unsigned int jj = 0; jj < m_ResolutionY; ++jj)
   {
-    jn = (jj + 1) % m_ResolutionY;
+    IdentifierType jn = (jj + 1) % m_ResolutionY;
     tripoints[2] = (m_ResolutionX - 1) * m_ResolutionY + jj;
     tripoints[1] = numpts - 1;
     tripoints[0] = tripoints[2] - jj + jn;

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -76,14 +76,6 @@ template <typename TInputMesh>
 void
 TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMeshType * inputMesh)
 {
-  MeshPointType e0;
-  MeshPointType e1;
-  MeshPointType e2;
-  double        A;
-  double        alpha0;
-  double        alpha1;
-  double        alpha2;
-
   const unsigned int numberOfPoints = inputMesh->GetNumberOfPoints();
 
   const auto K = make_unique_for_overwrite<double[]>(numberOfPoints);
@@ -112,6 +104,7 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
     MeshPointType v2 = inputMesh->GetPoint(point_ids[2]);
 
     // Edges
+    MeshPointType e0;
     e0[0] = v1[0];
     e0[1] = v1[1];
     e0[2] = v1[2];
@@ -119,6 +112,7 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
     e0[1] -= v0[1];
     e0[2] -= v0[2];
 
+    MeshPointType e1;
     e1[0] = v2[0];
     e1[1] = v2[1];
     e1[2] = v2[2];
@@ -126,6 +120,7 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
     e1[1] -= v1[1];
     e1[2] -= v1[2];
 
+    MeshPointType e2;
     e2[0] = v0[0];
     e2[1] = v0[1];
     e2[2] = v0[2];
@@ -133,12 +128,12 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
     e2[1] -= v2[1];
     e2[2] -= v2[2];
 
-    alpha0 = itk::Math::pi - angle(e1.GetVnlVector(), e2.GetVnlVector());
-    alpha1 = itk::Math::pi - angle(e2.GetVnlVector(), e0.GetVnlVector());
-    alpha2 = itk::Math::pi - angle(e0.GetVnlVector(), e1.GetVnlVector());
+    double alpha0 = itk::Math::pi - angle(e1.GetVnlVector(), e2.GetVnlVector());
+    double alpha1 = itk::Math::pi - angle(e2.GetVnlVector(), e0.GetVnlVector());
+    double alpha2 = itk::Math::pi - angle(e0.GetVnlVector(), e1.GetVnlVector());
 
     // Surface area
-    A = static_cast<double>(
+    double A = static_cast<double>(
       itk::Math::abs(vnl_cross_3d((v1 - v0).GetVnlVector(), (v2 - v0).GetVnlVector()).two_norm() / 2.0));
 
     dA[point_ids[0]] += A;

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -76,7 +76,6 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::Initialize()
   InputPointType v1;
   InputPointType v2;
   InputPointType v3;
-
   for (unsigned int idx1 = 0; idx1 < m_IdOffset; ++idx1)
   {
     m_FaceSet->insert(idx1);
@@ -161,10 +160,6 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateSimplexNeighbors
   OutputPointsContainerPointer  outputPointsContainer = output->GetPoints();
   OutputPointsContainerIterator points = outputPointsContainer->Begin();
 
-  CellIdentifier tp0;
-  CellIdentifier tp1;
-  CellIdentifier tp2;
-
   InputBoundaryAssignmentsContainerPointer cntlines = this->GetInput(0)->GetBoundaryAssignments(1);
 
   while (points != outputPointsContainer->End())
@@ -174,9 +169,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateSimplexNeighbors
     InputBoundnaryAssignmentIdentifier key1(idx, 1);
     InputBoundnaryAssignmentIdentifier key2(idx, 2);
 
-    tp0 = cntlines->GetElement(key0);
-    tp1 = cntlines->GetElement(key1);
-    tp2 = cntlines->GetElement(key2);
+    CellIdentifier tp0 = cntlines->GetElement(key0);
+    CellIdentifier tp1 = cntlines->GetElement(key1);
+    CellIdentifier tp2 = cntlines->GetElement(key2);
 
     CreateEdgeForTrianglePair(idx, tp0, output);
     CreateEdgeForTrianglePair(idx, tp1, output);
@@ -304,14 +299,13 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
   const InputPointsContainer *      pointsContainer = this->GetInput(0)->GetPoints();
   InputPointsContainerConstIterator points = pointsContainer->Begin();
   TOutputMesh *                     outputMesh = this->GetOutput();
-  PointIdentifier                   idx;
 
   using MapType = itk::MapContainer<CellIdentifier, CellIdentifier>;
 
   while (points != pointsContainer->End())
   {
-    idx = points.Index();
-    IndexSetType vertexNeighbors = m_VertexNeighborList->GetElement(idx);
+    PointIdentifier idx = points.Index();
+    IndexSetType    vertexNeighbors = m_VertexNeighborList->GetElement(idx);
 
     auto iterator1 = vertexNeighbors.begin();
 
@@ -409,22 +403,20 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::ComputeFaceCenter(Cell
                                                                             const InputMeshType * inputMesh)
   -> InputPointType
 {
-  InputPointType v1;
-  InputPointType v2;
-  InputPointType v3;
-
   CellAutoPointer cellPointer;
-
   inputMesh->GetCell(faceId, cellPointer);
   const PointIdentifier * tp = cellPointer->GetPointIds();
+  InputPointType          v1;
   if (!inputMesh->GetPoint(tp[0], &v1))
   {
     itkExceptionMacro("Point with id " << tp[0] << " does not exist in the input mesh");
   }
+  InputPointType v2;
   if (!inputMesh->GetPoint(tp[1], &v2))
   {
     itkExceptionMacro("Point with id " << tp[1] << " does not exist in the input mesh");
   }
+  InputPointType v3;
   if (!inputMesh->GetPoint(tp[2], &v3))
   {
     itkExceptionMacro("Point with id " << tp[2] << " does not exist in the input mesh");

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -61,17 +61,15 @@ SimplexMeshGeometry::~SimplexMeshGeometry()
 void
 SimplexMeshGeometry::ComputeGeometry()
 {
-  VectorType b;
-  VectorType c;
-  VectorType cXb;
-  VectorType tmp;
 
   // compute the circum circle (center and radius)
-  b = this->neighbors[2] - this->neighbors[0];
-  c = this->neighbors[1] - this->neighbors[0];
+  VectorType b = this->neighbors[2] - this->neighbors[0];
+  VectorType c = this->neighbors[1] - this->neighbors[0];
 
+  VectorType cXb;
   cXb.SetVnlVector(vnl_cross_3d<double>(c.GetVnlVector(), b.GetVnlVector()));
 
+  VectorType tmp;
   tmp.SetVnlVector(b.GetSquaredNorm() * vnl_cross_3d<double>(cXb.GetVnlVector(), c.GetVnlVector()) +
                    c.GetSquaredNorm() * vnl_cross_3d<double>(b.GetVnlVector(), cXb.GetVnlVector()));
 
@@ -84,15 +82,13 @@ SimplexMeshGeometry::ComputeGeometry()
   circleCenter = this->neighbors[0] + tmp;
 
   // Compute the circum sphere (center and radius) of a point
-  VectorType d;
+  VectorType d = pos - this->neighbors[0];
   VectorType dXc;
-  VectorType bXd;
-  VectorType sphereTmp;
-
-  d = pos - this->neighbors[0];
   dXc.SetVnlVector(vnl_cross_3d<double>(d.GetVnlVector(), c.GetVnlVector()));
+  VectorType bXd;
   bXd.SetVnlVector(vnl_cross_3d<double>(b.GetVnlVector(), d.GetVnlVector()));
 
+  VectorType sphereTmp;
   sphereTmp.SetVnlVector(d.GetSquaredNorm() * cXb.GetVnlVector() + b.GetSquaredNorm() * dXc.GetVnlVector() +
                          c.GetSquaredNorm() * bXd.GetVnlVector());
 

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -89,17 +89,12 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   image->Allocate();
   image->FillBuffer(backgroundValue);
 
-  unsigned int i;
-  unsigned int j;
-  unsigned int k;
-  unsigned int l;
-
   for (unsigned char counter = 0; counter < 18; ++counter)
   {
-    i = (counter / 1) % 2; // 0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1.
-    j = (counter / 2) % 2; // 0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1.
-    k = (counter / 4) % 2; // 0,0,0,0,1,1,1,1,0,0,0,0,1,1,1,1.
-    l = (counter / 8) % 2; // 0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1.
+    unsigned int i = (counter / 1) % 2; // 0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1.
+    unsigned int j = (counter / 2) % 2; // 0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1.
+    unsigned int k = (counter / 4) % 2; // 0,0,0,0,1,1,1,1,0,0,0,0,1,1,1,1.
+    unsigned int l = (counter / 8) % 2; // 0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1.
     Create16CubeConfig(image, 0, 0, 3 * counter, i, j, k, l);
   }
 

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -113,8 +113,8 @@ itkQuadrilateralCellTest(int, char *[])
    * different types of cells.
    */
   CellAutoPointer testCell1;
-  CellAutoPointer testCell2;
   testCell1.TakeOwnership(new QuadrilateralHelper); // polymorphism
+  CellAutoPointer testCell2;
   testCell2.TakeOwnership(new QuadrilateralHelper); // polymorphism
   // List the points that the polygon will use from the mesh.
   MeshType::PointIdentifier polygon1Points1[4] = { 1, 3, 2, 0 };
@@ -147,18 +147,11 @@ itkQuadrilateralCellTest(int, char *[])
   //
   // Test the EvaluatePosition() method of the QuadrilateralCell
   //
-  QuadrilateralCellType::CoordinateType          inputPoint[3];
-  QuadrilateralCellType::PointsContainer *       points = mesh->GetPoints();
-  QuadrilateralCellType::CoordinateType          closestPoint[3];
-  QuadrilateralCellType::CoordinateType          pcoords[2]; // Quadrilateral has 2 parametric coordinates
-  double                                         distance;
-  QuadrilateralCellType::InterpolationWeightType weights[4];
+  QuadrilateralCellType::PointsContainer * points = mesh->GetPoints();
 
   const double toleance = 1e-5;
-
-  bool isInside;
-
   // Test 1:  point on quad1
+  QuadrilateralCellType::CoordinateType inputPoint[3];
   inputPoint[0] = 4.0;
   inputPoint[1] = 4.0;
   inputPoint[2] = 3.0; // point on plane
@@ -168,7 +161,11 @@ itkQuadrilateralCellTest(int, char *[])
   std::cout << inputPoint[1] << ", ";
   std::cout << inputPoint[2] << std::endl;
 
-  isInside = testCell1->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);
+  QuadrilateralCellType::CoordinateType            closestPoint[3];
+  double                                         distance;
+  QuadrilateralCellType::InterpolationWeightType weights[4];
+  QuadrilateralCellType::CoordinateType            pcoords[2]; // Quadrilateral has 2 parametric coordinates
+  bool isInside = testCell1->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);
 
   if (!isInside)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
@@ -65,9 +65,9 @@ QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
   // from collapsing a volume into two facets glued together with opposite
   // orientations, such as would happen with any vertex of a tetrahedron.)
   PointIdentifier PointId1;
-  PointIdentifier PointId2;
   PointId1 = pList.back();
   pList.pop_back();
+  PointIdentifier PointId2;
   PointId2 = pList.back();
   pList.pop_back();
   FaceRefType FirstFace = this->m_Mesh->FindEdge(PointId1, PointId2)->GetLeft();

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
@@ -29,26 +29,29 @@ itkQuadEdgeMeshDeleteEdgeTest(int, char *[])
 
   // Points
   MeshType::PointType p0;
-  MeshType::PointType p1;
-  MeshType::PointType p2;
-  MeshType::PointType p3;
-  MeshType::PointType p4;
-  MeshType::PointType p5;
+
   p0[0] = 0.00000000000000;
   p0[1] = 0.00000000000000;
   p0[2] = 5.0;
+  MeshType::PointType p1;
   p1[0] = 0.00000000000000;
   p1[1] = 10.00000000000000;
   p1[2] = 0.0;
+
+  MeshType::PointType p2;
   p2[0] = -9.51056516295153;
   p2[1] = 3.09016994374947;
   p2[2] = 0.0;
+  MeshType::PointType p3;
   p3[0] = -5.87785252292473;
   p3[1] = -8.09016994374947;
   p3[2] = 0.0;
+
+  MeshType::PointType p4;
   p4[0] = 5.87785252292473;
   p4[1] = -8.09016994374948;
   p4[2] = 0.0;
+  MeshType::PointType p5;
   p5[0] = 9.51056516295154;
   p5[1] = 3.09016994374947;
   p5[2] = 0.0;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -100,12 +100,10 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
   }
   else
   {
-    PointType                               p1;
-    PointType                               p2;
-    DerivativeVectorType                    v1;
-    DerivativeVectorType                    v2;
     typename DerivativeVectorType::Iterator it = value.Begin();
+    DerivativeVectorType                    v1;
     auto                                    it_v1 = v1.cbegin();
+    DerivativeVectorType                    v2;
     auto                                    it_v2 = v2.cbegin();
 
     DerivativeOffsetType offsetDiv2;
@@ -115,8 +113,8 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
     }
     for (unsigned short i = 0; i < TDimension; i++, it++, it_v1++, it_v2++)
     {
-      p1 = point;
-      p2 = point;
+      PointType p1 = point;
+      PointType p2 = point;
 
       p1[i] -= offset[i];
       p2[i] += offset[i];

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -61,12 +61,9 @@ SpatialObjectDuplicator<TInputSpatialObject>::Update()
   }
 
   // Update only if the input SpatialObject has been modified
-  ModifiedTimeType t;
-  ModifiedTimeType t1;
-  ModifiedTimeType t2;
-  t1 = m_Input->GetPipelineMTime();
-  t2 = m_Input->GetMTime();
-  t = (t1 > t2 ? t1 : t2);
+  ModifiedTimeType t1 = m_Input->GetPipelineMTime();
+  ModifiedTimeType t2 = m_Input->GetMTime();
+  ModifiedTimeType t = (t1 > t2 ? t1 : t2);
 
   if (t == m_InternalSpatialObjectTime)
   {

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -41,12 +41,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  Vector axis;
-  Vector translation;
-  Point  in;
-  Point  out;
-  double angle;
-  bool   passed = true;
+  bool passed = true;
 
   //======================================
   // testing of a single SpatialObject...
@@ -84,8 +79,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   tube1->SetPoints(list);
   tube1->Update();
-
+  Point in;
   in.Fill(15);
+  Point out;
   out.Fill(5);
 
   std::cout << "IsInside()...";
@@ -301,13 +297,15 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[PASSED]" << std::endl;
   }
 
+  Vector translation;
   translation.Fill(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
+  Vector axis;
   axis.Fill(0);
   axis[1] = 1;
-  angle = itk::Math::pi_over_2;
+  double angle = itk::Math::pi_over_2;
   tube2->GetModifiableObjectToParentTransform()->Rotate3D(axis, angle);
   tube2->Update();
 
@@ -319,9 +317,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
   out.Fill(15);
 
   Point p1;
-  Point p2;
   p1.Fill(15);
   p1[2] = 5;
+  Point p2;
   p2.Fill(15);
   p2[0] = 5;
 
@@ -367,10 +365,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
   TubePointer  tube = TubeType::New();
   GroupPointer net = GroupType::New();
 
-  unsigned int tubeCount;
-  unsigned int netCount;
-  tubeCount = tube->GetReferenceCount();
-  netCount = net->GetReferenceCount();
+
+  unsigned int tubeCount = tube->GetReferenceCount();
+  unsigned int netCount = net->GetReferenceCount();
 
   std::cout << "References test...";
   if (tubeCount != 1)

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -41,12 +41,7 @@ itkTubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  Vector axis;
-  Vector translation;
-  Point  in;
-  Point  out;
-  double angle;
-  bool   passed = true;
+  bool passed = true;
 
   //======================================
   // testing of a single SpatialObject...
@@ -95,8 +90,9 @@ itkTubeSpatialObjectTest(int, char *[])
 
   tube1->SetPoints(list);
   tube1->Update();
-
+  Point in;
   in.Fill(15);
+  Point out;
   out.Fill(5);
 
   std::cout << "IsInside()...";
@@ -311,14 +307,15 @@ itkTubeSpatialObjectTest(int, char *[])
   {
     std::cout << "[PASSED]" << std::endl;
   }
-
+  Vector translation;
   translation.Fill(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
+  Vector axis;
   axis.Fill(0);
   axis[1] = 1;
-  angle = itk::Math::pi_over_2;
+  double angle = itk::Math::pi_over_2;
   tube2->GetModifiableObjectToParentTransform()->Rotate3D(axis, angle);
   tube2->Update();
 
@@ -330,9 +327,9 @@ itkTubeSpatialObjectTest(int, char *[])
   out.Fill(15);
 
   Point p1;
-  Point p2;
   p1.Fill(15);
   p1[2] = 5;
+  Point p2;
   p2.Fill(15);
   p2[0] = 5;
 
@@ -378,10 +375,8 @@ itkTubeSpatialObjectTest(int, char *[])
   TubePointer  tube = TubeType::New();
   GroupPointer net = GroupType::New();
 
-  unsigned int tubeCount;
-  unsigned int netCount;
-  tubeCount = tube->GetReferenceCount();
-  netCount = net->GetReferenceCount();
+  unsigned int tubeCount = tube->GetReferenceCount();
+  unsigned int netCount = net->GetReferenceCount();
 
   std::cout << "References test...";
   if (tubeCount != 1)

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -90,13 +90,10 @@ template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Scale(const OutputVectorType & factor, bool pre)
 {
-  MatrixType   trans;
-  unsigned int i;
-  unsigned int j;
-
-  for (i = 0; i < VDimension; ++i)
+  MatrixType trans;
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < VDimension; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -120,13 +117,10 @@ template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Rotate(int axis1, int axis2, TParametersValueType angle, bool pre)
 {
-  MatrixType   trans;
-  unsigned int i;
-  unsigned int j;
-
-  for (i = 0; i < VDimension; ++i)
+  MatrixType trans;
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < VDimension; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -180,28 +174,19 @@ AffineTransform<TParametersValueType, VDimension>::Rotate3D(const OutputVectorTy
                                                             TParametersValueType     angle,
                                                             bool                     pre)
 {
-  MatrixType trans;
-  ScalarType r;
-  ScalarType x1;
-  ScalarType x2;
-  ScalarType x3;
-  ScalarType q0;
-  ScalarType q1;
-  ScalarType q2;
-  ScalarType q3;
-
   // Convert the axis to a unit vector
-  r = std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
-  x1 = axis[0] / r;
-  x2 = axis[1] / r;
-  x3 = axis[2] / r;
+  ScalarType r = std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+  ScalarType x1 = axis[0] / r;
+  ScalarType x2 = axis[1] / r;
+  ScalarType x3 = axis[2] / r;
 
   // Compute quaternion elements
-  q0 = std::cos(angle / 2.0);
-  q1 = x1 * std::sin(angle / 2.0);
-  q2 = x2 * std::sin(angle / 2.0);
-  q3 = x3 * std::sin(angle / 2.0);
+  ScalarType q0 = std::cos(angle / 2.0);
+  ScalarType q1 = x1 * std::sin(angle / 2.0);
+  ScalarType q2 = x2 * std::sin(angle / 2.0);
+  ScalarType q3 = x3 * std::sin(angle / 2.0);
 
+  MatrixType trans;
   // Compute elements of the rotation matrix
   trans[0][0] = q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3;
   trans[0][1] = 2.0 * (q1 * q2 - q0 * q3);
@@ -232,13 +217,10 @@ template <typename TParametersValueType, unsigned int VDimension>
 void
 AffineTransform<TParametersValueType, VDimension>::Shear(int axis1, int axis2, TParametersValueType coef, bool pre)
 {
-  MatrixType   trans;
-  unsigned int i;
-  unsigned int j;
-
-  for (i = 0; i < VDimension; ++i)
+  MatrixType trans;
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < VDimension; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -278,17 +260,15 @@ auto
 AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const -> ScalarType
 {
   ScalarType result = 0.0;
-  ScalarType term;
-
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     for (unsigned int j = 0; j < VDimension; ++j)
     {
-      term = this->GetMatrix()[i][j] - other->GetMatrix()[i][j];
-      result += term * term;
+      ScalarType term1 = this->GetMatrix()[i][j] - other->GetMatrix()[i][j];
+      result += term1 * term1;
     }
-    term = this->GetOffset()[i] - other->GetOffset()[i];
-    result += term * term;
+    ScalarType term2 = this->GetOffset()[i] - other->GetOffset()[i];
+    result += term2 * term2;
   }
   return std::sqrt(result);
 }
@@ -298,12 +278,12 @@ auto
 AffineTransform<TParametersValueType, VDimension>::Metric() const -> ScalarType
 {
   ScalarType result = 0.0;
-  ScalarType term;
-
   for (unsigned int i = 0; i < VDimension; ++i)
   {
+
     for (unsigned int j = 0; j < VDimension; ++j)
     {
+      ScalarType term;
       if (i == j)
       {
         term = this->GetMatrix()[i][j] - 1.0;
@@ -314,8 +294,8 @@ AffineTransform<TParametersValueType, VDimension>::Metric() const -> ScalarType
       }
       result += term * term;
     }
-    term = this->GetOffset()[i];
-    result += term * term;
+    ScalarType term2 = this->GetOffset()[i];
+    result += term2 * term2;
   }
 
   return std::sqrt(result);

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -122,27 +122,19 @@ itkAffineTransformTest(int, char *[])
 
   int any = 0; // Any errors detected in testing?
 
-  Matrix2Type matrix2;
-  Matrix2Type matrix2Truth;
-  Vector2Type vector2;
-  Vector2Type vector2Truth;
-
   /* Create a 2D identity transformation and show its parameters */
   using Affine2DType = itk::AffineTransform<double, 2>;
-  auto id2 = Affine2DType::New();
-  matrix2 = id2->GetMatrix();
-  vector2 = id2->GetOffset();
+  auto        id2 = Affine2DType::New();
+  Matrix2Type matrix2 = id2->GetMatrix();
+  Vector2Type vector2 = id2->GetOffset();
   std::cout << "Matrix from instantiating an identity transform:" << std::endl << matrix2;
   std::cout << "Vector from instantiating an identity transform:" << std::endl;
   PrintVector(vector2);
 
+  Matrix2Type matrix2Truth;
   /* Test identity transform against truth */
-  matrix2Truth[0][0] = 1;
-  matrix2Truth[0][1] = 0;
-  matrix2Truth[1][0] = 0;
-  matrix2Truth[1][1] = 1;
-  vector2Truth[0] = 0;
-  vector2Truth[1] = 0;
+  matrix2Truth.SetIdentity();
+  Vector2Type vector2Truth({ 0, 0 });
 
   if (!testMatrix(matrix2, matrix2Truth) || !testVector(vector2, vector2Truth))
   {
@@ -350,16 +342,11 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Transform a point */
-  itk::Point<double, 2> u2;
-  itk::Point<double, 2> v2;
-  itk::Point<double, 2> v2T;
-  u2[0] = 3;
-  u2[1] = 5;
-  v2 = aff2->TransformPoint(u2);
+  itk::Point<double, 2> u2({ 3, 5 });
+  itk::Point<double, 2> v2 = aff2->TransformPoint(u2);
   std::cout << "Transform a point:" << std::endl << v2[0] << " , " << v2[1] << std::endl;
 
-  v2T[0] = 41.37;
-  v2T[1] = 26.254;
+  itk::Point<double, 2> v2T({ 41.37, 26.254 });
   if (!testValue(v2[0], v2T[0]) || !testValue(v2[1], v2T[1]))
   {
     std::cout << "Transform a point test failed." << std::endl;
@@ -372,16 +359,12 @@ itkAffineTransformTest(int, char *[])
   // << v2[0] << " , " << v2[1] << std::endl;
 
   /* Transform a vnl_vector */
-  vnl_vector_fixed<double, 2> x2;
-  vnl_vector_fixed<double, 2> y2;
-  vnl_vector_fixed<double, 2> y2T;
-  x2[0] = 1;
-  x2[1] = 2;
-  y2 = aff2->TransformVector(x2);
-  std::cout << "Transform a vnl_vector:" << std::endl << y2[0] << " , " << y2[1] << std::endl;
+  vnl_vector_fixed<double, 2> x2{ 1, 2 };
+  vnl_vector_fixed<double, 2> y2 = aff2->TransformVector(x2);
 
-  y2T[0] = 13.14;
-  y2T[1] = 8.268;
+
+  std::cout << "Transform a vnl_vector:" << std::endl << y2[0] << " , " << y2[1] << std::endl;
+  vnl_vector_fixed<double, 2> y2T{ 13.14, 8.268 };
   if (!testValue(y2[0], y2T[0]) || !testValue(y2[1], y2T[1]))
   {
     std::cout << "Transform a vnl_vector test failed." << std::endl;
@@ -394,16 +377,11 @@ itkAffineTransformTest(int, char *[])
   // << y2[0] << " , " << y2[1] << std::endl;
 
   /* Transform a vector */
-  itk::Vector<double, 2> u3;
-  itk::Vector<double, 2> v3;
-  itk::Vector<double, 2> v3T;
-  u3[0] = 3;
-  u3[1] = 5;
-  v3 = aff2->TransformVector(u3);
+  itk::Vector<double, 2> u3({ 3, 5 });
+  itk::Vector<double, 2> v3 = aff2->TransformVector(u3);
   std::cout << "Transform a vector:" << std::endl << v3[0] << " , " << v3[1] << std::endl;
 
-  v3T[0] = 35.37;
-  v3T[1] = 22.254;
+  itk::Vector<double, 2> v3T({ 35.37, 22.254 });
   if (!testVector(v3, v3T))
   {
     std::cout << "Transform a vector test failed." << std::endl;
@@ -423,10 +401,10 @@ itkAffineTransformTest(int, char *[])
 
   /* Transform a variable length vector */
   itk::VariableLengthVector<double> l3;
-  itk::VariableLengthVector<double> m3;
-  itk::VariableLengthVector<double> m3T;
   l3.SetSize(2);
+  itk::VariableLengthVector<double> m3T;
   m3T.SetSize(2);
+  itk::VariableLengthVector<double> m3;
   l3[0] = 3;
   l3[1] = 5;
   m3 = aff2->TransformVector(l3);
@@ -447,13 +425,13 @@ itkAffineTransformTest(int, char *[])
 
   /* Transform a Covariant vector */
   itk::CovariantVector<double, 2> u4;
-  itk::CovariantVector<double, 2> v4;
-  itk::CovariantVector<double, 2> v4T;
   u4[0] = 3;
   u4[1] = 5;
-  v4 = aff2->TransformCovariantVector(u4);
+  itk::CovariantVector<double, 2> v4 = aff2->TransformCovariantVector(u4);
   std::cout << "Transform a Covariant vector:" << std::endl << v4[0] << " , " << v4[1] << std::endl;
 
+
+  itk::CovariantVector<double, 2> v4T;
   v4T[0] = -379.16666666679;
   v4T[1] = 604.16666666687;
   if (!testVector(v4, v4T, 4000))
@@ -464,12 +442,12 @@ itkAffineTransformTest(int, char *[])
 
   /* Transform a variable length vector as covariant vector */
   itk::VariableLengthVector<double> l4;
-  itk::VariableLengthVector<double> m4;
-  itk::VariableLengthVector<double> m4T;
   l4.SetSize(2);
+  itk::VariableLengthVector<double> m4T;
   m4T.SetSize(2);
   l4[0] = 3;
   l4[1] = 5;
+  itk::VariableLengthVector<double> m4;
   m4 = aff2->TransformCovariantVector(l4);
   std::cout << "Transform a variable length covariant vector:" << std::endl << m4[0] << " , " << m4[1] << std::endl;
 
@@ -490,11 +468,8 @@ itkAffineTransformTest(int, char *[])
   Affine3DType::MatrixType matrix3Truth;
 
   /* Create a 3D transform and rotate in 3D */
+  itk::Vector<double, 3> axis({ .707, .707, .707 });
   auto                   aff3 = Affine3DType::New();
-  itk::Vector<double, 3> axis;
-  axis[0] = .707;
-  axis[1] = .707;
-  axis[2] = .707;
   aff3->Rotate3D(axis, 1.0, true);
   std::cout << "Create and rotate a 3D transform:" << std::endl;
   aff3->Print(std::cout);

--- a/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
@@ -42,21 +42,15 @@ PrintVector(const VectorType & v)
 int
 itkCenteredAffineTransformTest(int, char *[])
 {
-
-  int any = 0; // Any errors detected in testing?
-
-  MatrixType matrix2;
-  VectorType vector2;
-
-
   /* FIXME: This code exercises most of the methods but doesn't
      actually check that the results are correct. */
 
   /* Create a 2D identity transformation and show its parameters */
   using Affine2DType = itk::CenteredAffineTransform<double, 2>;
   auto id2 = Affine2DType::New();
-  matrix2 = id2->GetMatrix();
-  vector2 = id2->GetOffset();
+
+  MatrixType matrix2 = id2->GetMatrix();
+  VectorType vector2 = id2->GetOffset();
   std::cout << "Matrix from instantiating an identity transform:" << std::endl << matrix2;
   std::cout << "Vector from instantiating an identity transform:" << std::endl;
   PrintVector(vector2);
@@ -153,10 +147,9 @@ itkCenteredAffineTransformTest(int, char *[])
 
   /* Transform a point */
   itk::Point<double, 2> u2;
-  itk::Point<double, 2> v2;
   u2[0] = 3;
   u2[1] = 5;
-  v2 = aff2->TransformPoint(u2);
+  itk::Point<double, 2> v2 = aff2->TransformPoint(u2);
   std::cout << "Transform a point:" << std::endl << v2[0] << " , " << v2[1] << std::endl;
 
   // /* Back transform a point */
@@ -166,10 +159,9 @@ itkCenteredAffineTransformTest(int, char *[])
 
   /* Transform a vnl_vector */
   vnl_vector_fixed<double, 2> x2;
-  vnl_vector_fixed<double, 2> y2;
   x2[0] = 1;
   x2[1] = 2;
-  y2 = aff2->TransformVector(x2);
+  vnl_vector_fixed<double, 2> y2 = aff2->TransformVector(x2);
   std::cout << "Transform a vnl_vector:" << std::endl << y2[0] << " , " << y2[1] << std::endl;
 
   // /* Back transform a vector */
@@ -179,10 +171,9 @@ itkCenteredAffineTransformTest(int, char *[])
 
   /* Transform a vector */
   itk::Vector<double, 2> u3;
-  itk::Vector<double, 2> v3;
   u3[0] = 3;
   u3[1] = 5;
-  v3 = aff2->TransformVector(u3);
+  itk::Vector<double, 2> v3 = aff2->TransformVector(u3);
   std::cout << "Transform a vector:" << std::endl << v3[0] << " , " << v3[1] << std::endl;
 
   // /* Back transform a vector */
@@ -192,10 +183,9 @@ itkCenteredAffineTransformTest(int, char *[])
 
   /* Transform a Covariant vector */
   itk::Vector<double, 2> u4;
-  itk::Vector<double, 2> v4;
   u4[0] = 3;
   u4[1] = 5;
-  v4 = aff2->TransformVector(u4);
+  itk::Vector<double, 2> v4 = aff2->TransformVector(u4);
   std::cout << "Transform a Covariant vector:" << std::endl << v4[0] << " , " << v4[1] << std::endl;
 
   // /* Back transform a vector */
@@ -205,11 +195,8 @@ itkCenteredAffineTransformTest(int, char *[])
 
   /* Create a 3D transform and rotate in 3D */
   using Affine3DType = itk::CenteredAffineTransform<double, 3>;
-  auto                   aff3 = Affine3DType::New();
-  itk::Vector<double, 3> axis;
-  axis[0] = .707;
-  axis[1] = .707;
-  axis[2] = .707;
+  auto aff3 = Affine3DType::New();
+  auto axis = itk::MakeFilled<itk::Vector<double, 3>>(0.707);
   aff3->Rotate3D(axis, 1.0, true);
   std::cout << "Create and rotate a 3D transform:" << std::endl;
   aff3->Print(std::cout);
@@ -272,5 +259,6 @@ itkCenteredAffineTransformTest(int, char *[])
   std::cout << "A transform after SetParameters:" << std::endl;
   jaff->Print(std::cout);
 
+  int any = 0; // Any errors detected in testing?
   return any;
 }

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -160,11 +160,11 @@ itkCompositeTransformTest(int, char *[])
   using AffineType = itk::AffineTransform<ScalarType, VDimension>;
   auto        affine = AffineType::New();
   Matrix2Type matrix2;
-  Vector2Type vector2;
   matrix2[0][0] = 1;
   matrix2[0][1] = 2;
   matrix2[1][0] = 3;
   matrix2[1][1] = 4;
+  Vector2Type vector2;
   vector2[0] = 5;
   vector2[1] = 6;
   affine->SetMatrix(matrix2);
@@ -203,10 +203,8 @@ itkCompositeTransformTest(int, char *[])
   /* Get parameters with single transform.
    * Should be same as GetParameters from affine transform. */
   std::cout << "Get Parameters: " << std::endl;
-  CompositeType::ParametersType parametersTest;
-  CompositeType::ParametersType parametersTruth;
-  parametersTest = compositeTransform->GetParameters();
-  parametersTruth = affine->GetParameters();
+  CompositeType::ParametersType parametersTest = compositeTransform->GetParameters();
+  CompositeType::ParametersType parametersTruth = affine->GetParameters();
   std::cout << "affine parametersTruth: " << std::endl
             << parametersTruth << std::endl
             << "parametersTest from Composite: " << std::endl
@@ -220,7 +218,6 @@ itkCompositeTransformTest(int, char *[])
 
   /* Set parameters with single transform. */
   CompositeType::ParametersType parametersNew(6);
-  CompositeType::ParametersType parametersReturned;
   parametersNew[0] = 0;
   parametersNew[1] = 10;
   parametersNew[2] = 20;
@@ -230,7 +227,7 @@ itkCompositeTransformTest(int, char *[])
   std::cout << "Set Parameters: " << std::endl;
   compositeTransform->SetParameters(parametersNew);
   std::cout << "retrieving... " << std::endl;
-  parametersReturned = compositeTransform->GetParameters();
+  CompositeType::ParametersType parametersReturned = compositeTransform->GetParameters();
   std::cout << "parametersNew: " << std::endl
             << parametersNew << std::endl
             << "parametersReturned: " << std::endl
@@ -283,16 +280,14 @@ itkCompositeTransformTest(int, char *[])
   compositeTransform->AddTransform(affine);
 
   /* Setup test point and truth value for tests */
-  CompositeType::InputPointType  inputPoint;
-  CompositeType::OutputPointType outputPoint;
-  CompositeType::OutputPointType affineTruth;
+  CompositeType::InputPointType inputPoint;
   inputPoint[0] = 2;
   inputPoint[1] = 3;
+  CompositeType::OutputPointType affineTruth;
   affineTruth[0] = 13;
   affineTruth[1] = 24;
 
-  CompositeType::InputVectorType  inputVector;
-  CompositeType::OutputVectorType outputVector;
+  CompositeType::InputVectorType inputVector;
   inputVector[0] = 0.4;
   inputVector[1] = 0.6;
 
@@ -302,7 +297,7 @@ itkCompositeTransformTest(int, char *[])
   inputCVector[1] = 0.6;
 
   /* Test transforming the point with just the single affine transform */
-  outputPoint = compositeTransform->TransformPoint(inputPoint);
+  CompositeType::OutputPointType outputPoint = compositeTransform->TransformPoint(inputPoint);
   if (!testPoint(outputPoint, affineTruth))
   {
     std::cout << "Failed transforming point with single transform." << std::endl;
@@ -310,16 +305,15 @@ itkCompositeTransformTest(int, char *[])
   }
 
   /* Test inverse */
-  auto                           inverseTransform = CompositeType::New();
-  CompositeType::OutputPointType inverseTruth;
-  CompositeType::OutputPointType inverseOutput;
+  auto inverseTransform = CompositeType::New();
+
   if (!compositeTransform->GetInverse(inverseTransform))
   {
     std::cout << "ERROR: GetInverse() failed." << std::endl;
     return EXIT_FAILURE;
   }
-  inverseTruth = inputPoint;
-  inverseOutput = inverseTransform->TransformPoint(affineTruth);
+  CompositeType::OutputPointType inverseTruth = inputPoint;
+  CompositeType::OutputPointType inverseOutput = inverseTransform->TransformPoint(affineTruth);
   std::cout << "Transform point with inverse composite transform: " << std::endl
             << "  Test point: " << affineTruth << std::endl
             << "  Truth: " << inverseTruth << std::endl
@@ -331,14 +325,13 @@ itkCompositeTransformTest(int, char *[])
   }
 
   /* Test ComputeJacobianWithRespectToParameters */
-
-  CompositeType::JacobianType   jacComposite;
-  CompositeType::JacobianType   jacSingle;
   CompositeType::InputPointType jacPoint;
   jacPoint[0] = 1;
   jacPoint[1] = 2;
+  CompositeType::JacobianType jacSingle;
   affine->ComputeJacobianWithRespectToParameters(jacPoint, jacSingle);
   std::cout << "Single jacobian:" << std::endl << jacSingle << std::endl;
+  CompositeType::JacobianType jacComposite;
   compositeTransform->ComputeJacobianWithRespectToParameters(jacPoint, jacComposite);
   std::cout << "Composite jacobian:" << std::endl << jacComposite << std::endl;
   if (!testJacobian(jacComposite, jacSingle))
@@ -378,8 +371,7 @@ itkCompositeTransformTest(int, char *[])
 
   /* Transform a point with both transforms. Remember that transforms
    * are applied in *reverse* queue order, with most-recently added transform first. */
-  CompositeType::OutputPointType compositeTruth;
-  compositeTruth = affine2->TransformPoint(inputPoint);
+  CompositeType::OutputPointType compositeTruth = affine2->TransformPoint(inputPoint);
   compositeTruth = affine->TransformPoint(compositeTruth);
 
   outputPoint = compositeTransform->TransformPoint(inputPoint);
@@ -394,17 +386,15 @@ itkCompositeTransformTest(int, char *[])
     return EXIT_FAILURE;
   }
 
-  CompositeType::OutputVectorType compositeTruthVector;
-  compositeTruthVector = affine2->TransformVector(inputVector);
+  CompositeType::OutputVectorType compositeTruthVector = affine2->TransformVector(inputVector);
   compositeTruthVector = affine->TransformVector(compositeTruthVector);
-  outputVector = compositeTransform->TransformVector(inputVector);
+  CompositeType::OutputVectorType outputVector = compositeTransform->TransformVector(inputVector);
   std::cout << "Transform vector with two-component composite transform: " << std::endl
             << "  Test vector: " << inputVector << std::endl
             << "  Truth: " << compositeTruthVector << std::endl
             << "  Output: " << outputVector << std::endl;
 
-  CompositeType::OutputCovariantVectorType compositeTruthCVector;
-  compositeTruthCVector = affine2->TransformCovariantVector(inputCVector);
+  CompositeType::OutputCovariantVectorType compositeTruthCVector = affine2->TransformCovariantVector(inputCVector);
   compositeTruthCVector = affine->TransformCovariantVector(compositeTruthCVector);
   outputCVector = compositeTransform->TransformCovariantVector(inputCVector);
   std::cout << "Transform covariant vector with two-component composite transform: " << std::endl
@@ -413,33 +403,31 @@ itkCompositeTransformTest(int, char *[])
             << "  Output: " << outputCVector << std::endl;
 
 
-  CompositeType::InputDiffusionTensor3DType  inputTensor;
-  CompositeType::OutputDiffusionTensor3DType outputTensor;
+  CompositeType::InputDiffusionTensor3DType inputTensor;
   inputTensor[0] = 3.0;
   inputTensor[1] = 0.3;
   inputTensor[2] = 0.2;
   inputTensor[3] = 2.0;
   inputTensor[4] = 0.1;
   inputTensor[5] = 1.0;
-  CompositeType::OutputDiffusionTensor3DType compositeTruthTensor;
-  compositeTruthTensor = affine2->TransformDiffusionTensor3D(inputTensor);
+  CompositeType::OutputDiffusionTensor3DType compositeTruthTensor = affine2->TransformDiffusionTensor3D(inputTensor);
   compositeTruthTensor = affine->TransformDiffusionTensor3D(compositeTruthTensor);
-  outputTensor = compositeTransform->TransformDiffusionTensor3D(inputTensor);
+  CompositeType::OutputDiffusionTensor3DType outputTensor = compositeTransform->TransformDiffusionTensor3D(inputTensor);
   std::cout << "Transform tensor with two-component composite transform: " << std::endl
             << "  Test tensor: " << inputTensor << std::endl
             << "  Truth: " << compositeTruthTensor << std::endl
             << "  Output: " << outputTensor << std::endl;
 
-  CompositeType::InputSymmetricSecondRankTensorType  inputSTensor;
-  CompositeType::OutputSymmetricSecondRankTensorType outputSTensor;
+  CompositeType::InputSymmetricSecondRankTensorType inputSTensor;
   inputSTensor(1, 0) = 0.5;
   inputSTensor(0, 0) = 3.0;
   inputSTensor(1, 1) = 2.0;
 
-  CompositeType::OutputSymmetricSecondRankTensorType compositeTruthSTensor;
-  compositeTruthSTensor = affine2->TransformSymmetricSecondRankTensor(inputSTensor);
+  CompositeType::OutputSymmetricSecondRankTensorType compositeTruthSTensor =
+    affine2->TransformSymmetricSecondRankTensor(inputSTensor);
   compositeTruthSTensor = affine->TransformSymmetricSecondRankTensor(compositeTruthSTensor);
-  outputSTensor = compositeTransform->TransformSymmetricSecondRankTensor(inputSTensor);
+  CompositeType::OutputSymmetricSecondRankTensorType outputSTensor =
+    compositeTransform->TransformSymmetricSecondRankTensor(inputSTensor);
   std::cout << "Transform tensor with two-component composite transform: " << std::endl
             << "  Test tensor: " << inputSTensor << std::endl
             << "  Truth: " << compositeTruthSTensor << std::endl
@@ -478,9 +466,10 @@ itkCompositeTransformTest(int, char *[])
   }
 
   /* Get inverse transform again, but using other accessor. */
-  CompositeType::ConstPointer inverseTransform2;
+
   std::cout << "Call GetInverseTransform():" << std::endl;
-  inverseTransform2 = dynamic_cast<const CompositeType *>(compositeTransform->GetInverseTransform().GetPointer());
+  CompositeType::ConstPointer inverseTransform2 =
+    dynamic_cast<const CompositeType *>(compositeTransform->GetInverseTransform().GetPointer());
   if (!inverseTransform2)
   {
     std::cout << "Failed calling GetInverseTransform()." << std::endl;
@@ -672,8 +661,8 @@ itkCompositeTransformTest(int, char *[])
   }
 
   /* Get inverse and check TransformsToOptimize flags are correct */
-  CompositeType::ConstPointer inverseTransform3;
-  inverseTransform3 = dynamic_cast<const CompositeType *>(compositeTransform->GetInverseTransform().GetPointer());
+  CompositeType::ConstPointer inverseTransform3 =
+    dynamic_cast<const CompositeType *>(compositeTransform->GetInverseTransform().GetPointer());
   if (!inverseTransform3)
   {
     std::cout << "Failed calling GetInverseTransform() (3)." << std::endl;
@@ -729,18 +718,18 @@ itkCompositeTransformTest(int, char *[])
    * Remember that the point gets transformed by preceding transforms
    * before its used for individual Jacobian. */
   std::cout << "Test ComputeJacobianWithRespectToParameters with three transforms: " << std::endl;
-  CompositeType::JacobianType   jacTruth;
-  CompositeType::JacobianType   jacComposite2;
-  CompositeType::JacobianType   jacAffine;
-  CompositeType::JacobianType   jacAffine3;
   CompositeType::InputPointType jacPoint2;
   jacPoint2[0] = 1;
   jacPoint2[1] = 2;
+  CompositeType::JacobianType jacComposite2;
   compositeTransform->ComputeJacobianWithRespectToParameters(jacPoint2, jacComposite2);
+  CompositeType::JacobianType jacAffine3;
   affine3->ComputeJacobianWithRespectToParameters(jacPoint2, jacAffine3);
   jacPoint2 = affine3->TransformPoint(jacPoint2);
   jacPoint2 = affine2->TransformPoint(jacPoint2);
+  CompositeType::JacobianType jacAffine;
   affine->ComputeJacobianWithRespectToParameters(jacPoint2, jacAffine);
+  CompositeType::JacobianType jacTruth;
   jacTruth.SetSize(jacAffine3.rows(), jacAffine.cols() + jacAffine3.cols());
   jacTruth.update(affine->GetMatrix() * affine2->GetMatrix() * jacAffine3, 0, 0);
   jacTruth.update(jacAffine, 0, jacAffine3.cols());

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -271,12 +271,9 @@ itkEuler2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5;
-    TransformType::InputPointType p6;
-    TransformType::InputPointType p7;
-    p5 = t1->TransformPoint(p1);
-    p6 = t4->TransformPoint(p5);
-    p7 = t5->TransformPoint(p1);
+    TransformType::InputPointType p5 = t1->TransformPoint(p1);
+    TransformType::InputPointType p6 = t4->TransformPoint(p5);
+    TransformType::InputPointType p7 = t5->TransformPoint(p1);
 
     std::cout << "Test Compose(.,false): ";
     if (!CheckEqual(p6, p7))
@@ -370,10 +367,8 @@ itkEuler2DTransformTest(int, char *[])
     ip[0] = 8.0;
     ip[1] = 9.0;
 
-    TransformType::OutputPointType op1;
-    TransformType::OutputPointType op2;
-    op1 = t1->TransformPoint(ip);
-    op2 = t23->TransformPoint(ip);
+    TransformType::OutputPointType op1 = t1->TransformPoint(ip);
+    TransformType::OutputPointType op2 = t23->TransformPoint(ip);
 
     std::cout << "Test Set/GetMatrix() and Set/GetOffset(): ";
     if (!CheckEqual(op1, op2))

--- a/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
@@ -129,18 +129,16 @@ itkEuler3DTransformTest(int, char *[])
 
   std::cout << "Testing Rotation Change from ZXY to ZYX consistency:";
 
-  auto                                eulerTransform2 = EulerTransformType::New();
-  EulerTransformType::OutputPointType r1;
-  EulerTransformType::OutputPointType r2;
+  auto eulerTransform2 = EulerTransformType::New();
+
 
   // rotation angles already set above
   eulerTransform->SetComputeZYX(true);
 
   eulerTransform2->SetComputeZYX(true);
   eulerTransform2->SetRotation(angleX, angleY, angleZ);
-
-  r1 = eulerTransform->TransformPoint(p);
-  r2 = eulerTransform2->TransformPoint(p);
+  EulerTransformType::OutputPointType r1 = eulerTransform->TransformPoint(p);
+  EulerTransformType::OutputPointType r2 = eulerTransform2->TransformPoint(p);
   for (unsigned int i = 0; i < N; ++i)
   {
     if (itk::Math::abs(r1[i] - r2[i]) > epsilon)
@@ -217,13 +215,12 @@ itkEuler3DTransformTest(int, char *[])
   // Testing fixed parameters
   std::cout << "Testing Set/Get Fixed Parameters: ";
   EulerTransformType::FixedParametersType oldVersion(3);
-  EulerTransformType::FixedParametersType newVersion(4);
-  EulerTransformType::FixedParametersType res(4);
   oldVersion.Fill(0);
+  EulerTransformType::FixedParametersType newVersion(4);
   newVersion.Fill(0);
   eulerTransform->SetFixedParameters(oldVersion);
   eulerTransform->SetComputeZYX(true);
-  res = eulerTransform->GetFixedParameters();
+  EulerTransformType::FixedParametersType res = eulerTransform->GetFixedParameters();
   if (res[0] != 0 || res[1] != 0 || res[2] != 0 || res[3] != 1)
   {
     std::cout << "Setting/Getting fixed parameters failed." << std::endl;

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -151,11 +151,11 @@ itkMultiTransformTest(int, char *[])
   using AffineType = itk::AffineTransform<ScalarType, VDimension>;
   auto        affine = AffineType::New();
   Matrix2Type matrix2;
-  Vector2Type vector2;
   matrix2[0][0] = 0;
   matrix2[0][1] = -1;
   matrix2[1][0] = 1;
   matrix2[1][1] = 0;
+  Vector2Type vector2;
   vector2[0] = 10;
   vector2[1] = 100;
   affine->SetMatrix(matrix2);
@@ -196,10 +196,8 @@ itkMultiTransformTest(int, char *[])
   /* Get parameters with single transform.
    * Should be same as GetParameters from affine transform. */
   std::cout << "Get Parameters: " << std::endl;
-  Superclass::ParametersType parametersTest;
-  Superclass::ParametersType parametersTruth;
-  parametersTest = multiTransform->GetParameters();
-  parametersTruth = affine->GetParameters();
+  Superclass::ParametersType parametersTest = multiTransform->GetParameters();
+  Superclass::ParametersType parametersTruth = affine->GetParameters();
   std::cout << "affine parametersTruth: " << std::endl
             << parametersTruth << std::endl
             << "parametersTest from Multi: " << std::endl
@@ -213,7 +211,6 @@ itkMultiTransformTest(int, char *[])
 
   /* Set parameters with single transform. */
   Superclass::ParametersType parametersNew(6);
-  Superclass::ParametersType parametersReturned;
   parametersNew[0] = 0;
   parametersNew[1] = 10;
   parametersNew[2] = 20;
@@ -223,7 +220,7 @@ itkMultiTransformTest(int, char *[])
   std::cout << "Set Parameters: " << std::endl;
   multiTransform->SetParameters(parametersNew);
   std::cout << "retrieving... " << std::endl;
-  parametersReturned = multiTransform->GetParameters();
+  Superclass::ParametersType parametersReturned = multiTransform->GetParameters();
   std::cout << "parametersNew: " << std::endl
             << parametersNew << std::endl
             << "parametersReturned: " << std::endl
@@ -326,12 +323,13 @@ itkMultiTransformTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   auto field = FieldType::New(); // This is based on itk::Image
 
-  FieldType::SizeType   size;
-  FieldType::IndexType  start;
-  FieldType::RegionType region;
-  int                   dimLength = 4;
+
+  int                 dimLength = 4;
+  FieldType::SizeType size;
   size.Fill(dimLength);
+  FieldType::IndexType start;
   start.Fill(0);
+  FieldType::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);
   field->SetRegions(region);

--- a/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
@@ -126,10 +126,8 @@ itkRigid2DTransformTest(int, char *[])
       // Translate an itk::Point
       TransformType::InputPointType::ValueType pInit[2] = { 10, 10 };
       TransformType::InputPointType            p = pInit;
-      TransformType::InputPointType            q;
-      q = p + ioffset;
-      TransformType::OutputPointType r;
-      r = translation->TransformPoint(p);
+      TransformType::InputPointType            q = p + ioffset;
+      TransformType::OutputPointType           r = translation->TransformPoint(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - r[i]) > epsilon)
@@ -155,8 +153,7 @@ itkRigid2DTransformTest(int, char *[])
       // Translate an itk::Vector
       TransformType::InputVectorType::ValueType pInit[2] = { 10, 10 };
       TransformType::InputVectorType            p = pInit;
-      TransformType::OutputVectorType           q;
-      q = translation->TransformVector(p);
+      TransformType::OutputVectorType           q = translation->TransformVector(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - p[i]) > epsilon)
@@ -181,8 +178,7 @@ itkRigid2DTransformTest(int, char *[])
       // Translate an itk::CovariantVector
       TransformType::InputCovariantVectorType::ValueType pInit[2] = { 10, 10 };
       TransformType::InputCovariantVectorType            p = pInit;
-      TransformType::OutputCovariantVectorType           q;
-      q = translation->TransformCovariantVector(p);
+      TransformType::OutputCovariantVectorType           q = translation->TransformCovariantVector(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - p[i]) > epsilon)
@@ -209,8 +205,7 @@ itkRigid2DTransformTest(int, char *[])
       TransformType::InputVnlVectorType p;
       p[0] = 11;
       p[1] = 7;
-      TransformType::OutputVnlVectorType q;
-      q = translation->TransformVector(p);
+      TransformType::OutputVnlVectorType q = translation->TransformVector(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - p[i]) > epsilon)
@@ -343,8 +338,7 @@ itkRigid2DTransformTest(int, char *[])
       q[0] = p[0] * costh + p[1] * sinth;
       q[1] = -p[0] * sinth + p[1] * costh;
 
-      TransformType::OutputPointType r;
-      r = rotation->TransformPoint(p);
+      TransformType::OutputPointType r = rotation->TransformPoint(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - r[i]) > epsilon)
@@ -375,8 +369,7 @@ itkRigid2DTransformTest(int, char *[])
       q[0] = p[0] * costh + p[1] * sinth;
       q[1] = -p[0] * sinth + p[1] * costh;
 
-      TransformType::OutputVectorType r;
-      r = rotation->TransformVector(p);
+      TransformType::OutputVectorType r = rotation->TransformVector(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - r[i]) > epsilon)
@@ -407,8 +400,7 @@ itkRigid2DTransformTest(int, char *[])
       q[0] = p[0] * costh + p[1] * sinth;
       q[1] = -p[0] * sinth + p[1] * costh;
 
-      TransformType::OutputCovariantVectorType r;
-      r = rotation->TransformCovariantVector(p);
+      TransformType::OutputCovariantVectorType r = rotation->TransformCovariantVector(p);
 
       for (unsigned int i = 0; i < N; ++i)
       {
@@ -444,8 +436,7 @@ itkRigid2DTransformTest(int, char *[])
       q[1] = -p[0] * sinth + p[1] * costh;
 
 
-      TransformType::OutputVnlVectorType r;
-      r = rotation->TransformVector(p);
+      TransformType::OutputVnlVectorType r = rotation->TransformVector(p);
       for (unsigned int i = 0; i < N; ++i)
       {
         if (itk::Math::abs(q[i] - r[i]) > epsilon)
@@ -472,13 +463,11 @@ itkRigid2DTransformTest(int, char *[])
       auto t1 = TransformType::New();
 
       // Set parameters
-      double                          angle0;
-      TransformType::InputPointType   center;
-      TransformType::OutputVectorType translation;
-
-      angle0 = -21.0 / 180.0 * itk::Math::pi;
+      double                        angle0 = -21.0 / 180.0 * itk::Math::pi;
+      TransformType::InputPointType center;
       center[0] = 12.0;
       center[1] = -8.9;
+      TransformType::OutputVectorType translation;
       translation[0] = 67.8;
       translation[1] = -0.2;
 
@@ -497,8 +486,7 @@ itkRigid2DTransformTest(int, char *[])
       TransformType::Pointer t2;
       t1->CloneInverseTo(t2);
 
-      TransformType::InputPointType p3;
-      p3 = t2->TransformPoint(p2);
+      TransformType::InputPointType p3 = t2->TransformPoint(p2);
 
       std::cout << "Test CloneInverseTo(): ";
       if (!CheckEqual(p1, p3))
@@ -508,8 +496,7 @@ itkRigid2DTransformTest(int, char *[])
 
       auto t2dash = TransformType::New();
       t1->GetInverse(t2dash);
-      TransformType::InputPointType p3dash;
-      p3dash = t2dash->TransformPoint(p2);
+      TransformType::InputPointType p3dash = t2dash->TransformPoint(p2);
 
       std::cout << "Test GetInverse(): ";
       if (!CheckEqual(p1, p3dash))
@@ -536,8 +523,7 @@ itkRigid2DTransformTest(int, char *[])
       TransformType::Pointer t3;
       t1->CloneTo(t3);
 
-      TransformType::InputPointType p4;
-      p4 = t3->TransformPoint(p1);
+      TransformType::InputPointType p4 = t3->TransformPoint(p1);
 
       std::cout << "Test Clone(): ";
       if (!CheckEqual(p2, p4))
@@ -559,12 +545,9 @@ itkRigid2DTransformTest(int, char *[])
       t1->CloneTo(t5);
       t5->Compose(t4, false);
 
-      TransformType::InputPointType p5;
-      TransformType::InputPointType p6;
-      TransformType::InputPointType p7;
-      p5 = t1->TransformPoint(p1);
-      p6 = t4->TransformPoint(p5);
-      p7 = t5->TransformPoint(p1);
+      TransformType::InputPointType p5 = t1->TransformPoint(p1);
+      TransformType::InputPointType p6 = t4->TransformPoint(p5);
+      TransformType::InputPointType p7 = t5->TransformPoint(p1);
 
       std::cout << "Test Compose(.,false): ";
       if (!CheckEqual(p6, p7))

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -354,12 +354,9 @@ itkSimilarity2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5;
-    TransformType::InputPointType p6;
-    TransformType::InputPointType p7;
-    p5 = t1->TransformPoint(p1);
-    p6 = t4->TransformPoint(p5);
-    p7 = t5->TransformPoint(p1);
+    TransformType::InputPointType p5 = t1->TransformPoint(p1);
+    TransformType::InputPointType p6 = t4->TransformPoint(p5);
+    TransformType::InputPointType p7 = t5->TransformPoint(p1);
 
     std::cout << "Test Compose(.,false): ";
     if (!CheckEqual(p6, p7))
@@ -515,12 +512,9 @@ itkSimilarity2DTransformTest(int, char *[])
     t1->CloneTo(t5);
     t5->Compose(t4, false);
 
-    TransformType::InputPointType p5;
-    TransformType::InputPointType p6;
-    TransformType::InputPointType p7;
-    p5 = t1->TransformPoint(p1);
-    p6 = t4->TransformPoint(p5);
-    p7 = t5->TransformPoint(p1);
+    TransformType::InputPointType p5 = t1->TransformPoint(p1);
+    TransformType::InputPointType p6 = t4->TransformPoint(p5);
+    TransformType::InputPointType p7 = t5->TransformPoint(p1);
 
     std::cout << "Test Compose(.,false): ";
     if (!CheckEqual(p6, p7))
@@ -614,10 +608,8 @@ itkSimilarity2DTransformTest(int, char *[])
     ip[0] = 8.0;
     ip[1] = 9.0;
 
-    TransformType::OutputPointType op1;
-    TransformType::OutputPointType op2;
-    op1 = t1->TransformPoint(ip);
-    op2 = t2->TransformPoint(ip);
+    TransformType::OutputPointType op1 = t1->TransformPoint(ip);
+    TransformType::OutputPointType op2 = t2->TransformPoint(ip);
 
     t1->Print(std::cout);
     std::cout << "Test Set/GetMatrix() and Set/GetOffset(): ";

--- a/Modules/Core/Transform/test/itkTransformCloneTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformCloneTest.cxx
@@ -61,7 +61,6 @@ itkTransformCloneTest(int, char *[])
   using Transform3DType = itk::Transform<double, 3, 3>;
   auto                                  affineXfrm = AffineTransformType::New();
   AffineTransformType::OutputVectorType axis;
-  AffineTransformType::OutputVectorType offset;
   axis[0] = -1.0;
   axis[1] = 1.0;
   axis[2] = 0.0;
@@ -70,6 +69,7 @@ itkTransformCloneTest(int, char *[])
   axis[1] = 0.0;
   axis[2] = -1.0;
   affineXfrm->Rotate3D(axis, 0.5);
+  AffineTransformType::OutputVectorType offset;
   offset[0] = 999.0;
   offset[1] = -31415926.0;
   offset[2] = 32.768;

--- a/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
@@ -108,10 +108,9 @@ itkTranslationTransformTest(int, char *[])
 
   /* Transform a point */
   itk::Point<double, 2> u2;
-  itk::Point<double, 2> v2;
   u2[0] = 3;
   u2[1] = 5;
-  v2 = aff2->TransformPoint(u2);
+  itk::Point<double, 2> v2 = aff2->TransformPoint(u2);
   std::cout << "Transform a point:" << std::endl << v2[0] << " , " << v2[1] << std::endl;
 
   /* Back transform a point */
@@ -120,10 +119,9 @@ itkTranslationTransformTest(int, char *[])
 
   /* Transform a vnl_vector */
   vnl_vector_fixed<double, 2> x2;
-  vnl_vector_fixed<double, 2> y2;
   x2[0] = 1;
   x2[1] = 2;
-  y2 = aff2->TransformVector(x2);
+  vnl_vector_fixed<double, 2> y2 = aff2->TransformVector(x2);
   std::cout << "Transform a vnl_vector:" << std::endl << y2[0] << " , " << y2[1] << std::endl;
 
   /* Back transform a vector */
@@ -132,10 +130,9 @@ itkTranslationTransformTest(int, char *[])
 
   /* Transform a vector */
   itk::Vector<double, 2> u3;
-  itk::Vector<double, 2> v3;
   u3[0] = 3;
   u3[1] = 5;
-  v3 = aff2->TransformVector(u3);
+  itk::Vector<double, 2> v3 = aff2->TransformVector(u3);
   std::cout << "Transform a vector:" << std::endl << v3[0] << " , " << v3[1] << std::endl;
 
   /* Back transform a vector */
@@ -144,10 +141,9 @@ itkTranslationTransformTest(int, char *[])
 
   /* Transform a Covariant vector */
   itk::Vector<double, 2> u4;
-  itk::Vector<double, 2> v4;
   u4[0] = 3;
   u4[1] = 5;
-  v4 = aff2->TransformVector(u4);
+  itk::Vector<double, 2> v4 = aff2->TransformVector(u4);
   std::cout << "Transform a Covariant vector:" << std::endl << v4[0] << " , " << v4[1] << std::endl;
 
   /* Back transform a vector */

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -29,11 +29,8 @@ template <typename TImage>
 GradientNDAnisotropicDiffusionFunction<TImage>::GradientNDAnisotropicDiffusionFunction()
   : m_K(0.0)
 {
-  unsigned int i;
-  unsigned int j;
-  RadiusType   r;
-
-  for (i = 0; i < ImageDimension; ++i)
+  RadiusType r;
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     r[i] = 1;
   }
@@ -46,19 +43,19 @@ GradientNDAnisotropicDiffusionFunction<TImage>::GradientNDAnisotropicDiffusionFu
   // Slice the neighborhood
   m_Center = it.Size() / 2;
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Stride[i] = it.GetStride(i);
   }
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     x_slice[i] = std::slice(m_Center - m_Stride[i], 3, m_Stride[i]);
   }
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       // For taking derivatives in the i direction that are offset one
       // pixel in the j direction.
@@ -80,53 +77,39 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
                                                               void *,
                                                               const FloatOffsetType &) -> PixelType
 {
-  unsigned int i;
-  unsigned int j;
-
-  double accum;
-  double accum_d;
-  double Cx;
-  double Cxd;
-
   // PixelType is scalar in this context
-  PixelRealType delta;
-  PixelRealType dx_forward;
-  PixelRealType dx_backward;
-  PixelRealType dx[ImageDimension];
-  PixelRealType dx_aug;
-  PixelRealType dx_dim;
-
-  delta = PixelRealType{};
+  PixelRealType delta = PixelRealType{};
 
   // Calculate the centralized derivatives for each dimension.
-  for (i = 0; i < ImageDimension; ++i)
+  PixelRealType dx[ImageDimension];
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     dx[i] = (it.GetPixel(m_Center + m_Stride[i]) - it.GetPixel(m_Center - m_Stride[i])) / 2.0f;
     dx[i] *= this->m_ScaleCoefficients[i];
   }
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // "Half" directional derivatives
-    dx_forward = it.GetPixel(m_Center + m_Stride[i]) - it.GetPixel(m_Center);
+    PixelRealType dx_forward = it.GetPixel(m_Center + m_Stride[i]) - it.GetPixel(m_Center);
     dx_forward *= this->m_ScaleCoefficients[i];
-    dx_backward = it.GetPixel(m_Center) - it.GetPixel(m_Center - m_Stride[i]);
+    PixelRealType dx_backward = it.GetPixel(m_Center) - it.GetPixel(m_Center - m_Stride[i]);
     dx_backward *= this->m_ScaleCoefficients[i];
 
     // Calculate the conductance terms.  Conductance varies with each
     // dimension because the gradient magnitude approximation is different
     // along each  dimension.
-    accum = 0.0;
-    accum_d = 0.0;
-    for (j = 0; j < ImageDimension; ++j)
+    double accum = 0.0;
+    double accum_d = 0.0;
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       if (j != i)
       {
-        dx_aug =
+        PixelRealType dx_aug =
           (it.GetPixel(m_Center + m_Stride[i] + m_Stride[j]) - it.GetPixel(m_Center + m_Stride[i] - m_Stride[j])) /
           2.0f;
         dx_aug *= this->m_ScaleCoefficients[j];
-        dx_dim =
+        PixelRealType dx_dim =
           (it.GetPixel(m_Center - m_Stride[i] + m_Stride[j]) - it.GetPixel(m_Center - m_Stride[i] - m_Stride[j])) /
           2.0f;
         dx_dim *= this->m_ScaleCoefficients[j];
@@ -135,6 +118,8 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
       }
     }
 
+    double Cx;
+    double Cxd;
     if (m_K == 0.0)
     {
       Cx = 0.0;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -119,7 +119,6 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const Parameters
   else
   {
     typename ImageType::IndexType  origIndex = m_Region.GetIndex();
-    typename ImageType::IndexType  curIndex;
     typename TBiasField::IndexType indexBias(SpaceDimension);
     typename ImageType::SizeType   size = m_Region.GetSize();
     // Use indexing for incomplete sampling
@@ -127,6 +126,7 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const Parameters
     if (!m_Mask)
     {
       indexBias[2] = 0;
+      typename ImageType::IndexType curIndex;
       for (curIndex[2] = origIndex[2]; curIndex[2] < origIndex[2] + (IndexValueType)size[2];
            curIndex[2] = curIndex[2] + (IndexValueType)m_SamplingFactor[2])
       {
@@ -151,6 +151,7 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const Parameters
     else
     {
       indexBias[2] = 0;
+      typename ImageType::IndexType curIndex;
       for (curIndex[2] = origIndex[2]; curIndex[2] < origIndex[2] + (IndexValueType)size[2];
            curIndex[2] = curIndex[2] + (IndexValueType)m_SamplingFactor[2])
       {
@@ -294,11 +295,9 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::SetSchedule
   }
 
   this->Modified();
-  unsigned int level;
-  unsigned int dim;
-  for (level = 0; level < m_NumberOfLevels; ++level)
+  for (unsigned int level = 0; level < m_NumberOfLevels; ++level)
   {
-    for (dim = 0; dim < ImageDimension; ++dim)
+    for (unsigned int dim = 0; dim < ImageDimension; ++dim)
     {
       m_Schedule[level][dim] = schedule[level][dim];
 
@@ -322,12 +321,9 @@ bool
 MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::IsScheduleDownwardDivisible(
   const ScheduleType & schedule)
 {
-  unsigned int ilevel;
-  unsigned int idim;
-
-  for (ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
+  for (unsigned int ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
   {
-    for (idim = 0; idim < schedule.columns(); ++idim)
+    for (unsigned int idim = 0; idim < schedule.columns(); ++idim)
     {
       if (schedule[ilevel][idim] == 0)
       {
@@ -503,12 +499,10 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::EstimateBia
 
   try
   {
-    unsigned int level;
-    unsigned int dim;
-    for (level = 0; level < m_NumberOfLevels; ++level)
+    for (unsigned int level = 0; level < m_NumberOfLevels; ++level)
     {
       typename EnergyFunctionType::SamplingFactorType energySampling;
-      for (dim = 0; dim < ImageDimension; ++dim)
+      for (unsigned int dim = 0; dim < ImageDimension; ++dim)
       {
         energySampling[dim] = m_Schedule[level][dim];
       }
@@ -821,10 +815,9 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::ExpImage(In
   ImageRegionIterator<InternalImageType> s_iter(source, region);
   ImageRegionIterator<InternalImageType> t_iter(target, region);
 
-  double temp;
   while (!s_iter.IsAtEnd())
   {
-    temp = s_iter.Get();
+    double temp = s_iter.Get();
     // t_iter.Set( m_EnergyFunction->GetEnergy0(temp));
     temp = std::exp(temp) - 1;
     t_iter.Set((InternalImagePixelType)temp);
@@ -841,10 +834,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GetBiasFiel
   BiasFieldType::DomainSizeType & biasSize)
 {
   InputImageSizeType size = region.GetSize();
-  unsigned int       dim;
   int                biasDim = 0;
-
-  for (dim = 0; dim < ImageDimension; ++dim)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     if (size[dim] > 1)
     {
@@ -855,7 +846,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::GetBiasFiel
   biasSize.resize(biasDim);
 
   biasDim = 0;
-  for (dim = 0; dim < ImageDimension; ++dim)
+  for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     if (size[dim] > 1)
     {
@@ -882,21 +873,18 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
 
   IndexValueType coordFirst = indexFirst[m_SlicingDirection];
   IndexValueType coordLast = indexLast[m_SlicingDirection];
-  IndexValueType coordFirst2;
-  IndexValueType coordLast2;
-  IndexValueType tempCoordFirst;
-  IndexValueType tempCoordLast;
 
-  OutputImageRegionType tempRegion;
-  OutputImageSizeType   tempSize = size;
-  OutputImageIndexType  tempIndex = indexFirst;
+
+  OutputImageSizeType  tempSize = size;
+  OutputImageIndexType tempIndex = indexFirst;
 
   auto iter = slabs.begin();
   while (iter != slabs.end())
   {
-    coordFirst2 = iter->GetIndex()[m_SlicingDirection];
-    coordLast2 = coordFirst2 + static_cast<IndexValueType>(iter->GetSize()[m_SlicingDirection]) - 1;
+    IndexValueType coordFirst2 = iter->GetIndex()[m_SlicingDirection];
+    IndexValueType coordLast2 = coordFirst2 + static_cast<IndexValueType>(iter->GetSize()[m_SlicingDirection]) - 1;
 
+    IndexValueType tempCoordFirst;
     if (coordFirst > coordFirst2)
     {
       tempCoordFirst = coordFirst;
@@ -905,6 +893,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
     {
       tempCoordFirst = coordFirst2;
     }
+    IndexValueType tempCoordLast;
     if (coordLast < coordLast2)
     {
       tempCoordLast = coordLast;
@@ -917,6 +906,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
     {
       tempIndex[m_SlicingDirection] = tempCoordFirst;
       tempSize[m_SlicingDirection] = tempCoordLast - tempCoordFirst + 1;
+      OutputImageRegionType tempRegion;
       tempRegion.SetIndex(tempIndex);
       tempRegion.SetSize(tempSize);
       *iter = tempRegion;

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -53,20 +53,15 @@ CompositeValleyFunction::~CompositeValleyFunction() = default;
 void
 CompositeValleyFunction::Initialize()
 {
-  SizeValueType i;
-  SizeValueType low;
-  SizeValueType high;
-
   // build table
   // when using valley-func then the table values run from
   // lowest_my - 10 * sigma to highest_my + 10 * sigma
-
-  low = 0;
-  high = 0;
+  SizeValueType low{ 0 };
+  SizeValueType high{ 0 };
 
   auto noOfClasses = static_cast<SizeValueType>(m_Targets.size());
 
-  for (i = 0; i < noOfClasses; ++i)
+  for (SizeValueType i = 0; i < noOfClasses; ++i)
   {
     if (m_Targets[i].GetMean() > m_Targets[high].GetMean())
     {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -41,9 +41,6 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {
   this->AllocateOutputs();
 
-  unsigned int i;
-  unsigned int j;
-
   // Retrieve input and output pointers
   typename OutputImageType::Pointer     output = this->GetOutput();
   typename InputImageType::ConstPointer input = this->GetInput();
@@ -64,7 +61,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   typename TInputImage::RegionType paddedInputRegion = input->GetBufferedRegion();
   paddedInputRegion.PadByRadius(radius); // to support boundary values
   InputSizeType padBy = radius;
-  for (i = 0; i < KernelDimension; ++i)
+  for (unsigned int i = 0; i < KernelDimension; ++i)
   {
     padBy[i] = (padBy[i] > kernel.GetRadius(i) ? padBy[i] : kernel.GetRadius(i));
   }
@@ -215,7 +212,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
       // Test current pixel: it is a border pixel or an inner pixel?
       bool bIsOnContour = false;
 
-      for (i = 0; i < neighborhoodSize; ++i)
+      for (unsigned int i = 0; i < neighborhoodSize; ++i)
       {
         // If at least one neighbour pixel is off the center pixel
         // belongs to contour
@@ -263,7 +260,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
           nit += currentIndex - nit.GetIndex();
 
-          for (i = 0; i < neighborhoodSize; ++i)
+          for (unsigned int i = 0; i < neighborhoodSize; ++i)
           {
             // If pixel has not been already treated and it is a pixel
             // on, test if it is an inner pixel or a border pixel
@@ -283,7 +280,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
               bool bIsOnBorder = false;
 
-              for (j = 0; j < neighborhoodSize; ++j)
+              for (unsigned int j = 0; j < neighborhoodSize; ++j)
               {
                 // If at least one neighbour pixel is off the center
                 // pixel belongs to border

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -41,9 +41,6 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {
   this->AllocateOutputs();
 
-  unsigned int i;
-  unsigned int j;
-
   // Retrieve input and output pointers
   typename OutputImageType::Pointer     output = this->GetOutput();
   typename InputImageType::ConstPointer input = this->GetInput();
@@ -64,7 +61,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   typename TInputImage::RegionType paddedInputRegion = input->GetBufferedRegion();
   paddedInputRegion.PadByRadius(radius); // to support boundary values
   InputSizeType padBy = radius;
-  for (i = 0; i < KernelDimension; ++i)
+  for (unsigned int i = 0; i < KernelDimension; ++i)
   {
     padBy[i] = (padBy[i] > kernel.GetRadius(i) ? padBy[i] : kernel.GetRadius(i));
   }
@@ -207,7 +204,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
       // Test current pixel: it is a border pixel or an inner pixel?
       bool bIsOnContour = false;
 
-      for (i = 0; i < neighborhoodSize; ++i)
+      for (unsigned int i = 0; i < neighborhoodSize; ++i)
       {
         // If at least one neighbour pixel is off the center pixel
         // belongs to contour
@@ -255,7 +252,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
           nit += currentIndex - nit.GetIndex();
 
-          for (i = 0; i < neighborhoodSize; ++i)
+          for (unsigned int i = 0; i < neighborhoodSize; ++i)
           {
             // If pixel has not been already treated and it is a pixel
             // on, test if it is an inner pixel or a border pixel
@@ -275,7 +272,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
               bool bIsOnBorder = false;
 
-              for (j = 0; j < neighborhoodSize; ++j)
+              for (unsigned int j = 0; j < neighborhoodSize; ++j)
               {
                 // If at least one neighbour pixel is off the center
                 // pixel belongs to border

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -54,11 +54,6 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   m_KernelDifferenceSets.clear();
   m_KernelCCVector.clear();
 
-  std::vector<unsigned int> kernelOnElements;
-
-  IndexValueType i;
-  IndexValueType k;
-
   // **************************
   // Structuring element ( SE ) coding
   // **************************
@@ -82,9 +77,10 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   // of SE Kernel
   KernelIteratorType KernelBegin = this->GetKernel().Begin();
   KernelIteratorType KernelEnd = this->GetKernel().End();
-  KernelIteratorType kernel_it;
+  KernelIteratorType kernel_it = KernelBegin;
 
-  for (i = 0, kernel_it = KernelBegin; kernel_it != KernelEnd; ++kernel_it, ++i)
+  std::vector<unsigned int> kernelOnElements;
+  for (IndexValueType i = 0; kernel_it != KernelEnd; ++kernel_it, ++i)
   {
     if (*kernel_it)
     {
@@ -236,7 +232,7 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
          ++kernelOnElementsIt)
     {
       // Get the index in the SE neighb
-      k = *kernelOnElementsIt;
+      IndexValueType k = *kernelOnElementsIt;
 
       // Get the Nd position of current SE element. In order to do
       // that, we have not a "GetIndex" function.  So first we get the
@@ -307,7 +303,8 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
   // in this case because there is no shift ) we put the kernel set
   // itself, useful for the rest of the process.
   unsigned int centerKernelIndex = adjNeigh.Size() / 2;
-  for (k = 0, kernel_it = KernelBegin; kernel_it != KernelEnd; ++kernel_it, ++k)
+  kernel_it = KernelBegin;
+  for (IndexValueType k = 0; kernel_it != KernelEnd; ++kernel_it, ++k)
   {
     if (*kernel_it)
     {

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -115,23 +115,23 @@ itkCustomColormapFunctionTest(int argc, char * argv[])
 
   using RGBPixelType = itk::RGBPixel<unsigned char>;
 
-  double              value;
-  std::vector<double> redChannel;
-  std::vector<double> greenChannel;
-  std::vector<double> blueChannel;
-
   std::ifstream str(argv[1]);
-  std::string   line;
 
   // Get red values
+  std::string line;
   std::getline(str, line);
   std::istringstream issr(line);
+
+  double value;
+
+  std::vector<double> redChannel;
   while (issr >> value)
   {
     redChannel.push_back(value);
   }
 
   // Get green values
+  std::vector<double> greenChannel;
   std::getline(str, line);
   std::istringstream issg(line);
   while (issg >> value)
@@ -140,6 +140,7 @@ itkCustomColormapFunctionTest(int argc, char * argv[])
   }
 
   // Get blue values
+  std::vector<double> blueChannel;
   std::getline(str, line);
   std::istringstream issb(line);
   while (issb >> value)

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -216,18 +216,16 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
   // is required for convolution to succeed.
   // TODO: Improve readability by keeping the output index as-is rather than resetting to 0, if the filter allows it
 
-  const InputImageType * regionOfInterestImage;
-  InputRegionType        regionOfInterest;
-  InputSizeType          regionOfInterestSize;
-  InputIndexType         regionOfInterestIndex;
-
+  InputSizeType  regionOfInterestSize;
+  InputIndexType regionOfInterestIndex;
   for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
     regionOfInterestSize[dim] = outputRequestedSize[dim] + 2 * kernelRadius[dim];
     regionOfInterestIndex[dim] = outputRequestedIndex[dim] - kernelRadius[dim];
   }
-  regionOfInterest = InputRegionType(regionOfInterestIndex, regionOfInterestSize);
+  InputRegionType regionOfInterest = InputRegionType(regionOfInterestIndex, regionOfInterestSize);
 
+  const InputImageType * regionOfInterestImage;
   if (outputRequestedRegion != inputLargestRegion)
   {
 

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -607,11 +607,10 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // We need a few additional checks.
   // Check that the image sizes are the same as their corresponding
   // masks.
-  std::ostringstream fixedSizeString;
-  std::ostringstream movingSizeString;
   if (this->GetFixedImageMask() && this->GetFixedImage()->GetLargestPossibleRegion().GetSize() !=
                                      this->GetFixedImageMask()->GetLargestPossibleRegion().GetSize())
   {
+    std::ostringstream fixedSizeString;
     fixedSizeString << std::endl
                     << "The fixed image must be the same size as the fixed mask.  " << std::endl
                     << "FixedImage Size: " << this->GetFixedImage()->GetLargestPossibleRegion().GetSize()
@@ -622,6 +621,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   if (this->GetMovingImageMask() && this->GetMovingImage()->GetLargestPossibleRegion().GetSize() !=
                                       this->GetMovingImageMask()->GetLargestPossibleRegion().GetSize())
   {
+    std::ostringstream movingSizeString;
     movingSizeString << std::endl
                      << "The moving image must be the same size as the moving mask.  " << std::endl
                      << "MovingImage Size: " << this->GetMovingImage()->GetLargestPossibleRegion().GetSize()

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -52,27 +52,22 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                                              void *                   itkNotUsed(gd),
                                              const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
-  PixelRealType  firstderiv[ImageDimension];
-  PixelRealType  secderiv[ImageDimension];
-  PixelRealType  crossderiv[ImageDimension][ImageDimension] = {};
-  IdentifierType center;
-  IdentifierType stride[ImageDimension];
-  unsigned int   i;
-  unsigned int   j;
-
-  const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
-
-  // get the center pixel position
-  center = it.Size() / 2;
-
   // cache the stride for each dimension
-  for (i = 0; i < ImageDimension; ++i)
+  IdentifierType stride[ImageDimension];
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     stride[i] = it.GetStride((IdentifierType)i);
   }
 
-  PixelRealType magnitudeSqr = 0.0;
-  for (i = 0; i < ImageDimension; ++i)
+  // get the center pixel position
+  IdentifierType center = it.Size() / 2;
+
+  const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
+  PixelRealType                magnitudeSqr = 0.0;
+  PixelRealType                firstderiv[ImageDimension];
+  PixelRealType                secderiv[ImageDimension];
+  PixelRealType                crossderiv[ImageDimension][ImageDimension] = {};
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // compute first order derivatives
     firstderiv[i] = 0.5 * (it.GetPixel(center + stride[i]) - it.GetPixel(center - stride[i])) * neighborhoodScales[i];
@@ -82,7 +77,7 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
                   itk::Math::sqr(neighborhoodScales[i]);
 
     // compute cross derivatives
-    for (j = i + 1; j < ImageDimension; ++j)
+    for (unsigned int j = i + 1; j < ImageDimension; ++j)
     {
       crossderiv[i][j] = 0.25 *
                          (it.GetPixel(center - stride[i] - stride[j]) - it.GetPixel(center - stride[i] + stride[j]) -
@@ -104,10 +99,10 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   PixelRealType temp;
 
   // accumulate dx^2 * (dyy + dzz) terms
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     temp = 0.0;
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       if (j == i)
       {
@@ -120,9 +115,9 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   }
 
   // accumulate -2 * dx * dy * dxy terms
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    for (j = i + 1; j < ImageDimension; ++j)
+    for (unsigned int j = i + 1; j < ImageDimension; ++j)
     {
       update -= 2 * firstderiv[i] * firstderiv[j] * crossderiv[i][j];
     }

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -237,12 +237,12 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   auto field = FieldType::New();
 
-  FieldType::SizeType   size;
-  FieldType::IndexType  start;
-  FieldType::RegionType region;
-  int                   dimLength = 20;
+  int                 dimLength = 20;
+  FieldType::SizeType size;
   size.Fill(dimLength);
+  FieldType::IndexType start;
   start.Fill(0);
+  FieldType::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);
   field->SetRegions(region);
@@ -382,14 +382,13 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   // Test ComputeJacobianWithRespectToParameters: should return identity
 
   DisplacementTransformType::JacobianType identity(Dimensions, Dimensions);
-  DisplacementTransformType::JacobianType testIdentity;
-
   identity.Fill(0);
   for (unsigned int i = 0; i < Dimensions; ++i)
   {
     identity[i][i] = 1.0;
   }
 
+  DisplacementTransformType::JacobianType testIdentity;
   displacementTransform->ComputeJacobianWithRespectToParameters(testPoint, testIdentity);
 
   tolerance = 1e-10;
@@ -415,15 +414,11 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   // Test transforming of points
   //
-
-  DisplacementTransformType::OutputPointType deformOutput;
-  DisplacementTransformType::OutputPointType deformTruth;
-
   // Test a point with non-zero displacement
-  FieldType::IndexType idx = field->TransformPhysicalPointToIndex(testPoint);
-  deformTruth = testPoint + field->GetPixel(idx);
+  FieldType::IndexType                       idx = field->TransformPhysicalPointToIndex(testPoint);
+  DisplacementTransformType::OutputPointType deformTruth = testPoint + field->GetPixel(idx);
 
-  deformOutput = displacementTransform->TransformPoint(testPoint);
+  DisplacementTransformType::OutputPointType deformOutput = displacementTransform->TransformPoint(testPoint);
 
   if (!samePoint(deformOutput, deformTruth))
   {
@@ -432,14 +427,13 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  DisplacementTransformType::InputVectorType  testVector;
-  DisplacementTransformType::OutputVectorType deformVector;
-  DisplacementTransformType::OutputVectorType deformVectorTruth;
+  DisplacementTransformType::InputVectorType testVector;
   testVector[0] = 0.5;
   testVector[1] = 0.5;
 
-  deformVectorTruth = affineTransform->TransformVector(testVector);
-  deformVector = displacementTransform->TransformVector(testVector, testPoint);
+  DisplacementTransformType::OutputVectorType deformVectorTruth = affineTransform->TransformVector(testVector);
+  DisplacementTransformType::OutputVectorType deformVector =
+    displacementTransform->TransformVector(testVector, testPoint);
 
   tolerance = 1e-4;
   if (!sameVector(deformVector, deformVectorTruth, tolerance))
@@ -453,14 +447,12 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
 
   // Test VectorTransform for variable length vector
-  DisplacementTransformType::InputVectorPixelType  testVVector(DisplacementTransformType::Dimension);
-  DisplacementTransformType::OutputVectorPixelType deformVVector;
-  DisplacementTransformType::OutputVectorPixelType deformVVectorTruth(DisplacementTransformType::Dimension);
+  DisplacementTransformType::InputVectorPixelType testVVector(DisplacementTransformType::Dimension);
   testVVector[0] = 0.5;
   testVVector[1] = 0.5;
-
-  deformVVectorTruth = affineTransform->TransformVector(testVVector);
-  deformVVector = displacementTransform->TransformVector(testVVector, testPoint);
+  DisplacementTransformType::OutputVectorPixelType deformVVectorTruth = affineTransform->TransformVector(testVVector);
+  DisplacementTransformType::OutputVectorPixelType deformVVector =
+    displacementTransform->TransformVector(testVVector, testPoint);
 
   if (!sameVariableVector(deformVVector, deformVVectorTruth, tolerance))
   {
@@ -474,14 +466,14 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   ITK_TRY_EXPECT_EXCEPTION(deformVVector = displacementTransform->TransformVector(testVVector));
 
 
-  DisplacementTransformType::InputCovariantVectorType  testcVector;
-  DisplacementTransformType::OutputCovariantVectorType deformcVector;
-  DisplacementTransformType::OutputCovariantVectorType deformcVectorTruth;
+  DisplacementTransformType::InputCovariantVectorType testcVector;
   testcVector[0] = 0.5;
   testcVector[1] = 0.5;
 
-  deformcVectorTruth = affineTransform->TransformCovariantVector(testcVector);
-  deformcVector = displacementTransform->TransformCovariantVector(testcVector, testPoint);
+  DisplacementTransformType::OutputCovariantVectorType deformcVectorTruth =
+    affineTransform->TransformCovariantVector(testcVector);
+  DisplacementTransformType::OutputCovariantVectorType deformcVector =
+    displacementTransform->TransformCovariantVector(testcVector, testPoint);
 
   tolerance = 1e-1;
   if (!sameVector(deformcVector, deformcVectorTruth, tolerance))
@@ -496,14 +488,14 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   ITK_TRY_EXPECT_EXCEPTION(deformcVector = displacementTransform->TransformCovariantVector(testcVector));
 
 
-  DisplacementTransformType::InputVectorPixelType  testcVVector(DisplacementTransformType::Dimension);
-  DisplacementTransformType::OutputVectorPixelType deformcVVector;
-  DisplacementTransformType::OutputVectorPixelType deformcVVectorTruth(DisplacementTransformType::Dimension);
+  DisplacementTransformType::InputVectorPixelType testcVVector(DisplacementTransformType::Dimension);
   testcVVector[0] = 0.5;
   testcVVector[1] = 0.5;
 
-  deformcVVectorTruth = affineTransform->TransformCovariantVector(testcVVector);
-  deformcVVector = displacementTransform->TransformCovariantVector(testcVVector, testPoint);
+  DisplacementTransformType::OutputVectorPixelType deformcVVectorTruth =
+    affineTransform->TransformCovariantVector(testcVVector);
+  DisplacementTransformType::OutputVectorPixelType deformcVVector =
+    displacementTransform->TransformCovariantVector(testcVVector, testPoint);
 
   if (!sameVariableVector(deformcVVector, deformcVVectorTruth, tolerance))
   {
@@ -517,9 +509,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   ITK_TRY_EXPECT_EXCEPTION(deformcVVector = displacementTransform->TransformCovariantVector(testcVVector));
 
 
-  DisplacementTransformType::InputDiffusionTensor3DType  testTensor;
-  DisplacementTransformType::OutputDiffusionTensor3DType deformTensor;
-  DisplacementTransformType::OutputDiffusionTensor3DType deformTensorTruth;
+  DisplacementTransformType::InputDiffusionTensor3DType testTensor;
   testTensor[0] = 3;
   testTensor[1] = 0.01;
   testTensor[2] = 0.01;
@@ -528,8 +518,10 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   testTensor[5] = 1;
 
   // Pass thru functionality only for now
-  deformTensorTruth = affineTransform->TransformDiffusionTensor3D(testTensor);
-  deformTensor = displacementTransform->TransformDiffusionTensor3D(testTensor, testPoint);
+  DisplacementTransformType::OutputDiffusionTensor3DType deformTensorTruth =
+    affineTransform->TransformDiffusionTensor3D(testTensor);
+  DisplacementTransformType::OutputDiffusionTensor3DType deformTensor =
+    displacementTransform->TransformDiffusionTensor3D(testTensor, testPoint);
 
   tolerance = 1e-4;
   if (!sameTensor(deformTensor, deformTensorTruth, tolerance))

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -99,31 +99,21 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   constexpr int INNER_MASK = 2;
 
   typename NeighborhoodIterator<TInputImage>::RadiusType r;
-  bool                                                   in_bounds;
-
   r.Fill(1);
   NeighborhoodIterator<TInputImage> it(r, this->GetOutput(), m_RegionToProcess);
 
   const unsigned int center_voxel = it.Size() / 2;
   const auto         neighbor_type = make_unique_for_overwrite<int[]>(it.Size());
-  int                i;
-  unsigned int       n;
-  float              val[ImageDimension];
-  PixelType          center_value;
-  int                neighbor_start;
-  int                neighbor_end;
-  BandNodeType       node;
 
   /** 1st Scan , using neighbors from center_voxel+1 to it.Size()-1 */
-
   /** Precomputing the neighbor types */
-  neighbor_start = center_voxel + 1;
-  neighbor_end = it.Size() - 1;
+  int neighbor_start = center_voxel + 1;
+  int neighbor_end = it.Size() - 1;
 
-  for (i = neighbor_start; i <= neighbor_end; ++i)
+  for (int i = neighbor_start; i <= neighbor_end; ++i)
   {
     neighbor_type[i] = -1;
-    for (n = 0; n < ImageDimension; ++n)
+    for (unsigned int n = 0; n < ImageDimension; ++n)
     {
       neighbor_type[i] += static_cast<int>(it.GetOffset(i)[n] != 0);
     }
@@ -132,7 +122,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   /** Scan the image */
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
-    center_value = it.GetPixel(center_voxel);
+    PixelType center_value = it.GetPixel(center_voxel);
     if (center_value >= m_MaximumDistance)
     {
       continue;
@@ -144,15 +134,17 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     /** Update Positive Distance */
     if (center_value > -m_Weights[0])
     {
-      for (n = 0; n < ImageDimension; ++n)
+      float val[ImageDimension];
+      for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         val[n] = center_value + m_Weights[n];
       }
-      for (i = neighbor_start; i <= neighbor_end; ++i)
+      for (int i = neighbor_start; i <= neighbor_end; ++i)
       {
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] < it.GetPixel(i))
         {
+          bool in_bounds;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -160,16 +152,18 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     /** Update Negative Distance */
     if (center_value < m_Weights[0])
     {
-      for (n = 0; n < ImageDimension; ++n)
+      float val[ImageDimension];
+      for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         val[n] = center_value - m_Weights[n];
       }
 
-      for (i = neighbor_start; i <= neighbor_end; ++i)
+      for (int i = neighbor_start; i <= neighbor_end; ++i)
       {
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] > it.GetPixel(i))
         {
+          bool in_bounds;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -188,10 +182,10 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   neighbor_start = 0;
   neighbor_end = center_voxel - 1;
 
-  for (i = neighbor_start; i <= neighbor_end; ++i)
+  for (int i = neighbor_start; i <= neighbor_end; ++i)
   {
     neighbor_type[i] = -1;
-    for (n = 0; n < ImageDimension; ++n)
+    for (unsigned int n = 0; n < ImageDimension; ++n)
     {
       neighbor_type[i] += (it.GetOffset(i)[n] != 0);
     }
@@ -200,7 +194,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   /** Scan the image */
   for (it.GoToEnd(), --it; !it.IsAtBegin(); --it)
   {
-    center_value = it.GetPixel(center_voxel);
+    PixelType center_value = it.GetPixel(center_voxel);
     if (center_value >= m_MaximumDistance)
     {
       continue;
@@ -213,6 +207,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     // Update the narrow band
     if (m_NarrowBand.IsNotNull())
     {
+      BandNodeType node;
       if (itk::Math::abs(static_cast<float>(center_value)) <= m_NarrowBand->GetTotalRadius())
       {
         node.m_Index = it.GetIndex();
@@ -233,15 +228,17 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     /** Update Positive Distance */
     if (center_value > -m_Weights[0])
     {
-      for (n = 0; n < ImageDimension; ++n)
+      float val[ImageDimension];
+      for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         val[n] = center_value + m_Weights[n];
       }
-      for (i = neighbor_start; i <= neighbor_end; ++i)
+      for (int i = neighbor_start; i <= neighbor_end; ++i)
       {
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] < it.GetPixel(i))
         {
+          bool in_bounds;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -250,16 +247,18 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     /** Update Negative Distance */
     if (center_value < m_Weights[0])
     {
-      for (n = 0; n < ImageDimension; ++n)
+      float val[ImageDimension];
+      for (unsigned int n = 0; n < ImageDimension; ++n)
       {
         val[n] = center_value - m_Weights[n];
       }
 
-      for (i = neighbor_start; i <= neighbor_end; ++i)
+      for (int i = neighbor_start; i <= neighbor_end; ++i)
       {
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] > it.GetPixel(i))
         {
+          bool in_bounds;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -86,12 +86,10 @@ test(int testIdx)
   else
   {
     std::cout << "Compute with a 9x9 image, with a 5x5 square at the center set to ON." << std::endl << std::endl;
-    // Test the signed Danielsson Output for the a 5x5 square in a 9x9 image
-    int i;
-    int j;
-    for (i = 2; i <= 6; ++i)
+    // Test the signed Danielsson Output for the a 5x5 square in a 9x9 images
+    for (int i = 2; i <= 6; ++i)
     {
-      for (j = 2; j <= 6; ++j)
+      for (int j = 2; j <= 6; ++j)
       {
         index2D[0] = i;
         index2D[1] = j;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -147,29 +147,20 @@ template <typename TInput, typename TOutput>
 void
 FastMarchingImageFilterBase<TInput, TOutput>::UpdateNeighbors(OutputImageType * oImage, const NodeType & iNode)
 {
-  NodeType neighIndex = iNode;
-
-  unsigned char label;
-
-  typename NodeType::IndexValueType v;
-  typename NodeType::IndexValueType start;
-  typename NodeType::IndexValueType last;
-
-  int s;
-
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
-    v = iNode[j];
-    start = m_StartIndex[j];
-    last = m_LastIndex[j];
+    typename NodeType::IndexValueType v = iNode[j];
+    typename NodeType::IndexValueType start = m_StartIndex[j];
+    typename NodeType::IndexValueType last = m_LastIndex[j];
 
-    for (s = -1; s < 2; s += 2)
+    NodeType neighIndex = iNode;
+    for (int s = -1; s < 2; s += 2)
     {
       if ((v > start) && (v < last))
       {
         neighIndex[j] = v + s;
       }
-      label = m_LabelImage->GetPixel(neighIndex);
+      unsigned char label = m_LabelImage->GetPixel(neighIndex);
 
       if ((label != Traits::Alive) && (label != Traits::InitialTrial) && (label != Traits::Forbidden))
       {
@@ -211,31 +202,21 @@ FastMarchingImageFilterBase<TInput, TOutput>::GetInternalNodesUsed(OutputImageTy
 {
   NodeType neighbor_node = iNode;
 
-  OutputPixelType neighValue;
-
   // Just to make sure the index is initialized (really cautious)
   InternalNodeStructure temp_node;
   temp_node.m_Node = iNode;
-
-  typename NodeType::IndexValueType v;
-  typename NodeType::IndexValueType start;
-  typename NodeType::IndexValueType last;
-  typename NodeType::IndexValueType temp;
-
-  int s;
-
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     temp_node.m_Value = this->m_LargeValue;
 
-    v = iNode[j];
-    start = m_StartIndex[j];
-    last = m_LastIndex[j];
+    typename NodeType::IndexValueType v = iNode[j];
+    typename NodeType::IndexValueType start = m_StartIndex[j];
+    typename NodeType::IndexValueType last = m_LastIndex[j];
 
     // Find smallest valued neighbor in this dimension
-    for (s = -1; s < 2; s = s + 2)
+    for (int s = -1; s < 2; s = s + 2)
     {
-      temp = v + s;
+      typename NodeType::IndexValueType temp = v + s;
 
       // Make sure neighIndex is not outside from the image
       if ((temp <= last) && (temp >= start))
@@ -244,7 +225,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::GetInternalNodesUsed(OutputImageTy
 
         if (this->GetLabelValueForGivenNode(neighbor_node) == Traits::Alive)
         {
-          neighValue = this->GetOutputValue(oImage, neighbor_node);
+          OutputPixelType neighValue = this->GetOutputValue(oImage, neighbor_node);
 
           // let's find the minimum value given a direction j
           if (temp_node.m_Value > neighValue)
@@ -293,28 +274,21 @@ FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *           
     }
   }
 
-  double       discrim = 0.;
-  double       value = 0.;
-  double       spaceFactor = 0.;
-  unsigned int axis = 0;
-
   for (const auto & neighbor : iNeighbors)
   {
-    value = static_cast<double>(neighbor.m_Value);
+    double value = static_cast<double>(neighbor.m_Value);
 
     if (oSolution >= value)
     {
-      axis = neighbor.m_Axis;
-
+      unsigned int axis = neighbor.m_Axis;
       // spaceFactor = \frac{1}{spacing[axis]^2}
-      spaceFactor = itk::Math::sqr(1.0 / m_OutputSpacing[axis]);
+      double spaceFactor = itk::Math::sqr(1.0 / m_OutputSpacing[axis]);
 
       aa += spaceFactor;
       bb += value * spaceFactor;
       cc += itk::Math::sqr(value) * spaceFactor;
 
-      discrim = itk::Math::sqr(bb) - aa * cc;
-
+      double discrim = itk::Math::sqr(bb) - aa * cc;
       if (discrim < itk::Math::eps)
       {
         // Discriminant of quadratic eqn. is negative
@@ -462,9 +436,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
   m_LabelImage->Allocate();
   m_LabelImage->FillBuffer(Traits::Far);
 
-  NodeType        idx;
   OutputPixelType outputPixel = this->m_LargeValue;
-
   if (this->m_AlivePoints)
   {
     NodePairContainerConstIterator pointsIter = this->m_AlivePoints->Begin();
@@ -473,7 +445,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     while (pointsIter != pointsEnd)
     {
       // Get node from alive points container
-      idx = pointsIter->Value().GetNode();
+      NodeType idx = pointsIter->Value().GetNode();
 
       // Check if node index is within the output level set
       if (m_BufferedRegion.IsInside(idx))
@@ -503,7 +475,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
 
     while (pointsIter != pointsEnd)
     {
-      idx = pointsIter->Value().GetNode();
+      NodeType idx = pointsIter->Value().GetNode();
 
       // Check if node index is within the output level set
       if (m_BufferedRegion.IsInside(idx))
@@ -551,7 +523,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     while (pointsIter != pointsEnd)
     {
       // Get node from trial points container
-      idx = pointsIter->Value().GetNode();
+      NodeType idx = pointsIter->Value().GetNode();
 
       // Check if node index is within the output level set
       if (m_BufferedRegion.IsInside(idx))

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -54,10 +54,6 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   const double min_rms_error = 1.0e-14; // 7 digits of precision
 
-  unsigned int                                  i;
-  unsigned int                                  iter;
-  ProcessObject::DataObjectPointerArraySizeType number_of_input_files;
-
   // Allocate the output "fuzzy" image.
   this->GetOutput()->SetBufferedRegion(this->GetOutput()->GetRequestedRegion());
   this->GetOutput()->Allocate();
@@ -67,7 +63,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   W->FillBuffer(0.0);
 
   // Record the number of input files.
-  number_of_input_files = this->GetNumberOfIndexedInputs();
+  ProcessObject::DataObjectPointerArraySizeType number_of_input_files = this->GetNumberOfIndexedInputs();
 
   const auto D_it = make_unique_for_overwrite<IteratorType[]>(number_of_input_files);
 
@@ -77,7 +73,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   const auto last_q = make_unique_for_overwrite<double[]>(number_of_input_files);
   const auto last_p = make_unique_for_overwrite<double[]>(number_of_input_files);
 
-  for (i = 0; i < number_of_input_files; ++i)
+  for (unsigned int i = 0; i < number_of_input_files; ++i)
   {
     last_p[i] = -10.0;
     last_q[i] = -10.0;
@@ -85,17 +81,15 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Come up with an initial Wi which is simply the average of
   // all the segmentations.
-  IteratorType      in;
-  FuzzyIteratorType out;
-  for (i = 0; i < number_of_input_files; ++i)
+  for (unsigned int i = 0; i < number_of_input_files; ++i)
   {
     if (this->GetInput(i)->GetRequestedRegion() != W->GetRequestedRegion())
     {
       itkExceptionMacro("One or more input images do not contain matching RequestedRegions");
     }
 
-    in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
-    out = FuzzyIteratorType(W, W->GetRequestedRegion());
+    IteratorType      in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
+    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
 
     while (!in.IsAtEnd())
     {
@@ -114,36 +108,37 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
 
   // Divide sum by num of files, calculate the estimate of g_t
+
   double N = 0.0;
   double g_t = 0.0;
-  out.GoToBegin();
-  while (!out.IsAtEnd())
   {
-    while (!out.IsAtEndOfLine())
+    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
+    while (!out.IsAtEnd())
     {
-      out.Set(out.Get() / static_cast<double>(number_of_input_files));
-      g_t += out.Get();
-      N = N + 1.0;
-      ++out;
-    } // end of scanline
-    out.NextLine();
+      while (!out.IsAtEndOfLine())
+      {
+        out.Set(out.Get() / static_cast<double>(number_of_input_files));
+        g_t += out.Get();
+        N = N + 1.0;
+        ++out;
+      } // end of scanline
+      out.NextLine();
+    }
+    g_t = (g_t / N) * m_ConfidenceWeight;
   }
-  g_t = (g_t / N) * m_ConfidenceWeight;
-
-  double p_num;
-  double p_denom;
-  double q_num;
-  double q_denom;
-
-  for (iter = 0; iter < m_MaximumIterations; ++iter)
+  unsigned int iter = 0;
+  for (; iter < m_MaximumIterations; ++iter)
   {
     // Now iterate on estimating specificity and sensitivity
-    for (i = 0; i < number_of_input_files; ++i)
+    for (unsigned int i = 0; i < number_of_input_files; ++i)
     {
-      in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
-      out = FuzzyIteratorType(W, W->GetRequestedRegion());
+      IteratorType      in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
+      FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
 
-      p_num = p_denom = q_num = q_denom = 0.0;
+      double p_num{};
+      double p_denom{};
+      double q_num{};
+      double q_denom{};
 
       // Sensitivity and specificity of this user
       while (!in.IsAtEnd())
@@ -175,23 +170,19 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
     // Need an iterator on each D
     // const double g_t = 0.1;  // prior likelihood that a pixel is incl.in
     // segmentation
-    double alpha1;
-    double beta1;
-
-    for (i = 0; i < number_of_input_files; ++i)
+    for (unsigned int i = 0; i < number_of_input_files; ++i)
     {
       D_it[i] = IteratorType(this->GetInput(i), W->GetRequestedRegion());
     }
 
-    out = FuzzyIteratorType(W, W->GetRequestedRegion());
-
-    out.GoToBegin();
+    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
     while (!out.IsAtEnd())
     {
       while (!out.IsAtEndOfLine())
       {
-        alpha1 = beta1 = 1.0;
-        for (i = 0; i < number_of_input_files; ++i)
+        double alpha1{ 1.0 };
+        double beta1{ 1.0 };
+        for (unsigned int i = 0; i < number_of_input_files; ++i)
         {
           if (D_it[i].Get() > m_ForegroundValue - epsilon && D_it[i].Get() < m_ForegroundValue + epsilon)
           // Dij == 1
@@ -209,7 +200,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
         out.Set(g_t * alpha1 / (g_t * alpha1 + (1.0 - g_t) * beta1));
         ++out;
       } // end scanline
-      for (i = 0; i < number_of_input_files; ++i)
+      for (unsigned int i = 0; i < number_of_input_files; ++i)
       {
         D_it[i].NextLine();
       }
@@ -223,7 +214,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
     if (iter != 0) // not on the first iteration
     {
       flag = true;
-      for (i = 0; i < number_of_input_files; ++i)
+      for (unsigned int i = 0; i < number_of_input_files; ++i)
       {
         if (((p[i] - last_p[i]) * (p[i] - last_p[i])) > min_rms_error)
         {
@@ -237,7 +228,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
         }
       }
     }
-    for (i = 0; i < number_of_input_files; ++i)
+    for (unsigned int i = 0; i < number_of_input_files; ++i)
     {
       last_p[i] = p[i];
       last_q[i] = q[i];
@@ -259,7 +250,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   m_Sensitivity.clear();
   m_Specificity.clear();
-  for (i = 0; i < number_of_input_files; ++i)
+  for (unsigned int i = 0; i < number_of_input_files; ++i)
   {
     m_Sensitivity.push_back(p[i]);
     m_Specificity.push_back(q[i]);

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -112,19 +112,14 @@ template <typename TInputImage1, typename TInputImage2>
 void
 SimilarityIndexImageFilter<TInputImage1, TInputImage2>::AfterThreadedGenerateData()
 {
-  ThreadIdType  i;
-  SizeValueType countImage1;
-  SizeValueType countImage2;
-  SizeValueType countIntersect;
-
   ThreadIdType numberOfWorkUnits = this->GetNumberOfWorkUnits();
 
-  countImage1 = 0;
-  countImage2 = 0;
-  countIntersect = 0;
+  SizeValueType countImage1 = 0;
+  SizeValueType countImage2 = 0;
+  SizeValueType countIntersect = 0;
 
   // Accumulate counts over all threads
-  for (i = 0; i < numberOfWorkUnits; ++i)
+  for (ThreadIdType i = 0; i < numberOfWorkUnits; ++i)
   {
     countImage1 += m_CountOfImage1[i];
     countImage2 += m_CountOfImage2[i];

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -235,71 +235,61 @@ void
 BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  typename TInputImage::ConstPointer   input = this->GetInput();
-  typename TOutputImage::Pointer       output = this->GetOutput();
-  typename TInputImage::IndexValueType i;
-  const double                         rangeDistanceThreshold = m_DynamicRangeUsed;
+  typename TInputImage::ConstPointer input = this->GetInput();
+  typename TOutputImage::Pointer     output = this->GetOutput();
 
-  ZeroFluxNeumannBoundaryCondition<TInputImage> BC;
+  const double rangeDistanceThreshold = m_DynamicRangeUsed;
 
   // Find the boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        fC;
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
     fC(this->GetInput(), outputRegionForThread, m_GaussianKernel.GetRadius());
 
-  OutputPixelRealType centerPixel;
-  OutputPixelRealType val;
-  OutputPixelRealType tableArg;
-  OutputPixelRealType normFactor;
-  OutputPixelRealType rangeGaussian;
-  OutputPixelRealType rangeDistance;
-  OutputPixelRealType pixel;
-  OutputPixelRealType gaussianProduct;
-
   const double distanceToTableIndex = static_cast<double>(m_NumberOfRangeGaussianSamples) / m_DynamicRangeUsed;
 
   // Process all the faces, the NeighborhoodIterator will determine
   // whether a specified region needs to use the boundary conditions or
   // not.
-  NeighborhoodIteratorType             b_iter;
-  ImageRegionIterator<OutputImageType> o_iter;
-  KernelConstIteratorType              k_it;
-  KernelConstIteratorType              kernelEnd = m_GaussianKernel.End();
+
+
+  KernelConstIteratorType kernelEnd = m_GaussianKernel.End();
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
+  ZeroFluxNeumannBoundaryCondition<TInputImage> BC;
   for (const auto & face : faceList)
   {
     // walk the boundary face and the corresponding section of the output
-    b_iter = NeighborhoodIteratorType(m_GaussianKernel.GetRadius(), this->GetInput(), face);
+    NeighborhoodIteratorType b_iter = NeighborhoodIteratorType(m_GaussianKernel.GetRadius(), this->GetInput(), face);
     b_iter.OverrideBoundaryCondition(&BC);
-    o_iter = ImageRegionIterator<OutputImageType>(this->GetOutput(), face);
+    ImageRegionIterator<OutputImageType> o_iter = ImageRegionIterator<OutputImageType>(this->GetOutput(), face);
 
     while (!b_iter.IsAtEnd())
     {
       // Setup
-      centerPixel = static_cast<OutputPixelRealType>(b_iter.GetCenterPixel());
-      val = 0.0;
-      normFactor = 0.0;
+      OutputPixelRealType centerPixel = static_cast<OutputPixelRealType>(b_iter.GetCenterPixel());
+      OutputPixelRealType val = 0.0;
+      OutputPixelRealType normFactor = 0.0;
 
       // Walk the neighborhood of the input and the kernel
-      for (i = 0, k_it = m_GaussianKernel.Begin(); k_it < kernelEnd; ++k_it, ++i)
+      KernelConstIteratorType k_it = m_GaussianKernel.Begin();
+      for (typename TInputImage::IndexValueType i = 0; k_it < kernelEnd; ++k_it, ++i)
       {
         // range distance between neighborhood pixel and neighborhood center
-        pixel = static_cast<OutputPixelRealType>(b_iter.GetPixel(i));
+        OutputPixelRealType pixel = static_cast<OutputPixelRealType>(b_iter.GetPixel(i));
         // flip sign if needed
-        rangeDistance = std::abs(pixel - centerPixel);
+        OutputPixelRealType rangeDistance = std::abs(pixel - centerPixel);
 
         // if the range distance is close enough, then use the pixel
         if (rangeDistance < rangeDistanceThreshold)
         {
           // look up the range gaussian in a table
-          tableArg = rangeDistance * distanceToTableIndex;
-          rangeGaussian = m_RangeGaussianTable[Math::Floor<SizeValueType>(tableArg)];
+          OutputPixelRealType tableArg = rangeDistance * distanceToTableIndex;
+          OutputPixelRealType rangeGaussian = m_RangeGaussianTable[Math::Floor<SizeValueType>(tableArg)];
 
           // normalization factor so filter integrates to one
           // (product of the domain and the range gaussian)
-          gaussianProduct = (*k_it) * rangeGaussian;
+          OutputPixelRealType gaussianProduct = (*k_it) * rangeGaussian;
           normFactor += gaussianProduct;
 
           // Input Image * Domain Gaussian * Range Gaussian

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -83,18 +83,13 @@ template <typename TInputImage, typename TOutputImage, typename TInternalPixel>
 void
 GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::InitInterImage()
 {
-  unsigned int i;
-  double       b;
-  PixelType    c_vec;
-  PixelType    m_vec;
-
   m_IntermediateImage = TInputImage::New();
   m_IntermediateImage->SetLargestPossibleRegion(this->GetInput()->GetLargestPossibleRegion());
   m_IntermediateImage->SetRequestedRegionToLargestPossibleRegion();
   m_IntermediateImage->SetBufferedRegion(m_IntermediateImage->GetRequestedRegion());
   m_IntermediateImage->Allocate();
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_InternalImages[i] = InternalImageType::New();
     m_InternalImages[i]->SetLargestPossibleRegion(this->GetInput()->GetLargestPossibleRegion());
@@ -133,13 +128,14 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::InitIn
   /* Calculate b(x, y), c1(x, y), c2(x, y), etc.... (eqn 15) */
   while (!inputIt.IsAtEnd())
   {
-    b = 0.0;
-    m_vec = inputIt.Get();
-    for (i = 0; i < ImageDimension; ++i)
+    double    b = 0.0;
+    PixelType m_vec = inputIt.Get();
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       b = b + m_vec[i] * m_vec[i]; /*  b = fx^2 + fy^2 ... */
     }
-    for (i = 0; i < ImageDimension; ++i)
+    PixelType c_vec;
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       c_vec[i] = b * m_vec[i]; /* c1 = b * fx, c2 = b * fy ... */
     }
@@ -160,10 +156,9 @@ template <typename TInputImage, typename TOutputImage, typename TInternalPixel>
 void
 GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::UpdateInterImage()
 {
-  unsigned int       i;
   InputImageIterator intermediateIt(m_IntermediateImage, m_IntermediateImage->GetBufferedRegion());
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     InternalImageIterator internalIt(m_InternalImages[i], m_InternalImages[i]->GetBufferedRegion());
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -73,9 +73,8 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   stRegion.SetSize(this->m_Kernel.GetSize());
   stRegion.PadByRadius(1); // must pad the region by one because of the translation
 
-  OffsetType   centerOffset;
-  unsigned int i;
-  for (i = 0; i < ImageDimension; ++i)
+  OffsetType centerOffset;
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     centerOffset[i] = stRegion.GetSize()[i] / 2;
   }
@@ -106,7 +105,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   // iterator passes over the various dimensions.
   int Steps[ImageDimension];
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     HistVec[i] = histogram;
     PrevLineStartVec[i] = InLineIt.GetIndex();
@@ -138,12 +137,12 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
     // histogram to update and the direction in which to push
     // it. Then we need to copy that histogram to the relevant
     // places
-    OffsetType LineOffset;
-    OffsetType Changes;
     // Figure out which stored histogram to move and in
     // which direction
     int LineDirection = 0;
     // This function deals with changing planes etc
+    OffsetType LineOffset;
+    OffsetType Changes;
     this->GetDirAndOffset(LineStart, PrevLineStart, LineOffset, Changes, LineDirection);
     ++(Steps[LineDirection]);
     IndexType              PrevLineStartHist = LineStart - LineOffset;
@@ -158,7 +157,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
     // copy the updated histogram and line start entries to the
     // relevant directions. When updating direction 2, for example,
     // new copies of directions 0 and 1 should be made.
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       if (Steps[i] > Steps[LineDirection])
       {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
@@ -229,31 +229,25 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage
                                                                                  unsigned int       inTraverseSize,
                                                                                  ProgressReporter & progress)
 {
-  IndexValueType i1;
-  IndexValueType i2;
-
-  SizeValueType outK;
-  SizeValueType inK;
   SizeValueType outTraverseSize = inTraverseSize / 2;
 
-  inTraverseSize = outTraverseSize * 2; // ensures that an even number is used.
-  SizeValueType inModK;                 // number for modulus math of in
-  inModK = 2L * inTraverseSize;
+  inTraverseSize = outTraverseSize * 2;       // ensures that an even number is used.
+  SizeValueType inModK = 2L * inTraverseSize; // number for modulus math of in
 
   // TODO:  Need to allocate this once as a scratch variable instead of each
   // time through.
   std::vector<double> temp;
   temp.resize(inTraverseSize);
 
-  for (inK = 0; inK < inTraverseSize; ++inK)
+  for (SizeValueType inK = 0; inK < inTraverseSize; ++inK)
   {
     temp[inK] = in[inK] * this->m_G[0];
 
     for (int i = 1; i < this->m_GSize; ++i)
     {
       // Calculate indices for left and right of symmetrical filter.
-      i1 = inK - i;
-      i2 = inK + i;
+      IndexValueType i1 = inK - i;
+      IndexValueType i2 = inK + i;
       // reflect at boundaries if necessary
       if (i1 < 0)
       {
@@ -276,10 +270,10 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage
     }
   }
 
-  for (outK = 0; outK < outTraverseSize; ++outK)
+  for (SizeValueType outK = 0; outK < outTraverseSize; ++outK)
   {
-    i1 = 2 * outK;
-    double outVal = (temp[i1] + temp[i1 + 1]) / 2.0;
+    IndexValueType i1 = 2 * outK;
+    double         outVal = (temp[i1] + temp[i1 + 1]) / 2.0;
     out.Set(static_cast<OutputImagePixelType>(outVal));
     ++out;
     progress.CompletedPixel();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -191,26 +191,18 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage(const s
                                                                          unsigned int                inTraverseSize,
                                                                          ProgressReporter &          progress)
 {
-  int i1;
-  int i2;
-
-  unsigned int outK;
-  unsigned int inK;
   unsigned int outTraverseSize = inTraverseSize / 2;
 
-  inTraverseSize = outTraverseSize * 2; // ensures that an even number is used.
-  unsigned int inModK;                  // number for modulus math of in
-  inModK = inTraverseSize - 1;
-
-  double outVal;
+  inTraverseSize = outTraverseSize * 2;     // ensures that an even number is used.
+  unsigned int inModK = inTraverseSize - 1; // number for modulus math of in
 
   // TODO:  m_GSize < 2 has not been tested.
   if (m_GSize < 2)
   {
-    for (outK = 0; outK < outTraverseSize; ++outK)
+    for (unsigned int outK = 0; outK < outTraverseSize; ++outK)
     {
-      inK = 2 * outK;
-      i2 = inK + 1;
+      unsigned int inK = 2 * outK;
+      int          i2 = inK + 1;
       if (i2 > static_cast<int>(inModK))
       {
         // Original was
@@ -227,17 +219,17 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Reduce1DImage(const s
 
   else
   {
-    for (outK = 0; outK < outTraverseSize; ++outK)
+    for (unsigned int outK = 0; outK < outTraverseSize; ++outK)
     {
-      inK = 2L * outK;
+      unsigned int inK = 2L * outK;
 
-      outVal = in[inK] * m_G[0];
+      double outVal = in[inK] * m_G[0];
 
       for (int i = 1; i < m_GSize; ++i)
       {
         // Calculate indices for left and right of symmetrical filter.
-        i1 = inK - i;
-        i2 = inK + i;
+        int i1 = inK - i;
+        int i2 = inK + i;
         // reflect at boundaries if necessary
         if (i1 < 0)
         {
@@ -272,23 +264,14 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
                                                                          unsigned int                inTraverseSize,
                                                                          ProgressReporter &          progress)
 {
-  int i1;
-  int i2;
-
-  int          outK;
-  unsigned int inK;
   unsigned int outTraverseSize = inTraverseSize * 2;
   // inTraverseSize = outTraverseSize/2;  // ensures that an even number is used.
-  int inModK; // number for modulus math of in
-
-  inModK = inTraverseSize - 1;
-
-  double outVal;
+  int inModK = inTraverseSize - 1; // number for modulus math of in
 
   // TODO:  m_GSize < 2 has not been tested.
   if (m_HSize < 2)
   {
-    for (inK = 0; inK < inTraverseSize; ++inK)
+    for (unsigned int inK = 0; inK < inTraverseSize; ++inK)
     {
       out.Set(static_cast<OutputImagePixelType>(in[inK]));
       ++out;
@@ -300,12 +283,12 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
 
   else
   {
-    for (outK = 0; outK < static_cast<int>(outTraverseSize); ++outK)
+    for (int outK = 0; outK < static_cast<int>(outTraverseSize); ++outK)
     {
-      outVal = 0.0;
+      double outVal = 0.0;
       for (int k = (outK % 2); k < static_cast<int>(m_HSize); k += 2)
       {
-        i1 = (outK - k) / 2;
+        int i1 = (outK - k) / 2;
         if (i1 < 0)
         {
           i1 = (-i1) % inModK;
@@ -317,7 +300,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
       }
       for (int k = 2 - (outK % 2); k < static_cast<int>(m_HSize); k += 2)
       {
-        i2 = (outK + k) / 2;
+        int i2 = (outK + k) / 2;
         if (i2 > inModK)
         {
           i2 = i2 % inModK;
@@ -340,21 +323,16 @@ template <typename TInputImage, typename TOutputImage>
 void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputImageIterator & outItr)
 {
-  // Set up variables for waking the image regions.
-  RegionType validRegion;
-  SizeType   startSize;
-  SizeType   currentSize;
-
   // Does not support streaming
   typename Superclass::InputImagePointer inputPtr = const_cast<TInputImage *>(this->GetInput());
-  startSize = inputPtr->GetBufferedRegion().GetSize();
+  SizeType                               startSize = inputPtr->GetBufferedRegion().GetSize();
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
   auto scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
-  currentSize = startSize;
+  SizeType   currentSize = startSize;
   // scratchImage only needs the 1/2 the space of the original
   // image for the first dimension.
   // TODO: Is dividing by 2 correct or do I need something more complicated for
@@ -366,6 +344,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ReduceNDImage(OutputI
   scratchImage->Allocate();
 
   currentSize = startSize;
+  RegionType validRegion;
   validRegion.SetSize(currentSize);
   validRegion.SetIndex(inputPtr->GetBufferedRegion().GetIndex());
 
@@ -453,20 +432,16 @@ void
 BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputImageIterator & outItr)
 {
   // Set up variables for waking the image regions.
-  RegionType validRegion;
-  SizeType   startSize;
-  SizeType   currentSize;
-
   // Does not support streaming
   typename Superclass::InputImagePointer inputPtr = const_cast<TInputImage *>(this->GetInput());
-  startSize = inputPtr->GetBufferedRegion().GetSize();
+  SizeType                               startSize = inputPtr->GetBufferedRegion().GetSize();
 
   // Initialize scratchImage space and allocate memory
   InitializeScratch(startSize);
   auto scratchImage = TOutputImage::New();
   scratchImage->CopyInformation(inputPtr);
   RegionType scratchRegion = inputPtr->GetBufferedRegion();
-  currentSize = startSize;
+  SizeType   currentSize = startSize;
 
   // scratchImage 2 times the space of the original image .
 
@@ -479,6 +454,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::ExpandNDImage(OutputI
   scratchImage->Allocate();
 
   currentSize = startSize;
+  RegionType validRegion;
   validRegion.SetSize(currentSize);
   validRegion.SetIndex(inputPtr->GetBufferedRegion().GetIndex());
 

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -57,9 +57,8 @@ template <class TInputImage, class TOutputImage>
 void
 BinShrinkImageFilter<TInputImage, TOutputImage>::SetShrinkFactors(unsigned int factor)
 {
-  unsigned int j;
-
-  for (j = 0; j < ImageDimension; ++j)
+  unsigned int j = 0;
+  for (; j < ImageDimension; ++j)
   {
     if (factor != m_ShrinkFactors[j])
     {
@@ -111,10 +110,8 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   // Set up shaped neighbor hood by defining the offsets
   OutputOffsetType negativeOffset;
-  OutputOffsetType positiveOffset;
-  OutputOffsetType iOffset;
-
   negativeOffset[0] = 0;
+  OutputOffsetType positiveOffset;
   positiveOffset[0] = 0;
   for (unsigned int i = 1; i < TInputImage::ImageDimension; ++i)
   {
@@ -123,7 +120,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   }
 
   std::vector<OutputOffsetType> offsets;
-  iOffset = negativeOffset;
+  OutputOffsetType              iOffset = negativeOffset;
   while (iOffset[TInputImage::ImageDimension - 1] <= positiveOffset[TInputImage::ImageDimension - 1])
   {
     offsets.push_back(iOffset);
@@ -232,7 +229,6 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   typename TInputImage::IndexType inputIndex0;
   typename TInputImage::SizeType  inputSize;
-
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     inputIndex0[i] = outputRequestedRegionStartIndex[i] * m_ShrinkFactors[i];

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -43,10 +43,9 @@ PermuteAxesImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  unsigned int j;
-
   os << indent << "Order: [";
-  for (j = 0; j < ImageDimension - 1; ++j)
+  unsigned int j = 0;
+  for (; j < ImageDimension - 1; ++j)
   {
     os << m_Order[j] << ", ";
   }
@@ -64,8 +63,6 @@ template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
 {
-  unsigned int j;
-
   // check if it the same as current
   if (m_Order == order)
   {
@@ -76,7 +73,7 @@ PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
   // numbers from 0 to ImageDimension - 1
   auto used = MakeFilled<FixedArray<bool, ImageDimension>>(false);
 
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     if (order[j] > ImageDimension - 1)
     {
@@ -98,7 +95,7 @@ PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
   // copy to member variable
   this->Modified();
   m_Order = order;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     m_InverseOrder[m_Order[j]] = j;
   }
@@ -131,19 +128,15 @@ PermuteAxesImageFilter<TImage>::GenerateOutputInformation()
   typename TImage::DirectionType outputDirection;
   typename TImage::SizeType      outputSize;
   typename TImage::IndexType     outputStartIndex;
-
-  unsigned int i;
-  unsigned int j;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     // origin does not change by a Permute.  But spacing, directions,
     // size and start index do.
     outputOrigin[j] = inputOrigin[j];
-
     outputSpacing[j] = inputSpacing[m_Order[j]];
     outputSize[j] = inputSize[m_Order[j]];
     outputStartIndex[j] = inputStartIndex[m_Order[j]];
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       outputDirection[i][j] = inputDirection[i][m_Order[j]];
     }
@@ -180,8 +173,7 @@ PermuteAxesImageFilter<TImage>::GenerateInputRequestedRegion()
   typename TImage::SizeType  inputSize;
   typename TImage::IndexType inputIndex;
 
-  unsigned int j;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     inputSize[j] = outputSize[m_InverseOrder[j]];
     inputIndex[j] = outputIndex[m_InverseOrder[j]];
@@ -196,8 +188,6 @@ template <typename TImage>
 void
 PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  unsigned int j;
-
   // Get the input and output pointers
   typename Superclass::InputImageConstPointer inputPtr = this->GetInput();
   typename Superclass::OutputImagePointer     outputPtr = this->GetOutput();
@@ -208,7 +198,6 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
   using OutputIterator = ImageRegionIteratorWithIndex<TImage>;
 
   typename TImage::IndexType outputIndex;
-  typename TImage::IndexType inputIndex;
 
   // walk the output region, and sample the input image
   for (OutputIterator outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
@@ -217,7 +206,8 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
     outputIndex = outIt.GetIndex();
 
     // determine the input pixel location associated with this output pixel
-    for (j = 0; j < ImageDimension; ++j)
+    typename TImage::IndexType inputIndex;
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       inputIndex[j] = outputIndex[m_InverseOrder[j]];
     }

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -252,13 +252,11 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   }
 
   // Find the size of the largest cell for each "row" in each dimension.
-  ImageLinearConstIteratorWithIndex<TileImageType> tit(m_TileImage, m_TileImage->GetRequestedRegion());
-  int                                              value;
+
 
   std::vector<std::vector<int>> sizes;
-  std::vector<std::vector<int>> offsets;
-
   sizes.resize(OutputImageDimension);
+  std::vector<std::vector<int>> offsets;
   offsets.resize(OutputImageDimension);
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
@@ -269,6 +267,8 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       sizes[i][l] = 1;
     }
   }
+
+  ImageLinearConstIteratorWithIndex<TileImageType> tit(m_TileImage, m_TileImage->GetRequestedRegion());
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
     tit.SetDirection(i);
@@ -279,7 +279,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       int count = 0;
       while (!tit.IsAtEndOfLine())
       {
-        value = tit.Get().m_ImageNumber;
+        int value = tit.Get().m_ImageNumber;
         if (value != -1)
         {
           if (i < InputImageDimension)
@@ -314,7 +314,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
-    value = it.Get().m_ImageNumber;
+    int value = it.Get().m_ImageNumber;
     if (value >= 0)
     {
       typename TileImageType::IndexType tileIndex2 = it.GetIndex();
@@ -374,7 +374,6 @@ TileImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
   const unsigned int numComponents = image->GetNumberOfComponentsPerPixel();
 
   typename Superclass::DataObjectPointerArraySizeType idx = 1;
-
   for (; idx < this->GetNumberOfIndexedInputs(); ++idx)
   {
     image = this->GetInput(idx);

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -27,33 +27,31 @@ using ImagePointer = ImageType::Pointer;
 void
 PrintInformation(ImagePointer image1, ImagePointer image2)
 {
-  unsigned int i;
-  unsigned int j;
   std::cout << "Input  "
             << "      Output" << std::endl;
   std::cout << "Origin"
             << "      Origin" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "  " << image1->GetOrigin()[i] << "       " << image2->GetOrigin()[i] << std::endl;
   }
   std::cout << "Spacing"
             << "      Spacing" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "    " << image1->GetSpacing()[i] << "        " << image2->GetSpacing()[i] << std::endl;
   }
   std::cout << "Direction"
             << "  Direction" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "  ";
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       std::cout << image1->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       std::cout << image2->GetDirection()[i][j] << ' ';
     }
@@ -64,15 +62,13 @@ PrintInformation(ImagePointer image1, ImagePointer image2)
 void
 PrintInformation3(ImagePointer image1, ImagePointer image2, ImagePointer image3)
 {
-  unsigned int i;
-  unsigned int j;
   std::cout << "Input  "
             << "      Output"
             << "      Reference" << std::endl;
   std::cout << "Origin"
             << "      Origin"
             << "      Origin" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "  " << image1->GetOrigin()[i] << "       " << image2->GetOrigin()[i] << "       "
               << image3->GetOrigin()[i] << std::endl;
@@ -80,7 +76,7 @@ PrintInformation3(ImagePointer image1, ImagePointer image2, ImagePointer image3)
   std::cout << "Spacing"
             << "      Spacing"
             << "      Spacing" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "    " << image1->GetSpacing()[i] << "        " << image2->GetSpacing()[i] << "        "
               << image3->GetSpacing()[i] << std::endl;
@@ -88,20 +84,20 @@ PrintInformation3(ImagePointer image1, ImagePointer image2, ImagePointer image3)
   std::cout << "Direction"
             << "  Direction"
             << "  Direction" << std::endl;
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     std::cout << "  ";
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       std::cout << image1->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       std::cout << image2->GetDirection()[i][j] << ' ';
     }
     std::cout << "     ";
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       std::cout << image3->GetDirection()[i][j] << ' ';
     }

--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -36,8 +36,6 @@ itkConstantPadImageTest(int, char *[])
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
   ShortImage::RegionType region;
-  int                    row;
-  int                    column;
   region.SetSize(size);
   region.SetIndex(index);
   image->SetLargestPossibleRegion(region);
@@ -46,8 +44,7 @@ itkConstantPadImageTest(int, char *[])
 
   itk::ImageRegionIterator<ShortImage> iterator(image, region);
 
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
+  for (short i = 0; !iterator.IsAtEnd(); ++iterator, ++i)
   {
     iterator.Set(i);
   }
@@ -64,7 +61,7 @@ itkConstantPadImageTest(int, char *[])
   SizeValueType upperFactors[2] = { 0, 0 };
   SizeValueType lowerFactors[2] = { 0, 0 };
 
-  float constant = 13.3f;
+  constexpr float constant = 13.3f;
   constantPad->SetConstant(constant);
   // check the method using the SizeType rather than the simple table type.
   ShortImage::SizeType stfactors{};
@@ -78,10 +75,6 @@ itkConstantPadImageTest(int, char *[])
   std::cout << "Output spacing: " << constantPad->GetOutput()->GetSpacing()[0] << ", "
             << constantPad->GetOutput()->GetSpacing()[1] << std::endl;
 
-
-  ShortImage::RegionType requestedRegion;
-  bool                   passed;
-
   // CASE 1
   lowerFactors[0] = 1;
   lowerFactors[1] = 2;
@@ -90,11 +83,10 @@ itkConstantPadImageTest(int, char *[])
   constantPad->SetPadLowerBound(lowerFactors);
   constantPad->SetPadUpperBound(upperFactors);
   constantPad->UpdateLargestPossibleRegion();
-  requestedRegion = constantPad->GetOutput()->GetRequestedRegion();
+  ShortImage::RegionType requestedRegion = constantPad->GetOutput()->GetRequestedRegion();
 
-  itk::ImageRegionIterator<FloatImage> iteratorIn1(constantPad->GetOutput(), requestedRegion);
 
-  passed = true;
+  bool passed = true;
   size = requestedRegion.GetSize();
   index = requestedRegion.GetIndex();
   if ((index[0] != (0 - (IndexValueType)lowerFactors[0])) || (index[1] != (0 - (IndexValueType)lowerFactors[1])) ||
@@ -104,10 +96,12 @@ itkConstantPadImageTest(int, char *[])
   }
   else
   {
-    for (; !iteratorIn1.IsAtEnd(); ++iteratorIn1)
+    for (itk::ImageRegionIterator<FloatImage> iteratorIn1(constantPad->GetOutput(), requestedRegion);
+         !iteratorIn1.IsAtEnd();
+         ++iteratorIn1)
     {
-      row = iteratorIn1.GetIndex()[0];
-      column = iteratorIn1.GetIndex()[1];
+      int row = iteratorIn1.GetIndex()[0];
+      int column = iteratorIn1.GetIndex()[1];
       if ((row < 0) || (row > 7) || (column < 0) || (column > 11))
       {
         if (itk::Math::NotExactlyEquals(iteratorIn1.Get(), constant))
@@ -164,8 +158,6 @@ itkConstantPadImageTest(int, char *[])
     stream->UpdateLargestPossibleRegion();
     requestedRegion = stream->GetOutput()->GetRequestedRegion();
 
-    itk::ImageRegionIterator<FloatImage> iteratorIn2(stream->GetOutput(), requestedRegion);
-
     passed = true;
     size = requestedRegion.GetSize();
     index = requestedRegion.GetIndex();
@@ -176,10 +168,12 @@ itkConstantPadImageTest(int, char *[])
     }
     else
     {
-      for (; !iteratorIn2.IsAtEnd(); ++iteratorIn2)
+      for (itk::ImageRegionIterator<FloatImage> iteratorIn2(stream->GetOutput(), requestedRegion);
+           !iteratorIn2.IsAtEnd();
+           ++iteratorIn2)
       {
-        row = iteratorIn2.GetIndex()[0];
-        column = iteratorIn2.GetIndex()[1];
+        int row = iteratorIn2.GetIndex()[0];
+        int column = iteratorIn2.GetIndex()[1];
         if ((row < 0) || (row > 7) || (column < 0) || (column > 11))
         {
           if (itk::Math::NotExactlyEquals(iteratorIn2.Get(), constant))

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
@@ -30,12 +30,8 @@ namespace
 int
 VerifyPixel(int row, int col, int val)
 {
-  int nextVal;
-  int rowVal;
-  int colVal;
-
-  rowVal = row;
-  colVal = col;
+  int rowVal = row;
+  int colVal = col;
 
   if (row < 0)
   {
@@ -77,7 +73,7 @@ VerifyPixel(int row, int col, int val)
     col -= 12;
     colVal = col;
   }
-  nextVal = 8 * colVal + rowVal;
+  int nextVal = 8 * colVal + rowVal;
   return (val == nextVal);
 }
 } // namespace
@@ -85,11 +81,6 @@ VerifyPixel(int row, int col, int val)
 int
 itkMirrorPadImageTest(int, char *[])
 {
-  //  itk::FileOutputWindow::Pointer fow = itk::FileOutputWindow::New();
-  //  fow->SetInstance(fow);
-
-  //  itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(8);
-
   // type alias to simplify the syntax
   using SimpleImage = itk::Image<short, 2>;
   auto simpleImage = SimpleImage::New();
@@ -106,26 +97,23 @@ itkMirrorPadImageTest(int, char *[])
   ShortImage::IndexType  index = { { 0, 0 } };
   ShortImage::SizeType   size = { { 8, 12 } };
   ShortImage::RegionType region;
-  int                    row;
-  int                    column;
   region.SetSize(size);
   region.SetIndex(index);
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();
 
-  itk::ImageRegionIterator<ShortImage> iterator(if2, region);
-
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
   {
-    iterator.Set(i);
+    short i = 0;
+    for (itk::ImageRegionIterator<ShortImage> iterator(if2, region); !iterator.IsAtEnd(); ++iterator)
+    {
+      iterator.Set(i);
+      ++i;
+    }
   }
-
   // Create a filter
-  itk::MirrorPadImageFilter<ShortImage, ShortImage>::Pointer mirrorPad;
-
-  mirrorPad = itk::MirrorPadImageFilter<ShortImage, ShortImage>::New();
+  itk::MirrorPadImageFilter<ShortImage, ShortImage>::Pointer mirrorPad =
+    itk::MirrorPadImageFilter<ShortImage, ShortImage>::New();
   itk::SimpleFilterWatcher watcher(mirrorPad);
 
   mirrorPad->SetInput(if2);
@@ -146,10 +134,6 @@ itkMirrorPadImageTest(int, char *[])
   std::cout << "Output spacing: " << mirrorPad->GetOutput()->GetSpacing()[0] << ", "
             << mirrorPad->GetOutput()->GetSpacing()[1] << std::endl;
 
-
-  ShortImage::RegionType requestedRegion;
-  bool                   passed;
-
   // CASE 1
   lowerfactors[0] = 3;
   lowerfactors[1] = 7;
@@ -158,11 +142,10 @@ itkMirrorPadImageTest(int, char *[])
   mirrorPad->SetPadLowerBound(lowerfactors);
   mirrorPad->SetPadUpperBound(upperfactors);
   mirrorPad->UpdateLargestPossibleRegion();
-  requestedRegion = mirrorPad->GetOutput()->GetRequestedRegion();
+  ShortImage::RegionType requestedRegion = mirrorPad->GetOutput()->GetRequestedRegion();
 
-  itk::ImageRegionIterator<ShortImage> iteratorIn1(mirrorPad->GetOutput(), requestedRegion);
 
-  passed = true;
+  bool passed = true;
   size = requestedRegion.GetSize();
   index = requestedRegion.GetIndex();
   if ((index[0] != (0 - (IndexValueType)lowerfactors[0])) || (index[1] != (0 - (IndexValueType)lowerfactors[1])) ||
@@ -172,11 +155,12 @@ itkMirrorPadImageTest(int, char *[])
   }
   else
   {
-
-    for (; !iteratorIn1.IsAtEnd(); ++iteratorIn1)
+    for (itk::ImageRegionIterator<ShortImage> iteratorIn1(mirrorPad->GetOutput(), requestedRegion);
+         !iteratorIn1.IsAtEnd();
+         ++iteratorIn1)
     {
-      row = iteratorIn1.GetIndex()[0];
-      column = iteratorIn1.GetIndex()[1];
+      int row = iteratorIn1.GetIndex()[0];
+      int column = iteratorIn1.GetIndex()[1];
       if (!VerifyPixel(row, column, iteratorIn1.Get()))
       {
         std::cout << "Error: (" << row << ", " << column << "), got " << iteratorIn1.Get() << std::endl;
@@ -212,7 +196,6 @@ itkMirrorPadImageTest(int, char *[])
     mirrorPad->UpdateLargestPossibleRegion();
     requestedRegion = mirrorPad->GetOutput()->GetRequestedRegion();
 
-    itk::ImageRegionIterator<ShortImage> iteratorIn2(mirrorPad->GetOutput(), requestedRegion);
 
     passed = true;
     size = requestedRegion.GetSize();
@@ -224,10 +207,12 @@ itkMirrorPadImageTest(int, char *[])
     }
     else
     {
-      for (; !iteratorIn2.IsAtEnd(); ++iteratorIn2)
+      for (itk::ImageRegionIterator<ShortImage> iteratorIn2(mirrorPad->GetOutput(), requestedRegion);
+           !iteratorIn2.IsAtEnd();
+           ++iteratorIn2)
       {
-        row = iteratorIn2.GetIndex()[0];
-        column = iteratorIn2.GetIndex()[1];
+        int row = iteratorIn2.GetIndex()[0];
+        int column = iteratorIn2.GetIndex()[1];
         if (!VerifyPixel(row, column, iteratorIn2.Get()))
         {
           std::cout << "Error: (" << row << ", " << column << "), got " << iteratorIn2.Get() << std::endl;
@@ -270,7 +255,6 @@ itkMirrorPadImageTest(int, char *[])
     stream->UpdateLargestPossibleRegion();
     requestedRegion = stream->GetOutput()->GetRequestedRegion();
 
-    itk::ImageRegionIterator<ShortImage> iteratorIn3(stream->GetOutput(), requestedRegion);
 
     passed = true;
     size = requestedRegion.GetSize();
@@ -282,10 +266,12 @@ itkMirrorPadImageTest(int, char *[])
     }
     else
     {
-      for (; !iteratorIn3.IsAtEnd(); ++iteratorIn3)
+      for (itk::ImageRegionIterator<ShortImage> iteratorIn3(stream->GetOutput(), requestedRegion);
+           !iteratorIn3.IsAtEnd();
+           ++iteratorIn3)
       {
-        row = iteratorIn3.GetIndex()[0];
-        column = iteratorIn3.GetIndex()[1];
+        int row = iteratorIn3.GetIndex()[0];
+        int column = iteratorIn3.GetIndex()[1];
         if (!VerifyPixel(row, column, iteratorIn3.Get()))
         {
           std::cout << "Error: (" << row << ", " << column << "), got " << iteratorIn3.Get() << std::endl;

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -93,10 +93,9 @@ itkOrientImageFilterTest(int argc, char * argv[])
   PrintImg(SLA);
 
   ImageType::RegionType::SizeType originalSize = randImage->GetLargestPossibleRegion().GetSize();
-  ImageType::RegionType::SizeType transformedSize = SLA->GetLargestPossibleRegion().GetSize();
-  ImageType::IndexType            originalIndex;
-  ImageType::IndexType            transformedIndex;
 
+  ImageType::IndexType originalIndex;
+  ImageType::IndexType transformedIndex;
   for (originalIndex[2] = transformedIndex[2] = 0;
        originalIndex[2] < static_cast<ImageType::IndexType::IndexValueType>(originalSize[2]);
        originalIndex[2]++, transformedIndex[2]++)
@@ -128,7 +127,7 @@ itkOrientImageFilterTest(int argc, char * argv[])
   ImageType::Pointer LIP = orienter->GetOutput();
   std::cerr << "LIP" << std::endl;
   PrintImg(LIP);
-  transformedSize = LIP->GetLargestPossibleRegion().GetSize();
+  ImageType::RegionType::SizeType transformedSize = LIP->GetLargestPossibleRegion().GetSize();
 
   for (originalIndex[2] = transformedIndex[2] = 0;
        originalIndex[2] < static_cast<ImageType::IndexType::IndexValueType>(originalSize[2]);

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -57,12 +57,9 @@ CreateAxialImage()
   img->SetRegions(region);
   img->Allocate();
 
-  std::string row;
-  std::string column;
-  std::string slice;
-  std::string label;
   for (imageIndex[2] = 0; imageIndex[2] < 4; imageIndex[2]++)
   {
+    std::string slice;
     if (imageIndex[2] < 2)
     {
       slice = "I";
@@ -73,6 +70,7 @@ CreateAxialImage()
     }
     for (imageIndex[1] = 0; imageIndex[1] < 4; imageIndex[1]++)
     {
+      std::string row;
       if (imageIndex[1] < 2)
       {
         row = "A";
@@ -83,6 +81,7 @@ CreateAxialImage()
       }
       for (imageIndex[0] = 0; imageIndex[0] < 4; imageIndex[0]++)
       {
+        std::string column;
         if (imageIndex[0] < 2)
         {
           column = "R";
@@ -91,7 +90,7 @@ CreateAxialImage()
         {
           column = "L";
         }
-        label = column + row + slice;
+        std::string label = column + row + slice;
         img->SetPixel(imageIndex, label);
       }
     }
@@ -123,12 +122,9 @@ CreateCoronalImage()
   imageDirection[1][2] = 1;
   imageDirection[2][2] = 0;
   img->SetDirection(imageDirection);
-  std::string row;
-  std::string column;
-  std::string slice;
-  std::string label;
   for (imageIndex[2] = 0; imageIndex[2] < 4; imageIndex[2]++)
   {
+    std::string slice;
     if (imageIndex[2] < 2)
     {
       slice = "A";
@@ -139,6 +135,7 @@ CreateCoronalImage()
     }
     for (imageIndex[1] = 0; imageIndex[1] < 4; imageIndex[1]++)
     {
+      std::string row;
       if (imageIndex[1] < 2)
       {
         row = "S";
@@ -149,6 +146,7 @@ CreateCoronalImage()
       }
       for (imageIndex[0] = 0; imageIndex[0] < 4; imageIndex[0]++)
       {
+        std::string column;
         if (imageIndex[0] < 2)
         {
           column = "R";
@@ -157,7 +155,7 @@ CreateCoronalImage()
         {
           column = "L";
         }
-        label = column + row + slice;
+        std::string label = column + row + slice;
         img->SetPixel(imageIndex, label);
       }
     }

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
@@ -50,16 +50,14 @@ IntensityWindowingImageFilter<TInputImage, TOutputImage>::SetWindowLevel(const I
                                                                          const InputPixelType & level)
 {
   using InputRealType = typename NumericTraits<InputPixelType>::RealType;
-  InputRealType tmp1;
-  InputRealType tmp2;
 
-  tmp1 = static_cast<InputRealType>(level) - (static_cast<InputRealType>(window) / 2.0);
+  InputRealType tmp1 = static_cast<InputRealType>(level) - (static_cast<InputRealType>(window) / 2.0);
   if (tmp1 < NumericTraits<InputPixelType>::NonpositiveMin())
   {
     tmp1 = 0.0;
   }
 
-  tmp2 = static_cast<InputRealType>(level) + (static_cast<InputRealType>(window) / 2.0);
+  InputRealType tmp2 = static_cast<InputRealType>(level) + (static_cast<InputRealType>(window) / 2.0);
   tmp2 = std::min<InputRealType>(tmp2, NumericTraits<InputPixelType>::max());
 
   this->m_WindowMinimum = static_cast<InputPixelType>(tmp1);

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -173,26 +173,24 @@ itkNaryAddImageFilterTest(int, char *[])
   auto vectorImageB = VectorImageType::New();
   auto vectorImageC = VectorImageType::New();
 
-  VectorPixelType vectorImageValueA;
-  VectorPixelType vectorImageValueB;
-  VectorPixelType vectorImageValueC;
-
   constexpr VectorImageType::PixelType::ValueType vectorValueA = 12;
+  VectorPixelType                                 vectorImageValueA;
   vectorImageValueA.Fill(vectorValueA);
   vectorImageValueA[0] = 5;
 
   constexpr VectorImageType::PixelType::ValueType vectorValueB = 17;
+  VectorPixelType                                 vectorImageValueB;
   vectorImageValueB.Fill(vectorValueB);
   vectorImageValueB[0] = 9;
 
   const VectorImageType::PixelType::ValueType vectorValueC = -4;
+  VectorPixelType                             vectorImageValueC;
   vectorImageValueC.Fill(vectorValueC);
   vectorImageValueC[0] = -80;
 
   InitializeImage<VectorImageType>(vectorImageA, vectorImageValueA);
   InitializeImage<VectorImageType>(vectorImageB, vectorImageValueB);
   InitializeImage<VectorImageType>(vectorImageC, vectorImageValueC);
-
 
   // Create an ADD Filter
   using VectorAdderType = itk::NaryAddImageFilter<VectorImageType, VectorImageType>;

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -49,10 +49,6 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
   using inputVectorType = itk::Vector<double, iDimension>;
   using inputPolylineType = itk::PolyLineParametricPath<pDimension>;
 
-  // Create up and viewing direction vectors
-  inputVectorType inputUpVector;
-  inputVectorType inputViewVector;
-
   // Create polyline
   auto inputPolyline = inputPolylineType::New();
   std::cout << "Generating the synthetic object..." << std::endl;
@@ -70,13 +66,12 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
   using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, inputImageType>;
   auto imageGenerationFilter = SpatialObjectToImageFilterType::New();
 
-  inputImageType::SizeType  size;
   inputImageType::PointType origin;
-
   origin[0] = 0.0;
   origin[1] = 0.0;
   origin[2] = 20.0;
 
+  inputImageType::SizeType size;
   size[0] = 40;
   size[1] = 40;
   size[2] = 35;
@@ -121,11 +116,13 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
   std::cout << "Generating the view vector... " << std::endl;
 
   // View vector
+  inputVectorType inputViewVector;
   inputViewVector[0] = 0;
   inputViewVector[1] = 0;
   inputViewVector[2] = -1;
 
   // Up vector
+  inputVectorType inputUpVector;
   inputUpVector[0] = 1;
   inputUpVector[1] = 0;
   inputUpVector[2] = 0;

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -157,17 +157,12 @@ protected:
   {
     m_UnionFind = UnionFindType(numberOfLabels + 1);
 
-    typename LineMapType::iterator MapBegin;
-    typename LineMapType::iterator MapEnd;
-    typename LineMapType::iterator LineIt;
-    MapBegin = m_LineMap.begin();
-    MapEnd = m_LineMap.end();
-    LineIt = MapBegin;
-    InternalLabelType label = 1;
-    for (LineIt = MapBegin; LineIt != MapEnd; ++LineIt)
+    typename LineMapType::iterator MapBegin = m_LineMap.begin();
+    typename LineMapType::iterator MapEnd = m_LineMap.end();
+    InternalLabelType              label = 1;
+    for (typename LineMapType::iterator LineIt = MapBegin; LineIt != MapEnd; ++LineIt)
     {
-      LineEncodingIterator cIt;
-      for (cIt = LineIt->begin(); cIt != LineIt->end(); ++cIt)
+      for (LineEncodingIterator cIt = LineIt->begin(); cIt != LineIt->end(); ++cIt)
       {
         cIt->label = label;
         m_UnionFind[label] = label;
@@ -289,13 +284,9 @@ protected:
       offset = 1;
     }
 
-    LineEncodingConstIterator nIt;
-    LineEncodingConstIterator mIt;
-    LineEncodingConstIterator cIt;
+    LineEncodingConstIterator mIt = Neighbour.begin(); // out marker iterator
 
-    mIt = Neighbour.begin(); // out marker iterator
-
-    for (cIt = current.begin(); cIt != current.end(); ++cIt)
+    for (LineEncodingConstIterator cIt = current.begin(); cIt != current.end(); ++cIt)
     {
       if (!labelCompare || cIt->label != InternalLabelType(background))
       {
@@ -307,7 +298,7 @@ protected:
           mIt = Neighbour.begin();
         }
 
-        for (nIt = mIt; nIt != Neighbour.end(); ++nIt)
+        for (LineEncodingConstIterator nIt = mIt; nIt != Neighbour.end(); ++nIt)
         {
           if (!labelCompare || cIt->label != nIt->label)
           {
@@ -432,12 +423,12 @@ protected:
 
     typename LineNeighborhoodType::IndexListType ActiveIndexes = lnit.GetActiveIndexList();
 
-    typename LineNeighborhoodType::IndexListType::const_iterator LI;
-
     PretendIndexType idx = LineRegion.GetIndex();
     OffsetValueType  offset = fakeImage->ComputeOffset(idx);
 
-    for (LI = ActiveIndexes.begin(); LI != ActiveIndexes.end(); ++LI)
+    for (typename LineNeighborhoodType::IndexListType::const_iterator LI = ActiveIndexes.begin();
+         LI != ActiveIndexes.end();
+         ++LI)
     {
       m_LineOffsets.push_back(fakeImage->ComputeOffset(idx + lnit.GetOffset(*LI)) - offset);
     }

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -287,17 +287,15 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   }
 
   // compute some projections!
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3;
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj4;
   decomposer->SetImage(image3);
   ITK_TEST_SET_GET_VALUE(image3, decomposer->GetImage());
 
   decomposer->Compute();
-  proj3 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3 = decomposer->GetProjection();
 
   decomposer->SetImage(image4);
   decomposer->Compute();
-  proj4 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4 = decomposer->GetProjection();
 
   // get the basis images
   ImagePCAShapeModelEstimatorType::BasisImagePointerVector basis_check;
@@ -309,30 +307,26 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   basis.push_back(image7);
   decomposer->SetBasisImages(basis);
 
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_2;
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_2;
   // decomposer->SetImage(image4); // DON'T set image4 -- it should still
   // be cached with the decomposer. Test that this works between basis changes.
   decomposer->Compute();
-  proj4_2 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_2 = decomposer->GetProjection();
 
   decomposer->SetImage(image3);
   decomposer->Compute();
-  proj3_2 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_2 = decomposer->GetProjection();
 
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_3;
-  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_3;
   // now test it with a mean image set
   decomposer->SetMeanImage(image8);
   ITK_TEST_SET_GET_VALUE(image8, decomposer->GetMeanImage());
 
   decomposer->SetImage(image3);
   decomposer->Compute();
-  proj3_3 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj3_3 = decomposer->GetProjection();
 
   decomposer->SetImage(image4);
   decomposer->Compute();
-  proj4_3 = decomposer->GetProjection();
+  ImagePCAShapeModelEstimatorType::BasisVectorType proj4_3 = decomposer->GetProjection();
 
 
   // get the basis images

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -64,17 +64,16 @@ AnchorErodeDilateLine<TInputPix, TCompare>::DoLine(std::vector<TInputPix> & buff
 
   int middle = static_cast<int>(m_Size) / 2;
 
-  int                 outLeftP = 0;
-  int                 outRightP = static_cast<int>(bufflength) - 1;
-  int                 inLeftP = 0;
-  int                 inRightP = static_cast<int>(bufflength) - 1;
-  InputImagePixelType Extreme;
-  HistogramType       histo;
+  int           outLeftP = 0;
+  int           outRightP = static_cast<int>(bufflength) - 1;
+  int           inLeftP = 0;
+  int           inRightP = static_cast<int>(bufflength) - 1;
+  HistogramType histo;
   if (bufflength <= m_Size)
   {
     // basically a standard histogram method
     // Left border, first half of structuring element
-    Extreme = inbuffer[inLeftP];
+    InputImagePixelType Extreme = inbuffer[inLeftP];
     histo.AddPixel(Extreme);
     for (int i = 0; (i < middle); ++i)
     {
@@ -115,7 +114,7 @@ AnchorErodeDilateLine<TInputPix, TCompare>::DoLine(std::vector<TInputPix> & buff
   }
 
   // Left border, first half of structuring element
-  Extreme = inbuffer[inLeftP];
+  InputImagePixelType Extreme = inbuffer[inLeftP];
   histo.AddPixel(Extreme);
   for (int i = 0; (i < middle); ++i)
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -198,11 +198,10 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DoFaceOpen(
     typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
     unsigned int               start;
     unsigned int               end;
-    unsigned int               len;
     if (FillLineBuffer<TImage, BresType, KernelLType>(
           input, Ind, NormLine, tol, LineOffsets, AllImage, outbuffer, start, end))
     {
-      len = end - start + 1;
+      const unsigned int len = end - start + 1;
       // compat
       outbuffer[0] = border;
       outbuffer[len + 1] = border;

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -121,8 +121,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
   // code, and false to indicate finishLine
   Extreme = buffer[outLeftP];
   unsigned int currentP = outLeftP + 1;
-  unsigned int sentinel;
-  unsigned int endP;
+
 
   while ((currentP < outRightP) && Compare2(buffer[currentP], Extreme))
   {
@@ -130,8 +129,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
     ++outLeftP;
     ++currentP;
   }
-
-  sentinel = outLeftP + m_Size;
+  unsigned int sentinel = outLeftP + m_Size;
   if (sentinel > outRightP)
   {
     // finish
@@ -143,7 +141,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
   {
     if (Compare2(buffer[currentP], Extreme))
     {
-      endP = currentP;
+      unsigned int endP = currentP;
       for (unsigned int PP = outLeftP + 1; PP < endP; ++PP)
       {
         buffer[PP] = Extreme;
@@ -159,7 +157,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
   HistogramType histo;
   if (Compare2(buffer[currentP], Extreme))
   {
-    endP = currentP;
+    unsigned int endP = currentP;
     for (unsigned int PP = outLeftP + 1; PP < endP; ++PP)
     {
       buffer[PP] = Extreme;
@@ -192,7 +190,7 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
     if (Compare2(buffer[currentP], Extreme))
     {
       // Found a new extreme
-      endP = currentP;
+      unsigned int endP = currentP;
       for (unsigned int PP = outLeftP + 1; PP < endP; ++PP)
       {
         buffer[PP] = Extreme;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -336,11 +336,9 @@ FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringElement<
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
+        LType3 A = FacetArray[j].P2 - FacetArray[j].P1;
+        LType3 B = FacetArray[j].P3 - FacetArray[j].P1;
         LType3 L;
-        LType3 A;
-        LType3 B;
-        A = FacetArray[j].P2 - FacetArray[j].P1;
-        B = FacetArray[j].P3 - FacetArray[j].P1;
         L[0] = A[1] * B[2] - B[1] * A[2];
         L[1] = B[0] * A[2] - A[0] * B[2];
         L[2] = A[0] * B[1] - B[0] * A[1];
@@ -704,11 +702,9 @@ FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringElement<
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
+        LType3 A = FacetArray[j].P2 - FacetArray[j].P1;
+        LType3 B = FacetArray[j].P3 - FacetArray[j].P1;
         LType3 L;
-        LType3 A;
-        LType3 B;
-        A = FacetArray[j].P2 - FacetArray[j].P1;
-        B = FacetArray[j].P3 - FacetArray[j].P1;
         L[0] = A[1] * B[2] - B[1] * A[2];
         L[1] = B[0] * A[2] - A[0] * B[2];
         L[2] = A[0] * B[1] - B[0] * A[1];
@@ -740,59 +736,59 @@ FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringElement<
 
       // original corners of octahedron
       LType3 P0{};
-      LType3 P1{};
-      LType3 P2{};
-      LType3 P3{};
-      LType3 P4{};
-      LType3 P5{};
       P0[0] = 0;
       P0[1] = 0;
       P0[2] = 1;
+      LType3 P1{};
       P1[0] = 0;
       P1[1] = 0;
       P1[2] = -1;
+      LType3 P2{};
       P2[0] = -1.0 / sqrt2;
       P2[1] = -1 / sqrt2;
       P2[2] = 0;
+      LType3 P3{};
       P3[0] = 1 / sqrt2;
       P3[1] = -1 / sqrt2;
       P3[2] = 0;
+      LType3 P4{};
       P4[0] = 1 / sqrt2;
       P4[1] = 1 / sqrt2;
       P4[2] = 0;
+      LType3 P5{};
       P5[0] = -1 / sqrt2;
       P5[1] = 1 / sqrt2;
       P5[2] = 0;
 
       FacetType3 F0;
-      FacetType3 F1;
-      FacetType3 F2;
-      FacetType3 F3;
-      FacetType3 F4;
-      FacetType3 F5;
-      FacetType3 F6;
-      FacetType3 F7;
       F0.P1 = P0;
       F0.P2 = P3;
       F0.P3 = P4;
+      FacetType3 F1;
       F1.P1 = P0;
       F1.P2 = P4;
       F1.P3 = P5;
+      FacetType3 F2;
       F2.P1 = P0;
       F2.P2 = P5;
       F2.P3 = P2;
+      FacetType3 F3;
       F3.P1 = P0;
       F3.P2 = P2;
       F3.P3 = P3;
+      FacetType3 F4;
       F4.P1 = P1;
       F4.P2 = P4;
       F4.P3 = P3;
+      FacetType3 F5;
       F5.P1 = P1;
       F5.P2 = P5;
       F5.P3 = P4;
+      FacetType3 F6;
       F6.P1 = P1;
       F6.P2 = P2;
       F6.P3 = P5;
+      FacetType3 F7;
       F7.P1 = P1;
       F7.P2 = P3;
       F7.P3 = P2;
@@ -846,11 +842,9 @@ FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringElement<
       for (unsigned int j = 0; j < facets; ++j)
       {
         // Find a line perpendicular to each face
-        LType3 L;
-        LType3 A;
-        LType3 B;
-        A = FacetArray[j].P2 - FacetArray[j].P1;
-        B = FacetArray[j].P3 - FacetArray[j].P1;
+        LType3 A = FacetArray[j].P2 - FacetArray[j].P1;
+        LType3 B = FacetArray[j].P3 - FacetArray[j].P1;
+        LType3 L; /*one-line-declaration*/
         L[0] = A[1] * B[2] - B[1] * A[2];
         L[1] = B[0] * A[2] - A[0] * B[2];
         L[2] = A[0] * B[1] - B[0] * A[1];
@@ -942,13 +936,13 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
 
   // Create an image to hold the ellipsoid
   //
-  auto                           sourceImage = ImageType::New();
-  typename ImageType::RegionType region;
-  RadiusType                     size = radius;
+  auto       sourceImage = ImageType::New();
+  RadiusType size = radius;
   for (i = 0; i < static_cast<int>(VDimension); ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
+  typename ImageType::RegionType region;
   region.SetSize(size);
 
   sourceImage->SetRegions(region);
@@ -1047,13 +1041,13 @@ FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
 
   // Create an image to hold the ellipsoid
   //
-  auto                           kernelImage = ImageType::New();
-  typename ImageType::RegionType region;
-  RadiusType                     size = radius;
+  auto       kernelImage = ImageType::New();
+  RadiusType size = radius;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
+  typename ImageType::RegionType region;
   region.SetSize(size);
 
   kernelImage->SetRegions(region);
@@ -1209,13 +1203,13 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
 
   // Create an image to hold the ellipsoid
   //
-  auto                           sourceImage = ImageType::New();
-  typename ImageType::RegionType region;
-  RadiusType                     size = this->GetRadius();
+  auto       sourceImage = ImageType::New();
+  RadiusType size = this->GetRadius();
   for (int i = 0; i < static_cast<int>(VDimension); ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
+  typename ImageType::RegionType region;
   region.SetSize(size);
   sourceImage->SetRegions(region);
   sourceImage->Allocate();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -291,13 +291,6 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList =
     fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
 
-  typename NeighborhoodIteratorType::OffsetValueType i;
-  typename NeighborhoodIteratorType::OffsetType      offset;
-
-  MarkerImagePixelType value;
-  MarkerImagePixelType dilateValue;
-  MarkerImagePixelType maskValue;
-
   // Iterate over the faces
   for (const auto & face : faceList)
   {
@@ -308,6 +301,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
     markerIt.OverrideBoundaryCondition(&BC);
     markerIt.GoToBegin();
 
+    typename NeighborhoodIteratorType::OffsetType offset;
     if (!m_FullyConnected)
     {
       // setup the marker iterator to only visit face connected
@@ -316,7 +310,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
       markerIt.ActivateOffset(offset); // center pixel
       for (unsigned int d = 0; d < TInputImage::ImageDimension; ++d)
       {
-        for (i = -1; i <= 1; i += 2)
+        for (typename NeighborhoodIteratorType::OffsetValueType i = -1; i <= 1; i += 2)
         {
           offset[d] = i;
           markerIt.ActivateOffset(offset); // a neighbor pixel in dimension d
@@ -338,14 +332,14 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
     // iterate over image region
     while (!oIt.IsAtEnd())
     {
-      dilateValue = NumericTraits<MarkerImagePixelType>::NonpositiveMin();
+      MarkerImagePixelType dilateValue = NumericTraits<MarkerImagePixelType>::NonpositiveMin();
 
       // Dilate by checking the face connected neighbors (and center pixel)
       typename NeighborhoodIteratorType::ConstIterator sIt;
       for (sIt = markerIt.Begin(); !sIt.IsAtEnd(); ++sIt)
       {
         // a pixel in the neighborhood
-        value = sIt.Get();
+        MarkerImagePixelType value = sIt.Get();
 
         // dilation is a max operation
         if (value > dilateValue)
@@ -357,7 +351,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
       // Mask operation.  For geodesic dilation, the mask operation is
       // a pixelwise min operator with the elementary dilated image and
       // the mask image
-      maskValue = maskIt.Get();
+      MarkerImagePixelType maskValue = maskIt.Get();
 
       if (maskValue < dilateValue)
       {

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -287,13 +287,6 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType>::FaceListType faceList =
     fC(this->GetMarkerImage(), outputRegionForThread, kernelRadius);
 
-  typename NeighborhoodIteratorType::OffsetValueType i;
-  typename NeighborhoodIteratorType::OffsetType      offset;
-
-  MarkerImagePixelType value;
-  MarkerImagePixelType erodeValue;
-  MarkerImagePixelType maskValue;
-
   // Iterate over the faces
   //
   for (const auto & face : faceList)
@@ -309,11 +302,12 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
     {
       // setup the marker iterator to only visit face connected
       // neighbors and the center pixel
+      typename NeighborhoodIteratorType::OffsetType offset;
       offset.Fill(0);
       markerIt.ActivateOffset(offset); // center pixel
       for (unsigned int d = 0; d < TInputImage::ImageDimension; ++d)
       {
-        for (i = -1; i <= 1; i += 2)
+        for (typename NeighborhoodIteratorType::OffsetValueType i = -1; i <= 1; i += 2)
         {
           offset[d] = i;
           markerIt.ActivateOffset(offset); // a neighbor pixel in dimension d
@@ -328,6 +322,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
       {
         markerIt.ActivateOffset(markerIt.GetOffset(nd));
       }
+      typename NeighborhoodIteratorType::OffsetType offset;
       offset.Fill(0);
       markerIt.DeactivateOffset(offset);
     }
@@ -335,14 +330,14 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
     // iterate over image region
     while (!oIt.IsAtEnd())
     {
-      erodeValue = NumericTraits<MarkerImagePixelType>::max();
+      MarkerImagePixelType erodeValue = NumericTraits<MarkerImagePixelType>::max();
 
       // Erode by checking the face connected neighbors (and center pixel)
       typename NeighborhoodIteratorType::ConstIterator sIt;
       for (sIt = markerIt.Begin(); !sIt.IsAtEnd(); ++sIt)
       {
         // a pixel in the neighborhood
-        value = sIt.Get();
+        MarkerImagePixelType value = sIt.Get();
 
         // erosion is a min operation
         if (value < erodeValue)
@@ -354,7 +349,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
       // Mask operation.  For geodesic erosion, the mask operation is
       // a pixelwise max operator with the elementary eroded image and
       // the mask image
-      maskValue = maskIt.Get();
+      MarkerImagePixelType maskValue = maskIt.Get();
 
       if (maskValue > erodeValue)
       {

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -245,12 +245,12 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     // histogram to update and the direction in which to push
     // it. Then we need to copy that histogram to the relevant
     // places
-    OffsetType LineOffset;
-    OffsetType Changes;
     // Figure out which stored histogram to move and in
     // which direction
     int LineDirection = 0;
     // This function deals with changing planes etc
+    OffsetType LineOffset;
+    OffsetType Changes;
     this->GetDirAndOffset(LineStart, PrevLineStart, LineOffset, Changes, LineDirection);
     ++(Steps[LineDirection]);
     IndexType              PrevLineStartHist = LineStart - LineOffset;

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -231,13 +231,8 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
   setConnectivityLater(&mskNIt, m_FullyConnected);
   mskNIt.OverrideBoundaryCondition(&iBC);
 
-  typename NOutputIterator::IndexListType                 oIndexList;
-  typename NOutputIterator::IndexListType                 mIndexList;
-  typename NOutputIterator::IndexListType::const_iterator oLIt;
-  typename NOutputIterator::IndexListType::const_iterator mLIt;
-
-  oIndexList = outNIt.GetActiveIndexList();
-  mIndexList = mskNIt.GetActiveIndexList();
+  typename NOutputIterator::IndexListType oIndexList = outNIt.GetActiveIndexList();
+  typename NOutputIterator::IndexListType mIndexList = mskNIt.GetActiveIndexList();
 
   mskNIt.GoToEnd();
   while (!outNIt.IsAtBegin())
@@ -264,7 +259,9 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
 
     // now put indexes in the fifo
     // typename CNInputIterator::ConstIterator mIt;
-    for (oLIt = oIndexList.begin(), mLIt = mIndexList.begin(); oLIt != oIndexList.end(); ++oLIt, ++mLIt)
+    typename NOutputIterator::IndexListType::const_iterator mLIt = mIndexList.begin();
+    for (typename NOutputIterator::IndexListType::const_iterator oLIt = oIndexList.begin(); oLIt != oIndexList.end();
+         ++oLIt, ++mLIt)
     {
       InputImagePixelType VN = outNIt.GetPixel(*oLIt);
       InputImagePixelType iN = mskNIt.GetPixel(*mLIt);
@@ -296,8 +293,10 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
     // reposition the iterators
     outNIt += I - outNIt.GetIndex();
     mskNIt += I - mskNIt.GetIndex();
-    InputImagePixelType V = outNIt.GetCenterPixel();
-    for (oLIt = oIndexList.begin(), mLIt = mIndexList.begin(); oLIt != oIndexList.end(); ++oLIt, ++mLIt)
+    InputImagePixelType                                     V = outNIt.GetCenterPixel();
+    typename NOutputIterator::IndexListType::const_iterator mLIt = mIndexList.begin();
+    for (typename NOutputIterator::IndexListType::const_iterator oLIt = oIndexList.begin(); oLIt != oIndexList.end();
+         ++oLIt, ++mLIt)
     {
       InputImagePixelType VN = outNIt.GetPixel(*oLIt);
       InputImagePixelType iN = mskNIt.GetPixel(*mLIt);

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -95,9 +95,8 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
   float                      Tfar = NumericTraits<float>::max();
   float                      Tnear = NumericTraits<float>::NonpositiveMin();
   float                      domdir = NumericTraits<float>::NonpositiveMin();
-  int                        sPos;
-  int                        ePos;
-  unsigned int               perpdir = 0;
+
+  unsigned int perpdir = 0;
   for (unsigned int i = 0; i < TImage::RegionType::ImageDimension; ++i)
   {
     const auto abs_line_elmt_tmp = itk::Math::abs(line[i]);
@@ -139,8 +138,8 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
       }
     }
   }
-  sPos = static_cast<int>(Tnear * itk::Math::abs(line[perpdir]) + 0.5);
-  ePos = static_cast<int>(Tfar * itk::Math::abs(line[perpdir]) + 0.5);
+  int sPos = static_cast<int>(Tnear * itk::Math::abs(line[perpdir]) + 0.5);
+  int ePos = static_cast<int>(Tfar * itk::Math::abs(line[perpdir]) + 0.5);
 
   // std::cout << Tnear << ' ' << Tfar << std::endl;
   if (Tfar < Tnear) // seems to need some margin
@@ -306,14 +305,12 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
 
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
-    RegionType R1;
-    RegionType R2;
-    SizeType   S1 = AllImage.GetSize();
-    IndexType  I2 = AllImage.GetIndex();
+    SizeType  S1 = AllImage.GetSize();
+    IndexType I2 = AllImage.GetIndex();
 
     S1[i] = 1;
-    R1 = AllImage;
-    R2 = AllImage;
+    RegionType R1 = AllImage;
+    RegionType R2 = AllImage;
 
     // the first face will have the same starting index and one
     // dimension removed
@@ -328,10 +325,9 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
   }
   typename FaceListType::iterator fit = faceList.begin();
 
-  typename TInputImage::RegionType RelevantRegion;
-  bool                             foundFace = false;
-  float                            MaxComp = NumericTraits<float>::NonpositiveMin();
-  unsigned int                     DomDir = 0;
+  bool         foundFace = false;
+  float        MaxComp = NumericTraits<float>::NonpositiveMin();
+  unsigned int DomDir = 0;
   // std::cout << "------------" << std::endl;
   // figure out the dominant direction of the line
   for (unsigned int i = 0; i < TInputImage::RegionType::ImageDimension; ++i)
@@ -344,6 +340,7 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
     }
   }
 
+  typename TInputImage::RegionType RelevantRegion;
   for (; fit != faceList.end(); ++fit)
   {
     // check whether this face is suitable for parallel sweeping - i.e

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -150,8 +150,8 @@ DoFace(typename TImage::ConstPointer             input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int               start;
-    unsigned int               end;
+    unsigned int               start; /*one-line-declaration*/
+    unsigned int               end;   /*one-line-declaration*/
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -147,11 +147,11 @@ ContourExtractor2DImageFilter<TInputImage>::CreateSingleContour(InputPixelType  
     // 01    is numbered as    45
     // 23                      78
 
+    unsigned char  squareCase{ 0 };
     InputPixelType v0;
     InputPixelType v1;
     InputPixelType v2;
     InputPixelType v3;
-    unsigned char  squareCase{ 0 };
     if (m_LabelContours)
     {
       v0 = (neighborhoodRange[0] == label);

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -45,19 +45,16 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // Perform the remaining calculations; use dynamic programming
 
   // current swath column (all previous columns have been fully processed)
-  unsigned int x;
   // current first row and last row of the swath.
-  unsigned int F;
-  unsigned int L;
   // index used to access the processed swath image; filled in with x, F, & L
-  IndexType index;
 
   // CalcFirstStep (x=0)
   // Enter the initial merit values
+  IndexType index;
   index[0] = 0;
-  for (F = 0; F < m_SwathSize[1]; ++F)
+  for (unsigned int F = 0; F < m_SwathSize[1]; ++F)
   {
-    for (L = 0; L < m_SwathSize[1]; ++L)
+    for (unsigned int L = 0; L < m_SwathSize[1]; ++L)
     {
       if (F == L)
       {
@@ -75,9 +72,9 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // end of double for-loop covering F & L
 
   // PrepForRemainingSteps
-  for (F = 0; F < m_SwathSize[1]; ++F)
+  for (unsigned int F = 0; F < m_SwathSize[1]; ++F)
   {
-    for (L = 0; L < m_SwathSize[1]; ++L)
+    for (unsigned int L = 0; L < m_SwathSize[1]; ++L)
     {
       // find merit for x=1
       if (itk::Math::abs(F - L) <= 1)
@@ -102,11 +99,11 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // end of double for-loop covering F & L
 
   // CalcRestPath
-  for (x = 1; x < m_SwathSize[0] - 1; ++x)
+  for (unsigned int x = 1; x < m_SwathSize[0] - 1; ++x)
   {
-    for (F = 0; F < m_SwathSize[1]; ++F)
+    for (unsigned int F = 0; F < m_SwathSize[1]; ++F)
     {
-      for (L = 0; L < m_SwathSize[1]; ++L)
+      for (unsigned int L = 0; L < m_SwathSize[1]; ++L)
       {
         int bestL = FindAndStoreBestErrorStep(x, F, L);
         index[0] = x + 1;
@@ -120,15 +117,14 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   // Find the best starting and ending points (F & L) for the path
   int    bestF = 0;
   int    bestL = 0;
-  double meritTemp;
   double meritMax = NumericTraits<double>::NonpositiveMin();
-  for (F = 0; F < m_SwathSize[1]; ++F)
+  for (unsigned int F = 0; F < m_SwathSize[1]; ++F)
   {
-    for (L = 0; L < m_SwathSize[1]; ++L)
+    for (unsigned int L = 0; L < m_SwathSize[1]; ++L)
     {
       if (itk::Math::abs(F - L) <= 1) // only accept closed paths
       {
-        meritTemp = MeritValue(F, L, m_SwathSize[0] - 1);
+        double meritTemp = MeritValue(F, L, m_SwathSize[0] - 1);
         if (meritTemp > meritMax)
         {
           meritMax = meritTemp;
@@ -142,7 +138,7 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
 
   // Fill in the optimum path error-step (orthogonal correction) values
   m_OptimumStepsValues[m_SwathSize[0] - 1] = bestL;
-  for (x = m_SwathSize[0] - 2;; x--)
+  for (unsigned int x = m_SwathSize[0] - 2;; x--)
   {
     m_OptimumStepsValues[x] = StepValue(bestF, m_OptimumStepsValues[x + 1], x);
     if (0 == x)
@@ -152,7 +148,7 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::GenerateData()
   }
 
   // Convert from absolute indices to +/- orthogonal offset values
-  for (x = 0; x < m_SwathSize[0]; ++x)
+  for (unsigned int x = 0; x < m_SwathSize[0]; ++x)
   {
     m_FinalOffsetValues->InsertElement(
       x, static_cast<double>(m_OptimumStepsValues[x] - static_cast<int>(m_SwathSize[1] / 2)));

--- a/Modules/Filtering/Path/include/itkPathFunctions.h
+++ b/Modules/Filtering/Path/include/itkPathFunctions.h
@@ -36,21 +36,18 @@ MakeChainCodeTracePath(TChainCodePath & chainPath, const TPathInput & inPath, bo
   using ChainInputType = typename TChainCodePath::InputType;
   using InPathInputType = typename TPathInput::InputType;
 
-  OffsetType      offset;
-  OffsetType      tempOffset;
-  OffsetType      zeroOffset;
-  InPathInputType inPathInput;
-  int             dimension = OffsetType::GetOffsetDimension();
+  int dimension = OffsetType::GetOffsetDimension();
 
+  OffsetType zeroOffset;
   zeroOffset.Fill(0);
 
   chainPath.Clear();
-  inPathInput = inPath.StartOfInput();
+  InPathInputType inPathInput = inPath.StartOfInput();
   chainPath.SetStart(inPath.EvaluateToIndex(inPathInput));
 
   for (ChainInputType chainInput = 0;;)
   {
-    offset = inPath.IncrementInput(inPathInput);
+    OffsetType offset = inPath.IncrementInput(inPathInput);
     if (zeroOffset == offset)
     {
       break;
@@ -64,6 +61,7 @@ MakeChainCodeTracePath(TChainCodePath & chainPath, const TPathInput & inPath, bo
     {
       for (int d = 0; d < dimension; ++d)
       {
+        OffsetType tempOffset;
         tempOffset.Fill(0);
         tempOffset[d] = offset[d];
         chainPath.InsertStep(chainInput++, tempOffset);
@@ -91,13 +89,8 @@ MakeFourierSeriesPathTraceChainCode(TFourierSeriesPath &   FSPath,
   using FSInputType = typename TFourierSeriesPath::InputType;
   using ChainInputType = typename TChainCodePath::InputType;
 
-  IndexType   index;
-  VectorType  indexVector;
-  VectorType  cosCoefficient;
-  VectorType  sinCoefficient;
-  FSInputType theta;
-  int         dimension = OffsetType::GetOffsetDimension();
-  size_t      numSteps = chainPath.NumberOfSteps();
+  int    dimension = OffsetType::GetOffsetDimension();
+  size_t numSteps = chainPath.NumberOfSteps();
 
   const double PI = 4.0 * std::atan(1.0);
 
@@ -115,16 +108,19 @@ MakeFourierSeriesPathTraceChainCode(TFourierSeriesPath &   FSPath,
 
   for (unsigned int n = 0; n < numHarmonics; ++n)
   {
-    index = chainPath.GetStart();
+    IndexType  index = chainPath.GetStart();
+    VectorType cosCoefficient;
     cosCoefficient.Fill(0.0);
+    VectorType sinCoefficient;
     sinCoefficient.Fill(0.0);
 
     for (ChainInputType step = 0; step < numSteps; ++step)
     {
       index += chainPath.Evaluate(step);
-      theta = 2 * n * PI * (static_cast<double>(step + 1)) / numSteps;
+      FSInputType theta = 2 * n * PI * (static_cast<double>(step + 1)) / numSteps;
 
       // turn the current index into a vector
+      VectorType indexVector;
       for (int d = 0; d < dimension; ++d)
       {
         indexVector[d] = index[d];

--- a/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
+++ b/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
@@ -22,21 +22,10 @@ namespace itk
 OrthogonallyCorrected2DParametricPath::OutputType
 OrthogonallyCorrected2DParametricPath::Evaluate(const InputType & inputValue) const
 {
-  InputType input = inputValue; // we may want to remap
-                                // the input
-  InputType                         inputRange;
-  InputType                         normalizedInput;
-  OutputType                        output;
-  OrthogonalCorrectionTableSizeType numOrthogonalCorrections;
-  double                            softOrthogonalCorrectionTableIndex;
-  double                            Correction;
-  double                            Correction1;
-  double                            Correction2;
-  VectorType                        originalDerivative;
-
-  numOrthogonalCorrections = m_OrthogonalCorrectionTable->Size();
+  OrthogonalCorrectionTableSizeType numOrthogonalCorrections = m_OrthogonalCorrectionTable->Size();
 
   // If the original path is closed, then tail input is remapped to head input
+  InputType input = inputValue; // we may want to remap the input
   if (m_OriginalPath->EvaluateToIndex(m_OriginalPath->EndOfInput()) ==
       m_OriginalPath->EvaluateToIndex(m_OriginalPath->StartOfInput()))
   {
@@ -47,20 +36,22 @@ OrthogonallyCorrected2DParametricPath::Evaluate(const InputType & inputValue) co
     }
   }
 
-  inputRange = m_OriginalPath->EndOfInput() - m_OriginalPath->StartOfInput();
-  normalizedInput = (input - m_OriginalPath->StartOfInput()) / inputRange;
+  InputType  inputRange = m_OriginalPath->EndOfInput() - m_OriginalPath->StartOfInput();
+  InputType  normalizedInput = (input - m_OriginalPath->StartOfInput()) / inputRange;
+  OutputType output;
   output.Fill(0);
 
   // Find the linearly interpolated offset error value for this exact time.
-  softOrthogonalCorrectionTableIndex = normalizedInput * numOrthogonalCorrections;
-  Correction1 = m_OrthogonalCorrectionTable->ElementAt(static_cast<int>(softOrthogonalCorrectionTableIndex));
-  Correction2 = m_OrthogonalCorrectionTable->ElementAt(static_cast<int>(softOrthogonalCorrectionTableIndex + 1) %
-                                                       numOrthogonalCorrections);
-  Correction = Correction1 + (Correction2 - Correction1) * (softOrthogonalCorrectionTableIndex -
-                                                            static_cast<int>(softOrthogonalCorrectionTableIndex));
+  double softOrthogonalCorrectionTableIndex = normalizedInput * numOrthogonalCorrections;
+  double Correction1 = m_OrthogonalCorrectionTable->ElementAt(static_cast<int>(softOrthogonalCorrectionTableIndex));
+  double Correction2 = m_OrthogonalCorrectionTable->ElementAt(static_cast<int>(softOrthogonalCorrectionTableIndex + 1) %
+                                                              numOrthogonalCorrections);
+  double Correction =
+    Correction1 + (Correction2 - Correction1) *
+                    (softOrthogonalCorrectionTableIndex - static_cast<int>(softOrthogonalCorrectionTableIndex));
 
   // Find the direction of the offset
-  originalDerivative = m_OriginalPath->EvaluateDerivative(input);
+  VectorType originalDerivative = m_OriginalPath->EvaluateDerivative(input);
   originalDerivative.Normalize();
 
   // Find the actual point along this corrected path

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -30,18 +30,14 @@ itkFourierSeriesPathTest(int, char *[])
   using VectorType = PathType::VectorType;
 
   bool passed = true;
-
-  InputType  input;
-  OffsetType offset;
-  VectorType cosV;
-  VectorType sinV;
-
   auto path = PathType::New();
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(path, FourierSeriesPath, ParametricPath);
 
   // Average value is (5,5)
+  VectorType cosV;
   cosV.Fill(5);
+  VectorType sinV;
   sinV.Fill(0);
   path->AddHarmonic(cosV, sinV);
   cosV.Fill(2.7);
@@ -80,8 +76,8 @@ itkFourierSeriesPathTest(int, char *[])
     passed = false;
   }
 
-  input = 0;
-  offset = path->IncrementInput(input);
+  InputType  input = 0;
+  OffsetType offset = path->IncrementInput(input);
   std::cout << "Incrementing the input from 0 to " << input << ": " << offset << std::endl;
 
   input = 0.5;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -107,13 +107,11 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder() -> Inp
     itkGenericExceptionMacro("This filter requires at least one boundary");
   }
 
-  InputCoordinateType max_length(0.0);
-  InputCoordinateType length(0.0);
-  auto                oborder_it = list->begin();
-
+  InputCoordRepType max_length(0.0);
+  auto              oborder_it = list->begin();
   for (auto b_it = list->begin(); b_it != list->end(); ++b_it)
   {
-    length = 0.;
+    InputCoordRepType length(0.0);
 
     for (InputIteratorGeom e_it = (*b_it)->BeginGeomLnext(); e_it != (*b_it)->EndGeomLnext(); ++e_it)
     {
@@ -261,14 +259,12 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare() -> InputCoo
 
   InputPointType center = this->GetMeshBarycentre();
 
-  InputCoordinateType oRmax(0.);
-  InputCoordinateType r;
-
+  InputCoordRepType oRmax(0.);
   for (auto BoundaryPtIterator = this->m_BoundaryPtMap.begin(); BoundaryPtIterator != this->m_BoundaryPtMap.end();
        ++BoundaryPtIterator)
   {
-    r = static_cast<InputCoordinateType>(center.SquaredEuclideanDistanceTo(input->GetPoint(BoundaryPtIterator->first)));
-
+    InputCoordRepType r =
+      static_cast<InputCoordRepType>(center.SquaredEuclideanDistanceTo(input->GetPoint(BoundaryPtIterator->first)));
     if (r > oRmax)
     {
       oRmax = r;
@@ -357,28 +353,22 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ArcLengthSquareTransform()
 
   std::vector<InputCoordinateType> Length(NbBoundaryPt + 1, 0.0);
 
-  InputCoordinateType TotalLength(0.0);
-  InputCoordinateType distance;
-
-  InputPointIdentifier i(0);
-  InputPointIdentifier org(0);
-  InputPointIdentifier dest(0);
-  InputPointType       PtOrg;
-  InputPointType       PtDest;
-
-  for (InputIteratorGeom it = bdryEdge->BeginGeomLnext(); it != bdryEdge->EndGeomLnext(); ++it, ++i)
+  InputCoordRepType TotalLength(0.0);
   {
-    org = it.Value()->GetOrigin();
-    dest = it.Value()->GetDestination();
+    InputPointIdentifier i(0);
+    for (InputIteratorGeom it = bdryEdge->BeginGeomLnext(); it != bdryEdge->EndGeomLnext(); ++it, ++i)
+    {
+      InputPointIdentifier org = it.Value()->GetOrigin();
+      InputPointIdentifier dest = it.Value()->GetDestination();
 
-    PtOrg = input->GetPoint(org);
-    PtDest = input->GetPoint(dest);
+      InputPointType PtOrg = input->GetPoint(org);
+      InputPointType PtDest = input->GetPoint(dest);
 
-    distance = PtOrg.EuclideanDistanceTo(PtDest);
-    TotalLength += distance;
-    Length[i] = TotalLength;
+      InputCoordRepType distance = PtOrg.EuclideanDistanceTo(PtDest);
+      TotalLength += distance;
+      Length[i] = TotalLength;
+    }
   }
-
   if (this->m_Radius == 0.0)
   {
     this->m_Radius = 1000.;
@@ -387,7 +377,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ArcLengthSquareTransform()
   InputCoordinateType EdgeLength = 2.0 * this->m_Radius;
   InputCoordinateType ratio = 4.0 * EdgeLength / TotalLength;
 
-  for (i = 0; i < NbBoundaryPt + 1; ++i)
+
+  for (InputPointIdentifier i = 0; i < NbBoundaryPt + 1; ++i)
   {
     Length[i] *= ratio;
   }
@@ -399,7 +390,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ArcLengthSquareTransform()
 
   this->m_Border[0] = pt;
 
-  i = 1;
+  InputPointIdentifier i = 1;
   while (Length[i] < EdgeLength)
   {
     pt[0] = -this->m_Radius + Length[i];

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
@@ -89,10 +89,6 @@ protected:
     if (qe != nullptr)
     {
       OutputQEType * qe_it = qe;
-      OutputQEType * qe_it2;
-
-      OutputPointType q0;
-      OutputPointType q1;
 
       OutputCurvatureType sum_theta = 0.;
       OutputCurvatureType area = 0.;
@@ -100,9 +96,9 @@ protected:
       do
       {
         // cell_id = qe_it->GetLeft();
-        qe_it2 = qe_it->GetOnext();
-        q0 = output->GetPoint(qe_it->GetDestination());
-        q1 = output->GetPoint(qe_it2->GetDestination());
+        OutputQEType *  qe_it2 = qe_it->GetOnext();
+        OutputPointType q0 = output->GetPoint(qe_it->GetDestination());
+        OutputPointType q1 = output->GetPoint(qe_it2->GetDestination());
 
         // Compute Angle;
         sum_theta += static_cast<OutputCurvatureType>(TriangleType::ComputeAngle(q0, iP, q1));

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -101,28 +101,20 @@ protected:
         CoefficientType coefficent;
 
         OutputQEType * qe_it = qe;
-        OutputQEType * qe_it2;
-
-        OutputCurvatureType temp_area;
-        OutputCoordType     temp_coeff;
-
-        OutputPointType  q0;
-        OutputPointType  q1;
-        OutputVectorType face_normal;
 
         do
         {
-          qe_it2 = qe_it->GetOnext();
-          q0 = output->GetPoint(qe_it->GetDestination());
-          q1 = output->GetPoint(qe_it2->GetDestination());
+          OutputQEType *  qe_it2 = qe_it->GetOnext();
+          OutputPointType q0 = output->GetPoint(qe_it->GetDestination());
+          OutputPointType q1 = output->GetPoint(qe_it2->GetDestination());
 
-          temp_coeff = coefficent(output, qe_it);
+          OutputCoordType temp_coeff = coefficent(output, qe_it);
           Laplace += temp_coeff * (iP - q0);
 
-          temp_area = this->ComputeMixedArea(qe_it, qe_it2);
+          OutputCurvatureType temp_area = this->ComputeMixedArea(qe_it, qe_it2);
           area += temp_area;
 
-          face_normal = TriangleType::ComputeNormal(q0, iP, q1);
+          OutputVectorType face_normal = TriangleType::ComputeNormal(q0, iP, q1);
           normal += face_normal;
 
           qe_it = qe_it2;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -102,35 +102,25 @@ protected:
       if (qe_it != qe_it->GetOnext())
       {
         qe_it = qe;
-        OutputQEType * qe_it2;
-
-        OutputPointType  q0;
-        OutputPointType  q1;
-        OutputVectorType face_normal;
 
         OutputVectorType normal{};
-
-        OutputCurvatureType temp_area;
-        OutputCoordType     temp_coeff;
-
-        CoefficientType coefficent;
-
+        CoefficientType  coefficent;
         do
         {
-          qe_it2 = qe_it->GetOnext();
-          q0 = output->GetPoint(qe_it->GetDestination());
-          q1 = output->GetPoint(qe_it2->GetDestination());
+          OutputQEType *  qe_it2 = qe_it->GetOnext();
+          OutputPointType q0 = output->GetPoint(qe_it->GetDestination());
+          OutputPointType q1 = output->GetPoint(qe_it2->GetDestination());
 
-          temp_coeff = coefficent(output, qe_it);
+          OutputCoordType temp_coeff = coefficent(output, qe_it);
           Laplace += temp_coeff * (iP - q0);
 
           // Compute Angle;
           sum_theta += static_cast<OutputCurvatureType>(TriangleType::ComputeAngle(q0, iP, q1));
 
-          temp_area = this->ComputeMixedArea(qe_it, qe_it2);
+          OutputCurvatureType temp_area = this->ComputeMixedArea(qe_it, qe_it2);
           area += temp_area;
 
-          face_normal = TriangleType::ComputeNormal(q0, iP, q1);
+          OutputVectorType face_normal = TriangleType::ComputeNormal(q0, iP, q1);
           normal += face_normal;
 
           qe_it = qe_it2;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -221,12 +221,10 @@ protected:
     OutputMeshPointer           output = this->GetOutput();
     OutputCellsContainerPointer cells = output->GetCells();
 
-    std::list<OutputCellIdentifier> r1;
-    std::list<OutputCellIdentifier> r2;
-    std::list<OutputCellIdentifier> elements_to_be_tested;
-    OutputQEType *                  qe = iEdge;
-    OutputQEType *                  qe_it = qe->GetOnext();
+    OutputQEType * qe = iEdge;
+    OutputQEType * qe_it = qe->GetOnext();
 
+    std::list<OutputCellIdentifier> r1;
     do
     {
       r1.push_back(qe_it->GetLeft());
@@ -236,6 +234,7 @@ protected:
     qe = iEdge->GetSym();
     qe_it = qe->GetOnext();
 
+    std::list<OutputCellIdentifier> r2;
     do
     {
       r2.push_back(qe_it->GetLeft());
@@ -245,6 +244,7 @@ protected:
     r1.sort();
     r2.sort();
 
+    std::list<OutputCellIdentifier> elements_to_be_tested;
     std::set_symmetric_difference(
       r1.begin(), r1.end(), r2.begin(), r2.end(), std::back_inserter(elements_to_be_tested));
 
@@ -260,9 +260,6 @@ protected:
     int             k(0);
     int             replace_k(0);
     OutputPointType pt[3];
-
-    OutputVectorType n_bef;
-    OutputVectorType n_aft;
 
     while ((it != elements_to_be_tested.end()) && orientation_ok)
     {
@@ -284,7 +281,8 @@ protected:
         qe_it = qe_it->GetLnext();
       } while (qe_it != qe);
 
-      n_bef = TriangleType::ComputeNormal(pt[0], pt[1], pt[2]);
+      OutputVectorType n_bef = TriangleType::ComputeNormal(pt[0], pt[1], pt[2]);
+      OutputVectorType n_aft;
       switch (replace_k)
       {
         default:

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -486,8 +486,6 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::NumberOfCommonVer
   OutputQEType * e_it = qe->GetOnext();
 
   std::list<OutputPointIdentifier> dir_list;
-  std::list<OutputPointIdentifier> sym_list;
-  std::list<OutputPointIdentifier> intersection_list;
   do
   {
     dir_list.push_back(e_it->GetDestination());
@@ -496,7 +494,7 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::NumberOfCommonVer
 
   qe = qe->GetSym();
   e_it = qe;
-
+  std::list<OutputPointIdentifier> sym_list;
   do
   {
     sym_list.push_back(e_it->GetDestination());
@@ -506,6 +504,7 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::NumberOfCommonVer
   dir_list.sort();
   sym_list.sort();
 
+  std::list<OutputPointIdentifier> intersection_list;
   std::set_intersection(
     dir_list.begin(), dir_list.end(), sym_list.begin(), sym_list.end(), std::back_inserter(intersection_list));
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -76,20 +76,17 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
     typename OutputMeshType::PointsContainer * points = output->GetPoints();
 
     OutputPointIdentifier vId[3];
-
     vId[0] = iQE1->GetOrigin();
     vId[1] = iQE1->GetDestination();
     vId[2] = iQE2->GetDestination();
 
     OutputPointType p[3];
-
     for (int i = 0; i < 3; ++i)
     {
       p[i] = points->GetElement(vId[i]);
     }
 
     OutputCoordinateType area = TriangleType::ComputeMixedArea(p[0], p[1], p[2]);
-
     if (area < itk::Math::eps)
     {
       return OutputCoordinateType{};
@@ -196,18 +193,13 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
   Triple t(iId, iWeight, iDegree);
   todo.push_back(t);
 
-  OutputPointIdentifier vId;
-  unsigned int          degree;
-  OutputQEPrimal *      qe;
-  OutputQEPrimal *      temp;
-
   while (!todo.empty())
   {
     t = todo.back();
     todo.pop_back();
 
-    vId = t.m_Id;
-    degree = t.m_Degree;
+    OutputPointIdentifier vId = t.m_Id;
+    unsigned int          degree = t.m_Degree;
 
     if (degree == 0)
     {
@@ -227,10 +219,10 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
       OutputCoordinateType ww{};
       OutputCoordinateType w{};
 
-      qe = output->FindEdge(vId);
+      OutputQEPrimal * qe = output->FindEdge(vId);
       if (qe)
       {
-        temp = qe;
+        OutputQEPrimal * temp = qe;
 
         do
         {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
@@ -140,10 +140,10 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
     MatrixType A(Mt * M);
 
     VectorType Cx;
-    VectorType Cy;
-    VectorType Cz;
     Mt.mult(Bx, Cx);
+    VectorType Cy;
     Mt.mult(By, Cy);
+    VectorType Cz;
     Mt.mult(Bz, Cz);
 
     typename OutputMeshType::PointsContainer * points = output->GetPoints();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -137,14 +137,11 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdent
       // this test should be removed...
       if (poly->GetNumberOfPoints() == 3)
       {
-        int              internal_id(0);
-        int              k(0);
-        OutputPointType  pt[3];
-        OutputVectorType u;
-        OutputVectorType v;
-
-        OutputQEType * edge = poly->GetEdgeRingEntry();
-        OutputQEType * temp = edge;
+        OutputQEType *  edge = poly->GetEdgeRingEntry();
+        OutputQEType *  temp = edge;
+        OutputPointType pt[3];
+        int             internal_id(0);
+        int             k(0);
         do
         {
           pt[k] = outputMesh->GetPoint(temp->GetOrigin());
@@ -167,6 +164,8 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdent
           case WeightEnum::THURMER:
           {
             // this implementation may be included inside itkTriangle
+            OutputVectorType u;
+            OutputVectorType v;
             switch (internal_id)
             {
               case 0:

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
@@ -89,51 +89,33 @@ ParameterizationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::Fill
   InputMeshConstPointer input = this->GetInput();
   OutputMeshPointer     output = this->GetOutput();
 
-  InputCoordinateType value;
-
-  InputMapPointIdentifierIterator it;
-
-  InputPointIdentifier id1;
-  InputPointIdentifier id2;
-  InputPointIdentifier InternalId1;
-  InputPointIdentifier InternalId2;
-
-  OutputPointType pt2;
-
-  ValueType k[2];
-
   for (auto InternalPtIterator = m_InternalPtMap.begin(); InternalPtIterator != m_InternalPtMap.end();
        ++InternalPtIterator)
   {
-    id1 = InternalPtIterator->first;
-    InternalId1 = InternalPtIterator->second;
-
-    k[0] = 0.;
-    k[1] = 0.;
+    InputPointIdentifier id1 = InternalPtIterator->first;
+    InputPointIdentifier InternalId1 = InternalPtIterator->second;
+    ValueType            k[2]{};
 
     InputQEType * edge = input->FindEdge(id1);
     InputQEType * temp = edge;
-
     do
     {
-      id2 = temp->GetDestination();
-
-      it = m_BoundaryPtMap.find(id2);
-
+      InputPointIdentifier            id2 = temp->GetDestination();
+      InputMapPointIdentifierIterator it = m_BoundaryPtMap.find(id2);
       if (it != m_BoundaryPtMap.end())
       {
-        value = (*m_CoefficientsMethod)(input, temp);
-        pt2 = output->GetPoint(it->first);
+        InputCoordinateType value = (*m_CoefficientsMethod)(input, temp);
+        OutputPointType   pt2 = output->GetPoint(it->first);
         SolverTraits::AddToMatrix(iM, InternalId1, InternalId1, value);
         k[0] += static_cast<ValueType>(pt2[0] * value);
         k[1] += static_cast<ValueType>(pt2[1] * value);
       }
       else
       {
-        InternalId2 = m_InternalPtMap[id2];
+        InputPointIdentifier InternalId2 = m_InternalPtMap[id2];
         if (InternalId1 < InternalId2)
         {
-          value = (*m_CoefficientsMethod)(input, temp);
+          InputCoordinateType value = (*m_CoefficientsMethod)(input, temp);
           SolverTraits::FillMatrix(iM, InternalId1, InternalId2, -value);
           SolverTraits::FillMatrix(iM, InternalId2, InternalId1, -value);
           SolverTraits::AddToMatrix(iM, InternalId1, InternalId1, value);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -182,15 +182,11 @@ public:
   void
   AddPoint(const PointType & iP, const VectorType & iN, const CoordType & iWeight = static_cast<CoordType>(1.))
   {
-    unsigned int k(0);
-    unsigned int dim1;
-    unsigned int dim2;
-
-    CoordType d = -iN * iP.GetVectorFromOrigin();
-
-    for (dim1 = 0; dim1 < PointDimension; ++dim1)
+    unsigned int k(0); /*one-line-declaration*/
+    CoordType    d = -iN * iP.GetVectorFromOrigin();
+    for (unsigned int dim1 = 0; dim1 < PointDimension; ++dim1)
     {
-      for (dim2 = dim1; dim2 < PointDimension; ++dim2)
+      for (unsigned int dim2 = dim1; dim2 < PointDimension; ++dim2)
       {
         this->m_Coefficients[k++] += iWeight * iN[dim1] * iN[dim2];
       }
@@ -266,12 +262,9 @@ protected:
   ComputeAMatrixAndBVector()
   {
     unsigned int k(0);
-    unsigned int dim1;
-    unsigned int dim2;
-
-    for (dim1 = 0; dim1 < PointDimension; ++dim1)
+    for (unsigned int dim1 = 0; dim1 < PointDimension; ++dim1)
     {
-      for (dim2 = dim1; dim2 < PointDimension; ++dim2)
+      for (unsigned int dim2 = dim1; dim2 < PointDimension; ++dim2)
       {
         m_A[dim1][dim2] = m_A[dim2][dim1] = m_Coefficients[k++];
       }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -108,7 +108,6 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
 
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-
   using WriterType = itk::MeshFileWriter<MeshType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
@@ -120,15 +119,11 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
 
   it = constraints.begin();
 
-  MeshType::PointType  iPt;
-  MeshType::PointType  oPt;
-  MeshType::VectorType displacement;
-
   while (it != constraints.end())
   {
-    iPt = inputMesh->GetPoint(it->first);
-    oPt = outputMesh->GetPoint(it->first);
-    displacement = oPt - iPt;
+    MeshType::PointType  iPt = inputMesh->GetPoint(it->first);
+    MeshType::PointType  oPt = outputMesh->GetPoint(it->first);
+    MeshType::VectorType displacement = oPt - iPt;
 
     if ((displacement - it->second).GetNorm() > 1e-6)
     {
@@ -139,10 +134,9 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
     ++it;
   }
 
-  iPt = inputMesh->GetPoint(0);
-  oPt = outputMesh->GetPoint(0);
-  displacement = oPt - iPt;
-
+  MeshType::PointType  iPt = inputMesh->GetPoint(0);
+  MeshType::PointType  oPt = outputMesh->GetPoint(0);
+  MeshType::VectorType displacement = oPt - iPt;
   if (displacement.GetNorm() < 1e-6)
   {
     std::cerr << "No displacement" << std::endl;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -128,16 +128,11 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
   MeshType::Pointer outputMesh = filter->GetOutput();
 
   it = constraints.begin();
-
-  MeshType::PointType  iPt;
-  MeshType::PointType  oPt;
-  MeshType::VectorType displacement;
-
   while (it != constraints.end())
   {
-    iPt = inputMesh->GetPoint(it->first);
-    oPt = outputMesh->GetPoint(it->first);
-    displacement = oPt - iPt;
+    MeshType::PointType  iPt = inputMesh->GetPoint(it->first);
+    MeshType::PointType  oPt = outputMesh->GetPoint(it->first);
+    MeshType::VectorType displacement = oPt - iPt;
 
     if (it->second.GetNorm() > 1e-6)
     {

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -139,10 +139,6 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
   typename TTempImage::IndexType index;
   typename TTempImage::IndexType indexShift;
 
-  // Temporary pixel storage
-  double pixelA;
-  double pixelB;
-
   // walk the output image forwards and compute blur
   for (unsigned int rep = 0; rep < m_Repetitions; ++rep)
   {
@@ -174,8 +170,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
           }
 
           // Average the pixel of interest and shifted pixel
-          pixelA = tempPtr->GetPixel(index);
-          pixelB = tempPtr->GetPixel(indexShift);
+          double       pixelA = tempPtr->GetPixel(index);
+          const double pixelB = tempPtr->GetPixel(indexShift);
 
           pixelA += pixelB;
           pixelA = pixelA / 2.0;
@@ -215,8 +211,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
           }
 
           // Average the pixel of interest and shifted pixel
-          pixelA = tempPtr->GetPixel(index);
-          pixelB = tempPtr->GetPixel(indexShift);
+          double       pixelA = tempPtr->GetPixel(index);
+          const double pixelB = tempPtr->GetPixel(indexShift);
 
           pixelA += pixelB;
           pixelA = pixelA / 2;

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -117,13 +117,13 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
   A2[2] = static_cast<ScalarRealType>(0.3446);
   B2[2] = static_cast<ScalarRealType>(-2.2355);
 
-  ScalarRealType SD;
-  ScalarRealType DD;
-  ScalarRealType ED;
+  ScalarRealType SD; /*one-line-declaration*/
+  ScalarRealType DD; /*one-line-declaration*/
+  ScalarRealType ED; /*one-line-declaration*/
   this->ComputeDCoefficients(sigmad, W1, L1, W2, L2, SD, DD, ED);
-  ScalarRealType SN;
-  ScalarRealType DN;
-  ScalarRealType EN;
+  ScalarRealType SN; /*one-line-declaration*/
+  ScalarRealType DN; /*one-line-declaration*/
+  ScalarRealType EN; /*one-line-declaration*/
 
   switch (m_Order)
   {
@@ -173,20 +173,20 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       }
       // Approximation of convolution with the second derivative of a
       // Gaussian.
-      ScalarRealType N0_0;
-      ScalarRealType N1_0;
-      ScalarRealType N2_0;
-      ScalarRealType N3_0;
-      ScalarRealType N0_2;
-      ScalarRealType N1_2;
-      ScalarRealType N2_2;
-      ScalarRealType N3_2;
-      ScalarRealType SN0;
-      ScalarRealType DN0;
-      ScalarRealType EN0;
-      ScalarRealType SN2;
-      ScalarRealType DN2;
-      ScalarRealType EN2;
+      ScalarRealType N0_0; /*one-line-declaration*/
+      ScalarRealType N1_0; /*one-line-declaration*/
+      ScalarRealType N2_0; /*one-line-declaration*/
+      ScalarRealType N3_0; /*one-line-declaration*/
+      ScalarRealType N0_2; /*one-line-declaration*/
+      ScalarRealType N1_2; /*one-line-declaration*/
+      ScalarRealType N2_2; /*one-line-declaration*/
+      ScalarRealType N3_2; /*one-line-declaration*/
+      ScalarRealType SN0;  /*one-line-declaration*/
+      ScalarRealType DN0;  /*one-line-declaration*/
+      ScalarRealType EN0;  /*one-line-declaration*/
+      ScalarRealType SN2;  /*one-line-declaration*/
+      ScalarRealType DN2;  /*one-line-declaration*/
+      ScalarRealType EN2;  /*one-line-declaration*/
       ComputeNCoefficients(sigmad, A1[0], B1[0], W1, L1, A2[0], B2[0], W2, L2, N0_0, N1_0, N2_0, N3_0, SN0, DN0, EN0);
       ComputeNCoefficients(sigmad, A1[2], B1[2], W1, L1, A2[2], B2[2], W2, L2, N0_2, N1_2, N2_2, N3_2, SN2, DN2, EN2);
 

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
@@ -44,17 +44,6 @@ MomentsThresholdCalculator<THistogram, TOutput>::GenerateData()
   unsigned int size = histogram->GetSize(0);
 
   double                                     total = histogram->GetTotalFrequency();
-  double                                     m0 = 1.0;
-  double                                     m1 = 0.0;
-  double                                     m2 = 0.0;
-  double                                     m3 = 0.0;
-  double                                     sum = 0.0;
-  double                                     p0 = 0.0;
-  double                                     cd;
-  double                                     c0;
-  double                                     c1;
-  double                                     z0;
-  double                                     z1; // auxiliary variables
   typename HistogramType::InstanceIdentifier threshold = 0;
 
   std::vector<double> histo(size);
@@ -64,6 +53,10 @@ MomentsThresholdCalculator<THistogram, TOutput>::GenerateData()
   }
 
   // Calculate the first, second, and third order moments
+  double m0 = 1.0;
+  double m1 = 0.0;
+  double m2 = 0.0;
+  double m3 = 0.0;
   for (unsigned int i = 0; i < size; ++i)
   {
     double m = histogram->GetMeasurement(i, 0);
@@ -77,16 +70,16 @@ MomentsThresholdCalculator<THistogram, TOutput>::GenerateData()
   // of the target binary image. This leads to 4 equalities whose solutions
   // are given in the Appendix of Ref. 1
   //
-  cd = m0 * m2 - m1 * m1;
-  c0 = (-m2 * m2 + m1 * m3) / cd;
-  c1 = (m0 * -m3 + m2 * m1) / cd;
-  z0 = 0.5 * (-c1 - std::sqrt(c1 * c1 - 4.0 * c0));
-  z1 = 0.5 * (-c1 + std::sqrt(c1 * c1 - 4.0 * c0));
-  p0 = (z1 - m1) / (z1 - z0); // Fraction of the object pixels in the target binary image
+  double cd = m0 * m2 - m1 * m1;
+  double c0 = (-m2 * m2 + m1 * m3) / cd;
+  double c1 = (m0 * -m3 + m2 * m1) / cd;
+  double z0 = 0.5 * (-c1 - std::sqrt(c1 * c1 - 4.0 * c0));
+  double z1 = 0.5 * (-c1 + std::sqrt(c1 * c1 - 4.0 * c0));
+  double p0 = (z1 - m1) / (z1 - z0); // Fraction of the object pixels in the target binary image
 
   // The threshold is the gray-level closest to the p0-tile of the normalized
   // histogram
-  sum = 0;
+  double sum = 0;
   for (unsigned int i = 0; i < size; ++i)
   {
     sum += histo[i];

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
@@ -69,13 +69,12 @@ TriangleThresholdCalculator<THistogram, TOutput>::GenerateData()
   {
     cumSum[j] = histogram->GetFrequency(j, 0) + cumSum[j - 1];
   }
-
   typename HistogramType::MeasurementVectorType onePC(1);
-  typename HistogramType::MeasurementVectorType nnPC(1);
   onePC.Fill(histogram->Quantile(0, 0.01));
   typename HistogramType::IndexType localIndex;
   histogram->GetIndex(onePC, localIndex);
-  const IndexValueType onePCIdx = localIndex[0];
+  const IndexValueType                          onePCIdx = localIndex[0];
+  typename HistogramType::MeasurementVectorType nnPC(1);
   nnPC.Fill(histogram->Quantile(0, 0.99));
   histogram->GetIndex(nnPC, localIndex);
   const IndexValueType nnPCIdx = localIndex[0];

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
@@ -44,46 +44,40 @@ YenThresholdCalculator<THistogram, TOutput>::GenerateData()
   unsigned int size = histogram->GetSize(0);
 
   typename HistogramType::InstanceIdentifier threshold = 0;
-  int                                        ih;
-  int                                        it;
-  double                                     crit;
-  double                                     max_crit;
-  std::vector<double>                        norm_histo(size); // normalized histogram
-  std::vector<double>                        P1(size);         // cumulative normalized histogram
-  std::vector<double>                        P1_sq(size);
-  std::vector<double>                        P2_sq(size);
 
-  int total = histogram->GetTotalFrequency();
+  std::vector<double> norm_histo(size); // normalized histogram
+  int                 total = histogram->GetTotalFrequency();
 
-  for (ih = 0; static_cast<unsigned int>(ih) < size; ++ih)
+  for (int ih = 0; static_cast<unsigned int>(ih) < size; ++ih)
   {
     norm_histo[ih] = static_cast<double>(histogram->GetFrequency(ih, 0)) / total;
   }
 
+  std::vector<double> P1(size); // cumulative normalized histogram
   P1[0] = norm_histo[0];
-  for (ih = 1; static_cast<unsigned int>(ih) < size; ++ih)
+  for (int ih = 1; static_cast<unsigned int>(ih) < size; ++ih)
   {
     P1[ih] = P1[ih - 1] + norm_histo[ih];
   }
-
+  std::vector<double> P1_sq(size);
   P1_sq[0] = norm_histo[0] * norm_histo[0];
-  for (ih = 1; static_cast<unsigned int>(ih) < size; ++ih)
+  for (int ih = 1; static_cast<unsigned int>(ih) < size; ++ih)
   {
     P1_sq[ih] = P1_sq[ih - 1] + norm_histo[ih] * norm_histo[ih];
   }
-
+  std::vector<double> P2_sq(size);
   P2_sq[size - 1] = 0.0;
-  for (ih = static_cast<unsigned int>(size) - 2; ih >= 0; ih--)
+  for (int ih = static_cast<unsigned int>(size) - 2; ih >= 0; ih--)
   {
     P2_sq[ih] = P2_sq[ih + 1] + norm_histo[ih + 1] * norm_histo[ih + 1];
   }
 
   // Find the threshold that maximizes the criterion
-  max_crit = itk::NumericTraits<double>::NonpositiveMin();
-  for (it = 0; static_cast<unsigned int>(it) < size; ++it)
+  double max_crit = itk::NumericTraits<double>::NonpositiveMin();
+  for (int it = 0; static_cast<unsigned int>(it) < size; ++it)
   {
-    crit = -1.0 * ((P1_sq[it] * P2_sq[it]) > 0.0 ? std::log(P1_sq[it] * P2_sq[it]) : 0.0) +
-           2 * ((P1[it] * (1.0 - P1[it])) > 0.0 ? std::log(P1[it] * (1.0 - P1[it])) : 0.0);
+    double crit = -1.0 * ((P1_sq[it] * P2_sq[it]) > 0.0 ? std::log(P1_sq[it] * P2_sq[it]) : 0.0) +
+                  2 * ((P1[it] * (1.0 - P1[it])) > 0.0 ? std::log(P1[it] * (1.0 - P1[it])) : 0.0);
     if (crit > max_crit)
     {
       max_crit = crit;

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -81,27 +81,25 @@ BMPImageIO::CanReadFile(const char * filename)
   {
     return false;
   }
-
-  char magic_number1;
-  char magic_number2;
-  inputStream.read((char *)&magic_number1, sizeof(char));
-  inputStream.read((char *)&magic_number2, sizeof(char));
-
-  if ((magic_number1 != 'B') || (magic_number2 != 'M'))
   {
-    inputStream.close();
-    return false;
+    char magic_number1;
+    inputStream.read((char *)&magic_number1, sizeof(char));
+    char magic_number2;
+    inputStream.read((char *)&magic_number2, sizeof(char));
+
+    if ((magic_number1 != 'B') || (magic_number2 != 'M'))
+    {
+      inputStream.close();
+      return false;
+    }
   }
 
-  long tmp;
-  long infoSize;
-  int  iinfoSize; // in case we are on a 64bit machine
-  int  itmp;      // in case we are on a 64bit machine
 
   // get the size of the file
   ::size_t sizeLong = sizeof(long);
   if (sizeLong == 4)
   {
+    long tmp;
     inputStream.read((char *)&tmp, 4);
     // skip 4 bytes
     inputStream.read((char *)&tmp, 4);
@@ -110,6 +108,7 @@ BMPImageIO::CanReadFile(const char * filename)
   }
   else
   {
+    int itmp; // in case we are on a 64bit machine
     inputStream.read((char *)&itmp, 4);
     // skip 4 bytes
     inputStream.read((char *)&itmp, 4);
@@ -120,6 +119,7 @@ BMPImageIO::CanReadFile(const char * filename)
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
+    long infoSize;
     inputStream.read((char *)&infoSize, sizeof(long));
     ByteSwapper<long>::SwapFromSystemToLittleEndian(&infoSize);
     // error checking
@@ -131,9 +131,10 @@ BMPImageIO::CanReadFile(const char * filename)
   }
   else // else we are on a 64bit machine
   {
+    int iinfoSize; // in case we are on a 64bit machine
     inputStream.read((char *)&iinfoSize, 4);
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
-    infoSize = iinfoSize;
+    long infoSize = iinfoSize;
 
     // error checking
     if ((infoSize != 40) && (infoSize != 12))
@@ -342,32 +343,27 @@ BMPImageIO::Read(void * buffer)
 void
 BMPImageIO::ReadImageInformation()
 {
-  int   xsize;
-  int   ysize;
-  long  tmp;
-  short stmp;
-  long  infoSize;
-  int   iinfoSize; // in case we are on a 64bit machine
-  int   itmp;      // in case we are on a 64bit machine
-
   // Now check the content
   this->OpenFileForReading(m_Ifstream, m_FileName);
 
-  char magic_number1;
-  char magic_number2;
-  m_Ifstream.read((char *)&magic_number1, sizeof(char));
-  m_Ifstream.read((char *)&magic_number2, sizeof(char));
-
-  if ((magic_number1 != 'B') || (magic_number2 != 'M'))
   {
-    m_Ifstream.close();
-    itkExceptionMacro("BMPImageIO : Magic Number Fails = " << magic_number1 << " : " << magic_number2);
+    char magic_number1;
+    m_Ifstream.read((char *)&magic_number1, sizeof(char));
+    char magic_number2;
+    m_Ifstream.read((char *)&magic_number2, sizeof(char));
+
+    if ((magic_number1 != 'B') || (magic_number2 != 'M'))
+    {
+      m_Ifstream.close();
+      itkExceptionMacro("BMPImageIO : Magic Number Fails = " << magic_number1 << " : " << magic_number2);
+    }
   }
 
   // get the size of the file
   ::size_t sizeLong = sizeof(long);
   if (sizeLong == 4)
   {
+    long tmp;
     m_Ifstream.read((char *)&tmp, 4);
     // skip 4 bytes
     m_Ifstream.read((char *)&tmp, 4);
@@ -378,6 +374,7 @@ BMPImageIO::ReadImageInformation()
   }
   else
   {
+    int itmp; // in case we are on a 64bit machine
     m_Ifstream.read((char *)&itmp, 4);
     // skip 4 bytes
     m_Ifstream.read((char *)&itmp, 4);
@@ -387,6 +384,9 @@ BMPImageIO::ReadImageInformation()
     m_BitMapOffset = static_cast<long>(itmp);
   }
 
+  int  xsize;
+  int  ysize;
+  long infoSize;
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
@@ -409,6 +409,7 @@ BMPImageIO::ReadImageInformation()
     }
     else
     {
+      short stmp;
       m_Ifstream.read((char *)&stmp, sizeof(short));
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       xsize = stmp;
@@ -419,9 +420,10 @@ BMPImageIO::ReadImageInformation()
   }
   else // else we are on a 64bit machine
   {
+    int iinfoSize; // in case we are on a 64bit machine
+
     m_Ifstream.read((char *)&iinfoSize, sizeof(int));
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
-
     infoSize = iinfoSize;
 
     // error checking
@@ -441,7 +443,7 @@ BMPImageIO::ReadImageInformation()
     }
     else
     {
-      stmp = 0;
+      short stmp = 0;
       m_Ifstream.read((char *)&stmp, 2);
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       xsize = stmp;
@@ -467,6 +469,7 @@ BMPImageIO::ReadImageInformation()
   m_Dimensions[1] = ysize;
 
   // ignore planes
+  short stmp;
   m_Ifstream.read((char *)&stmp, 2);
   // read depth
   m_Ifstream.read((char *)&m_Depth, 2);
@@ -489,6 +492,7 @@ BMPImageIO::ReadImageInformation()
       m_Ifstream.read((char *)&m_BMPDataSize, 4);
       ByteSwapper<unsigned long>::SwapFromSystemToLittleEndian(&m_BMPDataSize);
       // Horizontal Resolution
+      long tmp;
       m_Ifstream.read((char *)&tmp, 4);
       // Vertical Resolution
       m_Ifstream.read((char *)&tmp, 4);
@@ -500,6 +504,7 @@ BMPImageIO::ReadImageInformation()
     }
     else
     {
+      int itmp; // in case we are on a 64bit machine
       // Compression
       m_Ifstream.read((char *)&itmp, 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
@@ -557,6 +562,7 @@ BMPImageIO::ReadImageInformation()
     p.SetGreen(uctmp);
     m_Ifstream.read((char *)&uctmp, 1);
     p.SetBlue(uctmp);
+    long tmp;
     m_Ifstream.read((char *)&tmp, 1);
     m_ColorPalette[i] = p;
   }

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -204,14 +204,13 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
   this->OpenFileForReading(file, m_FileName);
 
   // Find info...
-  bioradheader   h;
-  bioradheader * p;
-  p = &h;
+  bioradheader h;
   if (sizeof(h) != BIORAD_HEADER_LENGTH)
   {
     itkExceptionMacro("Problem of alignement on your platform");
   }
   file.seekg(0, std::ios::beg);
+  bioradheader * p = &h;
   file.read((char *)p, BIORAD_HEADER_LENGTH);
 
   // byteswap header fields

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -711,11 +711,11 @@ GDCMImageIO::InternalReadImageInformation()
 
   const double *     dircos = image.GetDirectionCosines();
   vnl_vector<double> rowDirection(3);
-  vnl_vector<double> columnDirection(3);
   rowDirection[0] = dircos[0];
   rowDirection[1] = dircos[1];
   rowDirection[2] = dircos[2];
 
+  vnl_vector<double> columnDirection(3);
   columnDirection[0] = dircos[3];
   columnDirection[1] = dircos[4];
   columnDirection[2] = dircos[5];
@@ -842,8 +842,6 @@ GDCMImageIO::Write(const void * buffer)
 
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
-  gdcm::Tag tag;
-
   itk::MetaDataDictionary::ConstIterator       itr = dict.Begin();
   const itk::MetaDataDictionary::ConstIterator end = dict.End();
 
@@ -851,7 +849,6 @@ GDCMImageIO::Write(const void * buffer)
   sf.SetFile(writer.GetFile());
 
   std::vector<std::string> problematicKeys;
-
   while (itr != end)
   {
     std::string         value;
@@ -862,7 +859,8 @@ GDCMImageIO::Write(const void * buffer)
     // currently ignored, same tag appears twice in the dictionary
     // once with comma separator and once with pipe. The last one
     // encountered is the one used to set the tag value.
-    bool b = tag.ReadFromPipeSeparatedString(key.c_str()) || tag.ReadFromCommaSeparatedString(key.c_str());
+    gdcm::Tag tag;
+    bool      b = tag.ReadFromPipeSeparatedString(key.c_str()) || tag.ReadFromCommaSeparatedString(key.c_str());
 
     // Anything that has been changed in the MetaData Dict will be pushed
     // into the DICOM header:
@@ -1272,13 +1270,13 @@ GDCMImageIO::Write(const void * buffer)
   // Whenever shift / scale is needed... do it !
   if (m_RescaleIntercept != 0.0 || m_RescaleSlope != 1.0 || outpixeltype != pixeltype)
   {
-    gdcm::Rescaler ir;
-    double         rescaleIntercept = m_RescaleIntercept;
+    double rescaleIntercept = m_RescaleIntercept;
     if (m_RescaleIntercept == 0.0 && outpixeltype != pixeltype)
     {
       // force type conversion when outputpixeltype != pixeltype
       rescaleIntercept = -0.0;
     }
+    gdcm::Rescaler ir;
     ir.SetIntercept(rescaleIntercept);
     ir.SetSlope(m_RescaleSlope);
     ir.SetPixelFormat(pixeltype);

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -59,12 +59,9 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   // reader->GetOutput()->Print(std::cout);
 
   itk::MetaDataDictionary & dict = dicomIO->GetMetaDataDictionary();
-  std::string               tagkey;
-  std::string               value;
-  std::string               commatagkey;
-  std::string               commavalue;
-  tagkey = "0002|0002";
-  value = "1.2.840.10008.5.1.4.1.1.4"; // Media Storage SOP Class UID
+  std::string               tagkey = "0002|0002";
+
+  std::string value = "1.2.840.10008.5.1.4.1.1.4"; // Media Storage SOP Class UID
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);
   tagkey = "0008|0060"; // Modality
   value = "MR";
@@ -81,8 +78,8 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   tagkey = "0020|1040"; // Position Reference Indicator
   value = "";
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);
-  commatagkey = "0018,0020"; // Scanning Sequence
-  commavalue = "GR";
+  std::string commatagkey = "0018,0020"; // Scanning Sequence
+  std::string commavalue = "GR";
   itk::EncapsulateMetaData<std::string>(dict, commatagkey, commavalue);
   tagkey = "0018|0021"; // Sequence Variant
   value = "SS\\SP";

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -66,10 +66,8 @@ itkGDCMImageReadSeriesWriteTest(int argc, char * argv[])
   auto namesGenerator = NamesGeneratorType::New();
 
   itk::MetaDataDictionary & dict = gdcmIO->GetMetaDataDictionary();
-  std::string               tagkey;
-  std::string               value;
-  tagkey = "0008|0060"; // Modality
-  value = "MR";
+  std::string               tagkey = "0008|0060"; // Modality
+  std::string               value = "MR";
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);
   tagkey = "0008|0008"; // Image Type
   value = "DERIVED\\SECONDARY";

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -69,11 +69,7 @@ GE5ImageIO::CheckGE5xImages(const char * const imageFileTemplate, std::string & 
     return -1;
   }
 
-  Ge5xPixelHeader imageHdr;     /* Header Structure for GE 5x images
-                                 */
-  char hdr[GENESIS_SU_HDR_LEN]; /* Header to hold GE Suite header */
-  char prod[16];                /* Product name from Suite Header */
-
+  Ge5xPixelHeader imageHdr; /* Header Structure for GE 5x images */
   // First pass see if image is a raw MR extracted via ximg
   if (!this->ReadBufferAsBinary(f, (void *)&imageHdr, sizeof(imageHdr)))
   {
@@ -92,12 +88,14 @@ GE5ImageIO::CheckGE5xImages(const char * const imageFileTemplate, std::string & 
   // Second pass see if image was extracted via tape by Gene's tape
   // reading software.
   //
+  char hdr[GENESIS_SU_HDR_LEN]; /* Header to hold GE Suite header */
   if (!this->ReadBufferAsBinary(f, (void *)hdr, GENESIS_SU_HDR_LEN))
   {
     reason = "Failed to read study header";
     f.close();
     return -1;
   }
+  char prod[16]; /* Product name from Suite Header */
   strncpy(prod, hdr + GENESIS_SU_PRODID, 13);
   prod[13] = '\0';
   if (strcmp(prod, GE_PROD_STR) == 0)
@@ -170,21 +168,19 @@ SwapPixHdr(Ge5xPixelHeader * hdr)
 GEImageHeader *
 GE5ImageIO::ReadHeader(const char * FileNameToRead)
 {
-  Ge5xPixelHeader imageHdr; // GE 5x Header
-  GEImageHeader * curImage;
-  bool            pixelHdrFlag;
-  std::string     reason;
+  std::string reason;
   if (this->CheckGE5xImages(FileNameToRead, reason) != 0)
   {
     itkExceptionMacro("GE5ImageIO could not open file " << FileNameToRead << " for reading." << std::endl
                                                         << "Reason: " << reason);
   }
 
-  curImage = new GEImageHeader();
+  GEImageHeader * curImage = new GEImageHeader();
 
   std::ifstream f;
   this->OpenFileForReading(f, FileNameToRead);
 
+  Ge5xPixelHeader imageHdr; // GE 5x Header
   f.read((char *)&imageHdr, sizeof(imageHdr));
   if (f.fail())
   {
@@ -204,6 +200,7 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   // if they don't have a header, we have to make assumptions
   // about where they start and hope we're right; below, the offset
   // is computed once the X & Y dims are known
+  bool pixelHdrFlag;
   if (imageHdr.GENESIS_IH_img_magic == GE_5X_MAGIC_NUMBER)
   {
     pixelHdrFlag = true;
@@ -452,24 +449,21 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
 void
 GE5ImageIO::ModifyImageInformation()
 {
-  vnl_vector<double> dirx(3);
-  vnl_vector<double> diry(3);
-  vnl_vector<double> dirz(3);
-
   // NOTE: itk use LPS coordinates while the GE system uses RAS
   // coordinates. Consequently, the R and A coordinates must be negated
   // to convert them to L and P.
-
+  vnl_vector<double> dirx(3);
   dirx[0] = -(m_ImageHeader->trhcR - m_ImageHeader->tlhcR);
   dirx[1] = -(m_ImageHeader->trhcA - m_ImageHeader->tlhcA);
   dirx[2] = (m_ImageHeader->trhcS - m_ImageHeader->tlhcS);
   dirx.normalize();
-
+  vnl_vector<double> diry(3);
   diry[0] = -(m_ImageHeader->brhcR - m_ImageHeader->trhcR);
   diry[1] = -(m_ImageHeader->brhcA - m_ImageHeader->trhcA);
   diry[2] = (m_ImageHeader->brhcS - m_ImageHeader->trhcS);
   diry.normalize();
 
+  vnl_vector<double> dirz(3);
   dirz[0] = -m_ImageHeader->normR;
   dirz[1] = -m_ImageHeader->normA;
   dirz[2] = m_ImageHeader->normS;
@@ -511,20 +505,13 @@ GE5ImageIO::ModifyImageInformation()
     const std::unique_ptr<const GEImageHeader> hdr1{ this->ReadHeader(file1.c_str()) };
     const std::unique_ptr<const GEImageHeader> hdr2{ this->ReadHeader(file2.c_str()) };
 
-    float origin1[3];
-    float origin2[3];
-    origin1[0] = hdr1->tlhcR;
-    origin1[1] = hdr1->tlhcA;
-    origin1[2] = hdr1->tlhcS;
+    float origin1[3] = { hdr1->tlhcR, hdr1->tlhcA, hdr1->tlhcS };
 
     // Origin shopuld always come from the first slice
     this->SetOrigin(0, -hdr1->tlhcR);
     this->SetOrigin(1, -hdr1->tlhcA);
     this->SetOrigin(2, hdr1->tlhcS);
-
-    origin2[0] = hdr2->tlhcR;
-    origin2[1] = hdr2->tlhcA;
-    origin2[2] = hdr2->tlhcS;
+    float origin2[3] = { hdr2->tlhcR, hdr2->tlhcA, hdr2->tlhcS };
 
     float distanceBetweenTwoSlices = std::sqrt((origin1[0] - origin2[0]) * (origin1[0] - origin2[0]) +
                                                (origin1[1] - origin2[1]) * (origin1[1] - origin2[1]) +

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -1093,9 +1093,9 @@ HDF5ImageIO::WriteImageInformation()
     //
     // MetaData.
     MetaDataDictionary & metaDict = this->GetMetaDataDictionary();
-    auto                 it = metaDict.Begin();
-    auto                 end = metaDict.End();
-    for (; it != end; ++it)
+
+    auto end = metaDict.End();
+    for (auto it = metaDict.Begin(); it != end; ++it)
     {
       MetaDataObjectBase * metaObj = it->second.GetPointer();
       std::string          objName(MetaDataGroupName);

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -259,14 +259,14 @@ IPLCommonImageIO::ReadImageInformation()
   AnatomicalOrientation::DirectionType dir =
     AnatomicalOrientation(m_ImageHeader->coordinateOrientation).GetAsDirection();
   std::vector<double> dirx(3, 0);
-  std::vector<double> diry(3, 0);
-  std::vector<double> dirz(3, 0);
   dirx[0] = dir[0][0];
   dirx[1] = dir[1][0];
   dirx[2] = dir[2][0];
+  std::vector<double> diry(3, 0);
   diry[0] = dir[0][1];
   diry[1] = dir[1][1];
   diry[2] = dir[2][1];
+  std::vector<double> dirz(3, 0);
   dirz[0] = dir[0][2];
   dirz[1] = dir[1][2];
   dirz[2] = dir[2][2];

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -490,15 +490,6 @@ JPEG2000ImageIO::Read(void * buffer)
                                                               << "Reason: opj_set_decode_area returns false");
   }
 
-  OPJ_INT32 l_current_tile_x0;
-  OPJ_INT32 l_current_tile_y0;
-  OPJ_INT32 l_current_tile_x1;
-  OPJ_INT32 l_current_tile_y1;
-
-  OPJ_UINT32 l_tile_index;
-  OPJ_UINT32 l_data_size;
-
-  OPJ_UINT32 l_nb_comps;
 
   OPJ_UINT32 l_max_data_size = 1000;
 
@@ -508,6 +499,15 @@ JPEG2000ImageIO::Read(void * buffer)
 
   while (l_go_on)
   {
+    OPJ_INT32 l_current_tile_x0;
+    OPJ_INT32 l_current_tile_y0;
+    OPJ_INT32 l_current_tile_x1;
+    OPJ_INT32 l_current_tile_y1;
+
+    OPJ_UINT32 l_tile_index;
+    OPJ_UINT32 l_data_size;
+
+    OPJ_UINT32 l_nb_comps;
     OPJ_BOOL tileHeaderRead = opj_read_tile_header(this->m_Internal->m_Dinfo,
                                                    l_stream,
                                                    &l_tile_index,
@@ -710,8 +710,6 @@ JPEG2000ImageIO::Write(const void * buffer)
 {
   itkDebugMacro("Write() " << this->GetNumberOfComponents());
 
-  bool bSuccess;
-
   opj_cparameters_t parameters;
   opj_set_default_encoder_parameters(&parameters);
 
@@ -785,10 +783,8 @@ JPEG2000ImageIO::Write(const void * buffer)
 
   //--------------------------------------------------------
   // Copy the contents into the image structure
-  int w;
-  int h;
-  w = this->m_Dimensions[0];
-  h = this->m_Dimensions[1];
+  int w = this->m_Dimensions[0];
+  int h = this->m_Dimensions[1];
 
 
   // Compute the proper number of resolutions to use.
@@ -979,7 +975,7 @@ JPEG2000ImageIO::Write(const void * buffer)
     opj_free(parameters.cp_comment);
   }
 
-  bSuccess = opj_start_compress(cinfo, l_image, cio);
+  bool bSuccess = opj_start_compress(cinfo, l_image, cio);
   if (!bSuccess)
   {
     opj_stream_destroy(cio);

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -127,7 +127,6 @@ LSMImageIO::CanReadFile(const char * filename)
     return false;
   }
 
-
   if (!this->HasSupportedReadExtension(filename))
   {
     itkDebugMacro("The filename extension is not recognized");
@@ -234,25 +233,20 @@ LSMImageIO::Write(const void * buffer)
 {
   const auto * outPtr = (const unsigned char *)buffer;
 
-  unsigned int width;
-  unsigned int height;
-  unsigned int page;
   unsigned int pages = 1;
   if (this->GetNumberOfDimensions() < 2)
   {
     itkExceptionMacro("TIFF requires images to have at least 2 dimensions");
   }
-  width = m_Dimensions[0];
-  height = m_Dimensions[1];
+  unsigned int width = m_Dimensions[0];
+  unsigned int height = m_Dimensions[1];
   if (m_NumberOfDimensions == 3)
   {
     pages = m_Dimensions[2];
   }
 
   uint16_t scomponents = this->GetNumberOfComponents();
-  float    resolution = -1;
   uint16_t bps;
-
   switch (this->GetComponentType())
   {
     case IOComponentEnum::UCHAR:
@@ -267,8 +261,7 @@ LSMImageIO::Write(const void * buffer)
       itkExceptionMacro("TIFF supports unsigned char and unsigned short");
   }
 
-  uint16_t predictor;
-
+  float  resolution = -1;
   TIFF * tif = TIFFOpen(m_FileName.c_str(), "w");
   if (!tif)
   {
@@ -284,7 +277,7 @@ LSMImageIO::Write(const void * buffer)
   {
     TIFFCreateDirectory(tif);
   }
-  for (page = 0; page < pages; ++page)
+  for (unsigned int page = 0; page < pages; ++page)
   {
     TIFFSetDirectory(tif, page);
     TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, w);
@@ -308,8 +301,7 @@ LSMImageIO::Write(const void * buffer)
       uint16_t   extra_samples = scomponents - 3;
       const auto sample_info = make_unique_for_overwrite<uint16_t[]>(scomponents - 3);
       sample_info[0] = EXTRASAMPLE_ASSOCALPHA;
-      int cc;
-      for (cc = 1; cc < scomponents - 3; ++cc)
+      for (int cc = 1; cc < scomponents - 3; ++cc)
       {
         sample_info[cc] = EXTRASAMPLE_UNSPECIFIED;
       }
@@ -347,6 +339,7 @@ LSMImageIO::Write(const void * buffer)
 
     uint16_t photometric = (scomponents == 1) ? PHOTOMETRIC_MINISBLACK : PHOTOMETRIC_RGB;
 
+    uint16_t predictor;
     if (compression == COMPRESSION_JPEG)
     {
       TIFFSetField(tif, TIFFTAG_JPEGQUALITY, this->GetCompressionLevel()); // Parameter
@@ -379,8 +372,8 @@ LSMImageIO::Write(const void * buffer)
       // We are writing single page of the multipage file
       TIFFSetField(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
     }
-    int rowLength; // in bytes
 
+    int rowLength; // in bytes
     switch (this->GetComponentType())
     {
       case IOComponentEnum::UCHAR:

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -319,18 +319,18 @@ MINCImageIO::ReadImageInformation()
 
   for (int i = 0; i < m_MINCPImpl->m_NDims; ++i)
   {
-    char *       name;
-    double       _sep;
-    const char * _sign = "+";
+    char * name;
     if (miget_dimension_name(m_MINCPImpl->m_MincFileDims[i], &name) < 0)
     {
       // Error getting dimension name
       itkExceptionMacro("Could not get dimension name!");
     }
-
+    double       _sep;
+    const char * _sign = "+";
     if (miget_dimension_separation(m_MINCPImpl->m_MincFileDims[i], MI_ORDER_FILE, &_sep) == MI_NOERROR && _sep < 0)
+    {
       _sign = "-";
-
+    }
     m_MINCPImpl->m_DimensionName[i] = name;
     if (!strcmp(name, MIxspace) || !strcmp(name, MIxfrequency)) // this is X space
     {
@@ -338,15 +338,13 @@ MINCImageIO::ReadImageInformation()
       dimension_order += _sign;
       dimension_order += "X";
     }
-    else if (!strcmp(name, MIyspace) || !strcmp(name, MIyfrequency)) // this is Y
-                                                                     // space
+    else if (!strcmp(name, MIyspace) || !strcmp(name, MIyfrequency)) // this is Y space
     {
       m_MINCPImpl->m_DimensionIndices[2] = i;
       dimension_order += _sign;
       dimension_order += "Y";
     }
-    else if (!strcmp(name, MIzspace) || !strcmp(name, MIzfrequency)) // this is Z
-                                                                     // space
+    else if (!strcmp(name, MIzspace) || !strcmp(name, MIzfrequency)) // this is Z space
     {
       m_MINCPImpl->m_DimensionIndices[3] = i;
       dimension_order += _sign;
@@ -358,8 +356,7 @@ MINCImageIO::ReadImageInformation()
       dimension_order += "+"; // vector dimension is always positive
       dimension_order += "V";
     }
-    else if (!strcmp(name, MItime) || !strcmp(name, MItfrequency)) // this is time
-                                                                   // space
+    else if (!strcmp(name, MItime) || !strcmp(name, MItfrequency)) // this is time space
     {
       m_MINCPImpl->m_DimensionIndices[4] = i;
       dimension_order += _sign;
@@ -423,8 +420,6 @@ MINCImageIO::ReadImageInformation()
     {
       itkExceptionMacro(" Can not get volume range!!\n");
     }
-
-
     global_scaling_flag = !(volume_min == valid_min && volume_max == valid_max);
   }
 
@@ -458,12 +453,12 @@ MINCImageIO::ReadImageInformation()
   dir_cos.SetIdentity();
 
   Vector<double, 3> origin;
-  Vector<double, 3> sep;
-  Vector<double, 3> o_origin;
   origin.Fill(0.0);
+  Vector<double, 3> o_origin;
   o_origin.Fill(0.0);
 
   // minc api uses inverse order of dimensions , fastest varying are last
+  Vector<double, 3> sep;
   for (int i = 3; i > 0; i--)
   {
     if (m_MINCPImpl->m_DimensionIndices[i] != -1)
@@ -477,12 +472,11 @@ MINCImageIO::ReadImageInformation()
       misize_t _sz;
       miget_dimension_size(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_sz);
 
-      std::vector<double> _dir(3);
-      double              _sep;
-      double              _start;
-
+      double _sep;
       miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_sep);
+      std::vector<double> _dir(3);
       miget_dimension_cosines(m_MINCPImpl->m_MincApparentDims[usable_dimensions], &_dir[0]);
+      double _start;
       miget_dimension_start(m_MINCPImpl->m_MincApparentDims[usable_dimensions], MI_ORDER_APPARENT, &_start);
 
       for (int j = 0; j < 3; ++j)
@@ -624,8 +618,8 @@ MINCImageIO::ReadImageInformation()
       }
       else
       {
-        this->SetPixelType(IOPixelEnum::VECTOR); // TODO: handle more types (i.e matrix,
-      } // tensor etc)
+        this->SetPixelType(IOPixelEnum::VECTOR); // TODO: handle more types (i.e matrix, tensor etc)
+      }
       break;
     case MI_CLASS_INT:
       if (numberOfComponents == 1)
@@ -634,8 +628,8 @@ MINCImageIO::ReadImageInformation()
       }
       else
       {
-        this->SetPixelType(IOPixelEnum::VECTOR); // TODO: handle more types (i.e matrix,
-      } // tensor etc)
+        this->SetPixelType(IOPixelEnum::VECTOR); // TODO: handle more types (i.e matrix, tensor etc)
+      }
       break;
     case MI_CLASS_LABEL:
       if (numberOfComponents == 1)
@@ -686,9 +680,9 @@ MINCImageIO::ReadImageInformation()
   {
     // store time dimension start and step in metadata for preservation
     double _sep;
-    double _start;
     miget_dimension_separation(
       m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_sep);
+    double _start;
     miget_dimension_start(m_MINCPImpl->m_MincFileDims[m_MINCPImpl->m_DimensionIndices[4]], MI_ORDER_APPARENT, &_start);
     EncapsulateMetaData<double>(thisDic, "tstart", _start);
     EncapsulateMetaData<double>(thisDic, "tstep", _sep);
@@ -747,11 +741,10 @@ MINCImageIO::ReadImageInformation()
 
   if ((milist_start(m_MINCPImpl->m_Volume, "", 0, &grplist)) == MI_NOERROR)
   {
-    char           group_name[256];
-    milisthandle_t attlist;
-
+    char group_name[256];
     while (milist_grp_next(grplist, group_name, sizeof(group_name)) == MI_NOERROR)
     {
+      milisthandle_t attlist;
       if ((milist_start(m_MINCPImpl->m_Volume, group_name, 1, &attlist)) == MI_NOERROR)
       {
         char attribute[256];
@@ -883,9 +876,6 @@ MINCImageIO::WriteImageInformation()
   MetaDataDictionary & thisDic = GetMetaDataDictionary();
 
   unsigned int minc_dimensions = 0;
-  double       tstart = 0.0;
-  double       tstep = 1.0;
-
   if (nComp > 3) // last dimension will be either vector or time
   {
     micreate_dimension(MItime,
@@ -894,6 +884,7 @@ MINCImageIO::WriteImageInformation()
                        nComp,
                        &m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1]);
 
+    double tstart = 0.0;
     if (!ExposeMetaData<double>(thisDic, "tstart", tstart))
     {
       tstart = 0.0;
@@ -901,6 +892,7 @@ MINCImageIO::WriteImageInformation()
 
     miset_dimension_start(m_MINCPImpl->m_MincApparentDims[m_MINCPImpl->m_NDims - minc_dimensions - 1], tstart);
 
+    double tstep = 1.0;
     if (!ExposeMetaData<double>(thisDic, "tstep", tstep))
     {
       tstep = 1.0;
@@ -1128,12 +1120,11 @@ MINCImageIO::WriteImageInformation()
           if (!positive && dimension_order[i * 2 + 1] != 'V' &&
               dimension_order[i * 2 + 1] != 'v') // Vector dimension is always positive
           {
-            double   _sep;
-            double   _start;
-            misize_t _sz;
-
+            double _sep;
             miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_sep);
+            double _start;
             miget_dimension_start(m_MINCPImpl->m_MincApparentDims[j], MI_ORDER_FILE, &_start);
+            misize_t _sz;
             miget_dimension_size(m_MINCPImpl->m_MincApparentDims[j], &_sz);
 
             _start = _start + (_sz - 1) * _sep;
@@ -1247,14 +1238,13 @@ MINCImageIO::WriteImageInformation()
 
     const char *         d = strchr(it->first.c_str(), ':');
     MetaDataObjectBase * bs = it->second;
-    const char *         tname = bs->GetMetaDataObjectTypeName();
-
     if (d)
     {
       std::string var(it->first.c_str(), d - it->first.c_str());
       std::string att(d + 1);
 
       // VF:THIS is not good OO style at all :(
+      const char * tname = bs->GetMetaDataObjectTypeName();
       if (!strcmp(tname, typeid(std::string).name()))
       {
         const std::string & tmp = dynamic_cast<MetaDataObject<std::string> *>(bs)->GetMetaDataObjectValue();

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -737,14 +737,12 @@ MINCReadWriteTestVector(const char * fileName,
   }
 
   itk::ImageRegionIterator<ImageType> it2(im2, im2->GetLargestPossibleRegion());
-  InternalPixelType                   pix1;
-  InternalPixelType                   pix2;
   if (tolerance == 0.0)
   {
     for (it.GoToBegin(), it2.GoToBegin(); !it.IsAtEnd() && !it2.IsAtEnd(); ++it, ++it2)
     {
-      pix1 = it.Get();
-      pix2 = it2.Get();
+      InternalPixelType pix1 = it.Get();
+      InternalPixelType pix2 = it2.Get();
       if (!equal<TPixel>(pix1, pix2))
       {
         std::cout << "Original Pixel (" << pix1 << ") doesn't match read-in Pixel (" << pix2 << " ) "
@@ -758,8 +756,8 @@ MINCReadWriteTestVector(const char * fileName,
   { // account for rounding errors
     for (it.GoToBegin(), it2.GoToBegin(); !it.IsAtEnd() && !it2.IsAtEnd(); ++it, ++it2)
     {
-      pix1 = it.Get();
-      pix2 = it2.Get();
+      InternalPixelType pix1 = it.Get();
+      InternalPixelType pix2 = it2.Get();
       if (abs_vector_diff<TPixel>(pix1, pix2) > tolerance)
       {
         std::cout << "Original Pixel (" << pix1 << ") doesn't match read-in Pixel (" << pix2 << " ) "

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -808,13 +808,10 @@ MetaImageIO::Write(const void * buffer)
 
   if (numberOfDimensions == 3)
   {
-    std::vector<double>                  dirx;
-    std::vector<double>                  diry;
-    std::vector<double>                  dirz;
     AnatomicalOrientation::DirectionType dir;
-    dirx = this->GetDirection(0);
-    diry = this->GetDirection(1);
-    dirz = this->GetDirection(2);
+    std::vector<double>                  dirx = this->GetDirection(0);
+    std::vector<double>                  diry = this->GetDirection(1);
+    std::vector<double>                  dirz = this->GetDirection(2);
     for (unsigned int ii = 0; ii < 3; ++ii)
     {
       dir[ii][0] = dirx[ii];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -53,11 +53,6 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
 
   //
   // swizzle up a random vector image.
-  typename VectorImageType::RegionType  imageRegion;
-  typename VectorImageType::SizeType    size;
-  typename VectorImageType::IndexType   index;
-  typename VectorImageType::SpacingType spacing;
-  typename VectorImageType::PointType   origin;
   // original test case was destined for failure.  NIfTI always writes out 3D
   // orientation.  The only sensible matrices you could pass in would be of the form
   // A B C 0
@@ -75,14 +70,11 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   std::cout << "======================== Initialized Direction" << std::endl;
   std::cout << myDirection << std::endl;
 
-  for (unsigned int i = 0; i < TDimension; ++i)
-  {
-    size[i] = dimsize;
-    index[i] = 0;
-    spacing[i] = 1.0;
-    origin[i] = 0;
-  }
-
+  auto                                 size = itk::MakeFilled<typename VectorImageType::SizeType>(dimsize);
+  auto                                 spacing = itk::MakeFilled<typename VectorImageType::SpacingType>(1.0);
+  typename VectorImageType::IndexType  index{};
+  typename VectorImageType::PointType  origin{};
+  typename VectorImageType::RegionType imageRegion;
   imageRegion.SetSize(size);
   imageRegion.SetIndex(index);
   typename VectorImageType::Pointer vi =
@@ -91,7 +83,6 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   vi->SetDirection(myDirection);
 
   size_t dims[7];
-  size_t _index[7];
   for (unsigned int i = 0; i < TDimension; ++i)
   {
     dims[i] = size[i];
@@ -103,6 +94,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
 
   ScalarType value = std::numeric_limits<ScalarType>::max();
   //  for(fillIt.GoToBegin(); !fillIt.IsAtEnd(); ++fillIt)
+  size_t _index[7];
   for (size_t l = 0; l < dims[6]; ++l)
   {
     _index[6] = l;
@@ -190,7 +182,6 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   {
     const itk::MetaDataDictionary & dictionary = readback->GetMetaDataDictionary();
     std::string                     readIntentCode;
-    std::string                     readDescription;
     if (itk::ExposeMetaData<std::string>(dictionary, "intent_code", readIntentCode))
     {
       if (readIntentCode != intentCode)
@@ -204,6 +195,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
       std::cout << "The read image should have an intent_code in its dictionary" << std::endl;
       same = false;
     }
+    std::string readDescription;
     if (itk::ExposeMetaData<std::string>(dictionary, "ITK_FileNotes", readDescription))
     {
       if (readDescription != description)
@@ -263,14 +255,12 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
               for (size_t k = 0; k < dims[0]; ++k)
               {
                 _index[0] = k;
-                FieldPixelType p1;
-                FieldPixelType p2;
                 for (size_t q = 0; q < TDimension; ++q)
                 {
                   index[q] = _index[q];
                 }
-                p1 = vi->GetPixel(index);
-                p2 = readback->GetPixel(index);
+                FieldPixelType p1 = vi->GetPixel(index);
+                FieldPixelType p2 = readback->GetPixel(index);
                 if (p1 != p2)
                 {
                   same = false;

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -601,23 +601,11 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
       break;
   }
 
-  png_uint_32 width;
-  png_uint_32 height;
-  double      rowSpacing;
-  double      colSpacing;
-  width = this->GetDimensions(0);
-  colSpacing = m_Spacing[0];
+  png_uint_32 width = this->GetDimensions(0);
+  double      colSpacing = m_Spacing[0];
 
-  if (m_NumberOfDimensions > 1)
-  {
-    height = this->GetDimensions(1);
-    rowSpacing = m_Spacing[1];
-  }
-  else
-  {
-    height = 1;
-    rowSpacing = 1;
-  }
+  png_uint_32 height = (m_NumberOfDimensions > 1) ? this->GetDimensions(1) : 1;
+  double      rowSpacing = (m_NumberOfDimensions > 1) ? m_Spacing[1] : 1;
 
   png_set_IHDR(png_ptr,
                info_ptr,

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -547,11 +547,6 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
   {
     case RESEARCH_IMAGE_EXPORT_TOOL_V3:
     {
-      struct image_info_defV3 tempInfo;
-      struct image_info_defV3 tempInfo1;
-      float                   fovAP;
-      float                   fovFH;
-      float                   fovRL;
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
       strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));
@@ -618,7 +613,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
         inString >> pPar->repetition_time[repTime];
       }
       inString.clear();
-      tempInfo = GetImageInformationDefinitionV3(parFile, 89, this);
+      struct image_info_defV3 tempInfo = GetImageInformationDefinitionV3(parFile, 89, this);
       if (tempInfo.problemreading)
       {
         std::ostringstream message;
@@ -634,6 +629,9 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       pPar->vox[0] = tempInfo.spacingx;
       pPar->vox[1] = tempInfo.spacingy;
       inString.str(this->GetGeneralInfoString(parFile, 32));
+      float fovAP;
+      float fovFH;
+      float fovRL;
       inString >> fovAP >> fovFH >> fovRL;
       inString.clear();
       // slice orientation: transversal
@@ -724,10 +722,10 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       // Also get echo times and trigger_times.
       if (pPar->slice > 1)
       {
-        int lineIncrement = 89;
-        int echoIndex = 0;
-        int cardiacIndex = 0;
-        tempInfo1 = GetImageInformationDefinitionV3(parFile, 90, this);
+        int                     lineIncrement = 89;
+        int                     echoIndex = 0;
+        int                     cardiacIndex = 0;
+        struct image_info_defV3 tempInfo1 = GetImageInformationDefinitionV3(parFile, 90, this);
         if (tempInfo1.problemreading)
         {
           pPar->problemreading = 1;
@@ -939,7 +937,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
         ++pPar->num_scanning_sequences;
         pPar->scanning_sequences[0] = tempInfo.scan_sequence;
         ++lineIncrement;
-        tempInfo1 = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
+        struct image_info_defV3 tempInfo1 = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
         while (!tempInfo1.problemreading && tempInfo1.slice)
         {
           if (slice == tempInfo1.slice)
@@ -1041,11 +1039,6 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_1:
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_2:
     {
-      struct image_info_defV4 tempInfo;
-      struct image_info_defV4 tempInfo1;
-      float                   fovAP;
-      float                   fovFH;
-      float                   fovRL;
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
       strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));
@@ -1104,6 +1097,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
         inString >> pPar->repetition_time[repTime];
       }
       inString.clear();
+      struct image_info_defV4 tempInfo;
       switch (pPar->ResToolsVersion)
       {
         case RESEARCH_IMAGE_EXPORT_TOOL_V4:
@@ -1139,6 +1133,9 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       pPar->vox[1] = tempInfo.spacingy;
       pPar->vox[2] = tempInfo.slice_thick + tempInfo.slice_gap;
       inString.str(this->GetGeneralInfoString(parFile, 31));
+      float fovAP;
+      float fovFH;
+      float fovRL;
       inString >> fovAP >> fovFH >> fovRL;
       inString.clear();
       // slice orientation: transversal
@@ -1224,9 +1221,10 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       // Also get echo times.
       if (pPar->slice > 1)
       {
-        int lineIncrement = 92;
-        int echoIndex = 0;
-        int cardiacIndex = 0;
+        int                     lineIncrement = 92;
+        int                     echoIndex = 0;
+        int                     cardiacIndex = 0;
+        struct image_info_defV4 tempInfo1;
         switch (pPar->ResToolsVersion)
         {
           case RESEARCH_IMAGE_EXPORT_TOOL_V4:
@@ -1479,7 +1477,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
             break;
         }
         ++lineIncrement;
-        tempInfo1 = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
+        struct image_info_defV4 tempInfo1 = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
         while (!tempInfo1.problemreading && tempInfo1.slice)
         {
           if (slice == tempInfo1.slice)
@@ -1810,13 +1808,12 @@ PhilipsPAR::GetImageTypesScanningSequence(std::string parFile)
   {
     case RESEARCH_IMAGE_EXPORT_TOOL_V3:
     {
-      struct image_info_defV3 tempInfo;
       for (int scanIndex = 0; scanIndex < parParam.num_scanning_sequences; ++scanIndex)
       {
         PhilipsPAR::PARImageTypeScanSequence imageTypeAndSequence;
         int                                  lineIncrement = 89;
-        int imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
-        tempInfo = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
+        int                     imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+        struct image_info_defV3 tempInfo = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
         while (!tempInfo.problemreading && tempInfo.slice)
         {
           if ((*(imageType + tempInfo.image_type_mr) < 0) &&
@@ -1841,13 +1838,12 @@ PhilipsPAR::GetImageTypesScanningSequence(std::string parFile)
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4:
     {
-      struct image_info_defV4 tempInfo;
       for (int scanIndex = 0; scanIndex < parParam.num_scanning_sequences; ++scanIndex)
       {
         PhilipsPAR::PARImageTypeScanSequence imageTypeAndSequence;
         int                                  lineIncrement = 92;
-        int imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
-        tempInfo = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
+        int                     imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+        struct image_info_defV4 tempInfo = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
         while (!tempInfo.problemreading && tempInfo.slice)
         {
           if ((*(imageType + tempInfo.image_type_mr) < 0) &&
@@ -1872,13 +1868,12 @@ PhilipsPAR::GetImageTypesScanningSequence(std::string parFile)
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_1:
     {
-      struct image_info_defV4 tempInfo;
       for (int scanIndex = 0; scanIndex < parParam.num_scanning_sequences; ++scanIndex)
       {
         PhilipsPAR::PARImageTypeScanSequence imageTypeAndSequence;
         int                                  lineIncrement = 99;
-        int imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
-        tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
+        int                     imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+        struct image_info_defV4 tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
         while (!tempInfo.problemreading && tempInfo.slice)
         {
           if ((*(imageType + tempInfo.image_type_mr) < 0) &&
@@ -1903,13 +1898,12 @@ PhilipsPAR::GetImageTypesScanningSequence(std::string parFile)
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_2:
     {
-      struct image_info_defV4 tempInfo;
       for (int scanIndex = 0; scanIndex < parParam.num_scanning_sequences; ++scanIndex)
       {
         PhilipsPAR::PARImageTypeScanSequence imageTypeAndSequence;
         int                                  lineIncrement = 101;
-        int imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
-        tempInfo = GetImageInformationDefinitionV42(parFile, lineIncrement, this);
+        int                     imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+        struct image_info_defV4 tempInfo = GetImageInformationDefinitionV42(parFile, lineIncrement, this);
         while (!tempInfo.problemreading && tempInfo.slice)
         {
           if ((*(imageType + tempInfo.image_type_mr) < 0) &&
@@ -1941,8 +1935,6 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
                                 PhilipsPAR::PARRescaleValuesContainer * rescaleValues,
                                 int                                     scan_sequence)
 {
-  int ResToolsVersion;
-
   rescaleValues->clear();
   // Must match size of image_types
   rescaleValues->resize(PAR_DEFAULT_IMAGE_TYPES_SIZE);
@@ -1953,7 +1945,7 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
   }
 
   // Check version of PAR file.
-  ResToolsVersion = this->GetPARVersion(parFile);
+  int ResToolsVersion = this->GetPARVersion(parFile);
   if (ResToolsVersion == RESEARCH_IMAGE_EXPORT_TOOL_UNKNOWN)
   {
     return false;
@@ -1963,11 +1955,10 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
   {
     case RESEARCH_IMAGE_EXPORT_TOOL_V3:
     {
-      struct image_info_defV3      tempInfo;
       PhilipsPAR::PARRescaleValues rescale;
       int                          imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
       int                          lineIncrement = 89;
-      tempInfo = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
+      struct image_info_defV3      tempInfo = GetImageInformationDefinitionV3(parFile, lineIncrement, this);
       while (!tempInfo.problemreading && tempInfo.slice)
       {
         if ((*(imageType + tempInfo.image_type_mr) < 0) && (tempInfo.scan_sequence == scan_sequence))
@@ -1985,11 +1976,10 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4:
     {
-      struct image_info_defV4      tempInfo;
       PhilipsPAR::PARRescaleValues rescale;
       int                          imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
       int                          lineIncrement = 92;
-      tempInfo = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
+      struct image_info_defV4      tempInfo = GetImageInformationDefinitionV4(parFile, lineIncrement, this);
       while (!tempInfo.problemreading && tempInfo.slice)
       {
         if ((*(imageType + tempInfo.image_type_mr) < 0) && (tempInfo.scan_sequence == scan_sequence))
@@ -2007,11 +1997,10 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_1:
     {
-      struct image_info_defV4      tempInfo;
       PhilipsPAR::PARRescaleValues rescale;
       int                          imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
       int                          lineIncrement = 99;
-      tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
+      struct image_info_defV4      tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
       while (!tempInfo.problemreading && tempInfo.slice)
       {
         if ((*(imageType + tempInfo.image_type_mr) < 0) && (tempInfo.scan_sequence == scan_sequence))
@@ -2029,11 +2018,10 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
     break;
     case RESEARCH_IMAGE_EXPORT_TOOL_V4_2:
     {
-      struct image_info_defV4      tempInfo;
       PhilipsPAR::PARRescaleValues rescale;
       int                          imageType[PAR_DEFAULT_IMAGE_TYPES_SIZE] = { -1, -1, -1, -1, -1, -1, -1, -1 };
       int                          lineIncrement = 101;
-      tempInfo = GetImageInformationDefinitionV42(parFile, lineIncrement, this);
+      struct image_info_defV4      tempInfo = GetImageInformationDefinitionV42(parFile, lineIncrement, this);
       while (!tempInfo.problemreading && tempInfo.slice)
       {
         if ((*(imageType + tempInfo.image_type_mr) < 0) && (tempInfo.scan_sequence == scan_sequence))
@@ -2060,23 +2048,21 @@ PhilipsPAR::GetDiffusionGradientOrientationAndBValues(std::string               
 {
   gradientValues->resize(0); // Reset to zero size.
   bValues->resize(0);
-  struct par_parameter tempPar;
-  int                  ResToolsVersion;
 
   // Check version of PAR file.
   // Diffusion gradients are only stored in PAR version >= 4.1
-  ResToolsVersion = this->GetPARVersion(parFile);
+  int ResToolsVersion = this->GetPARVersion(parFile);
   if (ResToolsVersion >= RESEARCH_IMAGE_EXPORT_TOOL_V4_1)
   {
-    struct image_info_defV4 tempInfo;
-    int                     gradientOrientationNumber = -1;
-    int                     lineIncrement = 99;
+    int gradientOrientationNumber = -1;
+    int lineIncrement = 99;
 
     if (ResToolsVersion == RESEARCH_IMAGE_EXPORT_TOOL_V4_2)
     {
       lineIncrement = 101;
     }
 
+    struct par_parameter tempPar;
     try
     {
       this->ReadPAR(parFile, &tempPar);
@@ -2094,10 +2080,9 @@ PhilipsPAR::GetDiffusionGradientOrientationAndBValues(std::string               
       return true;
     }
 
-    // Can use either version 4.1 or 4.2 GetImageInformationDefinition
-    // function.
-    int gradientDirectionCount = 0;
-    tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
+    // Can use either version 4.1 or 4.2 GetImageInformationDefinition function.
+    int                     gradientDirectionCount = 0;
+    struct image_info_defV4 tempInfo = GetImageInformationDefinitionV41(parFile, lineIncrement, this);
     while (!tempInfo.problemreading && tempInfo.slice && (gradientDirectionCount < tempPar.max_num_grad_orient))
     {
       int tempGradientOrientationNumber = tempInfo.gradient_orientation_number;
@@ -2123,18 +2108,17 @@ bool
 PhilipsPAR::GetLabelTypesASL(std::string parFile, PhilipsPAR::PARLabelTypesASLContainer * labelTypes)
 {
   labelTypes->resize(0); // Reset to zero size.
-  struct par_parameter tempPar;
-  int                  ResToolsVersion;
 
   // Check version of PAR file.
   // ASL labels are only stored in PAR version >= 4.2
-  ResToolsVersion = this->GetPARVersion(parFile);
+  int ResToolsVersion = this->GetPARVersion(parFile);
   if (ResToolsVersion >= RESEARCH_IMAGE_EXPORT_TOOL_V4_2)
   {
     struct image_info_defV4 tempInfo;
     int                     aslLabelNumber = -1;
     int                     lineIncrement = 101;
 
+    struct par_parameter tempPar;
     try
     {
       this->ReadPAR(parFile, &tempPar);

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -419,11 +419,10 @@ PhilipsRECImageIO::GetSliceIndex(IndexValueType index) const
 void
 PhilipsRECImageIO::Read(void * buffer)
 {
-  unsigned int       dim;
   const unsigned int dimensions = this->GetNumberOfDimensions();
   unsigned int       numberOfPixels = 1;
 
-  for (dim = 0; dim < dimensions; ++dim)
+  for (unsigned int dim = 0; dim < dimensions; ++dim)
   {
     numberOfPixels *= this->m_Dimensions[dim];
   }
@@ -739,11 +738,9 @@ PhilipsRECImageIO::ReadImageInformation()
 
   AffineMatrix direction;
   direction.SetIdentity();
-  int rows;
-  int columns;
-  for (rows = 0; rows < 3; ++rows)
+  for (int rows = 0; rows < 3; ++rows)
   {
-    for (columns = 0; columns < 3; ++columns)
+    for (int columns = 0; columns < 3; ++columns)
     {
       direction[columns][rows] = dir[columns][rows];
     }
@@ -823,23 +820,23 @@ PhilipsRECImageIO::ReadImageInformation()
   std::cout << "Final direction cosines after rotation = " << direction << std::endl;
 #endif
 
-  std::vector<double> dirx(numberOfDimensions, 0);
-  std::vector<double> diry(numberOfDimensions, 0);
-  std::vector<double> dirz(numberOfDimensions, 0);
   std::vector<double> dirBlock(numberOfDimensions, 0);
   dirBlock[numberOfDimensions - 1] = 1;
+
+  std::vector<double> dirx(numberOfDimensions, 0);
   dirx[0] = direction[0][0];
   dirx[1] = direction[1][0];
   dirx[2] = direction[2][0];
+  this->SetDirection(0, dirx);
+  std::vector<double> diry(numberOfDimensions, 0);
   diry[0] = direction[0][1];
   diry[1] = direction[1][1];
   diry[2] = direction[2][1];
+  this->SetDirection(1, diry);
+  std::vector<double> dirz(numberOfDimensions, 0);
   dirz[0] = direction[0][2];
   dirz[1] = direction[1][2];
   dirz[2] = direction[2][2];
-
-  this->SetDirection(0, dirx);
-  this->SetDirection(1, diry);
   this->SetDirection(2, dirz);
   if (numberOfDimensions > 3)
   {

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -117,22 +117,16 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   DB(hdr->name);
 
   int year;
-  int month;
-  int day;
-  int hour;
-  int minute;
-  int second;
-
   this->GetIntAt(f, HDR_REG_YEAR, &year);
-
+  int month;
   this->GetIntAt(f, HDR_REG_MONTH, &month);
-
+  int day;
   this->GetIntAt(f, HDR_REG_DAY, &day);
-
+  int hour;
   this->GetIntAt(f, HDR_REG_HOUR, &hour);
-
+  int minute;
   this->GetIntAt(f, HDR_REG_MIN, &minute);
-
+  int second;
   this->GetIntAt(f, HDR_REG_SEC, &second);
 
   snprintf(hdr->date, sizeof(hdr->date), "%d/%d/%d %d:%d:%d", year, month, day, hour, minute, second);
@@ -154,8 +148,6 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   }
 
   char tmpStr[TEMPLEN];
-  char tmpStr2[TEMPLEN];
-
   this->GetStringAt(f, TEXT_STUDY_NUM2, tmpStr, TEXT_STUDY_NUM2_LEN);
   tmpStr[TEXT_STUDY_NUM2_LEN] = '\0';
   hdr->seriesNumber = std::stoi(tmpStr);
@@ -210,6 +202,7 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   this->GetStringAt(f, TEXT_ANGLE_FLAG1, tmpStr, TEXT_ANGLE_FLAG1_LEN);
   tmpStr[TEXT_ANGLE_FLAG1_LEN] = '\0';
 
+  char tmpStr2[TEMPLEN];
   this->GetStringAt(f, TEXT_ANGLE_FLAG3, tmpStr2, TEXT_ANGLE_FLAG3_LEN);
   tmpStr2[TEXT_ANGLE_FLAG3_LEN] = '\0';
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -572,7 +572,6 @@ TIFFImageIO::InternalWrite(const void * buffer)
 {
   const auto * outPtr = static_cast<const char *>(buffer);
 
-  uint16_t page;
   uint16_t pages = 1;
 
   const SizeValueType width = m_Dimensions[0];
@@ -655,7 +654,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
   {
     TIFFCreateDirectory(tif);
   }
-  for (page = 0; page < pages; ++page)
+  for (uint16_t page = 0; page < pages; ++page)
   {
     TIFFSetDirectory(tif, page);
     TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, w);

--- a/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
@@ -36,9 +36,6 @@ itkIOEuler3DTransformTxtTest(int argc, char * argv[])
   itk::ObjectFactoryBase::RegisterFactory(itk::TxtTransformIOFactory::New());
 
   using TransformType = itk::Euler3DTransform<double>;
-  TransformType::Pointer oldStyleInput;
-  TransformType::Pointer newStyleInput;
-
   using ReaderType = itk::TransformFileReaderTemplate<double>;
   auto reader = ReaderType::New();
 
@@ -48,7 +45,8 @@ itkIOEuler3DTransformTxtTest(int argc, char * argv[])
   // read old style format in
   reader->SetFileName(argv[1]);
   reader->Update();
-  oldStyleInput = static_cast<TransformType *>((reader->GetTransformList()->begin())->GetPointer());
+  TransformType::Pointer oldStyleInput =
+    static_cast<TransformType *>((reader->GetTransformList()->begin())->GetPointer());
 
   // modify the interpretation of the Euler angles
   oldStyleInput->SetComputeZYX(true);
@@ -61,7 +59,8 @@ itkIOEuler3DTransformTxtTest(int argc, char * argv[])
   // read new style format back in
   reader->SetFileName(argv[2]);
   reader->Update();
-  newStyleInput = static_cast<TransformType *>((reader->GetTransformList()->begin())->GetPointer());
+  TransformType::Pointer newStyleInput =
+    static_cast<TransformType *>((reader->GetTransformList()->begin())->GetPointer());
 
   const TransformType::MatrixType & oldStyleMat = oldStyleInput->GetMatrix();
   const TransformType::MatrixType & newStyleMat = newStyleInput->GetMatrix();

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -57,12 +57,9 @@ InitializationBiasedParticleSwarmOptimizer::UpdateSwarm()
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {
     ParticleData &            p = m_Particles[j];
-    ParametersType::ValueType phi1;
-    ParametersType::ValueType phi2;
-    ParametersType::ValueType phi3;
-    phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
-    phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
-    phi3 = randomGenerator->GetVariateWithClosedRange() * initializationCoefficient;
+    ParametersType::ValueType phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
+    ParametersType::ValueType phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
+    ParametersType::ValueType phi3 = randomGenerator->GetVariateWithClosedRange() * initializationCoefficient;
     for (unsigned int k = 0; k < n; ++k)
     { // update velocity
       p.m_CurrentVelocity[k] = m_InertiaCoefficient * p.m_CurrentVelocity[k] +

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -201,14 +201,13 @@ LevenbergMarquardtOptimizer::GetOptimizer() const
 std::string
 LevenbergMarquardtOptimizer::GetStopConditionDescription() const
 {
-  std::ostringstream reason;
   std::ostringstream outcome;
-
   outcome.str("");
   if (GetOptimizer())
   {
     GetOptimizer()->diagnose_outcome(outcome);
   }
+  std::ostringstream reason;
   reason << this->GetNameOfClass() << ": " << ((!outcome.str().empty()) ? outcome.str().c_str() : "");
   return reason.str();
 }

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -54,10 +54,8 @@ ParticleSwarmOptimizer::UpdateSwarm()
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {
     ParticleData &            p = m_Particles[j];
-    ParametersType::ValueType phi1;
-    ParametersType::ValueType phi2;
-    phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
-    phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
+    ParametersType::ValueType phi1 = randomGenerator->GetVariateWithClosedRange() * this->m_PersonalCoefficient;
+    ParametersType::ValueType phi2 = randomGenerator->GetVariateWithClosedRange() * this->m_GlobalCoefficient;
     for (unsigned int k = 0; k < n; ++k)
     { // update velocity
       p.m_CurrentVelocity[k] = m_InertiaCoefficient * p.m_CurrentVelocity[k] +

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -152,10 +152,9 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Maximal number of iterations: " << this->m_MaximalNumberOfIterations << '\n';
   os << indent << "Number of generations with minimal improvement: ";
   os << this->m_NumberOfGenerationsWithMinimalImprovement << '\n';
-  ParameterBoundsType::const_iterator it;
   ParameterBoundsType::const_iterator end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
-  for (it = this->m_ParameterBounds.begin(); it != end; ++it)
+  for (ParameterBoundsType::const_iterator it = this->m_ParameterBounds.begin(); it != end; ++it)
   {
     os << " [" << it->first << ", " << it->second << ']';
   }
@@ -180,10 +179,9 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 void
 ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
 {
-  std::vector<ParticleData>::const_iterator it;
   std::vector<ParticleData>::const_iterator end = this->m_Particles.end();
   os << indent << "[\n";
-  for (it = this->m_Particles.begin(); it != end; ++it)
+  for (std::vector<ParticleData>::const_iterator it = this->m_Particles.begin(); it != end; ++it)
   {
     const ParticleData & p = *it;
     os << indent;
@@ -344,9 +342,8 @@ ParticleSwarmOptimizerBase::ValidateSettings()
     {
       itkExceptionMacro("cost function and particle data dimensions mismatch");
     }
-    std::vector<ParticleData>::iterator it;
     std::vector<ParticleData>::iterator end = this->m_Particles.end();
-    for (it = this->m_Particles.begin(); it != end; ++it)
+    for (std::vector<ParticleData>::iterator it = this->m_Particles.begin(); it != end; ++it)
     {
       ParticleData & p = (*it);
       for (unsigned int i = 0; i < n; ++i)

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -430,26 +430,15 @@ PowellOptimizer::StartOptimization()
   p = this->GetInitialPosition();
   pt = p;
 
-  unsigned int ibig;
-  double       fp;
-  double       del;
-  double       fptt;
-  double       ax;
-  double       xx;
-  double       bx;
-  double       fa;
-  double       fx;
-  double       fb;
-
-  xx = 0;
+  double xx = 0;
   this->SetLine(p, xit);
-  fx = this->GetLineValue(0, tempCoord);
+  double fx = this->GetLineValue(0, tempCoord);
 
   for (m_CurrentIteration = 0; m_CurrentIteration <= m_MaximumIteration; ++m_CurrentIteration)
   {
-    fp = fx;
-    ibig = 0;
-    del = 0.0;
+    double       fp = fx;
+    unsigned int ibig = 0;
+    double       del = 0.0;
 
     for (unsigned int i = 0; i < m_SpaceDimension; ++i)
     {
@@ -457,13 +446,15 @@ PowellOptimizer::StartOptimization()
       {
         xit[j] = xi[j][i];
       }
-      fptt = fx;
+      double fptt = fx;
 
       this->SetLine(p, xit);
 
-      ax = 0.0;
-      fa = fx;
+      double ax = 0.0;
+      double fa = fx;
       xx = m_StepLength;
+      double bx;
+      double fb;
       this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
       this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
       this->SetCurrentLinePoint(xx, fx);
@@ -494,7 +485,7 @@ PowellOptimizer::StartOptimization()
     }
 
     this->SetLine(ptt, xit);
-    fptt = this->GetLineValue(0, tempCoord);
+    double fptt = this->GetLineValue(0, tempCoord);
     if (fptt < fp)
     {
       double t = 2.0 * (fp - 2.0 * fx + fptt) * itk::Math::sqr(fp - fx - del) - del * itk::Math::sqr(fp - fptt);
@@ -502,9 +493,11 @@ PowellOptimizer::StartOptimization()
       {
         this->SetLine(p, xit);
 
-        ax = 0.0;
-        fa = fx;
+        double ax = 0.0;
+        double fa = fx;
         xx = 1;
+        double bx;
+        double fb;
         this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
         this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
         this->SetCurrentLinePoint(xx, fx);

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -503,7 +503,6 @@ AmoebaTest2()
   ITK_TEST_SET_GET_VALUE(initialSimplexDelta, itkOptimizer->GetInitialSimplexDelta());
 
   OptimizerType::ParametersType initialParameters(1);
-  OptimizerType::ParametersType finalParameters;
   // starting position
   initialParameters[0] = -100;
 
@@ -531,50 +530,54 @@ AmoebaTest2()
     return EXIT_FAILURE;
   }
 
+
   // we should have converged to the local minimum, -2
-  finalParameters = itkOptimizer->GetCurrentPosition();
-  double knownParameters = -2.0;
-  std::cout << "Standard Amoeba:\n";
-  std::cout << "Known parameters   = " << knownParameters << "   ";
-  std::cout << "Estimated parameters = " << finalParameters << std::endl;
-  std::cout << "Converged to local minimum." << std::endl;
-  if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
   {
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
+    constexpr double              knownParameters = -2.0;
+    std::cout << "Standard Amoeba:\n";
+    std::cout << "Known parameters   = " << knownParameters << "   ";
+    std::cout << "Estimated parameters = " << finalParameters << std::endl;
+    std::cout << "Converged to local minimum." << std::endl;
+    if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
+    {
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
+
+    // run again using multiple restarts
+    observer->Reset();
+    itkOptimizer->SetInitialPosition(initialParameters);
+    itkOptimizer->OptimizeWithRestartsOn();
+
+    try
+    {
+      itkOptimizer->StartOptimization();
+    }
+    catch (const itk::ExceptionObject & e)
+    {
+      std::cerr << "Exception thrown ! " << std::endl;
+      std::cerr << "An error occurred during Optimization" << std::endl;
+      std::cerr << "Location    = " << e.GetLocation() << std::endl;
+      std::cerr << "Description = " << e.GetDescription() << std::endl;
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
   }
-
-  // run again using multiple restarts
-  observer->Reset();
-  itkOptimizer->SetInitialPosition(initialParameters);
-  itkOptimizer->OptimizeWithRestartsOn();
-
-  try
   {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during Optimization" << std::endl;
-    std::cerr << "Location    = " << e.GetLocation() << std::endl;
-    std::cerr << "Description = " << e.GetDescription() << std::endl;
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
-  }
+    // we should have converged to the global minimum, 2
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
+    constexpr double              knownParameters = 2.0;
+    std::cout << "Amoeba with restarts:\n";
+    std::cout << "Known parameters   = " << knownParameters << "   ";
+    std::cout << "Estimated parameters = " << finalParameters << std::endl;
+    std::cout << "Converged to global minimum." << std::endl;
 
-  // we should have converged to the global minimum, 2
-  finalParameters = itkOptimizer->GetCurrentPosition();
-  knownParameters = 2.0;
-  std::cout << "Amoeba with restarts:\n";
-  std::cout << "Known parameters   = " << knownParameters << "   ";
-  std::cout << "Estimated parameters = " << finalParameters << std::endl;
-  std::cout << "Converged to global minimum." << std::endl;
-
-  if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
-  {
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
+    if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
+    {
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
   }
   std::cout << "[TEST 1 SUCCESS]\n";
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -81,12 +81,6 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
     initalizationBasedTestVerboseFlag = std::stoi(argv[5]) ? true : false;
   }
 
-  unsigned int i;
-  unsigned int allIterations = 10;
-  double       threshold = 0.8;
-  unsigned int success1;
-  unsigned int success2;
-  unsigned int success3;
 
   std::cout << "Initialization Biased Particle Swarm Optimizer Test \n \n";
 
@@ -95,8 +89,11 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
   auto globalCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[3]));
   auto initializationCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[4]));
 
-  success1 = success2 = success3 = 0;
-  for (i = 0; i < allIterations; ++i)
+  unsigned int           success1{ 0 };
+  unsigned int           success2{ 0 };
+  unsigned int           success3{ 0 };
+  constexpr unsigned int allIterations = 10;
+  for (unsigned int i = 0; i < allIterations; ++i)
   {
     if (EXIT_SUCCESS ==
         IBPSOTest1(inertiaCoefficient, personalCoefficient, globalCoefficient, initializationCoefficient))
@@ -116,7 +113,7 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
   }
 
   std::cout << "All Tests Completed." << std::endl;
-
+  double threshold = 0.8;
   if (static_cast<double>(success1) / static_cast<double>(allIterations) <= threshold ||
       static_cast<double>(success2) / static_cast<double>(allIterations) <= threshold ||
       static_cast<double>(success3) / static_cast<double>(allIterations) <= threshold)
@@ -172,7 +169,6 @@ IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
   constexpr double              xTolerance = 0.1;
   constexpr double              fTolerance = 0.001;
   OptimizerType::ParametersType initialParameters(1);
-  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -194,7 +190,7 @@ IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
     initialParameters[0] = 3;
     itkOptimizer->SetInitialPosition(initialParameters);
     itkOptimizer->StartOptimization();
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
 
     // show why we stopped and see if the optimization succeeded
 
@@ -300,7 +296,6 @@ IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
   constexpr double              xTolerance = 0.1;
   constexpr double              fTolerance = 0.001;
   OptimizerType::ParametersType initialParameters(2);
-  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -322,7 +317,7 @@ IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
     initialParameters[1] = -9;
     itkOptimizer->SetInitialPosition(initialParameters);
     itkOptimizer->StartOptimization();
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
 
     // show why we stopped and see if the optimization succeeded
 
@@ -400,7 +395,6 @@ IBPSOTest3(typename OptimizerType::CoefficientType inertiaCoefficient,
   constexpr double              xTolerance = 0.1;
   constexpr double              fTolerance = 0.01;
   OptimizerType::ParametersType initialParameters(2);
-  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -423,7 +417,7 @@ IBPSOTest3(typename OptimizerType::CoefficientType inertiaCoefficient,
     initialParameters[1] = 3;
     itkOptimizer->SetInitialPosition(initialParameters);
     itkOptimizer->StartOptimization();
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
 
     // show why we stopped and see if the optimization succeeded
     std::cout << "Reason for stopping optimization:\n";

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -66,17 +66,15 @@ itkParticleSwarmOptimizerTest(int argc, char * argv[])
     verboseFlag = std::stoi(argv[1]) ? true : false;
   }
 
-  unsigned int i;
   unsigned int allIterations = 10;
   double       threshold = 0.8;
-  unsigned int success1;
-  unsigned int success2;
-  unsigned int success3;
+  unsigned int success1{};
+  unsigned int success2{};
+  unsigned int success3{};
 
   std::cout << "Particle Swarm Optimizer Test \n \n";
 
-  success1 = success2 = success3 = 0;
-  for (i = 0; i < allIterations; ++i)
+  for (unsigned int i = 0; i < allIterations; ++i)
   {
     if (EXIT_SUCCESS == PSOTest1())
     {
@@ -129,7 +127,7 @@ PSOTest1()
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
   OptimizerType::ParametersType initialParameters(1);
-  OptimizerType::ParametersType finalParameters;
+
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -151,7 +149,7 @@ PSOTest1()
     initialParameters[0] = -9;
     itkOptimizer->SetInitialPosition(initialParameters);
     itkOptimizer->StartOptimization();
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
 
     // check why we stopped and see if the optimization succeeded
     std::cout << "Reason for stopping optimization:\n";
@@ -229,7 +227,6 @@ PSOTest2()
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.001;
   OptimizerType::ParametersType initialParameters(2);
-  OptimizerType::ParametersType finalParameters;
 
   itkOptimizer->SetParameterBounds(bounds);
   itkOptimizer->SetNumberOfParticles(numberOfParticles);
@@ -251,7 +248,7 @@ PSOTest2()
     initialParameters[1] = -9;
     itkOptimizer->SetInitialPosition(initialParameters);
     itkOptimizer->StartOptimization();
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
 
     // check why we stopped and see if the optimization succeeded
     std::cout << "Reason for stopping optimization:\n";
@@ -309,7 +306,6 @@ PSOTest3()
   double                        xTolerance = 0.1;
   double                        fTolerance = 0.01;
   OptimizerType::ParametersType initialParameters(2);
-  OptimizerType::ParametersType finalParameters;
 
   // Exercise Get/Set methods
   itkOptimizer->PrintSwarmOn();
@@ -402,7 +398,7 @@ PSOTest3()
     // check why we stopped and see if the optimization succeeded
     std::cout << "Reason for stopping optimization:\n";
     std::cout << '\t' << itkOptimizer->GetStopConditionDescription() << '\n';
-    finalParameters = itkOptimizer->GetCurrentPosition();
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
     std::cout << "Known parameters   = " << knownParameters << "   ";
     std::cout << "Estimated parameters = " << finalParameters << std::endl;
     if (itk::Math::abs(finalParameters[0] - knownParameters[0]) > xTolerance ||

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -512,12 +512,13 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
       !this->GetVirtualDirection().GetVnlMatrix().is_equal(field->GetDirection().GetVnlMatrix(), directionTol))
   {
     std::ostringstream originString;
-    std::ostringstream spacingString;
-    std::ostringstream directionString;
+
     originString << "Virtual Origin: " << this->GetVirtualOrigin()
                  << ", DisplacementField Origin: " << field->GetOrigin() << std::endl;
+    std::ostringstream spacingString;
     spacingString << "Virtual Spacing: " << this->GetVirtualSpacing()
                   << ", DisplacementField Spacing: " << field->GetSpacing() << std::endl;
+    std::ostringstream directionString;
     directionString << "Virtual Direction: " << this->GetVirtualDirection()
                     << ", DisplacementField Direction: " << field->GetDirection() << std::endl;
     itkExceptionMacro("Virtual Domain and DisplacementField do not "

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -424,26 +424,15 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
   p = this->m_Metric->GetParameters();
   pt = p;
 
-  unsigned int ibig;
-  double       fp;
-  double       del;
-  double       fptt;
-  double       ax;
-  double       xx;
-  double       bx;
-  double       fa;
-  double       fx;
-  double       fb;
-
-  xx = 0;
+  double xx = 0;
   this->SetLine(p, xit);
-  fx = this->GetLineValue(0, tempCoord);
+  double fx = this->GetLineValue(0, tempCoord);
 
   for (this->m_CurrentIteration = 0; this->m_CurrentIteration <= m_MaximumIteration; this->m_CurrentIteration++)
   {
-    fp = fx;
-    ibig = 0;
-    del = 0.0;
+    double       fp = fx;
+    unsigned int ibig = 0;
+    double       del = 0.0;
 
     for (unsigned int i = 0; i < m_SpaceDimension; ++i)
     {
@@ -451,13 +440,15 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
       {
         xit[j] = xi[j][i];
       }
-      fptt = fx;
+      double fptt = fx;
 
       this->SetLine(p, xit);
 
-      ax = 0.0;
-      fa = fx;
+      double ax = 0.0;
+      double fa = fx;
       xx = m_StepLength;
+      double bx;
+      double fb;
       this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
       this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
       this->SetCurrentLinePoint(xx, fx);
@@ -497,7 +488,7 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
     }
 
     this->SetLine(ptt, xit);
-    fptt = this->GetLineValue(0, tempCoord);
+    double fptt = this->GetLineValue(0, tempCoord);
     if (fptt < fp)
     {
       double t = 2.0 * (fp - 2.0 * fx + fptt) * itk::Math::sqr(fp - fx - del) - del * itk::Math::sqr(fp - fptt);
@@ -505,9 +496,11 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
       {
         this->SetLine(p, xit);
 
-        ax = 0.0;
-        fa = fx;
+        double ax = 0.0;
+        double fa = fx;
         xx = 1;
+        double bx;
+        double fb;
         this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
         this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
         this->SetCurrentLinePoint(xx, fx);

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -444,12 +444,10 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex() ->
   VirtualRegionType   region = this->m_Metric->GetVirtualRegion();
   const SizeValueType dim = this->GetDimension();
 
-  VirtualIndexType lowerIndex;
-  VirtualIndexType upperIndex;
-  VirtualIndexType centralIndex;
-  lowerIndex = region.GetIndex();
-  upperIndex = region.GetUpperIndex();
+  VirtualIndexType lowerIndex = region.GetIndex();
+  VirtualIndexType upperIndex = region.GetUpperIndex();
 
+  VirtualIndexType centralIndex;
   for (SizeValueType d = 0; d < dim; ++d)
   {
     centralIndex[d] = (IndexValueType)((lowerIndex[d] + upperIndex[d]) / 2.0);
@@ -467,10 +465,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion() -
   VirtualRegionType   region = this->m_Metric->GetVirtualRegion();
   const SizeValueType dim = this->GetDimension();
 
-  VirtualIndexType lowerIndex;
-  VirtualIndexType upperIndex;
-  lowerIndex = region.GetIndex();
-  upperIndex = region.GetUpperIndex();
+  VirtualIndexType lowerIndex = region.GetIndex();
+  VirtualIndexType upperIndex = region.GetUpperIndex();
 
   for (SizeValueType d = 0; d < dim; ++d)
   {
@@ -511,13 +507,13 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithRegion(Vir
   using RegionIterator = ImageRegionConstIteratorWithIndex<VirtualImageType>;
   RegionIterator regionIter(image, region);
 
-  VirtualPointType point;
 
   /* Iterate over the image */
   SizeValueType count = 0;
   regionIter.GoToBegin();
   while (!regionIter.IsAtEnd())
   {
+    VirtualPointType point;
     image->TransformIndexToPhysicalPoint(regionIter.GetIndex(), point);
     this->m_SamplePoints[count] = point;
     ++regionIter;
@@ -533,8 +529,6 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCorners()
 
   VirtualRegionType region = this->m_Metric->GetVirtualRegion();
   VirtualIndexType  firstCorner = region.GetIndex();
-  VirtualIndexType  corner;
-  VirtualPointType  point;
 
   VirtualSizeType    size = region.GetSize();
   const unsigned int cornerNumber = 1 << VirtualDimension; // 2^Dimension
@@ -543,12 +537,13 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithCorners()
 
   for (unsigned int i = 0; i < cornerNumber; ++i)
   {
+    VirtualIndexType corner;
     for (unsigned int d = 0; d < VirtualDimension; ++d)
     {
       const auto bit = static_cast<unsigned int>((i & (1 << d)) != 0); // 0 or 1
       corner[d] = firstCorner[d] + bit * (size[d] - 1);
     }
-
+    VirtualPointType point;
     image->TransformIndexToPhysicalPoint(corner, point);
     this->m_SamplePoints[i] = point;
   }
@@ -586,10 +581,9 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainRandomly()
   using RandomIterator = ImageRandomConstIteratorWithIndex<VirtualImageType>;
   RandomIterator randIter(image, this->m_Metric->GetVirtualRegion());
 
-  VirtualPointType point;
-
   randIter.SetNumberOfSamples(this->m_NumberOfRandomSamples);
   randIter.GoToBegin();
+  VirtualPointType point;
   for (SizeValueType i = 0; i < m_NumberOfRandomSamples; ++i)
   {
     image->TransformIndexToPhysicalPoint(randIter.GetIndex(), point);

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -500,7 +500,6 @@ AmoebaTest2()
   ITK_TEST_SET_GET_VALUE(initialSimplexDelta, itkOptimizer->GetInitialSimplexDelta());
 
   OptimizerType::ParametersType initialParameters(1);
-  OptimizerType::ParametersType finalParameters;
   // starting position
   initialParameters[0] = -100;
 
@@ -530,50 +529,53 @@ AmoebaTest2()
 
   std::cout << "StopConditionDescription: " << itkOptimizer->GetStopConditionDescription() << std::endl;
 
-  // we should have converged to the local minimum, -2
-  finalParameters = itkOptimizer->GetCurrentPosition();
-  double knownParameters = -2.0;
-  std::cout << "Standard Amoeba:\n";
-  std::cout << "Known parameters   = " << knownParameters << "   ";
-  std::cout << "Estimated parameters = " << finalParameters << std::endl;
-  std::cout << "Converged to local minimum." << std::endl;
-  if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
   {
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
+    // we should have converged to the local minimum, -2
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
+    double                        knownParameters = -2.0;
+    std::cout << "Standard Amoeba:\n";
+    std::cout << "Known parameters   = " << knownParameters << "   ";
+    std::cout << "Estimated parameters = " << finalParameters << std::endl;
+    std::cout << "Converged to local minimum." << std::endl;
+    if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
+    {
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
+
+    // run again using multiple restarts
+    observer->Reset();
+    metric->SetParameters(initialParameters);
+    itkOptimizer->OptimizeWithRestartsOn();
+
+    try
+    {
+      itkOptimizer->StartOptimization();
+    }
+    catch (const itk::ExceptionObject & e)
+    {
+      std::cerr << "Exception thrown ! " << std::endl;
+      std::cerr << "An error occurred during Optimization" << std::endl;
+      std::cerr << "Location    = " << e.GetLocation() << std::endl;
+      std::cerr << "Description = " << e.GetDescription() << std::endl;
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
   }
-
-  // run again using multiple restarts
-  observer->Reset();
-  metric->SetParameters(initialParameters);
-  itkOptimizer->OptimizeWithRestartsOn();
-
-  try
   {
-    itkOptimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during Optimization" << std::endl;
-    std::cerr << "Location    = " << e.GetLocation() << std::endl;
-    std::cerr << "Description = " << e.GetDescription() << std::endl;
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
-  }
+    // we should have converged to the global minimum, 2
+    OptimizerType::ParametersType finalParameters = itkOptimizer->GetCurrentPosition();
+    constexpr double              knownParameters = 2.0;
+    std::cout << "Amoeba with restarts:\n";
+    std::cout << "Known parameters   = " << knownParameters << "   ";
+    std::cout << "Estimated parameters = " << finalParameters << std::endl;
+    std::cout << "Converged to global minimum." << std::endl;
 
-  // we should have converged to the global minimum, 2
-  finalParameters = itkOptimizer->GetCurrentPosition();
-  knownParameters = 2.0;
-  std::cout << "Amoeba with restarts:\n";
-  std::cout << "Known parameters   = " << knownParameters << "   ";
-  std::cout << "Estimated parameters = " << finalParameters << std::endl;
-  std::cout << "Converged to global minimum." << std::endl;
-
-  if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
-  {
-    std::cerr << "[TEST 2 FAILURE]\n";
-    return EXIT_FAILURE;
+    if (itk::Math::abs(finalParameters[0] - knownParameters) > xTolerance)
+    {
+      std::cerr << "[TEST 2 FAILURE]\n";
+      return EXIT_FAILURE;
+    }
   }
   std::cout << "[TEST 1 SUCCESS]\n";
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
@@ -38,12 +38,12 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     measurementVectorSize,
     "EuclideanSquareDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp;
+
   double distance = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    temp = this->GetOrigin()[i] - x[i];
+    double temp = this->GetOrigin()[i] - x[i];
     distance += temp * temp;
   }
 
@@ -62,14 +62,12 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     itkExceptionMacro("EuclideanSquareDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp;
   double distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    temp = x1[i] - x2[i];
+    double temp = x1[i] - x2[i];
     distance += temp * temp;
   }
-
   return distance;
 }
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
@@ -88,14 +88,11 @@ GaussianMixtureModelComponent<TSample>::SetParameters(const ParametersType & par
   Superclass::SetParameters(parameters);
 
   unsigned int paramIndex = 0;
-  unsigned int i;
-  unsigned int j;
-
-  bool changed = false;
+  bool         changed = false;
 
   MeasurementVectorSizeType measurementVectorSize = this->GetSample()->GetMeasurementVectorSize();
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     if (Math::NotExactlyEquals(m_Mean[i], parameters[paramIndex]))
     {
@@ -110,16 +107,16 @@ GaussianMixtureModelComponent<TSample>::SetParameters(const ParametersType & par
 
   NumericTraits<typename NativeMembershipFunctionType::MeanVectorType>::SetLength(mean, measurementVectorSize);
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     mean[i] = m_Mean[i];
   }
 
   m_GaussianMembershipFunction->SetMean(mean);
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    for (j = 0; j < measurementVectorSize; ++j)
+    for (unsigned int j = 0; j < measurementVectorSize; ++j)
     {
       if (Math::NotExactlyEquals(m_Covariance.GetVnlMatrix().get(i, j), parameters[paramIndex]))
       {
@@ -138,29 +135,25 @@ template <typename TSample>
 double
 GaussianMixtureModelComponent<TSample>::CalculateParametersChange()
 {
-  unsigned int i;
-  unsigned int j;
-
   typename MeanVectorType::MeasurementVectorType meanEstimate = m_MeanEstimator->GetMean();
 
   CovarianceMatrixType                                 covEstimateDecoratedObject = m_CovarianceEstimator->GetOutput();
   typename CovarianceMatrixType::MeasurementVectorType covEstimate = covEstimateDecoratedObject->et();
 
-  double                    temp;
-  double                    changes = 0.0;
   MeasurementVectorSizeType measurementVectorSize = this->GetSample()->GetMeasurementVectorSize();
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  double changes = 0.0;
+  for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    temp = m_Mean[i] - meanEstimate[i];
+    double temp = m_Mean[i] - meanEstimate[i];
     changes += temp * temp;
   }
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    for (j = 0; j < measurementVectorSize; ++j)
+    for (unsigned int j = 0; j < measurementVectorSize; ++j)
     {
-      temp = m_Covariance.GetVnlMatrix().get(i, j) - covEstimate.GetVnlMatrix().get(i, j);
+      double temp = m_Covariance.GetVnlMatrix().get(i, j) - covEstimate.GetVnlMatrix().get(i, j);
       changes += temp * temp;
     }
   }
@@ -194,18 +187,14 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
   m_MeanEstimator->SetWeights(weights);
   m_MeanEstimator->Update();
 
-  MeasurementVectorSizeType i;
-  MeasurementVectorSizeType j;
-  double                    temp;
-  double                    changes;
   bool                      changed = false;
   ParametersType            parameters = this->GetFullParameters();
   MeasurementVectorSizeType paramIndex = 0;
 
   typename MeanEstimatorType::MeasurementVectorType meanEstimate = m_MeanEstimator->GetMean();
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
   {
-    changes = itk::Math::abs(m_Mean[i] - meanEstimate[i]);
+    double changes = itk::Math::abs(m_Mean[i] - meanEstimate[i]);
 
     if (changes > this->GetMinimalParametersChange())
     {
@@ -233,14 +222,14 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
   typename CovarianceEstimatorType::MatrixType covEstimate = m_CovarianceEstimator->GetCovarianceMatrix();
 
   changed = false;
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
   {
     if (!changed)
     {
-      for (j = 0; j < measurementVectorSize; ++j)
+      for (MeasurementVectorSizeType j = 0; j < measurementVectorSize; ++j)
       {
-        temp = m_Covariance.GetVnlMatrix().get(i, j) - covEstimate.GetVnlMatrix().get(i, j);
-        changes = itk::Math::abs(temp);
+        double temp = m_Covariance.GetVnlMatrix().get(i, j) - covEstimate.GetVnlMatrix().get(i, j);
+        double changes = itk::Math::abs(temp);
         if (changes > this->GetMinimalParametersChange())
         {
           changed = true;
@@ -253,9 +242,9 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
   if (changed)
   {
     m_Covariance = covEstimate;
-    for (i = 0; i < measurementVectorSize; ++i)
+    for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
     {
-      for (j = 0; j < measurementVectorSize; ++j)
+      for (MeasurementVectorSizeType j = 0; j < measurementVectorSize; ++j)
       {
         parameters[paramIndex] = covEstimate.GetVnlMatrix().get(i, j);
         ++paramIndex;
@@ -266,7 +255,7 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
 
   // THIS IS NEEDED TO update m_Mean and m_Covariance.SHOULD BE REMOVED
   paramIndex = 0;
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
   {
     m_Mean[i] = parameters[paramIndex];
     ++paramIndex;
@@ -275,15 +264,15 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
   typename NativeMembershipFunctionType::MeanVectorType mean;
   NumericTraits<typename NativeMembershipFunctionType::MeanVectorType>::SetLength(mean, measurementVectorSize);
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
   {
     mean[i] = m_Mean[i];
   }
   m_GaussianMembershipFunction->SetMean(mean);
 
-  for (i = 0; i < measurementVectorSize; ++i)
+  for (MeasurementVectorSizeType i = 0; i < measurementVectorSize; ++i)
   {
-    for (j = 0; j < measurementVectorSize; ++j)
+    for (MeasurementVectorSizeType j = 0; j < measurementVectorSize; ++j)
     {
       m_Covariance.GetVnlMatrix().put(i, j, parameters[paramIndex]);
       ++paramIndex;

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -597,22 +597,18 @@ template <typename TMeasurement, typename TFrequencyContainer>
 double
 Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, double p) const
 {
-  InstanceIdentifier n;
   const unsigned int size = this->GetSize(dimension);
-  double             p_n_prev;
-  double             p_n;
-  double             f_n;
-  double             cumulated = 0;
-  auto               totalFrequency = static_cast<double>(this->GetTotalFrequency());
-  double             binProportion;
-  double             min;
-  double             max;
-  double             interval;
 
+  double cumulated = 0;
+  auto   totalFrequency = static_cast<double>(this->GetTotalFrequency());
+
+
+  double f_n;
+  double p_n_prev;
   if (p < 0.5)
   {
-    n = 0;
-    p_n = 0.0;
+    InstanceIdentifier n = 0;
+    double             p_n = 0.0;
     do
     {
       f_n = this->GetFrequency(n, dimension);
@@ -622,18 +618,18 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
       ++n;
     } while (n < size && p_n < p);
 
-    binProportion = f_n / totalFrequency;
+    double binProportion = f_n / totalFrequency;
 
-    min = static_cast<double>(this->GetBinMin(dimension, n - 1));
-    max = static_cast<double>(this->GetBinMax(dimension, n - 1));
-    interval = max - min;
+    double min = static_cast<double>(this->GetBinMin(dimension, n - 1));
+    double max = static_cast<double>(this->GetBinMax(dimension, n - 1));
+    double interval = max - min;
     return min + ((p - p_n_prev) / binProportion) * interval;
   }
   else
   {
-    n = size - 1;
+    InstanceIdentifier n = size - 1;
     InstanceIdentifier m{};
-    p_n = 1.0;
+    double             p_n = 1.0;
     do
     {
       f_n = this->GetFrequency(n, dimension);
@@ -644,10 +640,10 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
       ++m;
     } while (m < size && p_n > p);
 
-    binProportion = f_n / totalFrequency;
-    min = static_cast<double>(this->GetBinMin(dimension, n + 1));
-    max = static_cast<double>(this->GetBinMax(dimension, n + 1));
-    interval = max - min;
+    double binProportion = f_n / totalFrequency;
+    double min = static_cast<double>(this->GetBinMin(dimension, n + 1));
+    double max = static_cast<double>(this->GetBinMax(dimension, n + 1));
+    double interval = max - min;
     return max - ((p_n_prev - p) / binProportion) * interval;
   }
 }

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -216,10 +216,8 @@ protected:
     void
     GetCentroids(InternalParametersType & centroids)
     {
-      unsigned int i;
-
       centroids.resize(this->Size());
-      for (i = 0; i < static_cast<unsigned int>(this->Size()); ++i)
+      for (unsigned int i = 0; i < static_cast<unsigned int>(this->Size()); ++i)
       {
         centroids[i] = m_Candidates[i].Centroid;
       }
@@ -230,14 +228,11 @@ protected:
     void
     UpdateCentroids()
     {
-      unsigned int i;
-      unsigned int j;
-
-      for (i = 0; i < static_cast<unsigned int>(this->Size()); ++i)
+      for (unsigned int i = 0; i < static_cast<unsigned int>(this->Size()); ++i)
       {
         if (m_Candidates[i].Size > 0)
         {
-          for (j = 0; j < m_MeasurementVectorSize; ++j)
+          for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
           {
             m_Candidates[i].Centroid[j] =
               m_Candidates[i].WeightedCentroid[j] / static_cast<double>(m_Candidates[i].Size);

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -136,12 +136,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
                                             MeasurementVectorType & lowerBound,
                                             MeasurementVectorType & upperBound)
 {
-  unsigned int i;
-  unsigned int j;
-
-  typename TKdTree::InstanceIdentifier tempId;
-  int                                  closest;
-  ParameterType                        individualPoint;
+  ParameterType individualPoint;
   NumericTraits<ParameterType>::SetLength(individualPoint, this->m_MeasurementVectorSize);
 
   if (node->IsTerminal())
@@ -153,12 +148,12 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
       return;
     }
 
-    for (i = 0; i < static_cast<unsigned int>(node->Size()); ++i)
+    for (unsigned int i = 0; i < static_cast<unsigned int>(node->Size()); ++i)
     {
-      tempId = node->GetInstanceIdentifier(i);
+      typename TKdTree::InstanceIdentifier tempId = node->GetInstanceIdentifier(i);
       this->GetPoint(individualPoint, m_KdTree->GetMeasurementVector(tempId));
-      closest = this->GetClosestCandidate(individualPoint, validIndexes);
-      for (j = 0; j < m_MeasurementVectorSize; ++j)
+      int closest = this->GetClosestCandidate(individualPoint, validIndexes);
+      for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
       {
         m_CandidateVector[closest].WeightedCentroid[j] += individualPoint[j];
       }
@@ -171,15 +166,14 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
   }
   else
   {
-    CentroidType  centroid;
-    CentroidType  weightedCentroid;
-    ParameterType closestPosition;
+    CentroidType weightedCentroid;
     node->GetWeightedCentroid(weightedCentroid);
+    CentroidType centroid;
     node->GetCentroid(centroid);
 
-    closest = this->GetClosestCandidate(centroid, validIndexes);
-    closestPosition = m_CandidateVector[closest].Centroid;
-    auto iter = validIndexes.begin();
+    int           closest = this->GetClosestCandidate(centroid, validIndexes);
+    ParameterType closestPosition = m_CandidateVector[closest].Centroid;
+    auto          iter = validIndexes.begin();
 
     while (iter != validIndexes.end())
     {
@@ -198,7 +192,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
 
     if (validIndexes.size() == 1)
     {
-      for (j = 0; j < m_MeasurementVectorSize; ++j)
+      for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
       {
         m_CandidateVector[closest].WeightedCentroid[j] += weightedCentroid[j];
       }
@@ -232,8 +226,6 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::FillClusterLabels(KdTreeNodeType * node, int closestIndex)
 {
-  unsigned int i;
-
   if (node->IsTerminal())
   {
     // terminal node
@@ -243,7 +235,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::FillClusterLabels(KdTreeNodeType * node, in
       return;
     }
 
-    for (i = 0; i < static_cast<unsigned int>(node->Size()); ++i)
+    for (unsigned int i = 0; i < static_cast<unsigned int>(node->Size()); ++i)
     {
       m_ClusterLabels[node->GetInstanceIdentifier(i)] = closestIndex;
     }
@@ -259,13 +251,11 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(ParametersType & source, InternalParametersType & target)
 {
-  unsigned int i;
-  unsigned int j;
-  int          index = 0;
+  int index = 0;
 
-  for (i = 0; i < static_cast<unsigned int>(source.size() / m_MeasurementVectorSize); ++i)
+  for (unsigned int i = 0; i < static_cast<unsigned int>(source.size() / m_MeasurementVectorSize); ++i)
   {
-    for (j = 0; j < m_MeasurementVectorSize; ++j)
+    for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
     {
       target[i][j] = source[index];
       ++index;
@@ -277,13 +267,11 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(InternalParametersType & source, ParametersType & target)
 {
-  unsigned int i;
-  unsigned int j;
-  int          index = 0;
+  int index = 0;
 
-  for (i = 0; i < static_cast<unsigned int>(source.size()); ++i)
+  for (unsigned int i = 0; i < static_cast<unsigned int>(source.size()); ++i)
   {
-    for (j = 0; j < m_MeasurementVectorSize; ++j)
+    for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
     {
       target[index] = source[i][j];
       ++index;
@@ -295,12 +283,9 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(InternalParametersType & source, InternalParametersType & target)
 {
-  unsigned int i;
-  unsigned int j;
-
-  for (i = 0; i < static_cast<unsigned int>(source.size()); ++i)
+  for (unsigned int i = 0; i < static_cast<unsigned int>(source.size()); ++i)
   {
-    for (j = 0; j < m_MeasurementVectorSize; ++j)
+    for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
     {
       target[i][j] = source[i][j];
     }
@@ -311,11 +296,9 @@ template <typename TKdTree>
 void
 KdTreeBasedKmeansEstimator<TKdTree>::StartOptimization()
 {
-  unsigned int          i;
   MeasurementVectorType lowerBound;
-  MeasurementVectorType upperBound;
-
   NumericTraits<MeasurementVectorType>::SetLength(lowerBound, this->m_MeasurementVectorSize);
+  MeasurementVectorType upperBound;
   NumericTraits<MeasurementVectorType>::SetLength(upperBound, this->m_MeasurementVectorSize);
 
   Algorithm::FindSampleBound<SampleType>(
@@ -326,11 +309,11 @@ KdTreeBasedKmeansEstimator<TKdTree>::StartOptimization()
   InternalParametersType currentPosition;
   // currentPosition.resize(m_Parameters.size() / m_MeasurementVectorSize);
 
-  for (i = 0; i < m_Parameters.size() / m_MeasurementVectorSize; ++i)
+  for (unsigned int i = 0; i < m_Parameters.size() / m_MeasurementVectorSize; ++i)
   {
     ParameterType m;
-    ParameterType m1;
     NumericTraits<ParameterType>::SetLength(m, m_MeasurementVectorSize);
+    ParameterType m1;
     NumericTraits<ParameterType>::SetLength(m1, m_MeasurementVectorSize);
     previousPosition.push_back(m);
     currentPosition.push_back(m1);
@@ -340,7 +323,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::StartOptimization()
   m_CurrentIteration = 0;
   std::vector<int> validIndexes;
 
-  for (i = 0; i < static_cast<unsigned int>(m_Parameters.size() / m_MeasurementVectorSize); ++i)
+  for (unsigned int i = 0; i < static_cast<unsigned int>(m_Parameters.size() / m_MeasurementVectorSize); ++i)
   {
     validIndexes.push_back(i);
   }
@@ -374,7 +357,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::StartOptimization()
     m_GenerateClusterLabels = true;
     m_ClusterLabels.clear();
     m_ClusterLabels.rehash(m_KdTree->GetSample()->Size());
-    for (i = 0; i < static_cast<unsigned int>(m_Parameters.size() / m_MeasurementVectorSize); ++i)
+    for (unsigned int i = 0; i < static_cast<unsigned int>(m_Parameters.size() / m_MeasurementVectorSize); ++i)
     {
       validIndexes.push_back(i);
     }

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
@@ -37,12 +37,10 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x) cons
                                   measurementVectorSize,
                                   "ManhattanDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp;
   double distance = 0.0;
-
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    temp = itk::Math::abs(this->GetOrigin()[i] - x[i]);
+    double temp = itk::Math::abs(this->GetOrigin()[i] - x[i]);
     distance += temp;
   }
   return distance;
@@ -59,11 +57,10 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
     itkExceptionMacro("ManhattanDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp;
   double distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
-    temp = itk::Math::abs(x1[i] - x2[i]);
+    double temp = itk::Math::abs(x1[i] - x2[i]);
     distance += temp;
   }
   return distance;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -119,18 +119,19 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   }
 
   // For each offset, calculate each feature
-  typename OffsetVector::ConstIterator offsetIt;
-  size_t                               offsetNum;
-  size_t                               featureNum;
   using InternalTextureFeatureName = itk::Statistics::HistogramToTextureFeaturesFilterEnums::TextureFeature;
 
-  for (offsetIt = m_Offsets->Begin(), offsetNum = 0; offsetIt != m_Offsets->End(); ++offsetIt, offsetNum++)
+  size_t offsetNum = 0;
+  for (typename OffsetVector::ConstIterator offsetIt = m_Offsets->Begin(); offsetIt != m_Offsets->End();
+       ++offsetIt, offsetNum++)
   {
     this->m_GLCMGenerator->SetOffset(offsetIt.Value());
     this->m_GLCMCalculator->Update();
 
-    typename FeatureNameVector::ConstIterator fnameIt;
-    for (fnameIt = m_RequestedFeatures->Begin(), featureNum = 0; fnameIt != m_RequestedFeatures->End();
+
+    size_t featureNum = 0;
+    for (typename FeatureNameVector::ConstIterator fnameIt = m_RequestedFeatures->Begin();
+         fnameIt != m_RequestedFeatures->End();
          ++fnameIt, featureNum++)
     {
       features[offsetNum][featureNum] = this->m_GLCMCalculator->GetFeature((InternalTextureFeatureName)fnameIt.Value());
@@ -154,7 +155,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   */
 
   // Set up the initial conditions (k = 1)
-  for (featureNum = 0; featureNum < numFeatures; ++featureNum)
+  for (size_t featureNum = 0; featureNum < numFeatures; ++featureNum)
   {
     tempFeatureMeans[featureNum] = features[0][featureNum];
     tempFeatureDevs[featureNum] = 0;
@@ -163,7 +164,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   for (offsetNum = 1; offsetNum < numOffsets; ++offsetNum)
   {
     size_t k = offsetNum + 1;
-    for (featureNum = 0; featureNum < numFeatures; ++featureNum)
+    for (size_t featureNum = 0; featureNum < numFeatures; ++featureNum)
     {
       double M_k_minus_1 = tempFeatureMeans[featureNum];
       double S_k_minus_1 = tempFeatureDevs[featureNum];
@@ -176,7 +177,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
       tempFeatureDevs[featureNum] = S_k;
     }
   }
-  for (featureNum = 0; featureNum < numFeatures; ++featureNum)
+  for (size_t featureNum = 0; featureNum < numFeatures; ++featureNum)
   {
     tempFeatureDevs[featureNum] = std::sqrt(tempFeatureDevs[featureNum] / numOffsets);
 

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -208,14 +208,7 @@ GaussianDistribution::CDF(double x, const ParametersType & p)
 double
 GaussianDistribution::InverseCDF(double p)
 {
-  double dp;
-  double dx;
-  double dt;
-  double ddq;
-  double dq;
-  int    newt;
-
-  dp = (p <= 0.5) ? (p) : (1.0 - p); /* make between 0 and 0.5 */
+  double dp = (p <= 0.5) ? (p) : (1.0 - p); /* make between 0 and 0.5 */
 
   // if original value is invalid, return +infinity or -infinity
   // changed from original code to reflect the fact that the
@@ -236,16 +229,16 @@ GaussianDistribution::InverseCDF(double p)
 
   /**  Step 1:  use 26.2.23 from Abramowitz and Stegun */
 
-  dt = std::sqrt(-2.0 * std::log(dp));
-  dx = dt - ((.010328e+0 * dt + .802853e+0) * dt + 2.515517e+0) /
-              (((.001308e+0 * dt + .189269e+0) * dt + 1.432788e+0) * dt + 1.e+0);
+  double dt = std::sqrt(-2.0 * std::log(dp));
+  double dx = dt - ((.010328e+0 * dt + .802853e+0) * dt + 2.515517e+0) /
+                     (((.001308e+0 * dt + .189269e+0) * dt + 1.432788e+0) * dt + 1.e+0);
 
   /**  Step 2:  do 3 Newton steps to improve this */
 
-  for (newt = 0; newt < 3; ++newt)
+  for (int newt = 0; newt < 3; ++newt)
   {
-    dq = 0.5e+0 * vnl_erfc(dx * itk::Math::sqrt1_2) - dp;
-    ddq = std::exp(-0.5e+0 * dx * dx) / 2.506628274631000e+0;
+    double dq = 0.5e+0 * vnl_erfc(dx * itk::Math::sqrt1_2) - dp;
+    double ddq = std::exp(-0.5e+0 * dx * dx) / 2.506628274631000e+0;
     dx = dx + dq / ddq;
   }
 

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -61,10 +61,8 @@ MaximumRatioDecisionRule::SetPriorProbabilities(const PriorProbabilityVectorType
   }
   else
   {
-    PriorProbabilityVectorType::const_iterator pit;
-    PriorProbabilityVectorType::const_iterator it;
-
-    for (pit = p.begin(), it = m_PriorProbabilities.begin(); pit != p.end(); ++pit, ++it)
+    PriorProbabilityVectorType::const_iterator pit = p.begin();
+    for (PriorProbabilityVectorType::const_iterator it = m_PriorProbabilities.begin(); pit != p.end(); ++pit, ++it)
     {
       if (itk::Math::abs(*pit - *it) > itk::Math::eps)
       {
@@ -94,10 +92,9 @@ MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScor
   if (uniformPrior)
   {
     // find the maximum discriminant score. if list is empty, return 0.
-    ClassIdentifierType i;
     ClassIdentifierType besti = 0;
     MembershipValueType best = NumericTraits<MembershipValueType>::NonpositiveMin();
-    for (i = 0; i < discriminantScores.size(); ++i)
+    for (ClassIdentifierType i = 0; i < discriminantScores.size(); ++i)
     {
       if (discriminantScores[i] > best)
       {
@@ -110,14 +107,11 @@ MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScor
 
   // Non-uniform prior case
   // find the maximum p(x|i)*p(i)
-  ClassIdentifierType i;
   ClassIdentifierType besti = 0;
   MembershipValueType best = NumericTraits<MembershipValueType>::NonpositiveMin();
-  MembershipValueType temp = NumericTraits<MembershipValueType>::NonpositiveMin();
-
-  for (i = 0; i < discriminantScores.size(); ++i)
+  for (ClassIdentifierType i = 0; i < discriminantScores.size(); ++i)
   {
-    temp = discriminantScores[i] * m_PriorProbabilities[i];
+    MembershipValueType temp = discriminantScores[i] * m_PriorProbabilities[i];
     if (temp > best)
     {
       best = temp;

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -99,11 +99,6 @@ TDistribution::PDF(double x, const ParametersType & p)
 double
 TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
 {
-  double bx;
-  double pin;
-  double qin;
-  double dof;
-
   // Based on Abramowitz and Stegun 26.7.1, which gives the probability
   // that the absolute value of a random variable with a Student-t
   // distribution is less than or equal to a specified t.
@@ -127,11 +122,11 @@ TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
   //           = 0.5 + 0.5 * P[|x| < t]           (from above)
   //           = 0.5 + 0.5 * (1 - Ix(v/2. 1/2))
   //           = 1 - 0.5 * Ix(v/2, 1/2)
-  //
-  dof = static_cast<double>(degreesOfFreedom);
-  bx = dof / (dof + (x * x));
-  pin = dof / 2.0;
-  qin = 0.5;
+
+  double dof = static_cast<double>(degreesOfFreedom);
+  double bx = dof / (dof + (x * x));
+  double pin = dof / 2.0;
+  double qin = 0.5;
 
   if (x >= 0.0)
   {
@@ -166,32 +161,22 @@ TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
     return itk::NumericTraits<double>::max();
   }
 
-  double x;
-  double dof;
-  double dof2;
-  double dof3;
-  double dof4;
-  double gaussX;
-  double gaussX3;
-  double gaussX5;
-  double gaussX7;
-  double gaussX9;
-
   // Based on Abramowitz and Stegun 26.7.5
-  dof = static_cast<double>(degreesOfFreedom);
-  dof2 = dof * dof;
-  dof3 = dof * dof2;
-  dof4 = dof * dof3;
+  double dof = static_cast<double>(degreesOfFreedom);
+  double dof2 = dof * dof;
+  double dof3 = dof * dof2;
+  double dof4 = dof * dof3;
 
-  gaussX = GaussianDistribution::InverseCDF(p);
-  gaussX3 = std::pow(gaussX, 3.0);
-  gaussX5 = std::pow(gaussX, 5.0);
-  gaussX7 = std::pow(gaussX, 7.0);
-  gaussX9 = std::pow(gaussX, 9.0);
+  double gaussX = GaussianDistribution::InverseCDF(p);
+  double gaussX3 = std::pow(gaussX, 3.0);
+  double gaussX5 = std::pow(gaussX, 5.0);
+  double gaussX7 = std::pow(gaussX, 7.0);
+  double gaussX9 = std::pow(gaussX, 9.0);
 
-  x = gaussX + (gaussX3 + gaussX) / (4.0 * dof) + (5.0 * gaussX5 + 16.0 * gaussX3 + 3 * gaussX) / (96.0 * dof2) +
-      (3.0 * gaussX7 + 19.0 * gaussX5 + 17.0 * gaussX3 - 15.0 * gaussX) / (384.0 * dof3) +
-      (79.0 * gaussX9 + 776.0 * gaussX7 + 1482.0 * gaussX5 - 1920.0 * gaussX3 - 945.0 * gaussX) / (92160.0 * dof4);
+  double x =
+    gaussX + (gaussX3 + gaussX) / (4.0 * dof) + (5.0 * gaussX5 + 16.0 * gaussX3 + 3 * gaussX) / (96.0 * dof2) +
+    (3.0 * gaussX7 + 19.0 * gaussX5 + 17.0 * gaussX3 - 15.0 * gaussX) / (384.0 * dof3) +
+    (79.0 * gaussX9 + 776.0 * gaussX7 + 1482.0 * gaussX5 - 1920.0 * gaussX3 - 945.0 * gaussX) / (92160.0 * dof4);
 
   // The polynomial approximation above is only accurate for large degrees
   // of freedom.  We'll improve the approximation by a few Newton

--- a/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
@@ -41,12 +41,9 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-
-  unsigned int i;
-  unsigned int j;
-  char *       dataFileName = argv[1];
-  int          dataSize = 2000;
-  int          maximumIteration = 200;
+  char * dataFileName = argv[1];
+  int    dataSize = 2000;
+  int    maximumIteration = 200;
   using ParametersType = itk::Array<double>;
   double                      minStandardDeviation = 28.54746;
   unsigned int                numberOfClasses = 2;
@@ -112,7 +109,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
 
   while (p_iter != pointsContainer->End())
   {
-    for (i = 0; i < PointSetType::PointDimension; ++i)
+    for (unsigned int i = 0; i < PointSetType::PointDimension; ++i)
     {
       dataStream >> temp;
       point[i] = temp;
@@ -131,7 +128,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
   /* Preparing the gaussian mixture components */
   using ComponentPointer = ComponentType::Pointer;
   std::vector<ComponentPointer> components;
-  for (i = 0; i < numberOfClasses; ++i)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     components.push_back(ComponentType::New());
     (components[i])->SetSample(sample);
@@ -144,7 +141,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
   estimator->SetMaximumIteration(maximumIteration);
   estimator->SetInitialProportions(initialProportions);
 
-  for (i = 0; i < numberOfClasses; ++i)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     estimator->AddComponent((ComponentType::Superclass *)(components[i]).GetPointer());
   }
@@ -156,7 +153,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
   bool               passed = true;
   double             displacement;
   const unsigned int measurementVectorSize = sample->GetMeasurementVectorSize();
-  for (i = 0; i < numberOfClasses; ++i)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     std::cout << "Cluster[" << i << ']' << std::endl;
     std::cout << "    Parameters:" << std::endl;
@@ -164,7 +161,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
     std::cout << "    Proportion: ";
     std::cout << "         " << (estimator->GetProportions())[i] << std::endl;
     displacement = 0.0;
-    for (j = 0; j < measurementVectorSize; ++j)
+    for (unsigned int j = 0; j < measurementVectorSize; ++j)
     {
       temp = (components[i])->GetFullParameters()[j] - trueParameters[i][j];
       displacement += (temp * temp);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -203,16 +203,11 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
     two_two[0] = 2;
     two_two[1] = 2;
 
-    float ooF;
-    float otF;
-    float toF;
-    float ttF;
-    float totalF;
-    ooF = hist->GetFrequency(one_one);
-    otF = hist->GetFrequency(one_two);
-    toF = hist->GetFrequency(two_one);
-    ttF = hist->GetFrequency(two_two);
-    totalF = hist->GetTotalFrequency();
+    float ooF = hist->GetFrequency(one_one);
+    float otF = hist->GetFrequency(one_two);
+    float toF = hist->GetFrequency(two_one);
+    float ttF = hist->GetFrequency(two_two);
+    float totalF = hist->GetTotalFrequency();
 
     if (itk::Math::NotAlmostEquals(ooF, 24.0f) || itk::Math::NotAlmostEquals(ttF, 16.0f) ||
         itk::Math::NotAlmostEquals(otF, 20.0f) || itk::Math::NotAlmostEquals(toF, 20.0f) ||
@@ -339,11 +334,9 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
     one_zero[0] = 1;
     one_zero[1] = 0;
 
-    float zoF;
-    float ozF;
     zzF = hist3->GetFrequency(zero_zero);
-    zoF = hist3->GetFrequency(zero_one);
-    ozF = hist3->GetFrequency(one_zero);
+    float zoF = hist3->GetFrequency(zero_one);
+    float ozF = hist3->GetFrequency(one_zero);
     ooF = hist3->GetFrequency(one_one);
     totalF = hist3->GetTotalFrequency();
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -162,16 +162,11 @@ itkScalarImageToCooccurrenceMatrixFilterTest2(int, char *[])
     two_two[0] = 2;
     two_two[1] = 2;
 
-    float ooF;
-    float otF;
-    float toF;
-    float ttF;
-    float totalF;
-    ooF = hist->GetFrequency(one_one);
-    otF = hist->GetFrequency(one_two);
-    toF = hist->GetFrequency(two_one);
-    ttF = hist->GetFrequency(two_two);
-    totalF = hist->GetTotalFrequency();
+    float ooF = hist->GetFrequency(one_one);
+    float otF = hist->GetFrequency(one_two);
+    float toF = hist->GetFrequency(two_one);
+    float ttF = hist->GetFrequency(two_two);
+    float totalF = hist->GetTotalFrequency();
 
     if (itk::Math::NotAlmostEquals(ooF, 4.0f) || itk::Math::NotAlmostEquals(ttF, 0.0f) ||
         itk::Math::NotAlmostEquals(otF, 0.0f) || itk::Math::NotAlmostEquals(toF, 0.0f) ||

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -196,10 +196,8 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       passed = false;
     }
 
-    RunLengthFilterType::FeatureValueVectorPointer means;
-    RunLengthFilterType::FeatureValueVectorPointer stds;
-    means = texFilter->GetFeatureMeans();
-    stds = texFilter->GetFeatureStandardDeviations();
+    RunLengthFilterType::FeatureValueVectorPointer means = texFilter->GetFeatureMeans();
+    RunLengthFilterType::FeatureValueVectorPointer stds = texFilter->GetFeatureStandardDeviations();
 
     double expectedMeans[10] = { 0.76, 7, 10.4, 20, 0.0826667, 15.4, 0.0628267, 11.704, 0.578667, 107.8 };
     double expectedDeviations[10] = { 0.415692, 10.3923,   4.50333, 8.66025,  0,

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -195,10 +195,8 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       passed = false;
     }
 
-    TextureFilterType::FeatureValueVectorPointer means;
-    TextureFilterType::FeatureValueVectorPointer stds;
-    means = texFilter->GetFeatureMeans();
-    stds = texFilter->GetFeatureStandardDeviations();
+    TextureFilterType::FeatureValueVectorPointer means = texFilter->GetFeatureMeans();
+    TextureFilterType::FeatureValueVectorPointer stds = texFilter->GetFeatureStandardDeviations();
 
     double expectedMeans[6] = { 0.505, 0.992738, 0.625, 0.75, 0.0959999, 0.2688 };
     double expectedDeviations[6] = { 0.00866027, 0.0125788, 0.216506351, 0.433012702, 0.166277, 0.465575 };

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -71,12 +71,12 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(
   // set the required number of outputs
   this->SetNumberOfRequiredOutputs(m_NumberOfLevels);
 
-  auto         numOutputs = static_cast<unsigned int>(this->GetNumberOfIndexedOutputs());
-  unsigned int idx;
+  auto numOutputs = static_cast<unsigned int>(this->GetNumberOfIndexedOutputs());
+
   if (numOutputs < m_NumberOfLevels)
   {
     // add extra outputs
-    for (idx = numOutputs; idx < m_NumberOfLevels; ++idx)
+    for (unsigned int idx = numOutputs; idx < m_NumberOfLevels; ++idx)
     {
       typename DataObject::Pointer output = this->MakeOutput(idx);
       this->SetNthOutput(idx, output.GetPointer());
@@ -85,7 +85,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(
   else if (numOutputs > m_NumberOfLevels)
   {
     // remove extra outputs
-    for (idx = m_NumberOfLevels; idx < numOutputs; ++idx)
+    for (unsigned int idx = m_NumberOfLevels; idx < numOutputs; ++idx)
     {
       this->RemoveOutput(idx);
     }
@@ -178,12 +178,10 @@ template <typename TInputImage, typename TOutputImage>
 bool
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::IsScheduleDownwardDivisible(const ScheduleType & schedule)
 {
-  unsigned int ilevel;
-  unsigned int idim;
 
-  for (ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
+  for (unsigned int ilevel = 0; ilevel < schedule.rows() - 1; ++ilevel)
   {
-    for (idim = 0; idim < schedule.columns(); ++idim)
+    for (unsigned int idim = 0; idim < schedule.columns(); ++idim)
     {
       if (schedule[ilevel][idim] == 0)
       {
@@ -247,12 +245,11 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   shrinkerFilter->SetInput(smoother->GetOutput());
 
-  unsigned int ilevel;
-  unsigned int idim;
+
   unsigned int factors[ImageDimension];
   double       variance[ImageDimension];
 
-  for (ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
+  for (unsigned int ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
   {
     this->UpdateProgress(static_cast<float>(ilevel) / static_cast<float>(m_NumberOfLevels));
 
@@ -262,7 +259,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateData()
     outputPtr->Allocate();
 
     // compute shrink factors and variances
-    for (idim = 0; idim < ImageDimension; ++idim)
+    for (unsigned int idim = 0; idim < ImageDimension; ++idim)
     {
       factors[idim] = m_Schedule[ilevel][idim];
       variance[idim] = itk::Math::sqr(0.5 * static_cast<float>(factors[idim]));
@@ -327,22 +324,19 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInfo
   using SizeType = typename OutputImageType::SizeType;
   using IndexType = typename OutputImageType::IndexType;
 
-  OutputImagePointer                    outputPtr;
-  typename OutputImageType::PointType   outputOrigin;
-  typename OutputImageType::SpacingType outputSpacing;
-  SizeType                              outputSize;
-  IndexType                             outputStartIndex;
-
   // we need to compute the output spacing, the output image size,
   // and the output image start index
   for (unsigned int ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
   {
-    outputPtr = this->GetOutput(ilevel);
+    OutputImagePointer outputPtr = this->GetOutput(ilevel);
     if (!outputPtr)
     {
       continue;
     }
 
+    SizeType                              outputSize;
+    IndexType                             outputStartIndex;
+    typename OutputImageType::SpacingType outputSpacing;
     for (unsigned int idim = 0; idim < OutputImageType::ImageDimension; ++idim)
     {
       const auto shrinkFactor = static_cast<double>(m_Schedule[ilevel][idim]);
@@ -360,6 +354,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInfo
     // Now compute the new shifted origin for the updated levels;
     const typename OutputImageType::PointType::VectorType outputOriginOffset =
       (inputDirection * (outputSpacing - inputSpacing)) * 0.5;
+    typename OutputImageType::PointType outputOrigin;
     for (unsigned int idim = 0; idim < OutputImageType::ImageDimension; ++idim)
     {
       outputOrigin[idim] = inputOrigin[idim] + outputOriginOffset[idim];
@@ -396,15 +391,13 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
     itkExceptionMacro("Could not cast refOutput to TOutputImage*.");
   }
 
-  unsigned int ilevel;
-  unsigned int idim;
 
   if (ptr->GetRequestedRegion() == ptr->GetLargestPossibleRegion())
   {
     // set the requested regions for the other outputs to their
     // requested region
 
-    for (ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
+    for (unsigned int ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
     {
       if (ilevel == refLevel)
       {
@@ -427,14 +420,14 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
     IndexType  baseIndex = ptr->GetRequestedRegion().GetIndex();
     SizeType   baseSize = ptr->GetRequestedRegion().GetSize();
 
-    for (idim = 0; idim < TOutputImage::ImageDimension; ++idim)
+    for (unsigned int idim = 0; idim < TOutputImage::ImageDimension; ++idim)
     {
       unsigned int factor = m_Schedule[refLevel][idim];
       baseIndex[idim] *= static_cast<IndexValueType>(factor);
       baseSize[idim] *= static_cast<SizeValueType>(factor);
     }
 
-    for (ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
+    for (unsigned int ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
     {
       if (ilevel == refLevel)
       {
@@ -445,7 +438,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputRequ
         continue;
       }
 
-      for (idim = 0; idim < TOutputImage::ImageDimension; ++idim)
+      for (unsigned int idim = 0; idim < TOutputImage::ImageDimension; ++idim)
       {
         auto factor = static_cast<double>(m_Schedule[ilevel][idim]);
 
@@ -492,8 +485,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
   SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
   IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
 
-  unsigned int idim;
-  for (idim = 0; idim < ImageDimension; ++idim)
+  for (unsigned int idim = 0; idim < ImageDimension; ++idim)
   {
     unsigned int factor = m_Schedule[refLevel][idim];
     baseIndex[idim] *= static_cast<IndexValueType>(factor);
@@ -512,7 +504,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
   RegionType inputRequestedRegion = baseRegion;
   refLevel = 0;
 
-  for (idim = 0; idim < TInputImage::ImageDimension; ++idim)
+  for (unsigned int idim = 0; idim < TInputImage::ImageDimension; ++idim)
   {
     oper.SetDirection(idim);
     oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(m_Schedule[refLevel][idim])));

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -89,36 +89,29 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateD
     shrinkerFilter = resampleShrinker.GetPointer();
   }
 
-  int          ilevel;
-  unsigned int idim;
-  unsigned int factors[ImageDimension];
-  double       variance[ImageDimension];
-
-  bool                              allOnes;
-  OutputImagePointer                outputPtr;
-  OutputImagePointer                swapPtr;
-  typename TOutputImage::RegionType LPRegion;
-
   smoother->SetUseImageSpacing(false);
   smoother->SetMaximumError(this->GetMaximumError());
   shrinkerFilter->SetInput(smoother->GetOutput());
 
   // recursively compute outputs starting from the last one
-  for (ilevel = this->GetNumberOfLevels() - 1; ilevel > -1; ilevel--)
+  OutputImagePointer swapPtr;
+  for (int ilevel = this->GetNumberOfLevels() - 1; ilevel > -1; ilevel--)
   {
     this->UpdateProgress(1.0 - static_cast<float>(1 + ilevel) / static_cast<float>(this->GetNumberOfLevels()));
 
     // Allocate memory for each output
-    outputPtr = this->GetOutput(ilevel);
+    OutputImagePointer outputPtr = this->GetOutput(ilevel);
     outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
     outputPtr->Allocate();
 
     // cached a copy of the largest possible region
-    LPRegion = outputPtr->GetLargestPossibleRegion();
+    typename TOutputImage::RegionType LPRegion = outputPtr->GetLargestPossibleRegion();
 
     // Check shrink factors and compute variances
-    allOnes = true;
-    for (idim = 0; idim < ImageDimension; ++idim)
+    bool         allOnes = true;
+    unsigned int factors[ImageDimension];
+    double       variance[ImageDimension];
+    for (unsigned int idim = 0; idim < ImageDimension; ++idim)
     {
       if (ilevel == static_cast<int>(this->GetNumberOfLevels()) - 1)
       {
@@ -237,8 +230,6 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   using IndexType = typename OutputImageType::IndexType;
   using RegionType = typename OutputImageType::RegionType;
 
-  int          ilevel;
-  int          idim;
   unsigned int factors[ImageDimension];
 
   typename TInputImage::SizeType radius;
@@ -248,13 +239,13 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   IndexType  requestedIndex;
 
   // compute requested regions for lower levels
-  for (ilevel = refLevel + 1; ilevel < static_cast<int>(this->GetNumberOfLevels()); ++ilevel)
+  for (int ilevel = refLevel + 1; ilevel < static_cast<int>(this->GetNumberOfLevels()); ++ilevel)
   {
     requestedRegion = this->GetOutput(ilevel - 1)->GetRequestedRegion();
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
+    for (int idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel - 1][idim] / this->GetSchedule()[ilevel][idim];
 
@@ -285,13 +276,13 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   }
 
   // compute requested regions for higher levels
-  for (ilevel = refLevel - 1; ilevel > -1; ilevel--)
+  for (int ilevel = refLevel - 1; ilevel > -1; ilevel--)
   {
     requestedRegion = this->GetOutput(ilevel + 1)->GetRequestedRegion();
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
+    for (int idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel][idim] / this->GetSchedule()[ilevel + 1][idim];
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -106,7 +106,6 @@ itkImageRegistrationMethodTest_14(int, char *[])
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -161,30 +160,27 @@ itkImageRegistrationMethodTest_14(int, char *[])
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
-
-  itk::Point<double, dimension>  p;
-  itk::Vector<double, dimension> d;
-  itk::Vector<double, dimension> d2;
 
   MovingImageIterator mIter(movingImage, region);
   FixedImageIterator  fIter(fixedImage, region);
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    itk::Point<double, dimension> p;
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
 
-    d = p - center;
+    itk::Vector<double, dimension> d = p - center;
 
     fIter.Set((PixelType)F(d));
 
-
+    itk::Vector<double, dimension> d2;
     d2[0] = d[0] * std::cos(angle) + d[1] * std::sin(angle) + displacement[0];
     d2[1] = -d[0] * std::sin(angle) + d[1] * std::cos(angle) + displacement[1];
     d2[2] = d[2] + displacement[2];
@@ -197,7 +193,7 @@ itkImageRegistrationMethodTest_14(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -216,7 +212,7 @@ itkImageRegistrationMethodTest_14(int, char *[])
 
   parametersScales.Fill(1.0);
 
-  for (j = 4; j < 7; ++j)
+  for (unsigned int j = 4; j < 7; ++j)
   {
     parametersScales[j] = 0.0001;
   }
@@ -269,7 +265,7 @@ itkImageRegistrationMethodTest_14(int, char *[])
   unsigned int           iter[numberOfLoops] = { 300, 300, 350 };
   double                 rates[numberOfLoops] = { 1e-3, 5e-4, 1e-4 };
 
-  for (j = 0; j < numberOfLoops; ++j)
+  for (unsigned int j = 0; j < numberOfLoops; ++j)
   {
 
     try
@@ -308,14 +304,14 @@ itkImageRegistrationMethodTest_14(int, char *[])
 
   std::cout << "True solution is: " << trueParameters << std::endl;
 
-  for (j = 0; j < 4; ++j)
+  for (unsigned int j = 0; j < 4; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
     {
       pass = false;
     }
   }
-  for (j = 4; j < 7; ++j)
+  for (unsigned int j = 4; j < 7; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
     {

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
@@ -176,26 +176,16 @@ DoRegistration()
 int
 itkImageRegistrationMethodTest_16(int itkNotUsed(argc), char *[] itkNotUsed(argv))
 {
-  bool result_uc;
-  bool result_c;
-  bool result_us;
-  bool result_s;
-  bool result_ui;
-  bool result_i;
-  bool result_ul;
-  bool result_l;
-  bool result_f;
-  bool result_d;
-  result_uc = DoRegistration<unsigned char>();
-  result_c = DoRegistration<char>();
-  result_us = DoRegistration<unsigned short>();
-  result_s = DoRegistration<short>();
-  result_ui = DoRegistration<unsigned int>();
-  result_i = DoRegistration<int>();
-  result_ul = DoRegistration<unsigned long>();
-  result_l = DoRegistration<long>();
-  result_f = DoRegistration<float>();
-  result_d = DoRegistration<double>();
+  bool result_uc = DoRegistration<unsigned char>();
+  bool result_c = DoRegistration<char>();
+  bool result_us = DoRegistration<unsigned short>();
+  bool result_s = DoRegistration<short>();
+  bool result_ui = DoRegistration<unsigned int>();
+  bool result_i = DoRegistration<int>();
+  bool result_ul = DoRegistration<unsigned long>();
+  bool result_l = DoRegistration<long>();
+  bool result_f = DoRegistration<float>();
+  bool result_d = DoRegistration<double>();
 
   std::cout << "<unsigned char>:  " << result_uc << std::endl;
   std::cout << "<char>:           " << result_c << std::endl;

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -375,14 +375,16 @@ itkLandmarkBasedTransformInitializerTest(int, char *[])
       // These landmark should match properly
       constexpr unsigned int                           numWorkingLandmark = 6;
       TransformInitializerType::LandmarkPointContainer fixedLandmarks;
+      fixedLandmarks.reserve(numWorkingLandmark);
       TransformInitializerType::LandmarkPointContainer movingLandmarks;
-      TransformInitializerType::LandmarkWeightType     landmarkWeights;
+      movingLandmarks.reserve(numWorkingLandmark);
+      TransformInitializerType::LandmarkWeightType landmarkWeights;
+      landmarkWeights.reserve(numWorkingLandmark);
 
       for (unsigned int i = 0; i < numWorkingLandmark; ++i)
       {
         TransformInitializerType::LandmarkPointType fixedPoint;
         TransformInitializerType::LandmarkPointType movingPoint;
-
         for (unsigned int j = 0; j < 3; ++j)
         {
           fixedPoint[j] = fixedLandMarkInit[i][j];
@@ -405,14 +407,16 @@ itkLandmarkBasedTransformInitializerTest(int, char *[])
       // dummy points should not matched based on given weights
       constexpr unsigned int                           numDummyLandmark = 8;
       TransformInitializerType::LandmarkPointContainer fixedLandmarks;
+      fixedLandmarks.reserve(numDummyLandmark);
       TransformInitializerType::LandmarkPointContainer movingLandmarks;
-      TransformInitializerType::LandmarkWeightType     landmarkWeights;
+      movingLandmarks.reserve(numDummyLandmark);
+      TransformInitializerType::LandmarkWeightType landmarkWeights;
+      landmarkWeights.reserve(numDummyLandmark);
 
       for (unsigned int i = 0; i < numDummyLandmark; ++i)
       {
         TransformInitializerType::LandmarkPointType fixedPoint;
         TransformInitializerType::LandmarkPointType movingPoint;
-
         for (unsigned int j = 0; j < 3; ++j)
         {
           fixedPoint[j] = fixedLandMarkInit[i][j];
@@ -441,10 +445,7 @@ itkLandmarkBasedTransformInitializerTest(int, char *[])
     FixedImageType::Pointer  fixedImage = CreateTestImage<Dimension>();
     MovingImageType::Pointer movingImage = CreateTestImage<Dimension>();
 
-    FixedImageType::PointType origin;
-    origin[0] = -5;
-    origin[1] = -5;
-    origin[2] = -5;
+    auto origin = itk::MakeFilled<FixedImageType::PointType>(-5);
     fixedImage->SetOrigin(origin);
 
     // Set the transform type

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -332,17 +332,16 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   // for parameters[4] = {-10,10} (arbitrary choice)
   //---------------------------------------------------------
 
-  typename MetricType::MeasureType    measure;
-  typename MetricType::MeasureType    measure2;
   typename MetricType::DerivativeType derivative(numberOfParameters);
 
   std::cout << "param[4]\tMI\tMI2\tdMI/dparam[4]" << std::endl;
 
+  typename MetricType::MeasureType measure;
   for (double trans = -10; trans <= 5; trans += 0.5)
   {
     parameters[4] = trans;
     metric->GetValueAndDerivative(parameters, measure, derivative);
-    measure2 = metric->GetValue(parameters);
+    typename MetricType::MeasureType measure2 = metric->GetValue(parameters);
 
     std::cout << trans << '\t' << measure << '\t' << measure2 << '\t' << derivative[4] << std::endl;
 
@@ -600,8 +599,6 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   // for parameters between {-10,10} (arbitrary choice)
   //---------------------------------------------------------
 
-  typename MetricType::MeasureType    measure;
-  typename MetricType::MeasureType    measure2;
   typename MetricType::DerivativeType derivative(numberOfParameters);
   unsigned int                        q = numberOfParameters / 4;
 
@@ -612,8 +609,9 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   {
     // parameters[q] = trans;
     parameters.Fill(trans);
+    typename MetricType::MeasureType measure;
     metric->GetValueAndDerivative(parameters, measure, derivative);
-    measure2 = metric->GetValue(parameters);
+    typename MetricType::MeasureType measure2 = metric->GetValue(parameters);
 
     std::cout << trans << '\t' << measure << '\t' << measure2 << '\t' << derivative[q] << std::endl;
 
@@ -625,8 +623,10 @@ TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
   // Check output gradients for numerical accuracy
   //---------------------------------------------------------
   parameters.Fill(4.5 * imgSpacing[0]);
-  metric->GetValueAndDerivative(parameters, measure, derivative);
-
+  {
+    typename MetricType::MeasureType measure;
+    metric->GetValueAndDerivative(parameters, measure, derivative);
+  }
   ParametersType                   parametersPlus(numberOfParameters);
   ParametersType                   parametersMinus(numberOfParameters);
   typename MetricType::MeasureType measurePlus;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -64,13 +64,11 @@ F(itk::Vector<double, 3> & v);
 int
 itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 {
-
   itk::OutputWindow::SetInstance(itk::TextOutput::New().GetPointer());
 
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -129,35 +127,31 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   movingImage->SetRegions(region);
   movingImage->Allocate();
 
-
   using MovingImageIterator = itk::ImageRegionIterator<MovingImageType>;
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
-
-  itk::Point<double, dimension>  p;
-  itk::Vector<double, dimension> d;
-  itk::Vector<double, dimension> d2;
 
   MovingImageIterator mIter(movingImage, region);
   FixedImageIterator  fIter(fixedImage, region);
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    itk::Point<double, dimension> p;
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
 
-    d = p - center;
+    itk::Vector<double, dimension> d = p - center;
 
     fIter.Set((PixelType)F(d));
 
-
+    itk::Vector<double, dimension> d2;
     d2[0] = d[0] * std::cos(angle) + d[1] * std::sin(angle) + displacement[0];
     d2[1] = -d[0] * std::sin(angle) + d[1] * std::cos(angle) + displacement[1];
     d2[2] = d[2] + displacement[2];
@@ -170,7 +164,7 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -189,7 +183,7 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 
   parametersScales.Fill(1.0);
 
-  for (j = 4; j < 7; ++j)
+  for (unsigned int j = 4; j < 7; ++j)
   {
     parametersScales[j] = 0.0001;
   }
@@ -248,12 +242,11 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   unsigned short numberOfLevels = 3;
 
   itk::Array<unsigned int> niter(numberOfLevels);
-  itk::Array<double>       rates(numberOfLevels);
-
   niter[0] = 300;
   niter[1] = 300;
   niter[2] = 350;
 
+  itk::Array<double> rates(numberOfLevels);
   rates[0] = 1e-3;
   rates[1] = 5e-4;
   rates[2] = 1e-4;
@@ -293,14 +286,14 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 
   std::cout << "True solution is: " << trueParameters << std::endl;
 
-  for (j = 0; j < 4; ++j)
+  for (unsigned int j = 0; j < 4; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
     {
       pass = false;
     }
   }
-  for (j = 4; j < 7; ++j)
+  for (unsigned int j = 4; j < 7; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
     {

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -182,10 +182,8 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   }
 
   // set image origin to be center of the image
-  double       transCenter[3];
-  unsigned int j;
-  unsigned int k;
-  for (j = 0; j < 3; ++j)
+  double transCenter[3];
+  for (unsigned int j = 0; j < 3; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]) * spacing[j];
   }
@@ -225,10 +223,10 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   // check the schedule
   ScheduleType schedule(numLevels, ImageDimension);
 
-  for (k = 0; k < numLevels; ++k)
+  for (unsigned int k = 0; k < numLevels; ++k)
   {
     unsigned int denominator = 1 << k;
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       schedule[k][j] = factors[j] / denominator;
       if (schedule[k][j] == 0)
@@ -257,10 +255,10 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   // check the schedule;
   schedule = ScheduleType(numLevels, ImageDimension, 0);
-  for (k = 0; k < numLevels; ++k)
+  for (unsigned int k = 0; k < numLevels; ++k)
   {
     unsigned int denominator = 1 << k;
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       schedule[k][j] = factors[j] / denominator;
       if (schedule[k][j] == 0)
@@ -281,7 +279,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
 
   // test start factors
   const unsigned int * ss = pyramid->GetStartingShrinkFactors();
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     if (ss[j] != factors[j])
     {
@@ -361,29 +359,32 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
       }
       // break;
     }
-    for (j = 0; j < ImageDimension; ++j)
     {
-      if (itk::Math::NotAlmostEquals(outputSpacing[j], inputSpacing[j] * static_cast<double>(schedule[testLevel][j])))
+      unsigned int j = 0;
+      for (; j < ImageDimension; ++j)
       {
-        break;
+        if (itk::Math::NotAlmostEquals(outputSpacing[j], inputSpacing[j] * static_cast<double>(schedule[testLevel][j])))
+        {
+          break;
+        }
+        unsigned int sz = inputSize[j] / schedule[testLevel][j];
+        if (sz == 0)
+        {
+          sz = 1;
+        }
+        if (outputSize[j] != sz)
+        {
+          break;
+        }
       }
-      unsigned int sz = inputSize[j] / schedule[testLevel][j];
-      if (sz == 0)
-      {
-        sz = 1;
-      }
-      if (outputSize[j] != sz)
-      {
-        break;
-      }
-    }
 
-    if (j != ImageDimension)
-    {
-      std::cout << "Output meta information incorrect." << std::endl;
-      pyramid->GetInput()->Print(std::cout);
-      pyramid->GetOutput(testLevel)->Print(std::cout);
-      return EXIT_FAILURE;
+      if (j != ImageDimension)
+      {
+        std::cout << "Output meta information incorrect." << std::endl;
+        pyramid->GetInput()->Print(std::cout);
+        pyramid->GetOutput(testLevel)->Print(std::cout);
+        return EXIT_FAILURE;
+      }
     }
   }
 

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -180,13 +180,12 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
       FixedImagePixelType  fixedImageValue;
       MovingImagePointType mappedMovingPoint;
       MovingImagePixelType movingImageValue;
-      bool                 pointIsValid;
 
       this->m_ANTSAssociate->TransformVirtualIndexToPhysicalPoint(index, virtualPoint);
 
       try
       {
-        pointIsValid =
+        bool pointIsValid =
           this->m_ANTSAssociate->TransformAndEvaluateFixedPoint(virtualPoint, mappedFixedPoint, fixedImageValue);
         if (pointIsValid)
         {
@@ -265,12 +264,11 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
     FixedImagePixelType  fixedImageValue;
     MovingImagePointType mappedMovingPoint;
     MovingImagePixelType movingImageValue;
-    bool                 pointIsValid;
 
     this->m_ANTSAssociate->TransformVirtualIndexToPhysicalPoint(index, virtualPoint);
     try
     {
-      pointIsValid =
+      bool pointIsValid =
         this->m_ANTSAssociate->TransformAndEvaluateFixedPoint(virtualPoint, mappedFixedPoint, fixedImageValue);
       if (pointIsValid)
       {

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -133,11 +133,11 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner,
   if (this->m_CorrelationAssociate->GetComputeDerivative())
   {
     DerivativeType fdm;
-    DerivativeType mdm;
     fdm.SetSize(globalDerivativeSize);
-    mdm.SetSize(globalDerivativeSize);
-
     fdm.Fill(DerivativeValueType{});
+
+    DerivativeType mdm;
+    mdm.SetSize(globalDerivativeSize);
     mdm.Fill(DerivativeValueType{});
 
     const auto fc = static_cast<InternalComputationValueType>(2.0);
@@ -169,15 +169,10 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
                                            const VirtualPointType & virtualPoint,
                                            const ThreadIdType       threadId)
 {
-  FixedImagePointType     mappedFixedPoint;
-  FixedImagePixelType     mappedFixedPixelValue;
-  FixedImageGradientType  mappedFixedImageGradient;
-  MovingImagePointType    mappedMovingPoint;
-  MovingImagePixelType    mappedMovingPixelValue;
-  MovingImageGradientType mappedMovingImageGradient;
-  bool                    pointIsValid = false;
-  MeasureType             metricValueResult;
-
+  FixedImagePointType    mappedFixedPoint;
+  FixedImagePixelType    mappedFixedPixelValue;
+  FixedImageGradientType mappedFixedImageGradient;
+  bool                   pointIsValid = false;
   /* Transform the point into fixed and moving spaces, and evaluate.
    * Different behavior with pre-warping enabled is handled transparently.
    * Do this in a try block to catch exceptions and print more useful info
@@ -205,6 +200,9 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
     return pointIsValid;
   }
 
+  MovingImagePointType    mappedMovingPoint;
+  MovingImagePixelType    mappedMovingPixelValue;
+  MovingImageGradientType mappedMovingImageGradient;
   try
   {
     pointIsValid = this->m_CorrelationAssociate->TransformAndEvaluateMovingPoint(
@@ -229,6 +227,7 @@ CorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
 
   /* Call the user method in derived classes to do the specific
    * calculations for value and derivative. */
+  MeasureType metricValueResult;
   try
   {
     pointIsValid = this->ProcessPoint(virtualIndex,

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -350,27 +350,23 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   2- The MI energy is bounded in the range of [0  min(H(x),H(y))].
   3- The ComputeMutualInformation() iterator range should cover the entire PDF.
   4- The normalization is done based on NumberOfHistogramBins-1 instead of NumberOfHistogramBins. */
-  TInternalComputationValueType                       px;
-  TInternalComputationValueType                       py;
-  TInternalComputationValueType                       pxy;
+
+  constexpr TInternalComputationValueType             eps = NumericTraits<TInternalComputationValueType>::epsilon();
   CompensatedSummation<TInternalComputationValueType> total_mi;
-  TInternalComputationValueType                       local_mi;
-  TInternalComputationValueType                       eps = NumericTraits<TInternalComputationValueType>::epsilon();
-  typename JointPDFType::IndexType                    index;
   for (SizeValueType ii = 0; ii < m_NumberOfHistogramBins; ++ii)
   {
     MarginalPDFIndexType mind;
     mind[0] = ii;
-    px = this->m_FixedImageMarginalPDF->GetPixel(mind);
+    TInternalComputationValueType px = this->m_FixedImageMarginalPDF->GetPixel(mind);
     for (SizeValueType jj = 0; jj < m_NumberOfHistogramBins; ++jj)
     {
       mind[0] = jj;
-      py = this->m_MovingImageMarginalPDF->GetPixel(mind);
-      TInternalComputationValueType denom = px * py;
-      index[0] = ii;
-      index[1] = jj;
-      pxy = m_JointPDF->GetPixel(index);
-      local_mi = 0;
+      TInternalComputationValueType    py = this->m_MovingImageMarginalPDF->GetPixel(mind);
+      TInternalComputationValueType    denom = px * py;
+      typename JointPDFType::IndexType index = { static_cast<long>(ii), static_cast<long>(jj) };
+
+      TInternalComputationValueType pxy = m_JointPDF->GetPixel(index);
+      TInternalComputationValueType local_mi = 0;
       if (itk::Math::abs(denom) > eps)
       {
         if (pxy / denom > eps)

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -366,10 +366,9 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   DisplacementTransformType::ParametersType parameters(transformMdisplacement->GetNumberOfParameters());
   parameters.Fill(static_cast<DisplacementTransformType::ParametersValueType>(1000.0));
   transformMdisplacement->SetParameters(parameters);
-  MetricType::MeasureType expectedMetricMax;
-  MetricType::MeasureType valueReturn;
-  expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
+  MetricType::MeasureType expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
+  MetricType::MeasureType valueReturn;
   metric->GetValueAndDerivative(valueReturn, derivativeReturn);
   if (metric->GetNumberOfValidPoints() != 0 || itk::Math::NotExactlyEquals(valueReturn, expectedMetricMax))
   {

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -67,9 +67,7 @@ itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(TMetricPointer &  me
 
   // Evaluate with GetValueAndDerivative
   typename MetricType::MeasureType    valueReturn1;
-  typename MetricType::MeasureType    valueReturn2;
   typename MetricType::DerivativeType derivativeReturn;
-
   try
   {
     std::cout << "Calling GetValueAndDerivative..." << std::endl;
@@ -97,6 +95,7 @@ itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(TMetricPointer &  me
     return EXIT_FAILURE;
   }
 
+  typename MetricType::MeasureType valueReturn2;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;
@@ -214,21 +213,20 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   metric->SetFixedTransform(fixedTransform);
   metric->SetMovingTransform(movingTransform);
 
-  MetricType::MeasureType    value1;
-  MetricType::MeasureType    value2;
-  MetricType::DerivativeType derivative1;
-  MetricType::DerivativeType derivative2;
-  int                        ret;
-  int                        result = EXIT_SUCCESS;
+  int result = EXIT_SUCCESS;
 
   metric->SetMaximumNumberOfWorkUnits(1);
   std::cerr << "Setting number of metric threads to " << metric->GetMaximumNumberOfWorkUnits() << std::endl;
-  ret = itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(metric, value1, derivative1);
+  MetricType::MeasureType    value1;
+  MetricType::DerivativeType derivative1;
+
+  int ret = itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(metric, value1, derivative1);
   if (ret == EXIT_FAILURE)
   {
     result = EXIT_FAILURE;
   }
-
+  MetricType::MeasureType    value2;
+  MetricType::DerivativeType derivative2;
   metric->SetMaximumNumberOfWorkUnits(8);
   std::cerr << "Setting number of metric threads to " << metric->GetMaximumNumberOfWorkUnits() << std::endl;
   ret = itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(metric, value2, derivative2);
@@ -260,11 +258,10 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   MovingTransformType::ParametersType parameters(imageDimensionality);
   parameters.Fill(static_cast<MovingTransformType::ParametersValueType>(1000));
   movingTransform->SetParameters(parameters);
-  MetricType::MeasureType    expectedMetricMax;
+  MetricType::MeasureType expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
+  std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
   MetricType::MeasureType    valueReturn;
   MetricType::DerivativeType derivativeReturn;
-  expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
-  std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
   metric->GetValueAndDerivative(valueReturn, derivativeReturn);
   if (metric->GetNumberOfValidPoints() != 0 || itk::Math::NotExactlyEquals(valueReturn, expectedMetricMax))
   {

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -205,11 +205,13 @@ itkDemonsImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   else
   {
     using PointType = PointSetType::PointType;
-    PointSetType::Pointer                             pset(PointSetType::New());
-    unsigned long                                     ind = 0;
-    unsigned long                                     ct = 0;
-    itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
-    for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+    PointSetType::Pointer pset(PointSetType::New());
+    unsigned long         ind = 0;
+    unsigned long         ct = 0;
+
+    for (itk::ImageRegionIteratorWithIndex<FixedImageType> It(fixedImage, fixedImage->GetLargestPossibleRegion());
+         !It.IsAtEnd();
+         ++It)
     {
       // take every N^th point
       if (ct % 10 == 0)

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -137,9 +137,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
 
   // Evaluate with GetValueAndDerivative
   MetricType::MeasureType    valueReturn1;
-  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
-
   try
   {
     std::cout << "Calling GetValueAndDerivative..." << std::endl;
@@ -162,7 +160,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
     std::cerr << "Caught unexpected exception during re-initialize: " << exc << std::endl;
     return EXIT_FAILURE;
   }
-
+  MetricType::MeasureType valueReturn2;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -81,10 +81,10 @@ itkEuclideanDistancePointSetMetricTestRun()
   metric->Initialize();
 
   typename PointSetMetricType::MeasureType    value = metric->GetValue();
-  typename PointSetMetricType::MeasureType    value2;
   typename PointSetMetricType::DerivativeType derivative;
-  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetValueAndDerivative(value2, derivative2);
 
   std::cout << "value: " << value << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -137,10 +137,11 @@ itkEuclideanDistancePointSetMetricTest2Run()
 
   // test
   typename PointSetMetricType::MeasureType    value = metric->GetValue();
-  typename PointSetMetricType::MeasureType    value2;
   typename PointSetMetricType::DerivativeType derivative;
-  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
+
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetValueAndDerivative(value2, derivative2);
 
   std::cout << "value: " << value << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -123,10 +123,11 @@ itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
 
   // test
   typename PointSetMetricType::MeasureType    value = metric->GetValue();
-  typename PointSetMetricType::MeasureType    value2;
   typename PointSetMetricType::DerivativeType derivative;
-  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative2;
+
   metric->GetValueAndDerivative(value2, derivative2);
 
   std::cout << "value: " << value << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -91,10 +91,11 @@ itkExpectationBasedPointSetMetricTestRun()
   metric->Initialize();
 
   typename PointSetMetricType::MeasureType    value = metric->GetValue();
-  typename PointSetMetricType::MeasureType    value2;
   typename PointSetMetricType::DerivativeType derivative;
-  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
+
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetValueAndDerivative(value2, derivative2);
 
   int result = EXIT_SUCCESS;

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -316,20 +316,19 @@ ImageToImageMetricv4TestRunSingleTest(const ImageToImageMetricv4TestMetricPointe
 {
   int result = EXIT_SUCCESS;
 
-  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn1;
-  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn2;
-  ImageToImageMetricv4TestMetricType::DerivativeType derivativeReturn;
-
   // Initialize.
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
   // Evaluate using GetValue
+  ImageToImageMetricv4TestMetricType::MeasureType valueReturn1;
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn1 = metric->GetValue());
 
   // Re-initialize.
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
   // Evaluate using GetValueAndDerivative
+  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn2;
+  ImageToImageMetricv4TestMetricType::DerivativeType derivativeReturn;
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn2, derivativeReturn));
 
   // Test same value returned by different methods

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -19,7 +19,7 @@
 #include "itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h"
 #include "itkTranslationTransform.h"
 #include "itkTestingMacros.h"
-
+#include "itkMakeFilled.h"
 #include <fstream>
 
 template <unsigned int Dimension>
@@ -36,14 +36,13 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
   auto movingPoints = PointSetType::New();
 
   // Produce two simple point sets of 1) a circle and 2) the same circle with an offset
-  PointType  offset;
-  float      normOffset = 0;
-  VectorType normalizedOffset;
+  auto offset = itk::MakeFilled<PointType>(2);
+  auto normalizedOffset = itk::MakeFilled<VectorType>(2);
+
+  float normOffset = 0;
   for (unsigned int d = 0; d < Dimension; ++d)
   {
-    offset[d] = 2;
     normOffset += itk::Math::sqr(offset[d]);
-    normalizedOffset[d] = offset[d];
   }
   normOffset = std::sqrt(normOffset);
   normalizedOffset /= normOffset;
@@ -51,8 +50,8 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
   unsigned long count = 0;
   for (float theta = 0; theta < 2.0 * itk::Math::pi; theta += 0.1)
   {
-    PointType fixedPoint;
     float     radius = 100.0;
+    PointType fixedPoint;
     fixedPoint[0] = radius * std::cos(theta);
     fixedPoint[1] = radius * std::sin(theta);
     // simplistic point set test:
@@ -130,10 +129,10 @@ itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
     metric->Initialize();
 
     typename PointSetMetricType::MeasureType    value = metric->GetValue();
-    typename PointSetMetricType::MeasureType    value2;
     typename PointSetMetricType::DerivativeType derivative;
-    typename PointSetMetricType::DerivativeType derivative2;
     metric->GetDerivative(derivative);
+    typename PointSetMetricType::MeasureType    value2;
+    typename PointSetMetricType::DerivativeType derivative2;
     metric->GetValueAndDerivative(value2, derivative2);
 
     derivative /= derivative.magnitude();

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -31,7 +31,6 @@
 int
 itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
 {
-
   constexpr unsigned int imageSize = 10;
   constexpr unsigned int imageDimensionality = 3;
   using ImageType = itk::Image<double, imageDimensionality>;
@@ -93,7 +92,6 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(metric, JointHistogramMutualInformationImageToImageMetricv4, ImageToImageMetricv4);
 
-
   itk::SizeValueType numberOfHistogramBins = 6;
   metric->SetNumberOfHistogramBins(numberOfHistogramBins);
   ITK_TEST_SET_GET_VALUE(numberOfHistogramBins, metric->GetNumberOfHistogramBins());
@@ -112,14 +110,12 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
-
   // Evaluate
-  MetricType::MeasureType    valueReturn1;
-  MetricType::MeasureType    valueReturn2;
-  MetricType::DerivativeType derivativeReturn;
-
+  MetricType::MeasureType valueReturn1;
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn1 = metric->GetValue());
 
+  MetricType::MeasureType    valueReturn2;
+  MetricType::DerivativeType derivativeReturn;
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn2, derivativeReturn));
 
   if (itk::Math::NotExactlyEquals(valueReturn1, valueReturn2))
@@ -146,7 +142,6 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
               << "  Expected metric max value: " << expectedMetricMax << std::endl;
   }
   movingTransform->SetIdentity();
-
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -103,10 +103,10 @@ itkLabeledPointSetMetricTestRun()
   metric->Initialize();
 
   typename PointSetMetricType::MeasureType    value = metric->GetValue();
-  typename PointSetMetricType::MeasureType    value2;
   typename PointSetMetricType::DerivativeType derivative;
-  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetDerivative(derivative);
+  typename PointSetMetricType::MeasureType    value2;
+  typename PointSetMetricType::DerivativeType derivative2;
   metric->GetValueAndDerivative(value2, derivative2);
 
   std::cout << "value: " << value << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -132,9 +132,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
 
   /* Evaluate with GetValueAndDerivative */
   MetricType::MeasureType    valueReturn1;
-  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
-
   try
   {
     std::cout << "Calling GetValueAndDerivative..." << std::endl;
@@ -157,7 +155,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
     std::cerr << "Caught unexpected exception during re-initialize: " << exc << std::endl;
     return EXIT_FAILURE;
   }
-
+  MetricType::MeasureType valueReturn2;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -117,9 +117,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
 
   // Evaluate with GetValueAndDerivative
   MetricType::MeasureType    valueReturn1;
-  MetricType::MeasureType    valueReturn2;
   MetricType::DerivativeType derivativeReturn;
-
   try
   {
     std::cout << "Calling GetValueAndDerivative..." << std::endl;
@@ -143,6 +141,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
     return EXIT_FAILURE;
   }
 
+  MetricType::MeasureType valueReturn2;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;
@@ -169,13 +168,13 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   // Test that using floating point correction produces
   // a different result
   std::cout << "Testing with different floating point correction settings." << std::endl;
-  MetricType::DerivativeType derivativeWithFPC;
-  MetricType::DerivativeType derivativeWithOutFPC;
   metric->SetMaximumNumberOfWorkUnits(1);
   metric->SetUseFloatingPointCorrection(false); // default
+  MetricType::DerivativeType derivativeWithOutFPC;
   metric->GetValueAndDerivative(valueReturn1, derivativeWithOutFPC);
   metric->SetUseFloatingPointCorrection(true);
   metric->SetFloatingPointCorrectionResolution(1e1); // severe truncation
+  MetricType::DerivativeType derivativeWithFPC;
   metric->GetValueAndDerivative(valueReturn1, derivativeWithFPC);
   if (derivativeWithFPC == derivativeWithOutFPC)
   {

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -124,9 +124,9 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
   }
 
   // Evaluate individually
-  MeasureType                     metricValue{};
-  MeasureType                     weightedMetricValue{};
-  MultiMetricType::DerivativeType metricDerivative;
+  MeasureType metricValue{};
+  MeasureType weightedMetricValue{};
+
   MultiMetricType::DerivativeType DerivResultOfGetValueAndDerivativeTruth(multiVariateMetric->GetNumberOfParameters());
   DerivResultOfGetValueAndDerivativeTruth.Fill(MultiMetricType::DerivativeValueType{});
   MultiMetricType::DerivativeValueType totalMagnitude{};
@@ -134,6 +134,7 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
   for (itk::SizeValueType i = 0; i < multiVariateMetric->GetNumberOfMetrics(); ++i)
   {
     std::cout << "GetValueAndDerivative on component metrics" << std::endl;
+    MultiMetricType::DerivativeType metricDerivative;
     multiVariateMetric->GetMetricQueue()[i]->GetValueAndDerivative(metricValue, metricDerivative);
     std::cout << " Metric " << i << " value : " << metricValue << std::endl;
     if (!useDisplacementTransform)
@@ -472,12 +473,6 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
   // Test that we get the same scales/step estimation
   // with a single metric and the same metric twice in a multimetric
   //
-  ScalesEstimatorMultiType::ScalesType singleScales;
-  ScalesEstimatorMultiType::ScalesType multiSingleScales;
-  ScalesEstimatorMultiType::ScalesType multiDoubleScales;
-  ScalesEstimatorMultiType::FloatType  singleStep;
-  ScalesEstimatorMultiType::FloatType  multiSingleStep;
-  ScalesEstimatorMultiType::FloatType  multiDoubleStep;
   step.SetSize(m1->GetNumberOfParameters());
   step.Fill(itk::NumericTraits<ScalesEstimatorMultiType::ParametersType::ValueType>::OneValue());
 
@@ -485,18 +480,20 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
   auto singleShiftScaleEstimator = ScalesEstimatorMeanSquaresType::New();
   singleShiftScaleEstimator->SetMetric(m1);
   m1->Initialize();
+  ScalesEstimatorMultiType::ScalesType singleScales;
   singleShiftScaleEstimator->EstimateScales(singleScales);
   std::cout << "Single metric estimated scales: " << singleScales << std::endl;
-  singleStep = singleShiftScaleEstimator->EstimateStepScale(step);
+  ScalesEstimatorMultiType::FloatType singleStep = singleShiftScaleEstimator->EstimateStepScale(step);
   std::cout << "Single metric estimated stepScale: " << singleStep << std::endl;
 
   auto multiSingleMetric = MultiMetricType::New();
   multiSingleMetric->AddMetric(m1);
   multiSingleMetric->Initialize();
   shiftScaleEstimator->SetMetric(multiSingleMetric);
+  ScalesEstimatorMultiType::ScalesType multiSingleScales;
   shiftScaleEstimator->EstimateScales(multiSingleScales);
   std::cout << "multi-single estimated scales: " << multiSingleScales << std::endl;
-  multiSingleStep = shiftScaleEstimator->EstimateStepScale(step);
+  ScalesEstimatorMultiType::FloatType multiSingleStep = shiftScaleEstimator->EstimateStepScale(step);
   std::cout << "multi-single estimated stepScale: " << multiSingleStep << std::endl;
 
   auto multiDoubleMetric = MultiMetricType::New();
@@ -504,9 +501,10 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
   multiDoubleMetric->AddMetric(m1);
   multiDoubleMetric->Initialize();
   shiftScaleEstimator->SetMetric(multiDoubleMetric);
+  ScalesEstimatorMultiType::ScalesType multiDoubleScales;
   shiftScaleEstimator->EstimateScales(multiDoubleScales);
   std::cout << "multi-double estimated scales: " << multiDoubleScales << std::endl;
-  multiDoubleStep = shiftScaleEstimator->EstimateStepScale(step);
+  ScalesEstimatorMultiType::FloatType multiDoubleStep = shiftScaleEstimator->EstimateStepScale(step);
   std::cout << "multi-double estimated stepScale: " << multiDoubleStep << std::endl;
 
   // Check that results are the same for all three estimations

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -124,17 +124,12 @@ template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 {
-  SizeValueType initCodebookSize;
-  SizeValueType finalCodebookSize;
-
   m_VectorDimension = InputImagePixelType::GetVectorDimension();
-
   if (m_ValidInCodebook)
   {
     m_NumberOfCodewords = m_Codebook.rows();
     m_VectorDimension = m_Codebook.cols();
     // Set the initial and final codebook size
-    finalCodebookSize = m_NumberOfCodewords;
   }
   else
   {
@@ -151,14 +146,13 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 
     // Set the initial and final codebook size
 
-    initCodebookSize = (SizeValueType)1;
-    finalCodebookSize = (SizeValueType)m_NumberOfCodewords;
-
+    SizeValueType initCodebookSize = (SizeValueType)1;
     m_Codebook.set_size(initCodebookSize, m_VectorDimension);
 
     // Initialize m_Codebook to 0 (it now has only one row)
     m_Codebook.fill(0);
   }
+  SizeValueType finalCodebookSize = (SizeValueType)m_NumberOfCodewords;
 
   // Allocate scratch memory for the centroid, codebook histogram
   // and the codebook distortion
@@ -283,14 +277,12 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
   // First pass requires very large distortion
 
   double olddistortion = m_DoubleMaximum;
-  double distortion;
-  double tempdistortion;
-  int    pass = 0; // no empty cells have been found yet
-  int    emptycells;
-  int    bestcodeword;
 
+
+  int pass = 0; // no empty cells have been found yet
   m_CurrentNumberOfCodewords = m_Codebook.rows();
 
+  double distortion;
   do
   {
     // Encode all of the input vectors using the given codebook
@@ -303,7 +295,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
     }
 
     // Find number of empty cells
-    emptycells = 0;
+    int emptycells = 0;
     for (unsigned int i = 0; i < m_CurrentNumberOfCodewords; ++i)
     {
       if (m_CodewordHistogram[i][0] == 0)
@@ -359,8 +351,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
       // faster sort algorithm, but this event should be very unlikely
       for (unsigned int n = 0; n < m_CurrentNumberOfCodewords - emptycells; ++n)
       {
-        tempdistortion = 0.0;
-        bestcodeword = 0;
+        double tempdistortion = 0.0;
+        int    bestcodeword = 0;
         for (unsigned int i = 0; i < m_NumberOfCodewords; ++i)
         {
           if ((m_CodewordDistortion[i][0] >= tempdistortion) && (m_CodewordHistogram[i][0] > 0))
@@ -401,10 +393,6 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
 {
   // itkDebugMacro(<<"Start nearest_neighbor_search_basic()");
 
-  double bestdistortion;
-  double tempdistortion;
-  double diff;
-  int    bestcodeword;
 
   // unused: double *centroidVecTemp = ( double * ) new double[m_VectorDimension];
 
@@ -443,18 +431,18 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
   for (unsigned int n = 0; n < totalNumVecsInInput; ++n)
   {
     // Keep convention that ties go to lower index
-    bestdistortion = m_DoubleMaximum;
-    bestcodeword = 0;
+    double bestdistortion = m_DoubleMaximum;
+    int    bestcodeword = 0;
 
     for (unsigned int i = 0; i < m_CurrentNumberOfCodewords; ++i)
     {
       // Find the best codeword
-      tempdistortion = 0.0;
+      double tempdistortion = 0.0;
       inputImagePixelVector = inputImageIt.Get();
 
       for (unsigned int j = 0; j < m_VectorDimension; ++j)
       {
-        diff = static_cast<double>(inputImagePixelVector[j] - m_Codebook[i][j]);
+        double diff = static_cast<double>(inputImagePixelVector[j] - m_Codebook[i][j]);
         tempdistortion += diff * diff;
 
         if (tempdistortion > bestdistortion)

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -182,10 +182,8 @@ itkKmeansModelEstimatorTest(int, char *[])
 
   vnl_matrix<double> inCDBK(NCODEWORDS, NUMBANDS);
   // There are 4 entries to the code book
-  int r;
-  int c;
-  r = 0;
-  c = 0;
+  int r{};
+  int c{};
   inCDBK.put(r, c, 10);
   r = 0;
   c = 1;
@@ -304,10 +302,9 @@ itkKmeansModelEstimatorTest(int, char *[])
   // closest to the fist pixel.
   unsigned int minidx = 0;
   double       mindist = 99999999;
-  double       classdist;
   for (unsigned int idx = 0; idx < membershipFunctions.size(); ++idx)
   {
-    classdist = membershipFunctions[idx]->Evaluate(outIt.Get());
+    double classdist = membershipFunctions[idx]->Evaluate(outIt.Get());
     std::cout << "Distance of first pixel to class " << idx << " is: " << classdist << std::endl;
     if (mindist > classdist)
     {

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -70,10 +70,8 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low;
-  InternalPixelType threshold_hi;
-  threshold_low = std::stoi(argv[3]);
-  threshold_hi = std::stoi(argv[4]);
+  InternalPixelType threshold_low = std::stoi(argv[3]);
+  InternalPixelType threshold_hi = std::stoi(argv[4]);
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());
@@ -124,11 +122,11 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   unsigned short numObjects = relabel->GetNumberOfObjects();
 
   std::vector<RGBPixelType> colormap;
-  RGBPixelType              px;
   colormap.resize(numObjects + 1);
   vnl_sample_reseed(1031571);
   for (auto & i : colormap)
   {
+    RGBPixelType px;
     px.SetRed(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
     px.SetGreen(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
     px.SetBlue(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -66,10 +66,8 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low;
-  InternalPixelType threshold_hi;
-  threshold_low = std::stoi(argv[3]);
-  threshold_hi = std::stoi(argv[4]);
+  InternalPixelType threshold_low = std::stoi(argv[3]);
+  InternalPixelType threshold_hi = std::stoi(argv[4]);
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<RGBPixelType>::OneValue());

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -42,53 +42,50 @@ DoIt(int argc, char * argv[], const std::string pixelType)
   using OutputImageType = itk::Image<PixelType, Dimension>;
   using IndexType = typename InputImageType::IndexType;
 
-  auto                                inputimg = InputImageType::New();
-  IndexType                           index{};
-  typename InputImageType::RegionType region;
-
+  auto                              inputimg = InputImageType::New();
+  IndexType                         index{};
   typename InputImageType::SizeType size;
   size[0] = width;
   size[1] = height;
 
+  typename InputImageType::RegionType region;
   region.SetSize(size);
   region.SetIndex(index);
 
   inputimg->SetRegions(region);
   inputimg->Allocate();
 
-  int       row;
-  int       col;
   IndexType myIndex;
-  for (row = 0; row < 20; ++row)
+  for (int row = 0; row < 20; ++row)
   {
-    for (col = 0; col < 20; ++col)
+    for (int col = 0; col < 20; ++col)
     {
       myIndex[1] = row;
       myIndex[0] = col;
       inputimg->SetPixel(myIndex, false);
     }
   }
-  for (row = 0; row < 15; ++row)
+  for (int row = 0; row < 15; ++row)
   {
-    for (col = 0; col < 20; ++col)
+    for (int col = 0; col < 20; ++col)
     {
       myIndex[1] = row;
       myIndex[0] = col;
       inputimg->SetPixel(myIndex, true);
     }
   }
-  for (row = 0; row < 10; ++row)
+  for (int row = 0; row < 10; ++row)
   {
-    for (col = 5; col < 15; ++col)
+    for (int col = 5; col < 15; ++col)
     {
       myIndex[1] = row;
       myIndex[0] = col;
       inputimg->SetPixel(myIndex, false);
     }
   }
-  for (row = 0; row < 7; ++row)
+  for (int row = 0; row < 7; ++row)
   {
-    for (col = 7; col < 12; ++col)
+    for (int col = 7; col < 12; ++col)
     {
       myIndex[1] = row;
       myIndex[0] = col;

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -68,10 +68,8 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  InternalPixelType threshold_low;
-  InternalPixelType threshold_hi;
-  threshold_low = std::stoi(argv[3]);
-  threshold_hi = std::stoi(argv[4]);
+  InternalPixelType threshold_low = std::stoi(argv[3]);
+  InternalPixelType threshold_hi = std::stoi(argv[4]);
 
   threshold->SetInput(reader->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());
@@ -91,16 +89,16 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
   MaskImageType::RegionType maskRegion = mask->GetLargestPossibleRegion();
   MaskImageType::SizeType   maskSize = maskRegion.GetSize();
 
-  MaskImageType::RegionType region;
-  MaskImageType::SizeType   size;
-  MaskImageType::IndexType  index;
-
   // use upper left corner
-  index.Fill(0);
+  MaskImageType::SizeType size;
   for (unsigned int i = 0; i < MaskImageType::ImageDimension; ++i)
   {
     size[i] = static_cast<unsigned long>(0.375 * maskSize[i]);
   }
+
+  MaskImageType::IndexType index;
+  index.Fill(0);
+  MaskImageType::RegionType region;
   region.SetIndex(index);
   region.SetSize(size);
 
@@ -161,11 +159,11 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
   unsigned short numObjects = relabel->GetNumberOfObjects();
 
   std::vector<RGBPixelType> colormap;
-  RGBPixelType              px;
   colormap.resize(numObjects + 1);
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer rvgen =
     itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
   rvgen->SetSeed(1031571);
+  RGBPixelType px;
   for (auto & i : colormap)
   {
     px.SetRed(static_cast<unsigned char>(255 * rvgen->GetUniformVariate(0.3333, 1.0)));

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -101,10 +101,8 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
   change->ChangeSpacingOn();
 
   // Create a binary input image to label
-  InternalPixelType threshold_low;
-  InternalPixelType threshold_hi;
-  threshold_low = std::stoi(argv[3]);
-  threshold_hi = std::stoi(argv[4]);
+  InternalPixelType threshold_low = std::stoi(argv[3]);
+  InternalPixelType threshold_hi = std::stoi(argv[4]);
 
   threshold->SetInput(change->GetOutput());
   threshold->SetInsideValue(itk::NumericTraits<InternalPixelType>::OneValue());

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
@@ -50,43 +50,38 @@ DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::PrintSelf(st
 
   os << indent << "Kappa: " << m_Kappa << std::endl;
 }
-
 template <typename TInputMesh, typename TOutputMesh>
 void
 DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::ComputeExternalForce(
   SimplexMeshGeometry *     data,
   const GradientImageType * gradientImage)
 {
-  PointType         vec_for;
-  PointType         tmp_vec_1;
-  PointType         tmp_vec_2;
-  PointType         tmp_vec_3;
   GradientIndexType coord;
-  GradientIndexType coord2;
-  GradientIndexType tmp_co_1;
-  GradientIndexType tmp_co_2;
-  GradientIndexType tmp_co_3;
-
   coord[0] = static_cast<GradientIndexValueType>(data->pos[0]);
   coord[1] = static_cast<GradientIndexValueType>(data->pos[1]);
   coord[2] = static_cast<GradientIndexValueType>(data->pos[2]);
 
+  GradientIndexType coord2;
   coord2[0] = static_cast<GradientIndexValueType>(std::ceil(data->pos[0]));
   coord2[1] = static_cast<GradientIndexValueType>(std::ceil(data->pos[1]));
   coord2[2] = static_cast<GradientIndexValueType>(std::ceil(data->pos[2]));
 
+  GradientIndexType tmp_co_1;
   tmp_co_1[0] = coord2[0];
   tmp_co_1[1] = coord[1];
   tmp_co_1[2] = coord[2];
 
+  GradientIndexType tmp_co_2;
   tmp_co_2[0] = coord[0];
   tmp_co_2[1] = coord2[1];
   tmp_co_2[2] = coord[2];
 
+  GradientIndexType tmp_co_3;
   tmp_co_3[0] = coord[0];
   tmp_co_3[1] = coord[1];
   tmp_co_3[2] = coord2[2];
 
+  PointType vec_for;
   if ((coord[0] >= 0) && (coord[1] >= 0) && (coord[2] >= 0) && (coord2[0] < this->GetImageWidth()) &&
       (coord2[1] < this->GetImageHeight()) && (coord2[2] < this->GetImageDepth()))
   {
@@ -94,12 +89,17 @@ DeformableSimplexMesh3DBalloonForceFilter<TInputMesh, TOutputMesh>::ComputeExter
     vec_for[1] = gradientImage->GetPixel(coord)[1];
     vec_for[2] = gradientImage->GetPixel(coord)[2];
 
+    PointType tmp_vec_1;
     tmp_vec_1[0] = gradientImage->GetPixel(tmp_co_1)[0] - gradientImage->GetPixel(coord)[0];
     tmp_vec_1[1] = gradientImage->GetPixel(tmp_co_1)[1] - gradientImage->GetPixel(coord)[1];
     tmp_vec_1[2] = gradientImage->GetPixel(tmp_co_1)[2] - gradientImage->GetPixel(coord)[2];
+
+    PointType tmp_vec_2;
     tmp_vec_2[0] = gradientImage->GetPixel(tmp_co_2)[0] - gradientImage->GetPixel(coord)[0];
     tmp_vec_2[1] = gradientImage->GetPixel(tmp_co_2)[1] - gradientImage->GetPixel(coord)[1];
     tmp_vec_2[2] = gradientImage->GetPixel(tmp_co_2)[2] - gradientImage->GetPixel(coord)[2];
+
+    PointType tmp_vec_3;
     tmp_vec_3[0] = gradientImage->GetPixel(tmp_co_3)[0] - gradientImage->GetPixel(coord)[0];
     tmp_vec_3[1] = gradientImage->GetPixel(tmp_co_3)[1] - gradientImage->GetPixel(coord)[1];
     tmp_vec_3[2] = gradientImage->GetPixel(tmp_co_3)[2] - gradientImage->GetPixel(coord)[2];

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -57,20 +57,18 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
   NodeType *             CenterNode = it.GetCenterPixel();
   const NormalVectorType CenterPixel = CenterNode->m_Data;
 
-  Vector<NodeValueType, ImageDimension> gradient[ImageDimension];
-  NormalVectorType                      PositiveSidePixel[2];
-  NormalVectorType                      NegativeSidePixel[2];
-  NormalVectorType                      flux;
-  SizeValueType                         stride[ImageDimension];
-
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
-
+  SizeValueType                stride[ImageDimension];
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     stride[j] = it.GetStride(j);
   }
   const auto center = it.Size() / 2;
 
+  NormalVectorType                      flux;
+  Vector<NodeValueType, ImageDimension> gradient[ImageDimension];
+  NormalVectorType                      PositiveSidePixel[2];
+  NormalVectorType                      NegativeSidePixel[2];
   for (unsigned int i = 0; i < ImageDimension; ++i) // flux offset axis
   {
     const auto PreviousNode = it.GetPrevious(i);

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -84,29 +84,24 @@ auto
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCurvatureFromSparseImageNeighborhood(
   SparseImageIteratorType & it) const -> ValueType
 {
-  unsigned int            counter;
-  SizeValueType           position;
-  SizeValueType           stride[ImageDimension];
-  SizeValueType           indicator[ImageDimension];
-  constexpr SizeValueType one = 1;
-  const SizeValueType     center = it.Size() / 2;
-  NormalVectorType        normalvector;
-  ValueType               curvature;
-  bool                    flag = false;
-
+  constexpr SizeValueType      one = 1;
+  const SizeValueType          center = it.Size() / 2;
+  bool                         flag = false;
   const NeighborhoodScalesType neighborhoodScales = this->GetDifferenceFunction()->ComputeNeighborhoodScales();
 
+  SizeValueType stride[ImageDimension];
+  SizeValueType indicator[ImageDimension];
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     stride[j] = it.GetStride(j);
     indicator[j] = one << j;
   }
 
-  curvature = ValueType{};
+  ValueType curvature = ValueType{};
 
-  for (counter = 0; counter < m_NumVertex; ++counter)
+  for (unsigned int counter = 0; counter < m_NumVertex; ++counter)
   {
-    position = center;
+    SizeValueType position = center;
     for (unsigned int k = 0; k < ImageDimension; ++k)
     {
       if (counter & indicator[k])
@@ -120,7 +115,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
     }
     else
     {
-      normalvector = it.GetPixel(position)->m_Data;
+      NormalVectorType normalvector = it.GetPixel(position)->m_Data;
       for (unsigned int j = 0; j < ImageDimension; ++j) // derivative axis
       {
         if (counter & indicator[j])
@@ -159,15 +154,12 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
   }
   SparseImageIteratorType sparseImageIterator(radius, sparseImage, sparseImage->GetRequestedRegion());
 
-  ValueType  distance;
-  NodeType * node;
-
   sparseImageIterator.GoToBegin();
   distanceImageIterator.GoToBegin();
   while (!distanceImageIterator.IsAtEnd())
   {
-    distance = distanceImageIterator.Value();
-    node = sparseImageIterator.GetCenterPixel();
+    ValueType  distance = distanceImageIterator.Value();
+    NodeType * node = sparseImageIterator.GetCenterPixel();
     if ((distance >= -m_CurvatureBandWidth) && (distance <= m_CurvatureBandWidth))
     {
       node->m_Curvature = ComputeCurvatureFromSparseImageNeighborhood(sparseImageIterator);
@@ -189,15 +181,13 @@ template <typename TInputImage, typename TOutputImage>
 bool
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ActiveLayerCheckBand() const
 {
-  typename LayerType::Iterator      layerIt;
   typename SparseImageType::Pointer im = m_LevelSetFunction->GetSparseTargetImage();
   bool                              flag = false;
-  NodeType *                        node;
 
-  layerIt = this->m_Layers[0]->Begin();
+  typename LayerType::Iterator layerIt = this->m_Layers[0]->Begin();
   while (layerIt != this->m_Layers[0]->End())
   {
-    node = im->GetPixel(layerIt->m_Value);
+    NodeType * node = im->GetPixel(layerIt->m_Value);
     if ((node == nullptr) || (node->m_CurvatureFlag == false))
     {
       // level set touching edge of normal band
@@ -213,13 +203,10 @@ template <typename TInputImage, typename TOutputImage>
 void
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ProcessNormals()
 {
-  typename NormalVectorFilterType::Pointer   NormalVectorFilter;
-  typename NormalVectorFunctionType::Pointer NormalVectorFunction;
-
   auto temp = static_cast<ValueType>(ImageDimension);
 
-  NormalVectorFilter = NormalVectorFilterType::New();
-  NormalVectorFunction = NormalVectorFunctionType::New();
+  typename NormalVectorFilterType::Pointer   NormalVectorFilter = NormalVectorFilterType::New();
+  typename NormalVectorFunctionType::Pointer NormalVectorFunction = NormalVectorFunctionType::New();
   NormalVectorFunction->SetNormalProcessType(m_NormalProcessType);
   NormalVectorFunction->SetConductanceParameter(m_NormalProcessConductance);
   NormalVectorFilter->SetNormalFunction(NormalVectorFunction);

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -55,10 +55,8 @@ circle(unsigned int x, unsigned int y)
 float
 square(unsigned int x, unsigned int y)
 {
-  float X;
-  float Y;
-  X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
-  Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
+  float X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
+  float Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS)))
   {

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -59,12 +59,9 @@ sphere(unsigned int x, unsigned int y, unsigned int z)
 float
 cube(unsigned int x, unsigned int y, unsigned int z)
 {
-  float X;
-  float Y;
-  float Z;
-  X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
-  Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
-  Z = itk::Math::abs(z - static_cast<float>(DEPTH) / 2.0);
+  float X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
+  float Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
+  float Z = itk::Math::abs(z - static_cast<float>(DEPTH) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS) && (Z > RADIUS)))
   {

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -50,10 +50,8 @@ const unsigned int WIDTH = (128);
 float
 square(unsigned int x, unsigned int y)
 {
-  float X;
-  float Y;
-  X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
-  Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
+  float X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
+  float Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS)))
   {

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -28,10 +28,8 @@ const unsigned int WIDTH = (128);
 float
 square(unsigned int x, unsigned int y)
 {
-  float X;
-  float Y;
-  X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
-  Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
+  float X = itk::Math::abs(x - static_cast<float>(WIDTH) / 2.0);
+  float Y = itk::Math::abs(y - static_cast<float>(HEIGHT) / 2.0);
   float dis;
   if (!((X > RADIUS) && (Y > RADIUS)))
   {

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -73,10 +73,7 @@ itkMRFImageFilterTest(int, char *[])
 
   // Set up the vector to store the image  data
   using DataVector = VecImageType::PixelType;
-  DataVector dblVec;
 
-  int i;
-  int k;
   int halfWidth = static_cast<int>(vecImgSize[0]) / 2;
   int halfHeight = static_cast<int>(vecImgSize[1]) / 2;
 
@@ -86,12 +83,13 @@ itkMRFImageFilterTest(int, char *[])
   // Slice 1
   //--------------------------------------------------------------------------
   // Row 1-3
-  for (k = 0; k < halfHeight; ++k)
+  DataVector dblVec;
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3
     dblVec[0] = 21;
     dblVec[1] = 19;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -99,19 +97,19 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6
     dblVec[0] = 18;
     dblVec[1] = 14;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
   }
 
   // Row 4-6
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3
     dblVec[0] = 15;
     dblVec[1] = 11;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -119,7 +117,7 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6
     dblVec[0] = 10;
     dblVec[1] = 16;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -129,12 +127,12 @@ itkMRFImageFilterTest(int, char *[])
   // Slice 2
   //--------------------------------------------------------------------------
   // Row 1-3
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
     dblVec[0] = 14;
     dblVec[1] = 20;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -142,19 +140,19 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6 Row k
     dblVec[0] = 18;
     dblVec[1] = 22;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
   }
 
   // Row 4-6
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
     dblVec[0] = 15;
     dblVec[1] = 15;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -162,7 +160,7 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6 Row k
     dblVec[0] = 12;
     dblVec[1] = 12;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -172,12 +170,12 @@ itkMRFImageFilterTest(int, char *[])
   // Slice 3
   //--------------------------------------------------------------------------
   // Row 1-3
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
     dblVec[0] = 19;
     dblVec[1] = 20;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -185,19 +183,19 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6 Row k
     dblVec[0] = 19;
     dblVec[1] = 21;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
   }
 
   // Row 4-6
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
     dblVec[0] = 12;
     dblVec[1] = 12;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -205,7 +203,7 @@ itkMRFImageFilterTest(int, char *[])
     // Vector no. 4-6 Row k
     dblVec[0] = 11;
     dblVec[1] = 10;
-    for (i = 0; i < halfWidth; ++i, ++outIt)
+    for (int i = 0; i < halfWidth; ++i, ++outIt)
     {
       outIt.Set(dblVec);
     }
@@ -243,19 +241,19 @@ itkMRFImageFilterTest(int, char *[])
   //--------------------------------------------------------------------------
   // Row 1-3
 
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
-    for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    for (int i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
     {
       classoutIt.Set(2);
     }
   }
 
   // Row 4-6
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
-    for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    for (int i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
     {
       classoutIt.Set(1);
     }
@@ -264,10 +262,10 @@ itkMRFImageFilterTest(int, char *[])
   // Slice 2
   //--------------------------------------------------------------------------
   // Row 1-6
-  for (k = 0; k < (halfHeight * 2); ++k)
+  for (int k = 0; k < (halfHeight * 2); ++k)
   {
     // Vector no. 1-3 Row k
-    for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    for (int i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
     {
       classoutIt.Set(0);
     }
@@ -276,19 +274,19 @@ itkMRFImageFilterTest(int, char *[])
   //--------------------------------------------------------------------------
   // Slice 3
   //--------------------------------------------------------------------------
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
     // Vector no. 1-3 Row k
-    for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    for (int i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
     {
       classoutIt.Set(2);
     }
   }
 
   // Row 4-6
-  for (k = 0; k < halfHeight; ++k)
+  for (int k = 0; k < halfHeight; ++k)
   {
-    for (i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
+    for (int i = 0; i < (halfWidth * 2); ++i, ++classoutIt)
     {
       classoutIt.Set(1);
     }
@@ -427,11 +425,8 @@ itkMRFImageFilterTest(int, char *[])
 
   // Define the face list for the input/labelled image
   OutImageFacesCalculator outImageFacesCalculator;
-
-  OutImageFaceListType outImageFaceList;
-
   // Compute the faces for the neighborhoods in the input/labelled image
-  outImageFaceList =
+  OutImageFaceListType outImageFaceList =
     outImageFacesCalculator(outClassImage, outClassImage->GetBufferedRegion(), outImageNeighborhoodRadius);
 
   // Set up a face list iterator
@@ -443,12 +438,11 @@ itkMRFImageFilterTest(int, char *[])
 
   int sum = 0;
   using ClassImagePixelType = ClassImageType::PixelType;
-  ClassImagePixelType * outLabel;
 
   // Loop through the labelled region and add the pixel labels
   while (!nOutImageNeighborhoodIter.IsAtEnd())
   {
-    outLabel = nOutImageNeighborhoodIter.GetCenterValue();
+    ClassImagePixelType * outLabel = nOutImageNeighborhoodIter.GetCenterValue();
     sum += static_cast<int>(*outLabel);
     ++nOutImageNeighborhoodIter;
   }

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -129,8 +129,6 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType>;
   using SecondIteratorType = FloodFilledImageFunctionConditionalConstIterator<InputImageType, SecondFunctionType>;
 
-  unsigned int loop;
-
   typename Superclass::InputImageConstPointer inputImage = this->GetInput();
   typename Superclass::OutputImagePointer     outputImage = this->GetOutput();
 
@@ -144,10 +142,6 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Set up the image function used for connectivity
   auto function = FunctionType::New();
   function->SetInputImage(inputImage);
-
-  InputRealType lower;
-  InputRealType upper;
-
   m_Mean = InputRealType{};
   m_Variance = InputRealType{};
 
@@ -228,8 +222,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     m_Variance = (sumOfSquares - (sum * sum / static_cast<double>(num))) / (static_cast<double>(num) - 1.0);
   }
 
-  lower = m_Mean - m_Multiplier * std::sqrt(m_Variance);
-  upper = m_Mean + m_Multiplier * std::sqrt(m_Variance);
+  InputRealType lower = m_Mean - m_Multiplier * std::sqrt(m_Variance);
+  InputRealType upper = m_Mean + m_Multiplier * std::sqrt(m_Variance);
 
   // Find the highest and lowest seed intensity.
   InputRealType lowestSeedIntensity = itk::NumericTraits<InputImagePixelType>::max();
@@ -293,7 +287,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   ProgressReporter progress(this, 0, region.GetNumberOfPixels() * m_NumberOfIterations);
 
-  for (loop = 0; loop < m_NumberOfIterations; ++loop)
+  for (unsigned int loop = 0; loop < m_NumberOfIterations; ++loop)
   {
     // Now that we have an initial segmentation, let's recalculate the
     // statistics.  Since we have already labelled the output, we visit
@@ -305,11 +299,9 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     secondFunction->SetInputImage(outputImage);
     secondFunction->ThresholdBetween(m_ReplaceValue, m_ReplaceValue);
 
-    typename NumericTraits<typename InputImageType::PixelType>::RealType sum;
-    typename NumericTraits<typename InputImageType::PixelType>::RealType sumOfSquares;
-    sum = InputRealType{};
-    sumOfSquares = InputRealType{};
-    typename TOutputImage::SizeValueType numberOfSamples = 0;
+    typename NumericTraits<typename InputImageType::PixelType>::RealType sum = InputRealType{};
+    typename NumericTraits<typename InputImageType::PixelType>::RealType sumOfSquares = InputRealType{};
+    typename TOutputImage::SizeValueType                                 numberOfSamples = 0;
 
     SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
     sit.GoToBegin();

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -816,11 +816,6 @@ VoronoiDiagram2DGenerator<TCoordinate>::clip_line(FortuneEdge * task)
   // Clip line
   FortuneSite * s1;
   FortuneSite * s2;
-  double        x1;
-  double        y1;
-  double        x2;
-  double        y2;
-
   if (((task->m_A) == 1.0) && ((task->m_B) >= 0.0))
   {
     s1 = task->m_Ep[1];
@@ -832,8 +827,13 @@ VoronoiDiagram2DGenerator<TCoordinate>::clip_line(FortuneEdge * task)
     s1 = task->m_Ep[0];
   }
 
-  int id1;
-  int id2;
+
+  double x1;
+  double y1;
+  double x2;
+  double y2;
+  int    id1;
+  int    id2;
   if ((task->m_A) == 1.0)
   {
     if ((s1 != nullptr) && ((s1->m_Coord[1]) > m_Pymin))
@@ -1074,33 +1074,21 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
   m_BottomSite = &(m_SeedSites[0]);
   FortuneSite * currentSite = &(m_SeedSites[1]);
 
-  PointType         currentCircle{};
-  FortuneHalfEdge * leftHalfEdge;
-  FortuneHalfEdge * rightHalfEdge;
-  FortuneHalfEdge * left2HalfEdge;
-  FortuneHalfEdge * right2HalfEdge;
-  FortuneHalfEdge * newHE;
-  FortuneSite *     findSite;
-  FortuneSite *     topSite;
-  FortuneSite *     saveSite;
-  FortuneEdge *     newEdge;
-  FortuneSite *     meetSite;
-  FortuneSite *     newVert;
-  bool              saveBool;
-
   std::vector<FortuneHalfEdge> HEpool;
-  std::vector<FortuneEdge>     Edgepool;
-  std::vector<FortuneSite>     Sitepool;
   HEpool.resize(5 * m_NumberOfSeeds);
+  std::vector<FortuneEdge> Edgepool;
   Edgepool.resize(5 * m_NumberOfSeeds);
+  std::vector<FortuneSite> Sitepool;
   Sitepool.resize(5 * m_NumberOfSeeds);
 
   int HEid = 0;
   int Edgeid = 0;
   int Siteid = 0;
 
-  unsigned int i = 2;
-  bool         ok = true;
+  unsigned int      i = 2;
+  bool              ok = true;
+  PointType         currentCircle{};
+  FortuneHalfEdge * leftHalfEdge;
   while (ok)
   {
     if (m_PQcount != 0)
@@ -1111,22 +1099,22 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
     {
       // Handling site event
       leftHalfEdge = findLeftHE(&(currentSite->m_Coord));
-      rightHalfEdge = leftHalfEdge->m_Right;
+      FortuneHalfEdge * rightHalfEdge = leftHalfEdge->m_Right;
 
-      findSite = getRightReg(leftHalfEdge);
+      FortuneSite * findSite = getRightReg(leftHalfEdge);
 
       bisect(&(Edgepool[Edgeid]), findSite, currentSite);
-      newEdge = &(Edgepool[Edgeid]);
+      FortuneEdge * newEdge = &(Edgepool[Edgeid]);
       ++Edgeid;
 
       createHalfEdge(&(HEpool[HEid]), newEdge, 0);
-      newHE = &(HEpool[HEid]);
+      FortuneHalfEdge * newHE = &(HEpool[HEid]);
       ++HEid;
 
       insertEdgeList(leftHalfEdge, newHE);
 
       intersect(&(Sitepool[Siteid]), leftHalfEdge, newHE);
-      meetSite = &(Sitepool[Siteid]);
+      FortuneSite * meetSite = &(Sitepool[Siteid]);
 
       if ((meetSite->m_Sitenbr) == -5)
       {
@@ -1160,13 +1148,13 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
       // Handling circle event
 
       leftHalfEdge = getPQmin();
-      left2HalfEdge = leftHalfEdge->m_Left;
-      rightHalfEdge = leftHalfEdge->m_Right;
-      right2HalfEdge = rightHalfEdge->m_Right;
-      findSite = getLeftReg(leftHalfEdge);
-      topSite = getRightReg(rightHalfEdge);
+      FortuneHalfEdge * left2HalfEdge = leftHalfEdge->m_Left;
+      FortuneHalfEdge * rightHalfEdge = leftHalfEdge->m_Right;
+      FortuneHalfEdge * right2HalfEdge = rightHalfEdge->m_Right;
+      FortuneSite *     findSite = getLeftReg(leftHalfEdge);
+      FortuneSite *     topSite = getRightReg(rightHalfEdge);
 
-      newVert = leftHalfEdge->m_Vert;
+      FortuneSite * newVert = leftHalfEdge->m_Vert;
       newVert->m_Sitenbr = m_Nvert;
       ++m_Nvert;
       m_OutputVD->AddVert(newVert->m_Coord);
@@ -1177,28 +1165,28 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
       deletePQ(rightHalfEdge);
       deleteEdgeList(rightHalfEdge);
 
-      saveBool = false;
+      bool saveBool = false;
       if ((findSite->m_Coord[1]) > (topSite->m_Coord[1]))
       {
-        saveSite = findSite;
+        FortuneSite * saveSite = findSite;
         findSite = topSite;
         topSite = saveSite;
         saveBool = true;
       }
 
       bisect(&(Edgepool[Edgeid]), findSite, topSite);
-      newEdge = &(Edgepool[Edgeid]);
+      FortuneEdge * newEdge = &(Edgepool[Edgeid]);
       ++Edgeid;
 
       createHalfEdge(&(HEpool[HEid]), newEdge, saveBool);
-      newHE = &(HEpool[HEid]);
+      FortuneHalfEdge * newHE = &(HEpool[HEid]);
       ++HEid;
 
       insertEdgeList(left2HalfEdge, newHE);
       makeEndPoint(newEdge, 1 - saveBool, newVert);
 
       intersect(&(Sitepool[Siteid]), left2HalfEdge, newHE);
-      meetSite = &(Sitepool[Siteid]);
+      FortuneSite * meetSite = &(Sitepool[Siteid]);
 
       if ((meetSite->m_Sitenbr) == -5)
       {
@@ -1224,7 +1212,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
   for ((leftHalfEdge = m_ELleftend.m_Right); (leftHalfEdge != (&m_ELrightend));
        (leftHalfEdge = (leftHalfEdge->m_Right)))
   {
-    newEdge = leftHalfEdge->m_Edge;
+    FortuneEdge * newEdge = leftHalfEdge->m_Edge;
     clip_line(newEdge);
   }
 }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -74,14 +74,9 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   PointTypeDeque vertlist,
   IndexList *    PixelPool)
 {
-  IndexType idx;
-  PointType currP;
-  PointType leftP;
-  PointType rightP;
-
-  currP = vertlist.front();
+  PointType currP = vertlist.front();
   vertlist.pop_front();
-  leftP = vertlist.front();
+  PointType leftP = vertlist.front();
   while (currP[1] > leftP[1])
   {
     vertlist.push_back(currP);
@@ -89,7 +84,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     vertlist.pop_front();
     leftP = vertlist.front();
   }
-  rightP = vertlist.back();
+  PointType rightP = vertlist.back();
   while (currP[1] > rightP[1])
   {
     vertlist.push_front(currP);
@@ -117,52 +112,25 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   leftP = vertlist.front();
   rightP = vertlist.back();
 
-  double beginy = currP[1];
-  auto   intbeginy = static_cast<int>(std::ceil(beginy));
-  idx[1] = intbeginy;
   double leftendy = leftP[1];
   double rightendy = rightP[1];
+  double endy = (leftendy > rightendy) ? rightendy : leftendy;
+  bool   RorL = (leftendy > rightendy) ? true : false;
+
   double beginx = currP[0];
+  double beginy = currP[1];
   double endx = currP[0];
-  double leftDx;
-  double rightDx;
-  double offset;
+  double leftDx = (Math::AlmostEquals(leftP[1], beginy)) ? 1.0 : (leftP[0] - beginx) / (leftP[1] - beginy);
+  double rightDx = (Math::AlmostEquals(rightP[1], beginy)) ? 1.0 : (rightP[0] - endx) / (rightP[1] - beginy);
+
   double leftheadx = beginx;
   double rightheadx = endx;
   double leftheady = beginy;
   double rightheady = beginy;
 
-  double endy;
-  bool   RorL;
-  int    i;
-  if (leftendy > rightendy)
-  {
-    RorL = true;
-    endy = rightendy;
-  }
-  else
-  {
-    RorL = false;
-    endy = leftendy;
-  }
-  if (Math::AlmostEquals(leftP[1], beginy))
-  {
-    leftDx = 1.0;
-  }
-  else
-  {
-    leftDx = (leftP[0] - beginx) / (leftP[1] - beginy);
-  }
-
-  if (Math::AlmostEquals(rightP[1], beginy))
-  {
-    rightDx = 1.0;
-  }
-  else
-  {
-    rightDx = (rightP[0] - endx) / (rightP[1] - beginy);
-  }
-
+  auto      intbeginy = static_cast<int>(std::ceil(beginy));
+  IndexType idx;
+  idx[1] = intbeginy;
   auto intendy = static_cast<int>(std::floor(endy));
   if (intbeginy > intendy)
   { // no scanline
@@ -185,7 +153,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     {
       beginx = leftP[0];
     }
-    for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+    for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
     {
       idx[0] = i;
       PixelPool->push_back(idx);
@@ -194,12 +162,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   }
   else
   { // normal case some scanlines
-    offset = static_cast<double>(intbeginy) - beginy;
+    double offset = static_cast<double>(intbeginy) - beginy;
     endx += offset * rightDx;
     beginx += offset * leftDx;
     while (idx[1] <= intendy)
     {
-      for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+      for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
         PixelPool->push_back(idx);
@@ -281,12 +249,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     }
     else
     { // normal case some scanlines
-      offset = static_cast<double>(intbeginy) - beginy;
+      double offset = static_cast<double>(intbeginy) - beginy;
       endx += offset * rightDx;
       beginx += offset * leftDx;
       while (idx[1] <= intendy)
       {
-        for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+        for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
         {
           idx[0] = i;
           PixelPool->push_back(idx);
@@ -339,12 +307,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       beginx = leftP[0];
       endx = rightP[0] + rightDx * (leftP[1] - rightP[1]);
     }
-    offset = static_cast<double>(intbeginy) - beginy;
+    double offset = static_cast<double>(intbeginy) - beginy;
     beginx += offset * leftDx;
     endx += offset * rightDx;
     while (idx[1] <= intendy)
     {
-      for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+      for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
         PixelPool->push_back(idx);
@@ -360,25 +328,19 @@ template <typename TInputImage, typename TOutputImage, typename TBinaryPriorImag
 void
 VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>::ClassifyDiagram()
 {
-  PointIdIterator currPit;
-  PointIdIterator currPitEnd;
-  PointType       currP;
-  PointTypeDeque  VertList;
-  IndexList       PixelPool;
-
   for (int i = 0; i < m_NumberOfSeeds; ++i)
   {
     CellAutoPointer currCell;
     m_WorkingVD->GetCellId(i, currCell);
-    currPitEnd = currCell->PointIdsEnd();
-    VertList.clear();
-    for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
+    PointIdIterator currPitEnd = currCell->PointIdsEnd();
+    PointTypeDeque  VertList;
+    for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
+      PointType currP;
       m_WorkingVD->GetPoint((*currPit), &(currP));
       VertList.push_back(currP);
     }
-
-    PixelPool.clear();
+    IndexList PixelPool;
     this->GetPixelIndexFromPolygon(VertList, &PixelPool);
     m_NumberOfPixels[i] = static_cast<int>(PixelPool.size());
     m_Label[i] = this->TestHomogeneity(PixelPool);
@@ -413,18 +375,15 @@ template <typename TInputImage, typename TOutputImage, typename TBinaryPriorImag
 void
 VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>::GenerateAddingSeeds()
 {
-  EdgeIterator eit;
-  auto         eitend = m_WorkingVD->EdgeEnd();
-  PointType    adds;
+  auto eitend = m_WorkingVD->EdgeEnd();
 
-  Point<int, 2> seeds;
-
-  for (eit = m_WorkingVD->EdgeBegin(); eit != eitend; ++eit)
+  for (EdgeIterator eit = m_WorkingVD->EdgeBegin(); eit != eitend; ++eit)
   {
-    seeds = m_WorkingVD->GetSeedsIDAroundEdge(&*eit);
+    Point<int, 2> seeds = m_WorkingVD->GetSeedsIDAroundEdge(&*eit);
     if (((m_Label[seeds[0]] == 2) || (m_Label[seeds[1]] == 2)) && (m_NumberOfPixels[seeds[0]] > m_MinRegion) &&
         (m_NumberOfPixels[seeds[1]] > m_MinRegion))
     {
+      PointType adds;
       adds[0] = (eit->m_Left[0] + eit->m_Right[0]) * 0.5;
       adds[1] = (eit->m_Left[1] + eit->m_Right[1]) * 0.5;
       m_SeedsToAdded.push_back(adds);
@@ -568,14 +527,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     ++oit;
   }
 
-  NeighborIdIterator nit;
-  NeighborIdIterator nitend;
   for (int i = 0; i < m_NumberOfSeeds; ++i)
   {
     if (m_Label[i] == 2)
     {
-      nitend = m_WorkingVD->NeighborIdsEnd(i);
-      for (nit = m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
+      NeighborIdIterator nitend = m_WorkingVD->NeighborIdsEnd(i);
+      for (NeighborIdIterator nit = m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
       {
         if (((*nit) > i) && (m_Label[*nit] == 2))
         {
@@ -598,20 +555,18 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     oit.Set(0);
     ++oit;
   }
-  PointIdIterator currPit;
-  PointIdIterator currPitEnd;
-  PointType       currP;
-  PointTypeDeque  VertList;
+
   for (int i = 0; i < m_NumberOfSeeds; ++i)
   {
     if (m_Label[i] == 1)
     {
       CellAutoPointer currCell;
       m_WorkingVD->GetCellId(i, currCell);
-      currPitEnd = currCell->PointIdsEnd();
-      VertList.clear();
-      for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
+      PointIdIterator currPitEnd = currCell->PointIdsEnd();
+      PointTypeDeque  VertList;
+      for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
       {
+        PointType currP;
         m_WorkingVD->GetPoint((*currPit), &(currP));
         VertList.push_back(currP);
       }
@@ -626,15 +581,10 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
                                                                                               OutputPixelType color)
 {
   TOutputImage * output = this->GetOutput();
-  IndexType      idx;
 
-  PointType currP;
-  PointType leftP;
-  PointType rightP;
-
-  currP = vertlist.front();
+  PointType currP = vertlist.front();
   vertlist.pop_front();
-  leftP = vertlist.front();
+  PointType leftP = vertlist.front();
   while (currP[1] > leftP[1])
   {
     vertlist.push_back(currP);
@@ -642,7 +592,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     vertlist.pop_front();
     leftP = vertlist.front();
   }
-  rightP = vertlist.back();
+  PointType rightP = vertlist.back();
   while (currP[1] > rightP[1])
   {
     vertlist.push_front(currP);
@@ -670,50 +620,26 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   leftP = vertlist.front();
   rightP = vertlist.back();
 
-  double beginy = currP[1];
-  auto   intbeginy = static_cast<int>(std::ceil(beginy));
+  double    beginy = currP[1];
+  auto      intbeginy = static_cast<int>(std::ceil(beginy));
+  IndexType idx;
   idx[1] = intbeginy;
   double leftendy = leftP[1];
   double rightendy = rightP[1];
   double beginx = currP[0];
   double endx = currP[0];
-  double leftDx;
-  double rightDx;
-  double offset;
+
   double leftheadx = beginx;
   double rightheadx = endx;
   double leftheady = beginy;
   double rightheady = beginy;
 
-  double endy;
-  bool   RorL;
-  int    i;
-  if (leftendy > rightendy)
-  {
-    RorL = true;
-    endy = rightendy;
-  }
-  else
-  {
-    RorL = false;
-    endy = leftendy;
-  }
-  if (Math::AlmostEquals(leftP[1], beginy))
-  {
-    leftDx = 1.0;
-  }
-  else
-  {
-    leftDx = (leftP[0] - beginx) / (leftP[1] - beginy);
-  }
-  if (Math::AlmostEquals(rightP[1], beginy))
-  {
-    rightDx = 1.0;
-  }
-  else
-  {
-    rightDx = (rightP[0] - endx) / (rightP[1] - beginy);
-  }
+  double endy = (leftendy > rightendy) ? rightendy : leftendy;
+  bool   RorL = (leftendy > rightendy) ? true : false;
+
+  double leftDx = (Math::AlmostEquals(leftP[1], beginy)) ? 1.0 : (leftP[0] - beginx) / (leftP[1] - beginy);
+  double rightDx = (Math::AlmostEquals(rightP[1], beginy)) ? 1.0 : (rightP[0] - endx) / (rightP[1] - beginy);
+
   auto intendy = static_cast<int>(std::floor(endy));
   if (intbeginy > intendy)
   { // no scanline
@@ -736,7 +662,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     {
       beginx = leftP[0];
     }
-    for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+    for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
     {
       idx[0] = i;
       output->SetPixel(idx, color);
@@ -745,12 +671,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   }
   else
   { // normal case some scanlines
-    offset = static_cast<double>(intbeginy) - beginy;
+    double offset = static_cast<double>(intbeginy) - beginy;
     endx += offset * rightDx;
     beginx += offset * leftDx;
     while (idx[1] <= intendy)
     {
-      for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+      for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
         output->SetPixel(idx, color);
@@ -832,12 +758,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     }
     else
     { // normal case some scanlines
-      offset = static_cast<double>(intbeginy) - beginy;
+      double offset = static_cast<double>(intbeginy) - beginy;
       endx += offset * rightDx;
       beginx += offset * leftDx;
       while (idx[1] <= intendy)
       {
-        for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+        for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
         {
           idx[0] = i;
           output->SetPixel(idx, color);
@@ -890,12 +816,12 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       beginx = leftP[0];
       endx = rightP[0] + rightDx * (leftP[1] - rightP[1]);
     }
-    offset = static_cast<double>(intbeginy) - beginy;
+    double offset = static_cast<double>(intbeginy) - beginy;
     beginx += offset * leftDx;
     endx += offset * rightDx;
     while (idx[1] <= intendy)
     {
-      for (i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
+      for (int i = static_cast<int>(std::ceil(beginx)); i <= static_cast<int>(std::floor(endx)); ++i)
       {
         idx[0] = i;
         output->SetPixel(idx, color);
@@ -935,23 +861,22 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     --y2;
   }
 
-  int       dx = x1 - x2;
-  int       adx = (dx > 0) ? dx : -dx;
-  int       dy = y1 - y2;
-  int       ady = (dy > 0) ? dy : -dy;
-  int       save;
-  float     curr;
-  IndexType idx;
+  int dx = x1 - x2;
+  int adx = (dx > 0) ? dx : -dx;
+  int dy = y1 - y2;
+  int ady = (dy > 0) ? dy : -dy;
+
+
   if (adx > ady)
   {
     if (x1 > x2)
     {
-      save = x1;
+      int save = x1;
       x1 = x2;
       x2 = save;
       y1 = y2;
     }
-    curr = static_cast<float>(y1);
+    float curr = static_cast<float>(y1);
     if (dx == 0)
     {
       dx = 1;
@@ -959,8 +884,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     float offset = static_cast<float>(dy) / dx;
     for (int i = x1; i <= x2; ++i)
     {
-      idx[0] = i;
-      idx[1] = y1;
+      IndexType idx = { i, y1 };
       output->SetPixel(idx, 1);
       curr += offset;
       y1 = static_cast<int>(curr + 0.5);
@@ -971,11 +895,11 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     if (y1 > y2)
     {
       x1 = x2;
-      save = y1;
+      int save = y1;
       y1 = y2;
       y2 = save;
     }
-    curr = static_cast<float>(x1);
+    float curr = static_cast<float>(x1);
     if (dy == 0)
     {
       dy = 1;
@@ -983,8 +907,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     float offset = static_cast<float>(dx) / dy;
     for (int i = y1; i <= y2; ++i)
     {
-      idx[0] = x1;
-      idx[1] = i;
+      IndexType idx = { x1, i };
       output->SetPixel(idx, 1);
       curr += offset;
       x1 = static_cast<int>(curr + 0.5);
@@ -1057,25 +980,23 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   {
     --y2;
   }
-  int       dx = x1 - x2;
-  int       adx = (dx > 0) ? dx : -dx;
-  int       dy = y1 - y2;
-  int       ady = (dy > 0) ? dy : -dy;
-  int       save;
-  float     curr;
-  IndexType idx;
+  int dx = x1 - x2;
+  int adx = (dx > 0) ? dx : -dx;
+  int dy = y1 - y2;
+  int ady = (dy > 0) ? dy : -dy;
+
   if (adx > ady)
   {
     if (x1 > x2)
     {
-      save = x1;
+      int save = x1;
       x1 = x2;
       x2 = save;
       save = y1;
       y1 = y2;
       y2 = save;
     }
-    curr = static_cast<float>(y1);
+    float curr = static_cast<float>(y1);
     if (dx == 0)
     {
       dx = 1;
@@ -1083,8 +1004,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     float offset = static_cast<float>(dy) / dx;
     for (int i = x1; i <= x2; ++i)
     {
-      idx[0] = i;
-      idx[1] = y1;
+      IndexType idx{ i, y1 };
       result->SetPixel(idx, color);
       curr += offset;
       y1 = static_cast<int>(curr + 0.5);
@@ -1094,14 +1014,14 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   {
     if (y1 > y2)
     {
-      save = x1;
+      int save = x1;
       x1 = x2;
       x2 = save;
       save = y1;
       y1 = y2;
       y2 = save;
     }
-    curr = static_cast<float>(x1);
+    float curr = static_cast<float>(x1);
     if (dy == 0)
     {
       dy = 1;
@@ -1109,8 +1029,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     float offset = static_cast<float>(dx) / dy;
     for (int i = y1; i <= y2; ++i)
     {
-      idx[0] = x1;
-      idx[1] = i;
+      IndexType idx = { x1, i };
       result->SetPixel(idx, color);
       curr += offset;
       x1 = static_cast<int>(curr + 0.5);

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -61,13 +61,11 @@ itkIsolatedWatershedImageFilterTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, IsolatedWatershedImageFilter, ImageToImageFilter);
 
-
   filter->SetInput(reader->GetOutput());
 
-
   FilterType::IndexType seed1;
-  FilterType::IndexType seed2;
   seed1.Fill(0);
+  FilterType::IndexType seed2;
   seed2.Fill(0);
 
   // Test the seeds being outside the input image exception

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -277,17 +277,13 @@ VideoSource<TOutputVideoStream>::SplitRequestedSpatialRegion(
 
   const typename TOutputVideoStream::SizeType & requestedRegionSize = framePtr->GetRequestedRegion().GetSize();
 
-  int                                    splitAxis;
-  typename TOutputVideoStream::IndexType splitIndex;
-  typename TOutputVideoStream::SizeType  splitSize;
-
   // Initialize the splitRegion to the output requested region
   splitRegion = framePtr->GetRequestedRegion();
-  splitIndex = splitRegion.GetIndex();
-  splitSize = splitRegion.GetSize();
+  typename TOutputVideoStream::IndexType splitIndex = splitRegion.GetIndex();
+  typename TOutputVideoStream::SizeType  splitSize = splitRegion.GetSize();
 
   // split on the outermost dimension available
-  splitAxis = framePtr->GetImageDimension() - 1;
+  int splitAxis = framePtr->GetImageDimension() - 1;
   while (requestedRegionSize[splitAxis] == 1)
   {
     --splitAxis;
@@ -343,20 +339,15 @@ template <typename TOutputVideoStream>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 VideoSource<TOutputVideoStream>::ThreaderCallback(void * arg)
 {
-  ThreadStruct * str;
-  int            total;
-  int            workUnitID;
-  int            threadCount;
+  int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  int threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-
-  str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  ThreadStruct * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
   typename TOutputVideoStream::SpatialRegionType splitRegion;
-  total = str->Filter->SplitRequestedSpatialRegion(workUnitID, threadCount, splitRegion);
+  int total = str->Filter->SplitRequestedSpatialRegion(workUnitID, threadCount, splitRegion);
 
   if (workUnitID < total)
   {


### PR DESCRIPTION
Changes for preferring initialization to assignment.

This involved moving variable initialization to
the smallest possible scope.

The more locally scoped variables allow for future
automated code refactorings.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
