### PR TITLE
COMP: Fix PyCommand inclusion (again)

### DIFF
--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.wrap
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.wrap
@@ -1,2 +1,3 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("${CMAKE_CURRENT_LIST_DIR}/itkPyCommand.h")
 itk_wrap_simple_class("itk::PyCommand" POINTER)


### PR DESCRIPTION
89d13df59f43d6d68375e217f6be3e7fb45d8447 added the full include path. But the include without the path remained.
And if it cannot be found, the compilation errors out. The full error message was:
```log
------ Build started: Project: ITKPyUtilsCastXML, Configuration: RelWithDebInfo x64 ------ Generating ../../../castxml_inputs/itkPyCommand.xml C:/Dev/ITK-py11/Wrapping/castxml_inputs/itkPyCommand.cxx:17:10: fatal error: 'itkPyCommand.h' file not found
   17 | #include "itkPyCommand.h"
      |          ^~~~~~~~~~~~~~~~
1 error generated.
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for 'C:\Dev\ITK-py11\CMakeFiles\c457ae660979b30ca172af3e0d43703c\itkPyCommand.xml.rule;C:\Dev\ITK-py11\CMakeFiles\c457ae660979b30ca172af3e0d43703c\itkPyImageFilter.xml.rule;C:\Dev\ITK-py11\CMakeFiles\21feeeee94fa208592d9019dcd27703a\ITKPyUtilsCastXML.rule' exited with code 1.
Done building project "ITKPyUtilsCastXML.vcxproj" -- FAILED.
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
