### PR TITLE
COMP: Update Azure Windows Python version to 3.11

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -43,7 +43,7 @@ jobs:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.11'
         architecture: 'x64'
 
     - script: |


### PR DESCRIPTION
We now require 3.9 -- 3.8 is end-of-life.
