### PR TITLE
STYLE: Make prototype match definition names

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -161,7 +161,7 @@ private:
 
   /** Swaps and writes the specified elements to the specified output stream. */
   static void
-  SwapWriteRange(const T * ptr, SizeValueType numberOfElements, std::ostream & outputStream);
+  SwapWriteRange(const T * buffer, SizeValueType numberOfElements, std::ostream & outputStream);
 
   static constexpr bool m_SystemIsBigEndian{
 #ifdef CMAKE_WORDS_BIGENDIAN

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -212,7 +212,7 @@ public:
    * image. Sets "IsInBounds" to false if the location is outside the
    * image and the pixel value returned is a boundary condition. */
   PixelType
-  GetPixel(NeighborIndexType i, bool & IsInBounds) const;
+  GetPixel(NeighborIndexType n, bool & IsInBounds) const;
 
   /** Returns the pixel value located at the itk::Offset o from the center of
       the neighborhood. */

--- a/Modules/Core/Common/include/itkImageIORegion.h
+++ b/Modules/Core/Common/include/itkImageIORegion.h
@@ -164,7 +164,7 @@ public:
 
   /** Test if a region (the argument) is completely inside of this region */
   bool
-  IsInside(const Self & region) const;
+  IsInside(const Self & otherRegion) const;
 
   /** Get the number of pixels contained in this region. This just
    * multiplies the size components. */

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -277,11 +277,11 @@ public:
   /** Special SetPixel method which quietly ignores out-of-bounds attempts.
    *  Sets status TRUE if pixel has been set, FALSE otherwise.  */
   void
-  SetPixel(const unsigned int i, const PixelType & v, bool & status);
+  SetPixel(const unsigned int n, const PixelType & v, bool & status);
 
   /** Set the pixel at the ith location. */
   void
-  SetPixel(const unsigned int i, const PixelType & v);
+  SetPixel(const unsigned int n, const PixelType & v);
 
   //  { *(this->operator[](i)) = v; }
 

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -282,7 +282,7 @@ public:
   itkGetConstMacro(SplineOrder, unsigned int);
 
   void
-  SetNumberOfWorkUnits(ThreadIdType numThreads);
+  SetNumberOfWorkUnits(ThreadIdType numWorkUnits);
 
   itkGetConstMacro(NumberOfWorkUnits, ThreadIdType);
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
@@ -131,7 +131,7 @@ protected:
 
   /** Discrete Gauss curvature (K) computation */
   void
-  ComputeGaussCurvature(const InputMeshType * input);
+  ComputeGaussCurvature(const InputMeshType * inputMesh);
 
 private:
   CurvaturesEnum               m_CurvatureType = CurvaturesEnum::GaussCurvature;

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -68,7 +68,7 @@ public:
   WriteMeta(const SpatialObjectType * spatialObject, const char * name);
 
   void
-  MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer spatialObject);
+  MetaObjectToSpatialObjectBase(const MetaObjectType * mo, SpatialObjectPointer rval);
 
   void
   SpatialObjectToMetaObjectBase(SpatialObjectConstPointer spatialObject, MetaObjectType * mo);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -465,7 +465,7 @@ public:
   AddChildrenToList(ChildrenListType * childrenList, unsigned int depth = 0, const std::string & name = "") const;
 
   virtual void
-  AddChildrenToConstList(ChildrenConstListType * childrenList,
+  AddChildrenToConstList(ChildrenConstListType * childrenCList,
                          unsigned int            depth = 0,
                          const std::string &     name = "") const;
 

--- a/Modules/Core/TestKernel/include/itkTestDriverInclude.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverInclude.h
@@ -125,7 +125,7 @@ extern void
 usage();
 
 extern int
-ProcessArguments(int * ac, ArgumentStringType * av, ProcessedOutputType * processedOutput = nullptr);
+ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * processedOutput = nullptr);
 
 
 /// Get the PixelType and ComponentType from fileName

--- a/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
@@ -35,6 +35,6 @@ void
 RegisterRequiredFFTFactories();
 
 void
-ProcessArgumentsAndRegisterRequiredFactories(int * ac, ArgumentStringType * av);
+ProcessArgumentsAndRegisterRequiredFactories(int * argc, ArgumentStringType * argv);
 
 #endif

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
@@ -162,7 +162,7 @@ protected:
 
   /** Multi-thread version GenerateData. */
   void
-  DynamicThreadedGenerateData(const RegionType & outputRegionForThread) override;
+  DynamicThreadedGenerateData(const RegionType & regionForThread) override;
 
 
   // Override since the filter needs all the data for the algorithm

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -91,7 +91,7 @@ protected:
   void
   GenerateInputRequestedRegion() override;
   void
-  EnlargeOutputRequestedRegion(DataObject * output) override;
+  EnlargeOutputRequestedRegion(DataObject * out) override;
 
 private:
   /** Direction in which the filter is to be applied

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -85,7 +85,7 @@ protected:
   void
   GenerateInputRequestedRegion() override;
   void
-  EnlargeOutputRequestedRegion(DataObject * output) override;
+  EnlargeOutputRequestedRegion(DataObject * out) override;
 
   /** Direction in which the filter is to be applied
    * this should be in the range [0,ImageDimension-1]. */

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -280,7 +280,7 @@ private:
   void
   CreateSingleContour(InputPixelType         label,
                       const InputImageType * input,
-                      const InputRegionType  extendedRegion,
+                      const InputRegionType  usableRegion,
                       SizeValueType          totalNumberOfPixels,
                       ContourContainerType & contoursOutput);
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -209,7 +209,7 @@ public:
 
   /** Set/Get number of work units to use for computations. */
   void
-  SetNumberOfWorkUnits(ThreadIdType numberOfThreads);
+  SetNumberOfWorkUnits(ThreadIdType numberOfWorkUnits);
   itkGetConstReferenceMacro(NumberOfWorkUnits, ThreadIdType);
 
   /** Set/Get gradient computation. */

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
@@ -251,7 +251,7 @@ public:
 
   /** Set the maximum number of threads to be used. */
   void
-  SetNumberOfWorkUnits(const ThreadIdType numberOfThreads);
+  SetNumberOfWorkUnits(const ThreadIdType numberOfWorkUnits);
   /** Set the maximum number of threads to be used. */
   ThreadIdType
   GetNumberOfWorkUnits() const;

--- a/Modules/Video/Core/include/itkImageToVideoFilter.h
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.h
@@ -88,7 +88,7 @@ public:
   SetInput(const InputImageType * image);
 
   virtual void
-  SetInput(unsigned int idx, const InputImageType * videoStream);
+  SetInput(unsigned int idx, const InputImageType * image);
 
   /** Get the input Image for this process object */
   const InputImageType *


### PR DESCRIPTION
Enforce consistency in large projects, where it often happens that a definition of a function is refactored, changing the parameter names, but its declaration in the header file is not updated. With this check, we can easily find and correct such inconsistencies, keeping declaration and definition always in sync.

Unnamed parameters are allowed and are not taken into account when comparing function declarations.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)