### PR TITLE
STYLE: Use default member initialization

### DIFF
--- a/Modules/Core/Common/include/itkConstSliceIterator.h
+++ b/Modules/Core/Common/include/itkConstSliceIterator.h
@@ -54,7 +54,6 @@ public:
   /** Constructor. */
   ConstSliceIterator(const TContainer * n, std::slice s)
     : m_ContainerPointer(n)
-    , m_Pos(0)
     , m_Slice(s)
   {}
 
@@ -146,7 +145,7 @@ private:
   const TContainer * m_ContainerPointer;
 
   /** Current position within the slice. */
-  SizeValueType m_Pos;
+  SizeValueType m_Pos{ 0 };
 
   /** Slice structure information. */
   std::slice m_Slice;

--- a/Modules/Core/Common/include/itkProgressReporter.h
+++ b/Modules/Core/Common/include/itkProgressReporter.h
@@ -114,7 +114,7 @@ protected:
   ProcessObject * m_Filter;
   ThreadIdType    m_ThreadId;
   float           m_InverseNumberOfPixels;
-  SizeValueType   m_CurrentPixel;
+  SizeValueType   m_CurrentPixel{ 0 };
   SizeValueType   m_PixelsPerUpdate;
   SizeValueType   m_PixelsBeforeUpdate;
   float           m_InitialProgress;

--- a/Modules/Core/Common/include/itkProgressTransformer.h
+++ b/Modules/Core/Common/include/itkProgressTransformer.h
@@ -67,7 +67,7 @@ private:
   using CommandType = SimpleMemberCommand<ProgressTransformer>;
   CommandType::Pointer m_ProgressCommand;
 
-  unsigned long m_ProgressTag;
+  unsigned long m_ProgressTag{ 0 };
 };
 } // end namespace itk
 #endif // itkProgressTransformer_h

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -27,7 +27,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   const ImageType * imagePtr,
   FunctionType *    fnPtr,
   IndexType         startIndex)
-  : m_FullyConnected(false)
+
 {
   this->m_Image = imagePtr;
   m_Function = fnPtr;
@@ -43,7 +43,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   FunctionType *           fnPtr,
   std::vector<IndexType> & startIndex)
   : m_Function(fnPtr)
-  , m_FullyConnected(false)
+
 {
   this->m_Image = imagePtr; // can not be done in the initialization list
 
@@ -61,7 +61,7 @@ template <typename TImage, typename TFunction>
 ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloodFilledFunctionConditionalConstIterator(
   const ImageType * imagePtr,
   FunctionType *    fnPtr)
-  : m_FullyConnected(false)
+
 {
   this->m_Image = imagePtr;
   m_Function = fnPtr;

--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -51,7 +51,6 @@ public:
   /** Constructor. */
   SliceIterator(TContainer * n, std::slice s)
     : m_ContainerPointer(n)
-    , m_Pos(0)
     , m_Slice(s)
   {}
 
@@ -145,7 +144,7 @@ private:
   TContainer * m_ContainerPointer;
 
   /** Current position within the slice. */
-  OffsetValueType m_Pos;
+  OffsetValueType m_Pos{ 0 };
 
   /** Slice structure information. */
   std::slice m_Slice;

--- a/Modules/Core/Common/include/itkTotalProgressReporter.h
+++ b/Modules/Core/Common/include/itkTotalProgressReporter.h
@@ -124,7 +124,7 @@ public:
 protected:
   ProcessObject * m_Filter;
   float           m_InverseNumberOfPixels;
-  SizeValueType   m_CurrentPixel;
+  SizeValueType   m_CurrentPixel{ 0 };
   SizeValueType   m_PixelsPerUpdate;
   SizeValueType   m_PixelsBeforeUpdate;
   float           m_ProgressWeight;

--- a/Modules/Core/Common/src/itkProgressReporter.cxx
+++ b/Modules/Core/Common/src/itkProgressReporter.cxx
@@ -29,7 +29,6 @@ ProgressReporter::ProgressReporter(ProcessObject * filter,
                                    float           progressWeight)
   : m_Filter(filter)
   , m_ThreadId(threadId)
-  , m_CurrentPixel(0)
   , m_InitialProgress(initialProgress)
   , m_ProgressWeight(progressWeight)
 {

--- a/Modules/Core/Common/src/itkProgressTransformer.cxx
+++ b/Modules/Core/Common/src/itkProgressTransformer.cxx
@@ -39,7 +39,7 @@ public:
 
 ProgressTransformer::ProgressTransformer(float start, float end, ProcessObject * targetFilter)
   : m_TargetFilter(targetFilter)
-  , m_ProgressTag(0)
+
 {
   m_Start = std::clamp(start, 0.0f, 1.0f);
   m_End = std::clamp(end, 0.0f, 1.0f);

--- a/Modules/Core/Common/src/itkTotalProgressReporter.cxx
+++ b/Modules/Core/Common/src/itkTotalProgressReporter.cxx
@@ -26,7 +26,6 @@ TotalProgressReporter::TotalProgressReporter(ProcessObject * filter,
                                              SizeValueType   numberOfUpdates,
                                              float           progressWeight)
   : m_Filter(filter)
-  , m_CurrentPixel(0)
   , m_ProgressWeight(progressWeight)
 {
   // Make sure we have at least one pixel.

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
@@ -23,8 +23,7 @@ namespace itk
 {
 template <typename TInputImage, typename TCoordinate>
 MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::MahalanobisDistanceThresholdImageFunction()
-  : m_Threshold(0.0)
-  , m_MahalanobisDistanceMembershipFunction(MahalanobisDistanceFunctionType::New())
+  : m_MahalanobisDistanceMembershipFunction(MahalanobisDistanceFunctionType::New())
 {}
 
 template <typename TInputImage, typename TCoordinate>

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -103,7 +103,7 @@ public:
 
   ScanlineFilterCommon(EnclosingFilter * enclosingFilter)
     : m_EnclosingFilter(enclosingFilter)
-    , m_FullyConnected(false)
+
   {}
   ~ScanlineFilterCommon() = default;
 
@@ -505,7 +505,7 @@ protected:
   }
 
 protected:
-  bool                  m_FullyConnected;
+  bool                  m_FullyConnected{ false };
   OffsetVectorType      m_LineOffsets;
   UnionFindType         m_UnionFind;
   ConsecutiveVectorType m_Consecutive;

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -35,9 +35,7 @@ template <typename TInputPixel, typename TOutputPixel>
 class BinaryAccumulator
 {
 public:
-  BinaryAccumulator(unsigned long)
-    : m_IsForeground(false)
-  {}
+  BinaryAccumulator(unsigned long) {}
   ~BinaryAccumulator() = default;
 
   inline void
@@ -68,7 +66,7 @@ public:
     }
   }
 
-  bool m_IsForeground;
+  bool m_IsForeground{ false };
 };
 } // end namespace Function
 

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -70,11 +70,7 @@ namespace itk
 class JPEGFileWrapper
 {
 public:
-  JPEGFileWrapper(const char * const fname, const char * const openMode)
-    : m_FilePointer(nullptr)
-  {
-    m_FilePointer = fopen(fname, openMode);
-  }
+  JPEGFileWrapper(const char * const fname, const char * const openMode) { m_FilePointer = fopen(fname, openMode); }
 
   virtual ~JPEGFileWrapper()
   {
@@ -84,7 +80,7 @@ public:
     }
   }
 
-  FILE * volatile m_FilePointer;
+  FILE * volatile m_FilePointer{ nullptr };
 };
 
 bool

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -415,6 +415,7 @@ public:
 NiftiImageIO::NiftiImageIO()
   : m_NiftiImageHolder(new NiftiImageProxy(nullptr))
   , m_NiftiImage(*m_NiftiImageHolder.get())
+  // initialization of m_LegacyAnalyze75Mode & m_SFORM_Permissive in cxx so itkNiftiImageIOConfigurePrivate.h is private
   , m_LegacyAnalyze75Mode{ ITK_NIFTI_IO_ANALYZE_FLAVOR_DEFAULT }
   , m_SFORM_Permissive{ ITK_NIFTI_IO_SFORM_PERMISSIVE_DEFAULT }
 {

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -43,11 +43,7 @@ namespace itk
 class PNGFileWrapper
 {
 public:
-  PNGFileWrapper(const char * const fname, const char * const openMode)
-    : m_FilePointer(nullptr)
-  {
-    m_FilePointer = fopen(fname, openMode);
-  }
+  PNGFileWrapper(const char * const fname, const char * const openMode) { m_FilePointer = fopen(fname, openMode); }
 
   virtual ~PNGFileWrapper()
   {
@@ -57,7 +53,7 @@ public:
     }
   }
 
-  FILE * volatile m_FilePointer;
+  FILE * volatile m_FilePointer{ nullptr };
 };
 
 bool

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -225,7 +225,7 @@ public:
       : m_MultivariateLegendrePolynomial(polynomial)
       , m_Dimension(m_MultivariateLegendrePolynomial->GetDimension())
       , m_DomainSize(m_MultivariateLegendrePolynomial->GetDomainSize())
-      , m_IsAtEnd(false)
+
     {
       m_Index.resize(m_Dimension);
       std::fill(m_Index.begin(), m_Index.end(), 0);
@@ -284,7 +284,7 @@ public:
     unsigned int                     m_Dimension;
     DomainSizeType                   m_DomainSize;
     IndexType                        m_Index;
-    bool                             m_IsAtEnd;
+    bool                             m_IsAtEnd{ false };
   }; // end of class Iterator
 
   void

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -31,7 +31,7 @@ class SimpleMultiResolutionImageRegistrationUI
 {
 public:
   SimpleMultiResolutionImageRegistrationUI(TRegistrator * ptr)
-    : m_Tag(0)
+
   {
 
     if (!ptr)


### PR DESCRIPTION
Converts a default constructor’s member initializers into the new default member initializers in C++11. Other member initializers that match the default member initializer are removed. This can reduce repeated code or allow use of ‘= default’.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)