### PR TITLE
STYLE: Replace `T var; var.Fill(x)` with `auto var = MakeFilled<T>(x)`

### DIFF
--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -442,8 +442,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using MatrixType =
     itk::Matrix<itk::SpacePrecisionType, Dimension, Dimension>;
-  MatrixType SpacingMatrix;
-  SpacingMatrix.Fill(0.0F);
+  auto SpacingMatrix = itk::MakeFilled<MatrixType>(0.0F);
 
   const ImageType::SpacingType & ImageSpacing = image->GetSpacing();
   SpacingMatrix(0, 0) = ImageSpacing[0];

--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -170,8 +170,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   // coordinates of the center of the first pixel in N-D
-  ImageType::PointType newOrigin;
-  newOrigin.Fill(0.0);
+  ImageType::PointType newOrigin{};
   image->SetOrigin(newOrigin);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/DataRepresentation/Image/Image5.cxx
+++ b/Examples/DataRepresentation/Image/Image5.cxx
@@ -117,8 +117,7 @@ main(int argc, char * argv[])
   size[1] = 200; // size along Y
   size[2] = 200; // size along Z
 
-  ImportFilterType::IndexType start;
-  start.Fill(0);
+  ImportFilterType::IndexType start{};
 
   ImportFilterType::RegionType region;
   region.SetIndex(start);

--- a/Examples/Filtering/GaussianBlurImageFunction.cxx
+++ b/Examples/Filtering/GaussianBlurImageFunction.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   auto gaussianFunction = GFunctionType::New();
   gaussianFunction->SetInputImage(inputImage);
 
-  GFunctionType::ErrorArrayType setError;
-  setError.Fill(0.01);
+  auto setError = itk::MakeFilled<GFunctionType::ErrorArrayType>(0.01);
   gaussianFunction->SetMaximumError(setError);
   gaussianFunction->SetSigma(std::stod(argv[3]));
   gaussianFunction->SetMaximumKernelWidth(std::stoi(argv[4]));

--- a/Examples/Filtering/ResampleImageFilter6.cxx
+++ b/Examples/Filtering/ResampleImageFilter6.cxx
@@ -69,8 +69,7 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  PixelType defaultValue;
-  defaultValue.Fill(50);
+  auto defaultValue = itk::MakeFilled<PixelType>(50);
 
   filter->SetDefaultPixelValue(defaultValue);
   // Software Guide : EndCodeSnippet

--- a/Examples/Filtering/ResampleImageFilter9.cxx
+++ b/Examples/Filtering/ResampleImageFilter9.cxx
@@ -95,8 +95,7 @@ main(int argc, char * argv[])
   linearFilter->SetTransform(transform);
 
   // Software Guide : BeginCodeSnippet
-  PixelType defaultValue;
-  defaultValue.Fill(50);
+  auto defaultValue = itk::MakeFilled<PixelType>(50);
   nearestFilter->SetDefaultPixelValue(defaultValue);
   linearFilter->SetDefaultPixelValue(defaultValue);
   // Software Guide : EndCodeSnippet

--- a/Examples/IO/TransformReadWrite.cxx
+++ b/Examples/IO/TransformReadWrite.cxx
@@ -55,9 +55,8 @@ main(int argc, char * argv[])
   auto composite = CompositeTransformType::New();
 
   using AffineTransformType = itk::AffineTransform<ScalarType, Dimension>;
-  auto                                affine = AffineTransformType::New();
-  AffineTransformType::InputPointType cor;
-  cor.Fill(12);
+  auto affine = AffineTransformType::New();
+  auto cor = itk::MakeFilled<AffineTransformType::InputPointType>(12);
   affine->SetCenter(cor);
 
   composite->AddTransform(affine);
@@ -76,10 +75,9 @@ main(int argc, char * argv[])
 
   auto bspline = BSplineTransformType::New();
 
-  BSplineTransformType::OriginType origin;
-  origin.Fill(100);
-  BSplineTransformType::PhysicalDimensionsType dimensions;
-  dimensions.Fill(1.5 * 9.0);
+  auto origin = itk::MakeFilled<BSplineTransformType::OriginType>(100);
+  auto dimensions =
+    itk::MakeFilled<BSplineTransformType::PhysicalDimensionsType>(1.5 * 9.0);
 
   bspline->SetTransformDomainOrigin(origin);
   bspline->SetTransformDomainPhysicalDimensions(dimensions);

--- a/Examples/Iterators/NeighborhoodIterators1.cxx
+++ b/Examples/Iterators/NeighborhoodIterators1.cxx
@@ -118,8 +118,7 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  NeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(1);
+  auto radius = itk::MakeFilled<NeighborhoodIteratorType::RadiusType>(1);
   NeighborhoodIteratorType it(
     radius, reader->GetOutput(), reader->GetOutput()->GetRequestedRegion());
   // Software Guide : EndCodeSnippet

--- a/Examples/Iterators/NeighborhoodIterators5.cxx
+++ b/Examples/Iterators/NeighborhoodIterators5.cxx
@@ -128,8 +128,8 @@ main(int argc, char ** argv)
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  NeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(gaussianOperator.GetRadius()[0]);
+  auto radius = itk::MakeFilled<NeighborhoodIteratorType::RadiusType>(
+    gaussianOperator.GetRadius()[0]);
   // Software Guide EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -164,8 +164,7 @@ main(int argc, char ** argv)
   bool flag = true;
   while (flag == true)
   {
-    NeighborhoodIteratorType::OffsetType nextMove;
-    nextMove.Fill(0);
+    NeighborhoodIteratorType::OffsetType nextMove{};
 
     flag = false;
 

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -141,8 +141,7 @@ main(int argc, char ** argv)
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  NeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(1);
+  auto radius = itk::MakeFilled<NeighborhoodIteratorType::RadiusType>(1);
   NeighborhoodIteratorType it(radius, input, input->GetRequestedRegion());
 
   it.SetLocation(index);

--- a/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
@@ -111,8 +111,8 @@ main(int argc, char ** argv)
 
   // Software Guide : BeginCodeSnippet
   unsigned int element_radius = std::stoi(argv[3]);
-  ShapedNeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(element_radius);
+  auto radius = itk::MakeFilled<ShapedNeighborhoodIteratorType::RadiusType>(
+    element_radius);
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
@@ -76,8 +76,8 @@ main(int argc, char ** argv)
   FaceCalculatorType::FaceListType           faceList;
   FaceCalculatorType::FaceListType::iterator fit;
 
-  ShapedNeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(element_radius);
+  auto radius = itk::MakeFilled<ShapedNeighborhoodIteratorType::RadiusType>(
+    element_radius);
 
   faceList =
     faceCalculator(reader->GetOutput(), output->GetRequestedRegion(), radius);

--- a/Examples/RegistrationITKv4/DeformableRegistration4.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration4.cxx
@@ -177,8 +177,8 @@ main(int argc, char * argv[])
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
-  TransformType::MeshSizeType meshSize;
-  meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
+  auto meshSize = itk::MakeFilled<TransformType::MeshSizeType>(
+    numberOfGridNodesInOneDimension - SplineOrder);
 
   transformInitializer->SetTransform(transform);
   transformInitializer->SetImage(fixedImage);

--- a/Examples/RegistrationITKv4/DeformableRegistration6.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration6.cxx
@@ -223,8 +223,8 @@ main(int argc, char * argv[])
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
-  TransformType::MeshSizeType meshSize;
-  meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
+  auto meshSize = itk::MakeFilled<TransformType::MeshSizeType>(
+    numberOfGridNodesInOneDimension - SplineOrder);
 
   transformInitializer->SetTransform(outputBSplineTransform);
   transformInitializer->SetImage(fixedImage);

--- a/Examples/RegistrationITKv4/DeformableRegistration7.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration7.cxx
@@ -214,8 +214,8 @@ main(int argc, char * argv[])
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
-  TransformType::MeshSizeType meshSize;
-  meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
+  auto meshSize = itk::MakeFilled<TransformType::MeshSizeType>(
+    numberOfGridNodesInOneDimension - SplineOrder);
 
   transformInitializer->SetTransform(outputBSplineTransform);
   transformInitializer->SetImage(fixedImage);

--- a/Examples/RegistrationITKv4/DeformableRegistration8.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration8.cxx
@@ -207,8 +207,8 @@ main(int argc, char * argv[])
 
   auto transformInitializer = InitializerType::New();
 
-  TransformType::MeshSizeType meshSize;
-  meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
+  auto meshSize = itk::MakeFilled<TransformType::MeshSizeType>(
+    numberOfGridNodesInOneDimension - SplineOrder);
 
   transformInitializer->SetTransform(transform);
   transformInitializer->SetImage(fixedImage);

--- a/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
@@ -217,8 +217,7 @@ main(int argc, char * argv[])
 
   pointsToImageFilter->SetInput(fixedPointSet);
 
-  BinaryImageType::SpacingType spacing;
-  spacing.Fill(1.0);
+  auto spacing = itk::MakeFilled<BinaryImageType::SpacingType>(1.0);
 
   BinaryImageType::PointType origin{};
   // Software Guide : EndCodeSnippet

--- a/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
@@ -220,8 +220,7 @@ main(int argc, char * argv[])
   BinaryImageType::SpacingType spacing;
   spacing.Fill(1.0);
 
-  BinaryImageType::PointType origin;
-  origin.Fill(0.0);
+  BinaryImageType::PointType origin{};
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Segmentation/GibbsPriorImageFilter1.cxx
+++ b/Examples/Segmentation/GibbsPriorImageFilter1.cxx
@@ -113,8 +113,7 @@ main(int argc, char * argv[])
   using VecImagePixelType = VecImageType::PixelType;
   VecImageType::SizeType vecImgSize = { { 181, 217, 1 } };
 
-  VecImageType::IndexType index;
-  index.Fill(0);
+  VecImageType::IndexType index{};
 
   VecImageType::RegionType region;
 

--- a/Examples/SpatialObjects/ArrowSpatialObject.cxx
+++ b/Examples/SpatialObjects/ArrowSpatialObject.cxx
@@ -83,8 +83,7 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ArrowType::VectorType direction;
-  direction.Fill(0);
+  ArrowType::VectorType direction{};
   direction[1] = 1.0;
   myArrow->SetDirectionInObjectSpace(direction);
   // Software Guide : EndCodeSnippet

--- a/Examples/SpatialObjects/ArrowSpatialObject.cxx
+++ b/Examples/SpatialObjects/ArrowSpatialObject.cxx
@@ -54,8 +54,7 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ArrowType::PointType pos;
-  pos.Fill(1);
+  auto pos = itk::MakeFilled<ArrowType::PointType>(1);
   myArrow->SetPositionInObjectSpace(pos);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/EllipseSpatialObject.cxx
+++ b/Examples/SpatialObjects/EllipseSpatialObject.cxx
@@ -97,16 +97,14 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  itk::Point<double, 3> insidePoint;
-  insidePoint.Fill(1.0);
+  auto insidePoint = itk::MakeFilled<itk::Point<double, 3>>(1.0);
   if (myEllipse->IsInsideInWorldSpace(insidePoint))
   {
     std::cout << "The point " << insidePoint;
     std::cout << " is really inside the ellipse" << std::endl;
   }
 
-  itk::Point<double, 3> outsidePoint;
-  outsidePoint.Fill(3.0);
+  auto outsidePoint = itk::MakeFilled<itk::Point<double, 3>>(3.0);
   if (!myEllipse->IsInsideInWorldSpace(outsidePoint))
   {
     std::cout << "The point " << outsidePoint;

--- a/Examples/SpatialObjects/GroupSpatialObject.cxx
+++ b/Examples/SpatialObjects/GroupSpatialObject.cxx
@@ -72,8 +72,7 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GroupType::VectorType offset;
-  offset.Fill(10);
+  auto offset = itk::MakeFilled<GroupType::VectorType>(10);
   myGroup->GetModifiableObjectToParentTransform()->SetOffset(offset);
   myGroup->Update();
   // Software Guide : EndCodeSnippet
@@ -88,8 +87,7 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GroupType::PointType point;
-  point.Fill(10);
+  auto point = itk::MakeFilled<GroupType::PointType>(10);
   std::cout << "Is my point " << point
             << " inside?: " << myGroup->IsInsideInWorldSpace(point, 2)
             << std::endl;

--- a/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
@@ -124,12 +124,10 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageMaskSpatialObject::PointType inside;
-  inside.Fill(20);
+  auto inside = itk::MakeFilled<ImageMaskSpatialObject::PointType>(20);
   std::cout << "Is my point " << inside << " inside my mask? "
             << maskSO->IsInsideInWorldSpace(inside) << std::endl;
-  ImageMaskSpatialObject::PointType outside;
-  outside.Fill(45);
+  auto outside = itk::MakeFilled<ImageMaskSpatialObject::PointType>(45);
   std::cout << "Is my point " << outside << " outside my mask? "
             << !maskSO->IsInsideInWorldSpace(outside) << std::endl;
   // Software Guide : EndCodeSnippet

--- a/Examples/SpatialObjects/ImageSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageSpatialObject.cxx
@@ -105,8 +105,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using Point = itk::Point<double, 2>;
-  Point insidePoint;
-  insidePoint.Fill(9);
+  auto insidePoint = itk::MakeFilled<Point>(9);
 
   if (imageSO->IsInsideInWorldSpace(insidePoint))
   {

--- a/Examples/SpatialObjects/MeshSpatialObject.cxx
+++ b/Examples/SpatialObjects/MeshSpatialObject.cxx
@@ -134,8 +134,7 @@ main(int, char *[])
     << "Mesh bounds : "
     << myMeshSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds()
     << std::endl;
-  MeshSpatialObjectType::PointType myPhysicalPoint;
-  myPhysicalPoint.Fill(1);
+  auto myPhysicalPoint = itk::MakeFilled<MeshSpatialObjectType::PointType>(1);
   std::cout << "Is my physical point inside? : "
             << myMeshSpatialObject->IsInsideInWorldSpace(myPhysicalPoint)
             << std::endl;

--- a/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
+++ b/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
@@ -66,8 +66,7 @@ main(int, char *[])
   using EllipseType = itk::EllipseSpatialObject<2>;
   auto ellipse = EllipseType::New();
   ellipse->SetRadiusInObjectSpace(2);
-  EllipseType::PointType offset;
-  offset.Fill(5);
+  auto offset = itk::MakeFilled<EllipseType::PointType>(5);
   ellipse->SetCenterInObjectSpace(offset);
   ellipse->Update();
   // Software Guide : EndCodeSnippet

--- a/Examples/Statistics/GaussianMembershipFunction.cxx
+++ b/Examples/Statistics/GaussianMembershipFunction.cxx
@@ -99,8 +99,7 @@ main(int, char *[])
   densityFunction->SetMean(mean);
   densityFunction->SetCovariance(cov);
 
-  MeasurementVectorType mv;
-  mv.Fill(0);
+  MeasurementVectorType mv{};
 
   std::cout << densityFunction->Evaluate(mv) << std::endl;
   // Software Guide : EndCodeSnippet

--- a/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
+++ b/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
@@ -27,13 +27,13 @@ template <typename TIterator>
 TIterator *
 setConnectivity(TIterator * it, bool fullyConnected = false)
 {
-  typename TIterator::OffsetType offset;
+
   it->ClearActiveList();
   if (!fullyConnected)
   {
     // only activate the neighbors that are face connected
     // to the current pixel. do not include the center pixel
-    offset.Fill(0);
+    typename TIterator::OffsetType offset{};
     for (unsigned int d = 0; d < TIterator::Dimension; ++d)
     {
       offset[d] = -1;
@@ -50,11 +50,11 @@ setConnectivity(TIterator * it, bool fullyConnected = false)
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
     for (unsigned int d = 0; d < centerIndex * 2 + 1; ++d)
     {
-      offset = it->GetOffset(d);
+      typename TIterator::OffsetType offset = it->GetOffset(d);
       it->ActivateOffset(offset);
     }
-    offset.Fill(0);
-    it->DeactivateOffset(offset);
+    typename TIterator::OffsetType offset_zeros{};
+    it->DeactivateOffset(offset_zeros);
   }
   return it;
 }
@@ -64,13 +64,13 @@ TIterator *
 setConnectivityPrevious(TIterator * it, bool fullyConnected = false)
 {
   // activate the "previous" neighbours
-  typename TIterator::OffsetType offset;
+
   it->ClearActiveList();
   if (!fullyConnected)
   {
     // only activate the neighbors that are face connected
     // to the current pixel. do not include the center pixel
-    offset.Fill(0);
+    typename TIterator::OffsetType offset{};
     for (unsigned int d = 0; d < TIterator::Dimension; ++d)
     {
       offset[d] = -1;
@@ -85,11 +85,11 @@ setConnectivityPrevious(TIterator * it, bool fullyConnected = false)
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
     for (unsigned int d = 0; d < centerIndex; ++d)
     {
-      offset = it->GetOffset(d);
+      typename TIterator::OffsetType offset = it->GetOffset(d);
       it->ActivateOffset(offset);
     }
-    offset.Fill(0);
-    it->DeactivateOffset(offset);
+    typename TIterator::OffsetType offset_zeros{};
+    it->DeactivateOffset(offset_zeros);
   }
   return it;
 }
@@ -99,13 +99,13 @@ TIterator *
 setConnectivityLater(TIterator * it, bool fullyConnected = false)
 {
   // activate the "later" neighbours
-  typename TIterator::OffsetType offset;
+
   it->ClearActiveList();
   if (!fullyConnected)
   {
     // only activate the neighbors that are face connected
     // to the current pixel. do not include the center pixel
-    offset.Fill(0);
+    typename TIterator::OffsetType offset{};
     for (unsigned int d = 0; d < TIterator::Dimension; ++d)
     {
       offset[d] = 1;
@@ -120,11 +120,11 @@ setConnectivityLater(TIterator * it, bool fullyConnected = false)
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
     for (unsigned int d = centerIndex + 1; d < 2 * centerIndex + 1; ++d)
     {
-      offset = it->GetOffset(d);
+      typename TIterator::OffsetType offset = it->GetOffset(d);
       it->ActivateOffset(offset);
     }
-    offset.Fill(0);
-    it->DeactivateOffset(offset);
+    typename TIterator::OffsetType offset_zeros{};
+    it->DeactivateOffset(offset_zeros);
   }
   return it;
 }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -651,8 +651,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::SetPixelPointers(const In
   const OffsetValueType * OffsetTable = m_ConstImage->GetOffsetTable();
   const SizeType          radius = this->GetRadius();
 
-  SizeType loop;
-  loop.Fill(0);
+  SizeType loop{};
 
   // Find first "upper-left-corner"  pixel address of neighborhood
   InternalPixelType * Iit = ptr->GetBufferPointer() + ptr->ComputeOffset(pos);

--- a/Modules/Core/Common/include/itkCrossHelper.h
+++ b/Modules/Core/Common/include/itkCrossHelper.h
@@ -49,27 +49,14 @@ public:
   VectorType
   operator()(const VectorType & iU, const VectorType & iV) const
   {
-    VectorType oCross;
+    VectorType oCross{};
 
     if constexpr (Dimension > 2)
     {
       oCross[0] = iU[1] * iV[2] - iV[1] * iU[2];
       oCross[1] = iV[0] * iU[2] - iU[0] * iV[2];
       oCross[2] = iU[0] * iV[1] - iV[0] * iU[1];
-
-      if constexpr (Dimension > 3)
-      {
-        for (unsigned int dim = 3; dim < Dimension; ++dim)
-        {
-          oCross[dim] = 0.0;
-        }
-      }
     }
-    else
-    {
-      oCross.Fill(0.);
-    }
-
     return oCross;
   }
 };

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -240,10 +240,11 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
     }
 
     using InputPointType = Point<SpacePrecisionType, InputImageType::ImageDimension>;
+    const InputPointType inputPoint =
+      inputImage->template TransformContinuousIndexToPhysicalPoint<SpacePrecisionType, SpacePrecisionType>(
+        currentInputCornerIndex);
     using OutputPointType = Point<SpacePrecisionType, OutputImageType::ImageDimension>;
-    InputPointType  inputPoint;
-    OutputPointType outputPoint;
-    inputImage->TransformContinuousIndexToPhysicalPoint(currentInputCornerIndex, inputPoint);
+    OutputPointType outputPoint{};
     if (transform != nullptr)
     {
       outputPoint = transform->TransformPoint(inputPoint);
@@ -253,7 +254,6 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
       // if InputDimension < OutputDimension then embed point in Output space.
       // else if InputDimension == OutputDimension copy the points.
       // else if InputDimension > OutputDimension project the point to first N-Dimensions of Output space.
-      outputPoint.Fill(0.0);
       for (unsigned int d = 0; d < std::min(inputPoint.GetPointDimension(), outputPoint.GetPointDimension()); ++d)
       {
         outputPoint[d] = inputPoint[d];

--- a/Modules/Core/Common/include/itkImageIORegion.h
+++ b/Modules/Core/Common/include/itkImageIORegion.h
@@ -251,11 +251,8 @@ public:
           ImageRegionType &         outImageRegion,
           const ImageIndexType &    largestRegionIndex)
   {
-    ImageSizeType  size;
-    ImageIndexType index;
-
-    size.Fill(1); // initialize with default values
-    index.Fill(0);
+    auto           size = MakeFilled<ImageSizeType>(1); // initialize with default values
+    ImageIndexType index{};
 
     //
     // The ImageRegion and ImageIORegion objects may have different dimensions.

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -231,12 +231,9 @@ ImageRegion<VImageDimension>::Slice(const unsigned int dim) const -> SliceRegion
       "The dimension to remove: " << dim << " is greater than the dimension of the image: " << VImageDimension);
   }
 
-  Index<SliceDimension> sliceIndex;
-  Size<SliceDimension>  sliceSize;
-
-  sliceIndex.Fill(0);
-  sliceSize.Fill(0);
-  unsigned int ii = 0;
+  Index<SliceDimension> sliceIndex{};
+  Size<SliceDimension>  sliceSize{};
+  unsigned int          ii = 0;
   for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (i != dim)

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -70,12 +70,7 @@ template <typename TPixel, unsigned int VDimension, typename TContainer>
 void
 Neighborhood<TPixel, VDimension, TContainer>::SetRadius(const SizeValueType s)
 {
-  SizeType k;
-
-  for (DimensionValueType i = 0; i < VDimension; ++i)
-  {
-    k[i] = s;
-  }
+  auto k = MakeFilled<SizeType>(s);
   this->SetRadius(k);
 }
 

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -295,11 +295,10 @@ TriangleCell<TCellInterface>::ComputeBarycenter(CoordinateType * iWeights, Point
     p[i] = iPoints->GetElement(m_PointIds[i]);
   }
 
-  PointType oP;
+  PointType oP{};
 
   if (sum_weights != 0.)
   {
-    oP.Fill(0.);
     for (i = 0; i < 3; ++i)
     {
       oP += p[i].GetVectorFromOrigin() * iWeights[i] / sum_weights;

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -106,14 +106,11 @@ TriangleHelper<TPoint>::ComputeBarycenter(const CoordinateType & iA1,
                                           const CoordinateType & iA3,
                                           const PointType &      iP3) -> PointType
 {
-  PointType oPt;
-
   CoordinateType total = iA1 + iA2 + iA3;
-
+  PointType      oPt{};
   if (Math::AlmostEquals(total, CoordinateType{}))
   {
     // in such case there is no barycenter;
-    oPt.Fill(0.);
     return oPt;
   }
 

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -220,9 +220,8 @@ itkConstantBoundaryConditionTest(int, char *[])
 
   // Test 1
   std::cout << "GetInputRequestedRegion() Test 1" << std::endl;
-  IndexType requestIndex;
-  requestIndex.Fill(0);
-  SizeType requestSize;
+  IndexType requestIndex{};
+  SizeType  requestSize;
   requestSize.Fill(2);
   RegionType requestRegion;
   requestRegion.SetIndex(requestIndex);

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -220,9 +220,8 @@ itkConstantBoundaryConditionTest(int, char *[])
 
   // Test 1
   std::cout << "GetInputRequestedRegion() Test 1" << std::endl;
-  IndexType requestIndex{};
-  SizeType  requestSize;
-  requestSize.Fill(2);
+  IndexType  requestIndex{};
+  auto       requestSize = SizeType::Filled(2);
   RegionType requestRegion;
   requestRegion.SetIndex(requestIndex);
   requestRegion.SetSize(requestSize);

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -61,12 +61,12 @@ ComputeOffset(TImage * image, unsigned int count, unsigned int repeat)
 {
   typename TImage::OffsetValueType offset = 0;
   typename TImage::OffsetValueType accum = 0;
-  typename TImage::IndexType       index;
-  auto                             indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
+
+  auto indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
 
   for (unsigned int j = 0; j < repeat; ++j)
   {
-    index.Fill(0);
+    typename TImage::IndexType index{};
     for (unsigned int i = 0; i < count; ++i)
     {
 
@@ -84,14 +84,14 @@ ComputeFastOffset(TImage * image, unsigned int count, unsigned int repeat)
 {
   typename TImage::OffsetValueType offset = 0;
   typename TImage::OffsetValueType accum = 0;
-  typename TImage::IndexType       index;
-  auto                             indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
+
+  auto indexIncr = itk::MakeFilled<typename TImage::OffsetType>(1);
 
   const typename TImage::OffsetValueType * offsetTable = image->GetOffsetTable();
 
   for (unsigned int j = 0; j < repeat; ++j)
   {
-    index.Fill(0);
+    typename TImage::IndexType index{};
     for (unsigned int i = 0; i < count; ++i)
     {
       offset = 0;
@@ -110,78 +110,66 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
   itk::TimeProbesCollectorBase collector;
 
-#define TRY_FAST_INDEX(dim)                                  \
-  {                                                          \
-    using PixelType = char;                                  \
-    using ImageType = itk::Image<PixelType, dim>;            \
-    auto                  myImage = ImageType::New();        \
-    ImageType::SizeType   size;                              \
-    ImageType::IndexType  index;                             \
-    ImageType::RegionType region;                            \
-    size.Fill(50);                                           \
-    index.Fill(0);                                           \
-    region.SetSize(size);                                    \
-    region.SetIndex(index);                                  \
-    myImage->SetRegions(region);                             \
-    myImage->Allocate();                                     \
-    collector.Start("ComputeIndexFast " #dim "D");           \
-    unsigned int totalSize = 1;                              \
-    for (unsigned int i = 0; i < dim; ++i)                   \
-      totalSize *= size[i];                                  \
-    unsigned int repeat = 1000;                              \
-    if (dim > 2)                                             \
-      repeat = 100;                                          \
-    if (dim > 3)                                             \
-      repeat = 10;                                           \
-    if (dim > 4)                                             \
-      repeat = 1;                                            \
-    ComputeFastIndex<ImageType>(myImage, totalSize, repeat); \
-    collector.Stop("ComputeIndexFast " #dim "D");            \
-  }                                                          \
+#define TRY_FAST_INDEX(dim)                                             \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::IndexType  index{};                                \
+    const ImageType::RegionType region{ index, size };                  \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeIndexFast " #dim "D");                      \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    unsigned int repeat = 1000;                                         \
+    if (dim > 2)                                                        \
+      repeat = 100;                                                     \
+    if (dim > 3)                                                        \
+      repeat = 10;                                                      \
+    if (dim > 4)                                                        \
+      repeat = 1;                                                       \
+    ComputeFastIndex<ImageType>(myImage, totalSize, repeat);            \
+    collector.Stop("ComputeIndexFast " #dim "D");                       \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define TRY_INDEX(dim)                                   \
-  {                                                      \
-    using PixelType = char;                              \
-    using ImageType = itk::Image<PixelType, dim>;        \
-    auto                  myImage = ImageType::New();    \
-    ImageType::SizeType   size;                          \
-    ImageType::IndexType  index;                         \
-    ImageType::RegionType region;                        \
-    size.Fill(50);                                       \
-    index.Fill(0);                                       \
-    region.SetSize(size);                                \
-    region.SetIndex(index);                              \
-    myImage->SetRegions(region);                         \
-    myImage->Allocate();                                 \
-    collector.Start("ComputeIndex " #dim "D");           \
-    unsigned int totalSize = 1;                          \
-    for (unsigned int i = 0; i < dim; ++i)               \
-      totalSize *= size[i];                              \
-    unsigned int repeat = 1000;                          \
-    if (dim > 2)                                         \
-      repeat = 100;                                      \
-    if (dim > 3)                                         \
-      repeat = 10;                                       \
-    if (dim > 4)                                         \
-      repeat = 1;                                        \
-    ComputeIndex<ImageType>(myImage, totalSize, repeat); \
-    collector.Stop("ComputeIndex " #dim "D");            \
-  }                                                      \
+#define TRY_INDEX(dim)                                                  \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::IndexType  index{};                                \
+    const ImageType::RegionType region{ index, size };                  \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeIndex " #dim "D");                          \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    unsigned int repeat = 1000;                                         \
+    if (dim > 2)                                                        \
+      repeat = 100;                                                     \
+    if (dim > 3)                                                        \
+      repeat = 10;                                                      \
+    if (dim > 4)                                                        \
+      repeat = 1;                                                       \
+    ComputeIndex<ImageType>(myImage, totalSize, repeat);                \
+    collector.Stop("ComputeIndex " #dim "D");                           \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define TRY_FAST_OFFSET(dim)                                            \
   {                                                                     \
     using PixelType = char;                                             \
     using ImageType = itk::Image<PixelType, dim>;                       \
-    auto                  myImage = ImageType::New();                   \
-    ImageType::SizeType   size;                                         \
-    ImageType::IndexType  index;                                        \
-    ImageType::RegionType region;                                       \
-    size.Fill(50);                                                      \
-    index.Fill(0);                                                      \
-    region.SetSize(size);                                               \
-    region.SetIndex(index);                                             \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::IndexType  index{};                                \
+    const ImageType::RegionType region{ index, size };                  \
     myImage->SetRegions(region);                                        \
     myImage->Allocate();                                                \
     collector.Start("ComputeOffsetFast " #dim "D");                     \
@@ -195,30 +183,26 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     collector.Stop("ComputeOffsetFast " #dim "D");                      \
   }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
-#define TRY_OFFSET(dim)                                             \
-  {                                                                 \
-    using PixelType = char;                                         \
-    using ImageType = itk::Image<PixelType, dim>;                   \
-    auto                  myImage = ImageType::New();               \
-    ImageType::SizeType   size;                                     \
-    ImageType::IndexType  index;                                    \
-    ImageType::RegionType region;                                   \
-    size.Fill(50);                                                  \
-    index.Fill(0);                                                  \
-    region.SetSize(size);                                           \
-    region.SetIndex(index);                                         \
-    myImage->SetRegions(region);                                    \
-    myImage->Allocate();                                            \
-    collector.Start("ComputeOffset " #dim "D");                     \
-    unsigned int repeat = 1;                                        \
-    if (dim < 4)                                                    \
-      repeat = 100;                                                 \
-    unsigned int totalSize = 1;                                     \
-    for (unsigned int i = 0; i < dim; ++i)                          \
-      totalSize *= size[i];                                         \
-    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat); \
-    collector.Stop("ComputeOffset " #dim "D");                      \
-  }                                                                 \
+#define TRY_OFFSET(dim)                                                 \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::IndexType  index{};                                \
+    const ImageType::RegionType region{ index, size };                  \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeOffset " #dim "D");                         \
+    unsigned int repeat = 1;                                            \
+    if (dim < 4)                                                        \
+      repeat = 100;                                                     \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);     \
+    collector.Stop("ComputeOffset " #dim "D");                          \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX(1);

--- a/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -257,15 +257,9 @@ itkImageRegionExclusionIteratorWithIndexTest(int, char *[])
   using IndexType = itk::Index<Dimension>;
   using RegionType = itk::ImageRegion<Dimension>;
 
-  SizeType   regionSize;
-  IndexType  regionStart;
-  RegionType region;
-
-  regionStart.Fill(0);
-  regionSize.Fill(7);
-
-  region.SetIndex(regionStart);
-  region.SetSize(regionSize);
+  IndexType  regionStart{};
+  auto       regionSize = itk::MakeFilled<SizeType>(7);
+  RegionType region{ regionStart, regionSize };
 
   SizeType::SizeValueType size[2] = { 4, 7 };
 

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -46,7 +46,6 @@ public:
 int
 itkImageTest(int, char *[])
 {
-
   using Image = itk::Image<float, 2>;
   auto                image = Image::New();
   Image::ConstPointer myconstptr = image;
@@ -85,9 +84,8 @@ itkImageTest(int, char *[])
 
   // test inverse direction
   std::cout << "Test inverse direction." << std::endl;
-  Image::DirectionType product;
-  product = direction * image->GetInverseDirection();
-  double eps = 1e-06;
+  Image::DirectionType product = direction * image->GetInverseDirection();
+  double               eps = 1e-06;
   if (itk::Math::abs(product[0][0] - 1.0) > eps || itk::Math::abs(product[1][1] - 1.0) > eps ||
       itk::Math::abs(product[0][1]) > eps || itk::Math::abs(product[1][0]) > eps)
   {
@@ -135,13 +133,9 @@ itkImageTest(int, char *[])
   imageRef->SetSpacing(spacingRef);
   imageRef->SetOrigin(originRef);
   imageRef->SetDirection(directionRef);
-  Image::RegionType regionRef;
-  Image::IndexType  indexRef;
-  Image::SizeType   sizeRef;
-  indexRef.Fill(0);
-  sizeRef.Fill(5);
-  regionRef.SetIndex(indexRef);
-  regionRef.SetSize(sizeRef);
+  Image::IndexType  indexRef{};
+  auto              sizeRef = itk::MakeFilled<Image::SizeType>(5);
+  Image::RegionType regionRef{ indexRef, sizeRef };
   imageRef->SetRegions(regionRef);
 
   using TransformType = itk::Transform<double, Image::ImageDimension, Image::ImageDimension>;

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -80,9 +80,7 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
 {
   int result = EXIT_SUCCESS;
 
-  ImageVectorPointer imageOfVectors = ImageVectorType::New();
-
-  IndexType start{};
+  const IndexType start{};
 
   SizeType      size;
   constexpr int dimLength = 3;
@@ -90,14 +88,12 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
 
   RegionType region{ start, size };
 
+  const ImageVectorPointer imageOfVectors = ImageVectorType::New();
   imageOfVectors->SetRegions(region);
   imageOfVectors->Allocate();
 
-  ImageVectorType::PointType   origin;
-  ImageVectorType::SpacingType spacing;
-
-  origin.Fill(0.0);
-  spacing.Fill(1.0);
+  ImageVectorType::PointType origin{};
+  auto                       spacing = itk::MakeFilled<ImageVectorType::SpacingType>(1.0);
 
   imageOfVectors->SetOrigin(origin);
   imageOfVectors->SetSpacing(spacing);

--- a/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -57,15 +57,15 @@ itkPhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   std::cout << std::endl;
 
 
-  PointType           point;
-  IndexType           index;
-  ContinuousIndexType continuousIndex;
-
-  point.Fill(0.05);
+  auto point = itk::MakeFilled<PointType>(0.05);
   point[2] = 3.1;
+
+  IndexType  index;
   const bool isIndexInside = image->TransformPhysicalPointToIndex(point, index);
   std::cout << "Point " << point << " -> Index " << index << (isIndexInside ? " inside" : " outside") << std::endl;
-  const bool isContinuousIndexInside = image->TransformPhysicalPointToContinuousIndex(point, continuousIndex);
+
+  ContinuousIndexType continuousIndex;
+  const bool          isContinuousIndexInside = image->TransformPhysicalPointToContinuousIndex(point, continuousIndex);
   std::cout << "Point " << point << " -> Continuous Index " << continuousIndex
             << (isContinuousIndexInside ? " inside" : " outside") << std::endl;
 

--- a/Modules/Core/Common/test/itkThreadedImageRegionPartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedImageRegionPartitionerTest.cxx
@@ -39,16 +39,11 @@ itkThreadedImageRegionPartitionerTest(int, char *[])
   using SizeType = ImageRegionType::SizeType;
   using IndexType = ImageRegionType::IndexType;
 
-  SizeType  size;
-  IndexType index;
+  auto size = itk::MakeFilled<SizeType>(97);
 
-  size.Fill(97);
-  index.Fill(4);
+  auto index = itk::MakeFilled<IndexType>(4);
 
-  ImageRegionType completeRegion;
-
-  completeRegion.SetSize(size);
-  completeRegion.SetIndex(index);
+  ImageRegionType completeRegion{ index, size };
 
   // Define the expected results
   ImageRegionType              expectedRegion;

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -35,14 +35,10 @@ itkVectorTest(int, char *[])
 
   using RealVector = itk::Vector<Real, 2>;
 
-  RealVector s;
-  RealVector t;
-  RealVector r;
+  const int i = 4;
+  Real      f = 2.1;
 
-  int  i = 4;
-  Real f = 2.1;
-
-  s.Fill(3.0);
+  auto s = itk::MakeFilled<RealVector>(3.0);
   if (different(s[0], 3.0) || different(s[1], 3.0))
   {
     passed = false;
@@ -66,8 +62,7 @@ itkVectorTest(int, char *[])
     passed = false;
   }
 
-
-  t = s;
+  RealVector t = s;
   if (different(t[0], s[0]) || different(t[1], s[1]))
   {
     passed = false;
@@ -119,8 +114,7 @@ itkVectorTest(int, char *[])
     passed = false;
   }
 
-
-  r = s + t;
+  RealVector r = s + t;
   if (different(r[0], 5.9) || different(r[1], 5.9))
   {
     passed = false;

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -122,12 +122,11 @@ int
 itkZeroFluxBoundaryConditionTest(int, char *[])
 {
   // Test an image to cover one operator() method.
-  auto       image = ImageType::New();
-  RegionType imageRegion;
-  SizeType   imageSize = { { 5, 5 } };
-  IndexType  imageIndex = { { 0, 0 } };
-  imageRegion.SetSize(imageSize);
-  imageRegion.SetIndex(imageIndex);
+  auto image = ImageType::New();
+
+  const SizeType  imageSize = { { 5, 5 } };
+  const IndexType imageIndex = { { 0, 0 } };
+  RegionType      imageRegion{ imageIndex, imageSize };
   image->SetRegions(imageRegion);
   image->Allocate();
 
@@ -152,7 +151,6 @@ itkZeroFluxBoundaryConditionTest(int, char *[])
   }
 
   RadiusType radius;
-  RadiusType radiusTwo;
   radius[0] = radius[1] = 1;
   IteratorType       it(radius, image, image->GetRequestedRegion());
   VectorIteratorType vit(radius, vectorImage, vectorImage->GetRequestedRegion());
@@ -177,6 +175,7 @@ itkZeroFluxBoundaryConditionTest(int, char *[])
     }
   }
 
+  RadiusType radiusTwo;
   radiusTwo[0] = radiusTwo[1] = 2;
   IteratorType       it2(radiusTwo, image, image->GetRequestedRegion());
   VectorIteratorType vit2(radiusTwo, vectorImage, vectorImage->GetRequestedRegion());
@@ -199,26 +198,15 @@ itkZeroFluxBoundaryConditionTest(int, char *[])
   }
 
   // Now test the input region calculation
-  IndexType  requestIndex;
-  SizeType   requestSize;
-  RegionType requestRegion;
-
-  IndexType  expectedIndex;
-  SizeType   expectedSize;
-  RegionType expectedRegion;
-
-  RegionType inputRegion;
-
   // Test 1
   std::cout << "GetInputRequestedRegion() Test 1" << std::endl;
-  requestIndex.Fill(0);
-  requestSize.Fill(2);
-  requestRegion.SetIndex(requestIndex);
-  requestRegion.SetSize(requestSize);
+  IndexType  requestIndex{};
+  auto       requestSize = itk::MakeFilled<SizeType>(2);
+  RegionType requestRegion{ requestIndex, requestSize };
 
-  expectedRegion = requestRegion;
+  RegionType expectedRegion = requestRegion;
 
-  inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
+  RegionType inputRegion = bc.GetInputRequestedRegion(imageRegion, requestRegion);
   if (!CheckInputRequestedRegion(imageRegion, inputRegion, expectedRegion))
   {
     std::cerr << "[FAILED]" << std::endl;
@@ -235,8 +223,10 @@ itkZeroFluxBoundaryConditionTest(int, char *[])
   requestRegion.SetIndex(requestIndex);
   requestRegion.SetSize(requestSize);
 
+  IndexType expectedIndex;
   expectedIndex[0] = 0;
   expectedIndex[1] = 0;
+  SizeType expectedSize;
   expectedSize[0] = 1;
   expectedSize[1] = 2;
   expectedRegion.SetIndex(expectedIndex);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -90,11 +90,9 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
 
   function->SetInputImage(image);
 
-  typename ImageType::IndexType index;
-
   // pick an index inside the image
-  index.Fill(8);
-  OutputType indexOutput = function->EvaluateAtIndex(index);
+  typename ImageType::IndexType index{ { 8, 8 } };
+  OutputType                    indexOutput = function->EvaluateAtIndex(index);
   std::cout << "Index: " << index << " Derivative: ";
   std::cout << indexOutput << std::endl;
 
@@ -102,10 +100,9 @@ itkCentralDifferenceImageFunctionOnVectorTestRun()
   OutputType truthOutput;
   for (unsigned int dim = 0; dim < ImageDimension; ++dim)
   {
-    PixelType                     deriv;
     typename ImageType::IndexType indexTest = index;
     indexTest[dim] = indexTest[dim] + 1;
-    deriv = image->GetPixel(indexTest);
+    PixelType deriv = image->GetPixel(indexTest);
     indexTest[dim] = indexTest[dim] - 2;
     deriv -= image->GetPixel(indexTest);
     deriv /= 2.0;

--- a/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
+++ b/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
@@ -44,14 +44,12 @@ makeRandomImageInterpolator(const int SplineOrder)
   }
   {
     using SpacingType = typename ImageType::SpacingType;
-    SpacingType spacing;
-    spacing.Fill(2.0);
+    auto spacing = itk::MakeFilled<SpacingType>(2.0);
     source->SetSpacing(spacing);
   }
   {
     using PointType = typename ImageType::PointType;
-    PointType origin;
-    origin.Fill(10.0);
+    auto origin = itk::MakeFilled<PointType>(10.0);
     source->SetOrigin(origin);
   }
   {

--- a/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
+++ b/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
@@ -56,8 +56,7 @@ makeRandomImageInterpolator(const int SplineOrder)
   }
   {
     using SizeType = typename ImageType::SizeType;
-    SizeType size;
-    size.Fill(32);
+    auto size = SizeType::Filled(32);
     source->SetSize(size);
   }
 

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -390,14 +390,10 @@ template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
 auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier idx) const -> CovariantVectorType
 {
-  PointType p;
-  p.Fill(0);
-  PointType n1;
-  n1.Fill(0);
-  PointType n2;
-  n2.Fill(0);
-  PointType n3;
-  n3.Fill(0);
+  PointType p{};
+  PointType n1{};
+  PointType n2{};
+  PointType n3{};
 
   IndexArray neighbors = this->GetNeighbors(idx);
   this->GetPoint(idx, &p);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -181,12 +181,9 @@ public:
     double
     ComputeArea(PointIdentifier p1, PointIdentifier p2, PointIdentifier p3)
     {
-      InputPointType v1;
-      v1.Fill(0);
-      InputPointType v2;
-      v2.Fill(0);
-      InputPointType v3;
-      v3.Fill(0);
+      InputPointType v1{};
+      InputPointType v2{};
+      InputPointType v3{};
 
       mesh->GetPoint(p1, &v1);
       mesh->GetPoint(p2, &v2);

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -182,10 +182,8 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
       PointIdentifier secondNewIndex = newPointId + 1;
 
       // create first new point
-      InputPointType p1;
-      p1.Fill(0);
-      InputPointType p2;
-      p2.Fill(0);
+      InputPointType p1{};
+      InputPointType p2{};
       outputMesh->GetPoint(lineOneFirstIdx, &p1);
       outputMesh->GetPoint(lineOneSecondIdx, &p2);
 
@@ -400,10 +398,8 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(Input
   OutputMeshPointer           outputMesh = this->GetOutput();
   InputPolygonPointIdIterator pointIt = simplexCell->PointIdsBegin();
 
-  InputPointType p1;
-  p1.Fill(0);
-  InputPointType cellCenter;
-  cellCenter.Fill(0);
+  InputPointType p1{};
+  InputPointType cellCenter{};
 
   // compute the cell center first
   while (pointIt != simplexCell->PointIdsEnd())

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -121,10 +121,8 @@ public:
     {
       using PointIdIterator = typename SimplexPolygonType::PointIdIterator;
       PointIdIterator it = poly->PointIdsBegin();
-      InputPointType  center;
-      center.Fill(0);
-      InputPointType p;
-      p.Fill(0.0);
+      InputPointType  center{};
+      InputPointType  p{};
 
       while (it != poly->PointIdsEnd())
       {

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -219,12 +219,9 @@ SimplexMeshVolumeCalculator<TInputMesh>::Compute()
 {
   this->Initialize();
 
-  InputPointType p1;
-  p1.Fill(0.0);
-  InputPointType p2;
-  p2.Fill(0.0);
-  InputPointType p3;
-  p3.Fill(0.0);
+  InputPointType p1{};
+  InputPointType p2{};
+  InputPointType p3{};
 
   InputPointsContainerPointer  Points = m_SimplexMesh->GetPoints();
   InputPointsContainerIterator pointsIt = Points->Begin();

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -161,10 +161,10 @@ itkQuadrilateralCellTest(int, char *[])
   std::cout << inputPoint[1] << ", ";
   std::cout << inputPoint[2] << std::endl;
 
-  QuadrilateralCellType::CoordinateType            closestPoint[3];
+  QuadrilateralCellType::CoordinateType          closestPoint[3];
   double                                         distance;
   QuadrilateralCellType::InterpolationWeightType weights[4];
-  QuadrilateralCellType::CoordinateType            pcoords[2]; // Quadrilateral has 2 parametric coordinates
+  QuadrilateralCellType::CoordinateType          pcoords[2]; // Quadrilateral has 2 parametric coordinates
   bool isInside = testCell1->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);
 
   if (!isInside)

--- a/Modules/Core/QuadEdgeMesh/test/itkDynamicQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkDynamicQuadEdgeMeshTest.cxx
@@ -59,21 +59,16 @@ itkDynamicQuadEdgeMeshTest(int, char *[])
    */
   MeshType::Pointer mesh(MeshType::New());
 
-  PointType pointA;
-  PointType pointB;
-  PointType pointC;
-  PointType pointD;
-
   VectorType displacement;
-
   displacement[0] = 2;
   displacement[1] = 5;
   displacement[2] = 0;
 
-  pointA.Fill(0.0);
-  pointB = pointA + displacement;
-  pointC = pointB + displacement;
-  pointD = pointC + displacement;
+  PointType pointA{};
+
+  PointType pointB = pointA + displacement;
+  PointType pointC = pointB + displacement;
+  PointType pointD = pointC + displacement;
 
   PointsContainer::Pointer pointsContainter = mesh->GetPoints();
 
@@ -81,7 +76,6 @@ itkDynamicQuadEdgeMeshTest(int, char *[])
   pointsContainter->SetElement(1, pointB);
   pointsContainter->SetElement(2, pointC);
   pointsContainter->SetElement(3, pointD);
-
 
   std::cout << "Number of Points = " << mesh->GetNumberOfPoints() << std::endl;
 
@@ -93,7 +87,6 @@ itkDynamicQuadEdgeMeshTest(int, char *[])
     std::cout << point.Index() << " = " << point.Value() << std::endl;
     point++;
   }
-
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -79,10 +79,8 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   tube1->SetPoints(list);
   tube1->Update();
-  Point in;
-  in.Fill(15);
-  Point out;
-  out.Fill(5);
+  auto in = itk::MakeFilled<Point>(15);
+  auto out = itk::MakeFilled<Point>(5);
 
   std::cout << "IsInside()...";
   if (!tube1->IsInsideInWorldSpace(in) || tube1->IsInsideInWorldSpace(out))
@@ -297,8 +295,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[PASSED]" << std::endl;
   }
 
-  Vector translation;
-  translation.Fill(10);
+  auto translation = itk::MakeFilled<Vector>(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
@@ -315,11 +312,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
   in.Fill(25);
   out.Fill(15);
 
-  Point p1;
-  p1.Fill(15);
+  auto p1 = itk::MakeFilled<Point>(15);
   p1[2] = 5;
-  Point p2;
-  p2.Fill(15);
+  auto p2 = itk::MakeFilled<Point>(15);
   p2[0] = 5;
 
   std::cout << "IsInside()...";

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -302,8 +302,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
-  Vector axis;
-  axis.Fill(0);
+  Vector axis{};
   axis[1] = 1;
   double angle = itk::Math::pi_over_2;
   tube2->GetModifiableObjectToParentTransform()->Rotate3D(axis, angle);

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -90,10 +90,8 @@ itkTubeSpatialObjectTest(int, char *[])
 
   tube1->SetPoints(list);
   tube1->Update();
-  Point in;
-  in.Fill(15);
-  Point out;
-  out.Fill(5);
+  auto in = itk::MakeFilled<Point>(15);
+  auto out = itk::MakeFilled<Point>(5);
 
   std::cout << "IsInside()...";
   if (!tube1->IsInsideInWorldSpace(in) || tube1->IsInsideInWorldSpace(out))
@@ -307,8 +305,7 @@ itkTubeSpatialObjectTest(int, char *[])
   {
     std::cout << "[PASSED]" << std::endl;
   }
-  Vector translation;
-  translation.Fill(10);
+  auto translation = itk::MakeFilled<Vector>(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
@@ -325,11 +322,9 @@ itkTubeSpatialObjectTest(int, char *[])
   in.Fill(25);
   out.Fill(15);
 
-  Point p1;
-  p1.Fill(15);
+  auto p1 = itk::MakeFilled<Point>(15);
   p1[2] = 5;
-  Point p2;
-  p2.Fill(15);
+  auto p2 = itk::MakeFilled<Point>(15);
   p2[0] = 5;
 
   std::cout << "IsInside()...";

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -312,8 +312,7 @@ itkTubeSpatialObjectTest(int, char *[])
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
 
-  Vector axis;
-  axis.Fill(0);
+  Vector axis{};
   axis[1] = 1;
   double angle = itk::Math::pi_over_2;
   tube2->GetModifiableObjectToParentTransform()->Rotate3D(axis, angle);

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -451,25 +451,23 @@ itkBSplineDeformableTransformTest2()
   using CoordRep = double;
   using TransformType = itk::BSplineDeformableTransform<CoordRep, Dimension, SplineOrder>;
   using ImageType = TransformType::ImageType;
-  TransformType::InputPointType  inputPoint;
-  TransformType::OutputPointType outputPoint;
 
   auto transform = TransformType::New();
 
   // Set up field spacing, origin, region
-  double                spacing[Dimension];
-  double                origin[Dimension];
-  ImageType::SizeType   size;
-  ImageType::RegionType region;
+  double spacing[Dimension];
+  double origin[Dimension];
+
   for (unsigned int j = 0; j < Dimension; ++j)
   {
     spacing[j] = 10.0;
     origin[j] = -10.0;
   }
-
+  ImageType::SizeType size;
   size[0] = 5;
   size[1] = 7;
 
+  ImageType::RegionType region;
   region.SetSize(size);
 
   TransformType::CoefficientImageArray field;
@@ -493,7 +491,8 @@ itkBSplineDeformableTransformTest2()
 
   // This should generate an exception because parameters have not yet
   // been set.
-  inputPoint.Fill(0.0);
+  auto                           inputPoint = itk::MakeFilled<TransformType::InputPointType>(0.0);
+  TransformType::OutputPointType outputPoint;
   {
     bool exceptionCaught(false);
     try
@@ -649,11 +648,11 @@ itkBSplineDeformableTransformTest3()
    */
   using PointType = TransformType::InputPointType;
 
-  PointType inputPoint;
+
   PointType outputPoint;
 
   // point within the grid support region
-  inputPoint.Fill(9.0);
+  auto inputPoint = itk::MakeFilled<PointType>(9.0);
   outputPoint = transform->TransformPoint(inputPoint);
 
   std::cout << "Input Point: " << inputPoint << std::endl;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -677,12 +677,10 @@ itkBSplineTransformTest3()
    */
   using PointType = TransformType::InputPointType;
 
-  PointType inputPoint;
-  PointType outputPoint;
-
   // point within the grid support region
-  inputPoint.Fill(9.0);
-  outputPoint = transform->TransformPoint(inputPoint);
+  auto inputPoint = itk::MakeFilled<PointType>(9.0);
+
+  PointType outputPoint = transform->TransformPoint(inputPoint);
 
   std::cout << "Input Point: " << inputPoint << std::endl;
   std::cout << "Output Point: " << outputPoint << std::endl;

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -185,12 +185,12 @@ itkEuler2DTransformTest(int, char *[])
 
     // Set parameters
     TransformType::ParametersType parameters2(t1->GetNumberOfParameters());
-    TransformType::InputPointType center;
 
     parameters2[0] = -21.0 / 180.0 * itk::Math::pi;
     parameters2[1] = 67.8;
     parameters2[2] = -0.2;
 
+    TransformType::InputPointType center;
     center[0] = 12.0;
     center[1] = -8.9;
 

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -327,8 +327,7 @@ itkMultiTransformTest(int, char *[])
   int                 dimLength = 4;
   FieldType::SizeType size;
   size.Fill(dimLength);
-  FieldType::IndexType start;
-  start.Fill(0);
+  FieldType::IndexType  start{};
   FieldType::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -324,9 +324,8 @@ itkMultiTransformTest(int, char *[])
   auto field = FieldType::New(); // This is based on itk::Image
 
 
-  int                 dimLength = 4;
-  FieldType::SizeType size;
-  size.Fill(dimLength);
+  int                   dimLength = 4;
+  auto                  size = itk::MakeFilled<FieldType::SizeType>(dimLength);
   FieldType::IndexType  start{};
   FieldType::RegionType region;
   region.SetSize(size);

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -237,9 +237,8 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   auto field = FieldType::New();
 
-  int                 dimLength = 20;
-  FieldType::SizeType size;
-  size.Fill(dimLength);
+  int                   dimLength = 20;
+  auto                  size = itk::MakeFilled<FieldType::SizeType>(dimLength);
   FieldType::IndexType  start{};
   FieldType::RegionType region;
   region.SetSize(size);

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -240,8 +240,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   int                 dimLength = 20;
   FieldType::SizeType size;
   size.Fill(dimLength);
-  FieldType::IndexType start;
-  start.Fill(0);
+  FieldType::IndexType  start{};
   FieldType::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -98,8 +98,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
   constexpr int SIGN_MASK = 1;
   constexpr int INNER_MASK = 2;
 
-  typename NeighborhoodIterator<TInputImage>::RadiusType r;
-  r.Fill(1);
+  auto                              r = MakeFilled<typename NeighborhoodIterator<TInputImage>::RadiusType>(1);
   NeighborhoodIterator<TInputImage> it(r, this->GetOutput(), m_RegionToProcess);
 
   const unsigned int center_voxel = it.Size() / 2;

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -174,18 +174,15 @@ itkNaryAddImageFilterTest(int, char *[])
   auto vectorImageC = VectorImageType::New();
 
   constexpr VectorImageType::PixelType::ValueType vectorValueA = 12;
-  VectorPixelType                                 vectorImageValueA;
-  vectorImageValueA.Fill(vectorValueA);
+  auto                                            vectorImageValueA = itk::MakeFilled<VectorPixelType>(vectorValueA);
   vectorImageValueA[0] = 5;
 
   constexpr VectorImageType::PixelType::ValueType vectorValueB = 17;
-  VectorPixelType                                 vectorImageValueB;
-  vectorImageValueB.Fill(vectorValueB);
+  auto                                            vectorImageValueB = itk::MakeFilled<VectorPixelType>(vectorValueB);
   vectorImageValueB[0] = 9;
 
   const VectorImageType::PixelType::ValueType vectorValueC = -4;
-  VectorPixelType                             vectorImageValueC;
-  vectorImageValueC.Fill(vectorValueC);
+  auto                                        vectorImageValueC = itk::MakeFilled<VectorPixelType>(vectorValueC);
   vectorImageValueC[0] = -80;
 
   InitializeImage<VectorImageType>(vectorImageA, vectorImageValueA);

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -302,8 +302,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
     {
       // setup the marker iterator to only visit face connected
       // neighbors and the center pixel
-      typename NeighborhoodIteratorType::OffsetType offset;
-      offset.Fill(0);
+      typename NeighborhoodIteratorType::OffsetType offset{};
       markerIt.ActivateOffset(offset); // center pixel
       for (unsigned int d = 0; d < TInputImage::ImageDimension; ++d)
       {
@@ -322,8 +321,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
       {
         markerIt.ActivateOffset(markerIt.GetOffset(nd));
       }
-      typename NeighborhoodIteratorType::OffsetType offset;
-      offset.Fill(0);
+      typename NeighborhoodIteratorType::OffsetType offset{};
       markerIt.DeactivateOffset(offset);
     }
 

--- a/Modules/Filtering/Path/include/itkPathFunctions.h
+++ b/Modules/Filtering/Path/include/itkPathFunctions.h
@@ -38,8 +38,7 @@ MakeChainCodeTracePath(TChainCodePath & chainPath, const TPathInput & inPath, bo
 
   int dimension = OffsetType::GetOffsetDimension();
 
-  OffsetType zeroOffset;
-  zeroOffset.Fill(0);
+  OffsetType zeroOffset{};
 
   chainPath.Clear();
   InPathInputType inPathInput = inPath.StartOfInput();
@@ -61,8 +60,7 @@ MakeChainCodeTracePath(TChainCodePath & chainPath, const TPathInput & inPath, bo
     {
       for (int d = 0; d < dimension; ++d)
       {
-        OffsetType tempOffset;
-        tempOffset.Fill(0);
+        OffsetType tempOffset{};
         tempOffset[d] = offset[d];
         chainPath.InsertStep(chainInput++, tempOffset);
       }
@@ -109,10 +107,8 @@ MakeFourierSeriesPathTraceChainCode(TFourierSeriesPath &   FSPath,
   for (unsigned int n = 0; n < numHarmonics; ++n)
   {
     IndexType  index = chainPath.GetStart();
-    VectorType cosCoefficient;
-    cosCoefficient.Fill(0.0);
-    VectorType sinCoefficient;
-    sinCoefficient.Fill(0.0);
+    VectorType cosCoefficient{};
+    VectorType sinCoefficient{};
 
     for (ChainInputType step = 0; step < numSteps; ++step)
     {

--- a/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
+++ b/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
@@ -38,8 +38,7 @@ OrthogonallyCorrected2DParametricPath::Evaluate(const InputType & inputValue) co
 
   InputType  inputRange = m_OriginalPath->EndOfInput() - m_OriginalPath->StartOfInput();
   InputType  normalizedInput = (input - m_OriginalPath->StartOfInput()) / inputRange;
-  OutputType output;
-  output.Fill(0);
+  OutputType output{};
 
   // Find the linearly interpolated offset error value for this exact time.
   double softOrthogonalCorrectionTableIndex = normalizedInput * numOrthogonalCorrections;

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -37,8 +37,7 @@ itkFourierSeriesPathTest(int, char *[])
   // Average value is (5,5)
   VectorType cosV;
   cosV.Fill(5);
-  VectorType sinV;
-  sinV.Fill(0);
+  VectorType sinV{};
   path->AddHarmonic(cosV, sinV);
   cosV.Fill(2.7);
   sinV.Fill(3.2);

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -35,8 +35,7 @@ itkFourierSeriesPathTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(path, FourierSeriesPath, ParametricPath);
 
   // Average value is (5,5)
-  VectorType cosV;
-  cosV.Fill(5);
+  auto       cosV = itk::MakeFilled<VectorType>(5);
   VectorType sinV{};
   path->AddHarmonic(cosV, sinV);
   cosV.Fill(2.7);

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -96,10 +96,8 @@ ImageSeriesReader<TOutputImage>::GenerateOutputInformation()
   typename TOutputImage::Pointer output = this->GetOutput();
 
   using SpacingScalarType = typename TOutputImage::SpacingValueType;
-  Array<SpacingScalarType> position1(TOutputImage::ImageDimension);
-  position1.Fill(0.0f);
-  Array<SpacingScalarType> positionN(TOutputImage::ImageDimension);
-  positionN.Fill(0.0f);
+  Array<SpacingScalarType> position1(TOutputImage::ImageDimension, 0.0f);
+  Array<SpacingScalarType> positionN(TOutputImage::ImageDimension, 0.0f);
 
   std::string key("ITK_ImageOrigin");
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -225,12 +225,9 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
   outputImage->SetSpacing(spacing);
   outputImage->SetDirection(direction);
 
-  Index<TInputImage::ImageDimension> inIndex;
-  Size<TInputImage::ImageDimension>  inSize;
 
-  SizeValueType pixelsPerFile = outputImage->GetRequestedRegion().GetNumberOfPixels();
-
-  inSize.Fill(1);
+  const SizeValueType pixelsPerFile = outputImage->GetRequestedRegion().GetNumberOfPixels();
+  auto                inSize = MakeFilled<Size<TInputImage::ImageDimension>>(1);
   for (unsigned int ns = 0; ns < TOutputImage::ImageDimension; ++ns)
   {
     inSize[ns] = outRegion.GetSize()[ns];
@@ -259,7 +256,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
   for (unsigned int slice = 0; slice < m_FileNames.size(); ++slice)
   {
     // Select a "slice" of the image.
-    inIndex = inputImage->ComputeIndex(offset);
+    Index<TInputImage::ImageDimension> inIndex = inputImage->ComputeIndex(offset);
     inRegion.SetIndex(inIndex);
     inRegion.SetSize(inSize);
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
@@ -45,19 +45,15 @@ itkImageFileWriterPastingTest1(int argc, char * argv[])
   reader->SetFileName(argv[1]);
   reader->SetUseStreaming(true);
 
-  ImageType::RegionType region;
-  ImageType::SizeType   size;
-  ImageType::SizeType   fullsize;
-  ImageType::IndexType  index;
-
   unsigned int m_NumberOfPieces = 10;
 
   // We decide how we want to read the image and we split accordingly
   // The image is read slice by slice
   reader->UpdateOutputInformation();
-  fullsize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType fullsize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
 
-  index.Fill(0);
+  ImageType::IndexType index{};
+  ImageType::SizeType  size;
   size[0] = fullsize[0];
   size[1] = fullsize[1];
   size[2] = 0;
@@ -85,8 +81,7 @@ itkImageFileWriterPastingTest1(int argc, char * argv[])
       size[2] = zsize;
     }
 
-    region.SetIndex(index);
-    region.SetSize(size);
+    const ImageType::RegionType region{ index, size };
 
     // Write the image
     itk::ImageIORegion ioregion(3);

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -33,13 +33,11 @@ itkImageFileWriterTest(int argc, char * argv[])
   using ImageNDType = itk::Image<short, 2>;
   using WriterType = itk::ImageFileWriter<ImageNDType>;
 
-  auto                    image = ImageNDType::New();
-  ImageNDType::RegionType region;
-  ImageNDType::IndexType  index;
-  auto                    size = ImageNDType::SizeType::Filled(5);
-  index.Fill(0);
-  region.SetSize(size);
-  region.SetIndex(index);
+  auto                   image = ImageNDType::New();
+  ImageNDType::IndexType index{};
+  auto                   size = itk::MakeFilled<ImageNDType::SizeType>(5);
+
+  ImageNDType::RegionType region{ index, size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
@@ -33,30 +33,24 @@ itkImageFileWriterTest2(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageNDType>;
   using ReaderType = itk::ImageFileReader<ImageNDType>;
 
-  auto                    image = ImageNDType::New();
-  ImageNDType::RegionType region;
-  ImageNDType::IndexType  index;
-  ImageNDType::SizeType   size;
+  auto image = ImageNDType::New();
 
-
-  ImageNDType::PointType originalPoint;
-  ImageNDType::PointType readPoint;
-
-  size.Fill(5);
-  index.Fill(1);
-  region.SetSize(size);
-  region.SetIndex(index);
+  auto                    size = itk::MakeFilled<ImageNDType::SizeType>(5);
+  auto                    index = itk::MakeFilled<ImageNDType::IndexType>(1);
+  ImageNDType::RegionType region{ index, size };
 
   image->SetRegions(region);
   image->AllocateInitialized();
 
+  ImageNDType::PointType originalPoint;
   image->TransformIndexToPhysicalPoint(index, originalPoint);
   std::cout << "Original Starting Index: " << index << std::endl;
   std::cout << "Original Starting Point (physical cooridents) : " << originalPoint << std::endl;
   std::cout << "Original Origin: " << image->GetOrigin() << std::endl;
 
-  auto writer = WriterType::New();
-  auto reader = ReaderType::New();
+  ImageNDType::PointType readPoint;
+  auto                   writer = WriterType::New();
+  auto                   reader = ReaderType::New();
   try
   {
     writer->SetInput(image);

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -41,19 +41,14 @@ itkLargeImageWriteConvertReadTest(int argc, char * argv[])
   itk::TimeProbesCollectorBase chronometer;
 
   { // begin write block
-    auto                        image = OutputImageType::New();
-    OutputImageType::RegionType region;
-    OutputImageType::IndexType  index;
-    OutputImageType::SizeType   size;
-
+    auto image = OutputImageType::New();
 
     const size_t numberOfPixelsInOneDimension = atol(argv[2]);
 
-    size.Fill(static_cast<OutputImageType::SizeValueType>(numberOfPixelsInOneDimension));
-    index.Fill(0);
-    region.SetSize(size);
-    region.SetIndex(index);
+    auto                       size = itk::MakeFilled<OutputImageType::SizeType>(numberOfPixelsInOneDimension);
+    OutputImageType::IndexType index{};
 
+    OutputImageType::RegionType region{ index, size };
     image->SetRegions(region);
 
     chronometer.Start("Allocate");

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -39,17 +39,11 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
   using IteratorType = itk::ImageRegionIterator<ImageType>;
   using ConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
 
-  typename ImageType::RegionType region;
-  typename ImageType::IndexType  index;
-
-
-  itk::TimeProbesCollectorBase chronometer;
+  typename ImageType::IndexType  index{};
+  typename ImageType::RegionType region{ index, size };
 
   { // begin write block
     auto image = ImageType::New();
-    index.Fill(0);
-    region.SetSize(size);
-    region.SetIndex(index);
 
     image->SetRegions(region);
 
@@ -63,6 +57,7 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 
     std::cout << "Trying to allocate an image of size " << sizeInMebiBytes << " MiB " << std::endl;
 
+    itk::TimeProbesCollectorBase chronometer;
     chronometer.Start("Allocate");
     image->Allocate();
     chronometer.Stop("Allocate");
@@ -106,6 +101,8 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 
   try
   {
+
+    itk::TimeProbesCollectorBase chronometer;
     chronometer.Start("Read");
     reader->Update();
     chronometer.Stop("Read");
@@ -128,6 +125,8 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 
   PixelType pixelValue{};
 
+
+  itk::TimeProbesCollectorBase chronometer;
   chronometer.Start("Compare");
   while (!ritr.IsAtEnd())
   {

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -38,7 +38,6 @@ itkNoiseImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  itk::Size<2> radius;
   using myImageIn = itk::Image<unsigned short, 2>;
   using myImageOut = itk::Image<float, 2>;
   using myImageChar = itk::Image<unsigned char, 2>;
@@ -58,7 +57,7 @@ itkNoiseImageFilterTest(int argc, char * argv[])
   rescale->SetOutputMaximum(255);
   rescale->SetInput(filter->GetOutput());
 
-  radius.Fill(5);
+  auto radius = itk::MakeFilled<itk::Size<2>>(5);
   filter->SetInput(input->GetOutput());
   filter->SetRadius(radius);
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -452,10 +452,8 @@ MINCImageIO::ReadImageInformation()
   Matrix<double, 3, 3> dir_cos{};
   dir_cos.SetIdentity();
 
-  Vector<double, 3> origin;
-  origin.Fill(0.0);
-  Vector<double, 3> o_origin;
-  o_origin.Fill(0.0);
+  Vector<double, 3> origin{};
+  Vector<double, 3> o_origin{};
 
   // minc api uses inverse order of dimensions , fastest varying are last
   Vector<double, 3> sep;

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -42,16 +42,14 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
   using IteratorType = itk::ImageRegionIterator<ImageType>;
   using ConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
 
-  typename ImageType::RegionType region;
-  typename ImageType::IndexType  index;
 
-  itk::TimeProbesCollectorBase chronometer;
+  typename ImageType::IndexType  index{};
+  typename ImageType::RegionType region{ index, size };
+  itk::TimeProbesCollectorBase   chronometer;
 
   { // begin write block
     auto image = ImageType::New();
-    index.Fill(0);
-    region.SetSize(size);
-    region.SetIndex(index);
+
 
     image->SetRegions(region);
 

--- a/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
@@ -49,19 +49,16 @@ itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
   reader->SetUseStreaming(true);
   metaImageIO->SetUseStreamedReading(true);
 
-  ImageType::RegionType region;
-  ImageType::SizeType   size;
-  ImageType::SizeType   fullsize;
-  ImageType::IndexType  index;
-
   itk::SizeValueType numberOfPieces = 10;
 
   // We decide how we want to read the image and we split accordingly
   // The image is read slice by slice
   reader->UpdateOutputInformation();
-  fullsize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType fullsize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
 
-  index.Fill(0);
+  ImageType::IndexType index{};
+
+  ImageType::SizeType size;
   size[0] = fullsize[0];
   size[1] = fullsize[1];
   size[2] = 0;
@@ -90,8 +87,7 @@ itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
       size[2] = zsize;
     }
 
-    region.SetIndex(index);
-    region.SetSize(size);
+    ImageType::RegionType region{ index, size };
 
     reader->GetOutput()->SetRequestedRegion(region);
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -43,24 +43,18 @@ itkNiftiImageIOTest11(int argc, char * argv[])
     return EXIT_FAILURE;
   }
   using ImageType = itk::Image<char, 3>;
-  ImageType::RegionType  imageRegion;
-  ImageType::SizeType    size;
-  ImageType::IndexType   index;
-  ImageType::SpacingType spacing;
-  ImageType::PointType   origin;
 
+  ImageType::SizeType size;
   size[0] = static_cast<long>(itk::NumericTraits<short>::max()) * 2;
   size[1] = 1;
   size[2] = 1;
 
-  index.Fill(0);
-  spacing.Fill(1.0);
-  origin.Fill(0.0);
+  ImageType::IndexType index{};
+  auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
-  imageRegion.SetSize(size);
-  imageRegion.SetIndex(index);
-  ImageType::Pointer       im = itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion, spacing);
-  ImageType::DirectionType dir(CORDirCosines<ImageType>());
+  ImageType::RegionType    imageRegion{ index, size };
+  const ImageType::Pointer im = itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion, spacing);
+  const ImageType::DirectionType dir(CORDirCosines<ImageType>());
   std::cout << "itkNiftiImageIOTest11" << std::endl;
   std::cout << "Direction = " << dir << std::endl;
   im->SetDirection(dir);

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -42,17 +42,11 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
 
   using SizeValueType = itk::SizeValueType;
 
-  typename ImageType::RegionType region;
-  typename ImageType::IndexType  index;
-
-  itk::TimeProbesCollectorBase chronometer;
-
+  typename ImageType::IndexType  index{};
+  typename ImageType::RegionType region{ index, size };
   {
     // Write block
     auto image = ImageType::New();
-    index.Fill(0);
-    region.SetSize(size);
-    region.SetIndex(index);
 
     image->SetRegions(region);
 
@@ -70,7 +64,7 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
 
 
     std::cout << "Trying to allocate an image of size " << sizeInMebiBytes << " MiB " << std::endl;
-
+    itk::TimeProbesCollectorBase chronometer;
     chronometer.Start("Allocate");
     image->Allocate();
     chronometer.Stop("Allocate");
@@ -113,10 +107,9 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
   itk::TIFFImageIO::Pointer io = itk::TIFFImageIO::New();
   reader->SetImageIO(io);
 
+  itk::TimeProbesCollectorBase chronometer;
   chronometer.Start("Read");
-
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
-
   chronometer.Stop("Read");
 
   typename ImageType::ConstPointer readImage = reader->GetOutput();

--- a/Modules/IO/XML/test/itkDOMTest6.cxx
+++ b/Modules/IO/XML/test/itkDOMTest6.cxx
@@ -239,18 +239,15 @@ testStringToolsWithItkArray()
 {
   using DataType = itk::Array<double>;
 
+  DataType    dataIn(10, -0.1);
   std::string svalue;
-  std::string s;
-
-  DataType dataIn(10);
-  dataIn.Fill(-0.1);
   itk::StringTools::FromData(svalue, dataIn);
   // add one more data element to the end of the string
   svalue.append(" 10 ");
 
   // read all data elements in the string
-  DataType dataOut1;
-  s = svalue;
+  std::string s = svalue;
+  DataType    dataOut1;
   itk::StringTools::ToData(s, dataOut1);
   // check successful or not
   if (dataOut1.GetSize() != (dataIn.GetSize() + 1) && dataOut1[10] != 10.0)
@@ -267,8 +264,7 @@ testStringToolsWithItkArray()
   std::cout << "testStringToolsWithItkArray: dataOut1 OK!" << std::endl;
 
   // read all data elements for the output vector
-  DataType dataOut2(5);
-  dataOut2.Fill(0.0);
+  DataType dataOut2(5, 0.0);
   s = svalue;
   itk::StringTools::ToData(s, dataOut2, 0);
   // check successful or not
@@ -286,8 +282,7 @@ testStringToolsWithItkArray()
   std::cout << "testStringToolsWithItkArray: dataOut2 OK!" << std::endl;
 
   // read user-specified number of data elements (output data exist)
-  DataType dataOut3(10);
-  dataOut3.Fill(0.0);
+  DataType dataOut3(10, 0.0);
   s = svalue;
   itk::StringTools::ToData(s, dataOut3, 5);
   // check successful or not

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -134,10 +134,8 @@ itkImageFunctionTest(int, char *[])
   image->SetRegions(region);
   image->Allocate();
 
-  ImageType::PointType   origin;
-  ImageType::SpacingType spacing;
-  origin.Fill(0.0);
-  spacing.Fill(1.0);
+  auto origin = MakeFilled<ImageType::PointType>(0.0);
+  auto spacing = MakeFilled<ImageType::SpacingType>(1.0);
 
   image->SetOrigin(origin);
   image->SetSpacing(spacing);

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -96,8 +96,7 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
     size[i] = static_cast<unsigned long>(0.375 * maskSize[i]);
   }
 
-  MaskImageType::IndexType index;
-  index.Fill(0);
+  MaskImageType::IndexType  index{};
   MaskImageType::RegionType region;
   region.SetIndex(index);
   region.SetSize(size);

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -230,8 +230,7 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::ComputeGeometry()
     data->neighbors[2] = points->GetElement(data->neighborIndices[2]);
 
     // compute normal
-    CovariantVectorType normal;
-    normal.Fill(0.0);
+    CovariantVectorType normal{};
 
     z.SetVnlVector(vnl_cross_3d((data->neighbors[1] - data->neighbors[0]).GetVnlVector(),
                                 (data->neighbors[2] - data->neighbors[0]).GetVnlVector()));

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -518,8 +518,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   // region faces.
   using BFCType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<StatusImageType>;
 
-  typename BFCType::SizeType sz;
-  sz.Fill(1);
+  auto sz = MakeFilled<typename BFCType::SizeType>(1);
 
   BFCType                        faceCalculator;
   typename BFCType::FaceListType faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -63,10 +63,8 @@ itkIsolatedWatershedImageFilterTest(int argc, char * argv[])
 
   filter->SetInput(reader->GetOutput());
 
-  FilterType::IndexType seed1;
-  seed1.Fill(0);
-  FilterType::IndexType seed2;
-  seed2.Fill(0);
+  FilterType::IndexType seed1{};
+  FilterType::IndexType seed2{};
 
   // Test the seeds being outside the input image exception
   ImageType::Pointer inputImage = reader->GetOutput();


### PR DESCRIPTION
Replace in Files, doing:
        Find what: ^( [ ]+)([^ ].*)[ ]+(\w+);[\r\n]+\1\3\.Fill\(
        Replace with: $1auto $3 = MakeFilled<$2>\(

Simplify the creation of containers with initial
values.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
