### PR TITLE
STYLE: Use range-based loops from C++11

### DIFF
--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1003,29 +1003,29 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset(
 
   else
   {
-    for (int i = 0; i < 3; ++i)
+    for (double & it : m_RayVoxelStartPosition)
     {
-      m_RayVoxelStartPosition[i] = 0.;
+      it = 0.;
     }
-    for (int i = 0; i < 3; ++i)
+    for (double & it : m_RayVoxelEndPosition)
     {
-      m_RayVoxelEndPosition[i] = 0.;
+      it = 0.;
     }
-    for (int i = 0; i < 3; ++i)
+    for (double & it : m_VoxelIncrement)
     {
-      m_VoxelIncrement[i] = 0.;
+      it = 0.;
     }
     m_TraversalDirection = TraversalDirectionEnum::UNDEFINED_DIRECTION;
 
     m_TotalRayVoxelPlanes = 0;
 
-    for (int i = 0; i < 4; ++i)
+    for (auto & m_RayIntersectionVoxel : m_RayIntersectionVoxels)
     {
-      m_RayIntersectionVoxels[i] = nullptr;
+      m_RayIntersectionVoxel = nullptr;
     }
-    for (int i = 0; i < 3; ++i)
+    for (int & it : m_RayIntersectionVoxelIndex)
     {
-      m_RayIntersectionVoxelIndex[i] = 0;
+      it = 0;
     }
   }
 }
@@ -1304,38 +1304,38 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
   m_VoxelDimensionInY = 0;
   m_VoxelDimensionInZ = 0;
 
-  for (int i = 0; i < 3; ++i)
+  for (double & it : m_CurrentRayPositionInMM)
   {
-    m_CurrentRayPositionInMM[i] = 0.;
+    it = 0.;
   }
-  for (int i = 0; i < 3; ++i)
+  for (double & it : m_RayDirectionInMM)
   {
-    m_RayDirectionInMM[i] = 0.;
+    it = 0.;
   }
-  for (int i = 0; i < 3; ++i)
+  for (double & it : m_RayVoxelStartPosition)
   {
-    m_RayVoxelStartPosition[i] = 0.;
+    it = 0.;
   }
-  for (int i = 0; i < 3; ++i)
+  for (double & it : m_RayVoxelEndPosition)
   {
-    m_RayVoxelEndPosition[i] = 0.;
+    it = 0.;
   }
-  for (int i = 0; i < 3; ++i)
+  for (double & it : m_VoxelIncrement)
   {
-    m_VoxelIncrement[i] = 0.;
+    it = 0.;
   }
   m_TraversalDirection = TraversalDirectionEnum::UNDEFINED_DIRECTION;
 
   m_TotalRayVoxelPlanes = 0;
   m_NumVoxelPlanesTraversed = -1;
 
-  for (int i = 0; i < 4; ++i)
+  for (auto & m_RayIntersectionVoxel : m_RayIntersectionVoxels)
   {
-    m_RayIntersectionVoxels[i] = nullptr;
+    m_RayIntersectionVoxel = nullptr;
   }
-  for (int i = 0; i < 3; ++i)
+  for (int & it : m_RayIntersectionVoxelIndex)
   {
-    m_RayIntersectionVoxelIndex[i] = 0;
+    it = 0;
   }
 }
 

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -86,16 +86,16 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
   {
     point[1] = 0.0;
 
-    for (unsigned int j = 0; j < 5; ++j)
+    for (double it : expectedValue)
     {
       const InterpolatorType::OutputType computedValue = interpolator->Evaluate(point);
 
-      if (!itk::Math::FloatAlmostEqual(computedValue, expectedValue[j], 7, 5e-6))
+      if (!itk::Math::FloatAlmostEqual(computedValue, it, 7, 5e-6))
       {
         std::cerr << "Error: computed and expected values are different" << std::endl;
         std::cerr << "Point: " << point << std::endl;
         std::cerr << "Computed: " << computedValue << std::endl;
-        std::cerr << "Expected: " << expectedValue[j] << std::endl;
+        std::cerr << "Expected: " << it << std::endl;
         return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -206,12 +206,10 @@ itkMeshTest(int, char *[])
     auto          cellVectorContainer = MeshType::CellsVectorContainer::New();
     int           index = 0;
     unsigned long value = 1;
-    for (std::map<itk::CellGeometryEnum, unsigned int>::iterator iter = cellPointMap.begin();
-         iter != cellPointMap.end();
-         ++iter)
+    for (auto & iter : cellPointMap)
     {
-      const itk::CellGeometryEnum cellType = iter->first;
-      const unsigned int          numOfPoints = iter->second;
+      const itk::CellGeometryEnum cellType = iter.first;
+      const unsigned int          numOfPoints = iter.second;
 
       // Insert cell type
       cellVectorContainer->InsertElement(index++, static_cast<unsigned long>(cellType));
@@ -231,11 +229,9 @@ itkMeshTest(int, char *[])
 
     // Check if right cells are recovered
     index = 0;
-    for (std::map<itk::CellGeometryEnum, unsigned int>::iterator iter = cellPointMap.begin();
-         iter != cellPointMap.end();
-         ++iter)
+    for (auto & iter : cellPointMap)
     {
-      const unsigned int numOfPoints = iter->second;
+      const unsigned int numOfPoints = iter.second;
       CellAutoPointer    temp_cell;
 
       if (mesh0->GetCell(index++, temp_cell))

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -433,9 +433,9 @@ CompositeTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse)
 
   /* Copy the optimization flags */
   inverse->m_TransformsToOptimizeFlags.clear();
-  for (auto ofit = this->m_TransformsToOptimizeFlags.begin(); ofit != this->m_TransformsToOptimizeFlags.end(); ++ofit)
+  for (bool m_TransformsToOptimizeFlag : this->m_TransformsToOptimizeFlags)
   {
-    inverse->m_TransformsToOptimizeFlags.push_front(*ofit);
+    inverse->m_TransformsToOptimizeFlags.push_front(m_TransformsToOptimizeFlag);
   }
 
   return true;
@@ -951,9 +951,9 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
   Superclass::PrintSelf(os, indent);
 
   os << indent << "TransformsToOptimizeFlags: " << std::endl << indent << indent;
-  for (auto it = m_TransformsToOptimizeFlags.begin(); it != m_TransformsToOptimizeFlags.end(); ++it)
+  for (bool m_TransformsToOptimizeFlag : m_TransformsToOptimizeFlags)
   {
-    os << indent.GetNextIndent() << *it << ' ';
+    os << indent.GetNextIndent() << m_TransformsToOptimizeFlag << ' ';
   }
   os << std::endl;
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -108,16 +108,16 @@ itkBSplineDeformableTransformTest1()
   using CoefficientType = ParametersType::ValueType;
   using CoefficientImageType = itk::Image<CoefficientType, SpaceDimension>;
 
-  CoefficientImageType::Pointer coeffImage[SpaceDimension];
+  CoefficientImageType::Pointer coeffImages[SpaceDimension];
   const unsigned int            numberOfControlPoints = region.GetNumberOfPixels();
   CoefficientType *             dataPointer = parameters.data_block();
-  for (unsigned int j = 0; j < SpaceDimension; ++j)
+  for (auto & it : coeffImages)
   {
-    coeffImage[j] = CoefficientImageType::New();
-    coeffImage[j]->SetRegions(region);
-    coeffImage[j]->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
+    it = CoefficientImageType::New();
+    it->SetRegions(region);
+    it->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
     dataPointer += numberOfControlPoints;
-    coeffImage[j]->FillBuffer(0.0);
+    it->FillBuffer(0.0);
   }
 
   /**
@@ -125,9 +125,9 @@ itkBSplineDeformableTransformTest1()
    */
   auto index = CoefficientImageType::IndexType::Filled(5);
 
-  coeffImage[1]->SetPixel(index, 1.0);
+  coeffImages[1]->SetPixel(index, 1.0);
 
-  const unsigned long n = coeffImage[1]->ComputeOffset(index) + numberOfControlPoints;
+  const unsigned long n = coeffImages[1]->ComputeOffset(index) + numberOfControlPoints;
 
   /**
    * Set the parameters in the transform
@@ -619,16 +619,16 @@ itkBSplineDeformableTransformTest3()
   using CoefficientType = ParametersType::ValueType;
   using CoefficientImageType = itk::Image<CoefficientType, SpaceDimension>;
 
-  CoefficientImageType::Pointer coeffImage[SpaceDimension];
+  CoefficientImageType::Pointer coeffImages[SpaceDimension];
   const unsigned int            numberOfControlPoints = region.GetNumberOfPixels();
   CoefficientType *             dataPointer = parameters.data_block();
-  for (unsigned int j = 0; j < SpaceDimension; ++j)
+  for (auto & it : coeffImages)
   {
-    coeffImage[j] = CoefficientImageType::New();
-    coeffImage[j]->SetRegions(region);
-    coeffImage[j]->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
+    it = CoefficientImageType::New();
+    it->SetRegions(region);
+    it->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
     dataPointer += numberOfControlPoints;
-    coeffImage[j]->FillBuffer(0.0);
+    it->FillBuffer(0.0);
   }
 
   /**
@@ -636,7 +636,7 @@ itkBSplineDeformableTransformTest3()
    */
   auto index = CoefficientImageType::IndexType::Filled(5);
 
-  coeffImage[1]->SetPixel(index, 1.0);
+  coeffImages[1]->SetPixel(index, 1.0);
 
   /**
    * Set the parameters in the transform

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -138,7 +138,7 @@ itkBSplineTransformTest1()
   using CoefficientType = ParametersType::ValueType;
   using CoefficientImageType = itk::Image<CoefficientType, SpaceDimension>;
 
-  CoefficientImageType::Pointer  coeffImage[SpaceDimension];
+  CoefficientImageType::Pointer  coeffImages[SpaceDimension];
   CoefficientImageType::SizeType size;
   unsigned int                   numberOfControlPoints = 0;
   for (unsigned int j = 0; j < SpaceDimension; ++j)
@@ -147,13 +147,13 @@ itkBSplineTransformTest1()
     numberOfControlPoints += size[j];
   }
   CoefficientType * dataPointer = parameters.data_block();
-  for (unsigned int j = 0; j < SpaceDimension; ++j)
+  for (auto & it : coeffImages)
   {
-    coeffImage[j] = CoefficientImageType::New();
-    coeffImage[j]->SetRegions(size);
-    coeffImage[j]->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
+    it = CoefficientImageType::New();
+    it->SetRegions(size);
+    it->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
     dataPointer += numberOfControlPoints;
-    coeffImage[j]->FillBuffer(0.0);
+    it->FillBuffer(0.0);
   }
 
   /**
@@ -161,9 +161,9 @@ itkBSplineTransformTest1()
    */
   auto index = CoefficientImageType::IndexType::Filled(5);
 
-  coeffImage[1]->SetPixel(index, 1.0);
+  coeffImages[1]->SetPixel(index, 1.0);
 
-  const unsigned long n = coeffImage[1]->ComputeOffset(index) + numberOfControlPoints;
+  const unsigned long n = coeffImages[1]->ComputeOffset(index) + numberOfControlPoints;
 
   /**
    * Set the parameters in the transform
@@ -642,7 +642,7 @@ itkBSplineTransformTest3()
   using CoefficientType = ParametersType::ValueType;
   using CoefficientImageType = itk::Image<CoefficientType, SpaceDimension>;
 
-  CoefficientImageType::Pointer  coeffImage[SpaceDimension];
+  CoefficientImageType::Pointer  coeffImages[SpaceDimension];
   CoefficientImageType::SizeType size;
   unsigned int                   numberOfControlPoints = 0;
   for (unsigned int j = 0; j < SpaceDimension; ++j)
@@ -651,13 +651,13 @@ itkBSplineTransformTest3()
     numberOfControlPoints += size[j];
   }
   CoefficientType * dataPointer = parameters.data_block();
-  for (unsigned int j = 0; j < SpaceDimension; ++j)
+  for (auto & it : coeffImages)
   {
-    coeffImage[j] = CoefficientImageType::New();
-    coeffImage[j]->SetRegions(size);
-    coeffImage[j]->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
+    it = CoefficientImageType::New();
+    it->SetRegions(size);
+    it->GetPixelContainer()->SetImportPointer(dataPointer, numberOfControlPoints);
     dataPointer += numberOfControlPoints;
-    coeffImage[j]->FillBuffer(0.0);
+    it->FillBuffer(0.0);
   }
 
   /**
@@ -665,7 +665,7 @@ itkBSplineTransformTest3()
    */
   auto index = CoefficientImageType::IndexType::Filled(5);
 
-  coeffImage[1]->SetPixel(index, 1.0);
+  coeffImages[1]->SetPixel(index, 1.0);
 
   /**
    * Set the parameters in the transform

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -28,9 +28,9 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::MRIBiasEnergyFunction()
   , m_Image(nullptr)
   , m_Mask(nullptr)
 {
-  for (unsigned int i = 0; i < SpaceDimension; ++i)
+  for (unsigned int & it : m_SamplingFactor)
   {
-    m_SamplingFactor[i] = 1;
+    it = 1;
   }
 }
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -630,12 +630,12 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed2D(const NodeT
 
   // Check for critical configurations: 4 90-degree rotations
 
-  for (unsigned int i = 0; i < 4; ++i)
+  for (const auto & m_RotationIndice : this->m_RotationIndices)
   {
     for (unsigned int j = 0; j < 9; ++j)
     {
-      neighborhoodPixels[j] = (It.GetPixel(this->m_RotationIndices[i][j]) != Traits::Alive);
-      if (this->m_RotationIndices[i][j] == 4)
+      neighborhoodPixels[j] = (It.GetPixel(m_RotationIndice[j]) != Traits::Alive);
+      if (m_RotationIndice[j] == 4)
       {
         neighborhoodPixels.flip(j);
       }
@@ -653,12 +653,12 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed2D(const NodeT
   // Note that the reflections for the C1 and C2 cases are covered by the
   // rotation cases above (except in the case of FullInvariance == false).
 
-  for (unsigned int i = 0; i < 2; ++i)
+  for (const auto & m_ReflectionIndice : this->m_ReflectionIndices)
   {
     for (unsigned int j = 0; j < 9; ++j)
     {
-      neighborhoodPixels[j] = (It.GetPixel(this->m_ReflectionIndices[i][j]) != Traits::Alive);
-      if (this->m_ReflectionIndices[i][j] == 4)
+      neighborhoodPixels[j] = (It.GetPixel(m_ReflectionIndice[j]) != Traits::Alive);
+      if (m_ReflectionIndice[j] == 4)
       {
         neighborhoodPixels.flip(j);
       }
@@ -871,13 +871,13 @@ template <typename TInput, typename TOutput>
 void
 FastMarchingImageFilterBase<TInput, TOutput>::InitializeIndices3D()
 {
-  for (unsigned int i = 0; i < 12; ++i)
+  for (auto & m_C1Indice : this->m_C1Indices)
   {
-    this->m_C1Indices[i].SetSize(4);
+    m_C1Indice.SetSize(4);
   }
-  for (unsigned int i = 0; i < 8; ++i)
+  for (auto & m_C2Indice : this->m_C2Indices)
   {
-    this->m_C2Indices[i].SetSize(8);
+    m_C2Indice.SetSize(8);
   }
 
   this->m_C1Indices[0][0] = 1;

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -290,10 +290,10 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
 
       // mark off connected points
       constexpr MapPixelType ineligeblePointCode = 0;
-      for (size_t j = 0, n = m_NonConnectivityOffsets.size(); j < n; ++j)
+      for (const auto & m_NonConnectivityOffset : m_NonConnectivityOffsets)
       {
         IndexType idx = rit->second;
-        idx += m_NonConnectivityOffsets[j];
+        idx += m_NonConnectivityOffset;
         selectionMap->SetPixel(idx, ineligeblePointCode);
       }
     }

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -93,9 +93,9 @@ itkExpandImageFilterTest(int, char *[])
 
   ImagePattern<ImageDimension> pattern;
   pattern.m_Offset = 64;
-  for (unsigned int j = 0; j < ImageDimension; ++j)
+  for (double & it : pattern.m_Coeff)
   {
-    pattern.m_Coeff[j] = 1.0;
+    it = 1.0;
   }
 
   using Iterator = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -118,9 +118,9 @@ itkWarpImageFilterTest(int, char *[])
   ImagePattern<ImageDimension> pattern;
 
   pattern.m_Offset = 64;
-  for (unsigned int j = 0; j < ImageDimension; ++j)
+  for (double & it : pattern.m_Coeff)
   {
-    pattern.m_Coeff[j] = 1.0;
+    it = 1.0;
   }
 
   using Iterator = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
@@ -65,9 +65,9 @@ itkOtsuMultipleThresholdsCalculatorTest(int argc, char * argv[])
   {
     const HistogramType::MeasurementType measurement = iter.GetMeasurementVector()[0];
 
-    for (ValuesVectorType::const_iterator viter = values.begin(); viter != values.end(); ++viter)
+    for (float value : values)
     {
-      if (measurement > (*viter - range) && measurement < (*viter + range))
+      if (measurement > (value - range) && measurement < (value + range))
       {
         iter.SetFrequency(1);
       }

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -102,9 +102,9 @@ itkOtsuMultipleThresholdsImageFilterTest(int argc, char * argv[])
 
   FilterType::ThresholdVectorType thresholds = filter->GetThresholds();
   std::cout << "filter->GetThresholds(): ";
-  for (unsigned int i = 0; i < thresholds.size(); ++i)
+  for (double threshold : thresholds)
   {
-    std::cout << itk::NumericTraits<FilterType::InputPixelType>::PrintType(thresholds[i]) << ' ';
+    std::cout << itk::NumericTraits<FilterType::InputPixelType>::PrintType(threshold) << ' ';
   }
   std::cout << std::endl;
 

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -206,9 +206,9 @@ CSVArray2DDataObject<TData>::PrintSelf(std::ostream & os, Indent indent) const
   if (this->m_HasColumnHeaders)
   {
     os << indent << indent;
-    for (unsigned int i = 0; i < this->m_ColumnHeaders.size(); ++i)
+    for (const auto & m_ColumnHeader : this->m_ColumnHeaders)
     {
-      os << this->m_ColumnHeaders[i] << indent;
+      os << m_ColumnHeader << indent;
     }
     os << std::endl;
   }

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -273,9 +273,9 @@ GiplImageIO::ReadImageInformation()
   unsigned short dims[4];
 
   unsigned int numberofdimension = 0;
-  for (unsigned int i = 0; i < 4; ++i)
+  for (unsigned short & dim : dims)
   {
-    dims[i] = 0;
+    dim = 0;
   }
 
   for (unsigned int i = 0; i < 4; ++i)
@@ -392,37 +392,37 @@ GiplImageIO::ReadImageInformation()
   }
 
   char line1[80]; /*   26   80  Patient / Text field        */
-  for (unsigned int i = 0; i < 80; ++i)
+  for (char & it : line1)
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&line1[i], static_cast<unsigned int>(sizeof(char)));
+      gzread(m_Internal->m_GzFile, (char *)&it, static_cast<unsigned int>(sizeof(char)));
     }
     else
     {
-      m_Ifstream.read((char *)&line1[i], sizeof(char));
+      m_Ifstream.read((char *)&it, sizeof(char));
     }
   }
 
   float matrix[20]; /*  106   80                              */
-  for (unsigned int i = 0; i < 20; ++i)
+  for (float & it : matrix)
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&matrix[i], static_cast<unsigned int>(sizeof(float)));
+      gzread(m_Internal->m_GzFile, (char *)&it, static_cast<unsigned int>(sizeof(float)));
     }
     else
     {
-      m_Ifstream.read((char *)&matrix[i], sizeof(float));
+      m_Ifstream.read((char *)&it, sizeof(float));
     }
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
-      ByteSwapper<float>::SwapFromSystemToBigEndian(&matrix[i]);
+      ByteSwapper<float>::SwapFromSystemToBigEndian(&it);
     }
     else if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
     {
-      ByteSwapper<float>::SwapFromSystemToLittleEndian(&matrix[i]);
+      ByteSwapper<float>::SwapFromSystemToLittleEndian(&it);
     }
   }
 

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -469,16 +469,16 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     std::cerr << "Failure reading metaData "
               << "acquisition:TestDoubleArray " << std::endl;
     std::cerr << "metaDataDoubleArray=";
-    for (size_t i = 0; i < metaDataDoubleArray.size(); ++i)
+    for (double value : metaDataDoubleArray)
     {
-      std::cerr << metaDataDoubleArray[i] << ' ';
+      std::cerr << value << ' ';
     }
     std::cerr << std::endl;
 
     std::cerr << "metaDataDoubleArray2=";
-    for (size_t i = 0; i < metaDataDoubleArray2.size(); ++i)
+    for (double value : metaDataDoubleArray2)
     {
-      std::cerr << metaDataDoubleArray2[i] << ' ';
+      std::cerr << value << ' ';
     }
     std::cerr << std::endl;
 
@@ -492,16 +492,16 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     std::cerr << "Failure reading metaData "
               << "acquisition:TestFloatArray " << std::endl;
     std::cerr << "metaDataFloatArray=";
-    for (size_t i = 0; i < metaDataFloatArray.size(); ++i)
+    for (float value : metaDataFloatArray)
     {
-      std::cerr << metaDataFloatArray[i] << ' ';
+      std::cerr << value << ' ';
     }
     std::cerr << std::endl;
 
     std::cerr << "metaDataFloatArray2=";
-    for (size_t i = 0; i < metaDataFloatArray2.size(); ++i)
+    for (float value : metaDataFloatArray2)
     {
-      std::cerr << metaDataFloatArray2[i] << ' ';
+      std::cerr << value << ' ';
     }
     std::cerr << std::endl;
 

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -975,11 +975,11 @@ NrrdImageIO::Write(const void * buffer)
   // or a key/value pair
   MetaDataDictionary &     thisDic = this->GetMetaDataDictionary();
   std::vector<std::string> keys = thisDic.GetKeys();
-  for (std::vector<std::string>::const_iterator keyIt = keys.begin(); keyIt != keys.end(); ++keyIt)
+  for (const auto & key : keys)
   {
-    if (!strncmp(KEY_PREFIX, keyIt->c_str(), strlen(KEY_PREFIX)))
+    if (!strncmp(KEY_PREFIX, key.c_str(), strlen(KEY_PREFIX)))
     {
-      const char * keyField = keyIt->c_str() + strlen(KEY_PREFIX);
+      const char * keyField = key.c_str() + strlen(KEY_PREFIX);
       // only of one of these can succeed
       const char * field = airEnumStr(nrrdField, nrrdField_thicknesses);
       if (!strncmp(keyField, field, strlen(field)))
@@ -987,7 +987,7 @@ NrrdImageIO::Write(const void * buffer)
         if (1 == sscanf(keyField + strlen(field), "[%u]", &axi) && axi + baseDim < nrrd->dim)
         {
           double thickness = 0.0;
-          ExposeMetaData<double>(thisDic, *keyIt, thickness);
+          ExposeMetaData<double>(thisDic, key, thickness);
           nrrd->axis[axi + baseDim].thickness = thickness;
         }
       }
@@ -997,7 +997,7 @@ NrrdImageIO::Write(const void * buffer)
         if (1 == sscanf(keyField + strlen(field), "[%u]", &axi) && axi + baseDim < nrrd->dim)
         {
           std::string value;
-          ExposeMetaData<std::string>(thisDic, *keyIt, value);
+          ExposeMetaData<std::string>(thisDic, key, value);
           nrrd->axis[axi + baseDim].center = airEnumVal(nrrdCenter, value.c_str());
         }
       }
@@ -1007,7 +1007,7 @@ NrrdImageIO::Write(const void * buffer)
         if (1 == sscanf(keyField + strlen(field), "[%u]", &axi) && axi + baseDim < nrrd->dim)
         {
           std::string value;
-          ExposeMetaData<std::string>(thisDic, *keyIt, value);
+          ExposeMetaData<std::string>(thisDic, key, value);
           nrrd->axis[axi + baseDim].kind = airEnumVal(nrrdKind, value.c_str());
         }
       }
@@ -1017,19 +1017,19 @@ NrrdImageIO::Write(const void * buffer)
         if (1 == sscanf(keyField + strlen(field), "[%u]", &axi) && axi + baseDim < nrrd->dim)
         {
           std::string value;
-          ExposeMetaData<std::string>(thisDic, *keyIt, value);
+          ExposeMetaData<std::string>(thisDic, key, value);
           nrrd->axis[axi + baseDim].label = airStrdup(value.c_str());
         }
       }
       field = airEnumStr(nrrdField, nrrdField_old_min);
       if (!strncmp(keyField, field, strlen(field)))
       {
-        ExposeMetaData<double>(thisDic, *keyIt, nrrd->oldMin);
+        ExposeMetaData<double>(thisDic, key, nrrd->oldMin);
       }
       field = airEnumStr(nrrdField, nrrdField_old_max);
       if (!strncmp(keyField, field, strlen(field)))
       {
-        ExposeMetaData<double>(thisDic, *keyIt, nrrd->oldMax);
+        ExposeMetaData<double>(thisDic, key, nrrd->oldMax);
       }
 
       field = airEnumStr(nrrdField, nrrdField_space);
@@ -1037,7 +1037,7 @@ NrrdImageIO::Write(const void * buffer)
       {
         int         space;
         std::string value;
-        ExposeMetaData<std::string>(thisDic, *keyIt, value);
+        ExposeMetaData<std::string>(thisDic, key, value);
         space = airEnumVal(nrrdSpace, value.c_str());
         if (nrrdSpaceDimension(space) == nrrd->spaceDim)
         {
@@ -1050,14 +1050,14 @@ NrrdImageIO::Write(const void * buffer)
       if (!strncmp(keyField, field, strlen(field)))
       {
         std::string value;
-        ExposeMetaData<std::string>(thisDic, *keyIt, value);
+        ExposeMetaData<std::string>(thisDic, key, value);
         nrrd->content = airStrdup(value.c_str());
       }
       field = airEnumStr(nrrdField, nrrdField_measurement_frame);
       if (!strncmp(keyField, field, strlen(field)))
       {
         std::vector<std::vector<double>> msrFrame;
-        ExposeMetaData<std::vector<std::vector<double>>>(thisDic, *keyIt, msrFrame);
+        ExposeMetaData<std::vector<std::vector<double>>>(thisDic, key, msrFrame);
         for (unsigned int saxi = 0; saxi < nrrd->spaceDim; ++saxi)
         {
           for (unsigned int saxj = 0; saxj < nrrd->spaceDim; ++saxj)
@@ -1087,16 +1087,15 @@ NrrdImageIO::Write(const void * buffer)
       // convert to string and dump to the file
       // const char *tname = thisDic.Get(*keyIt)->GetNameOfClass();
       std::ostringstream dump;
-      if (_dump_metadata_to_stream<std::string>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<double>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<float>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<int>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<unsigned int>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<Array<float>>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<Array<double>>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<Array<int>>(thisDic, *keyIt, dump) ||
-          _dump_metadata_to_stream<Array<unsigned int>>(thisDic, *keyIt, dump))
-        nrrdKeyValueAdd(nrrd, keyIt->c_str(), dump.str().c_str());
+      if (_dump_metadata_to_stream<std::string>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<double>(thisDic, key, dump) || _dump_metadata_to_stream<float>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<int>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<unsigned int>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<Array<float>>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<Array<double>>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<Array<int>>(thisDic, key, dump) ||
+          _dump_metadata_to_stream<Array<unsigned int>>(thisDic, key, dump))
+        nrrdKeyValueAdd(nrrd, key.c_str(), dump.str().c_str());
     }
   }
 

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -269,11 +269,11 @@ KdTreeBasedKmeansEstimator<TKdTree>::CopyParameters(InternalParametersType & sou
 {
   int index = 0;
 
-  for (unsigned int i = 0; i < static_cast<unsigned int>(source.size()); ++i)
+  for (auto & it : source)
   {
     for (unsigned int j = 0; j < m_MeasurementVectorSize; ++j)
     {
-      target[index] = source[i][j];
+      target[index] = it[j];
       ++index;
     }
   }

--- a/Modules/Registration/Common/test/itkPointSetToImageRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToImageRegistrationTest.cxx
@@ -177,9 +177,9 @@ itkPointSetToImageRegistrationTest(int, char *[])
   ParametersType parameters(transform->GetNumberOfParameters());
 
   // Initialize the offset/vector part
-  for (unsigned int k = 0; k < parameters.size(); ++k)
+  for (double & parameter : parameters)
   {
-    parameters[k] = 0.0f;
+    parameter = 0.0f;
   }
   transform->SetParameters(parameters);
   registration->SetInitialTransformParameters(transform->GetParameters());

--- a/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
@@ -148,9 +148,9 @@ itkPointSetToPointSetRegistrationTest(int, char *[])
   ParametersType parameters(transform->GetNumberOfParameters());
 
   // Initialize the offset/vector part
-  for (unsigned int k = 0; k < parameters.size(); ++k)
+  for (double & parameter : parameters)
   {
-    parameters[k] = 10.0;
+    parameter = 10.0;
   }
   transform->SetParameters(parameters);
   registration->SetInitialTransformParameters(transform->GetParameters());

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -382,12 +382,12 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
 
   double            max = 0;
   GradientIndexType coord2{};
-  for (std::vector<ImageVoxel *>::iterator it = m_Positive.begin(); it != m_Positive.end(); ++it)
+  for (auto & it : m_Positive)
   {
     GradientIndexType coord3;
-    coord3[0] = static_cast<GradientIndexValueType>((*it)->GetX());
-    coord3[1] = static_cast<GradientIndexValueType>((*it)->GetY());
-    coord3[2] = static_cast<GradientIndexValueType>((*it)->GetZ());
+    coord3[0] = static_cast<GradientIndexValueType>(it->GetX());
+    coord3[1] = static_cast<GradientIndexValueType>(it->GetY());
+    coord3[2] = static_cast<GradientIndexValueType>(it->GetZ());
 
     const GradientType & gradient3 = gradientImage->GetPixel(coord3);
 


### PR DESCRIPTION
Only 1 commit ahead of #5025 

C++11 Range based for loops can be used in
    
Used as a more readable equivalent to the traditional for loop operating over a
range of values, such as all elements in a container, in the forward direction..

Range based loopes are more explicit for only computing the
end location once for containers.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
